### PR TITLE
meta: update jekyll-base to 2020.01.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-ARG VERSION=2019.05.08
+ARG VERSION=2020.01.23
 FROM getsentry/jekyll-base:builder-${VERSION} AS builder
 FROM getsentry/jekyll-base:runtime-${VERSION} AS runtime


### PR DESCRIPTION
This updates our jekyll-base images to use 2020.01.23