### PR TITLE
fix(docs): Word joiner characters have width in Safari. Enforce 0 width on elements with .no-break

### DIFF
--- a/src/_assets/css/_includes/type.scss
+++ b/src/_assets/css/_includes/type.scss
@@ -132,6 +132,8 @@ dd {
 //
 .no-break {
   white-space: nowrap;
+  display: inline-block;
+  width: 0;
 
   &::after {
     content: '\2060';


### PR DESCRIPTION
Before:

<img width="1436" alt="Screen Shot 2020-01-23 at 7 48 09 PM" src="https://user-images.githubusercontent.com/139499/73036530-cb0db880-3e19-11ea-9348-f1f8f1c43ee8.png">

After:

<img width="1436" alt="Screen Shot 2020-01-23 at 7 48 48 PM" src="https://user-images.githubusercontent.com/139499/73036535-cf39d600-3e19-11ea-9548-cca3d40aec56.png">
