### PR TITLE
fix: Remove uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :jekyll_plugins do
   }
   gem 'jekyll-assets', '3.0.11'
   gem 'terminal-notifier'
-  gem 'uglifier'
   gem 'autoprefixer-rails'
   gem 'jekyll-extlinks'
   gem 'liquid-md5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,6 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.6)
-      execjs (>= 0.3.0, < 3)
     yell (2.0.7)
 
 PLATFORMS
@@ -135,7 +133,6 @@ DEPENDENCIES
   sprockets (~> 4.0.beta)
   terminal-notifier
   tzinfo-data
-  uglifier
 
 BUNDLED WITH
    1.16.3


### PR DESCRIPTION
uglifier is unable to parse the JS changes commit
c784cdfda5da54feed6666abea3165adca6f0486. Particularly the variable name
`anchor` is somehow not accepted.