### PR TITLE
send-before-hint/javascript: Fix "Can not access 'name' of undefined" error

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/before-send-hint/javascript.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-send-hint/javascript.md
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/browser';
 
 init({
   beforeSend(event, hint) {
-    const { message } = hint.originalException;
-    if (message && message.match(/database unavailable/i)) {
+    const error = hint.originalException;
+    if (error && error.message && error.message.match(/database unavailable/i)) {
       event.fingerprint = ['database-unavailable'];
     }
     return event;


### PR DESCRIPTION
In some cases `originalException` can be `null` or `undefined` and then the destructuring operation will fail.