### PR TITLE
max_request_body_size instead of request-bodies

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -140,7 +140,7 @@ This option can be overridden using `in-app-include`.
 {% endsupported %}
 
 {:.config-key}
-### `request-bodies`
+### `max_request_body_size`
 
 {% supported python php %}
 This parameter controls if integrations should capture HTTP request bodies.  It can be set to one


### PR DESCRIPTION
php crashes on `request-bodies` and only knows `max_request_body_size`.
This is in `sentry/sentry (2.2.5)` pulled from https://github.com/getsentry/sentry-php using composer on //12-12-2019

My guess is this does not differ from python, which also supports this variable.

Stacktrace from Xdebug:
```
Fatal error: Uncaught Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException: The option "request_bodies" does not exist. Defined options are: "attach_stacktrace", "before_breadcrumb", "before_send", "capture_silenced_errors", "class_serializers", "context_lines", "default_integrations", "dsn", "enable_compression", "environment", "error_types", "excluded_exceptions", "http_proxy", "in_app_exclude", "integrations", "logger", "max_breadcrumbs", "max_request_body_size", "max_value_length", "prefixes", "project_root", "release", "sample_rate", "send_attempts", "send_default_pii", "server_name", "tags". in C:\Users\Harm Zeinstra\workspace\prototyping\TreeCare\backend\vendor\symfony\options-resolver\OptionsResolver.php on line 798
```