### PR TITLE
feat(electron): Add navbar links for Electron

### DIFF
--- a/design/templates/layout.html
+++ b/design/templates/layout.html
@@ -240,6 +240,12 @@
                 </li>
                 <li{% if pagename.startswith('clients/electron/') %} class="active"{% endif %}>
                   {{ page_link('clients/electron/index', 'Electron') }}
+                  <ul>
+                    <li>{{ page_link('clients/electron/config', 'Config') }}</li>
+                    <li>{{ page_link('clients/electron/javascript', 'JavaScript Usage') }}</li>
+                    <li>{{ page_link('clients/electron/native', 'Native Usage') }}</li>
+                    <li>{{ page_link('clients/electron/sourcemaps', 'Source Maps') }}</li>
+                  </ul>
                 </li>
                 <li>{{ page_link('clients/perl/index', 'Perl') }}</li>
                 <li{% if pagename.startswith('clients/php/') %} class="active"{% endif %}>


### PR DESCRIPTION
Adds subnav items for Electron docs, similar to those from JavaScript or Node:

<img width="245" alt="screen shot 2018-04-09 at 09 03 43" src="https://user-images.githubusercontent.com/1433023/38483936-fc400abe-3bd4-11e8-9c76-a76bbd25015b.png">

They link to documentation created in https://github.com/getsentry/sentry-electron/pull/56, which needs to be merged first.