### PR TITLE
feat: Add marker comment for missing verification docs

### DIFF
--- a/src/collections/_documentation/clients/cocoa/index.md
+++ b/src/collections/_documentation/clients/cocoa/index.md
@@ -85,6 +85,8 @@ Before you can start capturing crashes you will need to tell Sentry about the de
 
 -   [With Bitcode]({%- link _documentation/clients/cocoa/dsym.md -%}#dsym-with-bitcode)
 -   [Without Bitcode]({%- link _documentation/clients/cocoa/dsym.md -%}#dsym-without-bitcode)
+
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Testing a Crash

--- a/src/collections/_documentation/clients/elixir/index.md
+++ b/src/collections/_documentation/clients/elixir/index.md
@@ -71,6 +71,7 @@ If using an environment with Plug or Phoenix add the following to your router:
 use Plug.ErrorHandler
 use Sentry.Plug
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Filtering Events

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -31,6 +31,7 @@ compile 'org.slf4j:slf4j-nop:1.7.25'
 ```
 
 For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-android%7C1.7.16%7Cjar).
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### Initialization
@@ -68,6 +69,7 @@ public class MainActivity extends Activity {
 
 You can optionally configure other values such as `environment` and `release`. [See the configuration page]({%- link _documentation/clients/java/config.md -%}#configuration) for ways you can do this.
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- WIZARD android -->
 ### Usage
 
@@ -120,6 +122,7 @@ public class MyClass {
     }
 }
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### ProGuard
@@ -292,6 +295,7 @@ For other dependency managers see the [central Maven repository](https://search.
 This module provides a new `SentryClientFactory` implementation which replaces the default async system with a Google App Engine compatible one. You’ll need to configure Sentry to use the `io.sentry.appengine.AppEngineSentryClientFactory` as its factory.
 
 The queue size and thread options will not be used as they are specific to the default Java threading system.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### Queue Name
@@ -369,6 +373,7 @@ $ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 ```
 
 Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page]({%- link _documentation/clients/java/config.md -%}#configuration) for ways you can do this.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### In Practice
@@ -500,6 +505,7 @@ Alternatively, using the `log4j.xml` format:
 ```
 
 Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page]({%- link _documentation/clients/java/config.md -%}#configuration) for ways you can do this.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### Additional Data
@@ -638,6 +644,7 @@ Example configuration using the `log4j2.xml` format:
 ```
 
 Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page]({%- link _documentation/clients/java/config.md -%}#configuration) for ways you can do this.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### Additional Data
@@ -783,6 +790,7 @@ Example configuration using the `logback.xml` format:
 ```
 
 Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page]({%- link _documentation/clients/java/config.md -%}#setting-the-dsn) for ways you can do this.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ### Additional Data

--- a/src/collections/_documentation/clients/javascript/integrations.md
+++ b/src/collections/_documentation/clients/javascript/integrations.md
@@ -144,6 +144,7 @@ angular.module(moduleName, [
 
 module.exports = moduleName;
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Angular
@@ -253,6 +254,7 @@ export class AppModule { }
 ```
 
 Once you’ve completed that step, you are done.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Backbone
@@ -276,6 +278,7 @@ Raven.config('___PUBLIC_DSN___').install()
 ```
 
 At this point, Raven is ready to capture any uncaught exception.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Ember

--- a/src/collections/_documentation/clients/php/integrations.md
+++ b/src/collections/_documentation/clients/php/integrations.md
@@ -356,6 +356,7 @@ $client = new Raven_Client('___PUBLIC_DSN___');
 $handler = new \Raven_Breadcrumbs_MonologHandler($client);
 $monolog->pushHandler($handler);
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Symfony

--- a/src/collections/_documentation/clients/python/integrations.md
+++ b/src/collections/_documentation/clients/python/integrations.md
@@ -1024,6 +1024,7 @@ You may want to setup other loggers as well.
   title="Note"
   content=__alert_content
 %}
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Pyramid

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -73,6 +73,7 @@ Sentry.config('___PUBLIC_DSN___').install();
 ```
 
 You can pass additional configuration options to the `config()` method if you want to do so.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Mixed Stacktraces

--- a/src/collections/_documentation/clients/ruby/integrations.md
+++ b/src/collections/_documentation/clients/ruby/integrations.md
@@ -97,6 +97,7 @@ end
 ### Caveats
 
 Currently, custom exception applications (_config.exceptions_app_) are not supported. If you are using a custom exception app, you must manually integrate Raven yourself.
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Rack (Sinatra etc.)
@@ -123,6 +124,7 @@ end
 
 use Raven::Rack
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Puma

--- a/src/collections/_documentation/platforms/javascript/angular.md
+++ b/src/collections/_documentation/platforms/javascript/angular.md
@@ -90,4 +90,5 @@ like this:
   });
 </script>
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->

