### PR TITLE
Update releases page to explain GitHub ownership needs

### DIFF
--- a/docs/learn/releases.rst
+++ b/docs/learn/releases.rst
@@ -68,6 +68,8 @@ commit data, which you will reference in the next step.
 
 * A GitHub owner needs to make sure Sentry is an `authorized application <https://github.com/settings/apps/authorizations>`__
 
+If you're still having trouble adding it, you can try to `disconnect <https://sentry.io/account/settings/identities/>`__ and then `reconnect <https://sentry.io/account/settings/social/associate/github/>`__ your GitHub identity.
+
 
 b. Associate commits with a release
 -----------------------------------

--- a/docs/learn/releases.rst
+++ b/docs/learn/releases.rst
@@ -62,6 +62,13 @@ You’ll need to be an Owner or Manager of your Sentry organization to do this.
 This creates a webhook on the repository and Sentry automatically starts collecting
 commit data, which you will reference in the next step.
 
+* If it's a public repository, you don't need to be an owner in GitHub
+
+* If it's a private repository, you'll need to be an owner in GitHub
+
+* A GitHub owner needs to make sure Sentry is an `authorized application <https://github.com/settings/apps/authorizations>`__
+
+
 b. Associate commits with a release
 -----------------------------------
 When you create a release of your code, create a corresponding release object in Sentry

--- a/docs/learn/releases.rst
+++ b/docs/learn/releases.rst
@@ -62,11 +62,11 @@ You’ll need to be an Owner or Manager of your Sentry organization to do this.
 This creates a webhook on the repository and Sentry automatically starts collecting
 commit data, which you will reference in the next step.
 
-* If it's a public repository, you don't need to be an owner in GitHub
+* If it's a public repository, you don't need to be an organization owner in GitHub
 
-* If it's a private repository, you'll need to be an owner in GitHub
+* If it's a private repository, you'll need to be an organization owner in GitHub
 
-* A GitHub owner needs to make sure Sentry is an `authorized application <https://github.com/settings/apps/authorizations>`__
+* A GitHub organization owner needs to make sure Sentry is an `authorized application <https://github.com/settings/apps/authorizations>`__
 
 If you're still having trouble adding it, you can try to `disconnect <https://sentry.io/account/settings/identities/>`__ and then `reconnect <https://sentry.io/account/settings/social/associate/github/>`__ your GitHub identity.
 


### PR DESCRIPTION
Added information about whether a user needs to be a Github owner to connect their repository

<img width="1055" alt="screenshot 2018-07-26 14 23 00" src="https://user-images.githubusercontent.com/29959063/43289364-935ff9ea-90df-11e8-9e15-35f7ccaddea3.png">

