### PR TITLE
Fix: broken platform build

### DIFF
--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -3,154 +3,154 @@
       support_level: production
       type: framework
       name: Koa
-      doc_link: https://docs.sentry.io/clients/node/integrations/koa/
+      doc_link: /clients/node/integrations/koa/
       wizard: ['_documentation/clients/node/index.md#installation', _documentation/clients/node/integrations/koa.md]
 -
       slug: node
       support_level: production
       type: language
       name: Node.js
-      doc_link: https://docs.sentry.io/clients/node/
+      doc_link: /clients/node/
       wizard: ['_documentation/clients/node/index.md#installation', '_documentation/clients/node/index.md#configuring-the-client', '_documentation/clients/node/index.md#reporting-errors']
 -
       slug: express
       support_level: production
       type: framework
       name: Express
-      doc_link: https://docs.sentry.io/clients/node/integrations/express/
+      doc_link: /clients/node/integrations/express/
       wizard: ['_documentation/clients/node/index.md#installation', _documentation/clients/node/integrations/express.md]
 -
       slug: connect
       support_level: production
       type: framework
       name: Connect
-      doc_link: https://docs.sentry.io/clients/node/integrations/connect/
+      doc_link: /clients/node/integrations/connect/
       wizard: ['_documentation/clients/node/index.md#installation', _documentation/clients/node/integrations/connect.md]
 -
       slug: cordova
       support_level: production
       type: language
       name: Cordova
-      doc_link: https://docs.sentry.io/clients/cordova/
+      doc_link: /clients/cordova/
       wizard: ['_documentation/clients/cordova/index.md#installation', '_documentation/clients/cordova/index.md#configuration']
 -
       slug: java
       support_level: production
       type: language
       name: Java
-      doc_link: https://docs.sentry.io/clients/java/
+      doc_link: /clients/java/
       wizard: ['_documentation/clients/java/usage.md#installation', '_documentation/clients/java/usage.md#capture-an-error']
 -
       slug: logging
       support_level: production
       type: framework
       name: java.util.logging
-      doc_link: https://docs.sentry.io/clients/java/modules/jul/
+      doc_link: /clients/java/modules/jul/
       wizard: ['_documentation/clients/java/modules/jul.md#installation', '_documentation/clients/java/modules/jul.md#usage']
 -
       slug: logback
       support_level: production
       type: framework
       name: Logback
-      doc_link: https://docs.sentry.io/clients/java/modules/logback/
+      doc_link: /clients/java/modules/logback/
       wizard: ['_documentation/clients/java/modules/logback.md#installation', '_documentation/clients/java/modules/logback.md#usage']
 -
       slug: android
       support_level: production
       type: framework
       name: Android
-      doc_link: https://docs.sentry.io/clients/java/modules/android/
+      doc_link: /clients/java/modules/android/
       wizard: ['_documentation/clients/java/modules/android.md#installation', '_documentation/clients/java/modules/android.md#usage']
 -
       slug: log4j2
       support_level: production
       type: framework
       name: 'Log4j 2.x'
-      doc_link: https://docs.sentry.io/clients/java/modules/log4j2/
+      doc_link: /clients/java/modules/log4j2/
       wizard: ['_documentation/clients/java/modules/log4j2.md#installation', '_documentation/clients/java/modules/log4j2.md#usage']
 -
       slug: log4j
       support_level: production
       type: framework
       name: 'Log4j 1.x'
-      doc_link: https://docs.sentry.io/clients/java/modules/log4j/
+      doc_link: /clients/java/modules/log4j/
       wizard: ['_documentation/clients/java/modules/log4j.md#installation', '_documentation/clients/java/modules/log4j.md#usage']
 -
       slug: appengine
       support_level: production
       type: framework
       name: 'Google App Engine'
-      doc_link: https://docs.sentry.io/clients/java/modules/appengine/
+      doc_link: /clients/java/modules/appengine/
       wizard: ['_documentation/clients/java/modules/appengine.md#installation', '_documentation/clients/java/modules/appengine.md#usage']
 -
       slug: python
       support_level: production
       type: language
       name: Python
