### PR TITLE
fix(user feedback): Pass event id to feedback dialog in JS examples

### DIFF
--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
@@ -1,4 +1,4 @@
-If you're using a framework like [React]({%- link _documentation/platforms/javascript/react.md -%}) or [Angular]({%- link _documentation/platforms/javascript/angular.md -%}), the best place to collect user feedback is in your error-handling component. If you're not using a framework, you collect feedback right before the event is sent in `beforeSend`:
+If you're using a framework like [React]({%- link _documentation/platforms/javascript/react.md -%}) or [Angular]({%- link _documentation/platforms/javascript/angular.md -%}), the best place to collect user feedback is in your error-handling component. (Please see platform-specific docs for examples.) If you're not using a framework, you can collect feedback right before the event is sent, using `beforeSend`:
 
 ```html
 <script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" crossorigin="anonymous"></script>

--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
@@ -9,7 +9,7 @@ If you're using a framework like [React]({%- link _documentation/platforms/javas
     beforeSend(event, hint) {
       // Check if it is an exception, and if so, show the report dialog
       if (event.exception) {
-        Sentry.showReportDialog({ eventId: event.eventId });
+        Sentry.showReportDialog({ eventId: event.event_id });
       }
       return event;
     }

--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
@@ -1,4 +1,4 @@
-If you're using a framework like [React]({%- link _documentation/platforms/javascript/react.md -%}) or [Angular]({%- link _documentation/platforms/javascript/angular.md -%}), the best place to collect user feedback is in your error-handling component. If not, you can do it right before the event is sent in `beforeSend`:
+If you're using a framework like [React]({%- link _documentation/platforms/javascript/react.md -%}) or [Angular]({%- link _documentation/platforms/javascript/angular.md -%}), the best place to collect user feedback is in your error-handling component. If you're not using a framework, you collect feedback right before the event is sent in `beforeSend`:
 
 ```html
 <script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" crossorigin="anonymous"></script>

--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/browser.md
@@ -1,13 +1,15 @@
+If you're using a framework like [React]({%- link _documentation/platforms/javascript/react.md -%}) or [Angular]({%- link _documentation/platforms/javascript/angular.md -%}), the best place to collect user feedback is in your error-handling component. If not, you can do it right before the event is sent in `beforeSend`:
+
 ```html
 <script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" crossorigin="anonymous"></script>
 
 <script>
   Sentry.init({
     dsn: '___PUBLIC_DSN___',
-    beforeSend(event) {
-      // Check if it is an exception, if so, show the report dialog
+    beforeSend(event, hint) {
+      // Check if it is an exception, and if so, show the report dialog
       if (event.exception) {
-        Sentry.showReportDialog();
+        Sentry.showReportDialog({ eventId: event.eventId });
       }
       return event;
     }

--- a/src/collections/_documentation/platforms/javascript/angular.md
+++ b/src/collections/_documentation/platforms/javascript/angular.md
@@ -8,7 +8,7 @@ This document uses Angular to refer to Angular 2+. If you use AngularJS, you'll 
 
 On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
 
-Additionally, `@sentry/browser` can be configured to catch any Angular-specific (2.x) exceptions reported through the [@angular/core/ErrorHandler](https://angular.io/api/core/ErrorHandler) component.
+Additionally, `@sentry/browser` can be configured to catch any Angular-specific (2.x) exceptions reported through the [@angular/core/ErrorHandler](https://angular.io/api/core/ErrorHandler) component. This is also a great opportunity to collect user feedback by using `Sentry.showReportDialog`.
 
 ```typescript
 import { BrowserModule } from "@angular/platform-browser";
@@ -26,8 +26,8 @@ Sentry.init({
 export class SentryErrorHandler implements ErrorHandler {
   constructor() {}
   handleError(error) {
-    Sentry.captureException(error.originalError || error);
-    throw error;
+    const eventId = Sentry.captureException(error.originalError || error);
+    Sentry.showReportDialog({ eventId });
   }
 }
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -45,7 +45,7 @@ class ExampleBoundary extends Component {
         if (this.state.error) {
             //render fallback UI
             return (
-              <a onClick={() => Sentry.showReportDialog(this.state.eventId)}>Report feedback</a>
+              <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
             );
         } else {
             //when there's not an error, render children untouched

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -6,7 +6,7 @@ sidebar_order: 30
 To use Sentry with your React application, you will need to use `@sentry/browser` (Sentry’s browser JavaScript SDK).  
 On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
 
-If you’re using React 16 or above, Error Boundaries are an important tool for defining the behavior of your application in the face of errors. Be sure to send errors they catch to Sentry using `Sentry.captureException`, and optionally this is also a great opportunity to surface User Feedback
+If you’re using React 16 or above, Error Boundaries are an important tool for defining the behavior of your application in the face of errors. Be sure to send errors they catch to Sentry using `Sentry.captureException`. This is also a great opportunity to collect user feedback by using `Sentry.showReportDialog`.
 
 {% capture __alert_content -%}
 One important thing to note about the behavior of error boundaries in development mode is that React will rethrow errors they catch. This will result in errors being reported twice to Sentry with the above setup, but this won’t occur in your production build.
@@ -24,21 +24,20 @@ import * as Sentry from '@sentry/browser';
 //  dsn: "___PUBLIC_DSN___"
 // });
 // should have been called before using it here
-// ideally before even rendering your react app 
+// ideally before even rendering your react app
 
 class ExampleBoundary extends Component {
     constructor(props) {
         super(props);
-        this.state = { error: null };
+        this.state = { error: null, eventId: null };
     }
 
     componentDidCatch(error, errorInfo) {
       this.setState({ error });
       Sentry.withScope(scope => {
-        Object.keys(errorInfo).forEach(key => {
-          scope.setExtra(key, errorInfo[key]);
-        });
-        Sentry.captureException(error);
+          scope.setExtras(errorInfo);
+          const eventId = Sentry.captureException(error);
+          this.setState({eventId})
       });
     }
 
@@ -46,7 +45,7 @@ class ExampleBoundary extends Component {
         if (this.state.error) {
             //render fallback UI
             return (
-              <a onClick={() => Sentry.showReportDialog()}>Report feedback</a>
+              <a onClick={() => Sentry.showReportDialog(this.state.eventId)}>Report feedback</a>
             );
         } else {
             //when there's not an error, render children untouched


### PR DESCRIPTION
Examples of using the user feedback dialog in other languages pass the event id to the method, but the JS examples (both vanilla and React) don't. Sometimes, race conditions mean that a different event id is associated with the feedback than that of the event itself. Passing the event id prevents that.

This makes that change, and also adds user feedback to the Angular usage example.