### PR TITLE
feat: Replace ___MINIDUMP_URL___ with the actual API url

### DIFF
--- a/design/js/main.js
+++ b/design/js/main.js
@@ -44,12 +44,12 @@ function dsnToHtml(parsedDsn, pub) {
 
 function tagInteractiveBlocks(parent) {
   parent.find('div.highlight pre').each(function() {
-    var hasVariables = /___(DSN|PUBLIC_DSN|PUBLIC_KEY|SECRET_KEY|API_URL|ENCODED_API_KEY|PROJECT_ID|ORG_NAME|PROJECT_NAME)___/g.test(this.innerHTML);
+    var hasVariables = /___(DSN|PUBLIC_DSN|PUBLIC_KEY|SECRET_KEY|API_URL|ENCODED_API_KEY|PROJECT_ID|ORG_NAME|PROJECT_NAME|MINIDUMP_URL)___/g.test(this.innerHTML);
     if (!hasVariables) {
       return;
     }
     var isApiKeySection = false;
-    var contents = this.innerHTML.replace(/___(DSN|PUBLIC_DSN|PUBLIC_KEY|SECRET_KEY|API_URL|ENCODED_API_KEY|PROJECT_ID|ORG_NAME|PROJECT_NAME)___/g, function(match) {
+    var contents = this.innerHTML.replace(/___(DSN|PUBLIC_DSN|PUBLIC_KEY|SECRET_KEY|API_URL|ENCODED_API_KEY|PROJECT_ID|ORG_NAME|PROJECT_NAME|MINIDUMP_URL)___/g, function(match) {
       if (match === '___DSN___') {
         return '<span class="rewrite-dsn" data-value="dsn">' + match + '</span>';
       } else if (match === '___PUBLIC_DSN___') {
@@ -69,6 +69,8 @@ function tagInteractiveBlocks(parent) {
         return '<span class="rewrite-dsn" data-value="project-slug">' + match + '</span>';
       } else if (match === '___ORG_NAME___') {
         return '<span class="rewrite-dsn" data-value="org-slug">' + match + '</span>';
+      } else if (match === '___MINIDUMP_URL___') {
+        return '<span class="rewrite-dsn" data-value="minidump-url">' + match + "</span>";
       }
     });
     var title = isApiKeySection ? 'API Key for Request' : 'Showing configuration for';
@@ -132,6 +134,15 @@ function selectItem(item, section) {
       case "item-id":
         newValue = escape('' + parsedDsn.item);
         break;
+			case "minidump-url":
+				newValue = '<span class="dsn">' +
+					escape(parsedDsn.scheme) +
+					escape(parsedDsn.host) +
+					'/api' +
+					escape(parsedDsn.pathSection) +
+					'/minidump?sentry_key=' + escape(parsedDsn.publicKey) +
+					'</span>';
+				break;
     }
 
     if (newValue) {


### PR DESCRIPTION
This adds a new magic string for rendering the minidump endpoint in docs:

**NOTE**: That the `/api` and `?sentry-key=` portions are currently hard coded. I couldn't come up with a nice way to infer those. This might become relevant once we start ingestion via Relay.

## Example (Electron Docs)

<img width="770" alt="screen shot 2018-04-06 at 09 05 20" src="https://user-images.githubusercontent.com/1433023/38407444-bdd56d1c-3979-11e8-8e55-6cb4848fa2b4.png">
