### PR TITLE
Fix configuration array append syntax

### DIFF
--- a/src/collections/_documentation/clients/ruby/processors.md
+++ b/src/collections/_documentation/clients/ruby/processors.md
@@ -100,7 +100,7 @@ Once you have your processor written, you simply need to add it to the processor
 
 ```ruby
 Raven.configure do |config|
-  config.processors += MyJobProcessor
+  config.processors << MyJobProcessor
 end
 ```
 


### PR DESCRIPTION
I think this is was should be written, or : 

```ruby
config.processors += [MyJobProcessor]
```