### PR TITLE
Remove fixed sdk version from composer require command in docs

### DIFF
--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -11,7 +11,7 @@ Sentry captures data by using an SDK within your application’s runtime. These 
 To install the PHP SDK, you need to be using Composer in your project. For more details about Composer, see the [Composer documentation](https://getcomposer.org/doc/).
 
 ```bash
-composer require sentry/sdk:{% sdk_version sentry.php.sdk %}
+composer require sentry/sdk
 ```
 
 ### Connecting the SDK to Sentry


### PR DESCRIPTION
It is misleading and hard to maintain, often leads to outdated and incorrect information.

For example right now it shows 2.0.3 and there is already 2.0.4 released.

As well if value is omitted, it uses latest stable version (if not prefered dev version by user's composer.json).