### PR TITLE
ref: simplify DynamicLoad

### DIFF
--- a/src/_js/lib/DynamicLoad.js
+++ b/src/_js/lib/DynamicLoad.js
@@ -1,112 +1,77 @@
 import { fullPath } from './Helpers';
 
-let currentPathName = document.location.pathname;
-
-const replaceContent = function(html) {
-  const $page = $(html.replace('<!DOCTYPE html>', ''));
-  const $new = $page.find('[data-dynamic-load]');
-  const $title = $page.filter('title').eq(0);
-  $('head title').text($title.text());
-
-  $new.each(function(i, el) {
-    const $el = $(el);
-    const slug = $el.data('dynamic-load');
-    const content = $el.html();
-    $(`[data-dynamic-load="${slug}"]`).html(content);
-  });
+const isDifferentDomain = function(here, there) {
+  return here.protocol !== there.protocol && here.host !== there.host;
 };
 
-const isSameDomain = function(here, there) {
-  return here.protocol === there.protocol && here.host === there.host;
+const isSamePage = function(here, there) {
+  return here.pathname === there.pathname && here.host === there.host;
 };
 
-const defaultLoader = function(url) {
-  if (url.pathname === currentPathName) return Promise.resolve();
-  return $.ajax({ type: 'GET', url: fullPath(url) });
-};
+const load = function(url, pushState) {
+  $('body').addClass('loading');
 
-class DynamicLoader {
-  constructor() {
-    this.loaders = {};
+  $.ajax({ type: 'GET', url: fullPath(url) })
+    .then(html => {
+      // Expose the jQuery object via an event for pre-render manipulation
+      const $page = $(html.replace('<!DOCTYPE html>', ''));
+      $(document).trigger('page.willUpdate', $page);
 
-    this.init = this.init.bind(this);
-    this.addLoader = this.addLoader.bind(this);
-    this.load = this.load.bind(this);
-  }
+      // Update the title
+      const $title = $page.filter('title').eq(0);
+      $('head title').text($title.text());
 
-  init() {
-    $(document).on(
-      'click',
-      '[data-dynamic-load] a:not([data-not-dynamic])',
-      event => {
-        if (event.ctrlKey || event.metaKey) return;
-        if (!isSameDomain(window.location, event.currentTarget)) return;
-        event.preventDefault();
-        this.load(event.currentTarget, true);
-      }
-    );
+      // Update each dynamic section
+      $page.find('[data-dynamic-load]').each(function(i, el) {
+        const $el = $(el);
+        const slug = $el.data('dynamic-load');
+        const content = $el.html();
+        $(`[data-dynamic-load="${slug}"]`).html(content);
+      });
 
-    $(window).on('popstate', event => {
-      const { pathname, hash, search } = document.location;
-      this.load({ pathname, hash, search }, false);
-    });
-  }
-
-  addLoader(path, handler) {
-    this.loaders[path] = handler;
-  }
-
-  load(url, pushState) {
-    const keys = Object.keys(this.loaders);
-    let matched = false;
-    let i = 0;
-    let loader = defaultLoader;
-
-    while (i < keys.length && !matched) {
-      const pathTest = keys[i];
-      matched = new RegExp(pathTest, 'i').test(fullPath(url));
-      if (matched) loader = this.loaders[pathTest];
-      i++;
-    }
-
-    const { pathname, hash, search } = url;
-    const done = function() {
-      // Send reload a pageview if this is a new page
-      if (pathname !== location.pathname) {
-        window.ra.page();
-        $('[data-feedback-toggle] label').removeClass('active');
-      }
-
-      // Update history if necessary
       if (pushState) {
         window.history.pushState(null, document.title, fullPath(url));
       }
 
-      // Handle vertical scroll position of new content
-      if (hash) {
-        const $el = $(hash).get(0);
-        if ($el) $el.scrollIntoView();
-      } else {
-        $('.main-scroll').scrollTop(0);
-      }
-
-      currentPathName = pathname;
-      $('#sidebar').collapse('hide');
+      $('body').removeClass('loading');
       $(document).trigger('page.didUpdate');
-    };
+    })
+    .catch(error => {
+      window.location = fullPath(url);
+    });
+};
 
-    $('body').addClass('loading');
-    loader({ pathname, hash, search })
-      .then(html => {
-        $(document).trigger('page.willUpdate');
-        $('body').removeClass('loading');
-        if (html) replaceContent(html);
-        done();
-      })
-      .catch(error => {
-        window.location = fullPath(url);
-      });
+$(document).on('click', '[data-dynamic-load] a', function(event) {
+  switch (true) {
+    // Just follow the default behavior in these scenarios
+    case event.ctrlKey:
+    case event.metaKey:
+    case isDifferentDomain(window.location, event.currentTarget):
+    case isSamePage(window.location, event.currentTarget):
+      return;
+    // Load the content if this is a new page within the site.
+    default:
+      event.preventDefault();
+      load(event.currentTarget, true);
+      // Send reload a pageview
+      window.ra.page();
   }
-}
+});
 
-export default new DynamicLoader();
+$(window).on('popstate', event => {
+  load(document.location);
+});
+
+$(document).on('page.didUpdate', function(event) {
+  // Handle vertical scroll position of new content
+  const hash = window.location.hash.replace('#', '');
+  if (hash) {
+    const $el = $(hash).get(0);
+    if ($el) $el.scrollIntoView();
+  } else {
+    $('.main-scroll').scrollTop(0);
+  }
+
+  // Collapse the mobile sidebar
+  $('#sidebar').collapse('hide');
+});

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -1,3 +1,4 @@
+// Send an event to reload whenever a feedback button is clicked
 $(document).on('change', '[data-feedback-toggle]', function(event) {
   event.preventDefault();
   const $el = $(event.currentTarget);
@@ -5,4 +6,9 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
   window.ra.event('docs.feedback-sent', {
     useful: $selected.val()
   });
+});
+
+// Reset the feedback widget for the new page
+$(document).on('page.didUpdate', function(event) {
+  $('[data-feedback-toggle] label').removeClass('active');
 });

--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -167,9 +167,6 @@ $(document).on('click', '[data-toggle="platform"]', function(event) {
 });
 
 $(document).on('page.didUpdate', function(event) {
-  // cameron help me. why do i need to do this -- mitsuhiko
-  $('a[href^="?platform"]').attr('data-not-dynamic', '1');
-
   // Update the preferredPlatform based on the url.
   showPlatform(qs.parse(location.search).platform);
 });

--- a/src/_js/lib/Search.js
+++ b/src/_js/lib/Search.js
@@ -41,7 +41,6 @@ class Search {
     this.pageTemplate = $('html').html();
 
     this.init = this.init.bind(this);
-    this.loader = this.loader.bind(this);
 
     this.$target = $target;
     this.Lunr = new Lunr({
@@ -63,20 +62,6 @@ class Search {
 
     return this.Lunr.search(params.q).then(results => {
       $('[data-search-results]').append(renderResults(results, params.q));
-    });
-  }
-
-  // This is a loader for DynamicLoader. It generates a full HTML page that
-  // DynamicLoader can parse.
-  loader(url) {
-    const { search } = url;
-    const params = qs.parse(search);
-    return fetchResults(params).then(res => {
-      const $page = $(this.pageTemplate);
-      return $page
-        .find('[data-search-results]')
-        .append(renderResults(res, params))
-        .html();
     });
   }
 }

--- a/src/_js/main.js
+++ b/src/_js/main.js
@@ -3,8 +3,8 @@ import 'bootstrap';
 import UserContent from './lib/UserContent';
 import Tracking from './lib/Tracking';
 import User from './lib/User';
-import DynamicLoad from './lib/DynamicLoad';
 import Search from './lib/Search';
+import './lib/DynamicLoad';
 import './lib/PlatformContent';
 import './lib/HeaderLinker';
 import './lib/Feedback';
@@ -27,8 +27,6 @@ $(function() {
   UserContent.init();
   Tracking.init();
   Search.init();
-  DynamicLoad.init();
-  DynamicLoad.addLoader('^/search/', Search.loader);
 
   window.User = new User();
   window.User.init();


### PR DESCRIPTION
My reviewer choices are arbitrary, please review if you feel relevant to do so.

DynamicLoad was beginning to feel too complicated and the confusion was causing bugs. This refactor simplifies the logic to try to make it a little easier to understand. Now:

- I removed the loaders concept (methods of handling different urls).
- Rather than listening for all anchor clicks, it only responds when a click:
  - Does not have a meta key pressed
  - Is not an external url
  - Is not on the same page
- In all the cases above, the default behavior is followed, that is, meta key links open in new tabs, external urls are followed, and links on the same page (like hashes) use the browser behavior or (like `#` links used as buttons) follow whatever their given event handler does.
- I moved the Reload page view and feedback stuff to event handlers on `page.didUpdate` to make them easier to understand in the lifecycle.

With something this crucial I want to get tests on it, but I couldn't manage to listen to the custom jquery events with jest. I'll swing back around on that at some point.

