### PR TITLE
Document payload size for javascript SDK

### DIFF
--- a/src/collections/_documentation/clients/javascript/config.md
+++ b/src/collections/_documentation/clients/javascript/config.md
@@ -299,12 +299,14 @@ Those configuration options are documented below:
 
 : `fetch()` init parameters ([https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)).
 
+  Setting `keepalive: true` parameter will allow SDK to send events in `unload` and `beforeunload` handlers.
+  However, it'll also restrict the size of a single event to 64kB, per [fetch specification](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) (point 8.5).
+
   Defaults:
 
   ```javascript
   {
       method: 'POST',
-      keepalive: true,
       referrerPolicy: 'origin'
   }
   ```

--- a/src/collections/_documentation/clients/javascript/usage.md
+++ b/src/collections/_documentation/clients/javascript/usage.md
@@ -127,6 +127,10 @@ The `captureMessage`, `captureException`, `context`, and `wrap` functions all al
   Raven.setTagsContext(tags);         // Add back the tags you want to keep.
   ```
 
+**Be aware of maximal payload size** - There are times, when you want to send a whole application state as an extra data.
+This can be quite a large object, which can easily weigh more than 200kB, which is currently maximamal payload size of a single event sent to Sentry.
+When this happens, you'll get an `HTTP Error 413 Payload Too Large` as the server response or (when `keepalive: true` is set as `fetch` parameter) request will stay in `pending` state forever (eg. in Chrome).
+
 `extra`
 
 : Arbitrary data to associate with the event.


### PR DESCRIPTION
Re: https://github.com/getsentry/sentry-javascript/pull/1496