### PR TITLE
ref: Update and clarify member roles

### DIFF
--- a/src/collections/_documentation/accounts/membership.md
+++ b/src/collections/_documentation/accounts/membership.md
@@ -3,54 +3,54 @@ title: Organization Management
 sidebar_order: 1
 ---
 
-## Membership
+# Membership
 
-User membership in Sentry is handled at the organizational level. The system is
-designed so each user has a singular account which can be reused across
-multiple organizations (even those using SSO). Each user of Sentry should have
-their own account, and will then be able to set their personal preferences
-in addition to receiving notifications for events.
+User membership in Sentry is handled at the organizational level.
+The system is designed so each user has a single Sentry account,
+which can then join one or more organizations. Each user should have
+their own account, where they can manage their personal preferences,
+including notification and security settings.
 
-### Roles
+## Roles
 
-Access to organizations is dictated by roles. Your role is scoped to an entire organization.
+Access within an organization is dictated by member roles.
 
-Roles include:
+### Owner
+ - Unrestricted access to the organization, its data, and settings.
+ - Can add, modify, and delete projects and members, as well as make billing and plan changes.
+ - Can delete an organization.
 
-: -   Owner
-  -   Manager
-  -   Admin
-  -   Member
-  -   Billing
+### Manager
+ - Gains admin access on all teams.
+ - Can add and remove members from the organization.
 
-| Action | Billing | Member | Admin | Manager | Owner |
-| --- | --- | --- | --- | --- | --- |
-| Can see/edit billing information and subscription details | X |   |   |   | X |
-| Can view and act on issues, such as assigning/resolving/etc. |   | X | X | X | X |
-| Can join and leave teams. |   | X | X | X | X |
-| Can change Project Settings |   |   | X | X | X |
-| Can add/remove projects* |   |   | X | X | X |
-| Can edit Global Integrations |   |   | X | X | X |
-| Can add/remove/change members |   |   |   | X | X |
-| Can add/remove teams* |   |   | X | X | X |
-| Can add Repositories |   |   | X | X | X |
-| Can delete Repositories |   |   |   |   | X |
-| Can change Organization Settings |   |   |   | X | X |
-| Can remove an Organization |   |   |   |   | X |
+### Admin
+ - Admin access only on teams they're a member of. 
+ - Can create new teams and projects, as well as remove teams and projects they're a member of.
 
-\* Admins can only remove teams and projects they're a member of (or all teams, if open membership is on).
+### Member
+ - Can view and act on events, as well as view most other data within the organization.
 
-### Restricting Access
+### Billing
+ - Can manage subscription and billing details.
 
--   Access to Organizations is dictated by Roles, which is scoped to an entire Organization.
--   Access to a Project is limited to the Team that owns the project. However, any Member, Admin, Manager or Owner can join a Team.
--   If you want to further restrict access to a Project, you can control access to Teams by making them accessible only through invitation by a Manager or Owner.
+## Open Membership
+
+Open membership is enabled by default, which allows members to freely join,
+leave and add other members to teams.
+
+## Restricting Access
+
+- Access to a Project is limited to the Team that owns the project. However, with open membership,
+members can freely join and add members to teams.
+- To further restrict access to a Project, you can control access to Teams by making them accessible
+only through invitation by a Manager, Owner or Team Admin.
 
 To restrict Team access, go to Organization Settings and flip the “Open Membership” toggle.
 
 {% asset membership-toggle.png %}
 
-## Transferring a project
+# Transferring a project
 
 To transfer a project go to the target project's Project Settings >> General
 Settings >> Transfer Project. Enter the email of the organization's owner you
@@ -58,7 +58,7 @@ wish to transfer it to, and they'll receive an email to approve the transfer.
 When the project is transferred to the new organization, it's recommended to
 add it to a team for better visibility.
 
-## Removing an Organization
+# Removing an Organization
 
 It is possible to remove an organization and all associated
 organization data completely. Doing so will *not* remove user accounts, but will remove

--- a/src/collections/_documentation/accounts/membership.md
+++ b/src/collections/_documentation/accounts/membership.md
@@ -13,7 +13,7 @@ including notification and security settings.
 
 ## Roles
 
-Access within an organization is dictated by member roles.
+Member roles dictate access within an organization.
 
 ### Owner
  - Unrestricted access to the organization, its data, and settings.
@@ -36,15 +36,14 @@ Access within an organization is dictated by member roles.
 
 ## Open Membership
 
-Open membership is enabled by default, which allows members to freely join,
-leave and add other members to teams.
+Open membership is enabled by default, which allows members to join, leave, and add other members to teams.
 
 ## Restricting Access
 
 - Access to a Project is limited to the Team that owns the project. However, with open membership,
-members can freely join and add members to teams.
+members can join and add members to teams.
 - To further restrict access to a Project, you can control access to Teams by making them accessible
-only through invitation by a Manager, Owner or Team Admin.
+only through invitation by a Manager, Owner, or Team Admin.
 
 To restrict Team access, go to Organization Settings and flip the “Open Membership” toggle.
 


### PR DESCRIPTION
- Update for the docs around open membership. Members can now join, leave, and *add other members to* teams if open membership is enabled.
- Removes the table for member roles and replaces it with a more general explanation of each role. I found the current table confusing, since roles can have different permissions depending on open/closed membership and whether an Admin is already in a team or not.

cc/ @ceorourke @mbauer404 Wondering what you think about removing the table. Okay with adding it back if you think it's helpful