### PR TITLE
fix(docs) Use new hostname

### DIFF
--- a/src/collections/_documentation/api/events/delete-group-details.md
+++ b/src/collections/_documentation/api/events/delete-group-details.md
@@ -14,7 +14,7 @@ DELETE /api/0/issues/_{issue_id}_/
 ```http
 DELETE /api/0/issues/5/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/delete-project-group-index.md
+++ b/src/collections/_documentation/api/events/delete-project-group-index.md
@@ -18,7 +18,7 @@ DELETE /api/0/projects/_{organization_slug}_/_{project_slug}_/issues/
 ```http
 DELETE /api/0/projects/the-interstellar-jurisdiction/amazing-plumbing/issues/?id=5&id=6 HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-group-details.md
+++ b/src/collections/_documentation/api/events/get-group-details.md
@@ -14,7 +14,7 @@ GET /api/0/issues/_{issue_id}_/
 ```http
 GET /api/0/issues/1/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-group-events-latest.md
+++ b/src/collections/_documentation/api/events/get-group-events-latest.md
@@ -14,7 +14,7 @@ GET /api/0/issues/_{issue_id}_/events/latest/
 ```http
 GET /api/0/issues/1/events/latest/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-group-events-oldest.md
+++ b/src/collections/_documentation/api/events/get-group-events-oldest.md
@@ -14,7 +14,7 @@ GET /api/0/issues/_{issue_id}_/events/oldest/
 ```http
 GET /api/0/issues/2/events/oldest/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-group-events.md
+++ b/src/collections/_documentation/api/events/get-group-events.md
@@ -14,7 +14,7 @@ GET /api/0/issues/_{issue_id}_/events/
 ```http
 GET /api/0/issues/1/events/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-group-hashes.md
+++ b/src/collections/_documentation/api/events/get-group-hashes.md
@@ -14,7 +14,7 @@ GET /api/0/issues/_{issue_id}_/hashes/
 ```http
 GET /api/0/issues/1/hashes/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-project-event-details.md
+++ b/src/collections/_documentation/api/events/get-project-event-details.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/events/_{event_id}_/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/events/332d51f6b28b4bc1ac52d16540c51394/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-project-events.md
+++ b/src/collections/_documentation/api/events/get-project-events.md
@@ -16,7 +16,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/events/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/events/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/get-project-group-index.md
+++ b/src/collections/_documentation/api/events/get-project-group-index.md
@@ -18,7 +18,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/issues/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/issues/?statsPeriod=24h HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/events/put-group-details.md
+++ b/src/collections/_documentation/api/events/put-group-details.md
@@ -14,7 +14,7 @@ PUT /api/0/issues/_{issue_id}_/
 ```http
 PUT /api/0/issues/1/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/events/put-project-group-index.md
+++ b/src/collections/_documentation/api/events/put-project-group-index.md
@@ -21,7 +21,7 @@ PUT /api/0/projects/_{organization_slug}_/_{project_slug}_/issues/
 ```http
 PUT /api/0/projects/the-interstellar-jurisdiction/pump-station/issues/?id=1&id=2 HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/organizations/get-event-id-lookup.md
+++ b/src/collections/_documentation/api/organizations/get-event-id-lookup.md
@@ -20,7 +20,7 @@ GET /api/0/organizations/_{organization_slug}_/eventids/_{event_id}_/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/eventids/332d51f6b28b4bc1ac52d16540c51394/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/get-organization-details.md
+++ b/src/collections/_documentation/api/organizations/get-organization-details.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/get-organization-index.md
+++ b/src/collections/_documentation/api/organizations/get-organization-index.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/
 ```http
 GET /api/0/organizations/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/get-organization-projects.md
+++ b/src/collections/_documentation/api/organizations/get-organization-projects.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/projects/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/projects/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/get-organization-stats.md
+++ b/src/collections/_documentation/api/organizations/get-organization-stats.md
@@ -23,7 +23,7 @@ GET /api/0/organizations/_{organization_slug}_/stats/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/stats/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/get-short-id-lookup.md
+++ b/src/collections/_documentation/api/organizations/get-short-id-lookup.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/shortids/_{short_id}_/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/shortids/PUMP-STATION-1/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/organizations/put-organization-details.md
+++ b/src/collections/_documentation/api/organizations/put-organization-details.md
@@ -14,7 +14,7 @@ PUT /api/0/organizations/_{organization_slug}_/
 ```http
 PUT /api/0/organizations/badly-misnamed/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/projects/delete-project-details.md
+++ b/src/collections/_documentation/api/projects/delete-project-details.md
@@ -16,7 +16,7 @@ DELETE /api/0/projects/_{organization_slug}_/_{project_slug}_/
 ```http
 DELETE /api/0/projects/the-interstellar-jurisdiction/plain-proxy/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/delete-project-key-details.md
