### PR TITLE
fix: Add noindex for docs that are already updated

### DIFF
--- a/src/collections/_documentation/clients/csharp/index.md
+++ b/src/collections/_documentation/clients/csharp/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'C#'
+robots: noindex
 ---
 
 Raven is the C# client for Sentry. Raven relies on the most popular logging libraries to capture and convert logs before sending details to a Sentry instance.

--- a/src/collections/_documentation/clients/go/config.md
+++ b/src/collections/_documentation/clients/go/config.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration
 sidebar_order: 1
+robots: noindex
 ---
 
 The Sentry Go SDK has some configurable options, which can enhance your user experience,

--- a/src/collections/_documentation/clients/go/context.md
+++ b/src/collections/_documentation/clients/go/context.md
@@ -1,6 +1,7 @@
 ---
 title: Context
 sidebar_order: 3
+robots: noindex
 ---
 
 All of the `Capture*` functions accept an additional argument for passing a `map` of tags as the second argument and context data as remaining ones.

--- a/src/collections/_documentation/clients/go/index.md
+++ b/src/collections/_documentation/clients/go/index.md
@@ -1,5 +1,6 @@
 ---
 title: Go
+robots: noindex
 ---
 
 {% capture __alert_content -%}

--- a/src/collections/_documentation/clients/go/integrations.md
+++ b/src/collections/_documentation/clients/go/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+robots: noindex
 ---
 
 The Raven Go package currently comes with an integration for the native `net/http` module to make it easy to handle common scenarios. More frameworks will be coming soon.

--- a/src/collections/_documentation/clients/go/usage.md
+++ b/src/collections/_documentation/clients/go/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Usage
 sidebar_order: 2
+robots: noindex
 ---
 
 <!-- WIZARD -->

--- a/src/collections/_documentation/clients/javascript/config.md
+++ b/src/collections/_documentation/clients/javascript/config.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration
 sidebar_order: 1
+robots: noindex
 ---
 
 To get started, you need to configure Raven.js to use your Sentry DSN:

--- a/src/collections/_documentation/clients/javascript/index.md
+++ b/src/collections/_documentation/clients/javascript/index.md
@@ -1,6 +1,7 @@
 ---
 title: JavaScript
 sidebar_order: 7
+robots: noindex
 ---
 
 Raven.js is the official browser JavaScript client for Sentry. It automatically reports uncaught JavaScript exceptions triggered from a browser environment, and provides a rich API for reporting your own errors.

--- a/src/collections/_documentation/clients/javascript/install.md
+++ b/src/collections/_documentation/clients/javascript/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installation
+robots: noindex
 ---
 
 Raven is distributed in a few different methods, and should get included after any other libraries are included, but before your own scripts.

--- a/src/collections/_documentation/clients/javascript/integrations.md
+++ b/src/collections/_documentation/clients/javascript/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+robots: noindex
 ---
 
 Integrations extend the functionality of Raven.js to cover common libraries and environments automatically using simple plugins.

--- a/src/collections/_documentation/clients/javascript/sourcemaps.md
+++ b/src/collections/_documentation/clients/javascript/sourcemaps.md
@@ -1,6 +1,7 @@
 ---
 title: 'Source Maps'
 sidebar_order: 3
+robots: noindex
 ---
 
 Sentry supports un-minifying JavaScript via [Source Maps](http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).

--- a/src/collections/_documentation/clients/javascript/tips.md
+++ b/src/collections/_documentation/clients/javascript/tips.md
@@ -1,6 +1,7 @@
 ---
 title: 'Tips and Tricks'
 sidebar_order: 4
+robots: noindex
 ---
 
 These are some general recommendations and tips for how to get the most out of Raven.js and Sentry.

--- a/src/collections/_documentation/clients/javascript/usage.md
+++ b/src/collections/_documentation/clients/javascript/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Usage
 sidebar_order: 2
+robots: noindex
 ---
 
 By default, Raven makes a few efforts to try its best to capture meaningful stack traces, but browsers make it pretty difficult.

--- a/src/collections/_documentation/clients/node/coffeescript.md
+++ b/src/collections/_documentation/clients/node/coffeescript.md
@@ -1,6 +1,7 @@
 ---
 title: CoffeeScript
 sidebar_order: 4
+robots: noindex
 ---
 
 In order to use raven-node with coffee-script or another library which overwrites Error.prepareStackTrace you might run into the exception “Traceback does not support Error.prepareStackTrace being defined already.”

