### PR TITLE
fix: Remove table border from all field lists

### DIFF
--- a/design/less/main.less
+++ b/design/less/main.less
@@ -632,10 +632,6 @@ dl.api-endpoint {
             width: 140px;
         }
 
-        tr {
-            border: none!important;
-        }
-
         td ul, td p {
             margin: 0;
         }
@@ -758,7 +754,7 @@ table.docutils {
         border-bottom: 2px solid @gray-light;
     }
 
-    tr + tr {
+    &:not(.field-list) tr + tr {
         border-top: 1px solid @gray-light;
     }
 }


### PR DESCRIPTION
When using field lists outside of the API documentation we still end up with borders. This removes the borders specifically from field lists.

before:
![image](https://user-images.githubusercontent.com/1421724/29902235-a271596a-8db1-11e7-9ea3-2f3e4f4706ea.png)

after:
![image](https://user-images.githubusercontent.com/1421724/29901921-ba49b746-8daf-11e7-978a-131ddbe8291a.png)