### PR TITLE
Update sourcemaps.md

### DIFF
--- a/src/collections/_documentation/clients/react-native/sourcemaps.md
+++ b/src/collections/_documentation/clients/react-native/sourcemaps.md
@@ -32,7 +32,14 @@ The values for `RELEASE_NAME` and `DISTRIBUTION_NAME` are as follows:
 
 `RELEASE_NAME`:
 
-: the bundle ID or package name (reverse dns notation of your app) followed by a dash and the human readable version name that is set for your release. So for instance `com.example.myapp-1.0`.
+: the bundle ID or package name (reverse dns notation of your app) followed by a dash and the human readable version name that 
+is set for your release. So for instance `com.example.myapp-1.0`.
+
+If you set the release name within your app, the `RELEASE_NAME` should be the same value. e.g.
+
+```js
+Sentry.setRelease(RELEASE_NAME)
+```
 
 `DISTRIBUTION_NAME`:
 


### PR DESCRIPTION
Add information about using `Sentry.setRelease(value)` when uploading sourcemaps.

This had be baffled for quite a while why my sourcemaps were not linking up to the correct release. I thought it would be better if we explicitly mention this in the Docs 😊