### PR TITLE
Update Sourcemaps instructions to prioritize uploading directly to Sentry

### DIFF
--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -306,7 +306,7 @@ then your uploaded artifact should be named `https://example.com/dist/maps/scrip
 
 ### Verify artifact names match stack trace frames
 
-If you’ve uploaded source maps and they aren’t applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we’re attempting to resolve the file  - i.e. `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
+If you’ve uploaded source maps and they aren’t applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we’re attempting to resolve the file  - for example, `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
 
 If you have **dynamic values in your path** (for example, `https://www.site.com/{some_value}/scripts/script.js`), you may want to use the [`rewriteFrames`]({%- link _documentation/platforms/javascript/index.md -%}#rewriteframes) integration to change your `abs_path` values.
 
@@ -332,13 +332,13 @@ This command uploads all JavaScript files in the current directory. The Artifact
 ~/scripts/script.min.js.map
 ```
 
-Alternately you can specify which files to upload, i.e. 
+Alternately you can specify which files to upload. For example:
 
 ```
 sentry-cli releases files VERSION upload-sourcemaps script.min.js script.min.js.map --url-prefix '~/scripts'
 ```
 
-You can also upload it with the fully qualified URL i.e.
+You can also upload it with the fully qualified URL. For example:
 ```
 sentry-cli releases files VERSION upload-sourcemaps . --url-prefix 'http://localhost:8000/scripts'
 ```

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -152,7 +152,7 @@ $ sentry-cli releases finalize <release_name>
 For convenience, you can alternatively pass the `--finalize` flag to the `new` command which will immediately finalize the release.
 
 {% capture __alert_content -%}
-You dont have to upload the source files (referenced by source maps), but **without them the grouping algorithm will not be as strong**, and the UI will not show any contextual source.
+You don't have to upload the source files (referenced by source maps), but **without them the grouping algorithm will not be as strong**, and the UI will not show any contextual source.
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -116,8 +116,8 @@ The TypeScript compiler can output source maps. Configure the `sourceRoot` prope
 
 Source maps can be either:
 
-1.  Served publicly over HTTP alongside your source files.
-2.  Uploaded directly to Sentry (**recommended**).
+1.  Uploaded directly to Sentry (**recommended**).
+2.  Served publicly over HTTP alongside your source files.
 
 ### Hosting Source Map Files
 
@@ -188,14 +188,6 @@ This command will upload all files ending in _.js_ and _.map_ to the specified r
 ```sh
 $ sentry-cli releases files <release_name> upload-sourcemaps --ext ts --ext map /path/to/files
 ```
-
-{% capture __alert_content -%}
-Unfortunately, it can be quite challenging to ensure that source maps are actually valid and uploaded correctly. To ensure that everything is working as intended, you can add the `--validate` flag when uploading source maps. It attempts to parse the source maps and verify source references locally. Note that this flag might produce false positives if you have references to external source maps.
-{%- endcapture -%}
-{%- include components/alert.html
-  title="Validating source maps with Sentry CLI"
-  content=__alert_content
-%}
 
 Until now, the release is in a draft state (“_unreleased_”). Once all source maps have been uploaded and your app has been published successfully, finalize the release with the following command:
 

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -3,7 +3,7 @@ title: 'Source Maps'
 sidebar_order: 60
 ---
 
-Sentry supports un-minifying JavaScript via source maps. This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
+Sentry supports un-minifying JavaScript via source maps. This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (for example, UglifyJS), or transpiled code from a higher-level language (for example, TypeScript, ES6).
 
 ## Specify the release
 
@@ -123,9 +123,9 @@ Source maps can be either:
 
 Except for [webpack]({%- link _documentation/platforms/javascript/sourcemaps.md -%}#webpack), the recommended way to upload source maps is using [Sentry CLI]({%- link _documentation/cli/index.md -%}). If you have used [_Sentry Wizard_](https://github.com/getsentry/sentry-wizard) to set up your project, it has already created all necessary configuration to upload source maps. Otherwise, follow the [CLI configuration docs]({%- link _documentation/cli/configuration.md -%}) to set up your project.
 
-Now you need to set up your build system to create a release, and attach the various source files. For Sentry to de-minify your stack traces you must provide both the minified files (e.g. app.min.js) and the corresponding source maps. In case the source map files do not contain your original source code (`sourcesContent`), you must additionally provide the original source files. (Alternatively, sentry-cli will automatically embed the sources (if missing) into your source maps if you pass the `--rewrite` flag.)
+Now you need to set up your build system to create a release, and attach the various source files. For Sentry to de-minify your stack traces you must provide both the minified files (for example, app.min.js) and the corresponding source maps. In case the source map files do not contain your original source code (`sourcesContent`), you must additionally provide the original source files. (Alternatively, sentry-cli will automatically embed the sources (if missing) into your source maps if you pass the `--rewrite` flag.)
 
-Sentry uses [**Releases**]({%- link _documentation/workflow/releases.md -%}) to match the correct source maps to your events. To create a new release, run the following command (e.g. during publishing):
+Sentry uses [**Releases**]({%- link _documentation/workflow/releases.md -%}) to match the correct source maps to your events. To create a new release, run the following command (for example, during publishing):
 
 ```sh
 $ sentry-cli releases new <release_name>
