### PR TITLE
ref(docs): remove mkvirtualenv recommendation for simplicity

### DIFF
--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -7,7 +7,7 @@ sidebar_order: 1
 
 ### Linux
 
-Just follow the [_official installation from source instructions_]({%- link _documentation/server/installation/python/index.md -%}).
+Follow the [_official installation from source instructions_]({%- link _documentation/server/installation/python/index.md -%}).
 
 ### Macintosh OS X
 
@@ -20,26 +20,15 @@ cd sentry
 
 Install [Homebrew](http://brew.sh), if you haven’t already, then run `brew install python@2`.
 
-It is highly recommended to develop inside a Python virtual environment, so install `virtualenv` and `virtualenvwrapper`:
+Setup and activate a python 2 virtual environment:
 
 ```bash
-pip install virtualenv virtualenvwrapper
+python2 -m pip install virtualenv
+python2 -m virtualenv .venv
+source .venv/bin/activate
 ```
 
-Then append the following to your shell profile (e.g. `~/.bashrc`) and reload it:
-
-```bash
-echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
-exec bash
-```
-
-Setup and activate a Python 2.7 virtual environment in the project root:
-
-```bash
-mkvirtualenv sentry
-```
-
-Install `nvm` and use it to install the node version specified in the `.nvmrc` file:
+Install `nvm` and use it to install the node version specified in sentry's `.nvmrc` file:
 
 ```bash
 brew install nvm


### PR DESCRIPTION
I don't think `mkvirtualenv` is worth all the extra fluff required to get it working; sourcing virtualenvs directly is easy, and removes the reader from that magic (brings them closer to how virtualenvs actually work).
