### PR TITLE
fix (sidebar): Add trailing slash to sidebar urls

### DIFF
--- a/src/_js/lib/Search.js
+++ b/src/_js/lib/Search.js
@@ -4,7 +4,7 @@ import Lunr from './Lunr';
 const renderResult = function(data) {
   const relativePath = data.path.replace(/^\/|\/$/g, '');
 
-  const url = `${window.location.origin}/${relativePath}`;
+  const url = `${window.location.origin}/${relativePath}/`;
   const path = relativePath
     .split(/[#\/]/)
     .map(segment => {


### PR DESCRIPTION
This fixes an issue where navigating to a page from search results does not expand the right sidebar item.