### PR TITLE
fix(discover): Tag names use . instead of _

### DIFF
--- a/src/collections/_documentation/workflow/discover.md
+++ b/src/collections/_documentation/workflow/discover.md
@@ -73,12 +73,6 @@ standard_fields:
     - name: geo.city
       type: string
 
-  "Tags":
-    - name: tags_key
-      type: string
-    - name: tags_value
-      type: string
-
   "HTTP":
     - name: http.method
       type: string
@@ -110,7 +104,7 @@ standard_fields:
       type: number
     - name: stack.lineno
       type: number
-    - name: stack.stack_levvel
+    - name: stack.stack_level
       type: number
 
 common_tags:
@@ -120,7 +114,7 @@ common_tags:
       type: string
     - name: logger
       type: string
-    - name: server_name
+    - name: server.name
       type: string
     - name: transaction
       type: string
@@ -130,23 +124,23 @@ common_tags:
       type: string
     - name: url
       type: string
-    - name: app_device
+    - name: app.device
       type: string
-    - name: device_family
+    - name: device.family
       type: string
     - name: runtime
       type: string
-    - name: runtime_name
+    - name: runtime.name
       type: string
     - name: browser
       type: string
-    - name: browser_name
+    - name: browser.name
       type: string
     - name: os
       type: string
-    - name: os_name
+    - name: os.name
       type: string
-    - name: os_rooted
+    - name: os.rooted
       type: boolean
     - name: sentry:release
       type: string


### PR DESCRIPTION
Also remove tag_keys and tag_values since we no longer expose these in
the Discover UI