### PR TITLE
Add configuration about vcs_remote

### DIFF
--- a/src/collections/_documentation/cli/configuration.md
+++ b/src/collections/_documentation/cli/configuration.md
@@ -96,6 +96,10 @@ The following settings are available (first is the environment variable, the val
 
 : The slug of the project to use for a command.
 
+`SENTRY_VCS_REMOTE` (_defaults.vcs_remote_):
+
+: The name of the _remote_ in the versioning control system. This defaults to `origin`.
+
 (_http.keepalive_):
 
 : This ini only setting is used to control the behavior of the SDK with regards to HTTP keepalives. The default is _true_ but it can be set to _false_ to disable keepalive support.


### PR DESCRIPTION
The configuration values in `.sentryclirc` file and in environment
variables have been added to the configuration documentation so
not only "origin" is usable as vcs remote.

This update is related to getsentry/sentry-cli#637, and it should be merged only once the pull request is accepted.