### PR TITLE
(ref) Remove 'admin' from list of users who can edit global integrations

### DIFF
--- a/src/collections/_documentation/product/membership.md
+++ b/src/collections/_documentation/product/membership.md
@@ -24,7 +24,7 @@ Roles include:
 | Can join and leave teams. |   | X | X | X | X |
 | Can change Project Settings |   |   | X | X | X |
 | Can add/remove projects |   |   | X | X | X |
-| Can edit Global Integrations |   |   | X | X | X |
+| Can edit Global Integrations |   |   |   | X | X |
 | Can add/remove/change members |   |   |   | X | X |
 | Can add/remove teams |   |   |   | X | X |
 | Can add Repositories |   |   |   | X | X |


### PR DESCRIPTION
Admins can't actually edit global integrations, so remove this from the membership table. 

Fixes SE-123