### PR TITLE
fix: escape selectors that come in via url

### DIFF
--- a/src/_js/lib/DynamicLoad.js
+++ b/src/_js/lib/DynamicLoad.js
@@ -80,7 +80,7 @@ class DynamicLoad {
   didUpdateHandler(event) {
     // Handle vertical scroll position of new content
     const hash = window.location.hash.replace('#', '');
-    if (hash) {
+    if ($.escapeSelector(hash)) {
       const $el = $(hash).get(0);
       if ($el) $el.scrollIntoView();
     } else {


### PR DESCRIPTION
This resolves the error caught here https://sentry.io/sentry/docs/issues/704848976

This smells of a larger issue though. Every inbound url has a trailing slash. The bug is caused because urls with deep links that are followed by a slash (i.e. `foo.com/bar/#bat/`). Some examples:

`https://docs.sentry.io/clients/python/api/?_ga=2.3661040.1934881031.1537935378-1489403293.1529895449#api-reference/`

`https://docs.sentry.io/ip-ranges/?platform=javascript#ip-ranges?platform=javascript`

`https://docs.sentry.io/clients/javascript/install/#installation/`

I've checked the codebase and don't see any obvious places where we are appending slashes that would cause this.