### PR TITLE
feat: Add troubleshooting note for Jira Server

### DIFF
--- a/src/collections/_documentation/workflow/integrations/global-integrations.md
+++ b/src/collections/_documentation/workflow/integrations/global-integrations.md
@@ -761,6 +761,15 @@ To configure Issue sync, navigate to **Organization Settings** > **Integrations*
 
 [{% asset jira-sync.png %}]({% asset jira-sync.png @path %})
 
+{% capture __alert_content -%}
+If you hit a 4xx or 5xx error during or after setting up the Jira Server integration, please take a look at this [Help Center article](https://help.sentry.io/hc/en-us/articles/360034547794-Why-am-I-receiving-a-4xx-5xx-error-for-the-Jira-Server-Integration-).
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Troubleshooting"
+  content=__alert_content
+  level="warning"
+%}
+
 ### Rookout
 
 Rookout's new integration adds a layer of depth to Sentry Issues by allowing you to jump right from an Issue to a non-breaking breakpoint on the line that caused the error. 


### PR DESCRIPTION
Add troubleshooting note for Jira Server when users receive a 4xx or 5xx error.

Help center article linked in note: https://help.sentry.io/hc/en-us/articles/360034547794-Why-am-I-receiving-a-4xx-5xx-error-for-the-Jira-Server-Integration-

<img width="766" alt="Screen Shot 2019-08-30 at 2 15 03 PM" src="https://user-images.githubusercontent.com/20312973/64052692-63866200-cb34-11e9-9ff1-79ce25cd0c12.png">

cc @getsentry/cops / anyone - any feedback welcome for messaging in the Help Center article and/or the Troubleshooting note.