### PR TITLE
feat: Non-breaking dashes in code blocks

### DIFF
--- a/src/_assets/css/_includes/type.scss
+++ b/src/_assets/css/_includes/type.scss
@@ -122,3 +122,20 @@ h3.config-key {
 dd {
   margin-left: $spacer;
 }
+
+// Inserts an invisble zero-width, non-breaking space to prevent a word from
+// breaking on the adjoining characters. Useful for stopping dashes from
+// breaking in code blocks. The special character is placed into the ::after
+// content so that it is not included when copy/pasting from code examples.
+//
+// Example:
+// --watch
+// -<span class="no-break"></span>-<span class="no-break"></span>watch
+//
+.no-break {
+  white-space: nowrap;
+
+  &::after {
+    content: '\2060';
+  }
+}

--- a/src/_plugins/code_wraping.rb
+++ b/src/_plugins/code_wraping.rb
@@ -1,0 +1,38 @@
+require "nokogiri"
+
+# When <code> blocks wrap, they tend to break on characters that make examples
+# difficult to follow. The problem is especially pronounced with dashes, which
+# in prose are considered safe to break upon but in code are most often
+# directly associated with the attached characters. This plugin inserts a span
+# with a css class that includes an uncopyable (to prevent syntax errors),
+# zero-width, non-breaking space to hold characters together within code blocks
+Jekyll::Hooks.register :documents, :post_render, priority: :low do |document|
+
+  nbr_markup = '<span class="no-break"></span>'
+
+  characters = [
+    '-'
+  ]
+
+  matched_characters = "[#{characters.join('')}]"
+
+  body = Nokogiri::HTML(document.output)
+  body.css('code.highlighter-rouge').each do |node|
+
+    # Chunk the input into strings of consecutive, non-space characters that do or
+    # don't contain matched_characters
+    chunks = node.content.split(Regexp.new("(\\S*#{matched_characters}\\S*)"))
+
+    # Split on matched_characters, then join with the nbr_markup. This ensures
+    # we don't add nbr_markup next to spaces.
+    chunks.map! do |chunk|
+      replacement_chunks = chunk.split(Regexp.new("(#{matched_characters})"))
+      replacement_chunks.reject! { |e| e.to_s.empty? }
+      replacement_chunks.join(nbr_markup)
+    end
+
+    node.inner_html = chunks.join('')
+  end
+
+  document.output = body
+end


### PR DESCRIPTION
When `code` blocks wrap, they often break up strings in ways that create confusing examples. This is particularly obvious with dashes.

As it stands, at a small enough resolution, `myscript --do-something` will wrap and look like:

```
myscript -
-do-something
```

It would be preferriable that it looks like:

```
myscript
--do-something
```

This PR adds a plugin that inserts a zero-width, nonbreaking space between dashes and adjoinging non-whitespace characters to ensure that sections with dashes don't get broken up.

- **Q:** Why not just use `white-space: nowrap;` on `code` elements?
  **A:** Because we still want the code to wrap, just not on dashes

- **Q:** Why not just insert `&#8288;` into each string or replace dashes with a non-breaking hyphen into the examples?
  **A:** Code samples are often copy/pasted. Those characters won't be interpreted as the characters they look like, and will cause much debugging confusion. By putting them in a css pseudo-selector, they're not in the DOM and thus not copyable.
