### PR TITLE
fix(CLI releases docs): Add additional required scope for `set-commits`

### DIFF
--- a/src/collections/_documentation/cli/configuration.md
+++ b/src/collections/_documentation/cli/configuration.md
@@ -3,30 +3,43 @@ title: 'Configuration and Authentication'
 sidebar_order: 1
 ---
 
-For most functionality you need to authenticate with Sentry. To sign in via the CLI tool, you can use the _login_ command which will guide you through it:
+For most functionality you need to authenticate with Sentry. Setting this up can be done either automatically, using `sentry-cli`, or manually. Either way, you'll need a token with at least the following scopes:
+
+- `project:read`
+- `project:releases`
+- `org:read`
+
+##### To use the automatic option:
 
 ```bash
 $ sentry-cli login
 ```
 
-If you want to manually authenticate `sentry-cli` you can go to your to your auth token settings in your user account (User Icon -> API) and generate a new token with at least the following scopes:
-
--   `project:read`
--   `project:releases`
-
-Afterwards, you can export the `SENTRY_AUTH_TOKEN` environment variable:
-
-```bash
-export SENTRY_AUTH_TOKEN=your-auth-token
-```
-
-Alternatively, you can provide the `--auth-token` command line parameter whenever you invoke `sentry-cli` or add it to your _.sentryclirc_ config file.
+This will give you the option to visit your auth token user settings, where you can create a new auth token, or simply copy an existing one. When you return to the CLI, you'll paste in your token and it will get added to `~/.sentrycli` automatically.
 
 By default, `sentry-cli` will connect to sentry.io but for on-premise you can also sign in elsewhere:
 
 ```bash
 $ sentry-cli --url https://myserver.invalid/ login
 ```
+
+##### To authenticate manually:
+
+Visit your [auth token user settings page](https://sentry.io/settings/account/api/auth-tokens/) and create or copy an existing token. Then either:
+
+- add it to `~/.sentrycli`:
+  ```ini
+  [auth]
+  token=your-auth-token
+  ```
+- export it as an environment variable:
+  ```bash
+  export SENTRY_AUTH_TOKEN=your-auth-token
+  ```
+- pass it as a parameter when you invoke `sentry-cli`:
+  ```bash
+  $ sentry-cli --auth-token your-auth-token
+  ```
 
 ## Configuration File
 

--- a/src/collections/_documentation/cli/configuration.md
+++ b/src/collections/_documentation/cli/configuration.md
@@ -15,7 +15,7 @@ For most functionality you need to authenticate with Sentry. Setting this up can
 $ sentry-cli login
 ```
 
-This will give you the option to visit your auth token user settings, where you can create a new auth token, or simply copy an existing one. When you return to the CLI, you'll paste in your token and it will get added to `~/.sentrycli` automatically.
+This will give you the option to visit your auth token user settings, where you can create a new auth token, or simply copy an existing one. When you return to the CLI, you'll paste in your token and it will get added to `~/.sentryclirc` automatically.
 
 By default, `sentry-cli` will connect to sentry.io but for on-premise you can also sign in elsewhere:
 
@@ -27,7 +27,7 @@ $ sentry-cli --url https://myserver.invalid/ login
 
 Visit your [auth token user settings page](https://sentry.io/settings/account/api/auth-tokens/) and create or copy an existing token. Then either:
 
-- add it to `~/.sentrycli`:
+- add it to `~/.sentryclirc`:
   ```ini
   [auth]
   token=your-auth-token
@@ -43,7 +43,7 @@ Visit your [auth token user settings page](https://sentry.io/settings/account/ap
 
 ## Configuration File
 
-The `sentry-cli` tool can be configured with a config file named `.sentryclirc` as well as environment variables and _.env_ files. The config file is looked for upwards from the current path and defaults from _~/.sentryclirc_ are always loaded. You can also override these settings from command line parameters.
+The `sentry-cli` tool can be configured with a config file named `.sentryclirc` as well as environment variables and `.env` files. The config file is looked for upwards from the current path and defaults from `~/.sentryclirc` are always loaded. You can also override these settings from command line parameters.
 
 The config file uses standard INI syntax.
 
@@ -53,7 +53,7 @@ By default `sentry-cli` will connect to sentry.io. For on-prem you can export th
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-Alternatively you can add it to your `~/.sentryclirc` config. This is also what the _login_ command does:
+Alternatively you can add it to your `~/.sentryclirc` config. This is also what the `login` command does:
 
 ```ini
 [defaults]


### PR DESCRIPTION
Currently, the [CLI authentication docs](https://docs.sentry.io/cli/configuration/) only list two required scopes:

![image](https://user-images.githubusercontent.com/14812505/54149757-20083200-43f4-11e9-99c8-06111de51dc3.png)

But as it turns out, you can't use `set-commits` unless you also have `org:read`scope:

- calling `set-commits` calls `list_org_repos`: https://github.com/getsentry/sentry-cli/blob/d12a258c681bb57f00769ea962b4355fb2979637/src/commands/releases.rs#L400

- `list_org_repos` makes a get requtest to the `/organizations/{org-slug}/repos/` endpoint: https://github.com/getsentry/sentry-cli/blob/d12a258c681bb57f00769ea962b4355fb2979637/src/api.rs#L1210

- that endpoint inherits from `OrgEndpoint`: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/endpoints/organization_repositories.py#L16

- `OrgEndpoint` uses `OrgPermissions`: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/bases/organization.py#L122

- `OrgPermissions` needs at least `org:read` for `GET`ing: https://github.com/getsentry/sentry/blob/f5998e667adb39907fb58db9fe66f1b2482db263/src/sentry/api/bases/organization.py#L31

This PR adds the missing scope and reorganizes the text a bit:

![image](https://user-images.githubusercontent.com/14812505/54219056-f4488300-44ab-11e9-92e1-54a7b898dc19.png)
