### PR TITLE
fix: Document sentry-cli upload-sourcemaps --ext correctly

### DIFF
--- a/src/collections/_documentation/learn/cli/releases.md
+++ b/src/collections/_documentation/learn/cli/releases.md
@@ -127,7 +127,7 @@ The following options exist to change the behavior of the upload command:
 
 `--ext`
 
-: Overrides the list of file extensions to upload. By default the following file extensions are processed: `js`, `map`, `jsbundle` and `bundle`. The tool will automatically detect the type of the file by the file contents (eg: sources, minified sources, and source maps) and act appropriately.
+: Overrides the list of file extensions to upload. By default the following file extensions are processed: `js`, `map`, `jsbundle` and `bundle`. The tool will automatically detect the type of the file by the file contents (eg: sources, minified sources, and source maps) and act appropriately. For multiple extensions you need to repeat the option, e.g.: `--ext js --ext map`.
 
 `--ignore`
 

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -181,7 +181,7 @@ $ sentry-cli releases files <release_name> upload-sourcemaps /path/to/files
 This command will upload all files ending in _.js_ and _.map_ to the specified release. If you wish to change these extensions – e.g. to upload typescript sources – use the `--ext` option:
 
 ```sh
-$ sentry-cli releases files <release_name> upload-sourcemaps --ext ts,map /path/to/files
+$ sentry-cli releases files <release_name> upload-sourcemaps --ext ts --ext map /path/to/files
 ```
 
 {% capture __alert_content -%}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cli/issues/398