### PR TITLE
Feat: Add deep link support to alert component

### DIFF
--- a/src/_includes/components/alert.html
+++ b/src/_includes/components/alert.html
@@ -1,5 +1,5 @@
 {% capture __alert %}
-<div class="alert{% if include.level %} alert-{{ include.level }}{% endif %}" role="alert">
+<div class="alert{% if include.level %} alert-{{ include.level }}{% endif %}" role="alert"{% if include.deep_link %} id="{{ include.deep_link }}"{% endif %}>
   {%- if include.dismiss -%}
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>

--- a/src/collections/_dev_components/includes/alert.md
+++ b/src/collections/_dev_components/includes/alert.md
@@ -13,6 +13,10 @@ arguments:
     type: String
     required: false
     desc: Severity of the alert. Must be a valid [Bootstrap severity level](https://getbootstrap.com/docs/4.0/components/alerts/).
+  - name: deep_link=""
+    type: String
+    required: false
+    desc: Slug to use after \# in a URL, to jump to the alert.
 examples:
   - title: Basic use
     source: |
@@ -34,6 +38,7 @@ examples:
   - title: Kitchen sink
     source: |
       {% include components/alert.html
+        deep_link="jump-here"
         title="Pay attention"
         content="This is the body of the alert"
         level="danger"

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -21,7 +21,6 @@ Sentry captures data by using an SDK within your application’s runtime. These 
 Your platform is not listed?  There are more SDKs we support: [list of SDKs]({%- link _documentation/platforms/index.md -%})
 {%- endcapture -%}
 {%- include components/alert.html
-  deep_link="test-link"
   title="Note"
   content=__alert_content
 %}

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -21,6 +21,7 @@ Sentry captures data by using an SDK within your application’s runtime. These 
 Your platform is not listed?  There are more SDKs we support: [list of SDKs]({%- link _documentation/platforms/index.md -%})
 {%- endcapture -%}
 {%- include components/alert.html
+  deep_link="test-link"
   title="Note"
   content=__alert_content
 %}


### PR DESCRIPTION
The following link will be possible with the code below:

```
https://docs.sentry.io/#jump-here
```

Note that when constructing urls with query parameters, the hash goes at the end

```
https://docs.sentry.io/?some=query#jump-here
```

```
      {% include components/alert.html
        deep_link="jump-here"
        title="Pay attention"
        content="This is the body of the alert"
        level="danger"
      %}
```