### PR TITLE
fix(github integration): Remove mention of webhooks on repos

### DIFF
--- a/src/collections/_documentation/workflow/releases.md
+++ b/src/collections/_documentation/workflow/releases.md
@@ -60,7 +60,7 @@ Once you are in Organization Settings > Integrations and have installed the inte
 
 {% asset releases-repo-add.png %}
 
-In the 'Repositories' panel, click 'Add Repository', and add any repositories you'd like to track commits from. This creates a webhook on the repository which sends Sentry metadata about each commit (such as authors and files changed).
+In the 'Repositories' panel, click 'Add Repository', and add any repositories you'd like to track commits from. The integration will then send Sentry metadata (such as authors and files changed) about each commit pushed to those repositories.
 
 If you’re linking a GitHub repository, ensure you have Admin or Owner permissions on the repository, and that Sentry is an authorized GitHub app in your [GitHub account settings](https://github.com/settings/applications).
 


### PR DESCRIPTION
Now that our GitHub integration is an actual GitHub app, we no longer attach webhooks to repos in a way that's visible to the user. This removes mention of same, so as not to create false expectations and confuse people into thinking something is wrong when it isn't.