### PR TITLE
fix(dev): Update development setup instructions

### DIFF
--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -51,8 +51,15 @@ nvm install
 Run the following to install the Python and JavaScript libraries and database services that Sentry depends on and some extra pieces that hold the development environment together:
 
 ```bash
-make develop
+make bootstrap
 ```
+
+{% capture __alert_content -%}
+`make bootstrap` will run `sentry upgrade`, which will prompt you to create a user. It is recommended to supply the prompts with a proper email address and password. It is also required to designate said user as a superuser because said user is responsible for the initial configurations.
+{%- endcapture -%}{%- include components/alert.html
+  title="Note"
+  content=__alert_content
+%}
 
 ## Running the Development Server
 
@@ -64,25 +71,13 @@ sentry init --dev
 
 This file ends up in `~/.sentry/sentry.conf.py`
 
-Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have gotten installed during `make develop`. If not, you can install with `brew cask install docker`. After installing Docker, make sure it is running by just launching `/Applications/Docker.app`.
+Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have gotten installed during `make bootstrap`. If not, you can install with `brew cask install docker`. After installing Docker, make sure it is running by just launching `/Applications/Docker.app`.
 
 ```bash
 sentry devservices up
 ```
 
-Lastly, we need to run our database migrations:
-
-```bash
-sentry upgrade
-```
-
 {% capture __alert_content -%}
-You will be prompted to create a user during `sentry upgrade`. It is recommended to supply the prompts with a proper email address and password. It is also required to designate said user as a superuser because said user is responsible for the initial configurations.
-{%- endcapture -%}
-{%- include components/alert.html
-  title="Note"
-  content=__alert_content
-%}{% capture __alert_content -%}
 If you would like to import an example dataset, running `./bin/load-mocks` will add a few example projects and teams to the main organization.
 {%- endcapture -%}
 {%- include components/alert.html

--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -55,27 +55,26 @@ make bootstrap
 ```
 
 {% capture __alert_content -%}
-`make bootstrap` will run `sentry upgrade`, which will prompt you to create a user. It is recommended to supply the prompts with a proper email address and password. It is also required to designate said user as a superuser because said user is responsible for the initial configurations.
+`make bootstrap` will run `sentry upgrade`, which will prompt you to create a user. It is recommended to supply the prompts with a proper email address and password. It is also required to designate said user as a **superuser** because said user is responsible for the initial configurations.
 {%- endcapture -%}{%- include components/alert.html
   title="Note"
   content=__alert_content
 %}
 
-## Running the Development Server
-
-Before you can run the development server, you need to first create a development configuration file:
+`make bootstrap` will generally run these sequence of commands (you can poke around through the `Makefile` file to see more details):
 
 ```bash
+make install-system-pkgs
+make develop
+# creates a development configuration file at ~/.sentry/sentry.conf.py
 sentry init --dev
-```
-
-This file ends up in `~/.sentry/sentry.conf.py`
-
-Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have been installed during `make bootstrap`. If not, you can install with `brew cask install docker`. After installing Docker, make sure it is running by just launching `/Applications/Docker.app`.
-
-```bash
+# start up our development services
 sentry devservices up
+make create-db
+make apply-migrations
 ```
+
+## Running the Development Server
 
 {% capture __alert_content -%}
 If you would like to import an example dataset, running `./bin/load-mocks` will add a few example projects and teams to the main organization.

--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -71,7 +71,7 @@ sentry init --dev
 
 This file ends up in `~/.sentry/sentry.conf.py`
 
-Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have gotten installed during `make bootstrap`. If not, you can install with `brew cask install docker`. After installing Docker, make sure it is running by just launching `/Applications/Docker.app`.
+Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have been installed during `make bootstrap`. If not, you can install with `brew cask install docker`. After installing Docker, make sure it is running by just launching `/Applications/Docker.app`.
 
 ```bash
 sentry devservices up


### PR DESCRIPTION
Adapt development setup instructions to Makefile changes introduced in https://github.com/getsentry/sentry/pull/12620 and https://github.com/getsentry/sentry/pull/13518

-----

I had some issues setting up `sentry` with just `make develop`. 