### PR TITLE
Change $http_host to $host in example config

### DIFF
--- a/src/collections/_documentation/server/nginx.md
+++ b/src/collections/_documentation/server/nginx.md
@@ -50,7 +50,7 @@ http {
     listen   443 ssl;
     server_name sentry.example.com;
 
-    proxy_set_header   Host                 $http_host;
+    proxy_set_header   Host                 $host;
     proxy_set_header   X-Forwarded-Proto    $scheme;
     proxy_set_header   X-Forwarded-For      $remote_addr;
     proxy_redirect     off;


### PR DESCRIPTION
See comment about $http_host and $host in http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header