### PR TITLE
perf: update jekyll to improve speed when globbing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
-gem "jekyll", "3.8.2"
+# gem "jekyll", "3.8.2"
+gem "jekyll", :git =>"https://github.com/jekyll/jekyll.git", :ref => '72dc3a56f399e5c249b2645391ebfd37d4d8a578'
 gem "nokogiri", "1.8.3"
 
 # If you have any plugins, put them here!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: https://github.com/jekyll/jekyll.git
+  revision: 72dc3a56f399e5c249b2645391ebfd37d4d8a578
+  ref: 72dc3a56f399e5c249b2645391ebfd37d4d8a578
+  specs:
+    jekyll (3.8.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (>= 0.9.5, < 2)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,19 +44,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.2)
-      addressable (~> 2.4)
-      colorator (~> 1.0)
-      em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
-      jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
-      liquid (~> 4.0)
-      mercenary (~> 0.3.3)
-      pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
-      safe_yaml (~> 1.0)
     jekyll-assets (3.0.11)
       activesupport (~> 5.0)
       execjs (~> 2.7)
@@ -76,15 +82,15 @@ GEM
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rack (2.0.5)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rouge (3.1.1)
+    rouge (3.2.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.6)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -104,7 +110,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
-  jekyll (= 3.8.2)
+  jekyll!
   jekyll-assets (= 3.0.11)
   jekyll-extlinks
   liquid-md5

--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,10 @@ defaults:
     values:
       layout: dev/default
       permalink: /:path/
+  - scope:
+      path: collections/_dev_components/markdown-styleguide/*
+    values:
+      layout: doc
 
 assets:
   source_maps: false # Prefer webpack sourcemaps

--- a/src/collections/_dev_components/markdown-styleguide/links.md
+++ b/src/collections/_dev_components/markdown-styleguide/links.md
@@ -1,6 +1,5 @@
 ---
 title: Links
-layout: doc
 ---
 
 ```liquid


### PR DESCRIPTION
The jekyll team just pushed a fix for the very slow performance caused by globbing for defaults. It isn't in a numbered release yet, so this fixes us to the commit (well, one slightly after) so we can have the new stuff but not be attached to master itself.