### PR TITLE
fix: move Getting Started doc to top of the sidebar

### DIFF
--- a/src/collections/_documentation/learn/quickstart.md
+++ b/src/collections/_documentation/learn/quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: 'Getting Started'
 permalink: /quickstart/
+sidebar_order: 0
 ---
 
 For an overview of what Sentry does, take a look at the Sentry [workflow](https://blog.sentry.io/2018/03/06/the-sentry-workflow).


### PR DESCRIPTION
This somehow got lost in the migration