### PR TITLE
docs: Use ES6 in React as Babel is required for JSX usage anyway

### DIFF
--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -50,10 +50,10 @@ class ExampleBoundary extends Component {
     }
 
     componentDidCatch(error, errorInfo) {
-      Sentry.withScope(function(scope) {
+      Sentry.withScope((scope) => {
           scope.setExtras(errorInfo);
           const eventId = Sentry.captureException(error);
-          this.setState({eventId: eventId});
+          this.setState({eventId});
       });
     }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/pull/1231/files/1e3e1416c4cc3a3750bb7d628960cfd993d37b38#diff-b9fbbcd7dd109912114415edf628bbcd