### PR TITLE
[broken/WIP] fix: Clean up getting-started navigation

### DIFF
--- a/bin/jekyll-watch
+++ b/bin/jekyll-watch
@@ -4,4 +4,4 @@ if [ "$JEKYLL_INCREMENTAL" = true ]; then
   INCREMENTAL=" --incremental"
 fi
 
-bundle exec jekyll serve --open-url --livereload --livereload-port 35727 --config _config.yml,_config.dev.yml --watch --host 0.0.0.0$INCREMENTAL
+bundle exec jekyll serve --open-url --livereload --livereload-port 35727 --config _config.yml,_config.dev.yml --watch --host 0.0.0.0$INCREMENTAL --trace

--- a/src/_data/documentation_categories.yml
+++ b/src/_data/documentation_categories.yml
@@ -3,6 +3,9 @@
 - title: Home
   slug: index
 
+- title: Test
+  slug: test
+
 - title: Error Reporting
   slug: error-reporting
 

--- a/src/collections/_documentation/test/index.md
+++ b/src/collections/_documentation/test/index.md
@@ -1,0 +1,6 @@
+---
+title: Test test test
+sidebar_order: 0
+---
+
+## Testing testing


### PR DESCRIPTION
Currently only change pushed in a test case for debugging the fact that adding a new sidebar category causes all categories to hide themselves at the index level of the docs site.

UPDATE: Cameron fixed my real problem as https://github.com/getsentry/sentry-docs/pull/560, so closing this PR.