### PR TITLE
fix(roles): Add repo deletion permission to table

### DIFF
--- a/src/collections/_documentation/accounts/membership.md
+++ b/src/collections/_documentation/accounts/membership.md
@@ -28,6 +28,7 @@ Roles include:
 | Can add/remove/change members |   |   |   | X | X |
 | Can add/remove teams* |   |   | X | X | X |
 | Can add Repositories |   |   | X | X | X |
+| Can delete Repositories |   |   |   |   | X |
 | Can change Organization Settings |   |   |   | X | X |
 | Can remove an Organization |   |   |   |   | X |
 


### PR DESCRIPTION
Though our docs don't currently mention this, only owners have permission to delete repos:

- The `RepoDetails` endpoint inherits from `OrgEndpoint`: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/endpoints/organization_repository_details.py#L33

- `OrgEndpoint` uses `Org Permissions`: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/bases/organization.py#L122

- `OrgPermissions` restricts deletion to `org:admin`: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/bases/organization.py#L34

- Only owners have this scope: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/conf/server.py#L1275

This fixes the docs to reflect that:

![image](https://user-images.githubusercontent.com/14812505/54064553-2f0b9c00-41ca-11e9-9d10-a19852170f43.png)

H/t to @mbauer404 for pointing this out.