### PR TITLE
Show user's own DSN in User Feedback example

### DIFF
--- a/src/collections/_documentation/clients/php/integrations/laravel.md
+++ b/src/collections/_documentation/clients/php/integrations/laravel.md
@@ -103,7 +103,7 @@ Next, create `resources/views/errors/500.blade.php`, and embed the feedback code
             Raven.showReportDialog({
                 eventId: '{{ Sentry::getLastEventID() }}',
                 // use the public DSN (dont include your secret!)
-                dsn: 'https://e9ebbd88548a441288393c457ec90441@sentry.io/3235',
+                dsn: '___PUBLIC_DSN___',
                 user: {
                     'name': 'Jane Doe',
                     'email': 'jane.doe@example.com',


### PR DESCRIPTION
In User Feedback example, a test DSN is being showed rather than the actual one.
It should show user's own DSN, same as in *Add your DSN to .env* step.