### PR TITLE
Lock docutils to 0.13.1 to fix docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ venv/bin/python:
 requirements: update-submodules venv/bin/python
 	@echo "--> Installing base requirements"
 	@venv/bin/pip install "pip>=8.1.1"
-	@venv/bin/pip install --upgrade awscli sphinx==1.3.4 click virtualenv
+	@venv/bin/pip install --upgrade awscli sphinx==1.3.4 docutils==0.13.1 click virtualenv
 	@echo ""
 
 build-only: design/node_modules


### PR DESCRIPTION
The docs are currently failing with the following build error:

```
Traceback (most recent call last):
  File "/usr/src/docs/venv/lib/python2.7/site-packages/sphinx/cmdline.py", line 244, in main
    app.build(opts.force_all, filenames)
  File "/usr/src/docs/venv/lib/python2.7/site-packages/sphinx/application.py", line 260, in build
    self.builder.build_all()
  File "/usr/src/docs/venv/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 211, in build_all
    self.build(None, summary='all source files', method='all')
  File "/usr/src/docs/venv/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 325, in build
    self.finish()
  File "/usr/src/docs/doc-support/sentryext.py", line 837, in finish
    self.__write_platforms()
  File "/usr/src/docs/doc-support/sentryext.py", line 810, in __write_platforms
    platforms.update(self.__process_platform(data, base_path))
  File "/usr/src/docs/doc-support/sentryext.py", line 764, in __process_platform
    platform_data['wizard'])
  File "/usr/src/docs/doc-support/sentryext.py", line 752, in __build_wizard_section
    _build_node(sect)
  File "/usr/src/docs/doc-support/sentryext.py", line 725, in _build_node
    self.docwriter.write(sub_doc, destination)
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/writers/__init__.py", line 80, in write
    self.translate()
  File "/usr/src/docs/venv/lib/python2.7/site-packages/sphinx/writers/html.py", line 53, in translate
    self.document.walkabout(visitor)
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/nodes.py", line 166, in walkabout
    visitor.dispatch_visit(self)
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/nodes.py", line 1882, in dispatch_visit
    return method(node)
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/writers/_html_base.py", line 712, in visit_document
    title = (node.get('title', '') or os.path.basename(node['source'])
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'source'

Exception occurred:
  File "/usr/src/docs/venv/lib/python2.7/site-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'source'
The full traceback has been saved in /tmp/sphinx-err-0hAc_E.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at . Thanks!
```

It does appear to be some type of rst syntax error, however..

Upon further inspection, the build can be restored to working state by reverting to docutils 0.13.1 from the latest 0.14 which was released on August 3rd.

We're already pinning sphinx to an older version. Possibly incompatibilities with the old sphinx?