### PR TITLE
Use Dependency Injection for User Feedback on ASP.NET Core

### DIFF
--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
@@ -16,7 +16,7 @@ With ASP.NET Core MVC, the `Error.cshtml` razor page:
 }
 ```
 
-If you configured Sentry without Dependency Injection (e.g. without `UseSentry()`) you can also configure the SDK using a hard-coded DSN in the template:
+If you configured Sentry without the Dependency Injection (for example, without `UseSentry()`) you can also configure the SDK using a hard-coded DSN in the template:
 
 ```js
 Sentry.init({ dsn: '___PUBLIC_DSN___' });

--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
@@ -5,11 +5,12 @@ With ASP.NET Core MVC, the `Error.cshtml` razor page:
 <script src="https://browser.sentry-cdn.com/{% sdk_version sentry.javascript.browser %}/bundle.min.js" integrity="{% sdk_cdn_checksum sentry.javascript.browser latest bundle.min.js %}" crossorigin="anonymous"></script>
 
 @using Sentry
+@inject IOptions<SentryAspNetCoreOptions> SentryOptions
 
 @if (SentrySdk.LastEventId != Guid.Empty)
 {
     <script>
-        Sentry.init({ dsn: '___PUBLIC_DSN___' });
+        Sentry.init({ dsn: '@(SentryOptions.Value.Dsn)' });
         Sentry.showReportDialog({ eventId: '@SentrySdk.LastEventId' });
     </script>
 }

--- a/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
+++ b/src/collections/_documentation/enriching-error-data/user-feedback-example/aspnetcore.md
@@ -15,3 +15,9 @@ With ASP.NET Core MVC, the `Error.cshtml` razor page:
     </script>
 }
 ```
+
+If you configured Sentry without Dependency Injection (e.g. without `UseSentry()`) you can also configure the SDK using a hard-coded DSN in the template:
+
+```js
+Sentry.init({ dsn: '___PUBLIC_DSN___' });
+```


### PR DESCRIPTION
The documentation should avoid using hard-coded DSNs in places where configuration settings are available as a single source of truth.