### PR TITLE
Consistency "client" -> "SDK"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ The structure of this repository is broken into a few separate parts:
   more information have a look into the `Makefile`.
 * ``doc-modules/``: this folder contains references to the submodules for
   the individual split docs.  The ``docs/clients`` folder contains a bunch of
-  symlinks that point to the appropriate place within the client doc
+  symlinks that point to the appropriate place within the SDK doc
   folder for instance.
 * ``design/``: this folder contains the JavaScript, CSS files and
   templates as well as some webpack related stuff for the final design of
@@ -49,7 +49,7 @@ various browser security controls will block some of our JavaScript::
 
     bin/web
 
-If you only need to rebuild pages in the sentry-docs repo (and not the client repo docs), you can use this command::
+If you only need to rebuild pages in the sentry-docs repo (and not the SDK repo docs), you can use this command::
 
     make fast-build
 

--- a/docs/clientdev/attributes.rst
+++ b/docs/clientdev/attributes.rst
@@ -27,7 +27,7 @@ The following attributes are required for all events:
 
 .. describe:: timestamp
 
-    Indicates when the logging record was created (in the Sentry client).
+    Indicates when the logging record was created (in the Sentry SDK).
 
     The Sentry server assumes the time is in UTC.
 
@@ -52,7 +52,7 @@ The following attributes are required for all events:
 
 .. describe:: platform
 
-    A string representing the platform the client is submitting from. This will
+    A string representing the platform the SDK is submitting from. This will
     be used by the Sentry interface to customize various components in the
     interface.
 
@@ -140,7 +140,7 @@ highly encouraged:
 
 .. describe:: server_name
 
-    Identifies the host client from which the event was recorded.
+    Identifies the host SDK from which the event was recorded.
 
     .. sourcecode:: json
 

--- a/docs/clientdev/context.rst
+++ b/docs/clientdev/context.rst
@@ -1,10 +1,10 @@
 Context Management
 ==================
 
-All clients should have the concept of a concurrency safe context storage.
+All SDKs should have the concept of a concurrency safe context storage.
 What this means heavily depends on the language.  The basic idea is that a
 user of the Raven library can call a method to provide additional context
-information from whererever the user has access to the client object in a
+information from whererever the user has access to the SDK object in a
 safe way.
 
 In general this is implemented as a thread local in most languages, but in
@@ -14,18 +14,18 @@ something that makes sense in the environment.
 User's Perspective
 ------------------
 
-From the user's perspective of the raven client there should be two types
+From the user's perspective of the raven SDK there should be two types
 of APIs:
 
 ``RavenClient.context``:
-    Given a raven client object it should be possible to get a reference
+    Given a raven SDK object it should be possible to get a reference
     to the underlying context object for manual updating.  This might not
     always be something that makes sense in the context of the language,
     so it's possible to hide this.
 
     If it is possible in the language, then it's encouraged that this is a
     thread local accessor to not break concurrent environments.  For
-    instance the Python client has a different context for each thread to
+    instance the Python SDK has a different context for each thread to
     support concurrent web frameworks and multithreaded environments.
 
     If the context is exposed it needs to provide two methods:
@@ -38,7 +38,7 @@ of APIs:
 
 ``RavenClient.*_context``:
     These are methods that update the context according to the name of the
-    method.  Which of those methods exist is up to the client developer,
+    method.  Which of those methods exist is up to the SDK developer,
     however as a general rule those should exist:
 
     *   ``user_context``
@@ -48,7 +48,7 @@ of APIs:
 
 Ideally a user never needs to be concerned with clearing the context.
 Framework integrations should do this automatically as far as possible.
-For instance if a client integration is configured for a web framework
+For instance if a SDK integration is configured for a web framework
 it should automatically hook the framework in a way where it will clear
 the context at the end of every request and ideally also already invoke
 things like ``http_context`` automatically.
@@ -56,11 +56,11 @@ things like ``http_context`` automatically.
 Context Clearing
 ----------------
 
-For most clients there should be a method to clear the context.  This is
+For most SDK there should be a method to clear the context.  This is
 especially imporant in multithreaded environments where threads might be
 re-used.  The preferred method to clear the context would be automatically
