### PR TITLE
ref(javascript): Various minor adjustments

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-install/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browser.md
@@ -1,7 +1,8 @@
 The quickest way to get started is to use the CDN hosted version of the JavaScript browser SDK:
 
 ```html
-<script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" crossorigin="anonymous"></script>
+<script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" crossorigin="anonymous">
+</script>
 ```
 
 {% wizard hide %}

--- a/src/collections/_documentation/error-reporting/getting-started-install/browsernpm.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browsernpm.md
@@ -1,13 +1,13 @@
-If you are using `yarn` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency easily:
 
 ```bash
+# Using yarn
 $ yarn add @sentry/browser@{% sdk_version sentry.javascript.browser %}
-```
 
-Or alternatively you can npm install it:
-
-```bash
+# Using npm
 $ npm install @sentry/browser@{% sdk_version sentry.javascript.browser %}
 ```
 
+{% wizard hide %}
 You can also [use our more convenient CDN version](?platform=browser).
+{% endwizard %}

--- a/src/collections/_documentation/error-reporting/getting-started-install/browsernpm.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browsernpm.md
@@ -1,4 +1,4 @@
-If you are using `yarn` or `npm` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
 # Using yarn

--- a/src/collections/_documentation/error-reporting/getting-started-install/electron.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/electron.md
@@ -1,11 +1,9 @@
-If you are using `yarn` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency easily:
 
 ```bash
+# Using yarn
 $ yarn add @sentry/electron@{% sdk_version sentry.javascript.electron %}
-```
 
-Or alternatively you can npm install it:
-
-```bash
+# Using npm
 $ npm install @sentry/electron@{% sdk_version sentry.javascript.electron %}
 ```

--- a/src/collections/_documentation/error-reporting/getting-started-install/electron.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/electron.md
@@ -1,4 +1,4 @@
-If you are using `yarn` or `npm` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
 # Using yarn

--- a/src/collections/_documentation/error-reporting/getting-started-install/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/node.md
@@ -1,11 +1,9 @@
-If you are using `yarn` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency easily:
 
 ```bash
+# Using yarn
 $ yarn add @sentry/node@{% sdk_version sentry.javascript.node %}
-```
 
-Or alternatively you can npm install it:
-
-```bash
+# Using npm
 $ npm install @sentry/node@{% sdk_version sentry.javascript.node %}
 ```

--- a/src/collections/_documentation/error-reporting/getting-started-install/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/node.md
@@ -1,4 +1,4 @@
-If you are using `yarn` or `npm` you can add our package as a dependency easily:
+If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
 # Using yarn

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -36,8 +36,6 @@ After you completed setting up a project in Sentry, you’ll be given a value wh
 
 {% include components/platform_content.html content_dir='getting-started-config' %}
 
-Most SDKs will now automatically collect data if available, some require some extra configuration as automatic error collecting is not
-available due to platform limitations.
 {% endwizard %}
 
 {% capture __alert_content -%}

--- a/src/collections/_documentation/platforms/javascript/ember.md
+++ b/src/collections/_documentation/platforms/javascript/ember.md
@@ -3,7 +3,8 @@ title: Ember
 sidebar_order: 50
 ---
 <!-- WIZARD -->
-To use Sentry with your Ember application, you will need to use `@sentry/browser` (Sentry’s browser JavaScript SDK).  
+To use Sentry with your Ember application, you will need to use Sentry’s browser JavaScript SDK: `@sentry/browser`.
+
 On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
 In order to use ESM imports without any additional configuration, you can use `ember-auto-import`
 by installing it with `ember install ember-auto-import`.
@@ -12,9 +13,11 @@ Starting with version `5.x` our `Ember` integration lives in it's own package `@
 You can install it with `npm` / `yarn` like:
 
 ```bash
-npm install @sentry/integrations
-# or
+# Using yarn
 yarn add @sentry/integrations
+
+# Using npm
+npm install @sentry/integrations
 ```
 
 Then add this to your `app.js`:

--- a/src/collections/_documentation/platforms/javascript/getting-started-dsn/react.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-dsn/react.md
@@ -1,9 +1,11 @@
 You should `init` the Sentry browser SDK as soon as possible during your application load up, before initializing React:
 
 ```jsx
+import React from 'react';
 import * as Sentry from '@sentry/browser';
+import App from 'src/App';
 
-Sentry.init({ dsn: '___PUBLIC_DSN___' });
+Sentry.init({dsn: "___PUBLIC_DSN___"});
 
-ReactDOM.render(<App />, document.querySelector('#app'));
+ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/browsernpm.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/browsernpm.md
@@ -1,7 +1,11 @@
-Add the `@sentry/browser` to your project:
+Add the Sentry SDK as a dependency using `yarn` or `npm`:
 
 ```bash
-$ npm install --save @sentry/browser
+# Using yarn
+$ yarn add @sentry/browser
+
+# Using npm
+$ npm install @sentry/browser
 ```
 
 {% wizard hide %}

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/electron.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/electron.md
@@ -1,11 +1,9 @@
-If you are using `yarn` you can add our package as a dependency:
+If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
+# Using yarn
 $ yarn add @sentry/electron@{% sdk_version sentry.javascript.electron %}
-```
 
-Or alternatively, you can npm install it:
-
-```bash
+# Using npm
 $ npm install @sentry/electron@{% sdk_version sentry.javascript.electron %}
 ```

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/node.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/node.md
@@ -1,11 +1,9 @@
-If you are using `yarn` you can add our package as a dependency:
+If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
+# Using yarn
 $ yarn add @sentry/node@{% sdk_version sentry.javascript.node %}
