### PR TITLE
[WIP] feat: Docs for new SDK

### DIFF
--- a/src/_data/categories.yml
+++ b/src/_data/categories.yml
@@ -1,4 +1,7 @@
 # This file dictates sort order and display properties for top-level categories
+- title: Setup
+  icon: releases
+  slug: setup
 
 - title: Error Tracking
   icon: error-tracking

--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -1,6 +1,18 @@
 - name: JavaScript
   slug: javascript
 
+- name: JavaScript / Browser
+  slug: javascript-browser
+
+- name: JavaScript / Node
+  slug: javascript-node
+
+- name: JavaScript / Electron
+  slug: javascript-electron
+
+- name: JavaScript / Cordova
+  slug: javascript-cordova
+
 - name: Ruby
   slug: ruby
 

--- a/src/_includes/components/platform_content.html
+++ b/src/_includes/components/platform_content.html
@@ -48,15 +48,27 @@ utilize their tokens across sites.
       </a>
 
       <div class="nav dropdown-menu" id="{{ __uniq }}-tab" role="tablist" aria-hidden="true">
+        {%- assign category = '' -%}
         {%- for __example in __platforms -%}
           {%- if __default[0] == __example[0] -%}
           {% assign __is_default = true %}
           {%- else -%}
           {% assign __is_default = false %}
           {%- endif -%}
+          {%- if __example[0] contains '/' -%}
+          {%- assign split = __example[0] | split: '/' -%}
+          {%- if split[0] != category -%}
+          <div class="dropdown-header">{{ split[0] }}</div>
+          {%- endif -%}
+          {%- assign category = split[0] -%}
+          {%- assign __name = split[1] -%}
+          {%- assign __slug = __example[0] | slugify -%}
+          <a class="dropdown-item{% if __is_default %} active{% endif %} sub" id="{{ __uniq }}-{{ __slug }}-tab" data-platform="{{ __slug }}" data-toggle="platform" href="#{{ __uniq }}-{{ __slug }}" role="tab" aria-controls="{{ __uniq }}-{{ __slug }}" aria-selected="{% if __is_default %}true{% else %}false{% endif %}">{{ __name }}</a>
+          {%- else -%}
           {%- assign __name = __example[0] -%}
           {%- assign __slug = __name | slugify -%}
           <a class="dropdown-item{% if __is_default %} active{% endif %}" id="{{ __uniq }}-{{ __slug }}-tab" data-platform="{{ __slug }}" data-toggle="platform" href="#{{ __uniq }}-{{ __slug }}" role="tab" aria-controls="{{ __uniq }}-{{ __slug }}" aria-selected="{% if __is_default %}true{% else %}false{% endif %}">{{ __name }}</a>
+          {%- endif -%}
         {%- endfor -%}
       </div>
     </div>

--- a/src/collections/_documentation/setup/configuration.md
+++ b/src/collections/_documentation/setup/configuration.md
@@ -1,0 +1,59 @@
+---
+title: Configuration
+sidebar_order: 1
+
+configuration_content:
+  JavaScript / Browser: |
+    - If you are using the <a href="#TODO">Loader</a> there are no additional steps you have to make.
+    Sentry is set up and works.
+
+    - If you are using Sentry via our CDN you have to call `init`.
+    `Sentry` should be a top level key on the `window` object.
+
+     ```javascript
+    Sentry.init({dsn: '___PUBLIC_DSN___'});
+    ```
+
+    - If you are using the `npm` package you have to first include it and call `init`:
+
+    ```javascript
+    import { init } from '@sentry/browser';
+
+    init({dsn: '___PUBLIC_DSN___'});
+    ```
+
+  JavaScript / Node: |
+    ```javascript
+    const Sentry = require('@sentry/node');
+
+    init({dsn: '___PUBLIC_DSN___'});
+    ```
+
+  JavaScript / Electron: |
+    ```javascript
+    import { init } from '@sentry/electron';
+
+    init({dsn: '___PUBLIC_DSN___'});
+    ```
+
+  JavaScript / Cordova: |
+    ```javascript
+    onDeviceReady: function() {
+        ...
+        var Sentry = cordova.require("sentry-cordova.Sentry");
+        Sentry.init({ dsn: '___PUBLIC_DSN___' });
+        ...
+    }
+    ```
+
+  Python: |
+    Test Python
+
+  Ruby: |
+    Test Ruby
+
+---
+
+In order for Sentry to work you need to _initialize_ the SDK you use.
+
+{% include components/platform_content.html content=page.configuration_content %}

