### PR TITLE
ref: Show deprecation warning in stronger color

### DIFF
--- a/src/_layouts/legacy-client.html
+++ b/src/_layouts/legacy-client.html
@@ -20,7 +20,7 @@ layout: doc
   <a href="{{ __new_platform.doc_link | default: __quickstart_link }}">Unified {{ __new_platform.name }} SDK</a>.
   {%- endcapture -%}
   {%- include components/alert.html
-    level="info"
+    level="danger"
     title="Deprecated Client"
     content=__alert_content
   %}


### PR DESCRIPTION
Before:

<img width="780" alt="Screenshot 2019-07-13 at 20 33 20" src="https://user-images.githubusercontent.com/837573/61175322-87560e80-a5ad-11e9-935a-b8d309f235da.png">

After:

<img width="768" alt="Screenshot 2019-07-13 at 20 33 05" src="https://user-images.githubusercontent.com/837573/61175321-87560e80-a5ad-11e9-95af-15e20ced3f86.png">