### PR TITLE
fix: Use loader only in prod

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -34,7 +34,9 @@ the following value in the page frontmatter
 <link href="{{ assets['favicon.ico'].digest_path }}" rel="icon" type="image/png">
 <link rel="canonical" href="{{ page.url | site.url | replace:'index.html',''}}">
 
+{% if jekyll.environment != "development" %}
 <script src="https://js.sentry-cdn.com/ad63ba38287245f2803dc220be959636.min.js" crossorigin="anonymous"></script>
+{% endif %}
 
 <script>
   window.loadIfTrackersOk = [];


### PR DESCRIPTION
I was cleaning up issues in our sentry project and noticed a few issues that were emitted during local development, I think it doesn't make sense to send them to Sentry.