### PR TITLE
going from above to below

### DIFF
--- a/src/collections/_documentation/platforms/go/index.md
+++ b/src/collections/_documentation/platforms/go/index.md
@@ -71,7 +71,7 @@ func main() {
 ```
 
 {% capture __alert_content -%}
-  By default, Sentry Go SDK uses an asynchronous transport, which in the code example below requires an explicit awaiting for event delivery to be finished using the `sentry.Flush` method. It is necessary, because otherwise the program would not wait for the async HTTP calls to return a response, and exit the process immediately when it reached the end of the `main` function. It would not be required inside a running goroutine or if you would use `HTTPSyncTransport`, which you can read about in the `Transports` section.
+  By default, Sentry Go SDK uses an asynchronous transport, which in the code example above requires an explicit awaiting for event delivery to be finished using the `sentry.Flush` method. It is necessary, because otherwise the program would not wait for the async HTTP calls to return a response, and exit the process immediately when it reached the end of the `main` function. It would not be required inside a running goroutine or if you would use `HTTPSyncTransport`, which you can read about in the `Transports` section.
 {%- endcapture -%}
 {%- include components/alert.html
 	level="info"


### PR DESCRIPTION
The warning block renders below the code example, but refers to _the example below_, when there isn't any. So rather than moving the block above the code example, I just changed the word **below** to **above**.

Happy Holidays 🎅🎊🎄