### PR TITLE
Fix run on sentence and grammar in DSN section

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -52,10 +52,9 @@ The DSN can be found in Sentry by navigating to [Project Name] -> Project Settin
 
     '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
 
-If you use the Hosted Sentry and you are signed into your account, the
-documentation will refer to your actual DSNs and you can select the
-correct one, on the top right of this page for adjusting the examples for
-easy copy pasting::
+If you are using the Hosted Sentry and signed into your account, the
+documentation will refer to your actual DSNs. You can select the 
+correct one which will adjust the examples for easy copy pasting::
 
     '___DSN___'
 


### PR DESCRIPTION
Divided into two seperate sentences and also removed  reference to 'top right of page' since there is no option on top right of page.