### PR TITLE
Add missing Sanic Import to Documentation

### DIFF
--- a/src/collections/_documentation/platforms/python/sanic.md
+++ b/src/collections/_documentation/platforms/python/sanic.md
@@ -22,7 +22,8 @@ Framework](https://github.com/huge-success/sanic).
     ```python
     import sentry_sdk
     from sentry_sdk.integrations.sanic import SanicIntegration
-
+    from sanic import Sanic
+    
     sentry_sdk.init(
         dsn="___PUBLIC_DSN___",
         integrations=[SanicIntegration()]


### PR DESCRIPTION
In the current helper document for `sanic`, the example code provided is missing an import for the `Sanic` class.  

This commit fixes that inconsistency. 