### PR TITLE
ref(go): Make test examples more clear

### DIFF
--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -466,6 +466,7 @@
       wizard_parent: go
       wizard:
         - _documentation/clients/go/index.md
+        - _documentation/clients/go/usage.md
 -
       slug: http
       support_level: in-development

--- a/src/collections/_documentation/clients/go/index.md
+++ b/src/collections/_documentation/clients/go/index.md
@@ -41,7 +41,7 @@ package main
 import "github.com/getsentry/raven-go"
 
 func init() {
-    raven.SetDSN("___DSN___")
+	raven.SetDSN("___DSN___")
 }
 ```
 <!-- ENDWIZARD -->

--- a/src/collections/_documentation/clients/go/integrations.md
+++ b/src/collections/_documentation/clients/go/integrations.md
@@ -27,7 +27,7 @@ package main
 import "github.com/getsentry/raven-go"
 
 func init() {
-    raven.SetDSN("___DSN___")
+	raven.SetDSN("___DSN___")
 }
 ```
 
@@ -36,10 +36,12 @@ If you don’t call `SetDSN`, we will attempt to read it from your environment u
 Next, we need to wrap our `http.Handler` with our `RecoveryHandler`:
 
 ```go
-func root(w http.ResponseWriter, r *http.Request) {
-    // ... do stuff
+func raisesError(w http.ResponseWriter, r *http.Request) {
+	panic("My first Sentry error!")
 }
-http.HandleFunc("/", raven.RecoveryHandler(root))
-```
-<!-- ENDWIZARD -->
 
+http.HandleFunc("/debug-sentry", raven.RecoveryHandler(raisesError))
+```
+
+You can use the above snippet to verify the Sentry integration by visiting the above route in your application and verifying the error in Sentry.
+<!-- ENDWIZARD -->

--- a/src/collections/_documentation/clients/go/usage.md
+++ b/src/collections/_documentation/clients/go/usage.md
@@ -13,8 +13,8 @@ To handle normal `error` responses, we have two options: `CaptureErrorAndWait` a
 ```go
 f, err := os.Open("filename.ext")
 if err != nil {
-    raven.CaptureErrorAndWait(err, nil)
-    log.Panic(err)
+	raven.CaptureErrorAndWait(err, nil)
+	log.Panic(err)
 }
 ```
 
@@ -24,9 +24,12 @@ Capturing a panic is pretty simple as well. We just need to wrap our code in `Ca
 
 ```go
 raven.CapturePanic(func() {
-    // do all of the scary things here
+	// do all of the scary things here
+	panic("My first Sentry error!")
 }, nil)
 ```
+
+You can verify your Sentry integration by using the above snippet to send a test event.
 <!-- ENDWIZARD -->
 
 Other than regular Errors and Panics, there are also two additional methods that allow sending information to Sentry.
@@ -46,11 +49,11 @@ To form a `Packet`, you can use `Packet` type directly, or `NewPacket` and `NewP
 
 ```go
 packet := &raven.Packet{
-    Message: "Hand-crafted event",
-    Extra: &raven.Extra{
-        "runtime.Version": runtime.Version(),
-        "runtime.NumCPU": runtime.NumCPU(),
-    },
+	Message: "Hand-crafted event",
+	Extra: &raven.Extra{
+		"runtime.Version": runtime.Version(),
+		"runtime.NumCPU": runtime.NumCPU(),
+	},
 }
 raven.Capture(packet)
 ```


### PR DESCRIPTION
Also swaps out spaces for tabs (go convention)