--- a/src/collections/_documentation/clients/node/config.md
+++ b/src/collections/_documentation/clients/node/config.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+robots: noindex
 ---
 
 To get started, you need to configure Raven to use your Sentry DSN:

--- a/src/collections/_documentation/clients/node/index.md
+++ b/src/collections/_documentation/clients/node/index.md
@@ -1,6 +1,7 @@
 ---
 title: Node.js
 sidebar_order: 9
+robots: noindex
 ---
 
 raven-node is the official Node.js client for Sentry.

--- a/src/collections/_documentation/clients/node/integrations.md
+++ b/src/collections/_documentation/clients/node/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+robots: noindex
 ---
 
 ## Connect

--- a/src/collections/_documentation/clients/node/sourcemaps.md
+++ b/src/collections/_documentation/clients/node/sourcemaps.md
@@ -1,6 +1,7 @@
 ---
 title: 'Source Maps'
 sidebar_order: 2
+robots: noindex
 ---
 
 Sentry supports un-minifying JavaScript via [Source Maps](http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).

--- a/src/collections/_documentation/clients/node/typescript.md
+++ b/src/collections/_documentation/clients/node/typescript.md
@@ -1,6 +1,7 @@
 ---
 title: TypeScript
 sidebar_order: 3
+robots: noindex
 ---
 
 Please read [Source Maps docs]({%- link _documentation/clients/node/sourcemaps.md -%}) first to learn how to configure Raven SDK, upload artifacts to our servers or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).

--- a/src/collections/_documentation/clients/node/usage.md
+++ b/src/collections/_documentation/clients/node/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Usage
 sidebar_order: 1
+robots: noindex
 ---
 
 ## Capturing Errors

--- a/src/collections/_documentation/clients/php/config.md
+++ b/src/collections/_documentation/clients/php/config.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+robots: noindex
 ---
 
 Several options exist that allow you to configure the behavior of the `Raven_Client`. These are passed as the second parameter of the constructor, and is expected to be an array of key value pairs:

--- a/src/collections/_documentation/clients/php/index.md
+++ b/src/collections/_documentation/clients/php/index.md
@@ -1,6 +1,7 @@
 ---
 title: PHP
 sidebar_order: 11
+robots: noindex
 ---
 
 The PHP SDK for Sentry supports PHP 5.3 and higher. It’s available as a BSD licensed Open Source library.

--- a/src/collections/_documentation/clients/php/integrations.md
+++ b/src/collections/_documentation/clients/php/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+robots: noindex
 ---
 
 ## Laravel

--- a/src/collections/_documentation/clients/php/usage.md
+++ b/src/collections/_documentation/clients/php/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Usage
 sidebar_order: 1
+robots: noindex
 ---
 
 Using Sentry with PHP is straightforward. After installation of the library you can directly interface with the client and start submitting data.

--- a/src/collections/_documentation/clients/python/advanced.md
+++ b/src/collections/_documentation/clients/python/advanced.md
@@ -1,6 +1,7 @@
 ---
 title: 'Advanced Usage'
 sidebar_order: 1
+robots: noindex
 ---
 
 This covers some advanced usage scenarios for raven Python.

--- a/src/collections/_documentation/clients/python/api.md
+++ b/src/collections/_documentation/clients/python/api.md
@@ -1,5 +1,6 @@
 ---
 title: 'API Reference'
+robots: noindex
 ---
 
 This gives you an overview of the public API that raven-python exposes.

--- a/src/collections/_documentation/clients/python/breadcrumbs.md
+++ b/src/collections/_documentation/clients/python/breadcrumbs.md
@@ -1,6 +1,7 @@
 ---
 title: 'Logging Breadcrumbs'
 sidebar_order: 2
+robots: noindex
 ---
 
 Newer Sentry versions support logging of breadcrumbs in addition of errors. This means that whenever an error or other Sentry event is submitted to the system, breadcrumbs that were logged before are sent along to make it easier to reproduce what lead up to an error.

--- a/src/collections/_documentation/clients/python/index.md
+++ b/src/collections/_documentation/clients/python/index.md
@@ -1,6 +1,7 @@
 ---
 title: Python
 sidebar_order: 12
+robots: noindex
 ---
 
 For pairing Sentry up with Python you can use the Raven for Python (raven-python) library. It is the official standalone Python client for Sentry. It can be used with any modern Python interpreter be it CPython 2.x or 3.x, PyPy or Jython. It’s an Open Source project and available under a very liberal BSD license.

