### PR TITLE
feat: add additional nodes to index in results

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,7 @@ extlinks:
 algolia:
   application_id: OOK48W9UCL
   index_name: sentry-docs
+  nodes_to_index: 'p,blockquote,li,h2,h3'
   search_only_api_key: 2d64ec1106519cbc672d863b0d200782
   settings:
     attributesToHighlight:


### PR DESCRIPTION
This adds `blockquote`, `li`, `h2`, and `h3` to the list of index nodes in posts