### PR TITLE
(fix) Remove Sprint.ly from the integrations page

### DIFF
--- a/src/collections/_documentation/integrations/index.md
+++ b/src/collections/_documentation/integrations/index.md
@@ -24,7 +24,6 @@ Sentry integrates seamlessly with your favorite apps and services.
 -   [_SessionStack_]({%- link _documentation/integrations/sessionstack.md -%})
 -   [_Slack_]({%- link _documentation/integrations/slack.md -%})
 -   [_Splunk_]({%- link _documentation/integrations/splunk.md -%})
--   Sprint.ly
 -   Taiga
 -   Teamwork
 -   Trello


### PR DESCRIPTION
Fixes SE-87