### PR TITLE
Avoid Error 422 when add a GitLab repository

### DIFF
--- a/src/collections/_documentation/workflow/integrations/global-integrations/gitlab.md
+++ b/src/collections/_documentation/workflow/integrations/global-integrations/gitlab.md
@@ -16,6 +16,15 @@ Sentry owner or manager permissions and GitLab owner or maintainer permissions a
   level="warning"
 %}
 
+{% capture __alert_content -%}
+GitLab -> Admim area -> Settings -> Network -> Outbound requests -> Allow requests to the local network from hooks and services
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Local requests should be enabled in GitLab"
+  content=__alert_content
+  level="warning"
+%}
+
 1. In Sentry, navigate to Organization Settings > **Integrations**.
 
 1. Within Integrations, find the GitLab icon and click **Install**.


### PR DESCRIPTION
Enabled this option is required to add GitLab repo.
see https://github.com/getsentry/sentry/issues/13079