### PR TITLE
fix(minidump): Recommend to turn off gzip for crashpad

### DIFF
--- a/docs/clients/minidump/crashpad.rst
+++ b/docs/clients/minidump/crashpad.rst
@@ -62,7 +62,9 @@ For more information on configuring the crashpad handler, see
 
     Sentry cannot handle gzip compressed minidump submissions and will respond
     with a 400 error. To fix this, pass the ``--no-upload-gzip`` argument to the
-    handler::
+    handler:
+
+    .. code-block:: cpp
 
         arguments.push_back("--no-upload-gzip");
 
@@ -80,6 +82,13 @@ the Crashpad database for automatic uploads:
     if (db != nullptr && db->GetSettings() != nullptr) {
       db->GetSettings()->SetUploadsEnabled(true);
     }
+
+By default, the crashpad handler will limit uploads to one per hour. To disable
+this limitation, pass the ``--no-rate-limit`` argument to the handler:
+
+.. code-block:: cpp
+
+    arguments.push_back("--no-rate-limit");
 
 .. _Crashpad: https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md
 .. _Developing Crashpad: https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/developing.md

--- a/docs/clients/minidump/crashpad.rst
+++ b/docs/clients/minidump/crashpad.rst
@@ -58,6 +58,14 @@ platforms, child processes must also register by using `SetHandlerIPCPipe()`_.
 For more information on configuring the crashpad handler, see
 `crashpad_handler`_.
 
+.. admonition:: Known Issue
+
+    Sentry cannot handle gzip compressed minidump submissions and will respond
+    with a 400 error. To fix this, pass the ``--no-upload-gzip`` argument to the
+    handler::
+
+        arguments.push_back("--no-upload-gzip");
+
 If you also want Crashpad to upload crashes to Sentry, additionally configure
 the Crashpad database for automatic uploads:
 


### PR DESCRIPTION
See:

 - https://forum.sentry.io/t/sentry-doesnt-like-reports-from-crashpad/4068
 - https://forum.sentry.io/t/minidump-crashpad-integration-documentation/4200
 - https://sentry.zendesk.com/agent/tickets/12786

<img width="1011" alt="screen shot 2018-07-11 at 10 32 07" src="https://user-images.githubusercontent.com/1433023/42560104-3485d0f6-84f6-11e8-9fe9-ffc11cafc8fd.png">
<img width="1010" alt="screen shot 2018-07-11 at 10 32 13" src="https://user-images.githubusercontent.com/1433023/42560105-34a451ac-84f6-11e8-87cf-7f18358f1da2.png">
