### PR TITLE
Fix Laravel example

### DIFF
--- a/src/collections/_documentation/platforms/php/laravel.md
+++ b/src/collections/_documentation/platforms/php/laravel.md
@@ -209,7 +209,7 @@ class SentryContext
     public function handle($request, Closure $next)
     {
         if (auth()->check() && app()->bound('sentry')) {
-            Sentry\configureScope(function (Scope $scope): void {
+            \Sentry\configureScope(function (Scope $scope): void {
                 $scope->setUser([
                     'id' => auth()->user()->id,
                     'email' => auth()->user()->email,


### PR DESCRIPTION
There was a missing `\` that causes errors when copy-pasted.

/cc @HazAT 
/fixes getsentry/sentry-laravel#219