-      doc_link: https://docs.sentry.io/clients/python/
+      doc_link: /clients/python/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/usage.md#capture-an-error', '_documentation/clients/python/usage.md#reporting-an-event']
 -
       slug: pyramid
       support_level: production
       type: framework
       name: Pyramid
-      doc_link: https://docs.sentry.io/clients/python/integrations/pyramid/
+      doc_link: /clients/python/integrations/pyramid/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/pyramid.md#pastedeploy-filter', '_documentation/clients/python/integrations/pyramid.md#logger-setup']
 -
       slug: rq
       support_level: production
       type: framework
       name: RQ
-      doc_link: https://docs.sentry.io/clients/python/integrations/rq/
+      doc_link: /clients/python/integrations/rq/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/rq.md#usage', '_documentation/clients/python/integrations/rq.md#extended-setup']
 -
       slug: flask
       support_level: production
       type: framework
       name: Flask
-      doc_link: https://docs.sentry.io/clients/python/integrations/flask/
+      doc_link: /clients/python/integrations/flask/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/flask.md#installation', '_documentation/clients/python/integrations/flask.md#setup']
 -
       slug: django
       support_level: production
       type: framework
       name: Django
-      doc_link: https://docs.sentry.io/clients/python/integrations/django/
+      doc_link: /clients/python/integrations/django/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/django.md#setup']
 -
       slug: celery
       support_level: production
       type: library
       name: Celery
-      doc_link: https://docs.sentry.io/clients/python/integrations/celery/
+      doc_link: /clients/python/integrations/celery/
       wizard: ['_documentation/clients/python/index.md#installation', _documentation/clients/python/integrations/celery.md]
 -
       slug: tornado
       support_level: production
       type: framework
       name: Tornado
-      doc_link: https://docs.sentry.io/clients/python/integrations/tornado/
+      doc_link: /clients/python/integrations/tornado/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/tornado.md#setup', '_documentation/clients/python/integrations/tornado.md#usage']
 -
       slug: bottle
       support_level: production
       type: framework
       name: Bottle
-      doc_link: https://docs.sentry.io/clients/python/integrations/bottle/
+      doc_link: /clients/python/integrations/bottle/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/bottle.md#setup', '_documentation/clients/python/integrations/bottle.md#usage']
 -
       slug: pylons
       support_level: production
       type: framework
       name: Pylons
-      doc_link: https://docs.sentry.io/clients/python/integrations/pylons/
+      doc_link: /clients/python/integrations/pylons/
       wizard: ['_documentation/clients/python/index.md#installation', '_documentation/clients/python/integrations/pylons.md#wsgi-middleware', '_documentation/clients/python/integrations/pylons.md#logger-setup']
 -
       slug: swift
       support_level: production
       type: language
       name: Swift
-      doc_link: https://docs.sentry.io/clients/cocoa/
+      doc_link: /clients/cocoa/
       wizard: ['_documentation/clients/cocoa/index.md#installation', '_documentation/clients/cocoa/index.md#configuration', '_documentation/clients/cocoa/index.md#debug-symbols', '_documentation/clients/cocoa/dsym.md#upload-symbols-with-sentry-cli']
       version: 4.1.0
       version_key: SENTRY_COCOA_TAG
@@ -159,7 +159,7 @@
       support_level: production
       type: language
       name: JavaScript
