### PR TITLE
feat: Add javascript examples for fingerprinting

### DIFF
--- a/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
@@ -6,10 +6,6 @@ Sentry.init({
   beforeSend: (event, hint) => {
     const exception = hint.originalException;
 
-    if (!(exception instanceof Error)) {
-      return event;
-    }
-
     if (exception instanceof DatabaseConnectionError) {
       event.fingerprint = ['database-connection-error'];
     }

--- a/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
@@ -1,0 +1,20 @@
+```javascript
+class DatabaseConnectionError extends Error {}
+
+Sentry.init({
+  ...,
+  beforeSend: (event, hint) => {
+    const exception = hint.originalException;
+
+    if (!(exception instanceof Error)) {
+      return event;
+    }
+
+    if (exception instanceof DatabaseConnectionError) {
+      event.fingerprint = ['database-connection-error'];
+    }
+
+    return event;
+  }
+});
+```

--- a/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
@@ -1,0 +1,34 @@
+```javascript
+class MyRPCError extends Error {
+  constructor(message, functionName, errorCode) {
+    super(message);
+
+    // The name of the RPC function that was called (e.g. "getAllBlogArticles")
+    this.functionName = functionName;
+
+    // For example a HTTP status code returned by the server.
+    this.errorCode = errorCode;
+  }
+}
+
+Sentry.init({
+  ...,
+  beforeSend: (event, hint) => {
+    const exception = hint.originalException;
+
+    if (!(exception instanceof Error)) {
+      return event;
+    }
+
+    if (exception instanceof MyRPCError) {
+      event.fingerprint = [
+        '{% raw %}{{ default }}{% endraw %}',
+        String(exception.functionName),
+        String(exception.errorCode)
+      ];
+    }
+
+    return event;
+  }
+});
+```

--- a/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
@@ -16,10 +16,6 @@ Sentry.init({
   beforeSend: (event, hint) => {
     const exception = hint.originalException;
 
-    if (!(exception instanceof Error)) {
-      return event;
-    }
-
     if (exception instanceof MyRPCError) {
       event.fingerprint = [
         '{% raw %}{{ default }}{% endraw %}',

--- a/src/collections/_documentation/data-management/fingerprint-rpc-example/python.md
+++ b/src/collections/_documentation/data-management/fingerprint-rpc-example/python.md
@@ -12,7 +12,11 @@ def before_send(event, hint):
 
     exception = hint['exc_info'][1]
     if isinstance(exception, MyRPCError):
-        event['fingerprint'] = ['{% raw %}{{ default }}{% endraw %}', str(exception.function), str(exception.error_code)]
+        event['fingerprint'] = [
+            '{% raw %}{{ default }}{% endraw %}',
+            str(exception.function),
+            str(exception.error_code)
+        ]
 
     return event
 


### PR DESCRIPTION
Currently, the second and third examples of [custom fingerprinting](https://docs.sentry.io/data-management/rollups/?platform=browser#custom-grouping) only exist in Python and C#. This adds JavaScript versions.

Note to reviewers:

1) I tried to hew as closely as possible to the Python versions.

2) I tagged you both b/c I don't know which one of you knows the other's language better to be able to say if I did so successfully.

3) JavaScript is not my first/native language, so please feel free to point out places where I did things wrong or weirdly.

First snippet (existing Python example):

![image](https://user-images.githubusercontent.com/14812505/54665243-bb0fa480-4aa3-11e9-841a-3722ab25c792.png)

First snippet (new JavaScript example):

![image](https://user-images.githubusercontent.com/14812505/54694974-5fb2d600-4ae6-11e9-9dea-45771640a421.png)

Second snippet (existing Python example):

![image](https://user-images.githubusercontent.com/14812505/54665403-37a28300-4aa4-11e9-8357-031463fbdedc.png)

Second snippet (new JavaScript example):

![image](https://user-images.githubusercontent.com/14812505/54695007-748f6980-4ae6-11e9-8ca8-b0f57a3ff4b5.png)