### PR TITLE
Fix information about official plugins

### DIFF
--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -47,19 +47,19 @@ All official plugins are tested against the latest version of Sentry, and compat
 -   Amazon SQS
 -   Asana
 -   Clubhouse
--   [Flowdock](https://github.com/getsentry/sentry-flowdock)
 -   Heroku
--   [IRC](https://github.com/getsentry/sentry-irc
 -   Pagerduty
 -   Phabricator
 -   Pivotal
 -   Pushover
--   [Redmine](https://github.com/getsentry/sentry-redmine)
 -   Segment
 -   Sessionstack
 -   Splunk
--   [Trello](https://github.com/getsentry/sentry-trello)
 -   Victorops
+-   [Flowdock](https://github.com/getsentry/sentry-flowdock)
+-   [IRC](https://github.com/getsentry/sentry-irc
+-   [Redmine](https://github.com/getsentry/sentry-redmine)
+-   [Trello](https://github.com/getsentry/sentry-trello)
 
 Most of the official plugins can be found in the [official sentry plugins repository](https://github.com/getsentry/sentry-plugins).
 

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -47,17 +47,21 @@ All official plugins are tested against the latest version of Sentry, and compat
 -   Amazon SQS
 -   Asana
 -   Clubhouse
+-   [Flowdock](https://github.com/getsentry/sentry-flowdock)
 -   Heroku
+-   [IRC](https://github.com/getsentry/sentry-irc
 -   Pagerduty
 -   Phabricator
 -   Pivotal
 -   Pushover
+-   [Redmine](https://github.com/getsentry/sentry-redmine)
 -   Segment
 -   Sessionstack
 -   Splunk
+-   [Trello](https://github.com/getsentry/sentry-trello)
 -   Victorops
 
-All of the official plugins can be found in the [official sentry plugins repository](https://github.com/getsentry/sentry-plugins).
+Most of the official plugins can be found in the [official sentry plugins repository](https://github.com/getsentry/sentry-plugins).
 
 ## Deprecated plugins
 

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -57,7 +57,7 @@ All official plugins are tested against the latest version of Sentry, and compat
 -   Splunk
 -   Victorops
 
-All of the official plugins can be found in the [official sentry plugins repositroy](https://github.com/getsentry/sentry-plugins).
+All of the official plugins can be found in the [official sentry plugins repository](https://github.com/getsentry/sentry-plugins).
 
 ## Deprecated plugins
 
@@ -65,7 +65,7 @@ The following plugins are deprecated and have been replaced with Sentry's built 
 
 * Slack
 * GitHub
-* Gitlab
+* GitLab
 * Bitbucket
 * Visual Studio Team Services
 * Jira

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -44,19 +44,31 @@ All official plugins are tested against the latest version of Sentry, and compat
   content=__alert_content
 %}
 
--   [GitHub](https://github.com/getsentry/sentry-github)
--   [JIRA](https://github.com/getsentry/sentry-jira)
--   [Hipchat](https://github.com/getsentry/sentry-hipchat-ac)
--   [Slack](https://github.com/getsentry/sentry-slack)
--   [GitLab](https://github.com/getsentry/sentry-gitlab)
--   [Phabricator](https://github.com/getsentry/sentry-phabricator)
--   [Pivotal Tracker](https://github.com/getsentry/sentry-pivotal)
--   [Pushover](https://github.com/getsentry/sentry-pushover)
--   [Flowdock](https://github.com/getsentry/sentry-flowdock)
--   [Redmine](https://github.com/getsentry/sentry-redmine)
--   [BitBucket](https://github.com/getsentry/sentry-bitbucket)
--   [Trello](https://github.com/getsentry/sentry-trello)
--   [IRC](https://github.com/getsentry/sentry-irc)
+-   Amazon SQS
+-   Asana
+-   Clubhouse
+-   Heroku
+-   Pagerduty
+-   Phabricator
+-   Pivotal
+-   Pushover
+-   Segment
+-   Sessionstack
+-   Splunk
+-   Victorops
+
+All of the official plugins can be found in the [official sentry plugins repositroy](https://github.com/getsentry/sentry-plugins).
+
+## Deprecated plugins
+
+The following plugins are deprecated and have been replaced with Sentry's built in [Global Integrations]({%- link _documentation/workflow/integrations/index.md -%}).
+
+* Slack
+* GitHub
+* Gitlab
+* Bitbucket
+* Visual Studio Team Services
+* Jira
 
 ## 3rd Party Plugins {#rd-party-plugins}
 


### PR DESCRIPTION
I saw that all the GitHub repositories of the official plugins were deprecated and pointed to a new official plugin repository so I changed the documentation accordingly.