### PR TITLE
Clarify that releases are org wide

### DIFF
--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -16,7 +16,7 @@ Because releases work on projects you will need to specify the organization and 
 
 ## Creating Releases
 
-Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the relases. It can be arbitrary but for certain platforms recommendations exist:
+Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions - the release name cannot contain newlines, spaces, or "\", be ".", "..", or exceed 200 characters. The value can be arbitrary but for certain platforms recommendations exist:
 
 - for mobile devices use `VERSION_NUMBER` or `VERSION_NUMBER (BUILD_NUMBER)`. So for instance `1.0.0` or `1.0.0 (1234)`.
 - if you use a DVCS we recommed using the identifying hash (eg: the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let sentry-cli automatically determine this hash for supported version control systems with `sentry-cli releases propose-version`.

--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -3,7 +3,7 @@ title: 'Release Management'
 sidebar_order: 2
 ---
 
-The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them.
+The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization, so make sure to prefix them with something project-specific if multiple projects' version numbers overlap.
 
 {% capture __alert_content -%}
 Because releases work on projects you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).

--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -10,7 +10,7 @@ Because releases work on projects you will need to specify the organization and 
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"
-  content=__alert_con	tent
+  content=__alert_content
   level="warning"
 %}
 

--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -3,14 +3,14 @@ title: 'Release Management'
 sidebar_order: 2
 ---
 
-The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization, so if you want the releases in different projects to be treated as separate entities, you should make the version name unique across the organization.
+The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization, so if you want the releases in different projects to be treated as separate entities, you should make the version name unique across the organization. For example, if you have projectA and projectB that share version numbers, you can name the releases `projectA-1.0` and `projectB-1.0` respectively.
 
 {% capture __alert_content -%}
 Because releases work on projects you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"
-  content=__alert_content
+  content=__alert_con	tent
   level="warning"
 %}
 

--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -3,7 +3,7 @@ title: 'Release Management'
 sidebar_order: 2
 ---
 
-The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization, so make sure to prefix them with something project-specific if multiple projects' version numbers overlap.
+The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization, so if you want the releases in different projects to be treated as separate entities, you should make the version name unique across the organization.
 
 {% capture __alert_content -%}
 Because releases work on projects you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).

--- a/src/collections/_documentation/enriching-error-data/environments.md
+++ b/src/collections/_documentation/enriching-error-data/environments.md
@@ -31,3 +31,5 @@ If you want to change the name of a given environment, you will have to modify y
 Environment data is sent to Sentry by tagging issues via your SDK:
 
 {% include components/platform_content.html content_dir='set-environment' %}
+
+There are a few restrictions - the environment name cannot contain newlines or spaces, cannot be the string "None", or exceed 64 characters.

--- a/src/collections/_documentation/workflow/releases.md
+++ b/src/collections/_documentation/workflow/releases.md
@@ -27,6 +27,8 @@ Setting up releases fully is a 4-step process:
 
 Include a release ID (a.k.a version) where you configure your client SDK. This is commonly a git SHA or a custom version number.
 
+There are a few restrictions - the release name cannot contain newlines, spaces, or "\", be ".", "..", or exceed 200 characters.
+
 {% capture __alert_content -%}
 Releases are global per organization, so make sure to prefix them with something project-specific.
 {%- endcapture -%}


### PR DESCRIPTION
Sometimes users are confused when they don't realize releases are scoped to the organization rather than a project. If you have 2 projects that use the same versioning like project A and B both have 1.5.6 it can be confusing, so we'd recommend they do `projectA-1.5.6` and `projectB-1.5.6` or something.