### PR TITLE
doc(java): Global tags/extra with logback appender encoder

### DIFF
--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -811,6 +811,7 @@ Example configuration using the `logback.xml` format:
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <!-- Optionally add an encoder -->
         <encoder>
            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -862,7 +862,7 @@ Tags are distinguished by the existing mdcTags configuration property detailed a
 
 Global log entries can also be added via third party encoders  
 (*whether such entries can be distinguished as tags or entries however is encoder implementation specific*).
-The net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder for example has a customFields option:
+The `net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder` for example has a `customFields` option:
 
 ```java
   <encoder class="net.logstash.logback.encoder.LogstashEncoder">

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -811,6 +811,9 @@ Example configuration using the `logback.xml` format:
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <encoder>
+           <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
     </appender>
 
     <!-- Enable the Console and Sentry appenders, Console is provided as an example
@@ -844,6 +847,29 @@ void logWithExtras() {
     logger.error("This is a test");
 }
 ```
+
+#### Global Tags
+
+Sometimes its useful to add tags and extra data to all log events.  
+Tags and extras can be added to logs globally (not threadbound) by adding entries to the LoggerContext.  
+Tags are distinguished by the existing mdcTags configuration property detailed above.
+
+```java
+  LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
+  context.putProperty("global", "value");
+```
+
+Global log entries can also be added via third party encoders  
+(*whether such entries can be distinguished as tags or entries however is encoder implementation specific*).
+The net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder for example has a customFields option:
+
+```java
+  <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+    <customFields>{"appname":"myWebservice","roles":["customerorder","auth"]}</customFields>
+  </encoder>
+```
+
+In the event of naming clashes, the more specific MDC tags will take precedence.
 
 ### In Practice
 
@@ -883,6 +909,24 @@ public class MyClass {
         MDC.put("extra_key", "extra_value");
         // This sends an event with extra data to Sentry
         logger.error("This is a test");
+    }
+    
+    void logWithGlobalTag() {
+       LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
+       // This adds a tag named 'logback-Marker' to every subsequent Sentry event
+       context.putProperty(MARKER, "This is a test");
+       
+        // This sends an event to Sentry, and a tag named 'logback-Marker' will be added.
+        logger.info("This is a test");
+    }
+    
+    void addGlobalExtras() {
+       LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
+       // This adds extra data to every subsequent Sentry event
+       context.putProperty("extra_key", "extra_value");
+       
+       // This sends an event to Sentry, and extra data ("extra_key", "extra_value") will be added.
+        logger.info("This is a test");
     }
 
     void logException() {

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -852,7 +852,7 @@ void logWithExtras() {
 #### Global Tags
 
 Sometimes it's useful to add tags and extra data to all log events.  
-Tags and extras can be added to logs globally (not threadbound) by adding entries to the LoggerContext.  
+You can add tags and extras to logs globally (not thread-bound) by adding entries to the LoggerContext.  
 Tags are distinguished by the existing mdcTags configuration property detailed above.
 
 ```java

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -861,7 +861,7 @@ Tags are distinguished by the existing mdcTags configuration property detailed a
 ```
 
 Global log entries can also be added via third-party encoders  
-(*whether such entries can be distinguished as tags or entries however is encoder implementation specific*).
+(*whether such entries can be distinguished as tags or entries, however, is encoder implementation-specific*).
 The `net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder` for example has a `customFields` option:
 
 ```java

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -851,7 +851,7 @@ void logWithExtras() {
 
 #### Global Tags
 
-Sometimes its useful to add tags and extra data to all log events.  
+Sometimes it's useful to add tags and extra data to all log events.  
 Tags and extras can be added to logs globally (not threadbound) by adding entries to the LoggerContext.  
 Tags are distinguished by the existing mdcTags configuration property detailed above.
 

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -860,7 +860,7 @@ Tags are distinguished by the existing mdcTags configuration property detailed a
   context.putProperty("global", "value");
 ```
 
-Global log entries can also be added via third party encoders  
+Global log entries can also be added via third-party encoders  
 (*whether such entries can be distinguished as tags or entries however is encoder implementation specific*).
 The `net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder` for example has a `customFields` option:
 


### PR DESCRIPTION
adds documentation for global tags and extras using the logback appender.

I'm not sure what the target version is likely to be however? unlikely to remain 1.7.27