-      doc_link: https://docs.sentry.io/clients/javascript/
+      doc_link: /clients/javascript/
       wizard: ['_documentation/clients/javascript/index.md#installation', '_documentation/clients/javascript/index.md#configuring-the-client', '_documentation/clients/javascript/index.md#manually-reporting-errors']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -168,7 +168,7 @@
       support_level: production
       type: framework
       name: Vue
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/vue/
+      doc_link: /clients/javascript/integrations/vue/
       wizard: ['_documentation/clients/javascript/integrations/vue.md#installation']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -177,7 +177,7 @@
       support_level: production
       type: framework
       name: Backbone
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/backbone/
+      doc_link: /clients/javascript/integrations/backbone/
       wizard: ['_documentation/clients/javascript/integrations/backbone.md#installation', '_documentation/clients/javascript/integrations/backbone.md#configuring-the-client']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -186,7 +186,7 @@
       support_level: production
       type: framework
       name: Ember
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/ember/
+      doc_link: /clients/javascript/integrations/ember/
       wizard: ['_documentation/clients/javascript/integrations/ember.md#installation']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -195,7 +195,7 @@
       support_level: production
       type: framework
       name: React
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/react/
+      doc_link: /clients/javascript/integrations/react/
       wizard: ['_documentation/clients/javascript/integrations/react.md#installation', '_documentation/clients/javascript/integrations/react.md#configuring-the-client']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -204,7 +204,7 @@
       support_level: production
       type: framework
       name: AngularJS
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/angularjs/
+      doc_link: /clients/javascript/integrations/angularjs/
       wizard: ['_documentation/clients/javascript/integrations/angularjs.md#installation', '_documentation/clients/javascript/integrations/angularjs.md#angularjs-configuration']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -213,7 +213,7 @@
       support_level: production
       type: framework
       name: Angular
-      doc_link: https://docs.sentry.io/clients/javascript/integrations/angular/
+      doc_link: /clients/javascript/integrations/angular/
       wizard: ['_documentation/clients/javascript/integrations/angular.md#installation', '_documentation/clients/javascript/integrations/angular.md#configuration']
       version: 3.26.4
       version_key: RAVEN_VERSION
@@ -222,28 +222,28 @@
       support_level: production
       type: language
       name: Electron
-      doc_link: https://docs.sentry.io/clients/electron/
+      doc_link: /clients/electron/
       wizard: ['_documentation/clients/electron/index.md#installation', '_documentation/clients/electron/index.md#configuring-the-client']
 -
       slug: elixir
       support_level: production
       type: language
       name: Elixir
-      doc_link: https://docs.sentry.io/clients/elixir/
+      doc_link: /clients/elixir/
       wizard: ['_documentation/clients/elixir/index.md#installation', '_documentation/clients/elixir/index.md#configuration', '_documentation/clients/elixir/usage.md#capturing-errors']
 -
       slug: cocoa
       support_level: beta
       type: language
       name: React-Native
-      doc_link: https://docs.sentry.io/clients/react-native/
+      doc_link: /clients/react-native/
       wizard: ['_documentation/clients/react-native/index.md#installation', '_documentation/clients/react-native/index.md#client-configuration']
 -
       slug: objc
       support_level: production
       type: language
       name: Objective-C
-      doc_link: https://docs.sentry.io/clients/cocoa/
+      doc_link: /clients/cocoa/
       wizard: ['_documentation/clients/cocoa/index.md#installation', '_documentation/clients/cocoa/index.md#configuration', '_documentation/clients/cocoa/index.md#debug-symbols', '_documentation/clients/cocoa/dsym.md#upload-symbols-with-sentry-cli']
       version: 4.1.0
       version_key: SENTRY_COCOA_TAG
@@ -252,77 +252,77 @@
       support_level: community
       type: language
       name: 'C#'
-      doc_link: https://docs.sentry.io/clients/csharp/
+      doc_link: /clients/csharp/
       wizard: ['_documentation/clients/csharp/index.md#installation', '_documentation/clients/csharp/index.md#capturing-exceptions']
 -
       slug: go
       support_level: in-development
       type: language
       name: Go
-      doc_link: https://docs.sentry.io/clients/go/
+      doc_link: /clients/go/
       wizard: ['_documentation/clients/go/index.md#installation', '_documentation/clients/go/index.md#configuring-the-client', '_documentation/clients/go/index.md#reporting-errors', '_documentation/clients/go/index.md#reporting-panics']
 -
       slug: http
       support_level: in-development
       type: framework
       name: net/http
-      doc_link: https://docs.sentry.io/clients/go/integrations/http/
+      doc_link: /clients/go/integrations/http/
       wizard: ['_documentation/clients/go/integrations/http.md#installation', '_documentation/clients/go/integrations/http.md#setup']
 -
       slug: laravel
       support_level: production
       type: framework
       name: Laravel
