### PR TITLE
fix: Duplicate anchor

### DIFF
--- a/src/collections/_documentation/clients/python/integrations.md
+++ b/src/collections/_documentation/clients/python/integrations.md
@@ -279,7 +279,7 @@ logger.error('There was some crazy error', exc_info=True, extra={
 })
 ```
 
-### 404 Logging {#logging}
+### 404 Logging {#404-logging}
 
 In certain conditions you may wish to log 404 events to the Sentry server. To do this, you simply need to enable a Django middleware:
 


### PR DESCRIPTION
I verified that this anchor is not referenced by any other page (the
other duplicate is intentionally linked from `clients/python/index`)

Fix #1091 