### PR TITLE
Correct ThreadingIntegration import name

### DIFF
--- a/src/collections/_documentation/platforms/python/default-integrations.md
+++ b/src/collections/_documentation/platforms/python/default-integrations.md
@@ -55,7 +55,7 @@ Adds `sys.argv` as `extra` attribute to each event.
 See [_Logging_]({% link _documentation/platforms/python/logging.md %})
 
 ## Threading
-*Import name: `sentry_sdk.integrations.logging.LoggingIntegration`*
+*Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`*
 
 {% version_added 0.7.3 %}
 


### PR DESCRIPTION
Correcting a copy-paste error in the python default integrations docs