### PR TITLE
fix: Remove all mentions of sentry-cli upload-dsym

### DIFF
--- a/src/collections/_documentation/clients/cocoa/dsym.md
+++ b/src/collections/_documentation/clients/cocoa/dsym.md
@@ -47,7 +47,7 @@ There are two ways to download the dSYM from iTunesConnect. After you do one of 
 Afterwards manually upload the symbols with _sentry-cli_:
 
 ```bash
-sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dsym --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
+sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
 ```
 
 {% capture __alert_content -%}
@@ -110,7 +110,7 @@ if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_NAME___
 export SENTRY_PROJECT=___PROJECT_NAME___
 export SENTRY_AUTH_TOKEN=YOUR_AUTH_TOKEN
-ERROR=$(sentry-cli upload-dsym 2>&1 >/dev/null)
+ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
 echo "warning: sentry-cli - $ERROR"
 fi
@@ -118,8 +118,6 @@ else
 echo "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
 fi
 ```
-
-The `upload-dsym` command automatically picks up the `DWARF_DSYM_FOLDER_PATH` environment variable that Xcode exports and look for dSYM files there.
 
 {% capture __alert_content -%}
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
@@ -145,14 +143,14 @@ Your dSYM file can be upload manually by you (or some automated process) with th
 
 Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory.
 
-Then run this:
+Then run this -- note that `--auth-token` needs to go before `upload-dif`:
 
 ```bash
-sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dsym --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
+sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
 ```
 
 {% capture __alert_content -%}
-By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
+By default, sentry-cli will connect to sentry.io. For on-prem you need to export the `SENTRY_URL` environment variable to instruct the tool to connect to your server:
 
 ```bash
 export SENTRY_URL=https://mysentry.invalid/

--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -68,10 +68,13 @@ If you wish to upload the source maps and symbols to Sentry, create a new Run Sc
 ```bash
 export SENTRY_PROPERTIES=../sentry.properties
 
-../node_modules/@sentry/cli/bin/sentry-cli upload-dsym
+../node_modules/@sentry/cli/bin/sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH"
 ``` 
 
-However this will not work for bitcode enabled builds. If you are using bitcode you need to remove that line (`sentry-cli upload-dsym`) and consult the documentation on dsym handling instead (see [With Bitcode]({%- link _documentation/clients/cocoa/dsym.md -%}#dsym-with-bitcode)).
+For bitcode enabled builds via iTunes Connect, additional steps are required.
+Follow the instructions at [With Bitcode]({%- link
+_documentation/clients/cocoa/dsym.md -%}#dsym-with-bitcode) to set up uploads of
+symbols for all build variants.
 
 Note that uploading of debug simulator builds by default is disabled for speed reasons. If you do want to also generate debug symbols for debug builds you can pass `--allow-fetch` as a parameter to `react-native-xcode` in the above mentioned build phase.
 
@@ -100,7 +103,7 @@ fi
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
 # Run sentry cli script to upload debug symbols
-$NODE_BINARY ../node_modules/@sentry/cli/bin/sentry-cli upload-dsym
+$NODE_BINARY ../node_modules/@sentry/cli/bin/sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH"
 
 # OR
 

--- a/src/collections/_documentation/platforms/javascript/cordova.md
+++ b/src/collections/_documentation/platforms/javascript/cordova.md
@@ -47,7 +47,7 @@ if [ ! -f $SENTRY_PROPERTIES ]; then
 fi
 echo "# Reading property from $SENTRY_PROPERTIES"
 SENTRY_CLI=$(getProperty "cli.executable")
-SENTRY_COMMAND="../../$SENTRY_CLI upload-dsym"
+SENTRY_COMMAND="../../$SENTRY_CLI upload-dif \"$DWARF_DSYM_FOLDER_PATH\""
 $SENTRY_COMMAND
 ```
 


### PR DESCRIPTION
Since `sentry-cli upload-dsym` is deprecated in favor of `upload-dif`, update all documentation to reflect that. 

@HazAT I quickly checked, and it seems that `upload-dsym` relied on the `$DWARF_DSYM_FOLDER_PATH` environment variable in some cases, but not for BitCode builds. Could you please verify this?