### PR TITLE
Add installation instructions for CLI via Scoop

### DIFF
--- a/src/collections/_documentation/cli/index.md
+++ b/src/collections/_documentation/cli/index.md
@@ -9,6 +9,7 @@ For certain actions, you can use the `sentry-cli` command line executable. It ca
     -   [Automatic Installation]({%- link _documentation/cli/installation.md -%}#automatic-installation)
     -   [Installation via NPM]({%- link _documentation/cli/installation.md -%}#installation-via-npm)
     -   [Installation via Homebrew]({%- link _documentation/cli/installation.md -%}#installation-via-homebrew)
+    -   [Installation via Scoop]({%- link _documentation/cli/installation.md -%}#installation-via-scoop)
     -   [Docker Image]({%- link _documentation/cli/installation.md -%}#docker-image)
     -   [Updating and Uninstalling]({%- link _documentation/cli/installation.md -%}#updating-and-uninstalling)
 -   [Configuration and Authentication]({%- link _documentation/cli/configuration.md -%})

--- a/src/collections/_documentation/cli/installation.md
+++ b/src/collections/_documentation/cli/installation.md
@@ -85,6 +85,14 @@ If you are on OS X, you can install `sentry-cli` via homebrew:
 $ brew install getsentry/tools/sentry-cli
 ```
 
+## Installation via Scoop
+
+If you are on Windows, you can install `sentry-cli` via [Scoop](https://scoop.sh):
+
+```powershell
+> scoop install sentry-cli
+```
+
 ## Docker Image
 
 For unsupported distributions and CI systems, we offer a Docker image that comes with `sentry-cli` preinstalled. It is recommended to use the `latest` tag, but you can also pin to a specific version. By default, the command runs inside the `/work` directory. Mount relevant project folders and build outputs there to allow `sentry-cli` to scan for resources:


### PR DESCRIPTION
Hi there! I created a [Scoop](https://scoop.sh) manifest for easy installation of sentry-cli on Windows, and it's PRd over at ScoopInstaller/Main#738. It would be great to see this documented once it's live!