### PR TITLE
fix(minidump): Do not cutoff `ul` in wizard html

### DIFF
--- a/src/collections/_documentation/platforms/minidump/index.md
+++ b/src/collections/_documentation/platforms/minidump/index.md
@@ -13,12 +13,14 @@ In order to receive symbolicated stack traces, you have to upload debug informat
 <!-- WIZARD -->
 ## Platform and Language Support
 
-Minidumps are currently supported for **Windows, macOS and Linux**. There is no limitation as to which programming language can be used. Sentry can also demangle symbols from the following languages; other languages will show the mangled name instead:
+Minidumps are currently supported for **Windows, macOS and Linux**. There is no limitation as to which programming language can be used. Sentry can also demangle symbols from the following languages:
 
 -   C and C++
 -   ObjectiveC and ObjectiveC++
 -   Swift
 -   Rust
+
+Other languages will show the mangled name instead.
 <!-- ENDWIZARD -->
 
 ## What is a Minidump? {#what-is-a-minidump}

--- a/src/collections/_documentation/platforms/minidump/index.md
+++ b/src/collections/_documentation/platforms/minidump/index.md
@@ -13,7 +13,7 @@ In order to receive symbolicated stack traces, you have to upload debug informat
 <!-- WIZARD -->
 ## Platform and Language Support
 
-Minidumps are currently supported for **Windows, macOS and Linux**. There is no limitation as to which programming language can be used. Sentry can also demangle symbols from the following languages:
+Sentry currently supports minidumps for **Windows, macOS and Linux**. There is no limitation as to which programming language you can use. Sentry can also demangle symbols from the following languages:
 
 -   C and C++
 -   ObjectiveC and ObjectiveC++

--- a/src/collections/_documentation/platforms/minidump/index.md
+++ b/src/collections/_documentation/platforms/minidump/index.md
@@ -20,7 +20,7 @@ Sentry currently supports minidumps for **Windows, macOS and Linux**. There is n
 -   Swift
 -   Rust
 
-Other languages will show the mangled name instead.
+Languages not listed above will show the mangled name instead.
 <!-- ENDWIZARD -->
 
 ## What is a Minidump? {#what-is-a-minidump}


### PR DESCRIPTION
When the `<!-- WIZARD -->` tags are processed they will cutoff the `ul` at the end of a list, causing additional wizard content to be nested under the last list item.

This fixes this for minidumps