### PR TITLE
(fix) Reformat defer note in JS docs

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-install/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-install/browser.md
@@ -10,7 +10,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
-  title="Use of `defer`"
+  title="Use of defer"
   content=__alert_content
   level="warning"
 %}

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/browser.md
@@ -9,7 +9,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
-  title="Use of `defer`"
+  title="Use of defer"
   content=__alert_content
   level="warning"
 %}

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -18,7 +18,7 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 It's possible to include `defer` in your script tag, but keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). We strongly recommend that if you use `defer`, you a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), thereby guaranteeing that it’s executed before any of the others.
 {%- endcapture -%}
 {%- include components/alert.html
-  title="Use of `defer`"
+  title="Use of defer"
   content=__alert_content
   level="warning"
 %}


### PR DESCRIPTION
Code formatting doesn't appear to work in alert box titles, so remove this formatting.

**Before**:
![docs sentry io_platforms_javascript_](https://user-images.githubusercontent.com/29959063/73503131-3ad2f480-4380-11ea-8e1b-827fbf7abedd.png)

**After**:
![0 0 0 0_9001_platforms_javascript_](https://user-images.githubusercontent.com/29959063/73503132-3d354e80-4380-11ea-9797-7d7075610700.png)