### PR TITLE
fix(jira) Note that jira assignee sync requires access to email addresses

### DIFF
--- a/src/collections/_documentation/workflow/integrations/global-integrations.md
+++ b/src/collections/_documentation/workflow/integrations/global-integrations.md
@@ -652,6 +652,10 @@ To configure Issue sync, navigate to Organization Settings > **Integrations**, a
 
 [{% asset jira-sync.png %}]({% asset jira-sync.png @path %})
 
+Sentry's assignee sync requires that user's email addresses be visible. You may
+need to adjust your Jira instance's privacy settings or the privacy settings of
+individual users if you experience assignee sync not behaving as expected.
+
 ### JIRA Server
 
 Connect errors from Sentry with your Jira Server issues.


### PR DESCRIPTION
When user enable enhanced privacy modes we can't get their email addresses which breaks assignee sync.

Refs SEN-605