### PR TITLE
fix: Remove quotes around github-app.id.

### DIFF
--- a/src/collections/_documentation/server/integrations/github/index.md
+++ b/src/collections/_documentation/server/integrations/github/index.md
@@ -43,7 +43,7 @@ sidebar_order: 1
 Add the following values to your `config.yml` file
 
 ```yml
-github-app.id: 'GITHUB_APP_ID'
+github-app.id: GITHUB_APP_ID
 github-app.name: 'GITHUB_APP_NAME'
 github-app.webhook-secret: 'GITHUB_WEBHOOK_SECRET' # Use only if configured in GitHub
 github-app.private-key: "GITHUB_APP_SECRET" # Replace new lines with \n to preserve them.


### PR DESCRIPTION
The application expects an integer, but if we put quotes there it's a string.