### PR TITLE
[sessionstack] Updated SessionStack integration snippets

### DIFF
--- a/docs/integrations/sessionstack.rst
+++ b/docs/integrations/sessionstack.rst
@@ -16,11 +16,12 @@ Add the SessionStack JavaScript snippet into the head element of your web app.
 
     <!-- Begin SessionStack code -->
     <script type="text/javascript">
-        !function(a,b){var c=window;c.SessionStack=a,c[a]=c[a]||function(){
-        c[a].q=c[a].q||[],c[a].q.push(arguments)},c[a].t=b;var d=document.createElement("script");
-        d.async=1,d.src="https://cdn.sessionstack.com/sessionstack.js";
-        var e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(d,e);
-        }("sessionstack","<YOUR TOKEN>");
+        !function(a,b){var c=window;c.SessionStackKey=a,c[a]=c[a]||{t:b,
+        q:[]};for(var d=["start","stop","identify","getSessionId","log"],e=0;e<d.length;e++)!function(b){
+        c[a][b]=c[a][b]||function(){c[a].q.push([b].concat([].slice.call(arguments,0)));
+        }}(d[e]);var f=document.createElement("script");f.async=1,f.src="https://cdn.sessionstack.com/sessionstack.js";
+        var g=document.getElementsByTagName("script")[0];g.parentNode.insertBefore(f,g);
+        }("SessionStack","<YOUR_TOKEN>");
     </script>
     <!-- End SessionStack Code -->
 
@@ -30,7 +31,7 @@ To associate each Sentry event with the respective user session at the time the 
 
     <!-- Begin SessionStack-Sentry code -->
     <script type="text/javascript">
-        sessionstack("getSessionId",function(s){s&&Raven.setDataCallback(function(t){return t
+        SessionStack.getSessionId(function(s){s&&Raven.setDataCallback(function(t){return t
         .contexts=t.contexts||{},t.contexts.sessionstack={session_id:s,timestamp:(new Date).
         getTime()},t})});
     </script>


### PR DESCRIPTION
We have updated our JavaScript API which requires some small changes in the way SessionStack and Sentry are integrated together. The users using the old snippet can still use the old API so they don't have to do any changes unless they decide to use the new API.