### PR TITLE
fix: ASP.NET Core use PascalCase

### DIFF
--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -59,6 +59,7 @@
       name: ASP.NET Core
       wizard_parent: csharp
       wizard: true
+      case_style: PascalCase
       fallback_platform: csharp
 -
       slug: java


### PR DESCRIPTION
Format the config options correctly 

cc @bruno-garcia 