--- a/src/collections/_documentation/platforms/javascript/ember.md
+++ b/src/collections/_documentation/platforms/javascript/ember.md
@@ -50,4 +50,5 @@ like this:
 </script>
 ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -75,4 +75,5 @@ like this:
 </script>
 ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->

--- a/src/collections/_documentation/platforms/node/koa.md
+++ b/src/collections/_documentation/platforms/node/koa.md
@@ -24,4 +24,5 @@ app.on('error', (err, ctx) => {
 app.listen(3000);
 ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->

--- a/src/collections/_documentation/platforms/python/aiohttp.md
+++ b/src/collections/_documentation/platforms/python/aiohttp.md
@@ -44,6 +44,7 @@ Framework](https://docs.aiohttp.org/en/stable/web.html). A Python version of
     web.run_app(app)
     ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -20,6 +20,7 @@ sentry_sdk.init(
 def my_function(event, context):
     ...
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/bottle.md
+++ b/src/collections/_documentation/platforms/python/bottle.md
@@ -33,6 +33,7 @@ However the integration with the development version (0.13) doesn't work properl
     app = Bottle()
     ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/celery.md
+++ b/src/collections/_documentation/platforms/python/celery.md
@@ -15,8 +15,10 @@ sentry_sdk.init("___PUBLIC_DSN___", integrations=[CeleryIntegration()])
 ```
 
 Additionally, the Sentry Python SDK will set the transaction on the event to the task name, and it will improve the grouping for global Celery errors such as timeouts.
-<!-- ENDWIZARD -->
 
 The integration will automatically report errors from all celery jobs.
+
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
+<!-- ENDWIZARD -->
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.

--- a/src/collections/_documentation/platforms/python/falcon.md
+++ b/src/collections/_documentation/platforms/python/falcon.md
@@ -31,6 +31,7 @@ The integration has been confirmed to work with Falcon 1.4 and 2.0.
     api = falcon.API()
     ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/pyramid.md
+++ b/src/collections/_documentation/platforms/python/pyramid.md
@@ -33,6 +33,7 @@ Framework](https://trypyramid.com/).
         ...
     ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/rq.md
+++ b/src/collections/_documentation/platforms/python/rq.md
@@ -25,6 +25,7 @@ rq worker \
     --sentry-dsn=""  # only necessary for RQ < 1.0
 ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 The integration will automatically report errors from all RQ jobs.

--- a/src/collections/_documentation/platforms/python/sanic.md
+++ b/src/collections/_documentation/platforms/python/sanic.md
@@ -37,6 +37,7 @@ greater is required.
     app = Sanic(__name__)
     ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/serverless.md
+++ b/src/collections/_documentation/platforms/python/serverless.md
@@ -22,6 +22,7 @@ sentry_sdk.init(dsn="___PUBLIC_DSN___")
 def my_function(...):
     ...
 ```
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior

--- a/src/collections/_documentation/platforms/python/wsgi.md
+++ b/src/collections/_documentation/platforms/python/wsgi.md
@@ -21,6 +21,7 @@ sentry_sdk.init(dsn="___PUBLIC_DSN___")
 wsgi_app = SentryWsgiMiddleware(wsgi_app)
 ```
 
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
 ## Behavior


### PR DESCRIPTION
This will be used in the in app onboarding wizzard to mark documentation that should warn the user that the documentation is incomplete (does not tell them how to actually send their first event).