### PR TITLE
fix: Don't mention Request

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/contexts.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/contexts.md
@@ -4,7 +4,7 @@ sidebar_order: 9
 ---
 
 The context interfaces provide additional context data. Typically, this is data
-related to the current user, the current HTTP request. Its canonical name is
+related to the current user and the environment, like the device or application version. Its canonical name is
 `contexts`.
 
 The `contexts` type can be used to define arbitrary contextual data on the

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/contexts.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/contexts.md
@@ -4,7 +4,7 @@ sidebar_order: 9
 ---
 
 The context interfaces provide additional context data. Typically, this is data
-related to the current user and the environment, like the device or application version. Its canonical name is
+related to the current user and the environment. For example, the device or application version. Its canonical name is
 `contexts`.
 
 The `contexts` type can be used to define arbitrary contextual data on the


### PR DESCRIPTION
It's confusing to say it's related to `Request` since [the `Request` interface hangs off of the event](https://docs.sentry.io/development/sdk-dev/event-payloads/request/) directly and is not part of the context.

Happy to rephrase it, just would like not to say `Request` here.