### PR TITLE
Update sidebar order

### DIFF
--- a/src/collections/_documentation/platforms/python/aiohttp.md
+++ b/src/collections/_documentation/platforms/python/aiohttp.md
@@ -1,6 +1,6 @@
 ---
 title: AIOHTTP
-sidebar_order: 4
+sidebar_order: 9
 ---
 
 {% version_added: 0.6.1 %}

--- a/src/collections/_documentation/platforms/python/asgi.md
+++ b/src/collections/_documentation/platforms/python/asgi.md
@@ -1,6 +1,6 @@
 ---
 title: ASGI
-sidebar_order: 5
+sidebar_order: 9
 ---
 
 {% version_added 0.10.2 %}

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -1,6 +1,6 @@
 ---
 title: AWS Lambda
-sidebar_order: 4
+sidebar_order: 7
 ---
 
 {% version_added 0.3.5 %}

--- a/src/collections/_documentation/platforms/python/beam.md
+++ b/src/collections/_documentation/platforms/python/beam.md
@@ -1,6 +1,6 @@
 ---
 title: Apache Beam
-sidebar_order: 2
+sidebar_order: 9
 ---
 
 {% version_added 0.11.0 %}

--- a/src/collections/_documentation/platforms/python/bottle.md
+++ b/src/collections/_documentation/platforms/python/bottle.md
@@ -1,6 +1,6 @@
 ---
 title: Bottle
-sidebar_order: 5
+sidebar_order: 4
 ---
 
 {% version_added 0.7.9 %}

--- a/src/collections/_documentation/platforms/python/celery.md
+++ b/src/collections/_documentation/platforms/python/celery.md
@@ -1,6 +1,6 @@
 ---
 title: Celery
-sidebar_order: 2
+sidebar_order: 3
 ---
 <!-- WIZARD -->
 The celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).

--- a/src/collections/_documentation/platforms/python/django.md
+++ b/src/collections/_documentation/platforms/python/django.md
@@ -1,6 +1,6 @@
 ---
 title: Django
-sidebar_order: 2
+sidebar_order: 1
 ---
 <!-- WIZARD -->
 The Django integration adds support for the [Django Web Framework](https://www.djangoproject.com/)

--- a/src/collections/_documentation/platforms/python/falcon.md
+++ b/src/collections/_documentation/platforms/python/falcon.md
@@ -1,6 +1,6 @@
 ---
 title: Falcon
-sidebar_order: 5
+sidebar_order: 9
 ---
 
 {% version_added 0.7.11 %}

--- a/src/collections/_documentation/platforms/python/gnu_backtrace.md
+++ b/src/collections/_documentation/platforms/python/gnu_backtrace.md
@@ -1,6 +1,6 @@
 ---
 title: GNU Backtrace
-sidebar_order: 2
+sidebar_order: 9
 ---
 <!-- WIZARD -->
 The GNU backtrace integration parses native stack trace produced by [`backtrace_symbols`](https://linux.die.net/man/3/backtrace_symbols) from error messages and concatenates them with the Python traceback.

--- a/src/collections/_documentation/platforms/python/logging.md
+++ b/src/collections/_documentation/platforms/python/logging.md
@@ -1,6 +1,6 @@
 ---
 title: Logging
-sidebar_order: 2
+sidebar_order: 9
 ---
 Calling ``sentry_sdk.init()`` already integrates with the logging module. It is
 equivalent to this explicit configuration:

--- a/src/collections/_documentation/platforms/python/redis.md
+++ b/src/collections/_documentation/platforms/python/redis.md
@@ -1,6 +1,6 @@
 ---
 title: Redis
-sidebar_order: 5
+sidebar_order: 9
 ---
 
 {% version_added 0.10.0 %}

--- a/src/collections/_documentation/platforms/python/rq.md
+++ b/src/collections/_documentation/platforms/python/rq.md
@@ -1,6 +1,6 @@
 ---
 title: RQ (Redis Queue)
-sidebar_order: 2
+sidebar_order: 9
 ---
 
 {% version_added 0.5.1 %}

--- a/src/collections/_documentation/platforms/python/sanic.md
+++ b/src/collections/_documentation/platforms/python/sanic.md
@@ -1,6 +1,6 @@
 ---
 title: Sanic
-sidebar_order: 3
+sidebar_order: 9
 ---
 
 {% version_added 0.3.6 %}

--- a/src/collections/_documentation/platforms/python/serverless.md
+++ b/src/collections/_documentation/platforms/python/serverless.md
@@ -1,6 +1,6 @@
 ---
 title: Serverless
-sidebar_order: 4
+sidebar_order: 9
 ---
 
 {% version_added 0.7.3 %}

--- a/src/collections/_documentation/platforms/python/sqlalchemy.md
+++ b/src/collections/_documentation/platforms/python/sqlalchemy.md
@@ -1,6 +1,6 @@
 ---
 title: SQLAlchemy
-sidebar_order: 5
+sidebar_order: 9
 ---
 
 {% version_added 0.11.0 %}

--- a/src/collections/_documentation/platforms/python/tornado.md
+++ b/src/collections/_documentation/platforms/python/tornado.md
@@ -1,6 +1,6 @@
 ---
 title: Tornado
-sidebar_order: 4
+sidebar_order: 6
 ---
 
 {% version_added: 0.6.3 %}

--- a/src/collections/_documentation/platforms/python/wsgi.md
+++ b/src/collections/_documentation/platforms/python/wsgi.md
@@ -1,6 +1,6 @@
 ---
 title: WSGI
-sidebar_order: 5
+sidebar_order: 8
 ---
 
 {% version_added 0.6.0 %}


### PR DESCRIPTION
Prioritizing our most popular frameworks to the top of the sidebar for easier user access.

![image](https://user-images.githubusercontent.com/25088225/63981014-307b9a00-ca72-11e9-9950-0ea004b0e8b2.png)
