### PR TITLE
Use the right configuration option for inline Typescript sourcemaps

### DIFF
--- a/src/collections/_documentation/platforms/node/typescript.md
+++ b/src/collections/_documentation/platforms/node/typescript.md
@@ -43,7 +43,7 @@ Create a new one called _tsconfig.production.json_ and paste the snippet below:
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "sourceMap": true,
+    "inlineSourceMap": true,
     "inlineSources": true,
     "sourceRoot": "/"
   }


### PR DESCRIPTION
Using the current recommended settings I had source map files generated separately alongside compiled source files. Changing the `sourceMap` option to `inlineSourceMap` made it work.

It sounds like it should work as it is, but what actually happens is that there's only the file path of the separate source map file emitted in the source files.

For reference: https://www.typescriptlang.org/docs/handbook/compiler-options.html


Option | Type | Default | Description
-- | -- | -- | --
--inlineSourceMap | boolean | false | Emit a single file with source maps instead of having a separate file.
--inlineSources | boolean | false | Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap or --sourceMap to be set.
--sourceMap | boolean | false | Generates corresponding .map file.


