### PR TITLE
docs: Add Node Source Maps to the navigation panel

### DIFF
--- a/design/templates/layout.html
+++ b/design/templates/layout.html
@@ -228,6 +228,7 @@
                   <ul>
                     <li>{{ page_link('clients/node/config', 'Config') }}</li>
                     <li>{{ page_link('clients/node/usage', 'Usage') }}</li>
+                    <li>{{ page_link('clients/node/sourcemaps', 'Source Maps') }}</li>
                     <li>{{ page_link('clients/node/coffeescript', 'CoffeeScript') }}</li>
                     <li class="divider"></li>
                     <li>{{ page_link('clients/node/integrations/connect', 'Connect') }}</li>


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry/issues/2632
cc @mitsuhiko it's available through he `usage` page already, but no direct link to the docs. This fixes it.