### PR TITLE
Update Sensitive Data page with instructions for before-send (SDK)

### DIFF
--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -19,7 +19,7 @@ Turning this option on is required for certain features in Sentry to work, but a
 
 ## Custom Event Processing in the SDK
 
-In the SDKs, you can configure a `before-send` function which is invoked before an event is sent and can be used to modify the event data and remove sensitive data. Using `before-send` in SDKs to **scrub any data before it is attached** as a payload request to [sentry.io](http://sentry.io/) is the recommended scrubbing approach, as SD is not attached to the event and therefore never makes it to Sentry.
+In the SDKs, you can configure a `before-send` function which is invoked before an event is sent and can be used to modify the event data and remove sensitive data. Using `before-send` in the SDKs to **scrub any data before it is attached** as a payload request to [sentry.io](http://sentry.io/) is the recommended scrubbing approach, as SD is not attached to the event and therefore never makes it to Sentry.
 
 ```javascript
 Sentry.init({
@@ -35,10 +35,9 @@ Sentry.init({
 });
 ```
 
-- **Use `beforeSend` upon integration/introduction** of the Sentry SDK to see what is being sent and implement proper scrubbing in `beforeSend`
-- Look out for SD **in event information** (stacktrace, breadcrumbs, and other values the SDK is picking up such as headers/etc). Some things to look out for:
-    - Stack-locals → some SDKs (Python + PHP) will pick up variable values. This can be scrubbed or disabled altogether if necessary
-    - Breadcrumbs → some SDKs (e.g. JavaScript, Java logging integrations) will pick up previously executed log statements. Do not log PII if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed
+- Look out for SD **in event information** (stack trace, breadcrumbs, and other values the SDK is picking up such as headers/etc.) Some things to look out for:
+    - Stack-locals → some SDKs (Python + PHP), will pick up variable values. This can be scrubbed or disabled altogether, if necessary
+    - Breadcrumbs → some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed
 - Be **aware** of what is being attached to the event and **code review SDK changes,** including context carefully
     - Context → Tags (including User-context) + extra-info + breadcrumbs
 

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -87,7 +87,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     });
      ```
 
-- Logging PII/SD (if breadcrumbs include console/log statements)
+- Logging PII/SD (if using breadcrumbs, include console/log statements)
 
     Don't do:
     
@@ -95,7 +95,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     console.log("user's name is: " + user.name);
     ```
     