-if that is something the client can provide.  As mentioned earlier the
-framework integrations in the clients should do this whenever possible.
+if that is something the SDK can provide.  As mentioned earlier the
+framework integrations in the SDK should do this whenever possible.
 
 For manual clearing ``client.context.clear()`` is the preferred method.
 If the context cannot be directly exposed, ``client.clearContext()`` or a
@@ -100,7 +100,7 @@ The following methods are recommended to exist:
 
         client.context.merge({'tags': data})
 
-For some clients it also makes sense to provide additional helpers to
+For some SDKs it also makes sense to provide additional helpers to
 bind http context and similar things to common language patterns.  For
 instance if you expect a CGI/WSGI/Rack environment you could provide
 ``client.cgi_context`` / ``client.wsgi_context`` methods.

--- a/docs/clientdev/context.rst
+++ b/docs/clientdev/context.rst
@@ -4,7 +4,7 @@ Context Management
 All SDKs should have the concept of a concurrency safe context storage.
 What this means heavily depends on the language.  The basic idea is that a
 user of the Raven library can call a method to provide additional context
-information from whererever the user has access to the SDK object in a
+information from whererever the user has access to the client object in a
 safe way.
 
 In general this is implemented as a thread local in most languages, but in

--- a/docs/clientdev/context.rst
+++ b/docs/clientdev/context.rst
@@ -14,11 +14,11 @@ something that makes sense in the environment.
 User's Perspective
 ------------------
 
-From the user's perspective of the raven SDK there should be two types
+From the user's perspective of the Sentry SDK there should be two types
 of APIs:
 
 ``RavenClient.context``:
-    Given a raven SDK object it should be possible to get a reference
+    Given a Sentry SDK object it should be possible to get a reference
     to the underlying context object for manual updating.  This might not
     always be something that makes sense in the context of the language,
     so it's possible to hide this.
@@ -56,11 +56,11 @@ things like ``http_context`` automatically.
 Context Clearing
 ----------------
 
-For most SDK there should be a method to clear the context.  This is
+For most SDKs there should be a method to clear the context.  This is
 especially imporant in multithreaded environments where threads might be
 re-used.  The preferred method to clear the context would be automatically
 if that is something the SDK can provide.  As mentioned earlier the
-framework integrations in the SDK should do this whenever possible.
+framework integrations in the SDKs should do this whenever possible.
 
 For manual clearing ``client.context.clear()`` is the preferred method.
 If the context cannot be directly exposed, ``client.clearContext()`` or a

--- a/docs/clientdev/data-handling.rst
+++ b/docs/clientdev/data-handling.rst
@@ -4,10 +4,10 @@ Data Handling
 Sensitive Data
 --------------
 
-Clients should provide some mechanism for scrubbing data. Ideally through
+SDKs should provide some mechanism for scrubbing data. Ideally through
 an extensible interface that the user can customize the behavior of.
 
