### PR TITLE
ref(docs): recommend running brew bundle directly

### DIFF
--- a/src/collections/_documentation/development/contribute/environment.md
+++ b/src/collections/_documentation/development/contribute/environment.md
@@ -18,7 +18,7 @@ git clone https://github.com/<your github username>/sentry.git
 cd sentry
 ```
 
-Install [Homebrew](http://brew.sh), if you haven’t already, then run `brew install python@2`.
+Install [Homebrew](http://brew.sh), if you haven’t already. Run `brew bundle` to install the various system packages as listed in sentry's `Brewfile`. This will install, among other things, Python 2 and docker.
 
 It is highly recommended to develop inside a Python virtual environment, so install `virtualenv` and `virtualenvwrapper`:
 


### PR DESCRIPTION
We have a top level Brewfile in sentry, but it's wrapped in a make recipe called `install-system-pkgs` which would only really make sense if we wanted to wrap other platforms in e.g. various linux distributions. Otherwise we might as well be calling it `install-macos-pkgs` and then, we might as well just tell people to run `brew bundle`.