### PR TITLE
feat: Indent first level of the sidebar

### DIFF
--- a/src/_assets/css/_includes/sidebar.scss
+++ b/src/_assets/css/_includes/sidebar.scss
@@ -17,8 +17,8 @@
     }
   }
 
-  .toc-item .toc-item {
-    padding-left: $spacer;
+  .toc-item {
+    padding-left: $spacer * 0.5;
   }
 
   ul a {


### PR DESCRIPTION
@lobsterkatie suggested that due alignment, it's tough to distinguish between the sections and first level of docs. This makes it so the first level is also indented and reduces the overall indent of all levels.

<details>
  <summary><kbd>View screenshots</kbd></summary>
  <br />
  <table>
    <thead><tr><td>Before</td><td>After</td></tr></thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/72919/47885071-92d32200-ddf0-11e8-8200-f9a5f5984551.jpg"/></td>
        <td><img src="https://user-images.githubusercontent.com/72919/47885168-ecd3e780-ddf0-11e8-8d0a-9d16ef36927a.jpg"/></td>
      </tr>
    </tbody>
  </table>
</details>
