### PR TITLE
Add PHP code examples to Getting Started docs

### DIFF
--- a/src/collections/_documentation/error-reporting/capture-error/php.md
+++ b/src/collections/_documentation/error-reporting/capture-error/php.md
@@ -1,0 +1,5 @@
+In PHP you can capture exceptions manually using the `captureException` instance method.
+
+```php
+$client->captureException($ex);
+```

--- a/src/collections/_documentation/error-reporting/capture-message/php.md
+++ b/src/collections/_documentation/error-reporting/capture-message/php.md
@@ -1,0 +1,5 @@
+In PHP you can capture messages using the `captureException` instance method.
+
+```php
+$client->captureMessage('Something went wrong');
+```

--- a/src/collections/_documentation/error-reporting/getting-started-config/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-config/php.md
@@ -1,0 +1,12 @@
+You need to first create a Raven client and initialize it with your project's DSN.
+
+```php
+$client = (new Raven_Client('___PUBLIC_DSN___'))->install();
+```
+
+{% wizard hide %}
+{% include components/alert.html
+  title="What's Raven?"
+  content="Raven is the legacy name of Sentry's PHP SDK."
+%}
+{% endwizard %}

--- a/src/collections/_documentation/error-reporting/getting-started-install/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/php.md
@@ -1,0 +1,5 @@
+The quickest way to get started with Sentry for PHP is with Composer:
+
+```bash
+$ composer require "sentry/sentry"
+```

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/php.md
@@ -1,0 +1,1 @@
+-  [_integrating with the PHP ecosystem_]({% link _documentation/clients/php/index.md %})


### PR DESCRIPTION
I understand this doesn't use the new "platform" (and that the PHP SDK might not have all the same API methods as the others), but it seems to work.