+++ b/src/collections/_documentation/api/projects/delete-project-key-details.md
@@ -14,7 +14,7 @@ DELETE /api/0/projects/_{organization_slug}_/_{project_slug}_/keys/_{key_id}_/
 ```http
 DELETE /api/0/projects/the-interstellar-jurisdiction/pump-station/keys/bb6cf36bf2a94bd9b7c57bee5ccb0993/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/get-project-details.md
+++ b/src/collections/_documentation/api/projects/get-project-details.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/get-project-index.md
+++ b/src/collections/_documentation/api/projects/get-project-index.md
@@ -14,7 +14,7 @@ GET /api/0/projects/
 ```http
 GET /api/0/projects/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/get-project-keys.md
+++ b/src/collections/_documentation/api/projects/get-project-keys.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/keys/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/keys/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/get-project-service-hooks.md
+++ b/src/collections/_documentation/api/projects/get-project-service-hooks.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/hooks/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/hooks/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/get-project-stats.md
+++ b/src/collections/_documentation/api/projects/get-project-stats.md
@@ -25,7 +25,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/stats/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/stats/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/projects/post-project-keys.md
+++ b/src/collections/_documentation/api/projects/post-project-keys.md
@@ -13,7 +13,7 @@ POST /api/0/projects/_{organization_slug}_/_{project_slug}_/keys/
 ```http
 POST /api/0/projects/the-interstellar-jurisdiction/pump-station/keys/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/projects/post-project-service-hooks.md
+++ b/src/collections/_documentation/api/projects/post-project-service-hooks.md
@@ -19,7 +19,7 @@ POST /api/0/projects/_{organization_slug}_/_{project_slug}_/hooks/
 ```http
 POST /api/0/projects/the-interstellar-jurisdiction/pump-station/hooks/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/projects/post-project-user-reports.md
+++ b/src/collections/_documentation/api/projects/post-project-user-reports.md
@@ -14,7 +14,7 @@ POST /api/0/projects/_{organization_slug}_/_{project_slug}_/user-feedback/
 ```http
 POST /api/0/projects/the-interstellar-jurisdiction/plain-proxy/user-feedback/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/projects/put-project-details.md
+++ b/src/collections/_documentation/api/projects/put-project-details.md
@@ -14,7 +14,7 @@ PUT /api/0/projects/_{organization_slug}_/_{project_slug}_/
 ```http
 PUT /api/0/projects/the-interstellar-jurisdiction/plain-proxy/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/releases/delete-project-release-file-details.md
