### PR TITLE
fix(build): xmlsec wheel requires libxmlsec1 deb package

### DIFF
--- a/Dockerfile.apidocs
+++ b/Dockerfile.apidocs
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libpq-dev \
     libxml2-dev \
+    libxmlsec1-dev \
     libxslt-dev \
     libyaml-dev \
     llvm \


### PR DESCRIPTION
`sentry:apidocs` needs libxmlsec1 for pip to build the wheel for xmlsec.

Should fix `bin/update-api-docs` (`docker run --rm sentry:apidocs`).