### PR TITLE
swap compile for implementation in android gradle snippet

### DIFF
--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -27,11 +27,11 @@ By default the UI thread needs to be blocked for at least 5 seconds for an event
 Using Gradle (Android Studio) in your `app/build.gradle` add:
 
 ```groovy
-compile 'io.sentry:sentry-android:1.7.27'
+implementation 'io.sentry:sentry-android:1.7.27'
 
 // this dependency is not required if you are already using your own
 // slf4j implementation
-compile 'org.slf4j:slf4j-nop:1.7.25'
+implementation 'org.slf4j:slf4j-nop:1.7.25'
 ```
 
 For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-android%7C1.7.27%7Cjar).


### PR DESCRIPTION
as compile is deprecated
https://developer.android.com/studio/build/dependencies#dependency_configurations