### PR TITLE
added keywords to help with whitelist URL search

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration
 sidebar_order: 2
+keywords: ["whitelistUrls", "whitelist URLs", "whitelist-urls"]
 ---
 
 SDKs are configurable in many ways.  The options are largely standardized between SDKs but there are


### PR DESCRIPTION
Customers needed direction to the Configuration page when learning how to set `whitelistUrls`. Adding the keyword into the frontmatter of the page to help with customer navigation of docs.