### PR TITLE
ref(javascript): Default to browsernpm over browser CDN

### DIFF
--- a/src/_plugins/platform_api.rb
+++ b/src/_plugins/platform_api.rb
@@ -78,9 +78,9 @@ Jekyll::Hooks.register :site, :post_render, priority: :high do |site|
     is_self = group_slug === platform["slug"]
     grouped_file = group_slug === platform["slug"] ? file_name : "#{group_slug}/#{file_name}"
 
-    # This is a workaround to match JavaScript to browser docs now
+    # XXX: This is a workaround to match JavaScript to browsernpm docs now
     if platform["wizard"] === true and platform["slug"] == "javascript"
-      platform["slug"] = "browser"
+      platform["slug"] = "browsernpm"
       is_self = true
       grouped_file = file_name
     end


### PR DESCRIPTION
By default in the sentry wizard clicking 'javascript' gives you the CDN version. I would argue that most people these days likely want the yarn/npm version.