### PR TITLE
fix(redirects): Make redirects not require trailing slash

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -19,20 +19,20 @@ server {
   
   rewrite ^/clientdev/(.*)$ /development/sdk-dev/$1$is_args$args redirect;
   rewrite ^/integrations/(.*)$ /workflow/integrations/$1$is_args$args redirect;
-  rewrite ^/internal/(api|docs|contributing|environment)/$ /development/contribute/$1/$is_args$args redirect;
+  rewrite ^/internal/(api|docs|contributing|environment)/?$ /development/contribute/$1/$is_args$args redirect;
   
-  rewrite ^/learn/(capturing|configuration|security-policy-reporting)/$ /error-reporting/$1/$is_args$args redirect;
-  rewrite ^/learn/(draining|filtering)/$ /error-reporting/configuration/$1/$is_args$args redirect;
-  rewrite ^/learn/(breadcrumbs|context|environments|scopes|user-feedback)/$ /enriching-error-data/$1/$is_args$args redirect;
-  rewrite ^/learn/(issue-owners|notifications|releases|search)/$ /workflow/$1/$is_args$args redirect;
-  rewrite ^/learn/(data-forwarding|rollups|sensitive-data)/$ /data-management/$1/$is_args$args redirect;
-  rewrite ^/learn/(membership|pricing|quotas|sso)/$ /accounts/$1/$is_args$args redirect;
+  rewrite ^/learn/(capturing|configuration|security-policy-reporting)/?$ /error-reporting/$1/$is_args$args redirect;
+  rewrite ^/learn/(draining|filtering)/?$ /error-reporting/configuration/$1/$is_args$args redirect;
+  rewrite ^/learn/(breadcrumbs|context|environments|scopes|user-feedback)/?$ /enriching-error-data/$1/$is_args$args redirect;
+  rewrite ^/learn/(issue-owners|notifications|releases|search)/?$ /workflow/$1/$is_args$args redirect;
+  rewrite ^/learn/(data-forwarding|rollups|sensitive-data)/?$ /data-management/$1/$is_args$args redirect;
+  rewrite ^/learn/(membership|pricing|quotas|sso)/?$ /accounts/$1/$is_args$args redirect;
   
-  rewrite ^/learn/cli/(configuration|dif|installation|releases|send-event)/$ /cli/$1/$is_args$args redirect;
-  rewrite ^/learn/cli/(breakpad|dsym|elf|pdb|proguard)/$ /cli/dif/$1/$is_args$args redirect;
+  rewrite ^/learn/cli/(configuration|dif|installation|releases|send-event)/?$ /cli/$1/$is_args$args redirect;
+  rewrite ^/learn/cli/(breakpad|dsym|elf|pdb|proguard)/?$ /cli/dif/$1/$is_args$args redirect;
   
-  rewrite ^/product/(membership|pricing|quotas|sso)/$ /accounts/$1/$is_args$args redirect;
-  rewrite ^/product/(discover|issue-owners|notifications|search)/$ /workflow/$1/$is_args$args redirect;
+  rewrite ^/product/(membership|pricing|quotas|sso)/?$ /accounts/$1/$is_args$args redirect;
+  rewrite ^/product/(discover|issue-owners|notifications|search)/?$ /workflow/$1/$is_args$args redirect;
   
   rewrite ^/relay/(.*)$ /data-management/relay/$1$is_args$args redirect;
   


### PR DESCRIPTION
Currently, `learn/xyz/` will redirect correctly, but `learn/xyz` will not. This fixes that.