### PR TITLE
[Feature]: Adds Optional Opt-out of Reporting Vue propsData

### DIFF
--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -12,7 +12,7 @@ Additionally, the Vue _integration_ will capture the name and props state of the
 
 Passing in `Vue` is optional, if you do not pass it `window.Vue` has to be present.
 
-Passing in `attachProps` is optional. If you set it to false, Sentry will suppress sending all Vue components' props for logging.
+Passing in `attachProps` is optional and is `true` if it is not provided. If you set it to `false`, Sentry will suppress sending all Vue components' props for logging.
 
 {% capture __alert %}
 Please note that if you enable this integration Vue internally will not call `logError` 

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -12,6 +12,8 @@ Additionally, the Vue _integration_ will capture the name and props state of the
 
 Passing in `Vue` is optional, if you do not pass it `window.Vue` has to be present.
 
+Passing in `attachProps` is optional. If you set it to false, Sentry will suppress sending all Vue components' props for logging.
+
 {% capture __alert %}
 Please note that if you enable this integration Vue internally will not call `logError` 
 due to a currently know limitation see: [GitHub Issue](https://github.com/vuejs/vue/issues/8433).  
@@ -25,11 +27,15 @@ This means that errors occurring in the Vue renderer will not show up in the dev
 %}
 
 ```javascript
+import Vue from 'vue'
 import * as Sentry from '@sentry/browser'
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [new Sentry.Integrations.Vue({ Vue })]
+  integrations: [new Sentry.Integrations.Vue({ 
+    Vue,
+    attachProps: true
+  })]
 })
 ```
 


### PR DESCRIPTION
## Summary

- Documents `attachProps` key to suppress sending propsData
- Corresponds with https://github.com/getsentry/sentry-javascript/pull/1885
