### PR TITLE
fix: Update node and yarn in docker file

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,19 +1,20 @@
 FROM python:2.7
 
 RUN set -x \
-    && export NODE_VERSION=9.3.0 \
+    && export NODE_VERSION=8.9.1 \
     && export YARN_VERSION=1.3.2 \
     && export GNUPGHOME="$(mktemp -d)" \
+    && export NPM_CONFIG_CACHE="$(mktemp -d)" \
     # gpg keys listed at https://github.com/nodejs/node
     && for key in \
-      9554F04D7259F04124DE6B476D5A82AC7E37093B \
       94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-      0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-      FD3A5288F042B6850C66B31F09FE44734EB7990E \
-      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
       B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A \
+      56730D5401028683275BD23C23EFEFE93C4CFFFE \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
       C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     ; do \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     done \
@@ -26,7 +27,7 @@ RUN set -x \
     && rm -r "$GNUPGHOME" "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
     && apt-get purge -y --auto-remove wget \
     && npm install -g yarn@$YARN_VERSION \
-    && npm cache clear
+    && rm -r "$NPM_CONFIG_CACHE"
 
 RUN mkdir -p /usr/src/docs
 WORKDIR /usr/src/docs

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,8 @@
 FROM python:2.7
 
 RUN set -x \
-    && export NODE_VERSION=4.7.2 \
-    && export YARN_VERSION=0.24.5 \
+    && export NODE_VERSION=9.3.0 \
+    && export YARN_VERSION=1.3.2 \
     && export GNUPGHOME="$(mktemp -d)" \
     # gpg keys listed at https://github.com/nodejs/node
     && for key in \


### PR DESCRIPTION
Docs build is failing since a npm dep in the `sentry` repo needs `node >= 5.10.0`
See:
https://freight.getsentry.net/deploys/docs/production/1193
```
error extract-text-webpack-plugin@3.0.2: The engine "node" is incompatible with this module. Expected version ">= 4.8 < 5.0.0 || >= 5.10".1:33:52 pm
error Found incompatible module
```

Soooo this upgrades both deps in the docker file to the latest version.
Probably that's not the smartest idea but I don't know the node/yarn version Sentry requires which would be the wiser choice I guess.

To prevent such thing in the future we could add something like this 
```
"engines": {
    "node": ">= 4.8 < 5.0.0 || >= 5.10"
  },
```
in Sentrys `package.json` so no one installs a dep that breaks other builds.