### PR TITLE
Add missing `error_types` parameter

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -59,9 +59,11 @@ environment variable (except for the browser SDK where this is not applicable).
 {:.config-key}
 ### `error_types`
 
+{% supported php %}
 Sets which errors are reported. It takes the same values as PHP's [`error_reporting`](https://www.php.net/manual/errorfunc.configuration.php#ini.error-reporting) configuration parameter.
 
-By default all types of errors will be reported (equivalent to `E_ALL`).
+By default all types of errors are be reported (equivalent to `E_ALL`).
+{% endsupported %}
 
 {:.config-key}
 ### `sample-rate`

--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -57,6 +57,13 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT`
 environment variable (except for the browser SDK where this is not applicable).
 
 {:.config-key}
+### `error_types`
+
+Sets which errors are reported. It takes the same values as PHP's [`error_reporting`](https://www.php.net/manual/errorfunc.configuration.php#ini.error-reporting) configuration parameter.
+
+By default all types of errors will be reported (equivalent to `E_ALL`).
+
+{:.config-key}
 ### `sample-rate`
 
 Configures the sample rate as a percentage of events to be sent in the range of `0.0` to `1.0`.  The


### PR DESCRIPTION
Add missing `error_types` configuration parameter to PHP SDK docs.