### PR TITLE
feat(JS CDN): Add async/defer note

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-install/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browser.md
@@ -7,7 +7,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 
 {% wizard hide %}
 {% capture __alert_content -%}
-It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Use of `defer`"

--- a/src/collections/_documentation/error-reporting/getting-started-install/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browser.md
@@ -6,5 +6,14 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 ```
 
 {% wizard hide %}
+{% capture __alert_content -%}
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Use of `defer`"
+  content=__alert_content
+  level="warning"
+%}
+
 You can also [NPM install our browser library](?platform=browsernpm).
 {% endwizard %}

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
@@ -6,7 +6,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 
 {% wizard hide %}
 {% capture __alert_content -%}
-It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Use of `defer`"

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
@@ -5,5 +5,14 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 ```
 
 {% wizard hide %}
+{% capture __alert_content -%}
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Use of `defer`"
+  content=__alert_content
+  level="warning"
+%}
+
 You can also [NPM install our browser library](?platform=browsernpm).
 {% endwizard %}

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -15,7 +15,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 ```
 
 {% capture __alert_content -%}
-It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Use of `defer`"

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -607,7 +607,7 @@ Sentry.withScope(function(scope) {
 For more information, see [Setting the Level](#level).
 
 ### Lazy Loading Sentry
-We recommend using our bundled CDN version for the browser as explained [here]({% link _documentation/error-reporting/quickstart.md %}?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer` you can, though keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
+We recommend using our bundled CDN version for the browser as explained [here]({% link _documentation/error-reporting/quickstart.md %}?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer`, you can, though keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
 
 We also offer an alternative we call the _Loader_. You install by just adding this script to your website instead of the SDK bundle. This line is everything you need; the script is <1kB gzipped and includes the `Sentry.init` call with your DSN.
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -14,6 +14,15 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
   crossorigin="anonymous"></script>
 ```
 
+{% capture __alert_content -%}
+It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). It is therefore recommended that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Use of `defer`"
+  content=__alert_content
+  level="warning"
+%}
+
 You can also add the Sentry SDK as a dependency using npm:
 
 ``` bash
@@ -598,9 +607,9 @@ Sentry.withScope(function(scope) {
 For more information, see [Setting the Level](#level).
 
 ### Lazy Loading Sentry
-We recommend using our bundled CDN version for the browser as explained [here]({% link _documentation/error-reporting/quickstart.md %}?platform=browser#pick-a-client-integration).
+We recommend using our bundled CDN version for the browser as explained [here]({% link _documentation/error-reporting/quickstart.md %}?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer` you can, though keep in mind that any errors which occur in scripts which execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
 
-But we also offer an alternative we call the _Loader_. You install by just adding this script to your website instead of the SDK bundle. This line is everything you need; the script is <1kB gzipped and includes the `Sentry.init` call with your DSN.
+We also offer an alternative we call the _Loader_. You install by just adding this script to your website instead of the SDK bundle. This line is everything you need; the script is <1kB gzipped and includes the `Sentry.init` call with your DSN.
 
 ```html
 <script src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Per https://app.asana.com/0/1144304343179777/1150463182095777/f, which came from me asking "Is this right?" in #discuss-sdks and Cramer saying, "That should be in the docs somewhere..."

I added it in three places:

1) The getting started page, where we tell people how to CDN.
2) The JS index page, where we tell people how to CDN.
3) An embed we don't seem to use, related to the JS index page.

Questions:

1) Does it belong in all of these places?
2) I don't super love how it's worded (it's adapted from an answer to a support ticket, and I fear it still sounds too conversational), so are there improvements I could make?
3) On the JS index page, I debated whether it should go in the Lazy Loading section instead, since it's kinnnnnnda related? But in the end that's not exactly what it is, and so I felt like I'd need to do more restructuring than I wanted to, and put it at the top. 
3b) That said, it's maybe not _as_ key a fact as its current placement would suggest (it's not a super common question) and so it really wants to move to some sort of FAQ eventually. I'll add it to the help center as well, but as for its home in the docs... what do you think?