### PR TITLE
filestore: document S3 parameters

### DIFF
--- a/src/collections/_documentation/server/filestore.md
+++ b/src/collections/_documentation/server/filestore.md
@@ -30,7 +30,24 @@ filestore.options:
 ```yaml
 filestore.backend: 's3'
 filestore.options:
-  access_key: '...'
-  secret_key: '...'
   bucket_name: '...'
 ```
+
+* Sentry uses the [boto3](https://pypi.org/project/boto3/) library to access S3. Boto supports a number of ways to [retrieve configuration information](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#guide-configuration) including EC2/ECS IAM roles (recommended), the environment, its own configuration files, and you may also specify specify  `access_key` and `secret_key` values in your Sentry `filestore.options`:
+
+    ```yaml
+    filestore.backend: 's3'
+    filestore.options:
+        bucket_name: '...'
+        access_key: '...'
+        secret_key: '...'
+    ```
+
+* By default, S3 objects are created with the `public-read` ACL which means that the account used must have the `PutObjectAcl` permission in addition to `PutObject`, along with `GetObject` and `DeleteObject`. If you don't want your uploaded files to be publically-accessible you can specify the default ACL using a value accepted by [boto's S3 `put_object` method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object):
+
+    ```yaml
+    filestore.backend: 's3'
+    filestore.options:
+        bucket_name: '...'
+        default_acl: 'private'
+    ```


### PR DESCRIPTION
I ran into a couple of hitches switching to S3 storage and wanted to document the necessary permissions and how to secure it.

Closes #953