### PR TITLE
moved Releases section above Source Maps

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -77,6 +77,25 @@ RSVP.on('error', function(reason) {
 Please consult your promise library documentation on how to hook into its global unhandled rejection handler, if it exposes one.
 
 &nbsp;
+## Releases
+A release is a version of your code that you deploy to an environment. When you give Sentry information about your releases, you unlock many new features:
+ - Determine the issue and regressions introduced in a new release
+ - Predict which commit caused an issue and who is likely responsible
+ - Resolve issues by including the issue number in your commit message
+ - Receive email notifications when your code gets deployed
+
+Additionally, the Sentry SDK uses releases for applying [source maps]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}).
+
+&nbsp;
+Setting up releases is a 3-step process:
+1. [Configure Your SDK]({%- link _documentation/workflow/releases.md -%}#configure-sdk)
+2. [Create Release and Associate Commits]({%- link _documentation/workflow/releases.md -%}#create-release)
+3. [Tell Sentry When You Deploy a Release]({%- link _documentation/workflow/releases.md -%}#create-deploy)
+
+&nbsp;
+For more information, see [Releases Are Better With Commits](https://blog.sentry.io/2017/05/01/release-commits.html).
+
+&nbsp;
 ## Source Maps
 
 {% include components/alert.html
@@ -561,25 +580,6 @@ Sentry.withScope(scope => {
   Sentry.captureException(err);
 });
 ```
-
-&nbsp;
-## Releases
-A release is a version of your code that you deploy to an environment. When you give Sentry information about your releases, you unlock many new features:
- - Determine the issue and regressions introduced in a new release
- - Predict which commit caused an issue and who is likely responsible
- - Resolve issues by including the issue number in your commit message
- - Receive email notifications when your code gets deployed
-
-Additionally, the Sentry SDK uses releases for applying [source maps]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}).
-
-&nbsp;
-Setting up releases is a 3-step process:
-1. [Configure Your SDK]({%- link _documentation/workflow/releases.md -%}#configure-sdk)
-2. [Create Release and Associate Commits]({%- link _documentation/workflow/releases.md -%}#create-release)
-3. [Tell Sentry When You Deploy a Release]({%- link _documentation/workflow/releases.md -%}#create-deploy)
-
-&nbsp;
-For more information, see [Releases Are Better With Commits](https://blog.sentry.io/2017/05/01/release-commits.html).
 
 &nbsp;
 ## Supported Browsers {#browser-table}

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -79,20 +79,18 @@ Please consult your promise library documentation on how to hook into its global
 &nbsp;
 ## Releases
 A release is a version of your code that you deploy to an environment. When you give Sentry information about your releases, you unlock many new features:
+
+ - Apply [source maps]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}) to receive the full benefit of error tracking and monitoring
  - Determine the issue and regressions introduced in a new release
  - Predict which commit caused an issue and who is likely responsible
  - Resolve issues by including the issue number in your commit message
  - Receive email notifications when your code gets deployed
+ 
 
-Additionally, the Sentry SDK uses releases for applying [source maps]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}).
+After configuring your SDK, setting up releases is a 2-step process:
+1. [Create Release and Associate Commits]({%- link _documentation/workflow/releases.md -%}#create-release)
+2. [Tell Sentry When You Deploy a Release]({%- link _documentation/workflow/releases.md -%}#create-deploy)
 
-&nbsp;
-Setting up releases is a 3-step process:
-1. [Configure Your SDK]({%- link _documentation/workflow/releases.md -%}#configure-sdk)
-2. [Create Release and Associate Commits]({%- link _documentation/workflow/releases.md -%}#create-release)
-3. [Tell Sentry When You Deploy a Release]({%- link _documentation/workflow/releases.md -%}#create-deploy)
-
-&nbsp;
 For more information, see [Releases Are Better With Commits](https://blog.sentry.io/2017/05/01/release-commits.html).
 
 &nbsp;


### PR DESCRIPTION
Releases makes more sense if it come before Source Maps. Moved the Releases section up to reflect this. 