### PR TITLE
Added clarification to controller location for Express

### DIFF
--- a/src/collections/_documentation/platforms/node/express.md
+++ b/src/collections/_documentation/platforms/node/express.md
@@ -26,6 +26,8 @@ Sentry.init({ dsn: '___PUBLIC_DSN___' });
 // The request handler must be the first middleware on the app
 app.use(Sentry.Handlers.requestHandler());
 
+// All controllers should live here
+
 // The error handler must be before any other error middleware
 app.use(Sentry.Handlers.errorHandler());
 

--- a/src/collections/_documentation/platforms/node/express.md
+++ b/src/collections/_documentation/platforms/node/express.md
@@ -27,6 +27,9 @@ Sentry.init({ dsn: '___PUBLIC_DSN___' });
 app.use(Sentry.Handlers.requestHandler());
 
 // All controllers should live here
+app.get('/', function rootHandler(req, res) {
+  res.end('Hello world!');
+});
 
 // The error handler must be before any other error middleware
 app.use(Sentry.Handlers.errorHandler());


### PR DESCRIPTION
While setting up a new project, I spent a very long and sad amount of time trying to figure out why Sentry wasn't receiving my errors that I was clearly seeing locally. It turns out I put the error handler too high up. In this PR:

- Added clarification to controller location for Express