### PR TITLE
Don't tell people to use a random string as a DSN

### DIFF
--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -26,7 +26,7 @@ const { testkit, sentryTransport } = sentryTestkit()
 
 // initialize your Sentry instance with sentryTransport
 Sentry.init({
-  dsn: 'some_dummy_dsn',
+  dsn: '',
   transport: sentryTransport
   //... other configurations
 })

--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -23,10 +23,11 @@ npm install sentry-testkit --save-dev
 const sentryTestkit = require("sentry-testkit")
 
 const { testkit, sentryTransport } = sentryTestkit()
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 // initialize your Sentry instance with sentryTransport
 Sentry.init({
-  dsn: '',
+  dsn: DUMMY_DSN,
   transport: sentryTransport
   //... other configurations
 })


### PR DESCRIPTION
`dsn` should look like a DSN, it can't be some random string. That will cause `SentryError: Invalid Dsn`

https://github.com/wix/sentry-testkit/blob/master/test/index.test.js#L17