### PR TITLE
Remove 'Import Name' from python framework specific docs

### DIFF
--- a/src/collections/_documentation/platforms/python/aiohttp.md
+++ b/src/collections/_documentation/platforms/python/aiohttp.md
@@ -6,8 +6,6 @@ sidebar_order: 4
 {% version_added: 0.6.1 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.aiohttp.AioHttpIntegration`*
-
 The AIOHTTP integration adds support for the [AIOHTTP-Server Web
 Framework](https://docs.aiohttp.org/en/stable/web.html). A Python version of
 3.6 or greater is required.

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -6,8 +6,6 @@ sidebar_order: 4
 {% version_added 0.3.5 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.aws_lambda.AwsLambdaIntegration`*
-
 You can use the AWS Lambda integration for the Python SDK like this:
 
 ```python

--- a/src/collections/_documentation/platforms/python/bottle.md
+++ b/src/collections/_documentation/platforms/python/bottle.md
@@ -7,8 +7,6 @@ sidebar_order: 5
 
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.bottle.BottleIntegration`*
-
 The Bottle integration adds support for the [Bottle Web Framework](https://bottlepy.org/).
 Currently it works well with the stable version of Bottle (0.12).
 However the integration with the development version (0.13) doesn't work properly.

--- a/src/collections/_documentation/platforms/python/celery.md
+++ b/src/collections/_documentation/platforms/python/celery.md
@@ -3,8 +3,6 @@ title: Celery
 sidebar_order: 2
 ---
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.celery.CeleryIntegration`*
-
 The celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).
 
 Just add ``CeleryIntegration()`` to your ``integrations`` list:

--- a/src/collections/_documentation/platforms/python/django.md
+++ b/src/collections/_documentation/platforms/python/django.md
@@ -3,8 +3,6 @@ title: Django
 sidebar_order: 2
 ---
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.django.DjangoIntegration`*
-
 The Django integration adds support for the [Django Web Framework](https://www.djangoproject.com/)
 from Version 1.6 upwards.
 

--- a/src/collections/_documentation/platforms/python/falcon.md
+++ b/src/collections/_documentation/platforms/python/falcon.md
@@ -7,8 +7,6 @@ sidebar_order: 5
 
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.falcon.FalconIntegration`*
-
 The Falcon integration adds support for the [Falcon Web Framework](https://falconframework.org/).
 The integration has been confirmed to work with Falcon 1.4 and 2.0.
 

--- a/src/collections/_documentation/platforms/python/flask.md
+++ b/src/collections/_documentation/platforms/python/flask.md
@@ -4,8 +4,6 @@ sidebar_order: 2
 ---
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.flask.FlaskIntegration`*
-
 The Flask integration adds support for the [Flask Web
 Framework](http://flask.pocoo.org/).
 

--- a/src/collections/_documentation/platforms/python/gnu_backtrace.md
+++ b/src/collections/_documentation/platforms/python/gnu_backtrace.md
@@ -3,8 +3,6 @@ title: GNU Backtrace
 sidebar_order: 2
 ---
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.gnu_backtrace.GnuBacktraceIntegration`*
-
 The GNU backtrace integration parses native stack trace produced by [`backtrace_symbols`](https://linux.die.net/man/3/backtrace_symbols) from error messages and concatenates them with the Python traceback.
 
 It is currently tested to work with server exceptions raised by [`clickhouse-driver`](https://github.com/mymarilyn/clickhouse-driver).

--- a/src/collections/_documentation/platforms/python/logging.md
+++ b/src/collections/_documentation/platforms/python/logging.md
@@ -2,8 +2,6 @@
 title: Logging
 sidebar_order: 2
 ---
-*Import name: `sentry_sdk.integrations.logging.LoggingIntegration`*
-
 Calling ``sentry_sdk.init()`` already integrates with the logging module. It is
 equivalent to this explicit configuration:
 

--- a/src/collections/_documentation/platforms/python/pyramid.md
+++ b/src/collections/_documentation/platforms/python/pyramid.md
@@ -6,8 +6,6 @@ sidebar_order: 5
 {% version_added 0.5.0 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.pyramid.PyramidIntegration`*
-
 The Pyramid integration adds support for the [Pyramid Web
 Framework](https://trypyramid.com/).
 

--- a/src/collections/_documentation/platforms/python/rq.md
+++ b/src/collections/_documentation/platforms/python/rq.md
@@ -6,8 +6,6 @@ sidebar_order: 2
 {% version_added 0.5.1 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.rq.RqIntegration`*
-
 The RQ integration adds support for the [RQ Job Queue System](https://python-rq.org/).
 
 Create a file called `mysettings.py` with the following content:

--- a/src/collections/_documentation/platforms/python/sanic.md
+++ b/src/collections/_documentation/platforms/python/sanic.md
@@ -6,8 +6,6 @@ sidebar_order: 3
 {% version_added 0.3.6 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.sanic.SanicIntegration`*
-
 The Sanic integration adds support for the [Sanic Web
 Framework](https://github.com/huge-success/sanic). A Python version of 3.6 or
 greater is required.

--- a/src/collections/_documentation/platforms/python/serverless.md
+++ b/src/collections/_documentation/platforms/python/serverless.md
@@ -6,8 +6,6 @@ sidebar_order: 4
 {% version_added 0.7.3 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.serverless.serverless_function`*
-
 It is recommended to use an [integration for your particular serverless environment if available]({% link _documentation/platforms/python/index.md %}#serverless), as those are easier to use and capture more useful information.
 
 If you use a serverless provider not directly supported by the SDK, you can use this generic integration.

--- a/src/collections/_documentation/platforms/python/tornado.md
+++ b/src/collections/_documentation/platforms/python/tornado.md
@@ -6,8 +6,6 @@ sidebar_order: 4
 {% version_added: 0.6.3 %}
 
 <!-- WIZARD -->
-*Import name: `sentry_sdk.integrations.tornado.TornadoIntegration`*
-
 The Tornado integration adds support for the [Tornado Web
 Framework](https://www.tornadoweb.org/). A Tornado version of 5 or greater and
 Python 3.6 or greater is required.

--- a/src/collections/_documentation/platforms/python/wsgi.md
+++ b/src/collections/_documentation/platforms/python/wsgi.md
@@ -6,9 +6,6 @@ sidebar_order: 5
 {% version_added 0.6.0 %}
 
 <!-- WIZARD -->
-
-*Import name: `sentry_sdk.integrations.wsgi.SentryWsgiMiddleware`*
-
 It is recommended to use an [integration for your particular WSGI framework if available]({% link _documentation/platforms/python/index.md %}#web-frameworks), as those are easier to use and capture more useful information.
 
 If you use a WSGI framework not directly supported by the SDK, or wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.


### PR DESCRIPTION
Many pthon docs have an italicized 'import name', however this doesn't add anything as immediately below this you can see the import in the code example. It just adds visual clutter