### PR TITLE
fix(apidocs) Update apidocs container to use postgres

### DIFF
--- a/Dockerfile.apidocs
+++ b/Dockerfile.apidocs
@@ -10,31 +10,38 @@
 # The container will dump the generated documentation in markdown and JSON
 # formats into the /usr/src/output directory which you should mount as a volume
 #
-FROM python:2.7.15-slim-jessie
+FROM postgres:9.6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        clang \
-        curl \
-        g++ \
-        gcc \
-        git \
-        libffi-dev \
-        libjpeg-dev \
-        libpq-dev \
-        libxml2-dev \
-        libxslt-dev \
-        libyaml-dev \
-        llvm \
-        bzip2 \
-        make \
-        redis-server \
-        unzip \
-    && rm -rf /var/lib/apt/lists/*
+      ca-certificates \
+      clang \
+      curl \
+      g++ \
+      gcc \
+      git \
+      libffi-dev \
+      libjpeg-dev \
+      libpq-dev \
+      libxml2-dev \
+      libxslt-dev \
+      libyaml-dev \
+      llvm \
+      bzip2 \
+      make \
+      python \
+      python-dev \
+      python-pip \
+      redis-server \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Sane defaults for pip
 ENV PIP_NO_CACHE_DIR off
 ENV PIP_DISABLE_PIP_VERSION_CHECK on
 ENV PYTHONUNBUFFERED 1
+
+# Disable yarn installation
+ENV SENTRY_LIGHT_BUILD=1
 
 RUN mkdir -p /usr/src/bin
 COPY scripts/build-api-docs /usr/bin

--- a/Dockerfile.apidocs
+++ b/Dockerfile.apidocs
@@ -10,29 +10,44 @@
 # The container will dump the generated documentation in markdown and JSON
 # formats into the /usr/src/output directory which you should mount as a volume
 #
-FROM postgres:9.6
+FROM python:2.7.15-slim-stretch
+
+RUN mkdir -p /usr/share/man/man1 \
+  /usr/share/man/man2 \
+  /usr/share/man/man3 \
+  /usr/share/man/man4 \
+  /usr/share/man/man5 \
+  /usr/share/man/man6 \
+  /usr/share/man/man7
+
+RUN groupadd -r redis --gid=998 \
+  && useradd -r -g redis --uid=998 redis \
+  && groupadd -r postgres --gid=999 \
+  && useradd -r -g postgres --uid=999 postgres
+
+ENV PG_MAJOR 9.6
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates \
-      clang \
-      curl \
-      g++ \
-      gcc \
-      git \
-      libffi-dev \
-      libjpeg-dev \
-      libpq-dev \
-      libxml2-dev \
-      libxslt-dev \
-      libyaml-dev \
-      llvm \
-      bzip2 \
-      make \
-      python \
-      python-dev \
-      python-pip \
-      redis-server \
-      unzip \
+    ca-certificates \
+    clang \
+    curl \
+    g++ \
+    gcc \
+    git \
+    libffi-dev \
+    libjpeg-dev \
+    libpq-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    llvm \
+    bzip2 \
+    make \
+    postgresql-$PG_MAJOR \
+    postgresql-contrib-$PG_MAJOR \
+    redis-server \
+    unzip \
   && rm -rf /var/lib/apt/lists/*
 
 # Sane defaults for pip
@@ -42,6 +57,13 @@ ENV PYTHONUNBUFFERED 1
 
 # Disable yarn installation
 ENV SENTRY_LIGHT_BUILD=1
+
+# Update postgres configuration to allow local access
+RUN rm "/etc/postgresql/$PG_MAJOR/main/pg_hba.conf" \
+  && touch "/etc/postgresql/$PG_MAJOR/main/pg_hba.conf" \
+  && chown -R postgres "/etc/postgresql/$PG_MAJOR/main/pg_hba.conf" \
+  && { echo; echo "host all all 0.0.0.0/0 trust"; } >> "/etc/postgresql/$PG_MAJOR/main/pg_hba.conf" \
+  && { echo; echo "local all all trust"; } >> "/etc/postgresql/$PG_MAJOR/main/pg_hba.conf"
 
 RUN mkdir -p /usr/src/bin
 COPY scripts/build-api-docs /usr/bin

--- a/scripts/build-api-docs
+++ b/scripts/build-api-docs
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+echo "--> Starting postgres"
+su postgres -c '/usr/lib/postgresql/9.6/bin/initdb'
+su postgres -c '/usr/lib/postgresql/9.6/bin/pg_ctl -D /var/lib/postgresql/data start' &
+su postgres -c 'createdb sentry_api_docs'
+
 echo "--> Fetching sentry source"
 curl -Ls https://github.com/getsentry/sentry/archive/master.zip --output sentry.zip
 unzip sentry.zip
@@ -7,6 +12,7 @@ echo "--> Installing sentry dependencies"
 cd sentry-master
 
 export SENTRY_LIGHT_BUILD=1
+pip install -U setuptools
 pip install -e '.[dev]'
 
 echo "--> Starting Redis"

--- a/scripts/build-api-docs
+++ b/scripts/build-api-docs
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 echo "--> Starting postgres"
-su postgres -c '/usr/lib/postgresql/9.6/bin/initdb'
+su postgres -c 'mkdir -p /var/lib/postgresql/data'
+su postgres -c '/usr/lib/postgresql/9.6/bin/initdb -D /var/lib/postgresql/data'
 su postgres -c '/usr/lib/postgresql/9.6/bin/pg_ctl -D /var/lib/postgresql/data start' &
-su postgres -c 'createdb sentry_api_docs'
+su postgres -c 'createdb -U postgres -E utf8 --template template0 sentry_api_docs'
+su postgres -c 'psql -U postgres -h 127.0.0.1 -c "CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;"'
 
 echo "--> Fetching sentry source"
 curl -Ls https://github.com/getsentry/sentry/archive/master.zip --output sentry.zip


### PR DESCRIPTION
We're removing support for sqlite from sentry so this container needs to provide a postgres database.