### PR TITLE
fix: Add more links

### DIFF
--- a/src/collections/_documentation/learn/getting-started-next-steps/csharp.md
+++ b/src/collections/_documentation/learn/getting-started-next-steps/csharp.md
@@ -1,0 +1,1 @@
+-  [_integrating with the .NET ecosystem_]({% link _documentation/platforms/dotnet/index.md %})

--- a/src/collections/_documentation/learn/getting-started-next-steps/javascript.md
+++ b/src/collections/_documentation/learn/getting-started-next-steps/javascript.md
@@ -1,0 +1,1 @@
+-  [_integrating with the Javascript ecosystem_]({% link _documentation/platforms/javascript/index.md %})

--- a/src/collections/_documentation/learn/getting-started-next-steps/python.md
+++ b/src/collections/_documentation/learn/getting-started-next-steps/python.md
@@ -1,0 +1,1 @@
+-  [_integrating with the Python ecosystem_]({% link _documentation/platforms/python/index.md %})

--- a/src/collections/_documentation/learn/getting-started-next-steps/rust.md
+++ b/src/collections/_documentation/learn/getting-started-next-steps/rust.md
@@ -1,0 +1,1 @@
+-  [_integrating with the Rust ecosystem_]({% link _documentation/platforms/rust/index.md %})

--- a/src/collections/_documentation/learn/quickstart.md
+++ b/src/collections/_documentation/learn/quickstart.md
@@ -61,6 +61,7 @@ Note: If you’re using Heroku, and you’ve added Hosted Sentry via the standar
 
 Now that you’ve got basic reporting setup, you’ll want to explore adding additional context to your data.
 
+{% include components/platform_content.html content_dir='getting-started-next-steps' %}
 -   [_manual error and event capturing_]({%- link _documentation/learn/capturing.md -%})
 -   [_configuration options_]({%- link _documentation/learn/configuration.md -%})
 -   [_identifying users via context_]({%- link _documentation/learn/context.md -%})

--- a/src/collections/_documentation/platforms/dotnet/index.md
+++ b/src/collections/_documentation/platforms/dotnet/index.md
@@ -7,7 +7,14 @@ sidebar_order: 10
 
 This section will describe features, configurations and general functionality which are specific to the .NET SDK.
 
-# Compatibility
+## Integrations
+
+- [_ASP.NET Core_]({% link _documentation/platforms/dotnet/aspnetcore.md %})
+- [_EntityFramework_]({% link _documentation/platforms/dotnet/entityframework.md %})
+- [_log4net_]({% link _documentation/platforms/dotnet/log4net.md %})
+- [_Microsoft.Extensions.Logging_]({% link _documentation/platforms/dotnet/microsoft-extensions-logging.md %})
+
+## Compatibility
 
 The main [Sentry NuGet package](https://www.nuget.org/packages/Sentry) targets .NET Standard 2.0. That means, according to the [compatibility table](https://docs.microsoft.com/en-us/dotnet/standard/net-standard), it is compatible with the following versions or newer:
 

--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -33,6 +33,7 @@ the following are supported:
 
 In addition to framework integrations there are also a few other integrations:
 
+* [AWS Lambda]({% link _documentation/platforms/python/aws_lambda.md %})
 * [Default integrations]({% link _documentation/platforms/python/default-integrations.md %})
 
 ## Hints


### PR DESCRIPTION
- [x] check each platform if it links to all integrations (*fixed: ignored javascript for now*)
- [x] check with @bruno-garcia  if platform naming mismatch `csharp` vs `dotnet` is intentional