### PR TITLE
Platform content urls

### DIFF
--- a/src/_includes/components/platform_content.html
+++ b/src/_includes/components/platform_content.html
@@ -56,7 +56,7 @@ utilize their tokens across sites.
           {%- endif -%}
           {%- assign __name = __example[0] -%}
           {%- assign __slug = __name | slugify -%}
-          <a class="dropdown-item{% if __is_default %} active{% endif %}" id="{{ __uniq }}-{{ __slug }}-tab" data-platform="{{ __name }}" data-toggle="tab" href="#{{ __uniq }}-{{ __slug }}" role="tab" aria-controls="{{ __uniq }}-{{ __slug }}" aria-selected="{% if __is_default %}true{% else %}false{% endif %}">{{ __name }}</a>
+          <a class="dropdown-item{% if __is_default %} active{% endif %}" id="{{ __uniq }}-{{ __slug }}-tab" data-platform="{{ __slug }}" data-toggle="platform" href="#{{ __uniq }}-{{ __slug }}" role="tab" aria-controls="{{ __uniq }}-{{ __slug }}" aria-selected="{% if __is_default %}true{% else %}false{% endif %}">{{ __name }}</a>
         {%- endfor -%}
       </div>
     </div>
@@ -71,7 +71,7 @@ utilize their tokens across sites.
     {% assign __is_default = false %}
     {%- endif -%}
     {%- assign __content = __example[1] -%}
-    <div class="tab-pane {% if __is_default %} show active{% endif %}" id="{{ __uniq }}-{{ __slug }}" role="tabpanel" aria-labelledby="{{ __uniq }}-{{ __slug }}-tab">
+    <div class="tab-pane{% if __is_default %} show active{% endif %}" id="{{ __uniq }}-{{ __slug }}" role="tabpanel" aria-labelledby="{{ __uniq }}-{{ __slug }}-tab">
       {{ __content | liquify | markdownify }}
     </div>
   {%- endfor -%}

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -35,6 +35,7 @@ the following value in the page frontmatter
 <link rel="canonical" href="{{ page.url | site.url | replace:'index.html',''}}">
 
 <script>window.loadIfTrackersOk=[];</script>
+<script>window.supportedPlatforms={{ site.data.platforms | jsonify }}</script>
 
 {% asset screen.css %}
 {% if jekyll.environment == "development" %}{% asset dev.css %}{% endif %}

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -34,8 +34,10 @@ the following value in the page frontmatter
 <link href="{{ assets['favicon.ico'].digest_path | prepend: site.url }}" rel="icon" type="image/png">
 <link rel="canonical" href="{{ page.url | site.url | replace:'index.html',''}}">
 
-<script>window.loadIfTrackersOk=[];</script>
-<script>window.supportedPlatforms={{ site.data.platforms | jsonify }}</script>
+<script>
+  window.loadIfTrackersOk=[];
+  window.supportedPlatforms={{ site.data.platforms | jsonify }}
+</script>
 
 {% asset screen.css %}
 {% if jekyll.environment == "development" %}{% asset dev.css %}{% endif %}

