### PR TITLE
Rephrase integration permission notices to focus on goal

### DIFF
--- a/src/collections/_documentation/workflow/integrations/azure-devops.md
+++ b/src/collections/_documentation/workflow/integrations/azure-devops.md
@@ -7,7 +7,7 @@ You can now use the data from your commits to Azure DevOps, formerly known as Vi
 ## Configure Azure DevOps
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions, and Azure project admin permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization, as well as have admin permissions on your Azure project.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/bitbucket.md
+++ b/src/collections/_documentation/workflow/integrations/bitbucket.md
@@ -7,7 +7,7 @@ You can now use the data from your Bitbucket commits to help you find and fix bu
 ## Configure Bitbucket
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions, and Bitbucket admin permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization, as well as have admin permissions on your Bitbucket organization.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/github-enterprise.md
+++ b/src/collections/_documentation/workflow/integrations/github-enterprise.md
@@ -7,7 +7,7 @@ You can now use the data from your GitHub Enterprise commits to help you find an
 ## Configure GitHub Enterprise
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions, and GitHub owner permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization, as well as have owner permissions on your GitHub organization.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/github.md
+++ b/src/collections/_documentation/workflow/integrations/github.md
@@ -7,7 +7,7 @@ You can now use the data from your GitHub commits to help you find and fix bugs 
 ## Configure GitHub
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions, and Github owner permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization, as well as have owner permissions on your GitHub organization.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/gitlab.md
+++ b/src/collections/_documentation/workflow/integrations/gitlab.md
@@ -8,7 +8,7 @@ Sentry’s GitLab integration helps you find and fix bugs faster by using data f
 ## Configure GitLab
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/jira.md
+++ b/src/collections/_documentation/workflow/integrations/jira.md
@@ -8,7 +8,7 @@ Connect errors from Sentry with your Jira issues.
 ## Installing Jira with Sentry
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions, and Jira admin permissions are required to install this integration.
+To install or configure this integration you must be an owner or manager of your Sentry organization, as well as have admin permissions on Jira.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/integrations/slack.md
+++ b/src/collections/_documentation/workflow/integrations/slack.md
@@ -8,7 +8,7 @@ The global Slack integration creates workflows for your team. Now you can triage
 ## Configure Slack
 
 {% capture __alert_content -%}
-Sentry owner or manager permissions are required to install this integration. Slack defaults to let any workspace member authorize apps, but they may have to request access. See this [Slack help article](https://get.slack.help/hc/en-us/articles/202035138-Add-an-app-to-your-workspace) for more details.
+To install this integration you must have owner or manager permissions on your Sentry organization. Slack defaults to let any workspace member authorize apps, but they may have to request access. See this [Slack help article](https://get.slack.help/hc/en-us/articles/202035138-Add-an-app-to-your-workspace) for more details.
 
 {%- endcapture -%}
 {%- include components/alert.html


### PR DESCRIPTION
I found these sentences awkward to read because the purpose, "to install this integration", doesn't come until the very end. This change makes that the very first part you read.