### PR TITLE
fix(native): Fix syntax error in native message example

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-verify/native.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/native.md
@@ -4,6 +4,6 @@ The quickest way to verify Sentry in your Native application is by capturing a m
 sentry_capture_event(sentry_value_new_message_event(
   /*   level */ SENTRY_LEVEL_INFO,
   /*  logger */ "custom",
-  /* message */ "It works!",
+  /* message */ "It works!"
 ));
 ```

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -119,7 +119,7 @@ by capturing a manual event:
 sentry_capture_event(sentry_value_new_message_event(
   /*   level */ SENTRY_LEVEL_INFO,
   /*  logger */ "custom",
-  /* message */ "It works!",
+  /* message */ "It works!"
 ));
 ```
 
@@ -192,7 +192,7 @@ optional.
 sentry_value_t event = sentry_value_new_message_event(
   /*   level */ SENTRY_LEVEL_INFO,
   /*  logger */ "custom",
-  /* message */ "It works!",
+  /* message */ "It works!"
 );
 ```
 


### PR DESCRIPTION
Trailing commas are not generally allowed in C and C++, and the example should in fact read:

```c
sentry_capture_event(sentry_value_new_message_event(
  /*   level */ SENTRY_LEVEL_INFO,
  /*  logger */ "custom",
  /* message */ "It works!"
));
```
