### PR TITLE
docs(plugins): update plugin listing and add Asana instructions

### DIFF
--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -111,7 +111,7 @@ You'll have to create an application in Asana to get a client ID and secret. Use
 
     <URL_TO_SENTRY>/account/settings/social/associate/complete/asana/
 
-Ensure you've configured Asana auth in Sentry::
+Ensure you've configured Asana auth in Sentry:
 
     ASANA_CLIENT_ID = 'Asana Client ID'
     ASANA_CLIENT_SECRET = 'Asana Client Secret'

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -47,20 +47,17 @@ All official plugins are tested against the latest version of Sentry, and compat
 
 -   Amazon SQS
 -   Asana
--   Clubhouse
 -   Heroku
 -   Pagerduty
 -   Phabricator
 -   Pivotal
 -   Pushover
+-   Redmine
 -   Segment
 -   Sessionstack
 -   Splunk
+-   Trello
 -   Victorops
--   [Flowdock](https://github.com/getsentry/sentry-flowdock)
--   [IRC](https://github.com/getsentry/sentry-irc)
--   [Redmine](https://github.com/getsentry/sentry-redmine)
--   [Trello](https://github.com/getsentry/sentry-trello)
 
 Most of the official plugins can be found in the [official sentry plugins repository](https://github.com/getsentry/sentry-plugins).
 
@@ -68,20 +65,23 @@ Most of the official plugins can be found in the [official sentry plugins reposi
 
 The following plugins are deprecated and have been replaced with Sentry's built in [Global Integrations]({%- link _documentation/workflow/integrations/index.md -%}).
 
-* Slack
+* Bitbucket
+* Clubhouse
 * GitHub
 * GitLab
-* Bitbucket
-* Visual Studio Team Services
 * Jira
+* Slack
+* Visual Studio Team Services
 
 ## 3rd Party Plugins {#rd-party-plugins}
 
-The following plugins are available and maintained by members of the Sentry community:
+The following plugins are available and were created by members of the Sentry community. Please note that many of these plugins have not been maintained may not work with the latest versions of sentry.
 
 -   [sentry-campfire](https://github.com/mkhattab/sentry-campfire)
+-   [sentry-flowdock](https://github.com/glasslion/sentry-flowdock)
 -   [sentry-fogbugz](https://github.com/glasslion/sentry-fogbugz)
 -   [sentry-groveio](https://github.com/mattrobenolt/sentry-groveio)
+-   [sentry-irc](https://github.com/getsentry/sentry-irc)
 -   [sentry-irccat](https://github.com/russss/sentry-irccat)
 -   [sentry-lighthouse](https://github.com/gthb/sentry-lighthouse)
 -   [sentry-msteams](https://github.com/Neko-Design/sentry-msteams)
@@ -100,3 +100,18 @@ The following plugins are available and maintained by members of the Sentry comm
 -   [sentry-youtrack](https://github.com/bogdal/sentry-youtrack)
 -   [sentry-zabbix](https://github.com/m0n5t3r/sentry-zabbix)
 -   [sentry-zendesk](https://github.com/ESSS/sentry-zendesk)
+
+## Setup
+
+Many of these plugins require configuration to work. The instruction on how to configure your environment for these plugins are contianed below.
+
+### Asana
+
+You'll have to create an application in Asana to get a client ID and secret. Use the following for the redirect URL:
+
+    <URL_TO_SENTRY>/account/settings/social/associate/complete/asana/
+
+Ensure you've configured Asana auth in Sentry::
+
+    ASANA_CLIENT_ID = 'Asana Client ID'
+    ASANA_CLIENT_SECRET = 'Asana Client Secret'

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -75,7 +75,7 @@ The following plugins are deprecated and have been replaced with Sentry's built 
 
 ## 3rd Party Plugins {#rd-party-plugins}
 
-The following plugins are available and were created by members of the Sentry community. Please note that many of these plugins have not been maintained may not work with the latest versions of Sentry.
+The following plugins are available and were created by members of the Sentry community. Please note that many of these plugins have not been maintained and may not work with the latest versions of Sentry.
 
 -   [sentry-campfire](https://github.com/mkhattab/sentry-campfire)
 -   [sentry-flowdock](https://github.com/glasslion/sentry-flowdock)

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -103,7 +103,7 @@ The following plugins are available and were created by members of the Sentry co
 
 ## Setup
 
-Many of these plugins require configuration to work. The instruction on how to configure your environment for these plugins are contianed below.
+Many of these plugins require configuration to work. The instructions on how to configure your environment for these plugins are below.
 
 ### Asana
 

--- a/src/collections/_documentation/server/plugins.md
+++ b/src/collections/_documentation/server/plugins.md
@@ -75,7 +75,7 @@ The following plugins are deprecated and have been replaced with Sentry's built 
 
 ## 3rd Party Plugins {#rd-party-plugins}
 
-The following plugins are available and were created by members of the Sentry community. Please note that many of these plugins have not been maintained may not work with the latest versions of sentry.
+The following plugins are available and were created by members of the Sentry community. Please note that many of these plugins have not been maintained may not work with the latest versions of Sentry.
 
 -   [sentry-campfire](https://github.com/mkhattab/sentry-campfire)
 -   [sentry-flowdock](https://github.com/glasslion/sentry-flowdock)


### PR DESCRIPTION
With plugin repos being archived, that information needed to be propagated here Our Asana plugin has instructions for on-prem users so they should be added here. I did not add instructions the existing instructions for BitBucket and Jira because those are deprecated and have replacements.