### PR TITLE
fix(data scrubbing): Clarify what gets scrubbed

### DIFF
--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -26,7 +26,7 @@ In the SDKs you can configure a `before-send` function which is invoked before a
 Within your project settings you’ll find a **Data Scrubber** option. By default this is enabled, and we highly recommend you keep it that way. With it enabled, Sentry will scrub the following:
 
 -   Values that look like they contain credit cards (using a basic regular expression)
--   Keys that contain any of the following values:
+-   Values that themselves contain, or whose keynames contain, any of the following strings: 
     -   password
     -   secret
     -   passwd


### PR DESCRIPTION
We check both keynames _and_ values for the blacklisted strings.