### PR TITLE
Fix formatting of levels in PHP docs

### DIFF
--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -166,7 +166,7 @@ We’ll automatically index all tags for an event, as well as the frequency and 
 
 ### Setting the Level
 
-You can set the severity of an event to one of five values: 'fatal,' 'error,' 'warning,' 'info,' and 'debug.' 'error' is the default, 'fatal' is the most severe and 'debug' is the least severe.
+You can set the severity of an event to one of five values: `fatal,` `error,` `warning,` `info,` and `debug.` `error` is the default, `fatal` is the most severe and `debug` is the least severe.
 
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {


### PR DESCRIPTION
What it looks like now:

<img width="782" alt="Screenshot 2019-09-09 12 20 35" src="https://user-images.githubusercontent.com/29959063/64560107-b8786400-d2fc-11e9-9113-26cea60bfb13.png">

What it should look like / will look like after merging:
<img width="782" alt="Screenshot 2019-09-09 12 22 41" src="https://user-images.githubusercontent.com/29959063/64560109-b8786400-d2fc-11e9-8012-99f6be544204.png">
