### PR TITLE
fix(search) Change 'muted' to 'ignored' in documentation

### DIFF
--- a/docs/learn/search.rst
+++ b/docs/learn/search.rst
@@ -25,7 +25,7 @@ The following tokens are reserved and known to Sentry:
 
     Filter on the status of an issue.
 
-    Values are ``resolved``, ``unresolved``, ``muted``, ``assigned``, and ``unassigned``.
+    Values are ``resolved``, ``unresolved``, ``ignored``, ``assigned``, and ``unassigned``.
 
 .. describe:: assigned
 


### PR DESCRIPTION
Searching for is:muted and is:ignored yield the same results, but the user facing button and related messaging says 'ignore' so this is more clear.