### PR TITLE
JavaScript: Made the example release version consistent with the suggested format in the releases docs

### DIFF
--- a/src/collections/_documentation/clients/javascript/config.md
+++ b/src/collections/_documentation/clients/javascript/config.md
@@ -17,7 +17,7 @@ At this point, Raven is ready to capture any uncaught exception.
 
 ```javascript
 Raven.config('___PUBLIC_DSN___', {
-    release: '1.3.0'
+    release: 'myapp@1.3.0'
 }).install()
 ```
 
@@ -43,7 +43,7 @@ Those configuration options are documented below:
   }
   ```
 
-  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`.
+  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. See the [releases](https://docs.sentry.io/workflow/releases/?platform=javascript) page for more information about releases.
 
 `environment`
 

--- a/src/collections/_documentation/clients/javascript/config.md
+++ b/src/collections/_documentation/clients/javascript/config.md
@@ -43,7 +43,7 @@ Those configuration options are documented below:
   }
   ```
 
-  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. See the [releases]({%- link _documentation/workflow/releases.md -%}) page for more information about releases.
+  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. To learn more about configuring releases and deploys, click [here]({%- link _documentation/workflow/releases.md -%}).
 
 `environment`
 

--- a/src/collections/_documentation/clients/javascript/config.md
+++ b/src/collections/_documentation/clients/javascript/config.md
@@ -43,7 +43,7 @@ Those configuration options are documented below:
   }
   ```
 
-  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. See the [releases](https://docs.sentry.io/workflow/releases/?platform=javascript) page for more information about releases.
+  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. See the [releases]({%- link _documentation/workflow/releases.md -%}) page for more information about releases.
 
 `environment`
 


### PR DESCRIPTION
https://docs.sentry.io/workflow/releases/?platform=javascript: `Note that releases are global per organization so make sure to prefix them with something project specific if needed:`