### PR TITLE
Added Getting Started to SDKs that aren't unified

### DIFF
--- a/src/collections/_documentation/clients/cocoa/index.md
+++ b/src/collections/_documentation/clients/cocoa/index.md
@@ -6,8 +6,15 @@ sidebar_relocation: platforms
 
 This is the documentation for our official clients for Cocoa (Swift and Objective-C). Starting with version `3.0.0` we’ve switched our internal code from Swift to Objective-C to maximize compatibility. Also we trimmed the public API of our sdk to a minimum. Some of the lesser used features that were present before are gone now, check out [Migration Guide]({%- link _documentation/clients/cocoa/migration.md -%}#migration) or [Advanced Usage]({%- link _documentation/clients/cocoa/advanced.md -%}#advanced) for details.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD -->
-## Installation
+## Installation {#install}
 
 The SDK can be installed using [CocoaPods](http://cocoapods.org) or [Carthage](https://github.com/Carthage/Carthage). This is the recommended client for both Swift and Objective-C.
 
@@ -37,7 +44,7 @@ Run `carthage update` to download the framework and drag the built _Sentry.frame
 
 We also provide a pre-built version for every release which can be downloaded at [releases on github](https://github.com/getsentry/sentry-cocoa/releases).
 
-## Configuration
+## Configuration {#configure}
 
 To use the client, change your AppDelegate’s _application_ method to instantiate the Sentry client:
 

--- a/src/collections/_documentation/clients/cocoa/index.md
+++ b/src/collections/_documentation/clients/cocoa/index.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD -->
 ## Installation {#install}

--- a/src/collections/_documentation/clients/elixir/index.md
+++ b/src/collections/_documentation/clients/elixir/index.md
@@ -6,8 +6,15 @@ sidebar_relocation: platforms
 
 The Elixir SDK for Sentry.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD -->
-## Installation
+## Installation {#install}
 
 Edit your mix.exs file to add it as a dependency and add the `:sentry` package to your applications:
 
@@ -21,7 +28,7 @@ defp deps do
 end
 ```
 
-## Configuration
+## Configuration {#configure}
 
 Setup the application production environment in your `config/prod.exs`
 

--- a/src/collections/_documentation/clients/elixir/index.md
+++ b/src/collections/_documentation/clients/elixir/index.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD -->
 ## Installation {#install}

--- a/src/collections/_documentation/clients/go/index.md
+++ b/src/collections/_documentation/clients/go/index.md
@@ -15,8 +15,15 @@ The Go SDK is maintained and supported by Sentry but currently under development
 
 Raven-Go provides a Sentry client implementation for the Go programming language.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD -->
-## Installation
+## Installation {#install}
 
 Raven-Go can be installed like any other Go library through `go get`:
 
@@ -24,7 +31,7 @@ Raven-Go can be installed like any other Go library through `go get`:
 $ go get github.com/getsentry/raven-go
 ```
 
-## Configuring the Client
+## Configuring the Client {#configure}
 
 To use `raven-go`, you’ll need to import the `raven` package, then initilize your DSN globally. If you specify the `SENTRY_DSN` environment variable, this will be done automatically for you. The release and environment can also be specified in the environment variables `SENTRY_RELEASE` and `SENTRY_ENVIRONMENT` respectively.
 

--- a/src/collections/_documentation/clients/go/index.md
+++ b/src/collections/_documentation/clients/go/index.md
@@ -20,7 +20,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD -->
 ## Installation {#install}

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -4,7 +4,7 @@ sidebar_order: 6
 sidebar_relocation: platforms
 ---
 
-Sentry for Java is a collection of modules provided by Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage]({%- link _documentation/clients/java/usage.md -%}) is another option. 
+Sentry for Java is a collection of modules provided by Sentry. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage]({%- link _documentation/clients/java/usage.md -%}) is another option. 
 
 {% capture __alert_content -%}
 The old `raven` library is no longer maintained. We recommended you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry`. [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `Raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
@@ -21,7 +21,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 ## Installation {#install}
 

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -71,25 +71,15 @@ Sentry.init("https://public:private@host:port/1");
 
 There are multiple ways to configure the Java SDK, but all of them take the same options. See the [configuration methods documentation]({%- link _documentation/clients/java/config.md -%}) for how to use each configuration method and how the option names might differ between them.
 
-
+## Next Steps
  
--   [Configuration]({%- link _documentation/clients/java/config.md -%})
 -   [Context & Breadcrumbs]({%- link _documentation/clients/java/context.md -%})
 -   [Manual Usage]({%- link _documentation/clients/java/usage.md -%})
 -   [Agent (Beta)]({%- link _documentation/clients/java/agent.md -%})
 -   [Migration from Raven Java]({%- link _documentation/clients/java/migration.md -%})
--   [Integrations]({%- link _documentation/clients/java/modules/index.md -%})
-    -   [Android]({%- link _documentation/clients/java/modules/android.md -%})
-    -   [Google App Engine]({%- link _documentation/clients/java/modules/appengine.md -%})
-    -   [java.util.logging]({%- link _documentation/clients/java/modules/jul.md -%})
-    -   [Log4j 1.x]({%- link _documentation/clients/java/modules/log4j.md -%})
-    -   [Log4j 2.x]({%- link _documentation/clients/java/modules/log4j2.md -%})
-    -   [Logback]({%- link _documentation/clients/java/modules/logback.md -%})
-    -   [Spring]({%- link _documentation/clients/java/modules/spring.md -%})
 
-Resources:
+## Resources
 
--   [Documentation]({%- link _documentation/clients/java/index.md -%})
 -   [Examples](https://github.com/getsentry/examples)
 -   [Bug Tracker](http://github.com/getsentry/sentry-java/issues)
 -   [Code](http://github.com/getsentry/sentry-java)

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -23,6 +23,8 @@ Getting started with Sentry is a three step process:
 2.  [Install your SDK](#install)
 2.  [Configure it](#configure)
 
+## Installation {#install}
+
 Once you've configured one of the integrations below, you can _also_ use Sentry's [static API]({%- link _documentation/clients/java/usage.md -%}) in order to do things like record breadcrumbs, set the current user, or manually send events.
 
 -   [Android]({%- link _documentation/clients/java/modules/android.md -%})

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -16,6 +16,7 @@ The old `raven` library is no longer maintained. We recommended you [migrate]({%
 %}
 
 ## Getting Started
+
 Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
@@ -31,6 +32,42 @@ Once you've configured one of the integrations below, you can _also_ use Sentry'
 -   [Log4j 2.x]({%- link _documentation/clients/java/modules/log4j2.md -%})
 -   [Logback]({%- link _documentation/clients/java/modules/logback.md -%})
 -   [Spring]({%- link _documentation/clients/java/modules/spring.md -%})
+
+## Configuration {#config}
+
+Use the configuration below in combination with any of the integrations from above. The configuration will only work after an integration is installed. After that, [set you DSN]{#setting-the-dsn}.
+
+### Setting the DSN (Data Source Name) {#setting-the-dsn}
+
+The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find your project’s DSN in the “Client Keys” section of your “Project Settings” in Sentry. You can configure it in multiple ways.
+
+In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
+
+```
+dsn=https://public:private@host:port/1
+```
+
+Via the Java System Properties _(not available on Android)_:
+
+```bash
+java -Dsentry.dsn=https://public:private@host:port/1 -jar app.jar
+```
+
+Via a System Environment Variable _(not available on Android)_:
+
+```bash
+SENTRY_DSN=https://public:private@host:port/1 java -jar app.jar
+```
+
+In code:
+
+```java
+import io.sentry.Sentry;
+
+Sentry.init("https://public:private@host:port/1");
+```
+
+
 
  
 -   [Configuration]({%- link _documentation/clients/java/config.md -%})

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -39,7 +39,7 @@ Use the configuration below in combination with any of the integrations from abo
 
 ### Setting the DSN (Data Source Name) {#setting-the-dsn}
 
-The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find your project’s DSN in the “Client Keys” section of your “Project Settings” in Sentry. You can configure it in multiple ways.
+The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find your project’s DSN in the “Client Keys” section of your “Project Settings” in Sentry.
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
@@ -67,6 +67,9 @@ import io.sentry.Sentry;
 Sentry.init("https://public:private@host:port/1");
 ```
 
+### Configuration Methods
+
+There are multiple ways to configure the Java SDK, but all of them take the same options. See the [configuration methods documentation]({%- link _documentation/clients/java/config.md -%}) for how to use each configuration method and how the option names might differ between them.
 
 
  

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -6,8 +6,22 @@ sidebar_relocation: platforms
 
 Sentry for Java is a collection of modules provided by Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage]({%- link _documentation/clients/java/usage.md -%}) is another option. 
 
-**Note:** The old `raven` library is no longer maintained. It is highly recommended that you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry` (which this documentation covers). [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
+{% capture __alert_content -%}
+The old `raven` library is no longer maintained. We recommended you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry`. [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `Raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
+{%-endcapture-%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+ 
 -   [Configuration]({%- link _documentation/clients/java/config.md -%})
 -   [Context & Breadcrumbs]({%- link _documentation/clients/java/context.md -%})
 -   [Manual Usage]({%- link _documentation/clients/java/usage.md -%})

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -4,7 +4,7 @@ sidebar_order: 6
 sidebar_relocation: platforms
 ---
 
-Sentry for Java is the official Java SDK for Sentry. At its core it provides a raw client for sending events to Sentry, but it is highly recommended that you use one of the included library or framework integrations listed below if at all possible.
+Sentry for Java is a collection of modules provided by Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage]({%- link _documentation/clients/java/usage.md -%}) is another option. 
 
 **Note:** The old `raven` library is no longer maintained. It is highly recommended that you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry` (which this documentation covers). [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
 

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -21,6 +21,17 @@ Getting started with Sentry is a three step process:
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
 2.  [Configure it](#configure)
+
+Once you've configured one of the integrations below, you can _also_ use Sentry's [static API]({%- link _documentation/clients/java/usage.md -%}) in order to do things like record breadcrumbs, set the current user, or manually send events.
+
+-   [Android]({%- link _documentation/clients/java/modules/android.md -%})
+-   [Google App Engine]({%- link _documentation/clients/java/modules/appengine.md -%})
+-   [java.util.logging]({%- link _documentation/clients/java/modules/jul.md -%})
+-   [Log4j 1.x]({%- link _documentation/clients/java/modules/log4j.md -%})
+-   [Log4j 2.x]({%- link _documentation/clients/java/modules/log4j2.md -%})
+-   [Logback]({%- link _documentation/clients/java/modules/logback.md -%})
+-   [Spring]({%- link _documentation/clients/java/modules/spring.md -%})
+
  
 -   [Configuration]({%- link _documentation/clients/java/config.md -%})
 -   [Context & Breadcrumbs]({%- link _documentation/clients/java/context.md -%})

--- a/src/collections/_documentation/clients/java/index.md
+++ b/src/collections/_documentation/clients/java/index.md
@@ -7,7 +7,7 @@ sidebar_relocation: platforms
 Sentry for Java is a collection of modules provided by Sentry. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage]({%- link _documentation/clients/java/usage.md -%}) is another option. 
 
 {% capture __alert_content -%}
-The old `raven` library is no longer maintained. We recommended you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry`. [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `Raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
+As of June 2017, the old `Raven` library is no longer maintained. We recommended you [migrate]({%- link _documentation/clients/java/migration.md -%}) to `sentry`. [Check out the migration guide]({%- link _documentation/clients/java/migration.md -%}) for more information. If you are still using `Raven` you can [find the old documentation here](https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst).
 {%-endcapture-%}
 {%- include components/alert.html
     title="Note"
@@ -37,7 +37,7 @@ Once you've configured one of the integrations below, you can _also_ use Sentry'
 
 ## Configuration {#config}
 
-Use the configuration below in combination with any of the integrations from above. The configuration will only work after an integration is installed. After that, [set you DSN]{#setting-the-dsn}.
+Use the configuration below in combination with any of the integrations from above. The configuration will only work after an integration is installed. After that, [set your DSN]{#setting-the-dsn}.
 
 ### Setting the DSN (Data Source Name) {#setting-the-dsn}
 

--- a/src/collections/_documentation/clients/php/index.md
+++ b/src/collections/_documentation/clients/php/index.md
@@ -6,8 +6,15 @@ sidebar_relocation: platforms
 
 The PHP SDK for Sentry supports PHP 5.3 and higher. It’s available as a BSD licensed Open Source library.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD installation -->
-## Installation
+## Installation {#install}
 
 There are various ways to install the PHP integration for Sentry. The recommended way is to use [Composer](http://getcomposer.org/):
 
@@ -27,7 +34,7 @@ Alternatively you can manually install it:
 <!-- ENDWIZARD -->
 
 <!-- WIZARD configuration -->
-## Configuration
+## Configuration {#configure}
 
 The most important part is the creation of the raven client. Create it once and reference it from anywhere you want to interface with Sentry:
 

--- a/src/collections/_documentation/clients/php/index.md
+++ b/src/collections/_documentation/clients/php/index.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD installation -->
 ## Installation {#install}

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -6,8 +6,15 @@ sidebar_relocation: platforms
 
 This is the documentation for our React-Native SDK. The React-Native SDK uses a native extension for iOS and Android but will fall back to a pure JavaScript version if necessary.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD -->
-## Installation
+## Installation {#install}
 
 Start by adding Sentry and then linking it:
 
@@ -57,7 +64,7 @@ When you use Xcode you can hook directly into the build process to upload debug 
 For Android we hook into gradle for the sourcemap build process. When you run `react-native link` the gradle files are automatically updated. When you run `./gradlew assembleRelease` sourcemaps are automatically built and uploaded to Sentry.
 
 <!-- WIZARD -->
-## Client Configuration
+## Client Configuration {#configure}
 
 Note: When you run `react-native link` we will automatically update your _index.ios.js_ / _index.android.js_ with the following changes:
 

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD -->
 ## Installation {#install}

--- a/src/collections/_documentation/clients/ruby/index.md
+++ b/src/collections/_documentation/clients/ruby/index.md
@@ -6,8 +6,15 @@ sidebar_relocation: platforms
 
 Raven for Ruby is a client and integration layer for the Sentry error reporting API. It supports Ruby 1.9.3 and 2.x. JRuby support is provided but experimental.
 
+## Getting Started
+Getting started with Sentry is a three step process:
+
+1.  [Sign up for an account](https://sentry.io/signup/)
+2.  [Install your SDK](#install)
+2.  [Configure it](#configure)
+
 <!-- WIZARD -->
-## Installation
+## Installation {#install}
 
 Raven Ruby comes as a gem and is straightforward to install. If you are using Bundler just add this to your `Gemfile`:
 
@@ -17,7 +24,7 @@ gem "sentry-raven"
 
 For other means of installation see [_Installation_]({%- link _documentation/clients/ruby/install.md -%}).
 
-## Configuration
+## Configuration {#configure}
 
 To use Raven Ruby all you need is your DSN. Like most Sentry libraries it will honor the `SENTRY_DSN` environment variable. You can find it on the project settings page under API Keys. You can either export it as environment variable or manually configure it with `Raven.configure`:
 

--- a/src/collections/_documentation/clients/ruby/index.md
+++ b/src/collections/_documentation/clients/ruby/index.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#install)
-2.  [Configure it](#configure)
+3.  [Configure it](#configure)
 
 <!-- WIZARD -->
 ## Installation {#install}


### PR DESCRIPTION
I've added Getting Started 1, 2, 3 to the index of each SDK in the main navigation that isn't unified. This will help users who miss the Getting Started under Error Reporting.