### PR TITLE
ref: Use es5 syntax for JS examples

### DIFF
--- a/src/collections/_documentation/data-management/event-grouping/sdk-fingerprinting.md
+++ b/src/collections/_documentation/data-management/event-grouping/sdk-fingerprinting.md
@@ -7,8 +7,8 @@ In supported SDKs, you can override the Sentry default grouping passing the `fin
 
 ```javascript
 function makeRequest(method, path, options) {
-    return fetch(method, path, options).catch(err => {
-        Sentry.withScope(scope => {
+    return fetch(method, path, options).catch(function(err) {
+        Sentry.withScope(function(scope) {
           // group errors together based on their request and response
           scope.setFingerprint([method, path, err.statusCode]);
           Sentry.captureException(err);
@@ -21,8 +21,8 @@ Similarly, you can pass `{% raw %}{{ default }}{% endraw %}` in the fingerprint 
 
 ```javascript
 function makeRequest(method, path, options) {
-    return fetch(method, path, options).catch(err => {
-        Sentry.withScope(scope => {
+    return fetch(method, path, options).catch(function(err) {
+        Sentry.withScope(function(scope) {
           // extend the fingerprint with the request path
           scope.setFingerprint(['{% raw %}{{ default }}{% endraw %}', path]);
           Sentry.captureException(err);

--- a/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-database-connection-example/javascript.md
@@ -3,7 +3,7 @@ class DatabaseConnectionError extends Error {}
 
 Sentry.init({
   ...,
-  beforeSend: (event, hint) => {
+  beforeSend: function(event, hint) {
     const exception = hint.originalException;
 
     if (exception instanceof DatabaseConnectionError) {

--- a/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
+++ b/src/collections/_documentation/data-management/fingerprint-rpc-example/javascript.md
@@ -13,7 +13,7 @@ class MyRPCError extends Error {
 
 Sentry.init({
   ...,
-  beforeSend: (event, hint) => {
+  beforeSend: function(event, hint) {
     const exception = hint.originalException;
 
     if (exception instanceof MyRPCError) {

--- a/src/collections/_documentation/data-management/set-fingerprint/javascript.md
+++ b/src/collections/_documentation/data-management/set-fingerprint/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setFingerprint(['my-view-function']);
 });
 ```

--- a/src/collections/_documentation/development/sdk-dev/unified-api.md
+++ b/src/collections/_documentation/development/sdk-dev/unified-api.md
@@ -159,7 +159,7 @@ A scope holds data that should implicitly be sent with Sentry events. It can hol
 The user should be able to modify the current scope easily (to set extra, tags, current user), through a global function `configure_scope`.  `configure_scope` takes a callback function to which it passes the current scope. Here's an example from another place in the docs:
 
 ```javascript
-Sentry.configureScope(scope => {
+Sentry.configureScope(function(scope) {
   scope.setExtra("character_name", "Mighty Fighter");
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/configure-scope/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/configure-scope/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setTag("my-tag", "my value");
   scope.setUser({
     id: 42,

--- a/src/collections/_documentation/enriching-error-data/set-extra/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}");
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-level/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-level/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setLevel('warning');
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-user/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-user/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setUser({"email": "{{ page.example_user_email }}"});
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/tracing.md
+++ b/src/collections/_documentation/enriching-error-data/tracing.md
@@ -14,7 +14,7 @@ Generate a unique transaction identifier and set as a Sentry tag in the service 
 ```javascript
 // generate unique transactionId and set as Sentry tag
 const transactionId = Math.random().toString(36).substr(2, 9);
-Sentry.configureScope(scope => {
+Sentry.configureScope(function(scope) {
     scope.setTag("transaction_id", transactionId);
 });
 ```
@@ -48,7 +48,7 @@ In the receiving service (the server responding to the request), extract the uni
 let transactionId = request.header('X-Transaction-ID');
 
 if (transactionId) {
-    Sentry.configureScope(scope => {
+    Sentry.configureScope(function(scope) {
         scope.setTag("transaction_id", transactionId);
     });
 }
@@ -128,7 +128,7 @@ class RequestIdMiddleware:
 app.use((req, res, next) => {
       let requestId = req.headers['x-request-id'];
       if (requestId) {
-        Sentry.configureScope((scope) => {
+        Sentry.configureScope(function(scope) {
           scope.setTag("request_id", requestId);
         });
       }

--- a/src/collections/_documentation/enriching-error-data/with-scope/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/with-scope/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.withScope(scope => {
+Sentry.withScope(function(scope) {
   scope.setTag("my-tag", "my value");
   scope.setLevel('warning');
   // will be tagged with my-tag="my value"

--- a/src/collections/_documentation/platforms/javascript/advance-settings.md
+++ b/src/collections/_documentation/platforms/javascript/advance-settings.md
@@ -30,7 +30,7 @@ const client = new BrowserClient({
 
 const hub = new Hub(client);
 
-hub.configureScope(scope => {
+hub.configureScope(function(scope) {
   scope.setTag("a", "b");
 });
 
@@ -43,7 +43,7 @@ try {
   hub.captureException(e);
 }
 
-hub.withScope(scope => {
+hub.withScope(function(scope) {
   hub.addBreadcrumb({ message: "crumb 2" });
   hub.captureMessage("test2");
 });
@@ -99,14 +99,14 @@ const hub2 = new Sentry.Hub(client2);
 
 hub1.run(currentHub => { // The hub.run method makes sure that Sentry.getCurrentHub() returns this hub during the callback
   currentHub.captureMessage("a");
-  currentHub.configureScope(scope => {
+  currentHub.configureScope(function(scope) {
     scope.setTag("a", "b");
   });
 });
 
 hub2.run(currentHub => { // The hub.run method makes sure that Sentry.getCurrentHub() returns this hub during the callback
   currentHub.captureMessage("x");
-  currentHub.configureScope(scope => {
+  currentHub.configureScope(function(scope) {
     scope.setTag("c", "d");
   });
 });

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -385,7 +385,7 @@ There are two different scopes for unsetting context --- a global scope which Se
 Sentry.setUser(someUser);
 
 // This will be changed only for the error caught inside and automatically discarded afterward
-Sentry.withScope(scope => {
+Sentry.withScope(function(scope) {
   scope.setUser(someUser);
   Sentry.captureException(error);
 });
@@ -466,7 +466,7 @@ Sentry.captureMessage('this is a debug message', 'debug');
 To set the level within scope, you can call `setLevel()`:
 
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setLevel('warning');
 });
 ```
@@ -474,7 +474,7 @@ Sentry.configureScope((scope) => {
 or per event:
 
 ```javascript
-Sentry.withScope((scope) => {
+Sentry.withScope(function(scope) {
   scope.setLevel("info");
   Sentry.captureException(error);
 });
@@ -493,7 +493,7 @@ For more information, see [Aggregate Errors with Custom Fingerprints](https://bl
 This minimal example will put all exceptions of the current scope into the same issue/group:
 
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setFingerprint(['my-view-function']);
 });
 ```
@@ -507,8 +507,8 @@ The following example will split up the default group Sentry would create (repre
 
 ```javascript
 function makeRequest(path, options) {
-    return fetch(path, options).catch(err => {
-        Sentry.withScope(scope => {
+    return fetch(path, options).catch(function(err) {
+        Sentry.withScope(function(scope) {
           scope.setFingerprint(['{{default}}', path]);
           Sentry.captureException(err);
         });
@@ -520,7 +520,7 @@ function makeRequest(path, options) {
 If you have an error that has many different stack traces and never groups together, you can merge them together by omitting `{{ "{{default"}}}}` from the fingerprint array.
 
 ```javascript
-Sentry.withScope(scope => {
+Sentry.withScope(function(scope) {
   scope.setFingerprint(['Database Connection Error']);
   Sentry.captureException(err);
 });
@@ -686,7 +686,7 @@ Sentry.captureMessage('This shouldnt happen', 'info');
 
 // or more explicit
 
-Sentry.withScope((scope) => {
+Sentry.withScope(function(scope) {
   scope.setLevel('info');
   Sentry.captureMessage('This shouldnt happen');
 });
@@ -721,7 +721,7 @@ By default, the _Loader_ contains all information needed for our SDK to function
 
 
 ```javascript
-Sentry.onLoad(() => {
+Sentry.onLoad(function() {
   Sentry.init({
     release: '1.0.0',
     environment: 'prod'
@@ -746,7 +746,7 @@ The _Loader_ also provides a function called `forceLoad()` which does the same, 
 ```html
 <script>
   Sentry.forceLoad();
-  Sentry.onLoad(() => {
+  Sentry.onLoad(function() {
     // Use whatever Sentry.* function you want
   });
 </script>
@@ -1001,7 +1001,7 @@ import * as Sentry from '@sentry/browser';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: integrations => {
+  integrations: function(integrations) {
     // integrations will be all default integrations
     return integrations.filter(integration => integration.name !== 'Breadcrumbs');
   }
@@ -1014,9 +1014,9 @@ import * as Sentry from '@sentry/browser';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: integrations => {
+  integrations: function(integrations) {
     // integrations will be all default integrations
-    return [...integrations, new MyCustomIntegration()];
+    return [].concat(integrations).push(new MyCustomIntegration());
   }
 });
 ```

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -1003,7 +1003,9 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return integrations.filter(integration => integration.name !== 'Breadcrumbs');
+    return integrations.filter(function(integration) {
+      return integration.name !== 'Breadcrumbs';
+    });
   }
 });
 ```
@@ -1016,7 +1018,7 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return [].concat(integrations).push(new MyCustomIntegration());
+    return integrations.concat(new MyCustomIntegrations());
   }
 });
 ```

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -50,7 +50,7 @@ class ExampleBoundary extends Component {
     }
 
     componentDidCatch(error, errorInfo) {
-      Sentry.withScope(scope => {
+      Sentry.withScope(function(scope) {
           scope.setExtras(errorInfo);
           const eventId = Sentry.captureException(error);
           this.setState({eventId});

--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -53,7 +53,7 @@ class ExampleBoundary extends Component {
       Sentry.withScope(function(scope) {
           scope.setExtras(errorInfo);
           const eventId = Sentry.captureException(error);
-          this.setState({eventId});
+          this.setState({eventId: eventId});
       });
     }
 

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -50,7 +50,9 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return integrations.filter(integration => integration.name !== 'Console');
+    return integrations.filter(function(integration) { 
+      return integration.name !== 'Console';
+    });
   }
 });
 ```
@@ -64,7 +66,7 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return [...integrations, new MyCustomIntegration()];
+    return integrations.concat(new MyCustomIntegrations());
   }
 });
 ```

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -48,7 +48,7 @@ import * as Sentry from '@sentry/node';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: integrations => {
+  integrations: function(integrations) {
     // integrations will be all default integrations
     return integrations.filter(integration => integration.name !== 'Console');
   }
@@ -62,7 +62,7 @@ import * as Sentry from '@sentry/node';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: integrations => {
+  integrations: function(integrations) {
     // integrations will be all default integrations
     return [...integrations, new MyCustomIntegration()];
   }
@@ -119,8 +119,8 @@ Also, `eventProcessors` optionally receive the hint (see: [Hints](#hints)).
 
 ```javascript
 // This will be set globally for every succeeding event send
-Sentry.configureScope(scope => {
-  scope.addEventProcessor((event, hint) => {
+Sentry.configureScope(function(scope) {
+  scope.addEventProcessor(function(event, hint) {
     // Add anything to the event here
     // returning null will drop the event
     return event;
@@ -129,8 +129,8 @@ Sentry.configureScope(scope => {
 
 // Using withScope, will only call the event processor for all "sends"
 // that happen within withScope
-Sentry.withScope(scope => {
-  scope.addEventProcessor((event, hint) => {
+Sentry.withScope(function(scope) {
+  scope.addEventProcessor(function(event, hint) {
     // Add anything to the event here
     // returning null will drop the event
     return event;

--- a/src/collections/_documentation/platforms/node/koa.md
+++ b/src/collections/_documentation/platforms/node/koa.md
@@ -15,7 +15,7 @@ const Sentry = require('@sentry/node');
 Sentry.init({ dsn: '___PUBLIC_DSN___' });
 
 app.on('error', (err, ctx) => {
-  Sentry.withScope(scope => {
+  Sentry.withScope(function(scope) {
     scope.addEventProcessor(event => Sentry.Handlers.parseRequest(event, ctx.request));
     Sentry.captureException(err);
   });

--- a/src/collections/_documentation/platforms/node/koa.md
+++ b/src/collections/_documentation/platforms/node/koa.md
@@ -16,7 +16,9 @@ Sentry.init({ dsn: '___PUBLIC_DSN___' });
 
 app.on('error', (err, ctx) => {
   Sentry.withScope(function(scope) {
-    scope.addEventProcessor(event => Sentry.Handlers.parseRequest(event, ctx.request));
+    scope.addEventProcessor(function(event) {
+      return Sentry.Handlers.parseRequest(event, ctx.request); 
+    });
     Sentry.captureException(err);
   });
 });

--- a/src/collections/_documentation/workflow/set-tag/javascript.md
+++ b/src/collections/_documentation/workflow/set-tag/javascript.md
@@ -1,5 +1,5 @@
 ```javascript
-Sentry.configureScope((scope) => {
+Sentry.configureScope(function(scope) {
   scope.setTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
 });
 ```

--- a/src/collections/_documentation/workflow/visibility.md
+++ b/src/collections/_documentation/workflow/visibility.md
@@ -72,7 +72,7 @@ Modern applications have many components that can produce errors, making it hard
 ```javascript
 // generate unique transactionId and set as Sentry tag
 const transactionId = getUniqueId();
-Sentry.configureScope(scope => {
+Sentry.configureScope(function(scope) {
     scope.setTag("transaction_id", transactionId);
 });
 


### PR DESCRIPTION
To improve comaptabilty