--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -1,22 +1,51 @@
-const init = function() {
-  const KEY = 'preferredPlatform';
-  const showPreferredPlatform = function() {
-    const preferredPlatform = localStorage.getItem(KEY);
-    if (preferredPlatform) {
-      $('[data-platform="' + preferredPlatform + '"]').click();
-    }
-  };
+import qs from 'query-string';
 
-  const $dropdownItems = $('[data-platform-specific-content] .dropdown-item');
-  $dropdownItems.on('click', function(event) {
+const KEY = 'preferredPlatform';
+
+const showPlatform = function(slug) {
+  const platform = window.supportedPlatforms.find(p => p.slug === slug);
+  if (!platform) return;
+
+  const $contentBlocks = $('[data-platform-specific-content]');
+
+  $contentBlocks.each((i, el) => {
+    const $block = $(el);
+    // Update dropdown target title
+    $block.find('[data-toggle="dropdown"]').text(platform.name);
+
+    // Update active state of dropdown items
+    const $dropdownItems = $block.find('[data-toggle="platform"]');
+    $dropdownItems.each((i, el) => {
+      const $el = $(el);
+      const isActive = $el.attr('data-platform') === platform.slug;
+      $el.toggleClass('active', isActive);
+      $el.attr('aria-selected', isActive);
+    });
+
+    // Update the active state of the tab panes
+    const $activeItem = $dropdownItems.filter('.active');
+    const activeID = $activeItem.attr('href').replace('#', '');
+    const $tabPanes = $block.find('.tab-pane');
+    $tabPanes.each((i, el) => {
+      const $el = $(el);
+      const isActive = $el.attr('id') === activeID;
+      $el.toggleClass('show active', isActive);
+    });
+  });
+};
+
+const init = function() {
+  $(document).on('click', '[data-toggle="platform"]', function(event) {
+    event.preventDefault();
     const $target = $(event.target);
-    const $parent = $target.closest('[data-platform-specific-content]');
-    const platform = $target.data('platform');
-    localStorage.setItem(KEY, platform);
-    $parent.find('.dropdown-toggle').text(platform);
+    const slug = $target.data('platform');
+    localStorage.setItem(KEY, slug);
+    showPlatform(slug);
   });
 
-  showPreferredPlatform();
+  const queryPlatform = qs.parse(location.search).platform;
+  const preferredPlatform = localStorage.getItem(KEY);
+  showPlatform(queryPlatform || preferredPlatform);
 };
 
 export default { init };

--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -11,6 +11,27 @@ const getPlatformBySlug = function(slug) {
   return window.supportedPlatforms.find(p => p.slug === slug);
 };
 
+// Update the url of hte page to reflect a current slug
+//
+//  slug - slug matching a platform in data/platforms.yml
+//
+// Returns nothing.
+const updateLocationPlatform = function(slug) {
+  history.replaceState({}, '', updateUrlPlatform(location.href, slug));
+};
+
+// Add or update the platform slug of a url
+//
+//  url  - a url string
+//  slug - slug matching a platform in data/platforms.yml
+//
+// Returns a string
+const updateUrlPlatform = function(url, slug) {
+  const { url: origin, query } = qs.parseUrl(url);
+  query.platform = slug;
+  return `${origin}?${qs.stringify(query)}`;
+};
+
 // Update UI state to show content for a given platform.
 //
 //  slug - slug matching a platform in data/platforms.yml
@@ -62,11 +83,7 @@ const addPlatformToLinks = function(slug) {
     const $el = $(el);
     const href = $el.attr('href');
     const isDocLink = /(^\/|docs.sentry.io)/.test(href);
-    if (isDocLink) {
-      const { url, query } = qs.parseUrl(href);
-      query.platform = platform.slug;
-      $el.attr('href', `${url}?${qs.stringify(query)}`);
-    }
+    if (isDocLink) $el.attr('href', updateUrlPlatform(href, platform.slug));
   });
 };
 
@@ -82,6 +99,8 @@ const init = function() {
     const slug = $target.data('platform');
     localStorage.setItem(KEY, slug);
     showPlatform(slug);
+    addPlatformToLinks(slug);
+    updateLocationPlatform(slug);
   });
 
   const queryPlatform = qs.parse(location.search).platform;

--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -2,12 +2,27 @@ import qs from 'query-string';
 
 const KEY = 'preferredPlatform';
 
