### PR TITLE
feat: Use sdk loader instead of bundled sdk

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -6,7 +6,7 @@ const env = getClientEnvironment();
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
-  entry: ['./src/_js/raven.js', './src/_js/main.js'],
+  entry: ['./src/_js/main.js'],
   output: {
     filename: 'bundle.js',
     path: path.resolve(process.cwd(), 'src/_assets/js/')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://docs.sentry.io/",
   "dependencies": {
-    "@sentry/browser": "4.0.6",
     "add": "^2.0.6",
     "amplitude-js": "^4.4.0",
     "babel-core": "^6.26.0",

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -34,6 +34,8 @@ the following value in the page frontmatter
 <link href="{{ assets['favicon.ico'].digest_path }}" rel="icon" type="image/png">
 <link rel="canonical" href="{{ page.url | site.url | replace:'index.html',''}}">
 
+<script src="https://js.sentry-cdn.com/ad63ba38287245f2803dc220be959636.min.js" crossorigin="anonymous"></script>
+
 <script>
   window.loadIfTrackersOk = [];
   window.analyticsAssetURL = '{% asset "amplitude.min.js" @path %}';

--- a/src/_js/raven.js
+++ b/src/_js/raven.js
@@ -1,3 +1,0 @@
-import * as Sentry from '@sentry/browser';
-const dsn = 'https://ad63ba38287245f2803dc220be959636@sentry.io/1267915';
-Sentry.init({ dsn });

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,48 +23,6 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@sentry/browser@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.0.6.tgz#6a9183371c9d6c2c1905f14af17ad68e305ce918"
-  dependencies:
-    "@sentry/core" "4.0.6"
-    "@sentry/types" "4.0.6"
-    "@sentry/utils" "4.0.6"
-    md5 "2.2.1"
-
-"@sentry/core@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.0.6.tgz#8e59445dde27e639ffcac23b4e40529cda4c9df7"
-  dependencies:
-    "@sentry/hub" "4.0.6"
-    "@sentry/minimal" "4.0.6"
-    "@sentry/types" "4.0.6"
-    "@sentry/utils" "4.0.6"
-
-"@sentry/hub@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.0.6.tgz#ab86bd50d12234a0699857452e925069311f54d1"
-  dependencies:
-    "@sentry/types" "4.0.6"
-    "@sentry/utils" "4.0.6"
-
-"@sentry/minimal@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.0.6.tgz#494d725f2d7c343724c47bbb0cd99302b6124e7d"
-  dependencies:
-    "@sentry/hub" "4.0.6"
-    "@sentry/types" "4.0.6"
-
-"@sentry/types@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.0.6.tgz#421478df17415802baa4d5e2d3db246e559a0fad"
-
-"@sentry/utils@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.0.6.tgz#77ca73fb7d2c436914d2dd84fa975dd5b618246d"
-  dependencies:
-    "@sentry/types" "4.0.6"
-
 "@types/events@*":
   version "1.2.0"
   resolved "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -1259,10 +1217,6 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-
 chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -1539,10 +1493,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -2608,7 +2558,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -3514,14 +3464,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-md5@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 mem@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Since we removed our internal usage of the loader on sentry.io I added it to the docs to have something dogfood it.