### PR TITLE
feat(context): Add level and fingerprint context methods

### DIFF
--- a/src/collections/_documentation/learn/context.md
+++ b/src/collections/_documentation/learn/context.md
@@ -14,23 +14,23 @@ Sentry supports additional context with events. Often this context is shared amo
 
 : Specific structured contexts (OS info, runtime information etc.).  This is normally set automatically.
 
-**User**
+[**User**](#capturing-the-user)
 
 : Information about the current actor
 
-**Tags**
+[**Tags**](#tagging-events)
 
 : Key/value pairs which generate breakdowns charts and search filters
 
-**Level**
+[**Level**](#setting-the-level)
 
 : An event's severity 
 
-**Fingerprint**
+[**Fingerprint**](#setting-the-fingerprint)
 
 : A value used for grouping events into issues
 
-**Unstructured Extra**
+[**Unstructured Extra Data**](#extra-context)
 
 : Arbitrary unstructured data which is stored with an event sample
 
@@ -95,7 +95,7 @@ You can set the severity of an event to one of five values: 'fatal', 'error', 'w
 
 ## Setting the Fingerprint
 
-Sentry uses one or more "fingerprints" to decide how to group errors into issues. More information can be found [here]({%- link _documentation/learn/rollups.md#custom-grouping -%}).
+Sentry uses one or more "fingerprints" to decide how to group errors into issues. More information can be found [here]({%- link _documentation/learn/rollups.md -%}#custom-grouping).
 
 ## Extra Context
 

--- a/src/collections/_documentation/learn/context.md
+++ b/src/collections/_documentation/learn/context.md
@@ -10,46 +10,32 @@ example_extra_value: 'Mighty Fighter'
 
 Sentry supports additional context with events. Often this context is shared amongst any issue captured in its lifecycle, and includes the following components:
 
-**User**
-
-: Information about the current actor
-
 **Structured Contexts**
 
 : Specific structured contexts (OS info, runtime information etc.).  This is normally set automatically.
+
+**User**
+
+: Information about the current actor
 
 **Tags**
 
 : Key/value pairs which generate breakdowns charts and search filters
 
+**Level**
+
+: An event's severity 
+
+**Fingerprint**
+
+: A value used for grouping events into issues
+
 **Unstructured Extra**
 
-: Arbitrary unstructured data which is stored with an event sample.
+: Arbitrary unstructured data which is stored with an event sample
 
 Context is held on the current scope and thus is cleared out at the end of each operation (request etc.).  For more information
 [have a look at the scopes and hub documentation]({%- link _documentation/learn/scopes.md -%}).
-
-## Tagging Events
-
-Sentry implements a system it calls tags. Tags are various key/value pairs that get assigned to an event, and can later be used as a breakdown or quick access to finding related events.
-
-Most SDKs generally support configuring tags by configuring the scope:
-
-{% include components/platform_content.html content_dir='set-tag' %}
-
-Several common uses for tags include:
-
--   The hostname of the server
--   The version of your platform (e.g. iOS 5.0)
--   The user’s language
-
-Once you’ve starting sending tagged data, you’ll see it show up in a few places:
-
--   The filters within the sidebar on the project stream page.
--   Summarized within an event on the sidebar.
--   The tags page on an aggregated event.
-
-We’ll automatically index all tags for an event, as well as the frequency and the last time a value has been seen. Even more so, we keep track of the number of distinct tags, and can assist in you determining hotspots for various issues.
 
 ## Capturing the User
 
@@ -78,6 +64,38 @@ Users consist of a few key pieces of information which are used to construct a u
 : The IP address of the user. If the user is unauthenticated providing the IP address will suggest that this is unique to that IP. We will attempt to pull this from HTTP request data if available.
 
 Additionally you can provide arbitrary key/value pairs beyond the reserved names and those will be stored with the user.
+
+## Tagging Events
+
+Sentry implements a system it calls tags. Tags are various key/value pairs that get assigned to an event, and can later be used as a breakdown or quick access to finding related events.
+
+Most SDKs generally support configuring tags by configuring the scope:
+
+{% include components/platform_content.html content_dir='set-tag' %}
+
+Several common uses for tags include:
+
+-   The hostname of the server
+-   The version of your platform (e.g. iOS 5.0)
+-   The user’s language
+
+Once you’ve starting sending tagged data, you’ll see it show up in a few places:
+
+-   The filters within the sidebar on the project stream page.
+-   Summarized within an event on the sidebar.
+-   The tags page on an aggregated event.
+
+We’ll automatically index all tags for an event, as well as the frequency and the last time a value has been seen. Even more so, we keep track of the number of distinct tags, and can assist in you determining hotspots for various issues.
+
+## Setting the Level
+
+You can set the severity of an event to one of five values: 'fatal', 'error', 'warning', 'info', and 'debug'. ('error' is the default.) 'fatal' is the most severe and 'debug' is the least.
+
+{% include components/platform_content.html content_dir='set-level' %}
+
+## Setting the Fingerprint
+
+Sentry uses one or more "fingerprints" to decide how to group errors into issues. More information can be found [here]({%- link _documentation/learn/rollups.md#custom-grouping -%}).
 
 ## Extra Context
 

--- a/src/collections/_documentation/learn/set-level/csharp.md
+++ b/src/collections/_documentation/learn/set-level/csharp.md
@@ -1,0 +1,8 @@
+```csharp
+using Sentry;
+
+SentrySdk.ConfigureScope(scope =>
+{
+    scope.Level = SentryLevel.Warning;
+});
+```

--- a/src/collections/_documentation/learn/set-level/javascript.md
+++ b/src/collections/_documentation/learn/set-level/javascript.md
@@ -1,0 +1,5 @@
+```javascript
+Sentry.configureScope((scope) => {
+  scope.setLevel('warning');
+});
+```

--- a/src/collections/_documentation/learn/set-level/python.md
+++ b/src/collections/_documentation/learn/set-level/python.md
@@ -1,0 +1,6 @@
+```python
+from sentry_sdk import configure_scope
+
+with configure_scope() as scope:
+    scope.level = 'warning'
+```

--- a/src/collections/_documentation/learn/set-level/rust.md
+++ b/src/collections/_documentation/learn/set-level/rust.md
@@ -1,0 +1,5 @@
+```rust
+sentry::configure_scope(|scope| {
+    scope.set_level(Some(Level::Warning));
+});
+```


### PR DESCRIPTION
As discussed in the docs team meeting 10/23:

`setLevel` and `setFingerprint` (and their other-language counterparts) are methods on the `Scope` class but were undocumented.

- add them
- reorder sections to match list in introduction
- make entries in intro list links to the relevant sections
- add example code for `setLevel` (`setFingerprint` already has explanation and examples in the Rollups & Grouping doc, so I just linked there)
