### PR TITLE
Fix broken linking in config.md

### DIFF
--- a/src/collections/_documentation/clients/java/config.md
+++ b/src/collections/_documentation/clients/java/config.md
@@ -41,7 +41,7 @@ import io.sentry.Sentry;
 Sentry.init("https://public:private@host:port/1");
 ```
 
-## Configuration methods {#id2}
+## Configuration methods {#configuration-methods}
 
 There are multiple ways to configure the Java SDK, but all of them take the same options. See below for how to use each configuration method and how the option names might differ between them.
 


### PR DESCRIPTION
The aforementioned paragraph is trying to link to #configuration-methods. See https://docs.sentry.io/clients/java/config/#setting-the-dsn