### PR TITLE
Fix quickstart links

### DIFF
--- a/src/_plugins/platform_api.rb
+++ b/src/_plugins/platform_api.rb
@@ -78,7 +78,7 @@ Jekyll::Hooks.register :site, :post_render, priority: :high do |site|
       end
 
       platform_slug = is_self ? "_self" : platform["slug"]
-      doc_link = platform["wizard"] === true ? "/quickstart?platform=#{platform["slug"]}" : platform["doc_link"]
+      doc_link = platform["wizard"] === true ? "/error-reporting/quickstart?platform=#{platform["slug"]}" : platform["doc_link"]
       platform["doc_link"] = "#{site.config["url"]}#{ doc_link }"
 
       index_payload[:platforms][group_slug] ||= {}


### PR DESCRIPTION
Fixes links to the installation docs in Sentry. This URL wasn't updated with the recent TOC changes