### PR TITLE
Fix syntax errors in code snippets for Go client

### DIFF
--- a/src/collections/_documentation/clients/go/context.md
+++ b/src/collections/_documentation/clients/go/context.md
@@ -11,8 +11,8 @@ For example:
 
 ```go
 raven.CaptureError(err, map[string]string{"browser": "Firefox"}, &raven.Http{
-  Method: "GET",
-  URL: "https://example.com/raven-go"
+    Method: "GET",
+    URL: "https://example.com/raven-go"
 })
 ```
 
@@ -25,8 +25,8 @@ Provides information about an HTTP call that the Sentry SDK processes when the e
 
 ```go
 h := &raven.Http{
-  Method: "GET",
-  URL: "https://example.com/raven-go"
+    Method: "GET",
+    URL: "https://example.com/raven-go",
 }
 // or
 h = raven.NewHttp(req) // where req is an implementation of `*http.Request` interface
@@ -50,10 +50,10 @@ Provides information about a User whos session was active when error happened.
 
 ```go
 u := &raven.User{
-  ID: "1337",
-  Username: "kamilogorek",
-  Email: "kamil@sentry.io",
-  IP: "127.0.0.1"
+    ID: "1337",
+    Username: "kamilogorek",
+    Email: "kamil@sentry.io",
+    IP: "127.0.0.1",
 }
 raven.SetUserContext(u)
 ```

--- a/src/collections/_documentation/clients/go/usage.md
+++ b/src/collections/_documentation/clients/go/usage.md
@@ -46,11 +46,11 @@ To form a `Packet`, you can use `Packet` type directly, or `NewPacket` and `NewP
 
 ```go
 packet := &raven.Packet{
-  Message: "Hand-crafted event"
-  Extra: &raven.Extra{
-    "runtime.Version": runtime.Version(),
-    "runtime.NumCPU": runtime.NumCPU()
-  }
+    Message: "Hand-crafted event",
+    Extra: &raven.Extra{
+        "runtime.Version": runtime.Version(),
+        "runtime.NumCPU": runtime.NumCPU(),
+    },
 }
 raven.Capture(packet)
 ```


### PR DESCRIPTION
The code snippets in the docs for the Go (golang) client throw a syntax error.

Go requires that each line of the composite literal ends with a comma, even the last line of the declaration.

I added the missing trailing commas and indented one code snippet correctly.