### PR TITLE
fix(permissions) Update permissions docs

### DIFF
--- a/src/collections/_documentation/accounts/membership.md
+++ b/src/collections/_documentation/accounts/membership.md
@@ -24,10 +24,10 @@ Roles include:
 | Can join and leave teams. |   | X | X | X | X |
 | Can change Project Settings |   |   | X | X | X |
 | Can add/remove projects* |   |   | X | X | X |
-| Can edit Global Integrations |   |   |   | X | X |
+| Can edit Global Integrations |   |   | X | X | X |
 | Can add/remove/change members |   |   |   | X | X |
 | Can add/remove teams* |   |   | X | X | X |
-| Can add Repositories |   |   |   | X | X |
+| Can add Repositories |   |   | X | X | X |
 | Can change Organization Settings |   |   |   | X | X |
 | Can remove an Organization |   |   |   |   | X |
 


### PR DESCRIPTION
* As of getsentry/sentry#12316 admin roles can add repositories.
* Admin roles have always been able to edit global integrations the docs
  were incorrect here.