### PR TITLE
doc: attach_stacktrace is supported in Python

### DIFF
--- a/src/collections/_documentation/learn/configuration.md
+++ b/src/collections/_documentation/learn/configuration.md
@@ -60,7 +60,6 @@ to `100`.
 {:.config-key}
 ### attach-stacktrace
 
-{% unsupported python %}
 When enabled, stacktraces are automatically attached to all messages logged.  Note that stacktraces
 are always attached to exceptions but when this is set stacktraces are also sent with messages.  This, for instance, means that stacktraces appear next to all log messages.
 
@@ -68,7 +67,6 @@ It's important to note that grouping in Sentry is different for events with stac
 This means that you will get new groups as you enable or disable this flag for certain events.
 
 This feature is `off` by default.
-{% endunsupported %}
 
 {:.config-key}
 ### send-default-pii


### PR DESCRIPTION
supported since 0.3.10, see https://github.com/getsentry/sentry-python/blob/master/CHANGES.md#0310