### PR TITLE
Update ASGI wizard link to point to the correct docs

### DIFF
--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -258,7 +258,7 @@
       doc_link: /platforms/python/asgi/
       wizard_parent: python
       wizard:
-        - _documentation/platforms/python/wsgi.md
+        - _documentation/platforms/python/asgi.md
 -
       slug: tornado
       support_level: production


### PR DESCRIPTION
Currently, the ASGI wizard doc link points to the WSGI wizard (say that three times fast :P ). This updates the wizard to reference the ASGI wizard.