### PR TITLE
fix: brew link must use --force

### DIFF
--- a/docs/internal/environment.rst
+++ b/docs/internal/environment.rst
@@ -36,7 +36,7 @@ Run the following to install, configure, and execute PostgreSQL as a daemonized 
 
     brew install postgresql@9.4
     brew services start postgresql@9.4
-    brew link postgresql@9.4
+    brew link --force postgresql@9.4
 
 When installing postgresql using brew you'll have to also create the ``postgres`` role::
 


### PR DESCRIPTION
$ brew link postgresql@9.4
Warning: postgresql@9.4 is keg-only and must be linked with --force
Note that doing so can interfere with building software.

$ brew link postgresql@9.4 --force
Linking /usr/local/Cellar/postgresql@9.4/9.4.15... 426 symlinks created