### PR TITLE
Use SetExtras() on scope instead of package

### DIFF
--- a/src/collections/_documentation/platforms/go/migration.md
+++ b/src/collections/_documentation/platforms/go/migration.md
@@ -357,7 +357,7 @@ path := "filename.ext"
 f, err := os.Open(path)
 if err != nil {
 	sentry.WithScope(func(scope *sentry.Scope) {
-		sentry.SetExtras(map[string]interface{}{"path": path, "cwd": os.Getwd()})
+		scope.SetExtras(map[string]interface{}{"path": path, "cwd": os.Getwd()})
 		sentry.CaptureException(err)
 	})
 }


### PR DESCRIPTION
The called method SetExtras() can only be called on the scope, not as previously noted on the package level