### PR TITLE
Document `ignore_errors` option

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -131,6 +131,14 @@ A list of string prefixes of module names that do not belong to the app, but rat
 This option can be overridden using `in-app-include`.
 {% endsupported %}
 
+
+{:.config-key}
+### `ignore_errors`
+
+{% supported python %}
+A list of exception class names (strings) to ignore. Cought exceptions will be not be reported if their class is in this list.
+
+
 {:.config-key}
 ### `request-bodies`
 

--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -137,7 +137,7 @@ This option can be overridden using `in-app-include`.
 
 {% supported python %}
 A list of exception class names (strings) to ignore. Cought exceptions will be not be reported if their class is in this list.
-
+{% endsupported %}
 
 {:.config-key}
 ### `request-bodies`


### PR DESCRIPTION
Found it in https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/client.py#L164