### PR TITLE
fix: require raven via wepack rather than env

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -6,7 +6,7 @@ const env = getClientEnvironment();
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
-  entry: ['./src/_js/main.js'],
+  entry: ['./src/_js/raven.js', './src/_js/main.js'],
   output: {
     filename: 'bundle.js',
     path: path.resolve(process.cwd(), 'src/_assets/js/')

--- a/src/_js/main.js
+++ b/src/_js/main.js
@@ -1,4 +1,3 @@
-import Raven from 'raven-js';
 import 'bootstrap';
 import UserContent from './lib/UserContent';
 import Tracking from './lib/Tracking';
@@ -9,11 +8,6 @@ import './lib/PlatformContent';
 import './lib/HeaderLinker';
 import './lib/Feedback';
 import './lib/Sidebar';
-
-if (process.env.NODE_ENV === 'production') {
-  const dsn = 'https://ad63ba38287245f2803dc220be959636@sentry.io/1267915';
-  Raven.config(dsn).install();
-}
 
 $(document).on('page.willUpdate', function(event) {
   $('[data-toggle="tooltip"]').tooltip('dispose');

--- a/src/_js/raven.js
+++ b/src/_js/raven.js
@@ -1,0 +1,3 @@
+import Raven from 'raven-js';
+const dsn = 'https://ad63ba38287245f2803dc220be959636@sentry.io/1267915';
+Raven.config(dsn).install();


### PR DESCRIPTION
I guess we must not have `NODE_ENV` set when building for production, so this makes webpack compile raven in the production bundle 