### PR TITLE
Link to Round Robin integration on Internal Integrations page

### DIFF
--- a/src/collections/_documentation/workflow/integrations/integration-platform/index.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/index.md
@@ -244,6 +244,8 @@ When you are ready for the publication process, you can click the 'publish' butt
 
 Internal integrations are meant for custom integrations unique to your organization. They can also be as simple as an organization-wide token. Whether you are using just the API or all the Integration Platform features combined, internal integrations are for use within a single Sentry organization. 
 
+For an example of how to build an internal integration, see [our Round Robin Issue Assignment integration](https://blog.sentry.io/2019/11/21/customize-your-sentry-workflow-a-sample-internal-integration) (or jump straight to [the code on GitHub](https://github.com/getsentry/sentry-round-robin)).
+
 Internal integrations don't require an OAuth flow. You receive an org-wide Auth Token immediately after creation.
 
 [{% asset integration-platform-index/authentication-flow.png alt="Buttons providing the options to publish or delete." %}]({% asset integration-platform-index/authentication-flow.png @path %})

--- a/src/collections/_documentation/workflow/integrations/integration-platform/index.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/index.md
@@ -244,11 +244,11 @@ When you are ready for the publication process, you can click the 'publish' butt
 
 Internal integrations are meant for custom integrations unique to your organization. They can also be as simple as an organization-wide token. Whether you are using just the API or all the Integration Platform features combined, internal integrations are for use within a single Sentry organization. 
 
-For an example of how to build an internal integration, see [our Round Robin Issue Assignment integration](https://blog.sentry.io/2019/11/21/customize-your-sentry-workflow-a-sample-internal-integration) (or jump straight to [the code on GitHub](https://github.com/getsentry/sentry-round-robin)).
-
 Internal integrations don't require an OAuth flow. You receive an org-wide Auth Token immediately after creation.
 
 [{% asset integration-platform-index/authentication-flow.png alt="Buttons providing the options to publish or delete." %}]({% asset integration-platform-index/authentication-flow.png @path %})
+
+For an example of how to build an internal integration, see [our Round Robin Issue Assignment integration](https://blog.sentry.io/2019/11/21/customize-your-sentry-workflow-a-sample-internal-integration) (or jump straight to [the code on GitHub](https://github.com/getsentry/sentry-round-robin)).
 
 ### Installation
 


### PR DESCRIPTION
Tiny update :) Added a link to:
https://docs.sentry.io/workflow/integrations/integration-platform/#internal-integrations

The link points to this blog post and the repo for its sample code:
https://blog.sentry.io/2019/11/21/customize-your-sentry-workflow-a-sample-internal-integration 

@MimiDumpling Is there an existing convention for example code links / related blog posts? For example, a note/alert box thing like the one at the top of [the Node platform docs page](https://docs.sentry.io/platforms/node/)? Or italic text? Or leave it as is?

I also wasn't sure where best to place the link... below the diagram about not needing OAuth? Or immediately below the "Internal Integrations" heading? Or at the very top of the Integration Platform page? Hrmm.