### PR TITLE
Added link to nlog integration in dotnet index page

### DIFF
--- a/src/collections/_documentation/platforms/dotnet/index.md
+++ b/src/collections/_documentation/platforms/dotnet/index.md
@@ -13,6 +13,7 @@ This section will describe features, configurations and general functionality wh
 - [_log4net_]({% link _documentation/platforms/dotnet/log4net.md %})
 - [_Microsoft.Extensions.Logging_]({% link _documentation/platforms/dotnet/microsoft-extensions-logging.md %})
 - [_Serilog_]({% link _documentation/platforms/dotnet/serilog.md %})
+- [_NLog_]({% link _documentation/platforms/dotnet/nlog.md %})
 
 ## Compatibility
 


### PR DESCRIPTION
This PR adds a link to the `NLog` integration in the `.NET` platform index page.