### PR TITLE
[FIX] sentry-docs: add missing logging import

### DIFF
--- a/src/collections/_documentation/platforms/python/logging.md
+++ b/src/collections/_documentation/platforms/python/logging.md
@@ -8,6 +8,7 @@ Calling ``sentry_sdk.init()`` already integrates with the logging module. It is
 equivalent to this explicit configuration:
 
 ```python
+import logging
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/11353