### PR TITLE
[WIP] feat(SDKs): Add plural forms of `setTags`, `setExtras`

### DIFF
--- a/src/collections/_documentation/enriching-error-data/context.md
+++ b/src/collections/_documentation/enriching-error-data/context.md
@@ -3,9 +3,13 @@ title: Context
 sidebar_order: 0
 example_tag_name: page_locale
 example_tag_value: de-at
+example_tag_name2: experiment_group
+example_tag_value2: control
 example_user_email: 'john.doe@example.com'
 example_extra_key: character_name
 example_extra_value: 'Mighty Fighter'
+example_extra_key2: sidekick
+example_extra_value2: 'Awesome Possum'
 ---
 
 {% include platforms/event-contexts.md %}

--- a/src/collections/_documentation/enriching-error-data/set-extra/csharp.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/csharp.md
@@ -4,5 +4,19 @@ using Sentry;
 SentrySdk.ConfigureScope(scope => 
 {
     scope.SetExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}");
+
+    // to set multiple key-value pairs at once:
+    scope.SetExtras(
+        new List<KeyValuePair<string, object>>{
+            new KeyValuePair<string, object>(
+                "{{ page.example_extra_key }}",
+                "{{ page.example_extra_value }}"
+            ),
+            new KeyValuePair<string, object>(
+                "{{ page.example_extra_key2 }}",
+                "{{ page.example_extra_value2 }}"
+            ),
+        }
+    );
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-extra/go.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/go.md
@@ -2,10 +2,10 @@
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}")
 
