### PR TITLE
separate-legacy-from-global-alert-integrations

### DIFF
--- a/src/collections/_documentation/workflow/notifications/index.md
+++ b/src/collections/_documentation/workflow/notifications/index.md
@@ -58,6 +58,11 @@ Sentry provides a few states for each issue, which significantly impacts how not
 
 ## Integrations with Notifications
 
+Global Integrations that can send Notifications:
+- [PagerDuty]({%- link _documentation/workflow/integrations/global-integrations.md -%}#pagerduty)
+- [Slack]({%- link _documentation/workflow/integrations/global-integrations.md -%}#slack)
+
+
 Legacy Integrations (via "Service" as any individual integration) that can send Notifications:
 
 {% include components/alert.html
@@ -69,9 +74,7 @@ Legacy Integrations (via "Service" as any individual integration) that can send 
 - Campfire*
 - IRC
 - OpsGenie
-- [PagerDuty]({%- link _documentation/workflow/integrations/global-integrations.md -%}#pagerduty)
 - Pushover
-- [Slack]({%- link _documentation/workflow/integrations/global-integrations.md -%}#slack)
 - Twilio
 - VictorOps
 


### PR DESCRIPTION
Both Slack and PagerDuty were previous under the Legacy Integrations section which doesn't exactly make sense since `(via "Service" as any individual integration)` is inaccurate.

![Screen Shot 2019-12-17 at 10 03 46 AM](https://user-images.githubusercontent.com/15368179/71022230-da7c4200-20b4-11ea-8146-0aa3d7255419.png)
