### PR TITLE
feat(navigation): Add link to old AngularJS docs from new Angular docs

### DIFF
--- a/src/collections/_documentation/platforms/javascript/angular.md
+++ b/src/collections/_documentation/platforms/javascript/angular.md
@@ -4,7 +4,9 @@ sidebar_order: 35
 ---
 
 <!-- WIZARD -->
-This document uses Angular to refer to Angular 2+. On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
+This document uses Angular to refer to Angular 2+. If you use AngularJS, you'll need to use our [legacy integration]({%- link _documentation/clients/javascript/integrations/angularjs.md -%}).
+
+On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
 
 Additionally, `@sentry/browser` can be configured to catch any Angular-specific (2.x) exceptions reported through the [@angular/core/ErrorHandler](https://angular.io/api/core/ErrorHandler) component.
 


### PR DESCRIPTION
Added the second sentence.

![image](https://user-images.githubusercontent.com/14812505/49843224-483fb080-fd73-11e8-8d2a-29559a191b46.png)
