### PR TITLE
fix: run the header linker on page.didUpdate

### DIFF
--- a/src/_js/lib/HeaderLinker.js
+++ b/src/_js/lib/HeaderLinker.js
@@ -1,4 +1,4 @@
-const init = function() {
+$(document).on('page.didUpdate', function() {
   $('h1,h2,h3,h4,h5,h6').each((i, el) => {
     const $el = $(el);
     const id = $el.attr('id');
@@ -11,5 +11,4 @@ const init = function() {
       $el.prepend($link);
     }
   });
-};
-export default { init };
+});

--- a/src/_js/main.js
+++ b/src/_js/main.js
@@ -6,7 +6,7 @@ import Tracking from './lib/Tracking';
 import User from './lib/User';
 import DynamicLoad from './lib/DynamicLoad';
 import Search from './lib/Search';
-import HeaderLinker from './lib/HeaderLinker';
+import './lib/HeaderLinker';
 import './lib/Feedback';
 import './lib/Sidebar';
 
@@ -30,7 +30,6 @@ $(function() {
   Search.init();
   DynamicLoad.init();
   DynamicLoad.addLoader('^/search/', Search.loader);
-  HeaderLinker.init();
 
   window.User = new User();
   window.User.init();


### PR DESCRIPTION
This fixes the header links that seemed to disappear after navigating to a new page