### PR TITLE
feat: Update PDB upload docs

### DIFF
--- a/src/collections/_documentation/cli/dif/pdb.md
+++ b/src/collections/_documentation/cli/dif/pdb.md
@@ -8,18 +8,19 @@ are the debug information container used by Microsoft for the Windows platform.
 Note that at the moment Sentry will upload Native PDBs, but not .NET Portable
 PDBs.
 
-In addition to PDBs, always consider to upload the actual executables and
-libraries. `sentry-cli` will determine during the upload process whether those
-files contain useful debug information. This is especially important for
+In addition to PDBs, always consider uploading the actual executables and
+libraries. The `sentry-cli` will determine during the upload process whether
+those files contain useful debug information. This is especially important for
 _64-bit_ systems, where unwind information is not stored in the PDB.
 
 ## Basic Upload
 
 Use `upload-dif` to upload PDBs and specify the `pdb` and `pe` types. The
-command will recurively scan the provided folders or ZIP archives. Depending on
+command will recursively scan the provided folders or ZIP archives. Depending on
 whether the executables contain debug information usable by Sentry, they may be
 selected for upload in addition to the PDBs. On 32-bit Intel platforms, expect
-that executables are omitted, on 64-bit Intel and other architectures they are usually uploaded.
+that executables are omitted. On 64-bit Intel and other architectures, they are
+usually uploaded.
 
 {% capture __alert_content -%}
 Because debug files belong to projects, you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).
@@ -44,13 +45,13 @@ Example:
 
 ## Upload Options
 
-There are a few options you can supply for the upload process
+There are a few options you can supply for the upload process:
 
 `--no-unwind`
 
 : Do not scan for stack unwinding information. Specify this flag for builds with
-  disabled FPO, or when stackwalking occurs on the device. This usually excludes
-  executables and libraries for 64-bit builds.
+  disabled FPO, or when stack walking occurs on the device. This usually
+  excludes executables and libraries for 64-bit builds.
 
 `--no-debug`
 
@@ -60,14 +61,14 @@ There are a few options you can supply for the upload process
 
 `--no-zips`
 
-: By default, sentry-cli will open and search ZIP archives for files. Use this
-  switch to disable if your search paths contain large ZIP archives without
+: By default, the `sentry-cli` will open and search ZIP archives for files. Use
+  this switch to disable if your search paths contain large ZIP archives without
   debug information files to speed up the search.
 
 `--no-reprocessing`
 
 : This parameter prevents Sentry from triggering reprocessing right away. It can
   be useful under rare circumstances where you want to upload files in multiple
-  batches and you want to ensure that Sentry does not start reprocessing before
-  some optional dsyms are uploaded. Note though that someone can still in the
+  batches, and you want to ensure that Sentry does not start reprocessing before
+  some optional dSYMs are uploaded. Note though, that someone can still in the
   meantime trigger reprocessing from the UI.

--- a/src/collections/_documentation/cli/dif/pdb.md
+++ b/src/collections/_documentation/cli/dif/pdb.md
@@ -3,27 +3,71 @@ title: 'PDB Upload'
 sidebar_order: 2
 ---
 
-Microsoft PDB files are not yet supported directly by Sentry. Until we provide official support, you can convert them to Breakpad symbols and upload those instead:
+`sentry-cli` can upload PDB files, as well as Windows executables and DLLs. PDBs
+are the debug information container used by Microsoft for the Windows platform.
+Note that at the moment Sentry will upload Native PDBs, but not .NET Portable
+PDBs.
 
-1.  Obtain the `.pdb` file and put it on a Windows machine
-2.  Download our [Breakpad Tools for Windows](https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip) and extract `dump_syms.exe`
-3.  Run `dump_syms foo.pdb > foo.sym`
-4.  Follow instructions at [_Breakpad Symbol Upload_]({%- link _documentation/cli/dif/breakpad.md -%}).
+In addition to PDBs, always consider to upload the actual executables and
+libraries. `sentry-cli` will determine during the upload process whether those
+files contain useful debug information. This is especially important for
+_64-bit_ systems, where unwind information is not stored in the PDB.
 
-## Troubleshooting
+## Basic Upload
 
-### “CoCreateInstance CLSID_DiaSource failed (msdia80.dll unregistered?)” {#cocreateinstance-clsid-diasource-failed-msdia80-dll-unregistered}
+Use `upload-dif` to upload PDBs and specify the `pdb` and `pe` types. The
+command will recurively scan the provided folders or ZIP archives. Depending on
+whether the executables contain debug information usable by Sentry, they may be
+selected for upload in addition to the PDBs. On 32-bit Intel platforms, expect
+that executables are omitted, on 64-bit Intel and other architectures they are usually uploaded.
 
-Download a copy of `msdia80.dll` and put it in `C:\Program Files\Common Files\Microsoft Shared\VC\`. Then as administrator, run:
+{% capture __alert_content -%}
+Because debug files belong to projects, you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Note"
+  content=__alert_content
+%}
 
+Example:
+
+```bash
+ $ sentry-cli upload-dif -t pdb -t pe .
+> Found 2 debug information files
+> Prepared debug information files for upload
+> Uploaded 2 missing debug information files
+> File processing complete:
+
+     OK 3003763b-afcb-4a97-aae3-28de8f188d7c-1 (crash.exe; x86_64 executable)
+     OK 3003763b-afcb-4a97-aae3-28de8f188d7c-1 (crash.pdb; x86_64 debug companion)
 ```
-> regsvr32 "C:\Program Files\Common Files\Microsoft Shared\VC\msdia80.dll"
-```
 
-Then, run the `dump_syms` command from a Visual Studio command prompt. This will also work with later versions, such as `msdia140.dll`.
+## Upload Options
 
-### “Unsupported file” error or “No debug debug information files found”
+There are a few options you can supply for the upload process
 
-Sentry CLI or Sentry do not recognize your Breakpad symbols file, most likely due to encoding issues. Make sure the file is saved without a byte order mark (BOM).
+`--no-unwind`
 
-Older PowerShell versions used to encode with BOM by default. To prevent this, set the `$OutputEncoding` variable before calling `dump_syms`.
+: Do not scan for stack unwinding information. Specify this flag for builds with
+  disabled FPO, or when stackwalking occurs on the device. This usually excludes
+  executables and libraries for 64-bit builds.
+
+`--no-debug`
+
+: Do not scan for debug information. This will usually exclude PDBs. They might
+  still be uploaded, if they contain stack unwinding information, usually for
+  32-bit builds.
+
+`--no-zips`
+
+: By default, sentry-cli will open and search ZIP archives for files. Use this
+  switch to disable if your search paths contain large ZIP archives without
+  debug information files to speed up the search.
+
+`--no-reprocessing`
+
+: This parameter prevents Sentry from triggering reprocessing right away. It can
+  be useful under rare circumstances where you want to upload files in multiple
+  batches and you want to ensure that Sentry does not start reprocessing before
+  some optional dsyms are uploaded. Note though that someone can still in the
+  meantime trigger reprocessing from the UI.


### PR DESCRIPTION
Similar to `elf.md` or `dsym.md` on the same level. Replaces the old description of how to convert PDBs to Breakpad files.

See https://github.com/getsentry/sentry/pull/13725