### PR TITLE
docs: fix fingerprint rpc example on Go platform

### DIFF
--- a/src/collections/_documentation/data-management/fingerprint-rpc-example/go.md
+++ b/src/collections/_documentation/data-management/fingerprint-rpc-example/go.md
@@ -21,7 +21,7 @@ sentry.Init(sentry.ClientOptions{
 	// ...
 	BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 		if ex, ok := hint.OriginalException.(MyRPCError); ok {
-			event.Fingerprint = []string{ex.ErrorCode(), ex.FunctionName()}
+			event.Fingerprint = []string{"{% raw %}{{ default }}{% endraw %}", ex.ErrorCode(), ex.FunctionName()}
 		}
 
 		return event


### PR DESCRIPTION
`fingerprint-rpc-example` contains examples with `{{ default }}`.
`fingerprint-database-connection-example` contains examples without `{{ default }}`.

But Go platform example doesn't contain `{{ default }}` in any example.