### PR TITLE
Fix typo in enriching-error-data/context.md

### DIFF
--- a/src/collections/_documentation/enriching-error-data/context.md
+++ b/src/collections/_documentation/enriching-error-data/context.md
@@ -35,7 +35,7 @@ Sentry supports additional context with events. Often this context is shared amo
 : Arbitrary unstructured data which is stored with an event sample
 
 {% capture __alert_content -%}
-Sentry will try it's best to accommodate the data you send it, but large context payloads will be trimmed or may be truncated entirely. For more details see the [data handling SDK documentation]({%- link _documentation/development/sdk-dev/data-handling.md -%})
+Sentry will try its best to accommodate the data you send it, but large context payloads will be trimmed or may be truncated entirely. For more details see the [data handling SDK documentation]({%- link _documentation/development/sdk-dev/data-handling.md -%})
 {%- endcapture -%}
 {%- include components/alert.html
   title="Context Size Limits"


### PR DESCRIPTION
Replace incorrect use of `it's` with `its`.