### PR TITLE
Docs: Add step to `Upload Symbols with sentry-cli` section

### DIFF
--- a/src/collections/_documentation/clients/cocoa/dsym.md
+++ b/src/collections/_documentation/clients/cocoa/dsym.md
@@ -102,9 +102,8 @@ Your project’s dSYM can be upload during the build phase as a “Run Script”
 
 You need to have an Auth Token for this to work. You can [create an Auth Token here](https://sentry.io/api/).
 
-1.  You will need to copy the below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
-2.  Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory
-
+1.  Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory
+2.  You will need to copy the below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
 ```bash
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_NAME___
@@ -117,6 +116,10 @@ fi
 else
 echo "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
 fi
+```
+3.  If you are using Xcode 10 or newer, you also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
+```bash
+${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 
 {% capture __alert_content -%}

--- a/src/collections/_documentation/clients/cocoa/dsym.md
+++ b/src/collections/_documentation/clients/cocoa/dsym.md
@@ -103,7 +103,7 @@ Your project’s dSYM can be upload during the build phase as a “Run Script”
 You need to have an Auth Token for this to work. You can [create an Auth Token here](https://sentry.io/api/).
 
 1.  Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory
-2.  You will need to copy the below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
+2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
 ```bash
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_NAME___


### PR DESCRIPTION
- step required to add the dsym file as a dependency to the run script
- new build system in xcode 10 parallelizes dsym generation and run scripts so the input file is required as outlined in the following resources
- https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes/build_system_release_notes_for_xcode_10
- https://stackoverflow.com/questions/53205108/run-script-phase-after-dsym-is-generated-with-xcode-10-on-build
- https://stackoverflow.com/questions/52709928/build-phase-script-is-running-before-needed-files-are-created-in-xcode-10