### PR TITLE
updated Android alpha to beta

### DIFF
--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -2,7 +2,7 @@
 title: Android
 ---
 {% capture __alert_content -%}
-This version of the Android SDK is in alpha. Sentry has been offering an official SDK for Android for years now. If you are looking for the stable LTS support of Sentry, please refer to the 1.x and its [docs]({%- link _documentation/clients/java/integrations.md -%}#android).
+This version of the Android SDK is in beta. Sentry has been offering an official SDK for Android for years now. If you are looking for the stable LTS support of Sentry, please refer to the 1.x and its [docs]({%- link _documentation/clients/java/integrations.md -%}#android).
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"


### PR DESCRIPTION
Android SDK is now in beta. Updated the note at the top of the page to reflect this change.

![image](https://user-images.githubusercontent.com/25088225/70560156-f031ba80-1b3c-11ea-875c-98ef02b0621e.png)
