### PR TITLE
fix(python): Minor formatting changes

### DIFF
--- a/src/_plugins/version_added.rb
+++ b/src/_plugins/version_added.rb
@@ -7,7 +7,7 @@ module Jekyll
     end
 
     def render(context)
-      "*(New in version #{@text})*"
+      "*(New in version #{@text.strip})*"
     end
   end
 end

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -22,7 +22,7 @@ def my_function(event, context):
 ```
 
 {% capture __alert_content -%}
-If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*]({% link _documentation/python/index.md %}#integrations) for more information.
+If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*]({% link _documentation/platforms/python/index.md %}#integrations) for more information.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -20,6 +20,16 @@ sentry_sdk.init(
 def my_function(event, context):
     ...
 ```
+
+{% capture __alert_content -%}
+If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*]({% link _documentation/python/index.md %}#integrations) for more information.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Note"
+  content=__alert_content
+  level="info"
+%}
+
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
@@ -28,15 +38,6 @@ def my_function(event, context):
 With the AWS Lambda integration enabled, the Python SDK will:
 
 * Automatically report all uncaught exceptions from your lambda functions.
-
-    {% capture __alert_content -%}
-    If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists.
-    {%- endcapture -%}
-    {%- include components/alert.html
-      title="Note"
-      content=__alert_content
-      level="info"
-    %}
 
 * {% include platforms/python/request-data.md %}
 

--- a/src/collections/_documentation/platforms/python/pyramid.md
+++ b/src/collections/_documentation/platforms/python/pyramid.md
@@ -40,7 +40,7 @@ Framework](https://trypyramid.com/).
 
 * The Sentry Python SDK will install the Pyramid integration for all of your apps. The integration hooks into Pyramid itself, not any of your apps specifically.
 
-*The SDK will report all exceptions leading to an Internal Server Error. These two kinds of exceptions are:
+* The SDK will report all exceptions leading to an Internal Server Error. These two kinds of exceptions are:
 
   * exceptions that are not handled by any exception view
   * exceptions whose exception view returns a status code of 500 (Pyramid version 1.9+ only)


### PR DESCRIPTION
* Version-added plugin created empty spaces before the parenthesis, rendering `(New in version: 0.5.0 )` instead of `(New in version: 0.5.0)`
* Move alert about framework integrations to setup section of AWS Lambda (putting it between two bulletpoints created two lists)
* List in pyramid docs did not render as list due to broken spacing