### PR TITLE
Fix: JS docs code snippet

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -17,10 +17,11 @@ The table below shows supported browsers:
 
 {% capture __alert %}
 Our SDK needs a polyfill for `Promise` in older browsers like IE 11 and below. 
-Please add this script tag  
-`<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise"></script>`  
-before loading our SDK. 
+Please add this script tag below before loading our SDK. 
 If you are using the npm package please use a polyfill for `Promise` respectively.
+```
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise"></script>
+```
 
 Additionally, keep in mind to also define `<!doctype html>` on top of your html page, 
 to make sure IE does not go into compatibility mode.


### PR DESCRIPTION
Before:
<img width="763" alt="screen shot 2019-01-10 at 2 23 38 pm" src="https://user-images.githubusercontent.com/16394317/51001104-d4b0d080-14e3-11e9-9ff1-f7b7cfd71a27.png">

After:
<img width="764" alt="screen shot 2019-01-10 at 2 23 24 pm" src="https://user-images.githubusercontent.com/16394317/51001115-db3f4800-14e3-11e9-86e3-dba4aea2c64a.png">