### PR TITLE
Add a note regarding event limit on Context page

### DIFF
--- a/src/collections/_documentation/learn/context.md
+++ b/src/collections/_documentation/learn/context.md
@@ -86,5 +86,5 @@ In addition to the structured context that Sentry understands, you can send arbi
 {% include components/platform_content.html content_dir='set-extra' %}
 
 **Be aware of maximum payload size** - There are times, when you may want to send the whole application state as extra data.
-This can be quite a large object, which can easily weigh more than 200kB. This 200kB is currently the maximum payload size of a single event you can send to Sentry.
+This is not recommended as application state can be very large and easily exceed the 200kB maximum that Sentry has on individual event payloads.
 When this happens, you'll get an `HTTP Error 413 Payload Too Large` message as the server response or (when `keepalive: true` is set as `fetch` parameter), the request will stay in the `pending` state forever (eg. in Chrome).

--- a/src/collections/_documentation/learn/context.md
+++ b/src/collections/_documentation/learn/context.md
@@ -84,3 +84,7 @@ Additionally you can provide arbitrary key/value pairs beyond the reserved names
 In addition to the structured context that Sentry understands, you can send arbitrary key/value pairs of data which will be stored alongside the event. These are not indexed and are simply used to add additional information about what might be happening:
 
 {% include components/platform_content.html content_dir='set-extra' %}
+
+**Be aware of maximum payload size** - There are times, when you may want to send the whole application state as extra data.
+This can be quite a large object, which can easily weigh more than 200kB. This 200kB is currently the maximum payload size of a single event you can send to Sentry.
+When this happens, you'll get an `HTTP Error 413 Payload Too Large` message as the server response or (when `keepalive: true` is set as `fetch` parameter), the request will stay in the `pending` state forever (eg. in Chrome).


### PR DESCRIPTION
Moved from https://docs.sentry.io/clients/javascript/usage/?platform=browser

Ref: https://github.com/getsentry/sentry-javascript/issues/1490#issuecomment-428586113