### PR TITLE
Fix: Convert newlines to spaces rather than stripping them

### DIFF
--- a/src/_includes/components/alert.html
+++ b/src/_includes/components/alert.html
@@ -7,8 +7,19 @@
   {%- endif -%}
   {%- if include.title -%}<h5 class="no_toc">{{- include.title -}}</h5>{%- endif -%}
   <div class="alert-body content-flush-bottom">
-    {{ include.content | markdownify }}
+    {%- comment -%}
+    Since this include renders markdown, and then the page itself renders
+    markdown, the content of this include can cause rendering issues due to
+    indents and newlines. To combat this, we replace any post-markdown-process
+    newlines with spaces.
+
+    Liquid doesn't understand \n so we have to capture a new line manually. The
+    indentation is important, so make sure there are no spaces before endcapture
+    {%- endcomment -%}
+{%- capture newline %}
+{% endcapture -%}
+    {{- include.content | markdownify | replace: newline, ' ' -}}
   </div>
 </div>
 {% endcapture -%}
-{{- __alert | strip_newlines }}
+{{- __alert -}}


### PR DESCRIPTION
With `strip_newlines`, markdown prose that includes newlines inside alerts will get truncated, creating weird typos. For example,

```
The last word will
join the first word
```

becomes

```
The last word willjoin the first word
```

We still need to strip the newlines because we're rendering markdown within markdown, so instead, this converst the post-render newlines to spaces, which the second markdown run will ignore.