### PR TITLE
Update source maps generate docs for Ionic v4 prod

### DIFF
--- a/src/collections/_documentation/platforms/javascript/ionic.md
+++ b/src/collections/_documentation/platforms/javascript/ionic.md
@@ -25,6 +25,11 @@ When building your app with ionic for production make sure you have source maps 
     "ionic_generate_source_map": "true"
 }
 ```
+Enable source maps for Ionic v4:
+
+```
+ionic build --prod --source-map
+```
 
 Otherwise we are not able to upload source maps to Sentry.
 


### PR DESCRIPTION
The documentation steps to enable source maps does not apply to Ionic 4 since it does not use ionic-app-scripts any more.