### PR TITLE
fix (links): Fix trailing slash issues

### DIFF
--- a/src/_includes/learn-sdk.md
+++ b/src/_includes/learn-sdk.md
@@ -1,6 +1,6 @@
 {% capture __alert_content -%}
 This page will provide you with details that are very specific to the platform, to learn how to use our unified 
-SDKs in general, please visit the [Learn section]({%- link _documentation/error-reporting/quickstart.md -%}?platform={{ include.platform }})
+SDKs in general, please visit the [Error Reporting]({%- link _documentation/error-reporting/quickstart.md -%}?platform={{ include.platform }}), [Enriching Error Data]({%- link _documentation/enriching-error-data/context.md -%}?platform={{ include.platform }}), [Releases]({%- link _documentation/workflow/releases.md -%}?platform={{ include.platform }}),  and [Data Management]({%- link _documentation/data-management/rollups.md -%}?platform={{ include.platform }}) sections.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Learn about SDK usage"

--- a/src/_layouts/legacy-client.html
+++ b/src/_layouts/legacy-client.html
@@ -12,7 +12,7 @@ layout: doc
 
 {%- if __page_platform.superseded_by -%}
   {%- assign __new_platform = site.data.platforms | where: 'slug', __page_platform.superseded_by | first %}
-  {%- assign __quickstart_link = '/error-reporting/quickstart?platform=' | append: __new_platform.slug -%}
+  {%- assign __quickstart_link = '/error-reporting/quickstart/?platform=' | append: __new_platform.slug -%}
   {% capture __alert_content -%}
   This SDK has been superseded by a new unified one.  The documentation here is
   preserved for customers using the old client.  For new projects have a look

--- a/src/_plugins/platform_api.rb
+++ b/src/_plugins/platform_api.rb
@@ -78,7 +78,7 @@ Jekyll::Hooks.register :site, :post_render, priority: :high do |site|
       end
 
       platform_slug = is_self ? "_self" : platform["slug"]
-      doc_link = platform["wizard"] === true ? "/error-reporting/quickstart?platform=#{platform["slug"]}" : platform["doc_link"]
+      doc_link = platform["wizard"] === true ? "/error-reporting/quickstart/?platform=#{platform["slug"]}" : platform["doc_link"]
       platform["doc_link"] = "#{site.config["url"]}#{ doc_link }"
 
       index_payload[:platforms][group_slug] ||= {}


### PR DESCRIPTION
Missing trailing slashes were making the sidebar disappear, even if the links were redirecting to the correct page. @cameronmcefee is looking into that, but in the meantime, this adds them back in in a few spots they were missing.

(Also, one of the spots in question was a link to the old "Learn" section, so I fixed the text for that, too.)