### PR TITLE
Fix typographic error in `enriching-error-data/scopes.md`

### DIFF
--- a/src/collections/_documentation/enriching-error-data/scopes.md
+++ b/src/collections/_documentation/enriching-error-data/scopes.md
@@ -78,7 +78,7 @@ While this example looks similar to `configure-scope` it's very different, in th
 will keep the changes.
 
 While on the other hand using `with-scope` creates a clone of the current scope
-and will stay isolated until the function call is completed.  
-So you can either set context information in there that you don't want to be somewhere 
-else or create do not attach any context information at all
-by calling `clear` on the scope, while the "global" scope remains unchanged.
+and will stay isolated until the function call is completed.  So you can either
+set context information in there that you don't want to be somewhere else or not
+attach any context information at all by calling `clear` on the scope, while the
+"global" scope remains unchanged.


### PR DESCRIPTION
Fixes the following typographic error in `enriching-error-data/scopes.md`.

Before:
> So you can either set context information in there that you don’t want to be somewhere
> else **_or create do not_** attach any context information at all

After:
> So you can either set context information in there that you don't want to be somewhere
> else **_or not_** attach any context information at all