### PR TITLE
Force bundler update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,8 @@ cache:
   yarn: true
   directories:
     - node_modules
+before_install:
+  - gem update --system
+  - gem install bundler
 script:
   - bin/test


### PR DESCRIPTION
Travis updated to Bundler 2.0 which has caused some recent builds to break on other Jekyll sites. This preemptively upgrades things so we don't get unexpected breakages the next time the gem cache updates.

https://docs.travis-ci.com/user/languages/ruby/#bundler-20