### PR TITLE
docs: Remove panic warning from goroutines docs

### DIFF
--- a/src/collections/_documentation/platforms/go/goroutines.md
+++ b/src/collections/_documentation/platforms/go/goroutines.md
@@ -9,7 +9,7 @@ The easiest way to handle this, is to create a new `Hub` for every goroutine you
 
 Once cloned, `Hub` is completly isolated and can be used safely inside concurrent call. However, instead of using globally exposed methods, they should be called directly on the `Hub`.
 
-Here are two examples: one that is non-deterministic, would leak information between threads, and could trigger a concurrent-write panic; and one that is totally safe, and should be used instead.
+Here are two examples: one that is non-deterministic, would leak information between threads, and one that is totally safe, and should be used instead.
 
 ```go
 // Example of __INCORRECT__ use of scopes inside a Goroutines - DON'T USE IT!
@@ -28,7 +28,7 @@ go func() {
 	sentry.CaptureMessage("Hello from Goroutine! #2")
 }()
 
-// at this point both events can have either `go#1` tag or `go#2` tag or it can panic with concurrent writes. We'll never know.
+// at this point both events can have either `go#1` tag or `go#2` tag. We'll never know.
 ```
 
 ```go

--- a/src/collections/_documentation/platforms/go/goroutines.md
+++ b/src/collections/_documentation/platforms/go/goroutines.md
@@ -9,7 +9,9 @@ The easiest way to handle this, is to create a new `Hub` for every goroutine you
 
 Once cloned, `Hub` is completly isolated and can be used safely inside concurrent call. However, instead of using globally exposed methods, they should be called directly on the `Hub`.
 
-Here are two examples: one that is non-deterministic, would leak information between threads, and one that is totally safe, and should be used instead.
+Here are two examples: 
+- a recommended deterministic call on `Hub` that is safe
+- a discouraged non-deterministic call on `Hub` that would leak information between threads
 
 ```go
 // Example of __INCORRECT__ use of scopes inside a Goroutines - DON'T USE IT!


### PR DESCRIPTION
It has been fixed in the most recent version