### PR TITLE
Separate integrations by maintainer

### DIFF
--- a/src/collections/_documentation/workflow/integrations/index.md
+++ b/src/collections/_documentation/workflow/integrations/index.md
@@ -9,21 +9,23 @@ Sentry integrates seamlessly with your favorite apps and services.
 
 These integrations are set up once per organization, and are then usable in all projects.
 
--   [_Amixr_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#amixr)
 -   [_Azure DevOps_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#azure-devops)
 -   [_Bitbucket_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#bitbucket)
--   [_ClickUp_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#clickup)
--   [_Clubhouse_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#clubhouse)
 -   [_GitHub_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#github)
 -   [_GitHub Enterprise_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#github-enterprise)
 -   [_GitLab_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#gitlab)
 -   [_JIRA_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#jira)
 -   [_JIRA Server_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#jira-server)
 -   [_PagerDuty_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#pagerduty)
--   [_Rookout_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#rookout)
 -   [_Slack_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#slack)
--   [_Split_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#split)
 
+These integrations are maintained and supported by the companies that created them. See [integration platform]({%- link _documentation/workflow/integrations/integration-platform/index.md -%}).
+
+-   [_Amixr_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#amixr)
+-   [_ClickUp_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#clickup)
+-   [_Clubhouse_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#clubhouse)
+-   [_Rookout_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#rookout)
+-   [_Split_]({%- link _documentation/workflow/integrations/global-integrations.md -%}#split)
 
 ### Per-Project Integrations
 


### PR DESCRIPTION
Visually separate the Sentry created integrations from the ones created by a 3rd party to make it clear which ones we support and maintain.

How it looks currently:
<img width="783" alt="Screenshot 2019-11-27 13 34 26" src="https://user-images.githubusercontent.com/29959063/72180862-f1087700-339c-11ea-8c01-cb7bb64294df.png">
How it'll look:
<img width="778" alt="Screenshot 2020-01-10 11 43 12" src="https://user-images.githubusercontent.com/29959063/72182424-485c1680-33a0-11ea-8c1b-ab8c45da44f7.png">

