### PR TITLE
feat(docs) Add a docker based api docs builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _site
 .jekyll-cache
 .asset-cache
 /node_modules/
+/apidocs
 package-lock.json
 .DS_Store
 src/_assets/js/bundle.js

--- a/Dockerfile.apidocs
+++ b/Dockerfile.apidocs
@@ -10,10 +10,7 @@
 # The container will dump the generated documentation in markdown and JSON
 # formats into the /usr/src/output directory which you should mount as a volume
 #
-FROM python:2.7.11-slim
-
-RUN groupadd -r redis --gid=998 && useradd -r -g redis --uid=998 redis \
-    && groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
+FROM python:2.7.15-slim-jessie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         clang \
@@ -27,9 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxml2-dev \
         libxslt-dev \
         libyaml-dev \
-        llvm-3.5 \
+        llvm \
         bzip2 \
         make \
+        redis-server \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,10 +35,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PIP_NO_CACHE_DIR off
 ENV PIP_DISABLE_PIP_VERSION_CHECK on
 ENV PYTHONUNBUFFERED 1
-
-# Install Redis
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends redis-server
 
 RUN mkdir -p /usr/src/bin
 COPY scripts/build-api-docs /usr/bin

--- a/Dockerfile.apidocs
+++ b/Dockerfile.apidocs
@@ -1,0 +1,51 @@
+# Sentry api documentation generation environment
+#
+# Instructions:
+#
+#   Build the container:
+#     $ docker build -t sentry:apidocs -f Dockerfile.apidocs .
+#   Run the container:
+#     $ docker run --rm -v $(pwd):/usr/src/output sentry:apidocs
+#
+# The container will dump the generated documentation in markdown and JSON
+# formats into the /usr/src/output directory which you should mount as a volume
+#
+FROM python:2.7.11-slim
+
+RUN groupadd -r redis --gid=998 && useradd -r -g redis --uid=998 redis \
+    && groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        clang \
+        curl \
+        g++ \
+        gcc \
+        git \
+        libffi-dev \
+        libjpeg-dev \
+        libpq-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libyaml-dev \
+        llvm-3.5 \
+        bzip2 \
+        make \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Sane defaults for pip
+ENV PIP_NO_CACHE_DIR off
+ENV PIP_DISABLE_PIP_VERSION_CHECK on
+ENV PYTHONUNBUFFERED 1
+
+# Install Redis
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends redis-server
+
+RUN mkdir -p /usr/src/bin
+COPY scripts/build-api-docs /usr/bin
+
+WORKDIR /usr/src
+VOLUME /usr/src/output
+
+CMD [ "/usr/bin/build-api-docs" ]

--- a/bin/update-api-docs
+++ b/bin/update-api-docs
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+echo "--> Building docker image"
+docker build -t sentry:apidocs -f Dockerfile.apidocs .
+
+echo "--> Building API docs"
+mkdir -p apidocs
+docker run -v $(pwd)/apidocs:/usr/src/output sentry:apidocs
+
+echo "--> Moving API docs in-place"
+rm -rf src/collections/_documentation/api/{events,organizations,projects,releases,teams}
+cp -R apidocs/markdown/ src/collections/_documentation/api

--- a/bin/update-api-docs
+++ b/bin/update-api-docs
@@ -8,4 +8,4 @@ docker run -v $(pwd)/apidocs:/usr/src/output sentry:apidocs
 
 echo "--> Moving API docs in-place"
 rm -rf src/collections/_documentation/api/{events,organizations,projects,releases,teams}
-cp -R apidocs/markdown/ src/collections/_documentation/api
+cp -R apidocs/markdown/{events,organizations,projects,releaeses,teams} src/collections/_documentation/api

--- a/scripts/build-api-docs
+++ b/scripts/build-api-docs
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+echo "--> Fetching sentry source"
+curl https://codeload.github.com/getsentry/sentry/zip/master --silent --output sentry.zip
+unzip sentry.zip
+
+echo "--> Installing sentry dependencies"
+cd sentry-master
+
+export SENTRY_LIGHT_BUILD=1
+pip install -e '.[dev]'
+
+echo "--> Starting Redis"
+redis-server &
+
+echo "--> Building API docs"
+python api-docs/generator.py --output-path=/usr/src/output --output-format=both

--- a/scripts/build-api-docs
+++ b/scripts/build-api-docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "--> Fetching sentry source"
-curl https://codeload.github.com/getsentry/sentry/zip/master --silent --output sentry.zip
+curl -Ls https://github.com/getsentry/sentry/archive/master.zip --output sentry.zip
 unzip sentry.zip
 
 echo "--> Installing sentry dependencies"


### PR DESCRIPTION
Add a docker container that will allow us to build API docs in a docker host. The generated tar file will be uploaded to GCS where it can be consumed and integrated into the sentry-docs project.

Docs can be built with

```bash
docker build -t sentry:apidocs -f Dockerfile.apidocs
docker run --rm -v $(pwd)/apidocs:/usr/src/output sentry:apidocs
```

The generated markdown files can then be moved in place with

```bash
cp -R apidocs/markdown/* _site/api/
```

For the time being updating the API docs will be a manual on-demand process.

Refs getsentry/sentry#9643