### PR TITLE
Fixed spelling and grammar in Node docs

### DIFF
--- a/src/collections/_documentation/platforms/node/connect.md
+++ b/src/collections/_documentation/platforms/node/connect.md
@@ -5,7 +5,7 @@ sidebar_order: 1012
 
 <!-- WIZARD -->
 
-Our Connect integration only requires _@sentry/node_ to be installed then you can use it like this:
+Our Connect integration only requires the installation of _@sentry/node_, and then you can use it like this:
 
 ```javascript
 const connect = require('connect');

--- a/src/collections/_documentation/platforms/node/default-integrations.md
+++ b/src/collections/_documentation/platforms/node/default-integrations.md
@@ -3,12 +3,12 @@ title: Default Integrations
 sidebar_order: 10
 ---
 
-System integrations are integrations enabled by default that integrate into the
-standard library or the interpreter itself. They are documented so you can see
+System integrations are integrations enabled by default that combine into the
+standard library or the interpreter itself. They're documented so you can see
 what they do and that they can be disabled if they cause issues. To disable
 system integrations set `defaultIntegrations: false` when calling `init()`.
 To override their settings, provide a new instance with your config
-to `integrations` option, for example to change fatal error handler
+to `integrations` option. For example: to change fatal error handler
 `integrations: [new Sentry.Integrations.OnUncaughtException({ onFatalError: () => { /** your implementation */ } })]`.
 
 ## Core
@@ -17,16 +17,13 @@ to `integrations` option, for example to change fatal error handler
 
 _Import name: `Sentry.Integrations.Dedupe`_
 
-This integration deduplicates certain events. This is enabled by default and should not
-be disabled except in rare circumstances. Disabling this integration for instance will
-cause duplicate error logging.
+This integration deduplicates certain events. It's enabled by default and should not be disabled, except in rare circumstances. Disabling this integration, for instance, will cause duplicate error logging.
 
 ### InboundFilters
 
 _Import name: `Sentry.Integrations.InboundFilter`_
 
-This integration allows developers to ignore specific errors based on the type or message,
-as well as blacklist/whitelist urls which exception originates from.
+This integration allows developers to ignore specific errors based on the type of message, as well as blacklist/whitelist URLs from which the exception originated.
 
 To configure it, use `ignoreErrors`, `blacklistUrls` and `whitelistUrls` SDK options directly.
 
@@ -34,15 +31,13 @@ To configure it, use `ignoreErrors`, `blacklistUrls` and `whitelistUrls` SDK opt
 
 _Import name: `Sentry.Integrations.FunctionToString`_
 
-This integration allows SDK to provide original functions and method names,
-even when they are wrapped by our error or breadcrumbs handlers.
+This integration allows the SDK to provide original functions and method names, even when they are wrapped by our error or breadcrumbs handlers.
 
 ### ExtraErrorData
 
 _Import name: `Sentry.Integrations.ExtraErrorData`_
 
-This integration extracts all non-native attributes from the Error object and attaches
-them to the event as the `extra` data.
+This integration extracts all non-native attributes from the Error object and attaches them to the event as the `extra` data.
 
 ## Node specific
 
@@ -50,7 +45,7 @@ them to the event as the `extra` data.
 
 _Import name: `Sentry.Integrations.Console`_
 
-This integration wraps `console` module to treat all it's calls as breadcrumbs.
+This integration wraps the `console` module to treat all its calls as breadcrumbs.
 
 ### Http
 
@@ -62,7 +57,7 @@ This integration wraps `http` and `https` modules to capture all network request
 
 _Import name: `Sentry.Integrations.OnUncaughtException`_
 
-This integration attaches global uncaught exception handler. Can be modified to provide a custom shutdown function.
+This integration attaches a global uncaught exception handler. It can be modified to provide a custom shutdown function.
 
 Available options:
 
@@ -82,8 +77,7 @@ This integration attaches global unhandled rejection handlers.
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows to configure linked errors. They'll be recursively read up to a specified limit
-and lookup will be performed by a specific key. By default, limit is set to 5 and key used is `cause`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit and lookup will be performed by a specific key. By default, the limit sets to 5 and the key used is `cause`.
 
 Available options:
 

--- a/src/collections/_documentation/platforms/node/express.md
+++ b/src/collections/_documentation/platforms/node/express.md
@@ -5,7 +5,7 @@ sidebar_order: 1010
 
 <!-- WIZARD -->
 
-Our Express integration only requires _@sentry/node_ to be installed then you can use it like this:
+Our Express integration only requires the installation of _@sentry/node_, and then you can use it like this:
 
 ```javascript
 const express = require('express');

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -86,10 +86,8 @@ And these exist for breadcrumbs:
 
 ## EventProcessors
 
