### PR TITLE
Fixes to get both source map and bundle

### DIFF
--- a/src/collections/_documentation/clients/react-native/codepush.md
+++ b/src/collections/_documentation/clients/react-native/codepush.md
@@ -19,9 +19,10 @@ Put this somewhere in your code where you already use CodePush. This makes sure 
 After updating your CodePush release you have to upload the new assets to Sentry:
 
 ```bash
-$ appcenter codepush release-react --app YourApp --output-dir ./build
+$ appcenter codepush release-react --app YourApp --output-dir ./build --sourcemap-output ./build/source.map
+cp ./build/CodePush/main.jsbundle ./build/main.jsbundle
 $ export SENTRY_PROPERTIES=./ios/sentry.properties
-$ sentry-cli react-native appcenter YourApp ios ./build/codePush
+$ sentry-cli react-native appcenter YourApp ios ./build
 ```
 
 {% capture __alert_content -%}


### PR DESCRIPTION
To get both the source map and bundle uploaded I had to have them in the same folder for sentry-cli. To do this I ended up copying the bundle up a folder since if you create the source map in the same folder as the rest of the build the whole blob gets uploaded to CodePush and I didn't want source maps in my releases there.