### PR TITLE
Fix: broken link to angular error handler docs

### DIFF
--- a/src/collections/_documentation/clients/javascript/integrations/angular.md
+++ b/src/collections/_documentation/clients/javascript/integrations/angular.md
@@ -5,7 +5,7 @@ sidebar_order: 7
 
 This document uses Angular to refer to Angular 2+. On its own, Raven.js will report any uncaught exceptions triggered from your application. For advanced usage examples of Raven.js, please read [_Raven.js usage_]({%- link _documentation/clients/javascript/usage.md -%}).
 
-Additionally, Raven.js can be configured to catch any Angular-specific (2.x) exceptions reported through the [@angular/core/ErrorHandler](https://angular.io/docs/js/latest/api/core/index/ErrorHandler-class.html) component.
+Additionally, Raven.js can be configured to catch any Angular-specific (2.x) exceptions reported through the [@angular/core/ErrorHandler](https://angular.io/api/core/ErrorHandler) component.
 
 ## TypeScript Support
 


### PR DESCRIPTION
Fixes #198