### PR TITLE
Pin guzzle6-adapter version on install

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-install/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/php.md
@@ -22,5 +22,5 @@ If you want to use Guzzle as an underlying HTTP client, you just need to run the
 following command to install the adapter and Guzzle itself:
 
 ```bash
-php composer.phar require php-http/guzzle6-adapter
+php composer.phar require php-http/guzzle6-adapter ^1.1
 ```


### PR DESCRIPTION
Due to mismatch for dependencies between libraries, Guzzle adapter fails to install.

```
xxx@xxx-35:~/xxx $ composer require php-http/guzzle6-adapter
Using version ^2.0 for php-http/guzzle6-adapter
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - php-http/guzzle6-adapter v2.0.0 requires php-http/httplug ^2.0 -> satisfiable by php-http/httplug[v2.0.0].
    - php-http/guzzle6-adapter v2.0.1 requires php-http/httplug ^2.0 -> satisfiable by php-http/httplug[v2.0.0].
    - Conclusion: don't install php-http/httplug v2.0.0
    - Installation request for php-http/guzzle6-adapter ^2.0 -> satisfiable by php-http/guzzle6-adapter[v2.0.0, v2.0.1].
```

```
xxx@xxx-35:~/xxx $ composer require php-http/guzzle6-adapter php-http/httplug
Using version ^2.0 for php-http/guzzle6-adapter
Using version ^2.0 for php-http/httplug
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - php-http/client-common 1.9.1 requires php-http/httplug ^1.1 -> satisfiable by php-http/httplug[v1.1.0] but these conflict with your requirements or minimum-stability.
    - php-http/client-common 1.9.1 requires php-http/httplug ^1.1 -> satisfiable by php-http/httplug[v1.1.0] but these conflict with your requirements or minimum-stability.
    - php-http/client-common 1.9.1 requires php-http/httplug ^1.1 -> satisfiable by php-http/httplug[v1.1.0] but these conflict with your requirements or minimum-stability.
    - Installation request for php-http/client-common (locked at 1.9.1) -> satisfiable by php-http/client-common[1.9.1].
```