--- a/src/collections/_documentation/setup/installation.md
+++ b/src/collections/_documentation/setup/installation.md
@@ -1,0 +1,68 @@
+---
+title: Installation
+sidebar_order: 0
+
+example_content:
+  JavaScript / Browser: |
+    Our Browser SDK should be used for any frontend application or Website.
+    By default it will capture JavaScript exceptions and unhandled promises. In addition we provide many integrations to handle framework specific error handling (e.g. React, Angular Vue, ...)
+
+    Our recommended way of using Sentry for your website is to use our Loader.
+    Just add this script at the top of your website and you are done, Sentry is fully setup and will catch errors for you.
+
+    If you want to know more of what the Loader actually does, <a href="#TODO">click here</a>.
+
+    ```javascript
+    <script src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous" />
+    ```
+
+    There are a few other ways to use / install our JavaScript SDK:
+
+    You could use our CDN link directly and load the latest SDK version there:
+
+    ```javascript
+    <script src="https://browser.sentry-cdn.com/__VERSION:@sentry/browser__/bundle.min.js" crossorigin="anonymous" />
+    ```
+
+    or if you are using `npm` or `yarn` call:
+    ```
+    $ npm install @sentry/browser
+    ```
+
+  JavaScript / Node: |
+    Our Node SDK should be used for Node application and supports many different framework integrations such as Express, ... #TODO
+
+    Install our Node SDK using `npm` or `yarn`:
+    ```
+    $ npm install @sentry/node
+    ```
+
+  JavaScript / Electron: |
+    Our Electron SDK can capture JavaScript exceptions in the main process and renderers, as well as collect native crash reports (Minidumps).
+
+    Install our Electron SDK using `npm` or `yarn`:
+    ```
+    $ npm install @sentry/electron
+    ```
+
+  JavaScript / Cordova: |
+    Our Cordova SDK can capture JavaScript exceptions as well as native crashs / exceptions that happen either on iOS or Android.
+
+    Install our using:
+    ```
+    $ cordova plugin add sentry-cordova
+    ```
+
+  Python: |
+    Test Python
+
+  Ruby: |
+    Test Ruby
+
+---
+
+Sentry provides many different SDKs for different programming languages / platforms.
+
+Please select the language / platform you are looking for:
+
+{% include components/platform_content.html content=page.example_content %}

--- a/src/collections/_documentation/setup/installation.md
+++ b/src/collections/_documentation/setup/installation.md
@@ -2,7 +2,7 @@
 title: Installation
 sidebar_order: 0
 
-example_content:
+installation_content:
   JavaScript / Browser: |
     Our Browser SDK should be used for any frontend application or Website.
     By default it will capture JavaScript exceptions and unhandled promises. In addition we provide many integrations to handle framework specific error handling (e.g. React, Angular Vue, ...)
@@ -65,4 +65,4 @@ Sentry provides many different SDKs for different programming languages / platfo
 
 Please select the language / platform you are looking for:
 
-{% include components/platform_content.html content=page.example_content %}
+{% include components/platform_content.html content=page.installation_content %}

--- a/src/collections/_documentation/setup/installation.md
+++ b/src/collections/_documentation/setup/installation.md
@@ -5,7 +5,7 @@ sidebar_order: 0
 installation_content:
   JavaScript / Browser: |
     Our Browser SDK should be used for any frontend application or Website.
-    By default it will capture JavaScript exceptions and unhandled promises. In addition we provide many integrations to handle framework specific error handling (e.g. React, Angular Vue, ...)
+    By default it will capture JavaScript exceptions and unhandled promises.  In addition we provide many integrations to handle framework specific error handling (e.g. React, Angular Vue, ...)
 
     Our recommended way of using Sentry for your website is to use our Loader.
     Just add this script at the top of your website and you are done, Sentry is fully setup and will catch errors for you.


### PR DESCRIPTION
This PR is meant to provide the basic structure for new SDK docs.
**Do not merge yet.**

- Add support for headers in dropdown

I was trying to add "headers" in the dropdown because while we mostly have languages depending on the SDK you run you still have different setup steps depending on the platform.

@cameronmcefee If you don't like that I mess with the base templates, I don't mind if you want to do it and I describe what kind of problem I am trying to solve.

![docs inst mov](https://user-images.githubusercontent.com/363802/42819542-2e528f0c-89d4-11e8-8712-b015d7f5ddb4.gif)

Things I've noticed so far:
- A lot of content is in the `installation_content:` section on top of the page and it's not really markdown highlighted. Which works but my syntax highlighting looks like this: 
![screenshot 2018-07-17 15 43 15](https://user-images.githubusercontent.com/363802/42821123-231a7a6a-89d8-11e8-9058-7e6d8b5b732f.png)
Maybe there is a better solution for this since I think the majority of the content lives inside this.
- There are no anchor links, like in the old docs, where I can link to a headline of one page.
- We need some kind of version variable like: https://github.com/getsentry/sentry-docs/pull/263/files#diff-09c82791fbcc3ae9624c90bbea8367e8R24
- I did not find a way to do a "soft wrap" meaning create a new line without a paragraph and just putting the next sentence into a new line.
- If you click on an `<a href="#TODO" ...` the page goes crazy with some reload loops.