--- a/src/collections/_documentation/clients/python/integrations.md
+++ b/src/collections/_documentation/clients/python/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+robots: noindex
 ---
 
 The Raven Python module also comes with integration for some commonly used libraries to automatically capture errors from common environments. This means that once you have such an integration configured you typically do not need to report errors manually.

--- a/src/collections/_documentation/clients/python/platform-support.md
+++ b/src/collections/_documentation/clients/python/platform-support.md
@@ -1,5 +1,6 @@
 ---
 title: 'Supported Platforms'
+robots: noindex
 ---
 
 -   Python 2.6

--- a/src/collections/_documentation/clients/python/transports.md
+++ b/src/collections/_documentation/clients/python/transports.md
@@ -1,5 +1,6 @@
 ---
 title: Transports
+robots: noindex
 ---
 
 A transport is the mechanism in which Raven sends the HTTP request to the Sentry server. By default, Raven uses a threaded asynchronous transport, but you can easily adjust this by passing your own transport class.

--- a/src/collections/_documentation/clients/react-native/cocoapods.md
+++ b/src/collections/_documentation/clients/react-native/cocoapods.md
@@ -1,5 +1,6 @@
 ---
 title: 'Setup With CocoaPods'
+robots: noindex
 ---
 
 In order to use Sentry with CocoaPods you have to install the packages with `npm` or `yarn` and link them locally in your `Podfile`.

--- a/src/collections/_documentation/clients/react-native/codepush.md
+++ b/src/collections/_documentation/clients/react-native/codepush.md
@@ -1,5 +1,6 @@
 ---
 title: 'Using Sentry with CodePush'
+robots: noindex
 ---
 
 If you want to use sentry together with CodePush you have to send us the CodePush version:

--- a/src/collections/_documentation/clients/react-native/config.md
+++ b/src/collections/_documentation/clients/react-native/config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Additional Configuration'
+robots: noindex
 ---
 
 These are functions you can call in your JavaScript code:

--- a/src/collections/_documentation/clients/react-native/expo.md
+++ b/src/collections/_documentation/clients/react-native/expo.md
@@ -1,5 +1,6 @@
 ---
 title: 'Using Sentry with Expo'
+robots: noindex
 ---
 
 [Expo](https://expo.io/) is an awesome way to quickly create and play around with your react native app. Now you can also use Sentry together with Expo which is pretty simple todo:

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'React Native'
+robots: noindex
 ---
 
 This is the documentation for our React-Native SDK. The React-Native SDK uses a native extension for iOS and Android but will fall back to a pure JavaScript version if necessary.

--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -1,5 +1,6 @@
 ---
 title: 'Manual Setup'
+robots: noindex
 ---
 
 If you can’t (or don’t want) to run the linking step you can see here what is happening on each platform.

--- a/src/collections/_documentation/clients/react-native/ram-bundles.md
+++ b/src/collections/_documentation/clients/react-native/ram-bundles.md
@@ -1,5 +1,6 @@
 ---
 title: 'Using RAM Bundles'
+robots: noindex
 ---
 
 The [RAM bundle](https://facebook.github.io/react-native/docs/performance#ram-bundles-inline-requires) format is a new approach to packaging React Native apps that optimizes your app's startup time. With RAM bundles, it is possible to load to memory only those modules that are needed for specific functionality, and only when needed.

--- a/src/collections/_documentation/clients/react-native/sourcemaps.md
+++ b/src/collections/_documentation/clients/react-native/sourcemaps.md
@@ -1,5 +1,6 @@
 ---
 title: 'Source Maps for Other Platforms'
+robots: noindex
 ---
 
 Currently automatic source map handling is only implemented for iOS with Xcode and Android with gradle. If you manually invoke the [react-native packager](https://github.com/facebook/metro) you can however get source maps anyways by passing _–sourcemap-output_ to it.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6532,7 +6532,3 @@ yargs@^3.19.0:
     string-width "^1.0.1"
     window-size "^0.1.4"
     y18n "^3.2.0"
-
-yarn@^1.10.1:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.12.3.tgz#fb4599bf1f8da01552bcc7e1571dfd4e53788203"


### PR DESCRIPTION
This adds 
```html
 <meta name="robots" content="noindex">
```
to all old doc pages that already have been updated so google doesn't index them and ppl are not misguided.

Disclaimer: Only added so many ppl for visibility and raising awareness we should do this in the future for all relevant pages.

cc @stayallive