### PR TITLE
Close unclosed tags

### DIFF
--- a/design/templates/layout.html
+++ b/design/templates/layout.html
@@ -59,7 +59,7 @@
               <h3>Endpoints</h3>
               {{ toc_parts.api_endpoints }}
             </li>
-          </div>
+          </ul>
           {% elif pagename.startswith('clientdev/') %}
           <a href="{{ pathto(master_doc) }}" class="return-link">Return to Docs Overview</a>
           <ul>
@@ -72,7 +72,7 @@
                 <li>{{ page_link('clientdev/data-handling', 'Data Handling')}}</li>
               </ul>
             </li>
-          </div>
+          </ul>
           {% elif pagename.startswith('server/') %}
           <a href="{{ pathto(master_doc) }}" class="return-link">Return to Docs Overview</a>
           <ul>
@@ -100,7 +100,7 @@
             <li>
               <h3>Operations</h3>
               <ul>
-                <li>{{ page_link('server/nginx', 'Deploying with Nginx')}}
+                <li>{{ page_link('server/nginx', 'Deploying with Nginx')}}</li>
                 <li>{{ page_link('server/monitoring', 'Monitoring')}}</li>
                 <li>{{ page_link('server/internal-metrics', 'Internal Metrics')}}</li>
                 <li>{{ page_link('server/performance', 'Performance Tuning')}}</li>
@@ -117,7 +117,7 @@
                 <li>{{ page_link('server/faq', 'FAQ')}}</li>
               </ul>
             </li>
-          </div>
+          </ul>
           {% elif pagename.startswith('internal/') %}
           <a href="{{ pathto(master_doc) }}" class="return-link">Return to Docs Overview</a>
           <ul>
@@ -130,7 +130,7 @@
                 <li>{{ page_link('internal/api', 'Web API')}}</li>
               </ul>
             </li>
-          </div>
+          </ul>
           {% else %}
           <ul>
             <li><h3>{{ page_link(master_doc, 'Home') }}</h3></li>


### PR DESCRIPTION
This PR fixes mobile rendering of docs by properly closing some mismatched tags.

@getsentry/product 