### PR TITLE
Correct DogStatsD metrics backend parameters

### DIFF
--- a/src/collections/_documentation/server/internal-metrics.md
+++ b/src/collections/_documentation/server/internal-metrics.md
@@ -53,8 +53,8 @@ $ pip install datadog
 ```python
 SENTRY_METRICS_BACKEND = 'sentry.metrics.datadog.DogStatsdMetricsBackend'
 SENTRY_METRICS_OPTIONS = {
-    'host': 'localhost',
-    'port': 8125,
+    'statsd_host': 'localhost',
+    'statsd_port': 8125,
     'tags': {},
 }
 ```


### PR DESCRIPTION
The parameters provided in `SENTRY_METRICS_OPTIONS` are provided as is (with the
exception of `tags`) to the `initialize()` of the datadog library:
https://github.com/getsentry/sentry/blob/872802a7934803ca3e46ca984bf77be2aa16efbd/src/sentry/metrics/dogstatsd.py#L14

That function does however not know about either the `host` or `port` arguments,
meaning that using the configuration specified in the documentation won't have
the intended consequences:
https://github.com/DataDog/datadogpy/blob/d575171bf38ad5841f2fab474193e17e50fa5974/datadog/__init__.py#L32

This fixes that by changing the key names to have the `statsd_` prefix which is
what the datadog library expects.