### PR TITLE
Update javascript documentation link

### DIFF
--- a/src/collections/_documentation/workflow/releases.md
+++ b/src/collections/_documentation/workflow/releases.md
@@ -304,4 +304,4 @@ You can also use our [API]({%- link _documentation/api/releases/post-release-dep
 
 ## Release Artifacts
 
-JavaScript and iOS projects can utilize release artifacts to unminify or symbolicate error stack traces. To learn more, please check out our [iOS]({%- link _documentation/clients/cocoa/index.md -%}#sentry-cocoa-debug-symbols) and [JavaScript]({%- link _documentation/clients/javascript/sourcemaps.md -%}) docs.
+JavaScript and iOS projects can utilize release artifacts to unminify or symbolicate error stack traces. To learn more, please check out our [iOS]({%- link _documentation/clients/cocoa/index.md -%}#sentry-cocoa-debug-symbols) and [JavaScript]({%- link _documentation/platforms/javascript/sourcemaps.md -%}) docs.


### PR DESCRIPTION
Update the JavaScript documentation link to point to the current JavaScript docs instead of the legacy client docs