### PR TITLE
meta: add keepalive timeout of 3600s to nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,8 @@ server {
   gzip_static on;
   gzip_vary on;
 
+  keepalive_timeout 3600s;
+
   error_page 404 /404/index.html;
   error_page 403 =404 /404/index.html;
   root /usr/share/nginx/html;


### PR DESCRIPTION
This adds a keepalive timeout of 3600s to the docs nginx config to help us out over in ops-land.