### PR TITLE
Update event rollup removal instructions

### DIFF
--- a/docs/learn/sensitive-data.rst
+++ b/docs/learn/sensitive-data.rst
@@ -75,7 +75,7 @@ going to want to leave it there. There are a few things to note in removal:
 
 - If you need to wipe just a single event, you'll find the ability to bulk
   delete all sampled events under a rollup by visiting the rollup details page
-  and selecting "Remove Event Data".
+  and selecting "Delete".
 
 - If you've set of sparse events to a project (potentially all of them), your
   only option is to remove the project and re-create it. Keep in mind this will


### PR DESCRIPTION
Update event deletion instructions to match current UI on the hosted version, which has this "Delete" button rather than a "Remove Event Data" link:
<img width="273" alt="event_rollup_delete_button" src="https://cloud.githubusercontent.com/assets/6729884/17877735/4febc5d2-689a-11e6-98b0-4e1b13baf619.png">

Unless I can't see the remove event data option (I'm an admin but not an owner)... in which case my bad :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-docs/54)
<!-- Reviewable:end -->
