### PR TITLE
ref(dev): Deprecate event.stacktrace

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/stacktrace.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/stacktrace.md
@@ -7,6 +7,22 @@ A stack trace contains a list of frames, each with various bits (most optional)
 describing the context of that frame. Frames should be sorted from oldest to
 newest.
 
+{% capture __alert_content -%}
+
+Stack traces are always part of an exception or a thread. They cannot be
+declared as a top-level event property. When adding a stack trace to an event,
+follow this rule of thumb:
+
+- If the stack trace is part of an error, exception or crash, add it to the
+  [_Exception Interface_]({%- link
+  _documentation/development/sdk-dev/event-payloads/exception.md -%}).
+- Otherwise, add it as a thread in the [_Threads Interface_]({%- link
+  _documentation/development/sdk-dev/event-payloads/threads.md -%}).
+
+{%- endcapture -%}
+
+{% include components/alert.html title="Note" content=__alert_content %}
+
 ## Attributes
 
 `frames`:
@@ -24,7 +40,7 @@ newest.
 ## Frame Attributes
 
 Each object should contain **at least** a `filename`, `function` or
-`instruction_addr` attribute. All values are optional, but recommended. 
+`instruction_addr` attribute. All values are optional, but recommended.
 
 `filename`:
 


### PR DESCRIPTION
We are now formally deprecating `event.stacktrace` in favor of `thread.stacktrace` or `exception.stacktrace`. 

Sentry will retain support for top-level stack traces and normalize them into either an exception or thread. SDKs should deprecate top-level stacktrace attributes and remove them with the next major release.

<img width="774" alt="Screenshot 2019-08-26 at 09 13 08" src="https://user-images.githubusercontent.com/1433023/63675198-8e954c80-c7e8-11e9-8b1e-2ba8dde4a289.png">
