### PR TITLE
fix: Change local hosting port to not conflict with clickhouse

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ home_url: https://sentry.io
 release_service: https://release-registry.services.sentry.io
 
 # Build settings
-port: 9000
+port: 9001
 markdown: kramdown
 highlighter: rouge
 


### PR DESCRIPTION
~Snuba's~ Clickhouse's docker container is blocking port 9000, so this moves the docs server to 9001.