### PR TITLE
docs: Remove str->str contraint from breadcrumb.data description

### DIFF
--- a/src/collections/_documentation/enriching-error-data/breadcrumbs.md
+++ b/src/collections/_documentation/enriching-error-data/breadcrumbs.md
@@ -17,7 +17,7 @@ Message
 
 Data
 
-: A mapping (str => str) of metadata around the event. This is often used
+: A key-value mapping of metadata around the event. This is often used
   instead of message, but may also be used in addition.  All keys here are
   rendered out as table in the breadcrumb on display but some crumb types
   might special case some keys.


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/pull/2415

The only thing that has to be fixed is displaying `boolean` values, which has been already reported few months ago, and there's open issue here: https://github.com/getsentry/sentry/issues/16637

![image](https://user-images.githubusercontent.com/1523305/73942309-1bdbe180-48ef-11ea-8d03-e18ae02f49e4.png)
