### PR TITLE
fix(minidumps) contact sales about event attachments

### DIFF
--- a/src/collections/_documentation/platforms/minidump/index.md
+++ b/src/collections/_documentation/platforms/minidump/index.md
@@ -112,7 +112,7 @@ is by default disabled. Raw minidumps are deleted permanently with their issues
 or after 30 days.
 
 {% capture __alert_content -%}
-Event attachments are not yet available to all organizations. If interested, please contact our friendly support team to enroll your organization and receive more information. We are working to bring this feature to all customers in near future.
+Event attachments are not yet available to all organizations. If interested, please [contact](https://sentry.io/contact/enterprise/) our friendly sales team to enroll your organization and receive more information. We are working to bring this feature to all customers in the near future.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Early Access"


### PR DESCRIPTION
this PR replaces "contact support" to "contact sales" as we don't have a way to self-serve event attachments today and they'll need to be sales convos.

cc @ceorourke @dsorkin 