### PR TITLE
fix(readme): Fix readme to reflect correct port

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run the local webserver:
 $ bin/server
 ```
 
-This will run Bundler to install all the necessary dependencies and then run a webserver at http://localhost:4000/.
+This will run Bundler to install all the necessary dependencies and then run a webserver at http://localhost:9001/.
 
 [jekyll]: https://jekyllrb.com/
 [ruby]: https://www.ruby-lang.org/


### PR DESCRIPTION
The local port changed from 9000 to 9001 in https://github.com/getsentry/sentry-docs/pull/830 but the repo readme was out of date even before that.