### PR TITLE
ref(api-docs): Document full param

### DIFF
--- a/src/collections/_documentation/api/events/get-group-events.md
+++ b/src/collections/_documentation/api/events/get-group-events.md
@@ -18,7 +18,7 @@
   ], 
   "query_parameters": [
     {
-      "description": "if this is set to true then the event payload will include the full event body, including the stacktrace. Set to 1 to enable.", 
+      "description": "if this is set to true, then the event payload will include the full event body, including the stack trace. Set to 1 to enable.", 
       "name": "full", 
       "type": "boolean"
     }

--- a/src/collections/_documentation/api/events/get-group-events.md
+++ b/src/collections/_documentation/api/events/get-group-events.md
@@ -16,7 +16,13 @@
       "type": "string"
     }
   ], 
-  "query_parameters": null, 
+  "query_parameters": [
+    {
+      "description": "if this is set to true then the event payload will include the full event body, including the stacktrace. Set to 1 to enable.", 
+      "name": "full", 
+      "type": "boolean"
+    }
+  ],  
   "sidebar_order": 9, 
   "title": "List an Issue's Events", 
   "warning": null

--- a/src/collections/_documentation/api/events/get-project-events.md
+++ b/src/collections/_documentation/api/events/get-project-events.md
@@ -21,7 +21,13 @@
       "type": "string"
     }
   ], 
-  "query_parameters": null, 
+  "query_parameters": [
+    {
+      "description": "if this is set to true then the event payload will include the full event body, including the stacktrace. Set to 1 to enable.", 
+      "name": "full", 
+      "type": "boolean"
+    }
+  ],  
   "sidebar_order": 1, 
   "title": "List a Project's Events", 
   "warning": null

--- a/src/collections/_documentation/api/events/get-project-events.md
+++ b/src/collections/_documentation/api/events/get-project-events.md
@@ -23,7 +23,7 @@
   ], 
   "query_parameters": [
     {
-      "description": "if this is set to true then the event payload will include the full event body, including the stacktrace. Set to 1 to enable.", 
+      "description": "if this is set to true, then the event payload will include the full event body, including the stack trace. Set to 1 to enable.", 
       "name": "full", 
       "type": "boolean"
     }


### PR DESCRIPTION
The api docs generator is broken I guess so https://github.com/getsentry/sentry/pull/14529 didn't do anything 