### PR TITLE
fix: Add missing slash to minidump endpoint

### DIFF
--- a/src/_js/lib/User.js
+++ b/src/_js/lib/User.js
@@ -108,7 +108,7 @@ const formatDsn = function(
 
 const formatMinidumpURL = function(dsn) {
   const { scheme, host, pathSection, publicKey } = dsn;
-  return `${scheme}${host}/api${pathSection}/minidump?sentry_key=${publicKey}`;
+  return `${scheme}${host}/api${pathSection}/minidump/?sentry_key=${publicKey}`;
 };
 
 const formatAPIURL = function(dsn) {

--- a/src/_js/lib/UserContentUI.test.js
+++ b/src/_js/lib/UserContentUI.test.js
@@ -32,7 +32,7 @@ const sampleProject1 = {
   PUBLIC_KEY: 'test1',
   SECRET_KEY: 'test1',
   API_URL: 'https://sentry.io/api',
-  MINIDUMP_URL: 'https://sentry.io/api/test1/minidump?sentry_key=test1'
+  MINIDUMP_URL: 'https://sentry.io/api/test1/minidump/?sentry_key=test1'
 };
 
 const sampleProject2 = {
@@ -46,7 +46,7 @@ const sampleProject2 = {
   PUBLIC_KEY: 'test2',
   SECRET_KEY: 'test2',
   API_URL: 'https://sentry.io/api',
-  MINIDUMP_URL: 'https://sentry.io/api/test2/minidump?sentry_key=test2'
+  MINIDUMP_URL: 'https://sentry.io/api/test2/minidump/?sentry_key=test2'
 };
 
 const sampleUser = {

--- a/src/_js/lib/__snapshots__/User.test.js.snap
+++ b/src/_js/lib/__snapshots__/User.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "preferred": Object {
     "API_URL": "https://sentry.io/api",
     "DSN": "https://test1:test1@sentry.io/test1",
-    "MINIDUMP_URL": "https://sentry.io/api/test1/minidump?sentry_key=test1",
+    "MINIDUMP_URL": "https://sentry.io/api/test1/minidump/?sentry_key=test1",
     "ORG_NAME": "test1",
     "PROJECT_ID": "1",
     "PROJECT_NAME": "test1",
@@ -19,7 +19,7 @@ Object {
     Object {
       "API_URL": "https://sentry.io/api",
       "DSN": "https://test1:test1@sentry.io/test1",
-      "MINIDUMP_URL": "https://sentry.io/api/test1/minidump?sentry_key=test1",
+      "MINIDUMP_URL": "https://sentry.io/api/test1/minidump/?sentry_key=test1",
       "ORG_NAME": "test1",
       "PROJECT_ID": "1",
       "PROJECT_NAME": "test1",
@@ -32,7 +32,7 @@ Object {
     Object {
       "API_URL": "https://sentry.io/api",
       "DSN": "https://test2:test2@sentry.io/test2",
-      "MINIDUMP_URL": "https://sentry.io/api/test2/minidump?sentry_key=test2",
+      "MINIDUMP_URL": "https://sentry.io/api/test2/minidump/?sentry_key=test2",
       "ORG_NAME": "test2",
       "PROJECT_ID": "2",
       "PROJECT_NAME": "test2",
@@ -57,7 +57,7 @@ Object {
   "preferred": Object {
     "API_URL": "https://sentry.io/api",
     "DSN": "https://&lt;key&gt;:&lt;secret&gt;@sentry.io/&lt;project&gt;",
-    "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump?sentry_key=&lt;key&gt;",
+    "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump/?sentry_key=&lt;key&gt;",
     "ORG_NAME": "your-org",
     "PROJECT_ID": "-1",
     "PROJECT_NAME": "your-project",
@@ -71,7 +71,7 @@ Object {
     Object {
       "API_URL": "https://sentry.io/api",
       "DSN": "https://&lt;key&gt;:&lt;secret&gt;@sentry.io/&lt;project&gt;",
-      "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump?sentry_key=&lt;key&gt;",
+      "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump/?sentry_key=&lt;key&gt;",
       "ORG_NAME": "your-org",
       "PROJECT_ID": "-1",
       "PROJECT_NAME": "your-project",
@@ -302,7 +302,7 @@ exports[`User constructDSNObject has default 1`] = `
 Object {
   "API_URL": "https://sentry.io/api",
   "DSN": "https://&lt;key&gt;:&lt;secret&gt;@sentry.io/&lt;project&gt;",
-  "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump?sentry_key=&lt;key&gt;",
+  "MINIDUMP_URL": "https://sentry.io/api/&lt;project&gt;/minidump/?sentry_key=&lt;key&gt;",
   "ORG_NAME": "your-org",
   "PROJECT_ID": "-1",
   "PROJECT_NAME": "your-project",
@@ -318,7 +318,7 @@ exports[`User constructDSNObject works 1`] = `
 Object {
   "API_URL": "https://sentry.io/api",
   "DSN": "https://test1:test1@sentry.io/test1",
-  "MINIDUMP_URL": "https://sentry.io/api/test1/minidump?sentry_key=test1",
+  "MINIDUMP_URL": "https://sentry.io/api/test1/minidump/?sentry_key=test1",
   "ORG_NAME": "test1",
   "PROJECT_ID": "1",
   "PROJECT_NAME": "test1",


### PR DESCRIPTION
We always use slashes. At some point the minidump endpoint used to not have slashes, but this has been corrected since.