### PR TITLE
Update csharp.md

### DIFF
--- a/src/collections/_documentation/enriching-error-data/configure-scope/csharp.md
+++ b/src/collections/_documentation/enriching-error-data/configure-scope/csharp.md
@@ -15,7 +15,7 @@ SentrySdk.ConfigureScope(scope =>
 Or when an asynchronous call is required:
 
 ```csharp
-await SentrySdk.ConfigureScopeAsync(scope =>
+await SentrySdk.ConfigureScopeAsync(async scope =>
 {
     scope.User = await _context.Users.FindAsync(id);
 });


### PR DESCRIPTION
`await` inside the lambda body doesn't work unless it begins with `async`.