### PR TITLE
Add link from Integrations to Integration Platform

### DIFF
--- a/src/collections/_documentation/workflow/integrations/index.md
+++ b/src/collections/_documentation/workflow/integrations/index.md
@@ -5,6 +5,10 @@ sidebar_order: 6
 
 Sentry integrates seamlessly with your favorite apps and services.
 
+### Integration Platform
+
+Sentry’s [Integration Platform]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}) provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#public-integrations) as well as [internal]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#internal-integrations) use cases.
+
 ### Global Integrations
 
 These integrations are set up once per organization, and are then usable in all projects.

--- a/src/collections/_documentation/workflow/integrations/index.md
+++ b/src/collections/_documentation/workflow/integrations/index.md
@@ -5,10 +5,6 @@ sidebar_order: 6
 
 Sentry integrates seamlessly with your favorite apps and services.
 
-### Integration Platform
-
-Sentry’s [Integration Platform]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}) provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#public-integrations) as well as [internal]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#internal-integrations) use cases.
-
 ### Global Integrations
 
 These integrations are set up once per organization, and are then usable in all projects.
@@ -57,3 +53,8 @@ These integrations are set up once per project, and are only usable in projects 
 -   Teamwork
 -   Trello*
 -   Twilio
+
+
+### Integration Platform
+
+Sentry’s [Integration Platform]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}) provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#public-integrations) as well as [internal]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}#internal-integrations) use cases.


### PR DESCRIPTION
Updates https://docs.sentry.io/workflow/integrations/
  - Adds a heading at the top for Integrations Platform
  - ...with the first paragraph straight from https://docs.sentry.io/workflow/integrations/integration-platform/ 