### PR TITLE
change 'mkvirtualenv .' to be 'mkvirtualenv sentry'

### DIFF
--- a/docs/internal/environment.rst
+++ b/docs/internal/environment.rst
@@ -83,7 +83,7 @@ and clone down a local version::
 
 Setup and activate a Python 2.7 virtual environment in the project root::
 
-    mkvirtualenv .
+    mkvirtualenv sentry
 
 Run the following to install both the Python and JavaScript
 libraries that Sentry depends on and some extra pieces that hold the development environment


### PR DESCRIPTION
I'm new to python, and this line in the docs really got me.

![image](https://user-images.githubusercontent.com/435981/31840257-63f5dfde-b599-11e7-85af-79cffd7e3ed8.png)

![image](https://user-images.githubusercontent.com/435981/31840363-efee7258-b599-11e7-9901-3c23afba4ea7.png)


