### PR TITLE
perf: Remove globbing defaults

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,10 +52,6 @@ defaults:
     values:
       layout: dev/default
       permalink: /:path/
-  - scope:
-      path: collections/_dev_components/markdown-styleguide/*
-    values:
-      layout: doc
 
 assets:
   source_maps: false # Prefer webpack sourcemaps

--- a/src/collections/_dev_components/markdown-styleguide/links.md
+++ b/src/collections/_dev_components/markdown-styleguide/links.md
@@ -1,5 +1,6 @@
 ---
 title: Links
+layout: doc
 ---
 
 ```liquid


### PR DESCRIPTION
The ability to set defaults via file globs is super nice, but in the case of this pr, removing it takes 2s of a 3s build. This is a known issue with Jekyll.

This is a no-braininer considering the glob currently matches a single file.