### PR TITLE
Fix JS example for setExtra

### DIFF
--- a/src/collections/_documentation/learn/set-extra/javascript.md
+++ b/src/collections/_documentation/learn/set-extra/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
 Sentry.configureScope((scope) => {
-  scope.setExtra("{{ page.example_extra_key }}": "{{ page.example_extra_value }}");
+  scope.setExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}");
 });
 ```


### PR DESCRIPTION
The signature being `public setExtra(key: string, extra: any): Scope`