### PR TITLE
fix(SDK config): Correctly grey out sendDefaultPii for JS SDK's

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -83,10 +83,12 @@ This feature is `off` by default.
 {:.config-key}
 ### `send-default-pii`
 
+{% unsupported browser javascript %}
 If this flag is enabled, certain personally identifiable information is added by active
 integrations.  Without this flag they are never added to the event, to begin with.  If possible,
 it's recommended to turn on this feature and use the server side PII stripping to remove the
 values instead.
+{% endunsupported %}
 
 {:.config-key}
 ### `server-name`


### PR DESCRIPTION
`sendDefaultPii` appears [nowhere in the JS SDK code](https://github.com/getsentry/sentry-javascript/search?q=sendDefaultPii&unscoped_q=sendDefaultPii), so we clearly don't support it. This updates the docs to reflect that.

![image](https://user-images.githubusercontent.com/14812505/54575045-f03aca80-49af-11e9-9321-dee4e132cfa2.png)

![image](https://user-images.githubusercontent.com/14812505/54575067-fd57b980-49af-11e9-9186-6a2be55c88ab.png)