-      doc_link: https://docs.sentry.io/clients/php/integrations/laravel/
+      doc_link: /clients/php/integrations/laravel/
       wizard: ['_documentation/clients/php/integrations/laravel.md#laravel-5-x', '_documentation/clients/php/integrations/laravel.md#laravel-4-x', '_documentation/clients/php/integrations/laravel.md#lumen-5-x']
 -
       slug: php
       support_level: production
       type: language
       name: PHP
-      doc_link: https://docs.sentry.io/clients/php/
+      doc_link: /clients/php/
       wizard: ['_documentation/clients/php/index.md#installation', '_documentation/clients/php/index.md#configuration', '_documentation/clients/php/usage.md#capturing-errors']
 -
       slug: monolog
       support_level: production
       type: framework
       name: Monolog
-      doc_link: https://docs.sentry.io/clients/php/integrations/monolog/
+      doc_link: /clients/php/integrations/monolog/
       wizard: ['_documentation/clients/php/index.md#installation', _documentation/clients/php/integrations/monolog.md]
 -
       slug: symfony2
       support_level: production
       type: framework
       name: Symfony2
-      doc_link: https://docs.sentry.io/clients/php/integrations/symfony2/
+      doc_link: /clients/php/integrations/symfony2/
       wizard: ['_documentation/clients/php/integrations/symfony2.md#symfony-2']
 -
       slug: ruby
       support_level: production
       type: language
       name: Ruby
-      doc_link: https://docs.sentry.io/clients/ruby/
+      doc_link: /clients/ruby/
       wizard: ['_documentation/clients/ruby/index.md#installation', '_documentation/clients/ruby/index.md#configuration', '_documentation/clients/ruby/index.md#reporting-failures']
 -
       slug: rack
       support_level: production
       type: framework
       name: Rack
-      doc_link: https://docs.sentry.io/clients/ruby/integrations/rack/
+      doc_link: /clients/ruby/integrations/rack/
       wizard: [_documentation/clients/ruby/integrations/rack.md]
 -
       slug: rails
       support_level: production
       type: framework
       name: Rails
-      doc_link: https://docs.sentry.io/clients/ruby/integrations/rails/
+      doc_link: /clients/ruby/integrations/rails/
       wizard: [_documentation/clients/ruby/integrations/rails.md]
 -
       slug: rust
       support_level: production
       type: language
       name: Rust
-      doc_link: https://docs.sentry.io/clients/rust/
+      doc_link: /clients/rust/
       wizard: ['_documentation/clients/rust/index.md#installation', '_documentation/clients/rust/index.md#configuring-the-client', '_documentation/clients/rust/index.md#reporting-errors', '_documentation/clients/rust/index.md#catching-panics']
       version: 0.6.0
       version_key: SENTRY_VERSION
@@ -331,5 +331,5 @@
       support_level: production
       type: language
       name: Minidump
-      doc_link: https://docs.sentry.io/clients/minidump/
+      doc_link: /clients/minidump/
       wizard: ['_documentation/clients/minidump/index.md#platform-and-language-support', '_documentation/clients/minidump/index.md#creating-and-uploading-minidumps']

--- a/src/_plugins/platform_api.rb
+++ b/src/_plugins/platform_api.rb
@@ -12,6 +12,7 @@ module Jekyll
       self.read_yaml(File.join(base, '_layouts'), 'json.json')
       keys = ["support_level","type","name","doc_link","body"]
       self.data['json'] = platform.select {|key,_| keys.include? key}
+      self.data['json']['doc_link'] = "#{site.config["url"]}#{self.data['json']['doc_link']}"
     end
   end
 
@@ -113,7 +114,7 @@ module Jekyll
         indexPayload[:platforms][platformKey][indexKey] = {
           :type => platform["type"],
           :details => pathData.size > 2 ? File.join(pathData[1], detailName) : detailName,
-          :doc_link => platform["doc_link"],
+          :doc_link => "#{site.config["url"]}#{platform["doc_link"]}",
           :name => platform["name"]
         }
 


### PR DESCRIPTION
(this is a good example case for why I want to improve our platform data handling)

The only way to generate the platform list based on the data available during migration was to infer it from the doc links. In recently changing the doc links to be relative in their source data, I disrupted the data being generated, which treated the origin as a platform.

Rather than hard code the links, this assembles them at build time.