### PR TITLE
feat(quickstart): Add examples for all quickstart platforms

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-verify/aspnetcore.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/aspnetcore.md
@@ -1,0 +1,1 @@
+See the [provided examples in the `dotnet` SDK repository](https://github.com/getsentry/sentry-dotnet/tree/master/samples) for simple examples to send your first event to Sentry.

--- a/src/collections/_documentation/error-reporting/getting-started-verify/aspnetcore.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/aspnetcore.md
@@ -1,1 +1,1 @@
-See the [provided examples in the `dotnet` SDK repository](https://github.com/getsentry/sentry-dotnet/tree/master/samples) for simple examples to send your first event to Sentry.
+See the [provided examples in the `dotnet` SDK repository](https://github.com/getsentry/sentry-dotnet/tree/master/samples) for examples to send your first event to Sentry.

--- a/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
@@ -1,0 +1,7 @@
+A simple way to break your JavaScript application is to call an undefined function:
+
+```js
+myUndefinedFunction();
+```
+
+You can verify the function caused an error by checking your browser console.

--- a/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
@@ -1,4 +1,4 @@
-A simple way to break your JavaScript application is to call an undefined function:
+One way to break your JavaScript application is to call an undefined function:
 
 ```js
 myUndefinedFunction();

--- a/src/collections/_documentation/error-reporting/getting-started-verify/browsernpm.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/browsernpm.md
@@ -1,0 +1,1 @@
+{% include_relative getting-started-verify/browser.md %}

--- a/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
@@ -1,0 +1,5 @@
+A simple way to break your Cordova application is to call an undefined function:
+
+```js
+myUndefinedFunction();
+```

--- a/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
@@ -1,4 +1,4 @@
-A simple way to break your Cordova application is to call an undefined function:
+One way to break your Cordova application is to call an undefined function:
 
 ```js
 myUndefinedFunction();

--- a/src/collections/_documentation/error-reporting/getting-started-verify/csharp.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/csharp.md
@@ -1,0 +1,8 @@
+You can easily verify Sentry is capturing unhandled exceptions by raising an exception, for example you can use the following snippet to raise a `DivideByZeroException`:
+
+```csharp
+using (SentrySdk.Init("___PUBLIC_DSN___"))
+{
+    Console.WriteLine(1 / 0);
+}
+```

--- a/src/collections/_documentation/error-reporting/getting-started-verify/csharp.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/csharp.md
@@ -1,4 +1,4 @@
-You can easily verify Sentry is capturing unhandled exceptions by raising an exception, for example you can use the following snippet to raise a `DivideByZeroException`:
+You can verify Sentry is capturing unhandled exceptions by raising an exception. For example, you can use the following snippet to raise a `DivideByZeroException`:
 
 ```csharp
 using (SentrySdk.Init("___PUBLIC_DSN___"))

--- a/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
@@ -1,4 +1,4 @@
-A simple way to break your Electron application is to call an undefined function:
+One way to break your Electron application is to call an undefined function:
 
 ```js
 myUndefinedFunction();

--- a/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
@@ -1,0 +1,8 @@
+A simple way to break your Electron application is to call an undefined function:
+
+```js
+myUndefinedFunction();
+```
+
+You may want to try inserting this into both your `main` and any `renderer`
+processes to verify Sentry is operational in both.

--- a/src/collections/_documentation/error-reporting/getting-started-verify/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/node.md
@@ -1,4 +1,4 @@
-A simple way to break your JavaScript application is to call an undefined function:
+One way to break your JavaScript application is to call an undefined function:
 
 ```js
 myUndefinedFunction();

--- a/src/collections/_documentation/error-reporting/getting-started-verify/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/node.md
@@ -1,0 +1,5 @@
+A simple way to break your JavaScript application is to call an undefined function:
+
+```js
+myUndefinedFunction();
+```

--- a/src/collections/_documentation/error-reporting/getting-started-verify/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/php.md
@@ -1,0 +1,5 @@
+You can easily trigger a PHP exception by throwing one in your application:
+
+```php
+throw new Exception("My first Sentry error!");
+```

--- a/src/collections/_documentation/error-reporting/getting-started-verify/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/php.md
@@ -1,4 +1,4 @@
-You can easily trigger a PHP exception by throwing one in your application:
+You can trigger a PHP exception by throwing one in your application:
 
 ```php
 throw new Exception("My first Sentry error!");

--- a/src/collections/_documentation/error-reporting/getting-started-verify/python.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/python.md
@@ -1,0 +1,6 @@
+You can easily cause a python error by inserting a divide by zero expression
+into your application:
+
+```py
+division_by_zero = 1 / 0
+```

--- a/src/collections/_documentation/error-reporting/getting-started-verify/python.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/python.md
@@ -1,4 +1,4 @@
-You can easily cause a python error by inserting a divide by zero expression
+You can cause a Python error by inserting a divide by zero expression
 into your application:
 
 ```py

--- a/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
@@ -1,4 +1,4 @@
-The quickets way to verify Sentry in your rust application is to cause a panic:
+The quickest way to verify Sentry in your Rust application is to cause a panic:
 
 ```rust
 fn main() {

--- a/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
@@ -1,0 +1,12 @@
+The quickets way to verify Sentry in your rust application is to cause a panic:
+
+```rust
+fn main() {
+    // Initialize sentry here
+
+    sentry::integrations::panic::register_panic_handler();
+
+    // Sentry will capture this
+    panic!("Everything is on fire!");
+}
+```

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -56,6 +56,14 @@ Note: If you’re using Heroku, and you’ve added Hosted Sentry via the standar
   content=__alert_content
 %}
 
+## Capturing your first event
+
+Once you have Sentry integrated into your project, you probably want to verify that everything is working as expected before deploying it, and what better way to do that than to break your application!
+
+{% wizard %}
+{% include components/platform_content.html content_dir='getting-started-verify' %}
+{% endwizard %}
+
 ## Next Steps
 
 Now that you’ve got basic reporting setup, you’ll want to explore adding additional context to your data.

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -66,7 +66,7 @@ Once you have Sentry integrated into your project, you probably want to verify t
 
 ## Next Steps
 
-Now that you’ve got basic reporting setup, you’ll want to explore adding additional context to your data.
+Now that you’ve got basic reporting set up, you’ll want to explore adding additional context to your data.
 
 {% include components/platform_content.html content_dir='getting-started-next-steps' %}
 -   [_manual error and event capturing_]({%- link _documentation/error-reporting/capturing.md -%})


### PR DESCRIPTION
Just for the quickstart page, adds a 'sending a verification event' section.