-    instead:
+    Instead:
     
     ```
     // 1. don't log SD/PII

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -19,7 +19,7 @@ Turning this option on is required for certain features in Sentry to work, but a
 
 ## Custom Event Processing in the SDK
 
-In the SDKs, you can configure a `before-send` function which is invoked before an event is sent and can be used to modify the event data and remove sensitive data. Using `before-send` in the SDKs to **scrub any data before it is attached** as a payload request to [sentry.io](http://sentry.io/) is the recommended scrubbing approach, as SD is not attached to the event and therefore never makes it to Sentry.
+In the SDKs, you can configure a `before-send` function, which is invoked before an event is sent and can be used to modify the event data and remove sensitive information. Using `before-send` in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, as SD never leaves the local environment.
 
 ```javascript
 Sentry.init({

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -50,17 +50,13 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     Don't do:
     
     ```javascript
-    Sentry.configureScope((scope) => {
-      Sentry.setTag('birthday', '08/03/1990');
-    });
+    Sentry.setTag('birthday', '08/03/1990');
     ```
     
     Instead, anonymize (by using `checksum`, `hash`, etc.):
     
     ```javascript
-    Sentry.configureScope((scope) => {
-      Sentry.setTag('birthday', checksum_or_hash('08/12/1990'));
-    });
+    Sentry.setTag('birthday', checksum_or_hash('08/12/1990'));
     ```
     
 - Attaching user/email information (if it is considered SD or not permitted)
@@ -68,24 +64,18 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     Don't do:
     
     ```javascript
-    Sentry.configureScope((scope) => {
-      scope.setUser({email: user.email});
-    });
+    Sentry.setUser({email: user.email});
     ```    
 
     Instead, anonymize (use `id`, `username`, etc.):
     
     ```javascript
-    Sentry.configureScope((scope) => {
-      Sentry.setUser({id: user.id});
-    });
+    Sentry.setUser({id: user.id});
     
     // or
     
-    Sentry.configureScope((scope) => {
-      Sentry.setUser({username: user.username});
-    });
-     ```
+    Sentry.setUser({username: user.username});
+    ```
 
 - Logging PII/SD (if using breadcrumbs, include console/log statements)
 

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -77,13 +77,13 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     
     ```javascript
     Sentry.configureScope((scope) => {
-      scope.setUser({id: user.id});
+      Sentry.setUser({id: user.id});
     });
     
     // or
     
     Sentry.configureScope((scope) => {
-      scope.setUser({username: user.username});
+      Sentry.setUser({username: user.username});
     });
      ```
 
@@ -100,7 +100,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     ```
     // 1. don't log SD/PII
     // 2. use `beforeBreadcrumb` to filter it out from breadcrumbs before it is attached
-    // 3. Disable logging breadcrumb integration (e.g. <https://docs.sentry.io/platforms/javascript/?platform=browser#alternative-way-of-setting-an-integration>)
+    // 3. Disable logging breadcrumb integration (e.g. <https://docs.sentry.io/platforms/javascript/?platform=browser#breadcrumbs-1>)
     ```
 
 ## Server-Side Scrubbing

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -69,7 +69,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     
     ```javascript
     Sentry.configureScope((scope) => {
-      scope.setUser({username: user.email});
+      scope.setUser({email: user.email});
     });
     ```    
 

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -59,7 +59,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     
     ```javascript
     Sentry.configureScope((scope) => {
-      scope.setTag('birthday', checksum_or_hash('08/12/1990'));
+      Sentry.setTag('birthday', checksum_or_hash('08/12/1990'));
     });
     ```
     

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -41,7 +41,7 @@ Sentry.init({
 - Be **aware** of what is being attached to the event and **code review SDK changes,** including context carefully
     - Context → Tags (including User-context) + extra-info + breadcrumbs
 
-See [_Filtering Events_]({%- link _documentation/error-reporting/configuration/filtering.md -%}) for more information.
+For more details, see [_Filtering Events_]({%- link _documentation/error-reporting/configuration/filtering.md -%}).
 
 ### Examples
 
@@ -55,7 +55,7 @@ See [_Filtering Events_]({%- link _documentation/error-reporting/configuration/f
     });
     ```
     
-    instead anonymize (by using checksum, hash, etc.):
+    Instead, anonymize (by using `checksum`, `hash`, etc.):
     
     ```javascript
     Sentry.configureScope((scope) => {
@@ -63,7 +63,7 @@ See [_Filtering Events_]({%- link _documentation/error-reporting/configuration/f
     });
     ```
     
-- Attaching user/email information (if that is considered SD or not permitted)
+- Attaching user/email information (if it is considered SD or not permitted)
 
     Don't do:
     
@@ -73,7 +73,7 @@ See [_Filtering Events_]({%- link _documentation/error-reporting/configuration/f
     });
     ```    
 
-    instead anonymize (use id, username, etc.)
+    Instead, anonymize (use `id`, `username`, etc.):
     
     ```javascript
     Sentry.configureScope((scope) => {

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -51,7 +51,7 @@ For more details, see [_Filtering Events_]({%- link _documentation/error-reporti
     
     ```javascript
     Sentry.configureScope((scope) => {
-      scope.setTag('birthday', '08/03/1990');
+      Sentry.setTag('birthday', '08/03/1990');
     });
     ```
     

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -19,7 +19,7 @@ Turning this option on is required for certain features in Sentry to work, but a
 
 ## Custom Event Processing in the SDK
 
-In the SDKs you can configure a `before-send` function which is invoked before an event is sent and can be used to modify the event data and remove sensitive data. Using `before-send` in SDKs to **scrub any data before it is attached** as a payload request to [sentry.io](http://sentry.io/) is the recommended scrubbing approach, as SD is not attached to the event and therefore never makes to Sentry.
+In the SDKs, you can configure a `before-send` function which is invoked before an event is sent and can be used to modify the event data and remove sensitive data. Using `before-send` in SDKs to **scrub any data before it is attached** as a payload request to [sentry.io](http://sentry.io/) is the recommended scrubbing approach, as SD is not attached to the event and therefore never makes it to Sentry.
 
 ```javascript
 Sentry.init({
@@ -80,23 +80,29 @@ See [_Filtering Events_]({%- link _documentation/error-reporting/configuration/f
     Sentry.configureScope((scope) => {
       scope.setUser({id: user.id});
     });
+    
     // or
+    
     Sentry.configureScope((scope) => {
       scope.setUser({username: user.username});
     });
-     ```   
+     ```
 
 - Logging PII/SD (if breadcrumbs include console/log statements)
 
     Don't do:
-
-        console.log("user's name is: " + user.name);
-
+    
+    ```javascript
+    console.log("user's name is: " + user.name);
+    ```
+    
     instead:
-
-        // 1. don't log SD/PII
-        // 2. use `beforeBreadcrumb` to filter it out from breadcrumbs before it is attached
-        // 3. Disable logging breadcrumb integration (e.g. <https://docs.sentry.io/platforms/javascript/?platform=browser#alternative-way-of-setting-an-integration>)
+    
+    ```
+    // 1. don't log SD/PII
+    // 2. use `beforeBreadcrumb` to filter it out from breadcrumbs before it is attached
+    // 3. Disable logging breadcrumb integration (e.g. <https://docs.sentry.io/platforms/javascript/?platform=browser#alternative-way-of-setting-an-integration>)
+    ```
 
 ## Server-Side Scrubbing
 


### PR DESCRIPTION
Sensitive Data page was missing a code snippet and additional instructions regarding `before-send`. Updated to include them.

![image](https://user-images.githubusercontent.com/25088225/70952652-b9b3de00-201b-11ea-8968-a9221159827b.png)