### PR TITLE
docs: Add troubleshooting alert for releases

### DIFF
--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -70,6 +70,12 @@ If you also want to set a previous commit instead of letting the server use the 
 sentry-cli releases set-commits "$VERSION" --commit "my-repo@from..to"
 ```
 
+{% include components/alert.html
+  title='Troubleshooting'
+  content='If you receive an "Unable to Fetch Commits" email, take a look at our [Help Center Article](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-).'
+  level='warning'
+%}
+
 ## Managing Release Artifacts
 
 When you are working with JavaScript and other platforms, you can upload release artifacts to Sentry which are then considered during processing. The most common release artifact are [source maps]({%- link _documentation/clients/javascript/sourcemaps.md -%}#raven-js-sourcemaps) for which `sentry-cli` has specific support.

--- a/src/collections/_documentation/workflow/releases.md
+++ b/src/collections/_documentation/workflow/releases.md
@@ -166,6 +166,12 @@ res = requests.post(
 
 For more information, see the [API reference]({%- link _documentation/api/releases/post-organization-releases.md -%}).
 
+{% include components/alert.html
+  title='Troubleshooting'
+  content='If you receive an "Unable to Fetch Commits" email, take a look at our [Help Center Article](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-).'
+  level='warning'
+%}
+
 #### After Associating Commits
 
 After this step, **suspect commits** and **suggested assignees** will start appearing on the issue page. We determine these by tying together the commits in the release, files touched by those commits, files observed in the stack trace, authors of those files, and [ownership rules]({%- link _documentation/workflow/issue-owners.md -%}).


### PR DESCRIPTION
Add troubleshooting alert that links to a Help Center article for when users receive the Unable to Fetch Commits email.

[Link to Help Center Article](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-)

<img width="775" alt="Screen Shot 2019-03-19 at 5 58 41 PM" src="https://user-images.githubusercontent.com/20312973/54652089-c7c7d480-4a72-11e9-8827-f91817842da3.png">
