### PR TITLE
(fix): Escape backslash in workflow release docs

### DIFF
--- a/src/collections/_documentation/workflow/releases.md
+++ b/src/collections/_documentation/workflow/releases.md
@@ -27,7 +27,7 @@ Setting up releases fully is a 4-step process:
 
 Include a release ID (a.k.a version) where you configure your client SDK. This is commonly a git SHA or a custom version number.
 
-There are a few restrictions -- the release name cannot contain newlines, spaces, or "\", be ".", "..", or exceed 200 characters.
+There are a few restrictions -- the release name cannot contain newlines, spaces, or "\\\", be ".", "..", or exceed 200 characters.
 
 {% capture __alert_content -%}
 Releases are global per organization, so make sure to prefix them with something project-specific.


### PR DESCRIPTION
I fixed this on the cli page in https://github.com/getsentry/sentry-docs/pull/1451 but forgot to update this here as well. 