### PR TITLE
conf(cloudbuild): set bucket+path for cloudbuilder logs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,4 +34,4 @@ images: [
   'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
 ]
 timeout: 20m
-logsBucket: 'gs://sentryio-cloudbuild-logs'
+logsBucket: 'gs://sentryio-cloudbuild-logs/sentry-docs/'


### PR DESCRIPTION
Add a directory to the bucket specified in #536 so logs can be cleaned up eventually.

(Otherwise the logs for every project are dumped in the root directory.)