### PR TITLE
Recommend `brew services start <service>`

### DIFF
--- a/docs/internal/environment.rst
+++ b/docs/internal/environment.rst
@@ -29,7 +29,7 @@ Redis is a popular in-memory datastore that Sentry uses for queuing and caching 
 Run the following to install, configure, and execute Redis as a daemonized server::
 
     brew install redis
-    redis-server --save --daemonize yes
+    brew services start redis
 
 PostgreSQL
 **********
@@ -38,7 +38,7 @@ PostgreSQL is the primary database that Sentry uses for all persistent storage.
 Run the following to install, configure, and execute PostgreSQL as a daemonized server::
 
     brew install postgresql
-    pg_ctl -D /usr/local/var/postgres start
+    brew services start postgresql
 
 .. note:: Sometimes OS X does not like to uphold standards, and does not create the ``postgres``
           role. If you are finding this problem, follow `this StackOverflow answer <http://stackoverflow.com/a/15309551>`_.


### PR DESCRIPTION
Running `pg_ctl -D` will at least dump stderr/stdout into your current running console and this is less than ideal. We can leverage `brew services` here now since we suggest `brew` anyways for installation.

/cc @torarnv