### PR TITLE
ref: Remove DSN secrets from the quickstart guide

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -51,21 +51,22 @@ required by the Sentry SDKs.  It consists of a few pieces, including the
 protocol, public and secret keys, the server address, and the project
 identifier.
 
-The DSN can be found in Sentry by navigating to [Project Name] -> Project Settings -> Client Keys (DSN). Its template resembles the following::
+The DSN can be found in Sentry by navigating to [Project Name] -> Project
+Settings -> Client Keys (DSN). Its template resembles the following::
 
-    '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
+    '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'
 
 If you are using the Hosted Sentry and signed into your account, the
-documentation will refer to your actual DSNs. You can select the 
+documentation will refer to your actual DSNs. You can select the
 correct one which will adjust the examples for easy copy pasting::
 
-    '___DSN___'
+    '___PUBLIC_DSN___'
 
 It is composed of five important pieces:
 
 * The Protocol used. This can be one of the following: http or https.
 
-* The public and secret keys to authenticate the SDK.
+* The public key to authenticate the SDK.
 
 * The destination Sentry server.
 
@@ -79,7 +80,7 @@ SDK's constructor.
 For example for the JavaScript SDK it works roughly like this::
 
     import Raven from 'raven-js'
-    Raven.config('___DSN___')
+    Raven.config('___PUBLIC_DSN___')
 
 Note: If you're using Heroku, and you've added Hosted Sentry via the
 standard addon hooks, most SDKs will automatically pick up the


### PR DESCRIPTION
Completely removes the secret from the quickstart guide:

<img width="1025" alt="screen shot 2018-04-17 at 08 25 50" src="https://user-images.githubusercontent.com/1433023/38852226-42018fce-4219-11e8-9427-a068e6f80b96.png">