@@ -137,7 +137,7 @@ The release name must be **unique within your organization** and match the `rele
 $ sentry-cli releases files <release_name> upload-sourcemaps /path/to/files
 ```
 
-This command will upload all files ending in _.js_ and _.map_ to the specified release. If you wish to change these extensions – e.g. to upload typescript sources – use the `--ext` option:
+This command will upload all files ending in _.js_ and _.map_ to the specified release. If you wish to change these extensions – for example, to upload typescript sources – use the `--ext` option:
 
 ```sh
 $ sentry-cli releases files <release_name> upload-sourcemaps --ext ts --ext map /path/to/files
@@ -166,8 +166,8 @@ Additional information can be found in the [Releases API documentation]({%- link
 It’s not uncommon for a web application to be accessible at multiple origins. For example:
 
 -   Website is operable over both `https` and `http`
--   Geolocated web addresses: e.g. `https://us.example.com`, `https://eu.example.com`
--   Multiple static CDNs: e.g. `https://static1.example.com`, `https://static2.example.com`
+-   Geolocated web addresses: for example, `https://us.example.com`, `https://eu.example.com`
+-   Multiple static CDNs: for example, `https://static1.example.com`, `https://static2.example.com`
 -   Customer-specific domains/subdomains
 
 In this situation, **identical** JavaScript and source map files may be located at two or more distinct origins. If you are dealing with such a deployment, you have two choices for naming your uploaded artifacts:
@@ -262,7 +262,7 @@ To verify this, open up the issue from the Sentry UI and check if the release is
 
 Once your release is properly configured and issues are tagged, from within an issue you can then click on the release >> Artifacts (or **Releases >> your specific release >> Artifacts**) to check that your source maps and the associated files are in fact uploaded to the correct release.
 
-Additionally, make sure all of the necessary files are available. For Sentry to de-minify your stack traces you must provide both the minified files (e.g. app.min.js) and the corresponding source maps. In case the source map files do not contain your original source code (`sourcesContent`), you must additionally provide the original source files. (Alternatively, sentry-cli will automatically embed the sources (if missing) into your source maps if you pass the `--rewrite` flag.)
+Additionally, make sure all of the necessary files are available. For Sentry to de-minify your stack traces you must provide both the minified files (for example, app.min.js) and the corresponding source maps. In case the source map files do not contain your original source code (`sourcesContent`), you must additionally provide the original source files. (Alternatively, sentry-cli will automatically embed the sources (if missing) into your source maps if you pass the `--rewrite` flag.)
 
 ### Verify `sourceMappingURL` is present
 
@@ -399,7 +399,7 @@ var fs        = require('fs'),
 // file output by Webpack, Uglify, etc.
 var GENERATED_FILE = path.join('.', 'app.min.js.map');
 
-// line and column located in your generated file (e.g. source of your error
+// line and column located in your generated file (for example, the source of your error
 // from your minified file)
 var GENERATED_LINE_AND_COLUMN = {line: 1, column: 1000};
 
@@ -424,7 +424,7 @@ Often users hit this limit because they are transmitting source files at an inte
 
 ### Verify artifacts are not gzipped
 
