### PR TITLE
make fingerprint example more clear

### DIFF
--- a/src/collections/_documentation/data-management/set-fingerprint/javascript.md
+++ b/src/collections/_documentation/data-management/set-fingerprint/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
-  scope.setFingerprint(['my-view-function']);
+Sentry.withScope((scope) => {
+  scope.setFingerprint(['group1']);
 });
 ```


### PR DESCRIPTION
It doesn't really make sense to use `configureScope` alongside fingerprints. The whole point of fingerprints is to be able to group one event differently than another and anything set in `configureScope` would be global to all events.

It also seems weird that the string example is `'my-view-function'`. This makes it seem like you need to pass the name of a function to be executed or something.