### PR TITLE
Fix broken link from commit integration page to releases page

### DIFF
--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -46,7 +46,7 @@ Then the UI will reflect the time it took for the release to be created. You can
 
 ## Commit Integration {#sentry-cli-commit-integration}
 
-If you have [repositories configured]({%- link _documentation/workflow/releases.md -%}#link-repository) within your Sentry organization you can associate commits with your release.
+If you have [repositories configured]({%- link _documentation/workflow/releases.md -%}#link-a-repository) within your Sentry organization you can associate commits with your release.
 
 There are two modes in which you can use this. One is the fully automatic mode. If you are deploying from a git repository and sentry-cli can discover the git repository from the current working directory you can set the commits with the `--auto` flag:
 


### PR DESCRIPTION
Currently if you click the "repositories configured" link [here](https://docs.sentry.io/cli/releases/#sentry-cli-commit-integration) it goes to the top of the page because the name of the anchor is incorrect.