### PR TITLE
Append "Sentry" to <title> tags

### DIFF
--- a/design/templates/layout.html
+++ b/design/templates/layout.html
@@ -8,7 +8,7 @@
   {{ metatags }}
 
   {%- block htmltitle %}
-  <title>{{ title|striptags|e }}</title>
+  <title>{{ title|striptags|e }} &ndash; Sentry</title>
   {%- endblock %}
 
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css">


### PR DESCRIPTION
Fixes #22

Looks a little odd for the index page ("Hosted Sentry Documentation - Sentry"), but I think that's fine.