-The Sentry API currently only works with source maps and source files that are uploaded as plain text (UTF-8 encoded). If the files are uploaded in a compressed format (e.g. gzip), they will be not be interpreted correctly.
+The Sentry API currently only works with source maps and source files that are uploaded as plain text (UTF-8 encoded). If the files are uploaded in a compressed format (for example, gzip), they will be not be interpreted correctly.
 
 This sometimes occurs with build scripts and plugins that produce pre-compressed minified files. For example, Webpack’s [compression plugin](https://github.com/webpack/compression-webpack-plugin). You’ll need to disable such plugins and perform the compression _after_ the generated source maps / source files have been uploaded to Sentry.
 

--- a/src/collections/_documentation/platforms/javascript/sourcemaps.md
+++ b/src/collections/_documentation/platforms/javascript/sourcemaps.md
@@ -119,52 +119,6 @@ Source maps can be either:
 1.  Uploaded directly to Sentry (**recommended**).
 2.  Served publicly over HTTP alongside your source files.
 
-### Hosting Source Map Files
-
-By default, Sentry will look for source map directives in your compiled JavaScript files, which are located on the last line and have the following format:
-
-```javascript
-//# sourceMappingURL=<url>
-```
-
-When Sentry encounters such a directive, it will resolve the source map URL relative the source file in which it is found, and attempt an HTTP request to fetch it.
-
-So for example if you have a minified JavaScript file located at `http://example.org/js/app.min.js`. And in that file, on the last line, the following directive is found:
-
-```javascript
-//# sourceMappingURL=app.js.map
-```
-
-Sentry will attempt to fetch `app.js.map` from [http://example.org/js/app.js.map](http://example.org/js/app.js.map).
-
-Alternatively, during source map generation you can specify a fully qualified URL where your source maps are located:
-
-```javascript
-//# sourceMappingURL=http://example.org/js/app.js.map
-```
-
-While making source maps available to Sentry from your servers is the easiest integration, it is not always advisable:
-
--   Sentry may not always be able to reach your servers.
--   If you do not specify versions in your asset URLs, there may be a version mismatch
--   The additional latency may mean that source mappings are not available for all errors.
-
-For these reasons, it is recommended to upload source maps to Sentry beforehand (see below).
-
-{% capture __alert_content -%}
-While the recommended solution is to upload your source artifacts to Sentry, sometimes it’s necessary to allow communication from Sentry’s internal IPs. For more information on Sentry’s public IPs, [IP Ranges]({%- link ip-ranges.md -%}#ip-ranges).
-{%- endcapture -%}
-{%- include components/alert.html
-  title="Working Behind a Firewall"
-  content=__alert_content
-%}{% capture __alert_content -%}
-If you want to keep your source maps secret and choose not to upload your source maps directly to Sentry, you can enable the “Security Token” option in your project settings. This will cause outbound requests from Sentry’s servers to URLs originating from your “Allowed Domains” to have the HTTP header “X-Sentry-Token: {token}” appended, where {token} is a secure value you define. You can then configure your web server to allow access to your source maps when this header/token pair is present. You can alternatively override the default header name (X-Sentry-Token) and use HTTP Basic Authentication, e.g. by passing “Authorization: Basic {encoded_password}”.
-{%- endcapture -%}
-{%- include components/alert.html
-  title="Secure Access to Source Maps"
-  content=__alert_content
-%}
-
 ### Uploading Source Maps to Sentry
 
 Except for [webpack]({%- link _documentation/platforms/javascript/sourcemaps.md -%}#webpack), the recommended way to upload source maps is using [Sentry CLI]({%- link _documentation/cli/index.md -%}). If you have used [_Sentry Wizard_](https://github.com/getsentry/sentry-wizard) to set up your project, it has already created all necessary configuration to upload source maps. Otherwise, follow the [CLI configuration docs]({%- link _documentation/cli/configuration.md -%}) to set up your project.
@@ -244,6 +198,52 @@ Here are some things you can check in addition to the validation step:
 {%- endcapture -%}
 {%- include components/alert.html
   title="Validating source maps with Sentry CLI"
+  content=__alert_content
+%}
+
+### Hosting Source Map Files
+
+By default, Sentry will look for source map directives in your compiled JavaScript files, which are located on the last line and have the following format:
+
+```javascript
+//# sourceMappingURL=<url>
+```
+
+When Sentry encounters such a directive, it will resolve the source map URL relative the source file in which it is found, and attempt an HTTP request to fetch it.
+
+So for example if you have a minified JavaScript file located at `http://example.org/js/app.min.js`. And in that file, on the last line, the following directive is found:
+
+```javascript
+//# sourceMappingURL=app.js.map
+```
+
+Sentry will attempt to fetch `app.js.map` from [http://example.org/js/app.js.map](http://example.org/js/app.js.map).
+
+Alternatively, during source map generation you can specify a fully qualified URL where your source maps are located:
+
+```javascript
+//# sourceMappingURL=http://example.org/js/app.js.map
+```
+
+While making source maps available to Sentry from your servers is the easiest integration, it is not always advisable:
+
+-   Sentry may not always be able to reach your servers.
+-   If you do not specify versions in your asset URLs, there may be a version mismatch
+-   The additional latency may mean that source mappings are not available for all errors.
+
+For these reasons, it is recommended to upload source maps to Sentry beforehand (see [above](#uploading-source-maps-to-sentry)).
+
+{% capture __alert_content -%}
+While the recommended solution is to upload your source artifacts to Sentry, sometimes it’s necessary to allow communication from Sentry’s internal IPs. For more information on Sentry’s public IPs, [IP Ranges]({%- link ip-ranges.md -%}#ip-ranges).
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Working Behind a Firewall"
+  content=__alert_content
+%}{% capture __alert_content -%}
+If you want to keep your source maps secret and choose not to upload your source maps directly to Sentry, you can enable the “Security Token” option in your project settings. This will cause outbound requests from Sentry’s servers to URLs originating from your “Allowed Domains” to have the HTTP header “X-Sentry-Token: {token}” appended, where {token} is a secure value you define. You can then configure your web server to allow access to your source maps when this header/token pair is present. You can alternatively override the default header name (X-Sentry-Token) and use HTTP Basic Authentication. For example, by passing “Authorization: Basic {encoded_password}”.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Secure Access to Source Maps"
   content=__alert_content
 %}
 


### PR DESCRIPTION
Updated page to emphasize uploading the minified js file and the source maps file. This method is cheaper/faster and Sentry doesn't have to go the extra step to request information. 

![image](https://user-images.githubusercontent.com/25088225/67992842-8a781780-fbfb-11e9-95df-977e7a7551ab.png)
