### PR TITLE
Fix wrong case, comparison and assignment

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/before-send/go.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-send/go.md
@@ -4,11 +4,7 @@ In Go, a function can be used to modify the event or return a completely new one
 sentry.Init(sentry.ClientOptions{
 	BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 		// Modify the event here
-		if event.user != nil {
-			// Don't send user's email address
-			event.user.email = nil
-		}
-		
+		event.User.Email = "" // Don't send user's email address
 		return event
 	},
 })


### PR DESCRIPTION
Exported fields in Go always start with uppercase, thus user->User and
email->Email.

Because Event contains a User value, not a pointer, event.User is never
nil. Similarly, one cannot set event.User.Email = nil, as that won't
compile.