-    // to set multiple key-value pairs at once:
-    scope.SetExtras(map[string]interface{}{
-        "{{ page.example_extra_key }}": "{{ page.example_extra_value }}",
-        "{{ page.example_extra_key2 }}": "{{ page.example_extra_value2 }}",
-    })
+	// to set multiple key-value pairs at once:
+	scope.SetExtras(map[string]interface{}{
+		"{{ page.example_extra_key }}": "{{ page.example_extra_value }}",
+		"{{ page.example_extra_key2 }}": "{{ page.example_extra_value2 }}",
+	})
 })
 ```

--- a/src/collections/_documentation/enriching-error-data/set-extra/go.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/go.md
@@ -1,5 +1,11 @@
 ```go
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}")
+
+    // to set multiple key-value pairs at once:
+    scope.SetExtras(map[string]interface{}{
+        "{{ page.example_extra_key }}": "{{ page.example_extra_value }}",
+        "{{ page.example_extra_key2 }}": "{{ page.example_extra_value2 }}",
+    })
 })
 ```

--- a/src/collections/_documentation/enriching-error-data/set-extra/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/javascript.md
@@ -1,5 +1,11 @@
 ```javascript
 Sentry.configureScope(function(scope) {
   scope.setExtra("{{ page.example_extra_key }}", "{{ page.example_extra_value }}");
+  
+  // to set multiple key-value pairs at once:
+  scope.setExtras({
+    {{ page.example_extra_key }}: "{{ page.example_extra_value }}",
+    {{ page.example_extra_key2 }}: "{{ page.example_extra_value2 }}",
+  });
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-extra/php.md
+++ b/src/collections/_documentation/enriching-error-data/set-extra/php.md
@@ -1,5 +1,11 @@
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {
   $scope->setExtra('{{ page.example_extra_key }}', '{{ page.example_extra_value }}');
+  
+  // to set multiple key-value pairs at once:
+  $scope->setExtras([
+    '{{ page.example_extra_key }}' => '{{ page.example_extra_value }}',
+    '{{ page.example_extra_key2 }}' => '{{ page.example_extra_value2 }}'
+  ]);
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/csharp.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/csharp.md
@@ -4,5 +4,19 @@ using Sentry;
 SentrySdk.ConfigureScope(scope => 
 {
     scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
+
+    // to set multiple key-value pairs at once:
+    scope.SetTags(
+        new List<KeyValuePair<string, object>>{
+            new KeyValuePair<string, object>(
+                "{{ page.example_tag_name }}",
+                "{{ page.example_tag_value }}"
+            ),
+            new KeyValuePair<string, object>(
+                "{{ page.example_tag_name2 }}",
+                "{{ page.example_tag_value2 }}"
+            ),
+        }
+    );
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/csharp.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/csharp.md
@@ -7,12 +7,12 @@ SentrySdk.ConfigureScope(scope =>
 
     // to set multiple key-value pairs at once:
     scope.SetTags(
-        new List<KeyValuePair<string, object>>{
-            new KeyValuePair<string, object>(
+        new List<KeyValuePair<string, string>>{
+            new KeyValuePair<string, string>(
                 "{{ page.example_tag_name }}",
                 "{{ page.example_tag_value }}"
             ),
-            new KeyValuePair<string, object>(
+            new KeyValuePair<string, string>(
                 "{{ page.example_tag_name2 }}",
                 "{{ page.example_tag_value2 }}"
             ),

--- a/src/collections/_documentation/enriching-error-data/set-tag/go.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/go.md
@@ -2,10 +2,10 @@
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}")
 
-    // to set multiple key-value pairs at once:
-    scope.SetTags(map[string]interface{}{
-        "{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
-        "{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
-    })
+	// to set multiple key-value pairs at once:
+	scope.SetTags(map[string]string{
+		"{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
+		"{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
+	})
 })
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/go.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/go.md
@@ -1,5 +1,11 @@
 ```go
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}")
+
+    // to set multiple key-value pairs at once:
+    scope.SetTags(map[string]interface{}{
+        "{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
+        "{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
+    })
 })
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/javascript.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/javascript.md
@@ -1,5 +1,11 @@
 ```javascript
 Sentry.configureScope(function(scope) {
   scope.setTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
+  
+  // to set multiple key-value pairs at once:
+  scope.setTags({
+    {{ page.example_tag_name }}: "{{ page.example_tag_value }}",
+    {{ page.example_tag_name2 }}: "{{ page.example_tag_value2 }}",
+  });
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/set-tag/php.md
+++ b/src/collections/_documentation/enriching-error-data/set-tag/php.md
@@ -1,5 +1,11 @@
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {
   $scope->setTag('{{ page.example_tag_name }}', '{{ page.example_tag_value }}');
+  
+  // to set multiple key-value pairs at once:
+  $scope->setTags([
+    '{{ page.example_tag_name }}' => '{{ page.example_tag_value }}',
+    '{{ page.example_tag_name2 }}' => '{{ page.example_tag_value2 }}'
+  ]);
 });
 ```

--- a/src/collections/_documentation/enriching-error-data/with-scope/php.md
+++ b/src/collections/_documentation/enriching-error-data/with-scope/php.md
@@ -4,9 +4,9 @@ Sentry\withScope(function (Sentry\State\Scope $scope): void {
   $scope->setTag('my-tag', 'my value');
   $scope->setLevel(Sentry\Severity::warning());
   // will be tagged with my-tag="my value"
-  Sentry\captureException(new \Throwable('my error'))
+  Sentry\captureException(new \Exception('my error'))
 });
 
 // will not be tagged with my-tag
-Sentry\captureException(new \Throwable('my other error'));
+Sentry\captureException(new \Exception('my other error'));
 ```

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -325,10 +325,34 @@ You can also set context when manually triggering events.
 {% include platforms/event-contexts.md %}
 
 ### Extra Context {#extra-context}
-In addition to the structured context that Sentry understands, you can send arbitrary key/value pairs of data which the Sentry SDK will store alongside the event. These are not indexed, and the Sentry SDK uses them to add additional information about what might be happening:
+In addition to the structured context that Sentry understands, you can send arbitrary key/value pairs of data which the Sentry SDK will store alongside the event. These are not indexed, and the Sentry SDK uses them to add additional information about what might be happening.
+
+You can add extra data to all events:
 
 ```javascript
 Sentry.setExtra("character_name", "Mighty Fighter");
+
+// to set multiple key-value pairs at once:
+Sentry.setExtras({
+  character_name: "Mighty Fighter",
+  sidekick: "Awesome Possum",
+});
+
+// alternate form
+Sentry.configureScope(function(scope) {
+  scope.setExtra("character_name", "Mighty Fighter");
+  // or scope.setExtras({ ... })
+});
+```
+
+or per event:
+
+```javascript
+Sentry.withScope(function(scope) {
+  scope.setExtra("character_name", "Mighty Fighter");
+  // or scope.setExtras({ ... })
+  Sentry.captureException(error);
+});
 ```
 
 {% capture __alert_content -%}
@@ -382,10 +406,32 @@ Sentry.setUser({"email": "john.doe@example.com"});
 Tags are key/value pairs assigned to events that can be used for breaking down
 issues or quick access to finding related events.
 
-Most SDKs generally support configuring tags by configuring the scope:
+You can set tags to be added to all events:
 
 ```javascript
 Sentry.setTag("page_locale", "de-at");
+
+// to set multiple key-value pairs at once:
+Sentry.setTags({
+  page_locale: "de-at",
+  experiment_group: "control",
+});
+
+// alternate form
+Sentry.configureScope(function(scope) {
+  scope.setTag("page_locale", "de-at");
+  // or scope.setTags({ ... })
+});
+```
+
+or per event:
+
+```javascript
+Sentry.withScope(function(scope) {
+  scope.setTag("my-tag", "my-value");
+  // or scope.setTags({ ... })
+  Sentry.captureException(error);
+});
 ```
 
 Several common uses for tags include:

--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -87,8 +87,8 @@ or per event:
 ```php
 Sentry\withScope(function (Sentry\State\Scope $scope): void {
   $scope->setExtra('character_name', 'Mighty Fighter');
-  // or $scope->setExtras([ ... ])
-  Sentry\captureException(new \Throwable('my error'))
+  // or $scope->setExtras([ ... ]);
+  Sentry\captureException(new \Exception('my error'));
 });
 
 ### Capturing the User
@@ -127,8 +127,8 @@ or per event:
 ```php
 Sentry\withScope(function (Sentry\State\Scope $scope): void {
   $scope->setTag('my-tag', 'my value');
-  // or $scope->setTags([ ... ])
-  Sentry\captureException(new \Throwable('my error'))
+  // or $scope->setTags([ ... ]);
+  Sentry\captureException(new \Exception('my error'));
 });
 
 Several common uses for tags include:

--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -68,11 +68,28 @@ Sentry\init([
 ### Extra Context
 In addition to the structured context that Sentry understands, you can send arbitrary key/value pairs of data which the Sentry SDK will store alongside the event. These are not indexed, and the Sentry SDK uses them to add additional information about what might be happening.
 
+You can add extra data to all events:
+
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {
   $scope->setExtra('character_name', 'Mighty Fighter');
+  
+  // to set multiple key-value pairs at once:
+  $scope->setExtras([
+    'character_name' => 'Mighty Fighter',
+    'sidekick' => 'Awesome Possum'
+  ]);
 });
 ```
+
+or per event:
+
+```php
+Sentry\withScope(function (Sentry\State\Scope $scope): void {
+  $scope->setExtra('character_name', 'Mighty Fighter');
+  // or $scope->setExtras([ ... ])
+  Sentry\captureException(new \Throwable('my error'))
+});
 
 ### Capturing the User
 
@@ -91,13 +108,28 @@ Sentry\configureScope(function (Sentry\State\Scope $scope): void {
 Tags are key/value pairs assigned to events that can be used for breaking down
 issues or quick access to finding related events.
 
-Most SDKs generally support configuring tags by configuring the scope:
+You can set tags to be added to all events:
 
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {
   $scope->setTag('page_locale', 'de-at');
+  
+  // to set multiple key-value pairs at once:
+  $scope->setTags([
+    'page_locale' => 'de-at',
+    'experiment_group' => 'control'
+  ]);
 });
 ```
+
+or per event:
+
+```php
+Sentry\withScope(function (Sentry\State\Scope $scope): void {
+  $scope->setTag('my-tag', 'my value');
+  // or $scope->setTags([ ... ])
+  Sentry\captureException(new \Throwable('my error'))
+});
 
 Several common uses for tags include:
 

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -3,6 +3,8 @@ title: Search
 sidebar_order: 3
 example_tag_name: page_locale
 example_tag_value: de-at
+example_tag_name2: experiment_group
+example_tag_value2: control
 ---
 
 Search is available on several major Sentry views: Issues, Events, and Releases.

--- a/src/collections/_documentation/workflow/set-tag/csharp.md
+++ b/src/collections/_documentation/workflow/set-tag/csharp.md
@@ -4,5 +4,19 @@ using Sentry;
 SentrySdk.ConfigureScope(scope => 
 {
     scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
+
+    // to set multiple key-value pairs at once:
+    scope.SetTags(
+        new List<KeyValuePair<string, object>>{
+            new KeyValuePair<string, object>(
+                "{{ page.example_tag_name }}",
+                "{{ page.example_tag_value }}"
+            ),
+            new KeyValuePair<string, object>(
+                "{{ page.example_tag_name2 }}",
+                "{{ page.example_tag_value2 }}"
+            ),
+        }
+    );
 });
 ```

--- a/src/collections/_documentation/workflow/set-tag/csharp.md
+++ b/src/collections/_documentation/workflow/set-tag/csharp.md
@@ -7,12 +7,12 @@ SentrySdk.ConfigureScope(scope =>
 
     // to set multiple key-value pairs at once:
     scope.SetTags(
-        new List<KeyValuePair<string, object>>{
-            new KeyValuePair<string, object>(
+        new List<KeyValuePair<string, string>>{
+            new KeyValuePair<string, string>(
                 "{{ page.example_tag_name }}",
                 "{{ page.example_tag_value }}"
             ),
-            new KeyValuePair<string, object>(
+            new KeyValuePair<string, string>(
                 "{{ page.example_tag_name2 }}",
                 "{{ page.example_tag_value2 }}"
             ),

--- a/src/collections/_documentation/workflow/set-tag/go.md
+++ b/src/collections/_documentation/workflow/set-tag/go.md
@@ -1,5 +1,11 @@
 ```go
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
+
+    // to set multiple key-value pairs at once:
+    scope.SetTags(map[string]interface{}{
+        "{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
+        "{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
+    })
 })
 ```

--- a/src/collections/_documentation/workflow/set-tag/go.md
+++ b/src/collections/_documentation/workflow/set-tag/go.md
@@ -2,10 +2,10 @@
 sentry.ConfigureScope(func(scope *sentry.Scope) {
 	scope.SetTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
 
-    // to set multiple key-value pairs at once:
-    scope.SetTags(map[string]interface{}{
-        "{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
-        "{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
-    })
+	// to set multiple key-value pairs at once:
+	scope.SetTags(map[string]string{
+		"{{ page.example_tag_name }}": "{{ page.example_tag_value }}",
+		"{{ page.example_tag_name2 }}": "{{ page.example_tag_value2 }}",
+	})
 })
 ```

--- a/src/collections/_documentation/workflow/set-tag/javascript.md
+++ b/src/collections/_documentation/workflow/set-tag/javascript.md
@@ -1,5 +1,11 @@
 ```javascript
 Sentry.configureScope(function(scope) {
   scope.setTag("{{ page.example_tag_name }}", "{{ page.example_tag_value }}");
+  
+  // to set multiple key-value pairs at once:
+  scope.setTags({
+    {{ page.example_tag_name }}: "{{ page.example_tag_value }}",
+    {{ page.example_tag_name2 }}: "{{ page.example_tag_value2 }}",
+  });
 });
 ```

--- a/src/collections/_documentation/workflow/set-tag/php.md
+++ b/src/collections/_documentation/workflow/set-tag/php.md
@@ -1,5 +1,11 @@
 ```php
 Sentry\configureScope(function (Sentry\State\Scope $scope): void {
   $scope->setTag('{{ page.example_tag_name }}', '{{ page.example_tag_value }}');
+  
+  // to set multiple key-value pairs at once:
+  $scope->setTags([
+    '{{ page.example_tag_name }}' => '{{ page.example_tag_value }}',
+    '{{ page.example_tag_name2 }}' => '{{ page.example_tag_value2 }}'
+  ]);
 });
 ```


### PR DESCRIPTION
Added to JS, Go, PHP, and C# (which is every SDK in which I found the plural methods). With everything but JS - Go and C# especially - I was doing pure pattern matching in order to come up with the code snippets (mostly from test files where we use the plural methods), so would appreciate a hard look at those from the relevant folks.

Tagging @bruno-garcia for C#, @kamilogorek for Go, @stayallive / @Jean85 / @ste93cry for PHP.

WIP because there's an open question of whether we want to emphasize the top-level (`Sentry.setTags()`) or scope (`sentry.configureScope(scope => {scope.setTags()})` versions of these methods. (Have included both, but the question is what's "here's how you do this" and what's "oh, BTW, you could also do it this way.")