### PR TITLE
(ref) Migrate browser compatibility chart to new SDK docs. Fixes SE-127

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -7,6 +7,14 @@ sidebar_order: 3
 
 All our JavaScript related SDKs provide the same API still there are some differences between them which this section of the docs explains.
 
+## Browser Compatability
+
+Our JavaScript SDK supports all major browsers. In older browsers, error reports may have a degraded level of detail – for example, missing stack trace data or missing source code column numbers.
+
+The table below shows supported browsers:
+
+![Sauce Test Status](https://saucelabs.com/browser-matrix/sentryio.svg)
+
 ## Integrations
 
 All of our SDKs provide _Integrations_ which can be seen of some kind of plugins. All JavaScript SDKs provide default _Integrations_ please check details of a specific SDK to see which _Integrations_ they provides.


### PR DESCRIPTION
If anyone has strong opinions about this being somewhere else lmk, this was the best page I could come up with. 