### PR TITLE
Update maxBreadcrumbs defaults 30

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -76,7 +76,7 @@ be sent.  Events are picked randomly.
 ### `max-breadcrumbs`
 
 This variable controls the total amount of breadcrumbs that should be captured.  This defaults
-to `100`.
+to `30`.
 
 {:.config-key}
 ### `attach-stacktrace`


### PR DESCRIPTION
fix: https://github.com/getsentry/sentry-docs/issues/1393