### PR TITLE
Update python documentation for extras

### DIFF
--- a/src/collections/_documentation/platforms/python/logging.md
+++ b/src/collections/_documentation/platforms/python/logging.md
@@ -27,7 +27,7 @@ sentry_sdk.init(
 ```python
 import logging
 logging.debug("I am a breadcrumb")
-logging.error("I am an event", bar=43)
+logging.error("I am an event", extra=dict(bar=43))
 ```
 
 * There will be an error event with the message `"I am an event"`.


### PR DESCRIPTION
As per https://github.com/getsentry/sentry-python/blob/master/tests/integrations/logging/test_logging.py#L46, extra data needs to be specified as a dict, passed as the keyword argument `extra`.

If you follow the current documentation, you get an error; c.f. with the updated way:
```
>>> logging.error('test', extras=dict(foo='asdf'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/Josh/.pyenv/versions/3.6.6/lib/python3.6/logging/__init__.py", line 1868, in error
    root.error(msg, *args, **kwargs)
  File "/Users/Josh/.pyenv/versions/3.6.6/lib/python3.6/logging/__init__.py", line 1336, in error
    self._log(ERROR, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'extras'
>>> logging.error('test', extra=dict(foo='asdf'))
ERROR:root:test
```