### PR TITLE
fix: Add dismiss feedback functionality

### DIFF
--- a/src/_includes/feedback_footer.html
+++ b/src/_includes/feedback_footer.html
@@ -3,14 +3,18 @@
     Was this page helpful to you?
   </div>
   <div class="col-6 text-right">
-    <div class="btn-group btn-group-toggle" data-toggle="buttons" data-feedback-toggle>
-      <label class="btn flex-fill btn-outline-secondary btn-sm px-3">
-        <input name="feedback" autocomplete="off" type="radio"  value=1> Yes
-      </label>
-      <label class="btn flex-fill btn-outline-secondary btn-sm px-3">
-        <input name="feedback" autocomplete="off" type="radio" value=0> No
-      </label>
+    <div class="d-flex align-items-center justify-content-end">
+      <div class="btn-group btn-group-toggle" data-toggle="buttons" data-feedback-toggle>
+        <label class="btn flex-fill btn-outline-secondary btn-sm px-3">
+          <input name="feedback" autocomplete="off" type="radio"  value=1> Yes
+        </label>
+        <label class="btn flex-fill btn-outline-secondary btn-sm px-3">
+          <input name="feedback" autocomplete="off" type="radio" value=0> No
+        </label>
+      </div>
+      <button type="button" class="close ml-2" aria-label="Close" data-feedback-close>
+        <span aria-hidden="true">&times;</span>
+      </button>
     </div>
-    <button type="button" feedback-close>x</button>
   </div>
 </div>

--- a/src/_includes/feedback_footer.html
+++ b/src/_includes/feedback_footer.html
@@ -11,5 +11,6 @@
         <input name="feedback" autocomplete="off" type="radio" value=0> No
       </label>
     </div>
+    <button type="button" feedback-close>x</button>
   </div>
 </div>

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -1,4 +1,3 @@
-var obj = document.getElementsByClassName('feedback-footer')[0];
 
 // Send an event to reload whenever a feedback button is clicked
 $(document).on('change', '[data-feedback-toggle]', function(event) {
@@ -8,29 +7,35 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
   window.ra.event('docs.feedback-sent', {
     useful: parseInt($selected.val(), 10)
   });
-  obj.style.display="none";
+  $('.feedback-footer').addClass('d-none');
 });
 
 // Send an event to reload whenever a feedback button is dismissed
