### PR TITLE
fix: Add note to Advanced Search docs re: plans

### DIFF
--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -40,7 +40,7 @@ The token `example error` is utilizing the optional raw search and is passed as 
 ### Advanced
 
 {% capture __alert_content -%}
-Advanced search is available for organizations on the Team and Business plans.
+Advanced search is available for organizations on the new Developer, Team, and Business plans.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -39,6 +39,15 @@ The token `example error` is utilizing the optional raw search and is passed as 
 
 ### Advanced
 
+{% capture __alert_content -%}
+Advanced search is available for organizations on the Team and Business plans.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Note"
+  content=__alert_content
+  level="warning"
+%}
+
 #### Exclusion
 
 By default, search terms are `AND`-ed together; they return the intersection of issues/events that match all search terms.


### PR DESCRIPTION
Advanced search is only available on `mm2` plans.