-```
 
-Or alternatively, you can npm install it:
-
-```bash
+# Using npm
 $ npm install @sentry/node@{% sdk_version sentry.javascript.node %}
 ```

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -12,8 +12,6 @@ After you've completed setting up a project in Sentry, Sentry will give you a va
 
 {% include components/platform_content.html content_dir='getting-started-dsn' %}
 
-Most SDKs will now automatically collect data if available; some require extra configuration as automatic error collecting is not possible due to platform limitations.
-
 ### Verifying Your Setup
 Great! Now that you've completed setting up the SDK, maybe you want to quickly test out how Sentry works. Start by capturing an exception:
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -28,13 +28,8 @@ In development mode React will rethrow errors caught within an error boundary. T
 %}
 
 ```jsx
+import React from 'react';
 import * as Sentry from '@sentry/browser';
-
-// Sentry.init({
-//  dsn: "___PUBLIC_DSN___"
-// });
-// should have been called before using it here
-// ideally before even rendering your react app
 
 class ExampleBoundary extends Component {
     constructor(props) {
@@ -57,10 +52,10 @@ class ExampleBoundary extends Component {
             return (
               <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
             );
-        } else {
-            //when there's not an error, render children untouched
-            return this.props.children;
         }
+
+        //when there's not an error, render children untouched
+        return this.props.children;
     }
 }
 ```

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -19,7 +19,7 @@ On its own, `@sentry/browser` will report any uncaught exceptions triggered by y
 Additionally, the Vue _integration_ will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
 
 Starting with version `5.x` our `Vue` integration lives in its own package `@sentry/integrations`.
-You can install it with `npm` / `yarn` like:
+You can install it with `npm` / `yarn`:
 
 ```bash
 # Using yarn

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -18,7 +18,7 @@ On its own, `@sentry/browser` will report any uncaught exceptions triggered by y
 
 Additionally, the Vue _integration_ will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
 
-Starting with version `5.x` our `Vue` integration lives in it's own package `@sentry/integrations`.
+Starting with version `5.x` our `Vue` integration lives in its own package `@sentry/integrations`.
 You can install it with `npm` / `yarn` like:
 
 ```bash

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -4,20 +4,37 @@ sidebar_order: 40
 ---
 
 <!-- WIZARD -->
+To use Sentry with your Vue application, you will need to use Sentry’s browser JavaScript SDK: `@sentry/browser`.
 
-To use Sentry with your Vue application, you will need to use `@sentry/browser` (Sentry’s browser JavaScript SDK).  
-On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
+```bash
+# Using yarn
+$ yarn add @sentry/browser
+
+# Using npm
+$ npm install @sentry/browser
+```
+
+On its own, `@sentry/browser` will report any uncaught exceptions triggered by your application.
 
 Additionally, the Vue _integration_ will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
 
-Passing in `Vue` is optional, if you do not pass it `window.Vue` has to be present.
+Starting with version `5.x` our `Vue` integration lives in it's own package `@sentry/integrations`.
+You can install it with `npm` / `yarn` like:
+
+```bash
+# Using yarn
+yarn add @sentry/integrations
+
+# Using npm
+npm install @sentry/integrations
+```
+
+Passing in `Vue` is optional, if you do not pass it `window.Vue` must be present.
 
 Passing in `attachProps` is optional and is `true` if it is not provided. If you set it to `false`, Sentry will suppress sending all Vue components' props for logging.
 
 {% capture __alert %}
-Please note that if you enable this integration Vue internally will not call `logError` 
-due to a currently know limitation see: [GitHub Issue](https://github.com/vuejs/vue/issues/8433).  
-This means that errors occurring in the Vue renderer will not show up in the developer console.
+Please note that if you enable this integration Vue internally will not call `logError` due to a currently know limitation see: [GitHub Issue](https://github.com/vuejs/vue/issues/8433). This means that errors occurring in the Vue renderer will not show up in the developer console.
 {% endcapture %}
 
 {% include components/alert.html
@@ -26,15 +43,6 @@ This means that errors occurring in the Vue renderer will not show up in the dev
   level="warning"
 %}
 
-Starting with version `5.x` our `Vue` integration lives in it's own package `@sentry/integrations`.
-You can install it with `npm` / `yarn` like:
-
-```bash
-npm install @sentry/integrations
-# or
-yarn add @sentry/integrations
-```
-
 ```javascript
 import Vue from 'vue'
 import * as Sentry from '@sentry/browser';
@@ -42,12 +50,7 @@ import * as Integrations from '@sentry/integrations';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    new Integrations.Vue({
-      Vue,
-      attachProps: true,
-    }),
-  ],
+  integrations: [new Integrations.Vue({Vue, attachProps: true})],
 });
 ```
 
@@ -65,12 +68,7 @@ like this:
 <script>
   Sentry.init({
     dsn: '___PUBLIC_DSN___',
-    integrations: [
-      new Sentry.Integrations.Vue({
-        Vue,
-        attachProps: true,
-      }),
-    ],
+    integrations: [new Sentry.Integrations.Vue({Vue, attachProps: true})],
   });
 </script>
 ```


### PR DESCRIPTION
Most of these are in regard to the wizard, but I've verified them in the
docs as well to ensure they look right.

 - Combine npm / yarn install options into a single code block.
 - Minorly better line breaks of various paragraphs (like breaks in
   paragraphs tend to look funny)
 - Minorly better line breaks in various code blocks.
 - Ensure we tell users how to install the sdk in some of our platform
   docs (React, vue)