### PR TITLE
Stop "Was this page Helpful to you" from floating around.

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -46,11 +46,11 @@
             {{content}}
 
           </section>
-        </div>
 
-        <footer class="border-top bg-white px-3 py-2 flex-grow-0 d-none js-feedback-footer">
-          {% include feedback_footer.html %}
-        </footer>
+          <footer class="border-top bg-white px-3 py-2 flex-grow-0 d-none js-feedback-footer">
+            {% include feedback_footer.html %}
+          </footer>
+        </div>
       </main>
 
     </div>


### PR DESCRIPTION
I'm sure there's a better way to do it, but this will cause "Was this page Helpful to you" to stop following you around and only show at the bottom of the page.

Rational: it takes up space and adds minimal value.