### PR TITLE
fix: Only show platform query on pages with platform content

### DIFF
--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -167,6 +167,7 @@ $(document).on('click', '[data-toggle="platform"]', function(event) {
 });
 
 $(document).on('page.didUpdate', function(event) {
+  if (!$('[data-platform-specific-content]').length) return
   // cameron help me. why do i need to do this -- mitsuhiko
   $('a[href^="?platform"]').attr('data-not-dynamic', '1');
 

--- a/src/_js/lib/PlatformContent.js
+++ b/src/_js/lib/PlatformContent.js
@@ -167,7 +167,7 @@ $(document).on('click', '[data-toggle="platform"]', function(event) {
 });
 
 $(document).on('page.didUpdate', function(event) {
-  if (!$('[data-platform-specific-content]').length) return
+  if (!$('[data-platform-specific-content]').length) return;
   // cameron help me. why do i need to do this -- mitsuhiko
   $('a[href^="?platform"]').attr('data-not-dynamic', '1');
 


### PR DESCRIPTION
It's kind of weird seeing a url like /platforms/go?platform=python. This disables the automatic addition of the platform slug on pages that don't have platform content, since the slug serves only as a helper to either force a platform to display or to provide a permalink to a page with a platform shown.