### PR TITLE
fix: in-app-include not in C#, fixes #815

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -106,7 +106,7 @@ will be sent.
 {:.config-key}
 ### `in-app-include`
 
-{% supported python rust csharp %}
+{% supported python rust %}
 A list of string prefixes of module names that belong to the app. This option takes precedence over `in_app_exclude`.
 {% endsupported %}
 


### PR DESCRIPTION
@mitsuhiko now that I open this I think we discussed and you wanted this in C# regardless of (IMHO) not adding much value for the sake of API parity with the _unified API_? If so please close this PR and I'll open an issue in the .NET repo to get it added.

See #815 