### PR TITLE
feat(SDK's): Add community SDK's to platforms page

### DIFF
--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -5,6 +5,29 @@ sidebar_order: 2
 
 To report to Sentry you’ll need to use a language-specific SDK. The Sentry team builds and maintains these for most popular languages, but there’s also a large ecosystem supported by the community.
 
+## Sentry-supported SDK's
+
+These SDK's are [maintained](https://github.com/getsentry) and [supported](https://sentry.io/contact/support/) by Sentry staff.
+
 {% include platform_icon_links.html %}
 
-Some platforms have been phased out or have been replaced with new SDKs. For those legacy integrations head over to the [legacy clients]({% link _documentation/clients/index.md %}) page. Your favorite language still cannot be found? Then we encourage you to start a discussion about supporting it on our [community forum](https://forum.sentry.io).
+Some platforms have been phased out or have been replaced with new SDKs. For those legacy integrations head over to the [legacy clients]({% link _documentation/clients/index.md %}) page.
+
+## Community-supported SDK's
+
+These SDK's are [maintained and supported](https://forum.sentry.io) by the Sentry community.
+
+* [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
+* [_Crystal_](https://github.com/Sija/raven.cr)
+* [_Dart_](https://github.com/flutter/sentry)
+* [_Grails_](https://github.com/agorapulse/grails-sentry)
+* [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
+* [_Lua_](https://github.com/cloudflare/raven-lua)
+* [_Nuxt_](https://github.com/nuxt-community/sentry-module)
+* [_OCaml_](https://github.com/brendanlong/sentry-ocaml)
+* [_Scrapy_](https://github.com/llonchj/scrapy-sentry)
+* [_Wordpress_](https://github.com/stayallive/wp-sentry)
+
+## Other platforms
+
+Your favorite language or framework still cannot be found? Then we encourage you to start a discussion about supporting it on our [community forum](https://forum.sentry.io).

--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -5,17 +5,17 @@ sidebar_order: 2
 
 To report to Sentry you’ll need to use a language-specific SDK. The Sentry team builds and maintains these for most popular languages, but there’s also a large ecosystem supported by the community.
 
-## Sentry-supported SDK's
+## Sentry-supported SDKs
 
-These SDK's are [maintained](https://github.com/getsentry) and [supported](https://sentry.io/contact/support/) by Sentry staff.
+These SDKs are [maintained](https://github.com/getsentry) and [supported](https://sentry.io/contact/support/) by Sentry staff.
 
 {% include platform_icon_links.html %}
 
 Some platforms have been phased out or have been replaced with new SDKs. For those legacy integrations head over to the [legacy clients]({% link _documentation/clients/index.md %}) page.
 
-## Community-supported SDK's
+## Community-supported SDKs
 
-These SDK's are [maintained and supported](https://forum.sentry.io) by the Sentry community.
+These SDKs are [maintained and supported](https://forum.sentry.io) by the Sentry community.
 
 * [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 * [_Crystal_](https://github.com/Sija/raven.cr)

--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -26,7 +26,9 @@ These SDK's are [maintained and supported](https://forum.sentry.io) by the Sentr
 * [_Nuxt_](https://github.com/nuxt-community/sentry-module)
 * [_OCaml_](https://github.com/brendanlong/sentry-ocaml)
 * [_Scrapy_](https://github.com/llonchj/scrapy-sentry)
+* [_Terraform_](https://github.com/jianyuan/terraform-provider-sentry)
 * [_Wordpress_](https://github.com/stayallive/wp-sentry)
+* [_Zend_](https://github.com/cloud-solutions/zend-sentry)
 
 ## Other platforms
 


### PR DESCRIPTION
- Add community SDK's
- Split SDK's into "sentry supported" and "community supported" sections
- Link to our GH and support pages for the former and the forums for the latter

To find these, I did a search through the SDK section of the forum, googled for any languages from the top 20 [here](https://www.tiobe.com/tiobe-index/) not covered by our SDK's, and paged through https://github.com/topics/sentry for any repos with at least 25 stars. Any project which seemed to still be being actively maintained (a commit within the last few months) I included. _I may have missed some - if there are any that are known and not there, please let me know!_

The one I didn't know whether to include or not is Perl - it's listed under "legacy clients" but there's a big banner at the top which says it's community maintained, so seems like it should be on this list rather than there? Maybe someone who knows more than I do can advise.