### PR TITLE
Fix example on how to check source map

### DIFF
--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -404,25 +404,22 @@ var fs        = require('fs'),
     path      = require('path'),
     sourceMap = require('source-map');
 
-async function run() {
-    // file output by Webpack, Uglify, etc.
-    var GENERATED_FILE = path.join('.', 'app.min.js.map');
+// file output by Webpack, Uglify, etc.
+var GENERATED_FILE = path.join('.', 'app.min.js.map');
 
-    // line and column located in your generated file (e.g. source of your error
-    // from your minified file)
-    var GENERATED_LINE_AND_COLUMN = {line: 1, column: 1000};
+// line and column located in your generated file (e.g. source of your error
+// from your minified file)
+var GENERATED_LINE_AND_COLUMN = {line: 1, column: 1000};
 
-    var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();
-    var smc = await new sourceMap.SourceMapConsumer(rawSourceMap);
+var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();
+new sourceMap.SourceMapConsumer(rawSourceMap)
+  .then(function(smc) {
+      var pos = smc.originalPositionFor(GENERATED_LINE_AND_COLUMN);
 
-    var pos = smc.originalPositionFor(GENERATED_LINE_AND_COLUMN);
-
-    // should see something like:
-    // { source: 'original.js', line: 57, column: 9, name: 'myfunc' }
-    console.log(pos);
-}
-
-run();
+      // should see something like:
+      // { source: 'original.js', line: 57, column: 9, name: 'myfunc' }
+      console.log(pos);
+  });
 ```
 
 If you have the same (incorrect) results locally as you do via Sentry, double-check your source map generation configuration.

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -404,21 +404,25 @@ var fs        = require('fs'),
     path      = require('path'),
     sourceMap = require('source-map');
 
-// file output by Webpack, Uglify, etc.
-var GENERATED_FILE = path.join('.', 'app.min.js.map');
+async function run() {
+    // file output by Webpack, Uglify, etc.
+    var GENERATED_FILE = path.join('.', 'app.min.js.map');
 
-// line and column located in your generated file (e.g. source of your error
-// from your minified file)
-var GENERATED_LINE_AND_COLUMN = {line: 1, column: 1000};
+    // line and column located in your generated file (e.g. source of your error
+    // from your minified file)
+    var GENERATED_LINE_AND_COLUMN = {line: 1, column: 1000};
 
-var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();
-var smc = new sourceMap.SourceMapConsumer(rawSourceMap);
+    var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();
+    var smc = await new sourceMap.SourceMapConsumer(rawSourceMap);
 
-var pos = smc.originalPositionFor(GENERATED_LINE_AND_COLUMN);
+    var pos = smc.originalPositionFor(GENERATED_LINE_AND_COLUMN);
 
-// should see something like:
-// { source: 'original.js', line: 57, column: 9, name: 'myfunc' }
-console.log(pos);
+    // should see something like:
+    // { source: 'original.js', line: 57, column: 9, name: 'myfunc' }
+    console.log(pos);
+}
+
+run();
 ```
 
 If you have the same (incorrect) results locally as you do via Sentry, double-check your source map generation configuration.


### PR DESCRIPTION
`new sourceMap.SourceMapConsumer` returns a promise in the latest version
of `source-map` so it needs to be `await`ed.