### PR TITLE
Redirect from old Jira Server link to new Jira Server link

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -164,6 +164,10 @@ server {
   location = /learn/hints {
     return 302 /error-reporting/configuration/filtering/$is_args$args;
   }
+  
+  location = /workflow/integrations/jira-server/ {
+    return 302 /workflow/integrations/global-integrations/jira-server/;
+  }
 
   location = /sitemap/ {
     return 301 /sitemap.xml$is_args$args;


### PR DESCRIPTION
When you google 'sentry jira server docs', you get an old link, which results in a 404 -- code here to redirect to the current page.