### PR TITLE
feat(elixir): Add sentence about `before_send_event` returning `nil`

### DIFF
--- a/src/collections/_documentation/clients/elixir/config.md
+++ b/src/collections/_documentation/clients/elixir/config.md
@@ -106,7 +106,7 @@ The backend can also be configured to capture Logger metadata, which is detailed
 
 `before_send_event`
 
-: This option allows performing operations on the event before it is sent by `Sentry.Client`. Accepts an anonymous function or a {module, function} tuple, and the event will be passed as the only argument.
+: This option allows performing operations on the event before it is sent by `Sentry.Client`. Accepts an anonymous function or a {module, function} tuple, and the event will be passed as the only argument. The function must return the modified event (or `nil` or `false` to prevent the event from being sent).
 
 `after_send_event`
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-elixir/pull/364 (which fixes https://github.com/getsentry/sentry-elixir/issues/363) brings the Elixir SDK's `before_send_event` config option in line with other, similar config options (`beforeSend` and `before_send`) in the unified SDKs, in that it now recognizes a falsy return value as a signal to drop the event. This PR adds a sentence explaining that behavior to the Elixir config docs.