### PR TITLE
fix(formatting): Fix missing `{{ default }}` in fingerprinting snippet

### DIFF
--- a/src/collections/_documentation/data-management/rollups.md
+++ b/src/collections/_documentation/data-management/rollups.md
@@ -12,7 +12,7 @@ function makeRequest(method, path, options) {
     return fetch(method, path, options).catch(err => {
         Sentry.withScope(scope => {
           // extend the fingerprint with the request path
-          scope.setFingerprint(['{{ default }}', path]);
+          scope.setFingerprint(['{% raw %}{{ default }}{% endraw %}', path]);
           Sentry.captureException(err);
         });
     });


### PR DESCRIPTION
It wasn't marked as `{% raw %}...{% endraw %}` and was therefore disappearing.