### PR TITLE
Update Sentry 5.x Compatibility

### DIFF
--- a/src/collections/_documentation/platforms/php/laravel.md
+++ b/src/collections/_documentation/platforms/php/laravel.md
@@ -135,13 +135,13 @@ require __DIR__ . '/../app/Http/routes.php';
 Add Sentry reporting to `app/Exceptions/Handler.php`:
 
 ```php
-public function report(Exception $e)
+public function report(Exception $exception)
 {
-    if (app()->bound('sentry') && $this->shouldReport($e)) {
-        app('sentry')->captureException($e);
+    if (app()->bound('sentry') && $this->shouldReport($exception)) {
+        app('sentry')->captureException($exception);
     }
 
-    parent::report($e);
+    parent::report($exception);
 }
 ```
 


### PR DESCRIPTION
Latest install's of sentry default to $exception instead of $e in the error handler file.
If this update isn't done no reports are processed and php artisan commands fail.