### PR TITLE
Add contribution instructions for Linux

### DIFF
--- a/docs/serverdev/index.rst
+++ b/docs/serverdev/index.rst
@@ -7,6 +7,10 @@ configuration of required dependencies, as well as standard procedures of contri
 Setting up Your Development Environment
 ---------------------------------------
 
+Linux
+''''''''''''''
+Just follow the :doc:`official installation from source instructions <../server/installation/python/index>`.
+
 Macintosh OS X
 ''''''''''''''
 


### PR DESCRIPTION
Simple link to normal installation doc, I could link to the 'docker' install too since the python one is depreciated.

Issue #44 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-docs/55)
<!-- Reviewable:end -->
