### PR TITLE
Change RNSentry import comment

### DIFF
--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -22,9 +22,9 @@ Update your `AppDelegate.m` file to pull in the proper native library and initia
 
 ```objc
 #if __has_include(<React/RNSentry.h>)
-#import <React/RNSentry.h> // This is used for versions of react >= 0.40
+#import <React/RNSentry.h> // This is used for versions of react-native >= 0.40
 #else
-#import "RNSentry.h" // This is used for versions of react < 0.40
+#import "RNSentry.h" // This is used for versions of react-native < 0.40
 #endif
 
 /* in your didFinishLaunchingWithOptions */


### PR DESCRIPTION
Current import comment states that
```
#import <React/RNSentry.h> // versions of react < 0.40 
```

instead it should be
```
#import <React/RNSentry.h> // versions of  react-native < 0.40
```