### PR TITLE
fix(docs) Add Docs prefix site wide.

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -42,4 +42,4 @@ the following value in the page frontmatter
 {% asset screen.css %}
 {% if jekyll.environment == "development" %}{% asset dev.css %}{% endif %}
 
-<title>{{ meta_title }}</title>
+<title>Docs - {{ meta_title }}</title>


### PR DESCRIPTION
This helps make it easier to find tabs that have docs vs. the application in them.

Fixes #300