### PR TITLE
docs: Remove go version from the install step

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-install/go.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/go.md
@@ -3,9 +3,3 @@ Install our Go SDK using [`go get`](https://golang.org/cmd/go/#hdr-Module_aware_
 ```bash
 $ go get github.com/getsentry/sentry-go
 ```
-
-Or, if you are already using Go Modules, specify a version number as well:
-
-```bash
-$ go get github.com/getsentry/sentry-go@v{% sdk_version sentry.go %}
-```

--- a/src/collections/_documentation/platforms/go/index.md
+++ b/src/collections/_documentation/platforms/go/index.md
@@ -24,16 +24,10 @@ Getting started with Sentry is a three step process:
 <!-- WIZARD -->
 ## Installation {#install}
 
-sentry-go can be installed like any other Go library through `go get`:
+sentry-go can be installed like any other Go library through `go get`, and if using Go Modules, it will pick up the latest tagged version:
 
 ```bash
 $ go get github.com/getsentry/sentry-go
-```
-
-Or, if you are already using Go Modules, specify a version number as well:
-
-```bash
-$ go get github.com/getsentry/sentry-go@v{% sdk_version sentry.go %}
 ```
 
 ## Configuration {#configure}

--- a/src/collections/_documentation/platforms/go/migration.md
+++ b/src/collections/_documentation/platforms/go/migration.md
@@ -16,7 +16,7 @@ $ go get github.com/getsentry/raven-go
 sentry-go
 
 ```bash
-$ go get github.com/getsentry/sentry-go@v{% sdk_version sentry.go %}
+$ go get github.com/getsentry/sentry-go
 ```
 
 ### Configuration


### PR DESCRIPTION
We can safely do this now :)