### PR TITLE
build(config): Use proper configuration instaed of symlinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,8 @@ defaults:
 
 assets:
   source_maps: false # Prefer webpack source maps
+  sources:
+    - ../node_modules
   plugins:
     css:
       autoprefixer:

--- a/src/_assets/css/_vendor/bootstrap/dist
+++ b/src/_assets/css/_vendor/bootstrap/dist
@@ -1,1 +1,0 @@
-../../../../../node_modules/bootstrap/dist/css/

--- a/src/_assets/css/_vendor/bootstrap/src
+++ b/src/_assets/css/_vendor/bootstrap/src
@@ -1,1 +1,0 @@
-../../../../../node_modules/bootstrap/scss/

--- a/src/_assets/css/screen.scss
+++ b/src/_assets/css/screen.scss
@@ -1,6 +1,6 @@
 @import '_includes/variables';
 @import '_includes/bootstrap-overrides';
-@import '_vendor/bootstrap/src/bootstrap';
+@import 'bootstrap/scss/bootstrap';
 @import '_includes/type';
 @import '_includes/grid';
 @import '_includes/highlight';


### PR DESCRIPTION
This patch replaces our hidden symlinks for bootstrap with the proper configuration so we can build the docs on Windows too.