### PR TITLE
Add `brew bundle` to the instructions for setting up the Sentry environment

### DIFF
--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -18,7 +18,11 @@ git clone https://github.com/<your github username>/sentry.git
 cd sentry
 ```
 
-Install [Homebrew](http://brew.sh), if you haven’t already, then run `brew install python@2`.
+Install [Homebrew](http://brew.sh), if you haven’t already, then run
+
+```bash
+brew bundle
+```
 
 It is highly recommended to develop inside a Python virtual environment, so install `virtualenv` and `virtualenvwrapper`:
 


### PR DESCRIPTION
Following the docs exactly, I hit errors in `make develop`:

```
py_GeoIP.c:23:10: fatal error: 'GeoIP.h' file not found
  #include "GeoIP.h"
           ^~~~~~~~~
  1 error generated.
  error: command 'clang' failed with exit status 1
```

and another like it related to XMLSEC.

I installed `geoip` manually with `brew`, got past that error, and then realized it was in the `Brewfile`.

I ran `brew bundle` and got past the XMLSEC error too.