### PR TITLE
Fix typo in Go configuration documentation

### DIFF
--- a/src/collections/_documentation/platforms/go/config.md
+++ b/src/collections/_documentation/platforms/go/config.md
@@ -55,7 +55,7 @@ type ClientOptions struct {
 	// This will default to the `HTTPS_PROXY` environment variable
 	// or `http_proxy` if that one exists.
 	HTTPSProxy string
-	// An optionsl CaCerts to use.
+	// An optional CaCerts to use.
 	// Defaults to `gocertifi.CACerts()`.
 	CaCerts *x509.CertPool
 }


### PR DESCRIPTION
Served at https://docs.sentry.io/platforms/go/config/

This matches the typo fix in the source code @ https://github.com/getsentry/sentry-go/pull/50