### PR TITLE
Export SentryErrorHandler class

### DIFF
--- a/src/collections/_documentation/platforms/javascript/angular.md
+++ b/src/collections/_documentation/platforms/javascript/angular.md
@@ -21,7 +21,7 @@ Sentry.init({
 });
 
 @Injectable()
-class SentryErrorHandler implements ErrorHandler {
+export class SentryErrorHandler implements ErrorHandler {
   constructor() {}
   handleError(error) {
     Sentry.captureException(error.originalError || error);


### PR DESCRIPTION
This solves the 'references to a non-exported class are not supported in decorators...' error when building angular application.