### PR TITLE
Updated Dart link in Community SDKs

### DIFF
--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -22,7 +22,7 @@ These SDKs are [maintained and supported](https://forum.sentry.io) by the Sentry
 * [_C++_](https://github.com/nlohmann/crow)
 * [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 * [_Crystal_](https://github.com/Sija/raven.cr)
-* [_Dart_](https://github.com/flutter/sentry)
+* [_Flutter_](https://flutter.dev/docs/cookbook/maintenance/error-reporting)
 * [_Grails_](https://github.com/agorapulse/grails-sentry)
 * [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
 * [_Lua_](https://github.com/cloudflare/raven-lua)


### PR DESCRIPTION
Changed Dart to Flutter and gave it a new link because users were searching specifically for Flutter.