### PR TITLE
fix: Restore information about supported Python versions

### DIFF
--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -12,7 +12,7 @@ Install our Python SDK using `pip`:
 $ pip install --upgrade sentry-sdk
 ```
 
-The SDK provides support for Python 2.7 and 3.4 or later.
+The SDK provides support for Python 2.7 and 3.4 or later. [Integrations](#integrations) with specific frameworks (particularly asynchronous ones) may impose additional requirements though.
 
 {% include components/alert.html
   title="Upgrading the SDK and want to understand what's new?"

--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -12,6 +12,8 @@ Install our Python SDK using `pip`:
 $ pip install --upgrade sentry-sdk
 ```
 
+The SDK provides support for Python 2.7 and 3.4 or later.
+
 {% include components/alert.html
   title="Upgrading the SDK and want to understand what's new?"
   content="Have a look at the [Changelog](https://github.com/getsentry/sentry-python/releases)."


### PR DESCRIPTION
As part of https://github.com/getsentry/sentry-docs/pull/1066 this
information was lost.