### PR TITLE
one at the time -> one at a time

### DIFF
--- a/src/collections/_documentation/server/installation/docker/index.md
+++ b/src/collections/_documentation/server/installation/docker/index.md
@@ -169,7 +169,7 @@ docker run \
   run cron
 ```
 
-It’s recommended to only run one of them at the time or you will see unnecessary extra tasks being pushed onto the queues but the system will still behave as intended if multiple beat processes are run. This can be used to achieve high availability.
+It’s recommended to only run one cron container at a time or you will see unnecessary extra tasks being pushed onto the queues, but the system will still behave as intended if multiple beat processes are run. This can be used to achieve high availability.
 
 ## What’s Next? {#what-s-next}
 


### PR DESCRIPTION
I think `one at a time` is idiomatic vs `one at the time`. I also clarified that `one of them` is `one cron container`.

One thing I don't know yet (at this point in the docs - I just started reading) is what `beat processes` are? Are beat processes something that run in the worker node or possibly a typo?