### PR TITLE
Update the PHP transport classes section

### DIFF
--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -427,9 +427,16 @@ use Sentry\State\Hub;
 
 $options = ['dsn' => '___PUBLIC_DSN___'];
 
-$spool = new MemorySpool();
-$transport = new SpoolTransport($spool);
+
 $httpTransport = new HttpTransport($options, HttpAsyncClientDiscovery::find(), MessageFactoryDiscovery::find());
+
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(\Sentry\Options $options): \Sentry\Transport\TransportInterface
+    {
+        $spool = new MemorySpool();
+        return new SpoolTransport($spool);
+    }
+};
 
 $builder = ClientBuilder::create($options);
 $builder->setTransport($transport);

--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -439,7 +439,7 @@ $transportFactory = new class implements TransportFactoryInterface {
 };
 
 $builder = ClientBuilder::create($options);
-$builder->setTransport($transport);
+$builder->setTransportFactory($transportFactory);
 
 Hub::getCurrent()->bindClient($builder->getClient());
 


### PR DESCRIPTION
This should be merged when version 2.3 of the PHP SDK. 

Related to getsentry/sentry-php#855 and getsentry/sentry-php#787