-$(document).on('click', '[feedback-close]', function(event) {
+$(document).on('click', '[data-feedback-close]', function(event) {
+
   event.preventDefault();
   window.ra.event('docs.feedback-dismissed');
-  obj.style.display="none";
+  $('.feedback-footer').addClass('d-none');
   dismissFeedback()
 });
 
 // Reset the feedback widget for the new page
 $(document).on('page.didUpdate', function(event) {
-	const dismissFeedback = window.localStorage.getItem('dismissFeedback');
+	const dismissTimestamp = window.localStorage.getItem('dismissTimestamp');
 
-	if(dismissFeedback === 'true'){
-		obj.style.display = "none";
+	if(dismissTimestamp && !pastDismissWindow(dismissTimestamp)){
+    $('.feedback-footer').addClass('d-none');
 	 } else {
-		obj.style.display = "";
-		$('[data-feedback-toggle] label').removeClass('active');
+    $('.feedback-footer').removeClass('d-none');
+    $('[data-feedback-toggle] label').removeClass('active');
 	 }
 });
 
 var dismissFeedback = function() {
-	window.localStorage.setItem('dismissFeedback', 'true')
+	window.localStorage.setItem('dismissTimestamp', Date.now())
+};
+
+// dismiss for 30mins
+var pastDismissWindow = function(dismissTimestamp) {
+  return ((Date.now() - dismissTimestamp)/ (1000*60)) > 30;
 };

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -6,9 +6,21 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
   window.ra.event('docs.feedback-sent', {
     useful: parseInt($selected.val(), 10)
   });
+  dismissFeedback()
 });
 
 // Reset the feedback widget for the new page
 $(document).on('page.didUpdate', function(event) {
-  $('[data-feedback-toggle] label').removeClass('active');
+	const showFeedback = window.localStorage.getItem('showFeedback');
+	if(!showFeedback){
+		$(".feedback-footer").remove();
+	} else{
+		$('[data-feedback-toggle] label').removeClass('active');
+  }
 });
+
+// dismiss the footer if they send feedback or close it out
+var dismissFeedback = function() {
+	window.localStorage.setItem('showFeedback', 'false')
+	$(".feedback-footer").remove();
+};

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -12,7 +12,6 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
 
 // Send an event to reload whenever a feedback button is dismissed
 $(document).on('click', '[data-feedback-close]', function(event) {
-
   event.preventDefault();
   window.ra.event('docs.feedback-dismissed');
   $('.feedback-footer').addClass('d-none');
@@ -21,18 +20,18 @@ $(document).on('click', '[data-feedback-close]', function(event) {
 
 // Reset the feedback widget for the new page
 $(document).on('page.didUpdate', function(event) {
-	const dismissTimestamp = window.localStorage.getItem('dismissTimestamp');
+  const dismissTimestamp = window.localStorage.getItem('dismissTimestamp');
 
   if(dismissTimestamp && !pastDismissWindow(dismissTimestamp)){
     $('.feedback-footer').addClass('d-none');
   } else {
     $('.feedback-footer').removeClass('d-none');
     $('[data-feedback-toggle] label').removeClass('active');
-	}
+  }
 });
 
 var dismissFeedback = function() {
-	window.localStorage.setItem('dismissTimestamp', Date.now())
+  window.localStorage.setItem('dismissTimestamp', Date.now())
 };
 
 // dismiss for 30mins

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -1,3 +1,5 @@
+var obj = document.getElementsByClassName('feedback-footer')[0];
+
 // Send an event to reload whenever a feedback button is clicked
 $(document).on('change', '[data-feedback-toggle]', function(event) {
   event.preventDefault();
@@ -6,21 +8,29 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
   window.ra.event('docs.feedback-sent', {
     useful: parseInt($selected.val(), 10)
   });
+  obj.style.display="none";
+});
+
+// Send an event to reload whenever a feedback button is dismissed
+$(document).on('click', '[feedback-close]', function(event) {
+  event.preventDefault();
+  window.ra.event('docs.feedback-dismissed');
+  obj.style.display="none";
   dismissFeedback()
 });
 
 // Reset the feedback widget for the new page
 $(document).on('page.didUpdate', function(event) {
-	const showFeedback = window.localStorage.getItem('showFeedback');
-	if(!showFeedback){
-		$(".feedback-footer").remove();
-	} else{
+	const dismissFeedback = window.localStorage.getItem('dismissFeedback');
+
+	if(dismissFeedback === 'true'){
+		obj.style.display = "none";
+	 } else {
+		obj.style.display = "";
 		$('[data-feedback-toggle] label').removeClass('active');
-  }
+	 }
 });
 
-// dismiss the footer if they send feedback or close it out
 var dismissFeedback = function() {
-	window.localStorage.setItem('showFeedback', 'false')
-	$(".feedback-footer").remove();
+	window.localStorage.setItem('dismissFeedback', 'true')
 };

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -7,14 +7,14 @@ $(document).on('change', '[data-feedback-toggle]', function(event) {
   window.ra.event('docs.feedback-sent', {
     useful: parseInt($selected.val(), 10)
   });
-  $('.feedback-footer').addClass('d-none');
+  $('.js-feedback-footer').addClass('d-none');
 });
 
 // Send an event to reload whenever a feedback button is dismissed
 $(document).on('click', '[data-feedback-close]', function(event) {
   event.preventDefault();
   window.ra.event('docs.feedback-dismissed');
-  $('.feedback-footer').addClass('d-none');
+  $('.js-feedback-footer').addClass('d-none');
   dismissFeedback()
 });
 
@@ -23,9 +23,9 @@ $(document).on('page.didUpdate', function(event) {
   const dismissTimestamp = window.localStorage.getItem('dismissTimestamp');
 
   if(dismissTimestamp && !pastDismissWindow(dismissTimestamp)){
-    $('.feedback-footer').addClass('d-none');
+    $('.js-feedback-footer').addClass('d-none');
   } else {
-    $('.feedback-footer').removeClass('d-none');
+    $('.js-feedback-footer').removeClass('d-none');
     $('[data-feedback-toggle] label').removeClass('active');
   }
 });

--- a/src/_js/lib/Feedback.js
+++ b/src/_js/lib/Feedback.js
@@ -23,12 +23,12 @@ $(document).on('click', '[data-feedback-close]', function(event) {
 $(document).on('page.didUpdate', function(event) {
 	const dismissTimestamp = window.localStorage.getItem('dismissTimestamp');
 
-	if(dismissTimestamp && !pastDismissWindow(dismissTimestamp)){
+  if(dismissTimestamp && !pastDismissWindow(dismissTimestamp)){
     $('.feedback-footer').addClass('d-none');
-	 } else {
+  } else {
     $('.feedback-footer').removeClass('d-none');
     $('[data-feedback-toggle] label').removeClass('active');
-	 }
+	}
 });
 
 var dismissFeedback = function() {

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -41,7 +41,7 @@
           </section>
         </div>
 
-        <footer class="border-top bg-white px-3 py-2 flex-grow-0 feedback-footer">
+        <footer class="border-top bg-white px-3 py-2 flex-grow-0 d-none feedback-footer">
           {% include feedback_footer.html %}
         </footer>
       </main>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -41,7 +41,7 @@
           </section>
         </div>
 
-        <footer class="border-top bg-white px-3 py-2 flex-grow-0 d-none feedback-footer">
+        <footer class="border-top bg-white px-3 py-2 flex-grow-0 d-none js-feedback-footer">
           {% include feedback_footer.html %}
         </footer>
       </main>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -41,7 +41,7 @@
           </section>
         </div>
 
-        <footer class="border-top bg-white px-3 py-2 flex-grow-0">
+        <footer class="border-top bg-white px-3 py-2 flex-grow-0 feedback-footer">
           {% include feedback_footer.html %}
         </footer>
       </main>


### PR DESCRIPTION
This PR aims to:
1) hide footer on page after feedback given
2) add an `x' out of feedback bar option. (Dismisses for 30minutes)

To Do
- [x] remove border around the button

![feedback_footer](https://user-images.githubusercontent.com/16228317/47326087-f0f74c80-d61b-11e8-9287-5dd5d6ae001c.gif)