### PR TITLE
fix(tooling): Make prettier not autoformat markdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
   "editor.trimAutoWhitespace": false,
   "files.trimTrailingWhitespace": false,
+  "prettier.disableLanguages": [
+    "vue", //default
+    "markdown"
+  ]
 }


### PR DESCRIPTION
So that it stops breaking internal links and changing the bullets in lists from `-` to `*`.