-With `eventProcessors` you are able to hook into the process of enriching the event with additional data.
-You can add you own `eventProcessor` on the current scope. The difference to `beforeSend` is that
-`eventProcessors` run on the scope level where `beforeSend` runs globally not matter in which scope you are.
-`eventProcessors` also optionally receive the hint see: [Hints](#hints).
+With `eventProcessors` you are able to hook into the process of enriching the event with additional data. You can add your own `eventProcessor` on the current scope. The difference between `beforeSend` and `eventProcessors` is that `eventProcessors` run on the scope level whereas `beforeSend` runs globally, not matter which scope you're in.
+Also, `eventProcessors` optionally receive the hint (see: [Hints](#hints)).
 
 ```javascript
 // This will be set globally for every succeeding event send

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -9,7 +9,7 @@ All our JavaScript-related SDKs provide the same API. Still, there are some diff
 
 ## Integrations
 
-All of our SDKs provide _Integrations_, which can be seen as some kind of plugin. All JavaScript SDKs provide default _Integrations_; please check details of a specific SDK to see which _Integrations_ it provides.
+All of our SDKs provide _Integrations_, similar to a plugin. All JavaScript SDKs provide default _Integrations_; please check details of a specific SDK to see which _Integrations_ it offers.
 
 One thing is the same across all our JavaScript SDKs --- how you add or remove _Integrations_. (Example: for `@sentry/node`)
 

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -63,17 +63,17 @@ Event and Breadcrumb `hints` are objects containing various information used to 
 
 They're available in two places: `beforeSend`/`beforeBreadcrumb` and `eventProcessors`. Those are the two ways we'll allow users to modify what we put together.
 
-These common hints currently exist for events:
+### Hints for Events
 
 `originalException`
 
-: The original exception that caused the event to be created. This is useful for changing how events are grouped, or to extract additional information.
+: The original exception that created the event. This is useful for changing how events are grouped, or to extract additional information.
 
 `syntheticException`
 
 : When a string or a non-error object is raised, Sentry creates a synthetic exception so you can get a basic stacktrace. This exception is stored here for further data extraction.
 
-And these exist for breadcrumbs:
+### Hints for Breadcrumbs
 
 `level` / `input`
 
@@ -86,7 +86,7 @@ And these exist for breadcrumbs:
 
 ## EventProcessors
 
-With `eventProcessors` you are able to hook into the process of enriching the event with additional data. You can add your own `eventProcessor` on the current scope. The difference between `beforeSend` and `eventProcessors` is that `eventProcessors` run on the scope level whereas `beforeSend` runs globally, not matter which scope you're in.
+With `eventProcessors` you can hook into the process of enriching the event with additional data. You can add your own `eventProcessor` on the current scope. The difference between `beforeSend` and `eventProcessors` is that `eventProcessors` run on the scope level whereas `beforeSend` runs globally, no matter which scope you're in.
 Also, `eventProcessors` optionally receive the hint (see: [Hints](#hints)).
 
 ```javascript

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -59,7 +59,7 @@ Sentry.init({
 
 ## Hints
 
-Event and Breadcrumb `hints` are objects containing various information used to put together an event or a breadcrumb. For events, those are things like `event_id`, `originalException`, `syntheticException` (used internally to generate a cleaner stacktrace), and any other arbitrary `data` that a user attaches. For breadcrumbs, it's all implementation dependent. For XHR requests, hint contains the xhr object itself. For user interactions, it contains the DOM element and event name, etc.
+Event and Breadcrumb `hints` are objects containing various information used to put together an event or a breadcrumb. For events, those are things like `event_id`, `originalException`, `syntheticException` (used internally to generate a cleaner stack trace), and any other arbitrary `data` that a user attaches. For breadcrumbs, it's all implementation dependent. For XHR requests, hint contains the xhr object itself. For user interactions, it contains the DOM element and event name, etc.
 
 They're available in two places: `beforeSend`/`beforeBreadcrumb` and `eventProcessors`. Those are the two ways we'll allow users to modify what we put together.
 
@@ -71,7 +71,7 @@ They're available in two places: `beforeSend`/`beforeBreadcrumb` and `eventProce
 
 `syntheticException`
 
-: When a string or a non-error object is raised, Sentry creates a synthetic exception so you can get a basic stacktrace. This exception is stored here for further data extraction.
+: When a string or a non-error object is raised, Sentry creates a synthetic exception so you can get a basic stack trace. This exception is stored here for further data extraction.
 
 ### Hints for Breadcrumbs
 

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -11,7 +11,7 @@ All our JavaScript-related SDKs provide the same API. Still, there are some diff
 
 All of our SDKs provide _Integrations_, similar to a plugin. All JavaScript SDKs provide default _Integrations_; please check details of a specific SDK to see which _Integrations_ it offers.
 
-One thing is the same across all our JavaScript SDKs --- how you add or remove _Integrations_. (Example: for `@sentry/node`)
+One thing that is the same across all our JavaScript SDKs --- how you add or remove _Integrations_. (Example: for `@sentry/node`)
 
 ### Adding an Integration
 

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -5,21 +5,21 @@ sidebar_order: 2
 
 {% include learn-sdk.md platform="node" %}
 
-All our JavaScript-related SDKs provide the same API still there are some differences between them which this section of the docs explains.
+All our JavaScript-related SDKs provide the same API. Still, there are some differences between them which this section of the docs explains.
 
 ## Integrations
 
-All of our SDKs provide _Integrations_, which can be seen as some kind of plugins. All JavaScript SDKs provide default _Integrations_; please check details of a specific SDK to see which _Integrations_ it provides.
+All of our SDKs provide _Integrations_, which can be seen as some kind of plugin. All JavaScript SDKs provide default _Integrations_; please check details of a specific SDK to see which _Integrations_ it provides.
 
-One thing is the same across all our JavaScript SDKs and that's how you add or remove _Integrations_, e.g.: for `@sentry/node`.
+One thing is the same across all our JavaScript SDKs --- how you add or remove _Integrations_. (Example: for `@sentry/node`)
 
 ### Adding an Integration
 
 ```javascript
 import * as Sentry from '@sentry/node';
 
-// All integration that come with an SDK can be found on Sentry.Integrations object
-// Custom integration must conform Integration interface: https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/index.ts
+// All integrations that come with an SDK can be found on the Sentry.Integrations object
+// Custom integrations must conform Integration interface: https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/index.ts
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
@@ -29,7 +29,7 @@ Sentry.init({
 
 ### Removing an Integration
 
-In this example we will remove the by default enabled integration for adding breadcrumbs to the event:
+In this example, we will remove the by default enabled integration for adding breadcrumbs to the event:
 
 ```javascript
 import * as Sentry from '@sentry/node';
@@ -59,32 +59,29 @@ Sentry.init({
 
 ## Hints
 
-Event and Breadcrumb `hints` are objects containing various information used to put together an event or a breadcrumb. For events, those are things like `event_id`, `originalException`, `syntheticException` (used internally to generate cleaner stacktrace), and any other arbitrary `data` that user attaches. For breadcrumbs it's all implementation dependent. For XHR requests, hint contains xhr object itself, for user interactions it contains DOM element and event name etc.
+Event and Breadcrumb `hints` are objects containing various information used to put together an event or a breadcrumb. For events, those are things like `event_id`, `originalException`, `syntheticException` (used internally to generate a cleaner stacktrace), and any other arbitrary `data` that a user attaches. For breadcrumbs, it's all implementation dependent. For XHR requests, hint contains the xhr object itself. For user interactions, it contains the DOM element and event name, etc.
 
-They are available in two places. `beforeSend`/`beforeBreadcrumb` and `eventProcessors`. Those are two ways we'll allow users to modify what we put together.
+They're available in two places: `beforeSend`/`beforeBreadcrumb` and `eventProcessors`. Those are the two ways we'll allow users to modify what we put together.
 
 These common hints currently exist for events:
 
 `originalException`
 
-: The original exception that caused the event to be created. This is useful for changing how events
-are grouped or to extract additional information.
+: The original exception that caused the event to be created. This is useful for changing how events are grouped, or to extract additional information.
 
 `syntheticException`
 
-: When a string or a non error object is raised, Sentry creates a synthetic exception so you can get a
-basic stacktrace. This exception is stored here for further data extraction.
+: When a string or a non-error object is raised, Sentry creates a synthetic exception so you can get a basic stacktrace. This exception is stored here for further data extraction.
 
 And these exist for breadcrumbs:
 
 `level` / `input`
 
-: For breadcrumbs created from console log interceptions this holds the original console log level and the
-original input data to the log function.
+: For breadcrumbs created from console log interceptions, this holds the original console log level and the original input data to the log function.
 
 `request` / `response` / `event`
 
-: For breadcrumbs created from HTTP requests this holds the request and response object
+: For breadcrumbs created from HTTP requests, this holds the request and response object
 (from the node HTTP API) as well as the node event (`response` or `error`).
 
 ## EventProcessors

--- a/src/collections/_documentation/platforms/node/koa.md
+++ b/src/collections/_documentation/platforms/node/koa.md
@@ -5,7 +5,7 @@ sidebar_order: 1011
 
 <!-- WIZARD -->
 
-Our Koa integration only requires _@sentry/node_ to be installed then you can use it like this:
+Our Koa integration only requires the installation of _@sentry/node_, and then you can use it like this:
 
 ```javascript
 const koa = require('koa');

--- a/src/collections/_documentation/platforms/node/pluggable-integrations.md
+++ b/src/collections/_documentation/platforms/node/pluggable-integrations.md
@@ -34,7 +34,7 @@ Available options:
 ```js
 {
   root: string; // root path that will be appended to the basename of the current frame's url
-  iteratee: (frame) => frame); // function that takes the frame, applys any transformation on it and returns it back
+  iteratee: (frame) => frame); // function that takes the frame, applies any transformation on it and returns it back
 }
 ```
 

--- a/src/collections/_documentation/platforms/node/pluggable-integrations.md
+++ b/src/collections/_documentation/platforms/node/pluggable-integrations.md
@@ -44,7 +44,7 @@ Available options:
 
 _Import name: `Sentry.Integrations.Modules`_
 
-This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, the list will cache for later reuse.
+This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, Sentry will cache the list for later reuse.
 
 ### Transaction
 

--- a/src/collections/_documentation/platforms/node/pluggable-integrations.md
+++ b/src/collections/_documentation/platforms/node/pluggable-integrations.md
@@ -27,7 +27,7 @@ Available options:
 
 _Import name: `Sentry.Integrations.RewriteFrames`_
 
-This integration allows you to apply a transformation to each frame of the stacktrace. In the simple scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
+This integration allows you to apply a transformation to each frame of the stack trace. In the simple scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
 
 Available options:
 
@@ -50,4 +50,4 @@ This integration fetches names of all currently installed Node modules and attac
 
 _Import name: `Sentry.Integrations.Transaction`_
 
-This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stacktrace frames and reads the first in-app frame's module and function name.
+This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stack trace frames and reads the first in-app frame's module and function name.

--- a/src/collections/_documentation/platforms/node/pluggable-integrations.md
+++ b/src/collections/_documentation/platforms/node/pluggable-integrations.md
@@ -3,11 +3,7 @@ title: Pluggable Integrations
 sidebar_order: 11
 ---
 
-Pluggable integrations are integrations that can be additionally enabled,
-to provide some very specific features. They are documented so you can see
-what they do and that they can be enabled.
-To enable pluggable integrations, provide a new instance with your config
-to `integrations` option, for example `integrations: [new Sentry.Integrations.Modules()]`.
+Pluggable integrations are integrations that can be additionally enabled, to provide specific features. They're documented so you can see what they do and that they can be enabled. To enable pluggable integrations, provide a new instance with your config to the `integrations` option. For example: `integrations: [new Sentry.Integrations.Modules()]`.
 
 
 ## Core
@@ -16,8 +12,7 @@ to `integrations` option, for example `integrations: [new Sentry.Integrations.Mo
 
 _Import name: `Sentry.Integrations.Debug`_
 
-This integration allows you to easily inspect the content of the processed event,
-that will be passed to `beforeSend` and effectively send to the Sentry.
+This integration allows you to quickly inspect the content of the processed event that will be passed to `beforeSend` and effectively send it to Sentry.
 
 Available options:
 
@@ -32,16 +27,14 @@ Available options:
 
 _Import name: `Sentry.Integrations.RewriteFrames`_
 
-This integration allows you to apply transformation to each frame of the stack trace.
-In the simple scenario, it can be used to change name of the file frame originates from,
-or can be fed with iteratee function, to apply any arbitrary transformation.
+This integration allows you to apply a transformation to each frame of the stacktrace. In the simple scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
 
 Available options:
 
 ```js
 {
   root: string; // root path that will be appended to the basename of the current frame's url
-  iteratee: (frame) => frame); // function that take the frame, apply any transformation on it and returns it back
+  iteratee: (frame) => frame); // function that takes the frame, applys any transformation on it and returns it back
 }
 ```
 
@@ -51,10 +44,10 @@ Available options:
 
 _Import name: `Sentry.Integrations.Modules`_
 
-This integration fetches names of all currently installed node modules and attaches the list to the event. Once fetched, the list will be cached for later reuse.
+This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, the list will cache for later reuse.
 
 ### Transaction
 
 _Import name: `Sentry.Integrations.Transaction`_
 
-This integration tries to extract usable transaction name, that will be used to distinguish the event from the rest. It walks through all stack trace frames and reads first in-app frame's module and function name.
+This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stacktrace frames and reads the first in-app frame's module and function name.

--- a/src/collections/_documentation/platforms/node/pluggable-integrations.md
+++ b/src/collections/_documentation/platforms/node/pluggable-integrations.md
@@ -27,7 +27,7 @@ Available options:
 
 _Import name: `Sentry.Integrations.RewriteFrames`_
 
-This integration allows you to apply a transformation to each frame of the stack trace. In the simple scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
+This integration allows you to apply a transformation to each frame of the stack trace. In the streamlined scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
 
 Available options:
 

--- a/src/collections/_documentation/platforms/node/sourcemaps.md
+++ b/src/collections/_documentation/platforms/node/sourcemaps.md
@@ -97,4 +97,4 @@ Sentry.init({
 
 There’s one critical thing to note here. This config assumes, that you’ll bundle your application into a single file, which will be served and then uploaded to Sentry from the root of the project's directory.
 
-If you're not doing this, e.g. you're using TypeScript and upload all your compiled files separately to the server, then we need to be a little smarter about this. Please refer to [TypeScript usage docs]({%- link _documentation/platforms/node/typescript.md -%}) to see a more complex and detailed example.
+If you're not doing this, e.g. you're using TypeScript and upload all your compiled files separately to the server, then this may take a little more effort. Please refer to [TypeScript usage docs]({%- link _documentation/platforms/node/typescript.md -%}) to see a more complex and detailed example.

--- a/src/collections/_documentation/platforms/node/sourcemaps.md
+++ b/src/collections/_documentation/platforms/node/sourcemaps.md
@@ -13,7 +13,7 @@ Most modern JavaScript transpilers support source maps. Below are instructions f
 
 Webpack is a powerful build tool that resolves and bundles your JavaScript modules into files fit for running in the browser. It also supports many different “loaders” which can convert higher-level languages like TypeScript and ES6/ES2015 into browser-compatible JavaScript.
 
-Webpack can be configured to output source maps by editing `webpack.config.js`.
+You can configure webpack to output source maps by editing `webpack.config.js`.
 
 ```javascript
 const path = require('path');
@@ -38,12 +38,12 @@ Source maps for Node.js projects should be uploaded directly to Sentry.
 
 ### Uploading Source Maps to Sentry
 
-Sentry provides an abstraction called **Releases** which you can attach source artifacts to. The release API is intended to allow you to store source files (and sourcemaps) within Sentry.
+Sentry provides an abstraction called **Releases** which you can attach source artifacts to. The release API is intended to allow you to store source files (and source maps) within Sentry.
 
-It can be easily done with a help of the `sentry-webpack-plugin`, which internally uses our Sentry CLI.
+You can do this with the help of the `sentry-webpack-plugin`, which internally uses our Sentry CLI.
 
 -   Start by creating a new authentication token under **[Account] > API**.
--   Ensure you you have `project:write` selected under scopes.
+-   Ensure you have `project:write` selected under scopes.
 -   Install `@sentry/webpack-plugin` using `npm`
 -   Create `.sentryclirc` file with necessary config (see Sentry Webpack Plugin docs below)
 -   Update your `webpack.config.json`
@@ -73,13 +73,20 @@ Sentry.init({
 });
 ```
 
-Note: You dont _have_ to use _RELEASE_ environment variables. You can provide them in any way you want, just make sure that `release` from your upload **matches** `release` from your `init` call.
+{% capture __alert_content -%}
+You don't _have_ to use _RELEASE_ environment variables. You can provide them in any way you want, just make sure that `release` from your upload **matches** `release` from your `init` call.
+{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="info"
+%}
 
 Additional information can be found in the [Releases API documentation]({%- link _documentation/api/releases/index.md -%}).
 
 ## Updating Sentry SDK configuration to support Source Maps
 
-In order for Sentry to understand how to resolve errors sources, we need to modify the data we send. Thankfully, we have an integration called `RewriteFrames` which can be used to do just that.
+For Sentry to understand how to resolve errors sources, we need to modify the data we send. Thankfully, we have an integration called `RewriteFrames` which can be used to do just that.
 
 ```javascript
 Sentry.init({
@@ -88,6 +95,6 @@ Sentry.init({
 });
 ```
 
-There’s one very important thing to note here. This config assumes, that you’ll bundle your application into a single file, which will be served and then uploaded to Sentry from the root of the project's directory.
+There’s one critical thing to note here. This config assumes, that you’ll bundle your application into a single file, which will be served and then uploaded to Sentry from the root of the project's directory.
 
-If you are not doing this, eg. you are using TypeScript and upload all your compiled files separately to the server, then we need to be a little smarter about this. Please refer to [TypeScript usage docs]({%- link _documentation/platforms/node/typescript.md -%}) to see a more complex and detailed example.
+If you're not doing this, e.g. you're using TypeScript and upload all your compiled files separately to the server, then we need to be a little smarter about this. Please refer to [TypeScript usage docs]({%- link _documentation/platforms/node/typescript.md -%}) to see a more complex and detailed example.

--- a/src/collections/_documentation/platforms/node/sourcemaps.md
+++ b/src/collections/_documentation/platforms/node/sourcemaps.md
@@ -13,7 +13,7 @@ Most modern JavaScript transpilers support source maps. Below are instructions f
 
 Webpack is a powerful build tool that resolves and bundles your JavaScript modules into files fit for running in the browser. It also supports many different “loaders” which can convert higher-level languages like TypeScript and ES6/ES2015 into browser-compatible JavaScript.
 
-You can configure webpack to output source maps by editing `webpack.config.js`.
+You can configure Webpack to output source maps by editing `webpack.config.js`.
 
 ```javascript
 const path = require('path');

--- a/src/collections/_documentation/platforms/node/typescript.md
+++ b/src/collections/_documentation/platforms/node/typescript.md
@@ -3,7 +3,9 @@ title: TypeScript
 sidebar_order: 3
 ---
 
-Please read [Source Maps docs]({%- link _documentation/platforms/node/sourcemaps.md -%}) first to learn how to configure Sentry SDK, upload artifacts to our servers or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).
+Please read [Source Maps docs]({%- link _documentation/platforms/node/sourcemaps.md -%}) first to learn how to configure Sentry SDK, upload artifacts to our servers, or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).
+
+## Sentry SDK and Source Maps with TypeScript
 
 Using Sentry SDK and Source Maps with TypeScript, unfortunately, requires slightly more configuration.
 
@@ -13,6 +15,8 @@ There are two main reasons for this:
 2.  SourceRoot is by default set to, well, source directory, which would require uploading artifacts from 2 separate directories and modification of source maps themselves
 
 We can still make it work with two additional steps, so let’s do this.
+
+### 1. Configuring TypeScript Compiler
 
 The first one is configuring TypeScript compiler in a way, in which we’ll override _sourceRoot_ and merge original sources with corresponding maps. The former is not required, but it’ll help Sentry display correct file paths, e.g. _/lib/utils/helper.ts_ instead of a full one like _/Users/Sentry/Projects/TSExample/lib/utils/helper.ts_. You can skip this option if you’re fine with long names.
 
@@ -48,11 +52,13 @@ Create a new one called _tsconfig.production.json_ and paste the snippet below:
 
 From now on, when you want to run the production build, which will then upload, you specify this specific config, e.g., _tsc -p tsconfig.production.json_. This will create necessary source maps and attach original sources to them instead of making us upload them and modify source paths in our maps by hand.
 
+### 2. Changing Events Frames
+
 The second step is changing events frames so that Sentry can link stacktraces with correct source files.
 
 This can be done using _dataCallback_, in a very similar manner as we do with a single entry point described in Source Maps docs, with one, significant difference. Instead of using _basename_, we have to somehow detect and pass the root directory of our project.
 
-Unfortunately, Node is very fragile in that manner and doesn’t have a very reliable way to do this. The easiest and the most reliable method we found, is to store the ___dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This has to be done as **the first thing in your code** and from the entry point, otherwise, the path will be incorrect.
+Unfortunately, Node is very fragile in that manner and doesn’t have a reliable way to do this. The easiest and the most reliable method we've found, is to store the ___dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This has to be done as **the first thing in your code** and from the entry point, otherwise, the path will be incorrect.
 
 If you want, you can set this value by hand to something like _/var/www/html/some-app_ if you can get this from some external source or you know it won’t ever change.
 
@@ -82,4 +88,4 @@ Sentry.init({
 });
 ```
 
-This config should be enough to make everything work and use TypeScript with Node and still being able to digest all original sources by Sentry.
+This config should be enough to make everything work and use TypeScript with Node. And, still be able to digest all original sources by Sentry.

--- a/src/collections/_documentation/platforms/node/typescript.md
+++ b/src/collections/_documentation/platforms/node/typescript.md
@@ -54,7 +54,7 @@ From now on, when you want to run the production build, which will then upload, 
 
 ### 2. Changing Events Frames
 
-The second step is changing events frames so that Sentry can link stacktraces with correct source files.
+The second step is changing events frames so that Sentry can link stack traces with correct source files.
 
 This can be done using _dataCallback_, in a very similar manner as we do with a single entry point described in Source Maps docs, with one, significant difference. Instead of using _basename_, we have to somehow detect and pass the root directory of our project.
 

--- a/src/collections/_documentation/platforms/node/typescript.md
+++ b/src/collections/_documentation/platforms/node/typescript.md
@@ -5,7 +5,7 @@ sidebar_order: 3
 
 Please read [Source Maps docs]({%- link _documentation/platforms/node/sourcemaps.md -%}) first to learn how to configure Sentry SDK, upload artifacts to our servers or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).
 
-Using Sentry SDK and Source Maps with TypeScript unfortunatelly requires slightly more configuration.
+Using Sentry SDK and Source Maps with TypeScript, unfortunately, requires slightly more configuration.
 
 There are two main reasons for this:
 
@@ -14,7 +14,7 @@ There are two main reasons for this:
 
 We can still make it work with two additional steps, so let’s do this.
 
-The first one is configuring TypeScript compiler in a way, in which we’ll override _sourceRoot_ and merge original sources with corresponding maps. The former is not required, but it’ll help Sentry display correct filepaths, eg. _/lib/utils/helper.ts_ instead of a full one like _/Users/Sentry/Projects/TSExample/lib/utils/helper.ts_. You can skip this option if you’re fine with such a long names.
+The first one is configuring TypeScript compiler in a way, in which we’ll override _sourceRoot_ and merge original sources with corresponding maps. The former is not required, but it’ll help Sentry display correct file paths, e.g. _/lib/utils/helper.ts_ instead of a full one like _/Users/Sentry/Projects/TSExample/lib/utils/helper.ts_. You can skip this option if you’re fine with long names.
 
 Assuming you already have a _tsconfig.json_ file similar to this:
 
@@ -33,7 +33,7 @@ Assuming you already have a _tsconfig.json_ file similar to this:
 }
 ```
 
-create a new one called _tsconfig.production.json_ and paste the snippet below:
+Create a new one called _tsconfig.production.json_ and paste the snippet below:
 
 ```json
 {
@@ -46,17 +46,17 @@ create a new one called _tsconfig.production.json_ and paste the snippet below:
 }
 ```
 
-From now on, when you want to run the production build, that’ll be uploaded you specify this very config, eg. _tsc -p tsconfig.production.json_. This will create necessary source maps and attach original sources to them instead of making us to upload them and modify source paths in our maps by hand.
+From now on, when you want to run the production build, which will then upload, you specify this specific config, e.g., _tsc -p tsconfig.production.json_. This will create necessary source maps and attach original sources to them instead of making us upload them and modify source paths in our maps by hand.
 
-The second step is changing events frames, so that Sentry can link stacktraces with correct source files.
+The second step is changing events frames so that Sentry can link stacktraces with correct source files.
 
-This can be done using _dataCallback_, in a very similar manner as we do with a single entrypoint described in Source Maps docs, with one, very important difference. Instead of using _basename_, we have to somehow detect and pass the root directory of our project.
+This can be done using _dataCallback_, in a very similar manner as we do with a single entry point described in Source Maps docs, with one, significant difference. Instead of using _basename_, we have to somehow detect and pass the root directory of our project.
 
-Unfortunately, Node is very fragile in that manner and doesn’t have a very reliable way to do this. The easiest and the most reliable way we found, is to store the ___dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This _has to be done_ as the first thing in your code and from the entrypoint, otherwise the path will be incorrect.
+Unfortunately, Node is very fragile in that manner and doesn’t have a very reliable way to do this. The easiest and the most reliable method we found, is to store the ___dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This has to be done as **the first thing in your code** and from the entry point, otherwise, the path will be incorrect.
 
 If you want, you can set this value by hand to something like _/var/www/html/some-app_ if you can get this from some external source or you know it won’t ever change.
 
-This can also be achieved by creating a separate file called _root.js_ or similar that’ll be placed in the same place as your entrypoint and exporting obtained value instead of exporting it globally.
+This can also be achieved by creating a separate file called _root.js_ or similar that’ll be placed in the same place as your entry point and exporting obtained value instead of exporting it globally.
 
 ```javascript
 // index.js


### PR DESCRIPTION
I've updated some language/grammar and fixed some spelling errors in the Node docs. This will provide clearer communication when reading. @kamilogorek, will you take a look? :)