### PR TITLE
(ref) Add reference to source map header in new docs

### DIFF
--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -259,6 +259,8 @@ Some CDNs automatically strip comments from static files, including JavaScript f
 
 Double-check that your deployed, final JavaScript files have `sourceMappingURL` present.
 
+Alternately, instead of `sourceMappingURL`, you can set a `SourceMap` HTTP header on your minified file. If this header is present, Sentry will use it to discover the location of your source map.
+
 ### Verify artifact names match sourceMappingURL
 
 When [uploading source maps to Sentry](#uploading-source-maps-to-sentry), you must name your source map files with the same name found in `sourceMappingURL`.


### PR DESCRIPTION
realized I added that last change to the "old" docs - this adds the same content to the new docs page. 