### PR TITLE
Put postgres role creation in the setup instructions

### DIFF
--- a/docs/internal/environment.rst
+++ b/docs/internal/environment.rst
@@ -37,8 +37,9 @@ Run the following to install, configure, and execute PostgreSQL as a daemonized 
     brew install postgresql
     brew services start postgresql
 
-.. note:: Sometimes OS X does not like to uphold standards, and does not create the ``postgres``
-          role. If you are finding this problem, follow `this StackOverflow answer <http://stackoverflow.com/a/15309551>`_.
+Make sure the ``postgres`` role exists::
+
+    createuser -s postgres
 
 Third Party Libraries
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This replaces the note referring to StackOverflow (introduced in https://github.com/getsentry/sentry-docs/pull/57) with a command that creates the `postgres` role if it doesn't already exist. This should save new users a few minutes of time on installation ⏱ 

@JTCunning Is this the command you used to create the role?

@LewisJEllis Bringing this to your attention since you reviewed https://github.com/getsentry/sentry-docs/pull/57