### PR TITLE
Added alert box to IP Ranges page

### DIFF
--- a/src/ip-ranges.md
+++ b/src/ip-ranges.md
@@ -3,7 +3,7 @@ title: 'IP Ranges'
 ---
 
 {% capture __alert_content -%}
-The contents of this page only apply to Sentry's SaaS product. It **does not** apply to on-premise or single tenant.
+The contents of this page only apply to Sentry's SaaS product. It **does not** apply to On-Premise or Single Tenant.
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"

--- a/src/ip-ranges.md
+++ b/src/ip-ranges.md
@@ -2,6 +2,15 @@
 title: 'IP Ranges'
 ---
 
+{% capture __alert_content -%}
+The contents of this page only apply to Sentry's SaaS product. It does not apply to on-premise or single tenant.
+{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 Sentry is served from a single IP address for all web traffic and all event accepting. The IP address is:
 
 ```python

--- a/src/ip-ranges.md
+++ b/src/ip-ranges.md
@@ -3,7 +3,7 @@ title: 'IP Ranges'
 ---
 
 {% capture __alert_content -%}
-The contents of this page only apply to Sentry's SaaS product. It **does not** apply to On-Premise or Single Tenant.
+The contents of this page only apply to Sentry's SaaS product. It **does not** apply to Self-hosted or Single Tenant.
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"

--- a/src/ip-ranges.md
+++ b/src/ip-ranges.md
@@ -3,7 +3,7 @@ title: 'IP Ranges'
 ---
 
 {% capture __alert_content -%}
-The contents of this page only apply to Sentry's SaaS product. It does not apply to on-premise or single tenant.
+The contents of this page only apply to Sentry's SaaS product. It **does not** apply to on-premise or single tenant.
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"


### PR DESCRIPTION
Our IP Ranges page only applies to the SaaS product -- not on-prem or single tenant. Added the alert box to give readers the correct expectations.

![image](https://user-images.githubusercontent.com/25088225/72849309-45440e80-3c5b-11ea-8374-efcc9c306c2f.png)
