### PR TITLE
add sentry-testkit docs section in Javascript platform

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -327,7 +327,6 @@ Array [
   "platforms/dotnet/serilog/index.html",
   "platforms/index.html",
   "platforms/javascript/advance-settings/index.html",
-  "platforms/javascript/sentry-testkit/index.html"
   "platforms/javascript/angular/index.html",
   "platforms/javascript/cordova/index.html",
   "platforms/javascript/default-integrations/index.html",
@@ -340,6 +339,7 @@ Array [
   "platforms/javascript/loader/index.html",
   "platforms/javascript/pluggable-integrations/index.html",
   "platforms/javascript/react/index.html",
+  "platforms/javascript/sentry-testkit/index.html",
   "platforms/javascript/sourcemaps/availability/index.html",
   "platforms/javascript/sourcemaps/generation/index.html",
   "platforms/javascript/sourcemaps/index.html",

--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -327,6 +327,7 @@ Array [
   "platforms/dotnet/serilog/index.html",
   "platforms/index.html",
   "platforms/javascript/advance-settings/index.html",
+  "platforms/javascript/sentry-testkit/index.html"
   "platforms/javascript/angular/index.html",
   "platforms/javascript/cordova/index.html",
   "platforms/javascript/default-integrations/index.html",

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -3,7 +3,7 @@ title: Sentry Testkit
 sidebar_order: 30002
 ---
 
-When building tests for your application, you want to assert that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to *Sentry* servers. This way you won't swamp Sentry with false reports during test running and other CI operations.
+When building tests for your application, you want to assert, that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to the *Sentry* servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
 
 ### This is where Sentry Testkit comes in!
 [Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin to allow intercepting Sentry's report and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -38,4 +38,4 @@ You may see more usage examples in the [testing section](https://github.com/wix/
 
 #### Testkit API
 Sentry Testkit consists of a very simple and straightforward API.
-See full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/)
+See the full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/).

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -5,7 +5,7 @@ sidebar_order: 30002
 
 When building tests for your application, you want to assert, that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to the *Sentry* servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
 
-### This is where Sentry Testkit comes in!
+### This is where the Sentry Testkit comes in!
 [Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin to allow intercepting Sentry's report and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
 
 ### Getting Started

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -36,6 +36,6 @@ expect(report).toHaveProperty(...)
 
 You may see more usage examples in the [testing section](https://github.com/wix/sentry-testkit/tree/master/test) of sentry-testkit repository as well.
 
-#### Test Kit API
+#### Testkit API
 Sentry testkit consists of a very simple and strait-forward API.
 See full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/)

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -3,39 +3,44 @@ title: Sentry Testkit
 sidebar_order: 30002
 ---
 
-When building tests for your application, you want to assert, that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to the *Sentry* servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
+When building tests for your application, you want to assert, that the right flow-tracking or error is being sent to _Sentry_, **but** without really sending it to the _Sentry_ servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
 
 ### This is where the Sentry Testkit comes in!
+
 [Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin that allows intercepting Sentry's reports and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry's transport mechanism, the report is not really sent, but rather logged locally into the memory. This way, logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
 
 ### Getting Started
+
 #### Installation
+
 ```
 npm install sentry-testkit --save-dev
 ```
 
 #### Using in tests
+
 ```javascript
-const sentryTestkit = require('sentry-testkit')
+const sentryTestkit = require("sentry-testkit")
 
 const { testkit, sentryTransport } = sentryTestkit()
 
 // initialize your Sentry instance with sentryTransport
 Sentry.init({
-    dsn: 'some_dummy_dsn',
-    transport: sentryTransport,
-    //... other configurations
+  dsn: 'some_dummy_dsn',
+  transport: sentryTransport
+  //... other configurations
 })
 
 // then run any scenario that should call Sentry.catchException(...)
 
 expect(testKit.reports()).toHaveLength(1)
 const report = testKit.reports()[0]
-expect(report).toHaveProperty(...)
+expect(report).toHaveProperty(/*...*/)
 ```
 
 You may see more usage examples in the [testing section](https://github.com/wix/sentry-testkit/tree/master/test) of sentry-testkit repository as well.
 
 #### Testkit API
+
 Sentry Testkit consists of a very simple and straightforward API.
 See the full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/).

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -34,7 +34,7 @@ const report = testKit.reports()[0]
 expect(report).toHaveProperty(...)
 ```
 
-You may see more usage examples in the testing section of this repository as well.
+You may see more usage examples in the [testing section](https://github.com/wix/sentry-testkit/tree/master/test) of sentry-testkit repository as well.
 
 #### Test Kit API
 Sentry testkit consists of a very simple and strait-forward API.

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -1,0 +1,41 @@
+---
+title: Sentry Testkit
+sidebar_order: 30002
+---
+
+When building tests for your application, you want to assert that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to *Sentry* servers. This way you won't swamp Sentry with false reports during test running and other CI operations.
+
+### This is where Sentry Testkit comes in!
+[Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin to allow intercepting Sentry's report and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
+
+### Getting Started
+#### Installation
+```
+npm install sentry-testkit --save-dev
+```
+
+#### Using in tests
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const { testkit, sentryTransport } = sentryTestkit()
+
+// initialize your Sentry instance with sentryTransport
+Sentry.init({
+    dsn: 'some_dummy_dsn',
+    transport: sentryTransport,
+    //... other configurations
+})
+
+// then run any scenario that should call Sentry.catchException(...)
+
+expect(testKit.reports()).toHaveLength(1)
+const report = testKit.reports()[0]
+expect(report).toHaveProperty(...)
+```
+
+You may see more usage examples in the testing section of this repository as well.
+
+#### Test Kit API
+Sentry testkit consists of a very simple and strait-forward API.
+See full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/)

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -6,7 +6,7 @@ sidebar_order: 30002
 When building tests for your application, you want to assert, that the right flow-tracking or error is being sent to *Sentry*, **but** without really sending it to the *Sentry* servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
 
 ### This is where the Sentry Testkit comes in!
-[Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin to allow intercepting Sentry's report and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
+[Sentry Testkit](https://wix.github.io/sentry-testkit/) is a Sentry plugin that allows intercepting Sentry's reports and further inspection of the data being sent. It enables Sentry to work natively in your application, and by overriding the default Sentry's transport mechanism, the report is not really sent, but rather logged locally into the memory. This way, logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
 
 ### Getting Started
 #### Installation

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -37,5 +37,5 @@ expect(report).toHaveProperty(...)
 You may see more usage examples in the [testing section](https://github.com/wix/sentry-testkit/tree/master/test) of sentry-testkit repository as well.
 
 #### Testkit API
-Sentry testkit consists of a very simple and strait-forward API.
+Sentry Testkit consists of a very simple and straightforward API.
 See full API description and documentation in [Sentry Testkit Docs](https://wix.github.io/sentry-testkit/)


### PR DESCRIPTION
As Sentry moved from Raven (Sentry's Javascript SDK) to a new Sentry API, there was a need to renovvate [`raven-testkit`](https://www.npmjs.com/package/raven-testkit) and change it accordingly.
It is now named `sentry-testkit` and has a brand new repository with stunning site: https://wix.github.io/sentry-testkit/.

As part of those changes, Sentry moved the `raven-testkit` docs to their [legacy section](https://docs.sentry.io/clients/javascript/tips/#raven-test-kit) and now it is time to update the current Sentry docs with the new `sentry-testkit` section