+++ b/src/collections/_documentation/api/releases/delete-project-release-file-details.md
@@ -16,7 +16,7 @@ DELETE /api/0/projects/_{organization_slug}_/_{project_slug}_/releases/_{version
 ```http
 DELETE /api/0/projects/the-interstellar-jurisdiction/pump-station/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/files/1/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/releases/get-organization-release-details.md
+++ b/src/collections/_documentation/api/releases/get-organization-release-details.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/releases/_{version}_/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/releases/get-organization-releases.md
+++ b/src/collections/_documentation/api/releases/get-organization-releases.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/releases/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/releases/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/releases/get-project-release-file-details.md
+++ b/src/collections/_documentation/api/releases/get-project-release-file-details.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/releases/_{version}_/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/files/2/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/releases/get-project-release-files.md
+++ b/src/collections/_documentation/api/releases/get-project-release-files.md
@@ -14,7 +14,7 @@ GET /api/0/projects/_{organization_slug}_/_{project_slug}_/releases/_{version}_/
 ```http
 GET /api/0/projects/the-interstellar-jurisdiction/pump-station/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/files/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/releases/post-organization-releases.md
+++ b/src/collections/_documentation/api/releases/post-organization-releases.md
@@ -14,7 +14,7 @@ POST /api/0/organizations/_{organization_slug}_/releases/
 ```http
 POST /api/0/organizations/the-interstellar-jurisdiction/releases/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/releases/post-project-release-files.md
+++ b/src/collections/_documentation/api/releases/post-project-release-files.md
@@ -18,7 +18,7 @@ POST /api/0/projects/_{organization_slug}_/_{project_slug}_/releases/_{version}_
 ```http
 POST /api/0/projects/the-interstellar-jurisdiction/pump-station/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/files/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: multipart/form-data; boundary=cde088f87d2f441ea66ea3ab74245f2b
 
 --cde088f87d2f441ea66ea3ab74245f2b

--- a/src/collections/_documentation/api/releases/put-organization-release-details.md
+++ b/src/collections/_documentation/api/releases/put-organization-release-details.md
@@ -14,7 +14,7 @@ PUT /api/0/organizations/_{organization_slug}_/releases/_{version}_/
 ```http
 PUT /api/0/organization/the-interstellar-jurisdiction/releases/3000/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/releases/put-project-release-file-details.md
+++ b/src/collections/_documentation/api/releases/put-project-release-file-details.md
@@ -14,7 +14,7 @@ PUT /api/0/projects/_{organization_slug}_/_{project_slug}_/releases/_{version}_/
 ```http
 PUT /api/0/projects/the-interstellar-jurisdiction/pump-station/releases/e48e7b5b90327ea1a4d1a4360c735eee7b536f82/files/3/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/teams/get-organization-teams.md
+++ b/src/collections/_documentation/api/teams/get-organization-teams.md
@@ -14,7 +14,7 @@ GET /api/0/organizations/_{organization_slug}_/teams/
 ```http
 GET /api/0/organizations/the-interstellar-jurisdiction/teams/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/teams/get-team-details.md
+++ b/src/collections/_documentation/api/teams/get-team-details.md
@@ -14,7 +14,7 @@ GET /api/0/teams/_{organization_slug}_/_{team_slug}_/
 ```http
 GET /api/0/teams/the-interstellar-jurisdiction/powerful-abolitionist/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/teams/get-team-projects.md
+++ b/src/collections/_documentation/api/teams/get-team-projects.md
@@ -14,7 +14,7 @@ GET /api/0/teams/_{organization_slug}_/_{team_slug}_/projects/
 ```http
 GET /api/0/teams/the-interstellar-jurisdiction/powerful-abolitionist/projects/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/teams/get-team-stats.md
+++ b/src/collections/_documentation/api/teams/get-team-stats.md
@@ -25,7 +25,7 @@ GET /api/0/teams/_{organization_slug}_/_{team_slug}_/stats/
 ```http
 GET /api/0/teams/the-interstellar-jurisdiction/powerful-abolitionist/stats/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 ```
 
 ```http

--- a/src/collections/_documentation/api/teams/post-organization-teams.md
+++ b/src/collections/_documentation/api/teams/post-organization-teams.md
@@ -14,7 +14,7 @@ POST /api/0/organizations/_{organization_slug}_/teams/
 ```http
 POST /api/0/organizations/the-interstellar-jurisdiction/teams/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/teams/post-team-projects.md
+++ b/src/collections/_documentation/api/teams/post-team-projects.md
@@ -13,7 +13,7 @@ POST /api/0/teams/_{organization_slug}_/_{team_slug}_/projects/
 ```http
 POST /api/0/teams/the-interstellar-jurisdiction/powerful-abolitionist/projects/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/api/teams/put-team-details.md
+++ b/src/collections/_documentation/api/teams/put-team-details.md
@@ -14,7 +14,7 @@ PUT /api/0/teams/_{organization_slug}_/_{team_slug}_/
 ```http
 PUT /api/0/teams/the-interstellar-jurisdiction/the-obese-philosophers/ HTTP/1.1
 Authorization: Bearer {base64-encoded-key-here}
-Host: app.getsentry.com
+Host: sentry.io
 Content-Type: application/json
 
 {

--- a/src/collections/_documentation/clients/php/integrations/laravel.md
+++ b/src/collections/_documentation/clients/php/integrations/laravel.md
@@ -213,7 +213,7 @@ You can test your configuration using the provided `artisan` command:
 ```bash
 $ php artisan sentry:test
 [sentry] Client configuration:
--> server: https://app.getsentry.com/api/3235/store/
+-> server: https://sentry.io/api/3235/store/
 -> project: 3235
 -> public_key: e9ebbd88548a441288393c457ec90441
 -> secret_key: 399aaee02d454e2ca91351f29bdc3a07


### PR DESCRIPTION
Update the documentation to use sentry.io instead of the old host name.

Fixes getsentry/docs#388