### PR TITLE
fix(API docs): Add note about CLI release management to permissions page

### DIFF
--- a/src/collections/_documentation/api/permissions.md
+++ b/src/collections/_documentation/api/permissions.md
@@ -62,6 +62,14 @@ Events in sentry are immutable and can only be deleted by deleting the whole iss
 
 | **GET/PUT/POST/DELETE**  | `project:releases` |
 
+{% capture markdown_content %}
+Be aware that if you're using `sentry-cli` to [manage your releases]({%- link _documentation/cli/releases.md -%}), you'll need a token which also has `org:read` scope.
+{% endcapture %}
+{% include components/alert.html
+  title="Note"
+  content=markdown_content
+%}
+
 <style>
 .prose table td {
   width: 50%;


### PR DESCRIPTION
A user trying to associate commits using the CLI got a 403 and came to the API permissions page to see which scopes were necessary for release endpoints. Though technically nothing on that page was incorrect (the CLI hits an org endpoint when executing `set-commits`, and its scope _is_ correctly listed), someone in the user's position would have no way to know to look anywhere besides the the release permissions.

This adds a note explaining the additional required scope.

![image](https://user-images.githubusercontent.com/14812505/54853490-3c865300-4cad-11e9-942e-07ec943fa11d.png)
