### PR TITLE
Update loglevel options for breadcrumbs from warn to warning, to match api

### DIFF
--- a/docs/learn/breadcrumbs.rst
+++ b/docs/learn/breadcrumbs.rst
@@ -22,7 +22,7 @@ Category
     area an event took place, such as ``auth``.
 
 Level
-    The level may be any of ``error``, ``warn``, ``info``, or ``debug``.
+    The level may be any of ``error``, ``warning``, ``info``, or ``debug``.
 
 
 Recording Crumbs


### PR DESCRIPTION
The log level options of 
https://docs.sentry.io/learn/breadcrumbs/ and https://docs.sentry.io/clientdev/interfaces/breadcrumbs/ are not matching.