### PR TITLE
feat: Add Electron docs

### DIFF
--- a/design/less/main.less
+++ b/design/less/main.less
@@ -881,6 +881,13 @@ div.platform-node h1:before {
     color: #2d292f;
 }
 
+li p.platformlink-electron a:first-child:before,
+div.platform-electron h1:before {
+    content: "\e801";
+    background: #2b2e3b;
+    color: #9feaf9;
+}
+
 li p.platformlink-react-native a:first-child:before,
 div.platform-react-native h1:before {
     content: "\e801";

--- a/design/templates/layout.html
+++ b/design/templates/layout.html
@@ -216,7 +216,6 @@
                     <li>{{ page_link('clients/javascript/integrations/angularjs', 'AngularJS') }}</li>
                     <li>{{ page_link('clients/javascript/integrations/angular', 'Angular') }}</li>
                     <li>{{ page_link('clients/javascript/integrations/backbone', 'Backbone') }}</li>
-                    <li>{{ page_link('clients/javascript/integrations/electron', 'Electron') }}</li>
                     <li>{{ page_link('clients/javascript/integrations/ember', 'Ember') }}</li>
                     <li>{{ page_link('clients/javascript/integrations/react', 'React') }}</li>
                     <li>{{ page_link('clients/react-native/index', 'React Native') }}</li>
@@ -238,6 +237,9 @@
                     <li>{{ page_link('clients/node/integrations/loopback', 'Loopback') }}</li>
                     <li>{{ page_link('clients/node/integrations/sails', 'Sails') }}</li>
                   </ul>
+                </li>
+                <li{% if pagename.startswith('clients/electron/') %} class="active"{% endif %}>
+                  {{ page_link('clients/electron/index', 'Electron') }}
                 </li>
                 <li>{{ page_link('clients/perl/index', 'Perl') }}</li>
                 <li{% if pagename.startswith('clients/php/') %} class="active"{% endif %}>

--- a/docs/clients/electron/index.rst
+++ b/docs/clients/electron/index.rst
@@ -10,7 +10,7 @@ This is the documentation for the Electron SDK.
 setup. Under the hood we use `raven-node <https://github.com/getsentry/raven-node>`_
 and `raven-js <https://github.com/getsentry/raven-js>`_.
 
-We also do support native crashes via Minidumps.
+We also support native crashes via Minidumps.
 
 Installation
 ------------

--- a/docs/clients/electron/index.rst
+++ b/docs/clients/electron/index.rst
@@ -1,0 +1,73 @@
+.. sentry:edition:: hosted, on-premise
+
+    .. class:: platform-electron
+
+    Electron
+    ========
+
+This is the documentation for the Electron SDK.
+`Sentry Wizard <https://github.com/getsentry/sentry-wizard>`_ helps you with the correct
+setup. Under the hood we use `raven-node <https://github.com/getsentry/raven-node>`_
+and `raven-js <https://github.com/getsentry/raven-js>`_.
+
+We also do support native crashes via Minidumps.
+
+Installation
+------------
+
+All packages are available via npm.
+
+.. code-block:: sh
+
+    $ npm install @sentry/electron --save
+
+This will also install `@sentry/wizard`. Run the wizard the help you finish your setup:
+With ``yarn`` you can just call:
+
+.. code-block:: sh
+
+    $ yarn sentry-wizard --integration=electron
+
+If you only have ``npm`` call:
+
+.. code-block:: sh
+
+    $ node node_modules/.bin/sentry-wizard --integration=electron
+
+``sentry-wizard`` will display recommended packages like `electron-download` which we need
+to symbolicate native crashes.
+The wizard will also create a file called ``sentry.properties`` (which does contain
+you account information) and ``sentry-symbols.js`` which helps you with the symbols
+upload.
+
+
+Configuring the Client
+----------------------
+
+The following code should reside in the ``main process`` and all ``renderer processes``:
+
+.. code-block:: javascript
+
+    const { SentryClient } = require('@sentry/electron');
+    
+    SentryClient.create({
+      dsn: '___PRIVATE_DSN___',
+      // ...
+    });
+
+This configuration will also take care of unhandled Promise rejections, which can be
+handled in various ways. By default, Electron uses the standard JS API.
+To learn more about handling promises, refer to :ref:`raven-js-promises` documentation.
+
+Uploading symbols
+~~~~~~~~~~~~~~~~~
+
+The wizard should create a file called ``sentry-symbols.js`` which takes care of uploading
+debug symbols to Sentry. Note that this is only necessary whenever you update your
+version of electron. It usually takes quiet a while because it downloads debug symbols
+of electron and uploads them to Sentry so we can symbolicate your native crashes.
+You can always execute the script by calling:
+
+.. code-block:: sh
+
+    $ node sentry-symbols.js

--- a/docs/clients/electron/sentry-doc-config.json
+++ b/docs/clients/electron/sentry-doc-config.json
@@ -1,0 +1,3 @@
+{
+  "support_level": "production"
+}

--- a/docs/clients/index.rst
+++ b/docs/clients/index.rst
@@ -16,6 +16,7 @@ discussion about supporting it on our `community forum <https://forum.sentry.io>
    java/index
    javascript/index
    node/index
+   electron/index
    react-native/index
    perl/index
    php/index

--- a/docs/clients/table.rst.inc
+++ b/docs/clients/table.rst.inc
@@ -6,11 +6,15 @@
 
 *   .. class:: platformlink-js
 
-    :doc:`/clients/javascript/index` Including React, Angular, Electron, Ember, Vue, and Backbone.
+    :doc:`/clients/javascript/index` Including React, Angular, Ember, Vue, and Backbone.
 
 *   .. class:: platformlink-node
 
     :doc:`/clients/node/index` Including Express, Koa, Loopback, Sails and Connect.
+
+*   .. class:: platformlink-electron
+
+    :doc:`/clients/electron/index` For Electron apps.
 
 *   .. class:: platformlink-react-native
 


### PR DESCRIPTION
This adds docs for our new Electron SDK and replaces the old ones.
See https://github.com/getsentry/raven-js/pull/1241 for the deletion PR.

Thanks @HazAT for putting together the docs.

**Screenshot of the clients menu**

![screen shot 2018-03-13 at 19 54 23](https://user-images.githubusercontent.com/1433023/37363539-773bb282-26f8-11e8-8281-cc8f92f267d8.png)

**Screenshot of the docs page**

![screen shot 2018-03-13 at 19 56 16](https://user-images.githubusercontent.com/1433023/37363618-a6dc5adc-26f8-11e8-85c7-6259e410ac37.png)

*(sorry for the bad quality, Chrome's full-size screenshot didn't work)*