### PR TITLE
Update express.md, flushTimeout default is not 2000

### DIFF
--- a/src/collections/_documentation/platforms/node/express.md
+++ b/src/collections/_documentation/platforms/node/express.md
@@ -72,7 +72,7 @@ user?: boolean | string[]; // default: true = ['id', 'username', 'email']
 // node version
 version?: boolean; // default: true
 // timeout for fatal route errors to be delivered
-flushTimeout?: number; // default: 2000
+flushTimeout?: number; // default: undefined
 ```
 
 For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:


### PR DESCRIPTION
The default value for flushTimeout is not 2000, it is undefined: 
https://github.com/getsentry/sentry-javascript/blob/645ff532941d9a23bb6531c6305e99544b356502/packages/node/src/handlers.ts#L293