### PR TITLE
fix(java): Make second init statement a comment

### DIFF
--- a/src/collections/_documentation/clients/java/usage.md
+++ b/src/collections/_documentation/clients/java/usage.md
@@ -69,7 +69,7 @@ public class MyClass {
         Sentry.init();
 
         // You can also manually provide the DSN to the ``init`` method.
-        Sentry.init("___PUBLIC_DSN___");
+        // Sentry.init("___PUBLIC_DSN___");
 
         /*
          It is possible to go around the static ``Sentry`` API, which means


### PR DESCRIPTION
People copy and paste without reading. Since we're saying this is the less preferred way of doing things, let's let this be information rather than something that actually runs if they engage in blind copy pasta.