### PR TITLE
fix: update docs to recommend Python 2

### DIFF
--- a/docs/internal/environment.rst
+++ b/docs/internal/environment.rst
@@ -58,7 +58,9 @@ Python
 While OS X ships with an acceptable version of Python, installing the latest binaries from Homebrew
 is recommended. Run the following to install and configure brewed Python::
 
-    brew install python
+    brew install python@2
+
+.. note:: Python 2.7 is required.
 
 Python Virtual Environment
 **************************


### PR DESCRIPTION
Homebrew installs Python 3 by default, which doesn't work with Sentry. I'm not sure if 2.7 is required specifically, but I figured I'd err on the side of verbosity.