### PR TITLE
Add more detailed explanation on beforeBreadcrumb function

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -195,9 +195,10 @@ sending.
 ### `before-breadcrumb`
 
 This function is called with an SDK specific breadcrumb object before the breadcrumb is added to the
-scope.  When nothing is returned from the function the breadcrumb is dropped.  The callback typically
-gets a second argument (called a "hint") which contains the original object that the breadcrumb was
-created from to further customize what the breadcrumb should look like.
+scope.  When nothing is returned from the function, the breadcrumb is dropped.  To pass the 
+breadcrumb through, simply return the first argument, which contains the breadcrumb object.
+The callback typically gets a second argument (called a "hint") which contains the original object 
+that the breadcrumb was created from to further customize what the breadcrumb should look like.
 
 ## Transport Options
 


### PR DESCRIPTION
I was stuck on why my Sentry breadcrumbs were just described as `generic` with a timestamp attached to it. I could not clearly find out where the issue was, I thought it would be because I was adding the breadcrumb incorrectly.

Instead, I found that in the `beforeBreadcrumb` function you had to return the actual (modified) breadcrumb instead of `true` or `false`, which I could not clearly find in the docs.

Hence this PR! If you have a different idea on how it should be worded, let me know!