### PR TITLE
removed minidump from getting started install

### DIFF
--- a/src/collections/_documentation/platforms/javascript/getting-started-install/minidump.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/minidump.md
@@ -1,7 +1,0 @@
-Sentry can process Minidump crash reports, a memory dump used on Windows and by open-source libraries like [_Breakpad_]({%- link _documentation/platforms/minidump/breakpad.md -%}) or [_Crashpad_]({%- link _documentation/platforms/minidump/crashpad.md -%}). You can either choose to generate and upload Minidumps yourself or use a higher-level SDK for platforms with built-in support for native crashes:
-
--   [_Cocoa_]({%- link _documentation/clients/cocoa/index.md -%})
--   [_Electron_]({%- link _documentation/platforms/javascript/electron/index.md -%})
--   [_Unreal Engine 4_]({%- link _documentation/platforms/unrealengine/index.md -%})
-
-For more information, see Sentry's [Minidump documentation]({%- link _documentation/platforms/minidump/index.md -%}).


### PR DESCRIPTION
Minidumps didn't belong in the Integrating the SDK dropdown. Removed it. 