### PR TITLE
Revise excerpt highlighting

### DIFF
--- a/src/search/index.json
+++ b/src/search/index.json
@@ -7,7 +7,7 @@ layout: null
     {
       "id": {{ document.url | prefix: site.url | jsonify }},
       "title": {{ document.title | jsonify }},
-      "body": {{ document.content | markdownify | strip_code | strip_html | compact_whitespace | jsonify }}
+      "body": {{ document.content | markdownify | strip_code | strip_html | compact_whitespace | strip | jsonify }}
     }{%- unless forloop.last -%},{%- endunless -%}
     {%- endfor %}
   ]


### PR DESCRIPTION
This updates the excerpt highlighting because it was fairly unreliable. Notably, there were some calculation errors because Lunr seems to trim strings before indexing, but the highlighter was measuring term location based on strings that occasionally began with spaces.

I also opted to rewrite the whole thing to be a little more mentally parsable, including some documentation, because the previous code felt a bit inscrutable even after just a few weeks.