### PR TITLE
Add language dropdown for verifying webhook signature

### DIFF
--- a/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/node.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/node.md
@@ -1,0 +1,10 @@
+```javascript
+const crypto = require('crypto');
+
+function verifySignature(request, secret='') {
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(JSON.stringify(request.body), 'utf8');
+  const digest = hmac.digest('hex');
+  return digest === request.headers['sentry-hook-signature'];
+}
+```

--- a/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/node.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/node.md
@@ -5,6 +5,6 @@ function verifySignature(request, secret='') {
   const hmac = crypto.createHmac('sha256', secret);
   hmac.update(JSON.stringify(request.body), 'utf8');
   const digest = hmac.digest('hex');
-  return digest === request.headers['sentry-hook-signature'];
+  return digest === request.headers['Sentry-Hook-Signature'];
 }
 ```

--- a/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/python.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/webhooks-verifying-signature/python.md
@@ -1,0 +1,11 @@
+```python
+    body = json.dumps(request.body)
+    expected = hmac.new(
+        key=client_secret.encode('utf-8'),
+        msg=body,
+        digestmod=sha256,
+    ).hexdigest()
+
+    if expected != request.headers['Sentry-Hook-Signature']:
+            raise UnauthorizedError
+```

--- a/src/collections/_documentation/workflow/integrations/integration-platform/webhooks.md
+++ b/src/collections/_documentation/workflow/integrations/integration-platform/webhooks.md
@@ -35,17 +35,9 @@ A hash generated using your Client Secret and the request itself – used to ver
 
 ## Verifying the Signature
 
-```python
-    body = json.dumps(request.body)
-    expected = hmac.new(
-        key=client_secret.encode('utf-8'),
-        msg=body,
-        digestmod=sha256,
-    ).hexdigest()
-
-    if expected != request.headers['Sentry-Hook-Signature']:
-            raise UnauthorizedError
-```
+{% wizard %}
+{% include components/platform_content.html content_dir='webhooks-verifying-signature' %}
+{% endwizard %}
 
 ## Request Structure
 


### PR DESCRIPTION
Adds a language dropdown with code snippet for Node as well as Python to the webhooks page:
https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/#verifying-the-signature

Do we want to add other language examples too? :)