### PR TITLE
Change all content h1s to h2s for consistency

### DIFF
--- a/src/collections/_documentation/enriching-error-data/environments.md
+++ b/src/collections/_documentation/enriching-error-data/environments.md
@@ -8,7 +8,7 @@ As of Sentry 9, you can easily filter issues, releases, and user feedback by env
 
 [{% asset environment_filter.png %}]({% asset environment_filter.png @path %})
 
-# Inside the Environment Filter
+## Inside the Environment Filter
 
 **Issues**
 
@@ -20,19 +20,19 @@ In addition, the environment filter affects all issue-related metrics like count
 
 You can filter releases by which environment they’ve been deployed to (to learn more about configuring releases and deploys, click [here]({%- link _documentation/workflow/releases.md -%})). For example, a release linked to a `QA` deploy and a `Prod` deploy will appear in your view when filtering by `QA` as well as `Prod`. All issue-related metics within a given release will be affected by the environment filter.
 
-# Hiding environments
+## Hiding environments
 
 If a certain environment is not a useful filter for your team, you can hide the environment from your environments dropdown by navigating to your project settings > Environments, and selecting ‘Hide’. Data sent from that environment will still be visible under _All Environments_, and will still count against your quota.
 
 If you want to change the name of a given environment, you will have to modify your SDK configuration. _Note: this will not change environment names for past data._
 
-# Setting a Default Environment
+## Setting a Default Environment
 
 If you would like to see Sentry filtered by a certain environment every time you open Sentry, you can set a default environment by navigating to your project settings > Environments, and clicking ‘Set as default.’
 
 [{% asset manage_environments.png %}]({% asset manage_environments.png @path %})
 
-# How to send environment data
+## How to send environment data
 
 Environment data is sent to Sentry by tagging issues via your SDK:
 

--- a/src/collections/_documentation/workflow/issue-owners.md
+++ b/src/collections/_documentation/workflow/issue-owners.md
@@ -5,7 +5,7 @@ sidebar_order: 2
 
 The Issue Owners feature allows you to reduce noise by directing notifications to specific teams or users based on a path or URL. This allows you to get issues into the hands of the developer who can fix them, faster.
 
-# How It Works
+## How It Works
 
 Issue owners builds upon your alert rules to specify who to notify about a given issue (to learn more about alert rules, click [here](https://blog.sentry.io/2017/10/12/proactive-alert-rules)).
 
@@ -17,7 +17,7 @@ If there is a match, only Owners will receive the alert for the exception. By de
 
 Note that at this time the Issue Owners feature is only available for email notifications. This means that your alert rules must trigger email notifications in order to be affected by your Issue Owners rules.
 
-# Configuration
+## Configuration
 
 **Adding a New Rule**
 
@@ -53,7 +53,7 @@ Issue Owner rules use the following structure:
 
 Note that teams and users must have access to the project to become owners. To grant a team access to a project, navigate to project settings > Project Teams, and click ‘Add Team to [project]’. To grant a user access to a project, the user must be a member of a team with access to the project. To add a user to a project’s team, navigate to Project Settings > Project Teams, select a team, then click ‘Add Member.’
 
-# Troubleshooting
+## Troubleshooting
 
 -   Make sure that all teams and users have access to the project; if they do not have the correct access, the Issue Owners rules will fail to save. To grant a team access to a project, navigate to project settings > Project Teams, and click ‘Add Team to [project]’. To grant a user access to a project, the user must be a member of a team with access to the project. To add a user to a project’s team, navigate to Project Settings > Project Teams, select a team, then click ‘Add Member.’
 -   Make sure that alert rules are configured to send email. First, check to see that the Mail plugin is enabled by navigating to project settings > Integrations. Then, navigate to project settings > Alerts > Rules, and confirm that notifications are being sent to Mail or to ‘all enabled legacy services.’


### PR DESCRIPTION
We shouldn't have multiple h1s in the same page. Looks terrible, not semantic, etc.

These were all the places I could find (via code search).