### PR TITLE
fix: Error chain header

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -381,6 +381,7 @@ Array [
   "platforms/python/wsgi/index.html",
   "platforms/rust/actix/index.html",
   "platforms/rust/env_logger/index.html",
+  "platforms/rust/error_chain/index.html",
   "platforms/rust/failure/index.html",
   "platforms/rust/index.html",
   "platforms/rust/log/index.html",

--- a/src/collections/_documentation/platforms/rust/error_chain.md
+++ b/src/collections/_documentation/platforms/rust/error_chain.md
@@ -1,7 +1,7 @@
---
+---
 title: error-chain
 sidebar_order: 2
---
+---
 
 *Feature: `with_error_chain` (disabled by default)*
 


### PR DESCRIPTION
This currently causes links to this page to download the raw markdown. Thanks to @timfish for bringing this up!

![image](https://user-images.githubusercontent.com/1433023/54481462-2e5faf00-4835-11e9-82c3-e9f1c2ef1d6f.png)
