### PR TITLE
Update github integration documentation with private key tip

### DIFF
--- a/src/collections/_documentation/server/integrations/github/index.md
+++ b/src/collections/_documentation/server/integrations/github/index.md
@@ -30,10 +30,10 @@ sidebar_order: 1
   - Pull Requests
   
 5. Take note of the following values after you have created your app:
-  - App ID (GITHUB_APP_ID)
-  - App Name (GITHUB_APP_NAME)
-  - Client ID (GITHUB_CLIENT_ID)
-  - Client Secret (GITHUB_CLIENT_SECRET)
+  - App ID (`GITHUB_APP_ID`)
+  - App Name (`GITHUB_APP_NAME`)
+  - Client ID (`GITHUB_CLIENT_ID`)
+  - Client Secret (`GITHUB_CLIENT_SECRET`)
 
 6. Generate and download a private key for your app.
 
@@ -52,10 +52,23 @@ github-app.client-secret: 'GITHUB_CLIENT_SECRET'
 ```
 
 {% include components/alert.html
-    content="Make sure to replace these values with the ones you noted in step 4."
+    content="Make sure to replace these values with the ones you noted in step 5."
     level="warning"
   %}
-  
+
+**YML Tip:** `github-app.private-key` can span multiple lines as seen below
+
+```yml
+github-app.private-key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  -----END RSA PRIVATE KEY-----
+```
+
 ## Redeploy your Sentry Instance
 
 ### Docker


### PR DESCRIPTION
Was browsing https://github.com/getsentry/sentry/issues/12670 and figured out how to add the private key without replacing every newline with `\n`. Wanted to update the documentation to show this. Also modified some of the formatting and changed step 4 to step 5.

Main difference is this:
```yml
github-app.private-key: |
  -----BEGIN RSA PRIVATE KEY-----
  privatekeyprivatekeyprivatekeyprivatekey
  privatekeyprivatekeyprivatekeyprivatekey
  privatekeyprivatekeyprivatekeyprivatekey
  privatekeyprivatekeyprivatekeyprivatekey
  privatekeyprivatekeyprivatekeyprivatekey
  -----END RSA PRIVATE KEY-----
```