### PR TITLE
Encourage safe usage of Sentry

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-config/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-config/browser.md
@@ -1,5 +1,7 @@
 You should `init` the Sentry Browser SDK as soon as possible during your page load:
 
 ```javascript
-Sentry.init({ dsn: '___PUBLIC_DSN___' });
+if (Sentry) {
+    Sentry.init({ dsn: '___PUBLIC_DSN___' });
+}
 ```


### PR DESCRIPTION
I have come across several websites the immediately fail due to blocking Sentry. Its especially bad since it is often within the first few lines of their javascript. Encourage safe checking of the `Sentry` object before using it.

Here are a couple documented websites that fail completely if Sentry does not load:

* https://github.com/lightswitch05/hosts/issues/40
* https://github.com/lightswitch05/hosts/issues/77