### PR TITLE
Update React Error Boundary example with bug fixes and enhanced formatting

### DIFF
--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -65,4 +65,6 @@ class ExampleBoundary extends Component {
         return this.props.children;
     }
 }
+
+export default ExampleBoundary;
 ```

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -35,7 +35,7 @@ In development mode React will rethrow errors caught within an error boundary. T
 %}
 
 ```jsx
-import React from 'react';
+import React, { Component } from 'react';
 import * as Sentry from '@sentry/browser';
 
 class ExampleBoundary extends Component {

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -55,13 +55,13 @@ class ExampleBoundary extends Component {
 
     render() {
         if (this.state.error) {
-            //render fallback UI
+            // render fallback UI
             return (
               <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
             );
         }
 
-        //when there's not an error, render children untouched
+        // when there's not an error, render children untouched
         return this.props.children;
     }
 }

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -49,7 +49,7 @@ class ExampleBoundary extends Component {
       Sentry.withScope(scope => {
           scope.setExtras(errorInfo);
           const eventId = Sentry.captureException(error);
-          this.setState({eventId})
+          this.setState({eventId});
       });
     }
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -39,31 +39,31 @@ import React, { Component } from 'react';
 import * as Sentry from '@sentry/browser';
 
 class ExampleBoundary extends Component {
-    constructor(props) {
-        super(props);
-        this.state = { error: null, eventId: null };
+  constructor(props) {
+    super(props);
+    this.state = { error: null, eventId: null };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error });
+    Sentry.withScope(scope => {
+      scope.setExtras(errorInfo);
+      const eventId = Sentry.captureException(error);
+      this.setState({ eventId });
+    });
+  }
+
+  render() {
+    if (this.state.error) {
+      // render fallback UI
+      return (
+        <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
+      );
     }
 
-    componentDidCatch(error, errorInfo) {
-      this.setState({ error });
-      Sentry.withScope(scope => {
-          scope.setExtras(errorInfo);
-          const eventId = Sentry.captureException(error);
-          this.setState({eventId});
-      });
-    }
-
-    render() {
-        if (this.state.error) {
-            // render fallback UI
-            return (
-              <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
-            );
-        }
-
-        // when there's not an error, render children untouched
-        return this.props.children;
-    }
+    // when there's not an error, render children untouched
+    return this.props.children;
+  }
 }
 
 export default ExampleBoundary;


### PR DESCRIPTION
* Ensure `Component` is imported in Boundary example
* Append missing semicolon to `setState` sample
* Add space after comments in accordance with other examples
* Complete the file example with a default export
* Use consistent indentation in example