### PR TITLE
fix: load google analytics on the page

### DIFF
--- a/src/_js/lib/Trackers.js
+++ b/src/_js/lib/Trackers.js
@@ -27,4 +27,14 @@ export const google = function() {
   }
   gtag('js', new Date());
   gtag('config', 'UA-47053361-1');
+
+  const script = document.createElement('script');
+  script.setAttribute(
+    'src',
+    'https://www.googletagmanager.com/gtag/js?id=UA-30327640-1'
+  );
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('async', true);
+  script.setAttribute('defer', true);
+  document.body.appendChild(script);
 };


### PR DESCRIPTION
Looks like I forgot to include the actual script link when moving google to the new docs