### PR TITLE
Adds steps for installing/importing sentry-go/http for panic recovery

### DIFF
--- a/src/collections/_documentation/platforms/go/migration.md
+++ b/src/collections/_documentation/platforms/go/migration.md
@@ -381,6 +381,14 @@ http.HandleFunc("/", raven.RecoveryHandler(root))
 
 sentry-go
 
+```bash
+$ go get github.com/getsentry/sentry-go/http
+```
+
+```go
+import sentryhttp "github.com/getsentry/sentry-go/http"
+```
+
 ```go
 sentryHandler := sentryhttp.New(sentryhttp.Options{
 	Repanic: false,


### PR DESCRIPTION
Small tweak - but I had to jump from https://docs.sentry.io/platforms/go/migration to the GitHub pkg readme to figure out how to get this imported!