### PR TITLE
Remove Algolia logo

### DIFF
--- a/src/_js/lib/Search.js
+++ b/src/_js/lib/Search.js
@@ -40,7 +40,7 @@ $(function() {
         empty:
           '<div class="list-group-item">No results</div><a href="https://www.algolia.com" class="list-group-item list-group-item-action"><img src="https://www.algolia.com/static_assets/images/pricing/pricing_new/algolia-powered-by-8762ce8b.svg" alt="Search by Algolia" /></a>',
         allItems:
-          '{{#hits}}<a href="{{ url }}" class="list-group-item list-group-item-action"><h6 class="mb-1">{{{ _highlightResult.title.value }}}</h6>{{{ _snippetResult.content.value }}}</a>{{/hits}}<a href="https://www.algolia.com" class="list-group-item list-group-item-action"><img src="https://www.algolia.com/static_assets/images/pricing/pricing_new/algolia-powered-by-8762ce8b.svg" alt="Search by Algolia" /></a>'
+          '{{#hits}}<a href="{{ url }}" class="list-group-item list-group-item-action"><h6 class="mb-1">{{{ _highlightResult.title.value }}}</h6>{{{ _snippetResult.content.value }}}</a>{{/hits}}'
       }
     })
   );


### PR DESCRIPTION
We're customers now, so the logo is not required.