### PR TITLE
Doc: Remove old performance note

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -29,8 +29,6 @@ else
     echo "🐇  - Platform API generation (docs.sentry.io/_platforms) is disabled"
   fi
 
-  echo "🐇  - The sidebar is memoized and has no active page indicator"
-
 fi
 
 echo -e $reset


### PR DESCRIPTION
The sidebar is no longer memoized, as it is handled by Javascript now