### PR TITLE
conf(cloudbuilder): set new logsBucket for build logs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,3 +34,4 @@ images: [
   'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
 ]
 timeout: 20m
+logsBucket: 'gs://sentryio-cloudbuild-logs'


### PR DESCRIPTION
this project is the guinea pig for this setting.

Before this can be merged, https://github.com/getsentry/ops/pull/1337 needs to be merged and applied.
