### PR TITLE
"Expo's docs page" link is broken

### DIFF
--- a/src/collections/_documentation/clients/react-native/expo.md
+++ b/src/collections/_documentation/clients/react-native/expo.md
@@ -40,4 +40,4 @@ For uploading source maps you have to add this to your `exp.json` or `app.json`
 }
 ```
 
-If you still need more help you can out the docs directly on [Expo’s docs page](https://docs.expo.io/versions/latest/guides/using-sentry.html#content)
+If you still need more help you can out the docs directly on [Expo’s docs page](https://docs.expo.io/versions/latest/guides/using-sentry/)


### PR DESCRIPTION
replaced it with the top result for a Google search on the term "expo using sentry"

seems to basically just drop the `.html` suffix ... i dropped `#content` as well since it seems unnecessary