### PR TITLE
fix: Remove context arg

### DIFF
--- a/src/_plugins/algolia_hooks.rb
+++ b/src/_plugins/algolia_hooks.rb
@@ -3,7 +3,7 @@ module Jekyll
     module Hooks
 
       # Exclude certain frontmatter keys form indexing
-      def self.before_indexing_each(record, node, context)
+      def self.before_indexing_each(record, node)
         [
           :sidebar_order,
           :collection,


### PR DESCRIPTION
After updating dependencies, it seems that this hook is not receiving the expected arguments, causing build errors.