### PR TITLE
Remove project_id from curl example

### DIFF
--- a/docs/api/auth.rst
+++ b/docs/api/auth.rst
@@ -11,7 +11,7 @@ authenticate as a user account with the API.
 
 .. sourcecode:: bash
 
-    $ curl -H 'Authorization: Bearer {TOKEN}' https://sentry.io/api/0/projects/1/
+    $ curl -H 'Authorization: Bearer {TOKEN}' https://sentry.io/api/0/projects/
 
 You can `find or create authentication tokens within Sentry <https://sentry.io/api/>`_.
 
@@ -33,7 +33,7 @@ bound to, you might make a request like so:
 
 .. sourcecode:: bash
 
-    $ curl -u {API_KEY}: https://sentry.io/api/0/projects/1/
+    $ curl -u {API_KEY}: https://sentry.io/api/0/projects/
 
 .. note:: You **must** pass a value for the password, which is the reason the ``:``
           is present in our example.


### PR DESCRIPTION
`1` is not a valid project, so users are not getting a response back when running.
```
$ curl -H 'Authorization: Bearer XXXXXXX' https://sentry.io/api/0/projects/1
$
```