### PR TITLE
fix: use url for distinct rather than title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ algolia:
     highlightPostTag: '</strong>'
     attributesToSnippet:
       - content:20
-    attributeForDistinct: title
+    attributeForDistinct: url
     attributesForFaceting:
       - searchable(categories)
       - searchable(tags)


### PR DESCRIPTION
When searching, we don't generally want multiple hits from a page. I initially set the value to use for determining distinct docs to the title, but we reuse titles in some places, notably "API Reference". The Python API reference doc and the API Reference both have the same title, and the Python doc was taking precedence, causing the API Reference to be discarded.

This switches to using the page url for `distinct`. We may eventually want to remove this entirely, but for now, this should improve results.