### PR TITLE
Manual setup instructions in settings.gradle

### DIFF
--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -130,3 +130,10 @@ public class MainApplication extends Application implements ReactApplication {
 
 }
 ```
+
+
+Add the following to your `settings.gradle` file:
+```java
+include ':react-native-sentry'
+project(':react-native-sentry').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sentry/android')
+```


### PR DESCRIPTION
The docs were missing a step in the manual setup for React Native Android. The only way I found out this missing step was to run `react-native link react-native-sentry` and look at the diff.