### PR TITLE
Remove objc docs git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "doc-modules/sentry-php"]
 	path = doc-modules/sentry-php
 	url = https://github.com/getsentry/sentry-php
-[submodule "doc-modules/raven-objc"]
-	path = doc-modules/raven-objc
-	url = https://github.com/getsentry/raven-objc
 [submodule "doc-modules/raven-java"]
 	path = doc-modules/raven-java
 	url = https://github.com/getsentry/raven-java

--- a/docs/clients/index.rst
+++ b/docs/clients/index.rst
@@ -16,7 +16,6 @@ discussion about supporting it on our `community forum <https://forum.sentry.io>
    java/index
    javascript/index
    node/index
-   objc/index
    perl/index
    php/index
    python/index

--- a/docs/clients/objc
+++ b/docs/clients/objc
@@ -1,1 +1,0 @@
-../../doc-modules/raven-objc/docs

--- a/docs/clients/table.rst.inc
+++ b/docs/clients/table.rst.inc
@@ -22,7 +22,7 @@
 
 *   .. class:: platformlink-objc
 
-    :doc:`/clients/cocoa/index` For iOS, macOS, and tvOS.
+    :doc:`/clients/cocoa/index` For iOS, macOS, tvOS and watchOS.
 
 *   .. class:: platformlink-java
 


### PR DESCRIPTION
Its obsolete, we use our swift sdk for both swift and objc