### PR TITLE
Require Trusty Travis Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ cache:
 script:
   - bin/test
   - yarn run snyk-protect
+dist: trusty


### PR DESCRIPTION
Travis has been slowly transitioning repos to a new build environment and ours flipped over last night, which broke everything. This fixes us to the previous environment.

Related reading: https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476