### PR TITLE
feat: Add volta to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,9 @@
     ],
     "testURL": "https://docs.sentry.io"
   },
+  "volta": {
+    "node": "8.11.3",
+    "yarn": "1.16.0"
+  },
   "snyk": true
 }


### PR DESCRIPTION
This configures the volta toolchain so that nvm is no longer necessary
for building the docs.