### PR TITLE
Update to whitelist + blacklist docs

### DIFF
--- a/src/collections/_documentation/learn/configuration.md
+++ b/src/collections/_documentation/learn/configuration.md
@@ -90,14 +90,14 @@ will attempt to auto-discover this value.
 ### blacklist-urls
 
 {% supported browser %}
-A pattern for error URLs which should not be sent to Sentry.  By default, all errors will be sent.
+A list of strings or regex patterns that match error URLs which should not be sent to Sentry.  By default, all errors will be sent.
 {% endsupported %}
 
 {:.config-key}
 ### whitelist-urls
 
 {% supported browser %}
-A pattern for error URLs which should exclusively be sent to Sentry.  By default, all errors
+A list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry.  By default, all errors
 will be sent.
 {% endsupported %}
 


### PR DESCRIPTION
## Motivation
The signature for those options is an array of either strings or regexes, while the documentation made it sound like it was a single pattern or string.

It may make sense generally for the docs to indicate the types accepted by each option.

## Changes
Clarify the language.