### PR TITLE
Fix typo's, import, ... in React docs

### DIFF
--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -41,7 +41,7 @@ import * as Sentry from '@sentry/browser';
 class ExampleBoundary extends Component {
     constructor(props) {
         super(props);
-        this.state = { error: null, eventId: null };
+        this.state = { eventId: null };
     }
 
   static getDerivedStateFromError(error) {
@@ -57,7 +57,7 @@ class ExampleBoundary extends Component {
   }
 
     render() {
-        if (this.state.error) {
+        if (this.state.hasError) {
             //render fallback UI
             return (
               <button onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</button>
@@ -68,4 +68,6 @@ class ExampleBoundary extends Component {
         return this.props.children;
     }
 }
+
+export default ExampleBoundary
 ```

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -52,7 +52,7 @@ class ExampleBoundary extends Component {
       Sentry.withScope(scope => {
           scope.setExtra(errorInfo);
           const eventId = Sentry.captureException(error);
-          this.setState({ eventId });
+          this.setState({eventId});
       });
     }
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -44,17 +44,17 @@ class ExampleBoundary extends Component {
         this.state = { eventId: null };
     }
 
-  static getDerivedStateFromError(error) {
-    return { hasError: true };
-  }
+    static getDerivedStateFromError(error) {
+      return { hasError: true };
+    }
 
-  componentDidCatch(error, errorInfo) {
-    Sentry.withScope(scope => {
-        scope.setExtra(errorInfo);
-        const eventId = Sentry.captureException(error);
-        this.setState({ eventId });
-    });
-  }
+    componentDidCatch(error, errorInfo) {
+      Sentry.withScope(scope => {
+          scope.setExtra(errorInfo);
+          const eventId = Sentry.captureException(error);
+          this.setState({ eventId });
+      });
+    }
 
     render() {
         if (this.state.hasError) {

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -50,9 +50,9 @@ class ExampleBoundary extends Component {
 
   componentDidCatch(error, errorInfo) {
     Sentry.withScope(scope => {
-      scope.setExtra(errorInfo);
-      const eventId = Sentry.captureException(error);
-      this.setState({ eventId });
+        scope.setExtra(errorInfo);
+        const eventId = Sentry.captureException(error);
+        this.setState({ eventId });
     });
   }
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -35,7 +35,7 @@ In development mode React will rethrow errors caught within an error boundary. T
 %}
 
 ```jsx
-import React from 'react';
+import React, { Component } from 'react';
 import * as Sentry from '@sentry/browser';
 
 class ExampleBoundary extends Component {
@@ -44,20 +44,23 @@ class ExampleBoundary extends Component {
         this.state = { error: null, eventId: null };
     }
 
-    componentDidCatch(error, errorInfo) {
-      this.setState({ error });
-      Sentry.withScope(scope => {
-          scope.setExtras(errorInfo);
-          const eventId = Sentry.captureException(error);
-          this.setState({eventId})
-      });
-    }
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    Sentry.withScope(scope => {
+      scope.setExtra(errorInfo);
+      const eventId = Sentry.captureException(error);
+      this.setState({ eventId });
+    });
+  }
 
     render() {
         if (this.state.error) {
             //render fallback UI
             return (
-              <a onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</a>
+              <button onClick={() => Sentry.showReportDialog({ eventId: this.state.eventId })}>Report feedback</button>
             );
         }
 

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -50,7 +50,7 @@ class ExampleBoundary extends Component {
 
     componentDidCatch(error, errorInfo) {
       Sentry.withScope(scope => {
-          scope.setExtra(errorInfo);
+          scope.setExtras(errorInfo);
           const eventId = Sentry.captureException(error);
           this.setState({eventId});
       });


### PR DESCRIPTION
- Add an import
- Change scope.setExtras(errorInfo) to scope.setExtra(errorInfo)
- use getDerivedStateFromError to indicate an error occurred ( React uses getDerivedStateFromError ) in their docs also
- Change anchor element to button element as ESLint will give warning because you don't use an href attribute