### PR TITLE
fix(test): document.output is already an HTML doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
   directories:
     - node_modules
 before_install:
+  - gem uninstall ffi
+  - gem install ffi --platform=ruby
   - gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 script:
   - bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ cache:
   directories:
     - node_modules
 before_install:
-  - gem uninstall ffi
-  - gem install ffi --platform=ruby
   - gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 script:
   - bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
   yarn: true
   directories:
     - node_modules
+before_install:
+  - gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 script:
   - bin/test
   - yarn run snyk-protect

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/bin/build
+++ b/bin/build
@@ -8,4 +8,4 @@ yarn
 
 ./node_modules/.bin/webpack --config ./config/webpack.config.prod.js
 
-(bundle check || bundle install) && JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,$1
+(bundle check || bundle install) && JEKYLL_ENV=production bundle exec jekyll build --trace --config _config.yml,$1

--- a/src/_plugins/test_content_hook.rb
+++ b/src/_plugins/test_content_hook.rb
@@ -1,17 +1,13 @@
-require "nokogiri"
-
 if ENV['TEST_MODE'] == 'true'
 
   # Get a plain text version of the final rendered post that we can use for
   # style guide testing
   Jekyll::Hooks.register :documents, :post_render, priority: :low do |document|
-
-    body = Nokogiri::HTML(document.output)
+    body = document.output
     body.css('pre').remove
     body.css('code').remove
 
     document.data['plaintext'] = body.xpath("//*[@id='main']//text()").text
-
   end
 
 end


### PR DESCRIPTION
I'm guessing in older versions of Jekyll, `document.output` was a string but currently it is already a `Nokogiri::HTML` instance which broke my local builds. This PR removes the obsolete and problematic logic