### PR TITLE
Typo when calling the SDK

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-config/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-config/php.md
@@ -1,5 +1,5 @@
 To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.
 
 ```php
-Sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
+\sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
 ```


### PR DESCRIPTION
I just had this issue when I was setting up the SDK.

Let me know if I am  correct and I will fix it everywhere else.

Cheers!