### PR TITLE
ref: make Platform related content use the event system

### DIFF
--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -47,16 +47,6 @@ const updateUrlPlatform = function(url, slug) {
   return `${origin}?${qs.stringify(query)}`;
 };
 
-const initRelatedElements = function() {
-  $('.config-key').each(function() {
-    this.setAttribute('data-config-key', $(this).text());
-  });
-
-  $('.unsupported').each(function() {
-    $('<div class="unsupported-hint"></div>').prependTo(this);
-  });
-};
-
 const syncRelatedElements = function() {
   let platform = window.platformData[window.activePlatform];
   let style = platform && platform.case_style || 'canonical';
@@ -144,6 +134,16 @@ const showPlatform = function(slug) {
   });
 
   history.replaceState({}, '', updateUrlPlatform(location.href, slug));
+
+  $('.config-key').each(function() {
+    this.setAttribute('data-config-key', $(this).text());
+  });
+
+  $('.unsupported-hint').remove();
+  $('.unsupported').each(function() {
+    $('<div class="unsupported-hint"></div>').prependTo(this);
+  });
+
   syncRelatedElements();
 };
 
@@ -156,14 +156,3 @@ $(document).on('page.didUpdate', function(event) {
   // Update the preferredPlatform based on the url.
   showPlatform(qs.parse(location.search).platform);
 });
-
-// Attach event listeners and set UI state based on the platform supplied via
-// query param, stored in localStorage as the preferred platform, or the
-// default platform, in that order.
-//
-// Returns nothing.
-const init = function() {
-  initRelatedElements();
-};
-
-export default { init };

--- a/src/_js/main.js
+++ b/src/_js/main.js
@@ -1,11 +1,11 @@
 import Raven from 'raven-js';
 import 'bootstrap';
-import PlatformContent from './lib/PlatformContent';
 import UserContent from './lib/UserContent';
 import Tracking from './lib/Tracking';
 import User from './lib/User';
 import DynamicLoad from './lib/DynamicLoad';
 import Search from './lib/Search';
+import './lib/PlatformContent';
 import './lib/HeaderLinker';
 import './lib/Feedback';
 import './lib/Sidebar';
@@ -24,7 +24,6 @@ $(document).on('page.didUpdate', function(event) {
 });
 
 $(function() {
-  PlatformContent.init();
   UserContent.init();
   Tracking.init();
   Search.init();


### PR DESCRIPTION
I'm trying to move stuff away from using init functions because most of the JS really needs to run whenever the page updates. This moves the platform related content into the method that fires every time there's a page update or when the platform changes.