### PR TITLE
Raven celery logging

### DIFF
--- a/src/collections/_documentation/clients/python/integrations/django.md
+++ b/src/collections/_documentation/clients/python/integrations/django.md
@@ -114,7 +114,7 @@ LOGGING = {
         }
     },
     'loggers': {
-        'celery': {  # Celery must be set explicitly
+        'celery': {  # Log unhandled exceptions from tasks
             'level': 'WARNING',
             'handlers': ['console', 'sentry'],
             'propagate': False

--- a/src/collections/_documentation/clients/python/integrations/django.md
+++ b/src/collections/_documentation/clients/python/integrations/django.md
@@ -114,6 +114,11 @@ LOGGING = {
         }
     },
     'loggers': {
+        'celery': {  # Celery must be set explicitly
+            'level': 'WARNING',
+            'handlers': ['console', 'sentry'],
+            'propagate': False
+        },
         'django.db.backends': {
             'level': 'ERROR',
             'handlers': ['console'],


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-python/issues/1004

Celery must be set explicitly in order to log unhandled exceptions.