+// Get the object associated with a given platform slug.
+//
+//  slug - slug matching a platform in data/platforms.yml
+//
+// Returns an object or null if no platform matches the slug.
+const getPlatformBySlug = function(slug) {
+  return window.supportedPlatforms.find(p => p.slug === slug);
+};
+
+// Update UI state to show content for a given platform.
+//
+//  slug - slug matching a platform in data/platforms.yml
+//
+// Returns nothing.
 const showPlatform = function(slug) {
-  const platform = window.supportedPlatforms.find(p => p.slug === slug);
+  const platform = getPlatformBySlug(slug);
   if (!platform) return;
 
   const $contentBlocks = $('[data-platform-specific-content]');
 
+  // Update UI
   $contentBlocks.each((i, el) => {
     const $block = $(el);
     // Update dropdown target title
@@ -34,6 +49,32 @@ const showPlatform = function(slug) {
   });
 };
 
+// Add the current platform to all links on the page.
+//
+//  slug - slug matching a platform in data/platforms.yml
+//
+// Returns nothing.
+const addPlatformToLinks = function(slug) {
+  const platform = getPlatformBySlug(slug);
+  if (!platform) return;
+
+  $('a').each((i, el) => {
+    const $el = $(el);
+    const href = $el.attr('href');
+    const isDocLink = /(^\/|docs.sentry.io)/.test(href);
+    if (isDocLink) {
+      const { url, query } = qs.parseUrl(href);
+      query.platform = platform.slug;
+      $el.attr('href', `${url}?${qs.stringify(query)}`);
+    }
+  });
+};
+
+// Attach event listeners and set UI state based on the platform supplied via
+// query param, stored in localStorage as the preferred platform, or the
+// default platform, in that order.
+//
+// Returns nothing.
 const init = function() {
   $(document).on('click', '[data-toggle="platform"]', function(event) {
     event.preventDefault();
@@ -46,6 +87,7 @@ const init = function() {
   const queryPlatform = qs.parse(location.search).platform;
   const preferredPlatform = localStorage.getItem(KEY);
   showPlatform(queryPlatform || preferredPlatform);
+  addPlatformToLinks(queryPlatform);
 };
 
 export default { init };

--- a/src/collections/_dev_components/layout-components/platform-content.md
+++ b/src/collections/_dev_components/layout-components/platform-content.md
@@ -31,9 +31,16 @@ example_2:
     - You have to
     - Say `end` a lot.
 
+example_3:
+  Python: Python Example
+  Ruby: Ruby Example
 ---
 
-You can customize content by platform. The switcher will globally remember the prefer language and load it by default until changed. Content is run through the Liquid compiler, then through the Markdown compiler, making it possible to create dynamic, rich styled content.
+You can customize content by platform. Content is run through the Liquid compiler, then through the Markdown compiler, making it possible to create dynamic, rich styled content.
+
+The switcher will globally remember the prefered language and load it by default until changed. If no prefered language is set, the first langage provided is the default. A content platform content block does not contain the preferred language, it will display the default language for the block.
+
+You may force the platform that is displayed on the page by appending a `platform=javascript` query parameter to the page url. This will cause subsequent pages in the browsing session to display that platform. Removing the query parameter will set the page back to the default behavior of looking for the prefered platform
 
 - `content=[]` _(required)_ A unique key to identify the switcher
 
@@ -81,6 +88,7 @@ example_content:
     ## I am an example about JavaScript
 
     Did you know 0 == false but 0 !== false?
+
   Python: |
     ```
     # This is a Python example. A python is a snake.
@@ -98,4 +106,28 @@ example_content:
 
 <div class="p-3 mb-3 mb-md-5 border rounded content-flush-bottom">
 {% include components/platform_content.html content=page.example_2 %}
+</div>
+
+### Mismatched platforms
+
+This example does not have a Javascript, while the others on the page do. Try
+using the other switchers to see how this one handles falling back when
+JavaScript is selected.
+
+#### Source
+
+```liquid
+{% raw %}---
+example_content:
+  Python: Python Example
+  Ruby: Ruby Example
+---
+
+{% include platform_content.html content=page.example_content %}{% endraw %}
+```
+
+#### Output
+
+<div class="p-3 mb-3 mb-md-5 border rounded content-flush-bottom">
+{% include components/platform_content.html content=page.example_3 %}
 </div>

--- a/src/collections/_dev_components/layout-components/platform-content.md
+++ b/src/collections/_dev_components/layout-components/platform-content.md
@@ -2,25 +2,35 @@
 title: Platform Content
 source: components/platform_content.html
 example_string: Hello world
+
 example_1:
   JavaScript: |
-    This is a JavaScript example.
-
     ``` javascript
     console.log("{{ page.example_string }}")
     ```
   Python: |
-    This is a Python example.
-
     ``` python
     print("{{ page.example_string }}")
     ```
   Ruby: |
-    This is a Ruby example.
-
     ``` ruby
     puts "{{ page.example_string }}"
     ```
+
+example_2:
+  JavaScript: |
+    ## I am an example about JavaScript
+
+    Did you know 0 == false but 0 !== false?
+  Python: |
+    ```
+    # This is a Python example. A python is a snake.
+    ```
+  Ruby: |
+    - In Ruby
+    - You have to
+    - Say `end` a lot.
+
 ---
 
 You can customize content by platform. The switcher will globally remember the prefer language and load it by default until changed. Content is run through the Liquid compiler, then through the Markdown compiler, making it possible to create dynamic, rich styled content.
@@ -38,20 +48,14 @@ You can customize content by platform. The switcher will globally remember the p
 example_string: Hello world
 example_content:
   JavaScript: |
-    This is a JavaScript example.
-
     ``` javascript
     console.log("{{ page.example_string }}")
     ```
   Python: |
-    This is a Python example.
-
     ``` python
     print("{{ page.example_string }}")
     ```
   Ruby: |
-    This is a Ruby example.
-
     ``` ruby
     puts "{{ page.example_string }}"
     ```
@@ -64,4 +68,34 @@ example_content:
 
 <div class="p-3 mb-3 mb-md-5 border rounded content-flush-bottom">
 {% include components/platform_content.html content=page.example_1 %}
+</div>
+
+### Arbitrary content
+
+#### Source
+
+```liquid
+{% raw %}---
+example_content:
+  JavaScript: |
+    ## I am an example about JavaScript
+
+    Did you know 0 == false but 0 !== false?
+  Python: |
+    ```
+    # This is a Python example. A python is a snake.
+    ```
+  Ruby: |
+    - In Ruby
+    - You have to
+    - Say `end` a lot.
+---
+
+{% include platform_content.html content=page.example_content %}{% endraw %}
+```
+
+#### Output
+
+<div class="p-3 mb-3 mb-md-5 border rounded content-flush-bottom">
+{% include components/platform_content.html content=page.example_2 %}
 </div>


### PR DESCRIPTION
This adds support for a `platform` query parameter, as well as fallback support.

- Switching the platform via the switcher updates the preferred platform, adds a `platform` query param, and updates all urls to have that same param.
- Visiting a page via a url that includes the `platform` param displays that platform and updates all urls to use that param, but *does not* update the preferred platform.
- When switchers are asked to load a platform they do not have content for, they will attempt to load the preferred platform and will fall back to the first platform in the list if preferred is not yet set.

cc @ehfeng 