### PR TITLE
added link to Discover v1

### DIFF
--- a/src/collections/_documentation/workflow/discover2/index.md
+++ b/src/collections/_documentation/workflow/discover2/index.md
@@ -4,7 +4,7 @@ sidebar_order: 4
 ---
 
 {% capture __alert_content -%}
-The following is documentation for our new query builder Discover v2. Discover v1 will deprecate at the end of February 2020.
+The following is documentation for our new query builder Discover v2. [Discover v1]({%- link _documentation/workflow/discover.md -%}) will deprecate at the end of February 2020.
 {%- endcapture -%}
 {%- include components/alert.html
     title="Note"


### PR DESCRIPTION
Updated the alert box at the top of Discover v2 and linked to Discover v1.

![image](https://user-images.githubusercontent.com/25088225/73695725-8abaff80-468f-11ea-9d40-73b4bba7a484.png)