-This is generally done as part of the client configuration::
+This is generally done as part of the SDK configuration::
 
     client = Client(..., {
         'processors': ['processor.className'],
@@ -37,7 +37,7 @@ We recommend scrubbing the following values:
 * Session cookies.
 * The Authentication header (HTTP).
 
-Keep in mind, that if your client is passing extra interface data (e.g.
+Keep in mind, that if your SDK is passing extra interface data (e.g.
 HTTP POST variables) you will also want to scrub those interfaces. Given
 that, it is a good idea to simply recursively scrub most variables other
 than predefined things (like HTTP headers).

--- a/docs/clientdev/interfaces/index.rst
+++ b/docs/clientdev/interfaces/index.rst
@@ -9,7 +9,7 @@ including storing stacktraces, HTTP request information, and other
 metadata.
 
 For the most part interfaces are an evolving part of Sentry.  Like with
-attributes, SDK are expected to assume more can appear at any point in
+attributes, SDKs are expected to assume more can appear at any point in
 the future.  More than that however, for on-premise installations of
 Sentry the interfaces can be customized so SDK libraries should ideally
 be written in a way that custom interfaces can be emitted.

--- a/docs/clientdev/interfaces/index.rst
+++ b/docs/clientdev/interfaces/index.rst
@@ -9,9 +9,9 @@ including storing stacktraces, HTTP request information, and other
 metadata.
 
 For the most part interfaces are an evolving part of Sentry.  Like with
-attributes, clients are expected to assume more can appear at any point in
+attributes, SDK are expected to assume more can appear at any point in
 the future.  More than that however, for on-premise installations of
-Sentry the interfaces can be customized so client libraries should ideally
+Sentry the interfaces can be customized so SDK libraries should ideally
 be written in a way that custom interfaces can be emitted.
 
 Interfaces are typically identified by their full canonical path as it

--- a/docs/clientdev/overview.rst
+++ b/docs/clientdev/overview.rst
@@ -8,7 +8,7 @@ guidelines for how clients should look and behave.
 Writing an SDK
 --------------
 
-A SDK at its core is simply a set of utilities for capturing various
+An SDK at its core is simply a set of utilities for capturing various
 logging parameters. Given these parameters, it then builds a JSON payload
 which it will send to a Sentry server using some sort of authentication
 method.
@@ -210,7 +210,7 @@ header, it's possible to send these values via the querystring::
     The secret key which should be provided as part of the SDK configuration.
 
     .. note:: You should only pass the secret key if you're communicating via
-              secure communication to the server. SDK-side behavior (such
+              secure communication to the server. Client-side behavior (such
               as JavaScript) should use CORS, and only pass the public key.
 
 A Working Example

--- a/docs/clientdev/overview.rst
+++ b/docs/clientdev/overview.rst
@@ -2,18 +2,18 @@ Overview
 ========
 
 This part of the documentation guides you towards implementing a new
-Client for Sentry.  It covers the protocol for event submission as well as
+SDK for Sentry.  It covers the protocol for event submission as well as
 guidelines for how clients should look and behave.
 
-Writing a Client
-----------------
+Writing an SDK
+--------------
 
-A client at its core is simply a set of utilities for capturing various
+A SDK at its core is simply a set of utilities for capturing various
 logging parameters. Given these parameters, it then builds a JSON payload
 which it will send to a Sentry server using some sort of authentication
 method.
 
-The following items are expected of production-ready clients:
+The following items are expected of production-ready SDKs:
 
 * DSN configuration
 * Graceful failures (e.g. Sentry server unreachable)
@@ -36,10 +36,10 @@ Additionally, the following features are highly encouraged:
 Usage for End-users
 -------------------
 
-Generally, a client consists of three steps to the end user, which should
+Generally, an SDK consists of three steps to the end user, which should
 look almost identical no matter the language:
 
-1. Creation of the client (sometimes this is hidden to the user)::
+1. Creation of the SDK (sometimes this is hidden to the user)::
 
       var myClient = new SentryClient('{DSN}');
 
@@ -60,13 +60,13 @@ optional secondary argument which is a map of options::
     })
 
 .. note:: If an empty DSN is passed, you should treat it as valid option
-   which signifies disabling the client.
+   which signifies disabling the SDK.
 
 Which options you support is up to you, but ideally you would provide
 defaults for generic values that can be passed to the capture methods.
 
 Once you accept the options, you should output a logging message
-describing whether the client has been configured actively (as in, it will
+describing whether the SDK has been configured actively (as in, it will
 send to the remote server), or if it has been disabled. This should be
 done with whatever standard logging module is available for your platform.
 
@@ -93,7 +93,7 @@ something like the following::
 .. note:: In the above example, we're passing any options that would
    normally be passed to the capture methods along with the block wrapper.
 
-Finally, provide a CLI to test your client's configuration. Python example::
+Finally, provide a CLI to test your SDK's configuration. Python example::
 
     raven test {DSN}
 
@@ -104,7 +104,7 @@ Ruby example::
 Parsing the DSN
 ---------------
 
-Clients are encouraged to allow arbitrary options via the constructor, but must
+SDKs are encouraged to allow arbitrary options via the constructor, but must
 allow the first argument as a DSN string. This string contains the following bits::
 
     '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
@@ -129,8 +129,8 @@ The resulting POST request would then transmit to::
 
   'https://sentry.example.com/api/1/store/'
 
-.. note:: If any of configuration values are not present, the client should notify the user
-          immediately that they've misconfigured the client.
+.. note:: If any of configuration values are not present, the SDK should notify the user
+          immediately that they've misconfigured the SDK.
 
 Building the JSON Packet
 ------------------------
@@ -176,7 +176,7 @@ body, which acts as an ownership identifier::
       sentry_key=<public api key>,
       sentry_secret=<secret api key>
 
-.. note:: You should include the client version string in the User-Agent
+.. note:: You should include the SDK version string in the User-Agent
    portion of the header, and it will be used if sentry_client is not sent
    in the auth header.
 
@@ -191,11 +191,11 @@ header, it's possible to send these values via the querystring::
 
 .. describe:: sentry_client
 
-    An arbitrary string which identifies your client, including its version.
+    An arbitrary string which identifies your SDK, including its version.
 
     The typical pattern for this is '**client_name**/**client_version**'.
 
-    For example, the Python client might send this as 'raven-python/1.0'.
+    For example, the Python SDK might send this as 'raven-python/1.0'.
 
 .. describe:: sentry_timestamp
 
@@ -203,14 +203,14 @@ header, it's possible to send these values via the querystring::
 
 .. describe:: sentry_key
 
-    The public key which should be provided as part of the client configuration.
+    The public key which should be provided as part of the SDK configuration.
 
 .. describe:: sentry_secret
 
-    The secret key which should be provided as part of the client configuration.
+    The secret key which should be provided as part of the SDK configuration.
 
     .. note:: You should only pass the secret key if you're communicating via
-              secure communication to the server. Client-side behavior (such
+              secure communication to the server. SDK-side behavior (such
               as JavaScript) should use CORS, and only pass the public key.
 
 A Working Example
@@ -250,7 +250,7 @@ The request body should then somewhat resemble the following:
 Request Encoding
 ----------------
 
-Clients are heavily encouraged to gzip or deflate encode the request body
+SDKs are heavily encouraged to gzip or deflate encode the request body
 before sending it to the server to keep the data small.  The preferred
 method for this is to send an ``Content-Encoding: gzip`` header.
 Alternatively the server also accepts gzip compressed json in a base64
@@ -296,7 +296,7 @@ For example, you might get something like this::
 Handling Failures
 -----------------
 
-It is **highly encouraged** that your client handles failures from the
+It is **highly encouraged** that your SDK handles failures from the
 Sentry server gracefully. This means taking care of several key things:
 
 * Soft failures when the Sentry server fails to respond in a reasonable
@@ -305,7 +305,7 @@ Sentry server gracefully. This means taking care of several key things:
   server is offline)
 * Failover to a standard logging module on errors.
 
-For example, the Python client will log any failed requests to the Sentry
+For example, the Python SDK will log any failed requests to the Sentry
 server to a named logger, ``sentry.errors``.  It will also only retry
 every few seconds, based on how many consecutive failures its seen. The
 code for this is simple::
@@ -322,12 +322,12 @@ Tags
 Tags are key/value pairs that describe an event. They should be
 configurable in the following contexts:
 
-* Environment (client-level)
+* Environment (SDK-level)
 * Thread (block-level)
 * Event (as part of capture)
 
 Each of these should inherit its parent. So for example, if you configure
-your client as so::
+your SDK as so::
 
     client = Client(..., {
         'tags': {'foo': 'bar'},
@@ -339,7 +339,7 @@ And then you capture an event::
         'tags': {'foo': 'baz'},
     })
 
-The client should send the following upstream for ``tags``::
+The SDK should send the following upstream for ``tags``::
 
     {
         "tags": [
@@ -358,7 +358,7 @@ present context.
 
 This interface consists of `*_context` methods, access to the `context`
 dictionary as well as a `clear` and `merge` context method.  Method
-methods exist usually depend on the client.  The following methods
+methods exist usually depend on the SDK.  The following methods
 generally make sense:
 
 *   ``client.user_context``

--- a/docs/clients/actionscript/index.rst
+++ b/docs/clients/actionscript/index.rst
@@ -23,10 +23,10 @@ Grab the source code from GitHub:
 Now simply add it to your class path.
 
 
-Configuring the Client
-----------------------
+Configuring the SDK
+-------------------
 
-Create a new instance of the client:
+Create a new instance of the SDK:
 
 .. code-block:: actionscript
 

--- a/docs/clients/perl/index.rst
+++ b/docs/clients/perl/index.rst
@@ -21,10 +21,10 @@ Installation
     cpanm Sentry::Raven
 
 
-Configuring the Client
-----------------------
+Configuring the SDK
+-------------------
 
-Create a new instance of the client:
+Create a new instance of the SDK:
 
 
 .. code-block:: perl

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -14,7 +14,7 @@ around many of the open source repos (and some of the Sentry dependencies)
 you'll see a common thread: StarCraft 2. Originally we started with the
 name Sentry representing a Protoss unit that had a shield, which was
 fairly fitting as Sentry helps shield you from problems, but doesn't
-prevent them, just like the unit. When we named the SDK we went with
+prevent them, just like the unit. When we named the first SDK we went with
 Raven, which represents a Terran air unit that also happens to place
 Sentry turrets.
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -14,7 +14,7 @@ around many of the open source repos (and some of the Sentry dependencies)
 you'll see a common thread: StarCraft 2. Originally we started with the
 name Sentry representing a Protoss unit that had a shield, which was
 fairly fitting as Sentry helps shield you from problems, but doesn't
-prevent them, just like the unit. When we named the client we went with
+prevent them, just like the unit. When we named the SDK we went with
 Raven, which represents a Terran air unit that also happens to place
 Sentry turrets.
 

--- a/docs/internal/docs.rst
+++ b/docs/internal/docs.rst
@@ -92,7 +92,7 @@ The repository for the documentation can be found on our github home:
 `getsentry/sentry-docs <https://github.com/getsentry/sentry-docs>`_.
 
 Some documentation sources are not contained within that repository but
-referenced through submodules from the raven clients or the sentry server.
+referenced through submodules from the raven SDKs or the sentry server.
 You can easily find those repositories from the github repository as they
 are cross linked.
 

--- a/docs/internal/docs.rst
+++ b/docs/internal/docs.rst
@@ -92,7 +92,7 @@ The repository for the documentation can be found on our github home:
 `getsentry/sentry-docs <https://github.com/getsentry/sentry-docs>`_.
 
 Some documentation sources are not contained within that repository but
-referenced through submodules from the raven SDKs or the sentry server.
+referenced through submodules from the Sentry SDKs or the sentry server.
 You can easily find those repositories from the github repository as they
 are cross linked.
 

--- a/docs/learn/cli.rst
+++ b/docs/learn/cli.rst
@@ -79,7 +79,7 @@ config key in the config file):
 ``SENTRY_PROJECT`` (`defaults.project`):
     the slug of the project to use for a command.
 (`http.keepalive`):
-    This ini only setting is used to control the behavior of the client
+    This ini only setting is used to control the behavior of the SDK
     with regards to HTTP keepalives.  The default is `true` but it can
     be set to `false` to disable keepalive support.
 ``http_proxy`` (`http.proxy_url`):
@@ -93,7 +93,7 @@ config key in the config file):
     This ini only setting sets the proxy password in case proxy
     authentication is required.
 ``SENTRY_LOG_LEVEL`` (`log.level`):
-    Configures the log level for the client.  The default is ``warning``.
+    Configures the log level for the SDK.  The default is ``warning``.
     If you want to see what the library is doing you can set it to
     ``info`` which will spit out more information which might help to
     debug some issues with permissions.

--- a/docs/learn/context.rst
+++ b/docs/learn/context.rst
@@ -14,8 +14,8 @@ amongst any issue captured in its lifecycle, and includes the following componen
     Arbitrary unstructured data which is stored with an event sample
 
 Context is considered to be request state, and thus should be cleared
-out at the beginning (or end) of each operation. Clients like the JavaScript
-client usually won't need to worry about this as they are generally are not
+out at the beginning (or end) of each operation. SDKs like the JavaScript
+SDK usually won't need to worry about this as they are generally are not
 long lived.
 
 Tagging Events
@@ -42,10 +42,10 @@ and the last time a value has been seen. Even more so, we keep track of
 the number of distinct tags, and can assist in you determining hotspots
 for various issues.
 
-Most clients generally support configuring tags at the global client level
+Most SDKs generally support configuring tags at the global SDK level
 configuration, as well as on a per event basis.
 
-For example, in the JavaScript client:
+For example, in the JavaScript SDK:
 
 .. code-block:: javascript
 
@@ -94,7 +94,7 @@ the user to be captured:
 Additionally you can provide arbitrary key/value pairs beyond the reserved names and those
 will be stored with the user.
 
-Capturing the user is fairly straight forward. For example, in the JavaScript client:
+Capturing the user is fairly straight forward. For example, in the JavaScript SDK:
 
 .. code-block:: javascript
 
@@ -113,7 +113,7 @@ and are simply used to add additional information about what might be happening.
 Extra context can generally be passed in both the event constructor, as well as the
 global context state:
 
-For example, in the JavaScript client:
+For example, in the JavaScript SDK:
 
 .. code-block:: javascript
 

--- a/docs/learn/quotas.rst
+++ b/docs/learn/quotas.rst
@@ -34,7 +34,7 @@ Inbound Data Filters
 --------------------
 
 In some cases the data you're receiving in Sentry is hard to filter, or you simply
-don't have the ability to update the client's application to apply the filters. Due
+don't have the ability to update the SDK's application to apply the filters. Due
 to this Sentry provides several ways to filter data server-side, which will also
 apply before any rate limits are checked.
 
@@ -48,9 +48,9 @@ as web crawlers or old browsers, and can be enabled as needed by the specific ap
 IP Blocklist
 ~~~~~~~~~~~~
 
-If you have a rogue client you may find yourself simple wanting to block that IP from
+If you have a rogue SDK you may find yourself simple wanting to block that IP from
 sending data. Sentry supports this by going to **[Project] » General** and adding the
-IP addresses (or subnets) under the **Client Security** section.
+IP addresses (or subnets) under the **SDK Security** section.
 
 Attributes Limits
 -----------------

--- a/docs/learn/quotas.rst
+++ b/docs/learn/quotas.rst
@@ -34,7 +34,7 @@ Inbound Data Filters
 --------------------
 
 In some cases the data you're receiving in Sentry is hard to filter, or you simply
-don't have the ability to update the SDK's application to apply the filters. Due
+don't have the ability to update the SDK's configuration to apply the filters. Due
 to this Sentry provides several ways to filter data server-side, which will also
 apply before any rate limits are checked.
 
@@ -48,9 +48,9 @@ as web crawlers or old browsers, and can be enabled as needed by the specific ap
 IP Blocklist
 ~~~~~~~~~~~~
 
-If you have a rogue SDK you may find yourself simple wanting to block that IP from
+If you have a rogue client you may find yourself simple wanting to block that IP from
 sending data. Sentry supports this by going to **[Project] » General** and adding the
-IP addresses (or subnets) under the **SDK Security** section.
+IP addresses (or subnets) under the **Client Security** section.
 
 Attributes Limits
 -----------------

--- a/docs/learn/rollups.rst
+++ b/docs/learn/rollups.rst
@@ -36,7 +36,7 @@ stacktrace.  This grouping is fairly involved but easy enough to
 understand.
 
 The first and most important part is that Sentry only groups by stack
-trace frames reported in the application.  Not all clients might report
+trace frames reported in the application.  Not all SDKs might report
 this, but if that information is provided, it's used for grouping.  This
 means that if the stacktrace is modified from one event to another
 exclusively in parts of the stack that is not related to the application,
@@ -58,8 +58,8 @@ dealt with:
     :ref:`raven-js-sourcemaps`.
 *   if you modify your stacktrace by introducing a new level through the
     use of decorators, your stacktrace will change and so will the
-    grouping.  For this matter many clients support hiding irrelevant
-    stack trace frames.  For instance the Python client will skip all
+    grouping.  For this matter many SDKs support hiding irrelevant
+    stack trace frames.  For instance the Python SDK will skip all
     stack frames with a local variable called ``__traceback_hide__`` set
     to `True`).
 
@@ -90,7 +90,7 @@ not available, it uses the message attribute.
 Customize Grouping with Fingerprints
 ------------------------------------
 
-For some very advanced use cases clients can override the Sentry default
+For some very advanced use cases SDKs can override the Sentry default
 grouping.
 
 Two common cases generally come up here:
@@ -103,7 +103,7 @@ Two common cases generally come up here:
 
 To work around these the Sentry protocol supports a ``fingerprint`` attribute.
 
-In supported clients, this attribute can be passed with the event information,
+In supported SDKs, this attribute can be passed with the event information,
 and should be an array of strings:
 
 .. code-block:: javascript

--- a/docs/learn/search.rst
+++ b/docs/learn/search.rst
@@ -16,7 +16,7 @@ In the above there are four tokens:
 * ``example error``
 
 The first two are standard search tokens, both using reserved keywords. The third
-is pointing to a custom tag sent by the client. The fourth is passed as part of the
+is pointing to a custom tag sent by the SDK. The fourth is passed as part of the
 issue search query (which uses a CONTAINS match).
 
 The following tokens are reserved and known to Sentry:

--- a/docs/project-resources.rst
+++ b/docs/project-resources.rst
@@ -15,7 +15,7 @@ used services:
   Source project.
 * `The GitHub Organization <https://github.com/getsentry>`_ for the entire
   list of Open Source projects which also includes many of the Raven
-  clients.
+  SDKs.
 * `Mailing List <https://groups.google.com/group/getsentry>`_ on Google
   Groups.
 * `#sentry IRC Channel <irc://irc.freenode.net/sentry>`_ on

--- a/docs/project-resources.rst
+++ b/docs/project-resources.rst
@@ -14,7 +14,7 @@ used services:
 * `Code <https://github.com/getsentry/sentry>`_ on GitHub for the Open
   Source project.
 * `The GitHub Organization <https://github.com/getsentry>`_ for the entire
-  list of Open Source projects which also includes many of the Raven
+  list of Open Source projects which also includes many of the Sentry
   SDKs.
 * `Mailing List <https://groups.google.com/group/getsentry>`_ on Google
   Groups.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -34,7 +34,7 @@ Popular integrations are:
 *   :doc:`Elixir <clients/elixir/index>`
 
 For exact configuration for the integration consult the corresponding
-documentation.  For all SDK however, the basics are the same.
+documentation.  For all SDKs however, the basics are the same.
 
 .. _configure-the-dsn:
 
@@ -44,7 +44,7 @@ About the DSN
 After you complete setting up a project in Sentry, you'll be given a value
 which we call a *DSN*, or *Data Source Name*.  It looks a lot like a
 standard URL, but it's actually just a representation of the configuration
-required by the Raven SDKs.  It consists of a few pieces, including the
+required by the Sentry SDKs.  It consists of a few pieces, including the
 protocol, public and secret keys, the server address, and the project
 identifier.
 
@@ -73,7 +73,7 @@ It is composed of five important pieces:
 You'll have a few options for plugging the DSN into the SDK, depending
 on what it supports. At the very least, most SDKs will allow you to set
 it up as the ``SENTRY_DSN`` environment variable or by passing it into the
-SDK constructor.
+SDK's constructor.
 
 For example for the JavaScript SDK it works roughly like this::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ Configure an SDK
 Sentry captures data by using an SDK within your application's runtime. These
 are platform specific, and allow Sentry to have a deep understanding of both
 how your application works. In case your environment is very specific, you can
-also roll your own SDK using our document :doc:`Client API <clientdev/index>`.
+also roll your own SDK using our document :doc:`SDK API <clientdev/index>`.
 
 Popular integrations are:
 
@@ -34,7 +34,7 @@ Popular integrations are:
 *   :doc:`Elixir <clients/elixir/index>`
 
 For exact configuration for the integration consult the corresponding
-documentation.  For all clients however, the basics are the same.
+documentation.  For all SDK however, the basics are the same.
 
 .. _configure-the-dsn:
 
@@ -44,7 +44,7 @@ About the DSN
 After you complete setting up a project in Sentry, you'll be given a value
 which we call a *DSN*, or *Data Source Name*.  It looks a lot like a
 standard URL, but it's actually just a representation of the configuration
-required by the Raven clients.  It consists of a few pieces, including the
+required by the Raven SDKs.  It consists of a few pieces, including the
 protocol, public and secret keys, the server address, and the project
 identifier.
 
@@ -64,24 +64,24 @@ It is composed of five important pieces:
 
 * The Protocol used. This can be one of the following: http or https.
 
-* The public and secret keys to authenticate the client.
+* The public and secret keys to authenticate the SDK.
 
 * The destination Sentry server.
 
 * The project ID which the authenticated user is bound to.
 
-You'll have a few options for plugging the DSN into the client, depending
+You'll have a few options for plugging the DSN into the SDK, depending
 on what it supports. At the very least, most SDKs will allow you to set
 it up as the ``SENTRY_DSN`` environment variable or by passing it into the
-client constructor.
+SDK constructor.
 
-For example for the JavaScript client it works roughly like this::
+For example for the JavaScript SDK it works roughly like this::
 
     import raven
     raven.Client('___DSN___')
 
 Note: If you're using Heroku, and you've added Hosted Sentry via the
-standard addon hooks, most clients will automatically pick up the
+standard addon hooks, most SDKs will automatically pick up the
 ``SENTRY_DSN`` environment variable that we've already configured for you.
 
 

--- a/docs/ssl.rst
+++ b/docs/ssl.rst
@@ -10,8 +10,8 @@ Certificates
 ------------
 
 Due to the complexities of root CAs and distributions, you may find
-that your client does not contain the root certificate authority used
-by sentry.io.  While we bundle this in official raven clients,
+that your SDK does not contain the root certificate authority used
+by sentry.io.  While we bundle this in official raven SDK,
 that's not true for everything.
 
 Our CA is DigiCert, a widely trusted name. Below you'll find our
@@ -28,10 +28,10 @@ Bundles:
 -   `getsentry.pem <https://sentry.io/_static/getsentry/ssl/getsentry.pem>`_
 -   `getsentry.p7b <https://sentry.io/_static/getsentry/ssl/getsentry.p7b>`_
 
-Using this varies from case to case. Many clients you will have to
+Using this varies from case to case. Many SDKs you will have to
 explicit specify the path to the certificate bundle.  Covering this is
 outside of the scope of these docs, so we suggest referring to your
-specific client's documentation.
+specific SDK's documentation.
 
 Note on Java:
 

--- a/docs/ssl.rst
+++ b/docs/ssl.rst
@@ -11,7 +11,7 @@ Certificates
 
 Due to the complexities of root CAs and distributions, you may find
 that your SDK does not contain the root certificate authority used
-by sentry.io.  While we bundle this in official raven SDK,
+by sentry.io.  While we bundle this in official Sentry SDKs,
 that's not true for everything.
 
 Our CA is DigiCert, a widely trusted name. Below you'll find our

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -25,9 +25,9 @@ We offer community support through at `forum.sentry.io <https://forum.sentry.io/
 is a great place to provide product feedback, get help and advice with various issues,
 as well as to take part in the larger Sentry community.
 
-If you're looking for support on a specific client, check the
-documentation specific to that client. Several clients are maintained by
-the Sentry team, whereas others are not. Nearly every client also has its
+If you're looking for support on a specific SDK, check the
+documentation specific to that SDK. Several SDKs are maintained by
+the Sentry team, whereas others are not. Nearly every SDK also has its
 own bug tracker, which is generally where the code lives (i.e. on GitHub).
 
 Paid Support


### PR DESCRIPTION
This updates usage of the work "client" to "SDK" per new style preferences.

I did my best to update where appropriate, but left out a couple instances like "client-side" and actual code examples with classnames that involved "client" that wouldn't make sense for the change.

I wouldn't mind a review to make sure the context of each of these is appropriate.
