### PR TITLE
ref: move relay and supercession info to new templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,16 @@ defaults:
     values:
       layout: doc
       permalink: /:path/
+  - scope:
+      path: collections/_documentation/clients/*
+      type: documentation
+    values:
+      layout: legacy-client
+  - scope:
+      path: collections/_documentation/relay/*
+      type: documentation
+    values:
+      layout: relay
 
   # Development mode collections. These exist here because placing them in
   # _config.dev.yml will clober the entire defaults object. The collections

--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -238,15 +238,6 @@
       wizard: true
       case_style: camelCase
       fallback_platform: javascript
-
--
-      slug: browsernpm
-      support_level: production
-      type: language
-      name: Browser Javascript NPM
-      doc_link: /clients/javascript/
-      case_style: camelCase
-      fallback_platform: javascript
 -
       slug: javascript
       support_level: production
@@ -265,6 +256,14 @@
       version_key: RAVEN_VERSION
       case_style: camelCase
       superseded_by: browser
+-
+      slug: browsernpm
+      support_level: production
+      type: language
+      name: Browser Javascript NPM
+      doc_link: /clients/javascript/
+      case_style: camelCase
+      fallback_platform: javascript
 -
       slug: vue
       support_level: production

--- a/src/_layouts/doc.html
+++ b/src/_layouts/doc.html
@@ -2,41 +2,6 @@
 layout: default
 ---
 
-
-{%- assign __is_active = page.url | url_starts_with: "/relay" %}
-{%- if __is_active %}
-  {% capture __alert_content -%}
-  Relay is currently in alpha.  Not all functionality is currently available and
-  the user experience did not receive the necessary polishing yet.
-  {%- endcapture -%}
-  {%- include components/alert.html
-    level="warning"
-    title="Alpha Functionality"
-    content=__alert_content
-  %}
-{%- endif %}
-
-{%- for platform in site.data.platforms -%}
-  {%- if platform.superseded_by %}
-    {%- assign __is_active = page.url | url_starts_with: platform.doc_link %}
-    {%- if __is_active %}
-      {%- assign __new_platform = site.data.platforms | where: 'slug', platform.superseded_by | first %}
-      {%- assign __quickstart_link = '/quickstart?platform=' | append: __new_platform.slug -%}
-      {% capture __alert_content -%}
-      This SDK has been superseded by a new unified one.  The documentation here is
-      preserved for customers using the old client.  For new projects have a look
-      at the new client documentation:
-      <a href="{{ __new_platform.doc_link | default: __quickstart_link }}">Unified {{ __new_platform.name }} SDK</a>.
-      {%- endcapture -%}
-      {%- include components/alert.html
-        level="info"
-        title="Deprecated Client"
-        content=__alert_content
-      %}
-    {%- endif %}
-  {%- endif %}
-{%- endfor %}
-
 {{content}}
 
 <aside>

--- a/src/_layouts/legacy-client.html
+++ b/src/_layouts/legacy-client.html
@@ -1,0 +1,29 @@
+---
+layout: doc
+---
+
+{%- capture where_exp -%}
+"{{ page.url }}" contains platform.doc_link
+{%- endcapture -%}
+{%- assign __page_platform = site.data.platforms
+  | where_exp: "platform", where_exp
+  | first
+-%}
+
+{%- if __page_platform.superseded_by -%}
+  {%- assign __new_platform = site.data.platforms | where: 'slug', __page_platform.superseded_by | first %}
+  {%- assign __quickstart_link = '/quickstart?platform=' | append: __new_platform.slug -%}
+  {% capture __alert_content -%}
+  This SDK has been superseded by a new unified one.  The documentation here is
+  preserved for customers using the old client.  For new projects have a look
+  at the new client documentation:
+  <a href="{{ __new_platform.doc_link | default: __quickstart_link }}">Unified {{ __new_platform.name }} SDK</a>.
+  {%- endcapture -%}
+  {%- include components/alert.html
+    level="info"
+    title="Deprecated Client"
+    content=__alert_content
+  %}
+{%- endif -%}
+
+{{ content }}

--- a/src/_layouts/relay.html
+++ b/src/_layouts/relay.html
@@ -1,0 +1,15 @@
+---
+layout: doc
+---
+
+{%- capture __alert_content -%}
+Relay is currently in alpha. Not all functionality is currently available and
+the the user experience has not received the necessary polishing yet.
+{%- endcapture -%}
+{%- include components/alert.html
+  level="warning"
+  title="Alpha Functionality"
+  content=__alert_content
+%}
+
+{{ content }}


### PR DESCRIPTION
Since the docs have to build 380+ files, I'm working to reduce the places we globally do computation. In this case, I've created new layouts for the Relay and legacy client docs so we can keep those evaluations to a limited group of documents.

While I was here, I cleaned up the query for the page platform because the loop made things a little challenging comprehend.

Note, I moved the position of the `browsernpm` platform because two platforms have `doc_link: /clients/javascript/` and browsernpm was coming up first. I'm surprised the previous version didn't have the same problem.