### PR TITLE
feat: switch to a javascript-based strategy for collapsing the sidebar

### DIFF
--- a/src/_includes/sidebar/LEGACY_category.html
+++ b/src/_includes/sidebar/LEGACY_category.html
@@ -3,7 +3,7 @@
   | first
 -%}
 {%- if include.document -%}
-<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center mb-0">
+<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center mb-0" data-sidebar-link>
   <h6>
     {{- __category.title -}}
   </h6>

--- a/src/_includes/sidebar/category.html
+++ b/src/_includes/sidebar/category.html
@@ -3,7 +3,7 @@
   | first
 -%}
 {%- if include.document -%}
-<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center mb-2{% if include.document.path == page.path %} active{% endif %}">
+<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center mb-2{% if include.document.path == page.path %} active{% endif %}" data-sidebar-link>
   {% include /svg/{{ __category.icon }}.svg %}
   <h6 class="ml-2">
     {{- __category.title -}}

--- a/src/_includes/sidebar/default.html
+++ b/src/_includes/sidebar/default.html
@@ -1,3 +1,3 @@
-<a class="d-block{% if include.document.path == page.path %} active{% endif %}" href="{{ include.document.url }}">
+<a class="d-block{% if include.document.path == page.path %} active{% endif %}" href="{{ include.document.url }}" data-sidebar-link>
   {{ include.document.title }}
 </a>

--- a/src/_includes/sidebar/dev_category.html
+++ b/src/_includes/sidebar/dev_category.html
@@ -3,7 +3,7 @@
   | first
 -%}
 {%- if include.document -%}
-<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center text-warning mb-2{% if include.document.path == page.path %} active{% endif %}" data-toggle="tooltip" data-placement="bottom" title="Development only">
+<a href="{{ include.document.url }}" class="sidebar-title d-flex align-items-center text-warning mb-2{% if include.document.path == page.path %} active{% endif %}" data-toggle="tooltip" data-placement="bottom" title="Development only" data-sidebar-link>
   {% include /svg/{{ __category.icon }}.svg %}
   <h6 class="ml-2">
     {{- __category.title -}}

--- a/src/_includes/sidebar/tree.html
+++ b/src/_includes/sidebar/tree.html
@@ -2,7 +2,7 @@
 Save the previous context so this loop doesn't clobber data from it's parent call
 {% endcomment %}
 {%- assign __CONTEXT_items_at_current_depth = __items_at_current_depth -%}
-<ul class="list-unstyled">
+<ul class="list-unstyled" data-sidebar-tree>
 {%- for __item in include.data -%}
 <li class="{% if include.is_category %}mb-2{% else %}toc-item{% endif %}">
   {%- include sidebar/preserve_context.html -%}
@@ -26,25 +26,23 @@ Save the previous context so this loop doesn't clobber data from it's parent cal
   -%}
 
   {%- assign __item_category = __item.parent_path | split: '/' | slice: 1,1 | first -%}
-  {%- if (__item.items and __page_category == __item_category) or jekyll.environment == "development" -%}
-    {%- assign __new_template_list_length = __template_list.size
-      | minus: 1
+
+  {%- assign __new_template_list_length = __template_list.size
+    | minus: 1
+  -%}
+  {%- if __new_template_list_length < 1 -%}
+    {%- assign __new_template_list = __template_slug -%}
+  {%- else -%}
+    {%- assign __new_template_list = __template_list
+      | slice: 1, __new_template_list_length
+      | join: ','
     -%}
-    {%- if __new_template_list_length < 1 -%}
-      {%- assign __new_template_list = __template_slug -%}
-    {%- else -%}
-      {%- assign __new_template_list = __template_list
-        | slice: 1, __new_template_list_length
-        | join: ','
-      -%}
-    {%- endif -%}
-
-    {% include sidebar/tree.html
-      data=__item.items
-      templates=__new_template_list
-    %}
-
   {%- endif -%}
+
+  {% include sidebar/tree.html
+    data=__item.items
+    templates=__new_template_list
+  %}
 
   {%- include sidebar/restore_context.html -%}
 </li>

--- a/src/_js/lib/Sidebar.js
+++ b/src/_js/lib/Sidebar.js
@@ -1,0 +1,31 @@
+const onlyCategories = (i, el) => {
+  const $parents = $(el).parentsUntil(
+    '[data-sidebar-root]',
+    '[data-sidebar-tree]'
+  );
+  return $parents.length === 1;
+};
+
+$(document).on('page.didUpdate', function(event) {
+  const $links = $('[data-sidebar-link]');
+  let $active = $links.filter(`[href="${location.pathname}"]`);
+  $active = !!$active.length
+    ? $active
+    : $('[data-sidebar-tree]')
+        .filter(onlyCategories)
+        .eq(0)
+        .siblings('[data-sidebar-link]');
+
+  $links.each((i, el) => {
+    const $el = $(el);
+    $el.toggleClass('active', $el.is($active));
+  });
+
+  const $trees = $('[data-sidebar-tree]');
+  $trees.each((i, el) => {
+    const $el = $(el);
+    const containsActive = !!$el.has($active.get(0)).length;
+    const isChildOfActive = $el.parent().is($active.parent());
+    $el.toggleClass('collapse', !(containsActive || isChildOfActive));
+  });
+});

--- a/src/_js/main.js
+++ b/src/_js/main.js
@@ -8,6 +8,7 @@ import DynamicLoad from './lib/DynamicLoad';
 import Search from './lib/Search';
 import HeaderLinker from './lib/HeaderLinker';
 import './lib/Feedback';
+import './lib/Sidebar';
 
 if (process.env.NODE_ENV === 'production') {
   const dsn = 'https://ad63ba38287245f2803dc220be959636@sentry.io/1267915';

--- a/src/_layouts/doc.html
+++ b/src/_layouts/doc.html
@@ -8,14 +8,8 @@ layout: default
     {% meminclude global_brand.html %}
 
     <div class="toc collapse navbar-collapse" id="sidebar">
-      <div class="text-white p-3" data-dynamic-load="sidebar">
-
-        {%- if jekyll.environment == "development" -%}
+      <div class="text-white p-3" data-dynamic-load="sidebar" data-sidebar-root>
         {% meminclude sidebar.html %}
-        {%- else -%}
-        {% include sidebar.html %}
-        {%- endif -%}
-
       </div>
     </div>
 


### PR DESCRIPTION
This uses a JavaScript approach for selecting active items in the side bar, as well as determining what expands and collapses.

Due to the large number of documents, it's impractical in development mode to render the active state of each page's sidebar (builds around 60s). Instead, the sidebar is memoized in a fully expanded state. However, the list is huge and it's impossible to navigate.  This new solution adds a javascript layer that manages expanding and collapsing items to both production and dev have a sane experience.