### PR TITLE
(ref) Add link to Python fingerprinting code samples

### DIFF
--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -203,9 +203,12 @@ with configure_scope() as scope:
 
 Sentry uses a fingerprint to decide how to group errors into issues.
 
-For some very advanced use cases, you can override the Sentry default grouping using the `fingerprint` attribute. In supported SDKs, this attribute can be passed with the event information and should be an array of strings.
-
+For some very advanced use cases, you can override the Sentry default grouping using the `fingerprint` attribute. In supported SDKs, this attribute can be passed with the event information and should be an array of strings. 
+{% raw %}
 If you wish to append information, thus making the grouping slightly less aggressive, you can do that as well by adding the special string `{{default}}` as one of the items.
+{% endraw %}
+
+For code samples, see the [Grouping & Fingerprints]({%- link _documentation/data-management/rollups.md -%}?platform=python#use-cases) page.
 
 For more information, see [Aggregate Errors with Custom Fingerprints](https://blog.sentry.io/2018/01/18/setting-up-custom-fingerprints).
 


### PR DESCRIPTION
also fixed what was supposed to be `{{default}}` showing up as ``

Now:
<img width="792" alt="Screenshot 2019-08-15 14 32 00" src="https://user-images.githubusercontent.com/29959063/63128418-c17a4d80-bf69-11e9-8980-22861260c4fc.png">

In this change:
<img width="776" alt="Screenshot 2019-08-15 14 33 22" src="https://user-images.githubusercontent.com/29959063/63128423-c5a66b00-bf69-11e9-847d-729a13b0901a.png">
