### PR TITLE
fix: Bad code-block type for go shell snippet

### DIFF
--- a/src/collections/_documentation/clients/go/index.md
+++ b/src/collections/_documentation/clients/go/index.md
@@ -18,7 +18,7 @@ Raven-Go provides a Sentry client implementation for the Go programming language
 
 Raven-Go can be installed like any other Go library through `go get`:
 
-```python
+```bash
 $ go get github.com/getsentry/raven-go
 ```
 
@@ -88,11 +88,11 @@ func init() {
 
 For more detailed information about how to get the most out of `raven-go` there is additional documentation available that covers all the rest:
 
--   [Integrations]({%- link _documentation/clients/go/integrations/index.md -%})
-    -   [net/http]({%- link _documentation/clients/go/integrations/http.md -%})
+- [Integrations]({%- link _documentation/clients/go/integrations/index.md -%})
+  - [net/http]({%- link _documentation/clients/go/integrations/http.md -%})
 
 Resources:
 
--   [Bug Tracker](https://github.com/getsentry/raven-go/issues)
--   [GitHub Project](https://github.com/getsentry/raven-go)
--   [Godocs](https://godoc.org/github.com/getsentry/raven-go)
+- [Bug Tracker](https://github.com/getsentry/raven-go/issues)
+- [GitHub Project](https://github.com/getsentry/raven-go)
+- [Godocs](https://godoc.org/github.com/getsentry/raven-go)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/45594244-08bc2080-b94c-11e8-954a-73e294246bf8.png)

Should fix this red box on our go setup page