### PR TITLE
Replace request.ip with request.remote_ip

### DIFF
--- a/src/collections/_documentation/clients/ruby/context.md
+++ b/src/collections/_documentation/clients/ruby/context.md
@@ -53,7 +53,7 @@ Raven.user_context(
   username: current_user.username, # "foo"
 
   # the actor's IP address, if available
-  ip_address: request.ip # '127.0.0.1'
+  ip_address: request.remote_ip # '127.0.0.1'
 )
 ```
 
@@ -62,7 +62,7 @@ When dealing with anonymous users you will still want to send basic user context
 ```ruby
 Raven.user_context(
   # the actor's IP address, if available
-  ip_address: request.ip # '127.0.0.1'
+  ip_address: request.remote_ip # '127.0.0.1'
 )
 ```
 


### PR DESCRIPTION
`request.ip` provides the IP address of the server/client, which requested the page. `request.remote_ip` in contrast will ignore known proxies and instead return for real clients IP address. So if the app server is deployed behind a proxy, the value in `request.remote_ip` will be more interesting. Since `request.remote_ip` will fall back to `request.ip`, this should not cause undesired side effects.

See Rails' documentation for more details: https://api.rubyonrails.org/classes/ActionDispatch/RemoteIp.html