### PR TITLE
fix: Suggest not stripping exception names

### DIFF
--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -198,7 +198,7 @@ First, you need to add the following to your ProGuard rules file:
 -dontwarn org.slf4j.**
 -dontwarn javax.**
 -keep class io.sentry.event.Event { *; }
--keep public class * extends java.lang.Exception
+-keep class * extends java.lang.Exception
 ```
 
 ##### ProGuard UUIDs

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -198,6 +198,7 @@ First, you need to add the following to your ProGuard rules file:
 -dontwarn org.slf4j.**
 -dontwarn javax.**
 -keep class io.sentry.event.Event { *; }
+-keep public class * extends java.lang.Exception
 ```
 
 ##### ProGuard UUIDs


### PR DESCRIPTION
Documenting the manual setup of proguard rules require instructing proguard not to strip exception names.

Relates to: https://github.com/getsentry/sentry-java/issues/711

Won't be needed on `sentry-android` 2.0.0, if https://github.com/getsentry/sentry-android/pull/124 gets merged.