### PR TITLE
Update Android docs for GA release

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -294,6 +294,7 @@ Array [
   "license/index.html",
   "markdown-styleguide/links/index.html",
   "platforms/android/index.html",
+  "platforms/android/migrate/index.html",
   "platforms/dotnet/aspnetcore/index.html",
   "platforms/dotnet/entityframework/index.html",
   "platforms/dotnet/index.html",

--- a/src/collections/_documentation/clients/java/integrations.md
+++ b/src/collections/_documentation/clients/java/integrations.md
@@ -9,7 +9,7 @@ The Sentry Java SDK comes with support for some frameworks and libraries so that
 
 ### Features
 
-The Sentry Android SDK is built on top of the main Java SDK and supports all of the same features, [configuration options]({%- link _documentation/clients/java/config.md -%}), and more. Adding version `1.7.27` of the Android SDK to a sample application that doesn’t even use Proguard only increased the release `.apk` size by approximately 200KB.
+The Sentry Android SDK is built on top of the main Java SDK and supports all of the same features, [configuration options]({%- link _documentation/clients/java/config.md -%}), and more. Adding version `1.7.30` of the Android SDK to a sample application that doesn’t even use Proguard only increased the release `.apk` size by approximately 200KB.
 
 Events will be [buffered to disk]({%- link _documentation/clients/java/config.md -%}#buffering-events-to-disk) (in the application’s cache directory) by default. This allows events to be sent at a later time if the device does not have connectivity when an event is created. This can be disabled by [setting the option]({%- link _documentation/clients/java/config.md -%}#configuration) `buffer.enabled` to `false`.
 
@@ -27,14 +27,14 @@ By default the UI thread needs to be blocked for at least 5 seconds for an event
 Using Gradle (Android Studio) in your `app/build.gradle` add:
 
 ```groovy
-implementation 'io.sentry:sentry-android:1.7.27'
+implementation 'io.sentry:sentry-android:1.7.30'
 
 // this dependency is not required if you are already using your own
 // slf4j implementation
 implementation 'org.slf4j:slf4j-nop:1.7.25'
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-android%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-android%7C1.7.30%7Cjar).
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 <!-- ENDWIZARD -->
 
@@ -152,7 +152,7 @@ And declare a dependency in your toplevel `build.gradle`:
 ```groovy
 buildscript {
     dependencies {
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.27'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.30'
     }
 }
 ```
@@ -277,23 +277,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-appengine</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-appengine:1.7.27'
+compile 'io.sentry:sentry-appengine:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-appengine" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry-appengine" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-appengine%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-appengine%7C1.7.30%7Cjar).
 
 ### Usage
 
@@ -343,23 +343,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:1.7.27'
+compile 'io.sentry:sentry:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
 
 ### Usage
 
@@ -452,23 +452,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-log4j:1.7.27'
+compile 'io.sentry:sentry-log4j:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-log4j" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry-log4j" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j%7C1.7.30%7Cjar).
 
 ### Usage
 
@@ -624,23 +624,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j2</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-log4j2:1.7.27'
+compile 'io.sentry:sentry-log4j2:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-log4j2" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry-log4j2" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j2%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j2%7C1.7.30%7Cjar).
 
 ### Usage
 
@@ -773,23 +773,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-logback</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-logback:1.7.27'
+compile 'io.sentry:sentry-logback:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-logback%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-logback%7C1.7.30%7Cjar).
 
 ### Usage
 
@@ -971,23 +971,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-spring:1.7.27'
+compile 'io.sentry:sentry-spring:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-spring" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry-spring" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-spring%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-spring%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/collections/_documentation/clients/java/usage.md
+++ b/src/collections/_documentation/clients/java/usage.md
@@ -21,23 +21,23 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
-    <version>1.7.27</version>
+    <version>1.7.30</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:1.7.27'
+compile 'io.sentry:sentry:1.7.30'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry" % "1.7.27"
+libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.27%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
 <!-- ENDWIZARD -->
 
 <!-- WIZARD capture-an-error -->

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -292,21 +292,63 @@ sentry-cli upload-proguard \
 
 ## Releases
 
-To correlate the error reports and crash reports with specific releases of your application, we automatically attach the package name and the version code to every event from the SDK.
+The Sentry Android SDK automatically attaches a release version to every event.
 
-With the releases information, you unlock many new features:
+Once Sentry receives an event with the updated release version, a new release object will be available on the releases page in-app. [MIMI: To learn more about how is the release name build please check (link to the next section - Release Version Format)
 
-- Determine the issue and regressions introduced in a new release
-- Predict which commit caused an issue and who is likely responsible
+With the releases you can:
+
+- Build queries and reports in the [MIMI link: Discover] page to correlate bugs with releases
+- Filter events and issues by the release version directly in the tag search on the Issues and Events pages
+- Check what new issues were introduced with the new release
+
+With the releases and a GitHub/GitLab integration, you can:
+
+- Determine the issues and regressions introduced in a new release
+- Receive suggestions about which commit caused an issue and who is likely responsible
 - Resolve issues by including the issue number in your commit message
-- Receive email notifications when your code gets deployed
+- Receive email notifications when your code deploys
 
-After configuring your SDK, setting up releases is a 2-step process (recommended for the use of suspect commits):
+Even though releases are automatically created as events come in, to take advantage of the *suspected commits* feature, you need to create the release in Sentry as part of your build process.
+
+Sentry offers a command-line tool to aid with this task. After configuring your SDK, setting up releases is a 2-step process (recommended for the use of suspect commits):
 
 1. [Create Release and Associate Commits](https://docs.sentry.io/workflow/releases/#create-release)
 2. [Tell Sentry When You Deploy a Release](https://docs.sentry.io/workflow/releases/#create-deploy)
 
 For more information, see [Releases Are Better With Commits](https://blog.sentry.io/2017/05/01/release-commits.html).
+
+### Release Version Format
+
+The default format of the release version that is sent with each event from the SDK is:
+
+```
+packageName@versionName+versionCode
+```
+
+Please note that if you are using multiple flavors in your application, the release version is going to be different for each flavor and different release objects will be created in-app for each flavor.
+
+If you want to change the release name you can do it in the AndroidManifest.xml or directly in the code. 
+
+The release version can be any random string but we recommend you use a similar format to the default one.
+
+To have the text identifier of your application as a first part connected with the version string using @ and with the last optional suffix dedicated to build or additional identifier. 
+
+With this format we will be able to show you the release name in the UI in an intuitive format. (1.1.0 instead of 'com.company.demo.app@1.1.1')    
+
+To change the release version in the AndroidManifest.xml
+
+```xml
+<meta-data android:name="io.sentry.release" android:value="io.example@1.1.0" />
+```
+
+Or you can set the release version in your code during the manual initialization of the SDK as described in the section [https://docs.sentry.io/platforms/android/#manual-initialization](https://docs.sentry.io/platforms/android/#manual-initialization).
+
+```java
+SentryAndroid.init(this, options -> {
+    options.setRelease("io.sentry@1.1.0");
+});
+```
 
 ## Context
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -296,11 +296,9 @@ The Sentry Android SDK automatically attaches a release version to every event.
 
 Once Sentry receives an event with the updated release version, a new release object will be available on the releases page in-app. For more details about formatting your releases, see [Release Version Format](#release-version-format).
 
-[MIMI: To learn more about how is the release name build please check (link to the next section - Release Version Format)
-
 With the releases you can:
 
-- Build queries and reports in the [MIMI link: Discover] page to correlate bugs with releases
+- Build queries and reports in the [Discover]({%- link _documentation/workflow/discover2/index.md -%}) page to correlate bugs with releases
 - Filter events and issues by the release version directly in the tag search on the Issues and Events pages
 - Check what new issues were introduced with the new release
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -326,15 +326,11 @@ The default format of the release version that is sent with each event from the 
 packageName@versionName+versionCode
 ```
 
-Please note that if you are using multiple flavors in your application, the release version is going to be different for each flavor and different release objects will be created in-app for each flavor.
+Please note that if you're using multiple flavors in your application, the release version will be different for each flavor, and different release objects will be created in-app for each flavor.
 
-If you want to change the release name you can do it in the AndroidManifest.xml or directly in the code. 
+If you want to change the release name, you can do it in the AndroidManifest.xml or directly in the code. 
 
-The release version can be any random string but we recommend you use a similar format to the default one.
-
-To have the text identifier of your application as a first part connected with the version string using @ and with the last optional suffix dedicated to build or additional identifier. 
-
-With this format we will be able to show you the release name in the UI in an intuitive format. (1.1.0 instead of 'com.company.demo.app@1.1.1')    
+The release version can be any random string, but we recommend using a similar format to the default. The default involves having the text identifier of your app connected with the version string using "@" and the last optional suffix dedicated to build or an additional identifier. With this format, the Sentry UI will display a more comprehensive release name. For example, company.demo.app@1.1.1 instead of 1.1.0.
 
 To change the release version in the AndroidManifest.xml
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -294,7 +294,9 @@ sentry-cli upload-proguard \
 
 The Sentry Android SDK automatically attaches a release version to every event.
 
-Once Sentry receives an event with the updated release version, a new release object will be available on the releases page in-app. [MIMI: To learn more about how is the release name build please check (link to the next section - Release Version Format)
+Once Sentry receives an event with the updated release version, a new release object will be available on the releases page in-app. For more details about formatting your releases, see [Release Version Format](#release-version-format).
+
+[MIMI: To learn more about how is the release name build please check (link to the next section - Release Version Format)
 
 With the releases you can:
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -342,7 +342,7 @@ Or, you can set the release version in your code during the manual initializatio
 
 ```java
 SentryAndroid.init(this, options -> {
-    options.setRelease("io.sentry@1.1.0");
+    options.setRelease("io.example@1.1.0");
 });
 ```
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -302,7 +302,7 @@ With the releases you can:
 - Filter events and issues by the release version directly in the tag search on the Issues and Events pages
 - Check what new issues were introduced with the new release
 
-With the releases and a GitHub/GitLab integration, you can:
+With the releases and a [GitHub]({%- link _documentation/workflow/integrations/global-integrations.md -%}#github)/[GitLab]({%- link _documentation/workflow/integrations/global-integrations.md -%}#gitlab) integration, you can:
 
 - Determine the issues and regressions introduced in a new release
 - Receive suggestions about which commit caused an issue and who is likely responsible
@@ -328,17 +328,17 @@ packageName@versionName+versionCode
 
 Please note that if you're using multiple flavors in your application, the release version will be different for each flavor, and different release objects will be created in-app for each flavor.
 
-If you want to change the release name, you can do it in the AndroidManifest.xml or directly in the code. 
+If you want to change the release name, you can do it in the `AndroidManifest.xml` or directly in the code. 
 
 The release version can be any random string, but we recommend using a similar format to the default. The default involves having the text identifier of your app connected with the version string using "@" and the last optional suffix dedicated to build or an additional identifier. With this format, the Sentry UI will display a more comprehensive release name. For example, company.demo.app@1.1.1 instead of 1.1.0.
 
-To change the release version in the AndroidManifest.xml
+To change the release version in the `AndroidManifest.xml`:
 
 ```xml
 <meta-data android:name="io.sentry.release" android:value="io.example@1.1.0" />
 ```
 
-Or you can set the release version in your code during the manual initialization of the SDK as described in the section [https://docs.sentry.io/platforms/android/#manual-initialization](https://docs.sentry.io/platforms/android/#manual-initialization).
+Or, you can set the release version in your code during the manual initialization of the SDK as described in [Manual Initialization](#manual-initialization).
 
 ```java
 SentryAndroid.init(this, options -> {

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -2,6 +2,7 @@
 title: Android
 ---
 
+<!-- WIZARD android -->
 ## Integrating the SDK
 
 Sentry captures data by using an SDK within your application’s runtime. These are platform-specific and allow Sentry to have a deep understanding of how your app works.
@@ -9,10 +10,17 @@ Sentry captures data by using an SDK within your application’s runtime. These 
 To install the Android SDK, please update your build.gradle file as follows:
 
 ```groovy
+// ADD JCENTER REPOSITORY
+repositories {
+    jcenter()
+}
+
 // ADD COMPATIBILITY OPTIONS TO BE COMPATIBLE WITH JAVA 1.8
-compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 }
 
 // ADD SENTRY ANDROID AS A DEPENDENCY
@@ -20,6 +28,7 @@ dependencies {
     implementation 'io.sentry:sentry-android:{version}'
 }
 ```
+<!-- ENDWIZARD -->
 
 {% capture __alert_content -%}
 For the minimal required API level, see [Requirements](#requirements).
@@ -37,7 +46,9 @@ After you’ve completed setting up a project in Sentry, Sentry will give you a 
 Add your DSN to the manifest file.
 
 ```xml
-<meta-data android:name="io.sentry.dsn" android:value="https://key@sentry.io/123" />
+<application
+    <meta-data android:name="io.sentry.dsn" android:value="https://key@sentry.io/123" />
+</application>
 ```
 
 ### Verifying Your Setup
@@ -45,10 +56,6 @@ Add your DSN to the manifest file.
 Great! Now that you’ve completed setting up the SDK, maybe you want to quickly test out how Sentry works. Start by capturing an exception:
 
 ```java
-import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
-import io.sentry.core.Sentry;
-
 public class MyActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -74,7 +81,9 @@ Initialize the SDK manually when you need to provide additional configuration to
 To initialize the SDK manually, disable the auto initialization. You can do so by adding the following line into your manifest:
 
 ```xml
-<meta-data android:name="io.sentry.auto-init" android:value="false" />
+<application
+    <meta-data android:name="io.sentry.auto-init" android:value="false" />
+</application>
 ```
 
 The next step is to initialize the SDK directly in your code.
@@ -84,10 +93,6 @@ The SDK can catch errors and crashes only after you've initialized it. So, we re
 Configuration options will be loaded from the manifest so that you don't need to have the static properties in your code. In the `init` method, you can provide a callback that will modify the configuration and also register new options.
 
 ```java
-import android.app.Application;
-import io.sentry.android.core.SentryAndroid;
-import io.sentry.core.SentryLevel;
-
 public class SentryApplication extends Application {
     public void onCreate() {
         super.onCreate();
@@ -131,20 +136,20 @@ Insight into the health of your application doesn't require crashes. You can rep
 ```java
 public class DemoClass {
     /**
-        * An example method that throws an exception.
-        */
+    * An example method that throws an exception.
+    */
     public void unsafeMethod() {
         throw new RuntimeException();
     }
 
     /**
-        * An Example of how to report an error and how to enrich the error context.
-        */
-    void logWithStaticAPI() {
-    /*
-    Record a breadcrumb in the current context, which will be sent
-    with the next event(s). By default, the last 100 breadcrumbs are kept.
+    * An Example of how to report an error and how to enrich the error context.
     */
+    void logWithStaticAPI() {
+        /*
+        Record a breadcrumb in the current context, which will be sent
+        with the next event(s). By default, the last 100 breadcrumbs are kept.
+        */
         Sentry.addBreadcrumb("User made an action.");
 
         // Set the user in the current context.
@@ -152,10 +157,9 @@ public class DemoClass {
         user.setEmail("hello@sentry.io");
         Sentry.setUser(user);
 
-    /*
-    This sends a simple event to Sentry, with a simple String message.
-    */
-
+        /*
+        This sends a simple event to Sentry, with a simple String message.
+        */
         Sentry.captureMessage("This is a test");
 
         try {
@@ -185,11 +189,11 @@ And declare a dependency in your top-level `build.gradle`:
 ```groovy
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     
     dependencies {
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.29'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.30'
     }
 }
 ```
@@ -335,7 +339,9 @@ The release version can be any random string, but we recommend using a similar f
 To change the release version in the `AndroidManifest.xml`:
 
 ```xml
-<meta-data android:name="io.sentry.release" android:value="io.example@1.1.0" />
+<application
+    <meta-data android:name="io.sentry.release" android:value="io.example@1.1.0" />
+</application>
 ```
 
 Or, you can set the release version in your code during the manual initialization of the SDK as described in [Manual Initialization](#manual-initialization).
@@ -511,9 +517,11 @@ dependencies {
 If you want to use the SDK with the NDK but you still want to support the devices on the API level lower than 21 you can update your manifest as follows:
 
 ```xml
+<manifest>
     <!-- Merging strategy for the imported manifests -->
       <uses-sdk
             tools:overrideLibrary="io.sentry.android" />
+</manifest>
 ```
 
 With these changes, the NDK integration is going to be used only on the devices with the API level ≥ 21 and the rest of the devices with API level ≥14, but ≤21 will use just the SDK.
@@ -544,7 +552,9 @@ The NDK integration is packed with the SDK and enabled out by default with each 
 Alternatively, you can disable the NDK integration by adding the following line into your manifest.
 
 ```xml
-<meta-data android:name="io.sentry.ndk.enable" android:value="false" />
+<application
+    <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
+</application>
 ```
 
 **Application Not Responding (ANR)** 
@@ -554,13 +564,17 @@ Whenever the main UI thread of the application is blocked for more than four sec
 If you do not want to monitor the ANR, please add the following line into your manifest.
 
 ```xml
-<meta-data android:name="io.sentry.anr.enable" android:value="false" />
+<application
+    <meta-data android:name="io.sentry.anr.enable" android:value="false" />
+</application>
 ```
 
 If you want to specify how long the thread should be blocked before the ANR is reported, provide the duration in the attribute `io.sentry.anr.timeout-interval-mills` in your manifest.
 
 ```xml
-<meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
+<application
+    <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
+</application>
 ```
 
 **“In Application” Stack Frames**
@@ -617,9 +631,15 @@ To do so, use the AndroidNativeBundle Gradle plugin that copies the native libra
 First, we need to declare the dependency in the project build.gradle file:
 
 ```groovy
-dependencies {
-    // Add the line below, the plugin that copies the binaries
-    classpath 'com.ydq.android.gradle.build.tool:nativeBundle:1.0.4'
+buildscript {
+    repositories {
+        jcenter()
+    }
+    
+    dependencies {
+        // Add the line below, the plugin that copies the binaries
+        classpath 'com.ydq.android.gradle.build.tool:nativeBundle:1.0.4'
+    }
 }
 ```
 

--- a/src/collections/_documentation/platforms/android/index.md
+++ b/src/collections/_documentation/platforms/android/index.md
@@ -1,14 +1,6 @@
 ---
 title: Android
 ---
-{% capture __alert_content -%}
-This version of the Android SDK is in beta. Sentry has been offering an official SDK for Android for years now. If you are looking for the stable LTS support of Sentry, please refer to the 1.x and its [docs]({%- link _documentation/clients/java/integrations.md -%}#android).
-{%- endcapture -%}
-{%- include components/alert.html
-    title="Note"
-    content=__alert_content
-    level="warning"
-%}
 
 ## Integrating the SDK
 

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -71,7 +71,9 @@ Sentry.getContext().addTag("tagName", "tagValue");
 
 *New*:
 
-    Sentry.setTag("tagName", "tagValue");
+```java
+Sentry.setTag("tagName", "tagValue");
+```
 
 **Capture custom exception**
 

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -38,7 +38,9 @@ To initialize the SDK manually:
 - Disable the `auto-init` feature by providing the following line in the manifest:
 
     ```xml
-    <meta-data android:name="io.sentry.auto-init" android:value="false" />
+    <application
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+    </application>
     ```
 
 - Initialize the SDK directly in your application:

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -37,13 +37,17 @@ To initialize the SDK manually:
 
 - Disable the `auto-init` feature by providing the following line in the manifest:
 
-        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+    ```xml
+    <meta-data android:name="io.sentry.auto-init" android:value="false" />
+    ```
 
 - Initialize the SDK directly in your application:
 
-        SentryAndroid.init(context, options -> {
-          options.setDsn("___PUBLIC_DSN___");    
-        });
+    ```java
+    SentryAndroid.init(context, options -> {
+        options.setDsn("___PUBLIC_DSN___");    
+    });
+    ```
 
 ### Releases
 

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -5,7 +5,7 @@ sidebar_order: 1
 
 ## Migrating from `sentry-android 1.x` to `sentry-android 2.0`
 
-With Sentry Android, we've updated the API to be closer to the unified API [https://docs.sentry.io/development/sdk-dev/unified-api/](https://docs.sentry.io/development/sdk-dev/unified-api/). And now that the SDK isn't built on top of `sentry-java`, Sentry Android has more Android-specific features.
+With Sentry Android, we've updated the API to resemble the [Unified API]({%- link _documentation/development/sdk-dev/unified-api.md -%}) more closely. And now that the SDK isn't built on top of `sentry-java`, Sentry Android has more Android-specific features.
 
 If you want to upgrade from the previous version of the SDK, please check the following sections of changes that may need updating in your code.
 
@@ -23,11 +23,11 @@ Example of the configuration in the Manifest:
 </application>
 ```
 
-If you want to set the configuration manually in the code, you need to initialize the SDK with `SentryAndroid.init()`  (described in the Installation [LINK: to installation sect]) in the same file as `SentryAndroidOptions`, which holds configuration items.
+If you want to set the configuration manually in the code, you need to initialize the SDK with `SentryAndroid.init()` --- described in [Installation](#installation) --- in the same file as `SentryAndroidOptions`, which holds configuration items.
 
 ### Installation
 
-The new SDK can initialize automatically; all you need to do is provide the DSN in your Manifest file, as shown on the previous example in the [LINK: configuration] section.
+The new SDK can initialize automatically; all you need to do is provide the DSN in your Manifest file, as shown in the previous example in [Configuration](#configuration).
 
 **Manual Installation**
 
@@ -53,11 +53,11 @@ To initialize the SDK manually:
 
 Please note that the new SDK will send with each event a release version in a different format than the previous SDK.
 
-If you are using the GitHub or GitLab integrations, you need to do one of the following:
+If you are using the [GitHub]({%- link _documentation/workflow/integrations/global-integrations.md -%}#github) or [GitLab]({%- link _documentation/workflow/integrations/global-integrations.md -%}#gitlab) integrations, you need to do one of the following:
 
-- use the new format LINK: ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
-- set the release in your `AndroidManifest.xml`
-- change your code as described in the configuration section.
+- Use the new format LINK: ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
+- Set the release in your `AndroidManifest.xml`
+- Change your code as described in the configuration section
 
 ### API
 

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -11,21 +11,23 @@ If you want to upgrade from the previous version of the SDK, please check the fo
 
 ### Configuration
 
-The file `sentry.properties` used by the previous version of the SDK has been discontinued, and configurations of the new SDK is in `AndroidManifest.xml` or directly in the code.
+The file `sentry.properties` used by the previous version of the SDK has been discontinued. Configurations for the new SDK are in `AndroidManifest.xml` or directly in the code.
 
 Example of the configuration in the Manifest:
 
-    <application>
-    <!-- The configuration must be inside of the application tag -->
-    <!-- Example of the Sentry DSN setting -->
-      <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN__" />
-    </application>
+```xml
+<application>
+<!-- The configuration must be inside of the application tag -->
+<!-- Example of the Sentry DSN setting -->
+    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN__" />
+</application>
+```
 
-If you want to set the configuration manually in the code, you need to initialize the SDK with `SentryAndroid.init()`  (described in the Installation [LINK: to installation sect]) in the same file as `SentryAndroidOptions` , which holds configuration items.
+If you want to set the configuration manually in the code, you need to initialize the SDK with `SentryAndroid.init()`  (described in the Installation [LINK: to installation sect]) in the same file as `SentryAndroidOptions`, which holds configuration items.
 
 ### Installation
 
-The new SDK can initialize automatically; all you need to do is provide the DSN in your Manifest file, as shown on the previous example in the configuration sections.
+The new SDK can initialize automatically; all you need to do is provide the DSN in your Manifest file, as shown on the previous example in the [LINK: configuration] section.
 
 **Manual Installation**
 
@@ -33,11 +35,11 @@ If you want to register any callback to filter and modify events and/or breadcru
 
 To initialize the SDK manually:
 
-- disable the `auto-init` feature by providing the following line in the manifest:
+- Disable the `auto-init` feature by providing the following line in the manifest:
 
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
-- initialize the SDK directly in your application:
+- Initialize the SDK directly in your application:
 
         SentryAndroid.init(context, options -> {
           options.setDsn("___PUBLIC_DSN___");    
@@ -49,7 +51,7 @@ Please note that the new SDK will send with each event a release version in a di
 
 If you are using the GitHub or GitLab integrations, you need to do one of the following:
 
-- use the new format ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
+- use the new format LINK: ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
 - set the release in your `AndroidManifest.xml`
 - change your code as described in the configuration section.
 
@@ -59,7 +61,9 @@ If you are using the GitHub or GitLab integrations, you need to do one of the fo
 
 *Old*:
 
-    Sentry.getContext().addTag("tagName", "tagValue");
+```java
+Sentry.getContext().addTag("tagName", "tagValue");
+```
 
 *New*:
 
@@ -69,76 +73,100 @@ If you are using the GitHub or GitLab integrations, you need to do one of the fo
 
 *Old*:
 
-    try {
-      int x = 1 / 0;
-    } catch (Exception e) {
-      Sentry.capture(e);
-    }
+```java
+try {
+    int x = 1 / 0;
+} catch (Exception e) {
+    Sentry.capture(e);
+}
+```
 
 *New*:
 
-    try {
-      int x = 1 / 0;
-    } catch (Exception e) {
-      Sentry.captureException(e);
-    } 
+```java
+try {
+    int x = 1 / 0;
+} catch (Exception e) {
+    Sentry.captureException(e);
+}
+```
 
 **Capture a message**
 
 *Old*:
 
-    Sentry.capture("This is a test");
+```java
+Sentry.capture("This is a test");
+```
 
 *New*:
 
-    Sentry.captureMessage("This is a test"); // SentryLevel.INFO by default
-    Sentry.captureMessage("This is a test", SentryLevel.WARNING); // or specific level 
+```java
+Sentry.captureMessage("This is a test"); // SentryLevel.INFO by default
+Sentry.captureMessage("This is a test", SentryLevel.WARNING); // or specific level 
+```
 
 **Breadcrumbs**
 
 *Old*:
 
-    Sentry.getContext().recordBreadcrumb(
-      new BreadcrumbBuilder().setMessage("User made an action").build()
-    );
+```java
+Sentry.getContext().recordBreadcrumb(
+    new BreadcrumbBuilder().setMessage("User made an action").build()
+);
+```
 
 *New*:
 
-    Sentry.addBreadcrumb("User made an action");
+```java
+Sentry.addBreadcrumb("User made an action");
+```
 
 **User**
 
 *Old*:
 
-    Sentry.getContext().setUser(
-      new UserBuilder().setEmail("hello@sentry.io").build()
-    );
+```java
+Sentry.getContext().setUser(
+    new UserBuilder().setEmail("hello@sentry.io").build()
+);
+```
 
 *New*:
 
-    User user = new User();
-    user.setEmail("hello@sentry.io");
-    Sentry.setUser(user); 
+```java
+User user = new User();
+user.setEmail("hello@sentry.io");
+Sentry.setUser(user); 
+```
 
 **Set extra**
 
 *Old*:
 
-    Sentry.getContext().addExtra("extra", "thing");
+```java
+Sentry.getContext().addExtra("extra", "thing");
+```
 
 *New*:
 
-    Sentry.setExtra("extra", "thing");
+```java
+Sentry.setExtra("extra", "thing");
+```
 
 ### Multi-Dex support
 
 If you are using multi-dex and our SDK we would recommend you to update your multi dex configuration
 
-    release {
-       multiDexKeepProguard file('multidex-config.pro')
-    }
+```groovy
+release {
+    multiDexKeepProguard file('multidex-config.pro')
+}
+```
 
 and add to the [multidex-config.pro](http://multidex-config.pro) the following lines:
 
-    -keep class io.sentry.android.core.SentryAndroidOptions
-    -keep class io.sentry.android.ndk.SentryNdk
+```
+-keep class io.sentry.android.core.SentryAndroidOptions
+-keep class io.sentry.android.ndk.SentryNdk
+```

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -1,0 +1,144 @@
+---
+title: Migration
+sidebar_order: 1
+---
+
+## Migrating from `sentry-android 1.x` to `sentry-android 2.0`
+
+With Sentry Android, we've updated the API to be closer to the unified API [https://docs.sentry.io/development/sdk-dev/unified-api/](https://docs.sentry.io/development/sdk-dev/unified-api/). And now that the SDK isn't built on top of `sentry-java`, Sentry Android has more Android-specific features.
+
+If you want to upgrade from the previous version of the SDK, please check the following sections of changes that may need updating in your code.
+
+### Configuration
+
+The file `sentry.properties` used by the previous version of the SDK has been discontinued, and configurations of the new SDK is in `AndroidManifest.xml` or directly in the code.
+
+Example of the configuration in the Manifest:
+
+    <application>
+    <!-- The configuration must be inside of the application tag -->
+    <!-- Example of the Sentry DSN setting -->
+      <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN__" />
+    </application>
+
+If you want to set the configuration manually in the code, you need to initialize the SDK with `SentryAndroid.init()`  (described in the Installation [LINK: to installation sect]) in the same file as `SentryAndroidOptions` , which holds configuration items.
+
+### Installation
+
+The new SDK can initialize automatically; all you need to do is provide the DSN in your Manifest file, as shown on the previous example in the configuration sections.
+
+**Manual Installation**
+
+If you want to register any callback to filter and modify events and/or breadcrumbs, or if you want to provide the configuration values via code, you need to initialize the SDK using the `SentryAndroid.init()`.
+
+To initialize the SDK manually:
+
+- disable the `auto-init` feature by providing the following line in the manifest:
+
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+
+- initialize the SDK directly in your application:
+
+        SentryAndroid.init(context, options -> {
+          options.setDsn("___PUBLIC_DSN___");    
+        });
+
+### Releases
+
+Please note that the new SDK will send with each event a release version in a different format than the previous SDK.
+
+If you are using the GitHub or GitLab integrations, you need to do one of the following:
+
+- use the new format ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
+- set the release in your `AndroidManifest.xml`
+- change your code as described in the configuration section.
+
+### API
+
+**Set tag**
+
+*Old*:
+
+    Sentry.getContext().addTag("tagName", "tagValue");
+
+*New*:
+
+    Sentry.setTag("tagName", "tagValue");
+
+**Capture custom exception**
+
+*Old*:
+
+    try {
+      int x = 1 / 0;
+    } catch (Exception e) {
+      Sentry.capture(e);
+    }
+
+*New*:
+
+    try {
+      int x = 1 / 0;
+    } catch (Exception e) {
+      Sentry.captureException(e);
+    } 
+
+**Capture a message**
+
+*Old*:
+
+    Sentry.capture("This is a test");
+
+*New*:
+
+    Sentry.captureMessage("This is a test"); // SentryLevel.INFO by default
+    Sentry.captureMessage("This is a test", SentryLevel.WARNING); // or specific level 
+
+**Breadcrumbs**
+
+*Old*:
+
+    Sentry.getContext().recordBreadcrumb(
+      new BreadcrumbBuilder().setMessage("User made an action").build()
+    );
+
+*New*:
+
+    Sentry.addBreadcrumb("User made an action");
+
+**User**
+
+*Old*:
+
+    Sentry.getContext().setUser(
+      new UserBuilder().setEmail("hello@sentry.io").build()
+    );
+
+*New*:
+
+    User user = new User();
+    user.setEmail("hello@sentry.io");
+    Sentry.setUser(user); 
+
+**Set extra**
+
+*Old*:
+
+    Sentry.getContext().addExtra("extra", "thing");
+
+*New*:
+
+    Sentry.setExtra("extra", "thing");
+
+### Multi-Dex support
+
+If you are using multi-dex and our SDK we would recommend you to update your multi dex configuration
+
+    release {
+       multiDexKeepProguard file('multidex-config.pro')
+    }
+
+and add to the [multidex-config.pro](http://multidex-config.pro) the following lines:
+
+    -keep class io.sentry.android.core.SentryAndroidOptions
+    -keep class io.sentry.android.ndk.SentryNdk

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -170,7 +170,7 @@ release {
 }
 ```
 
-And, add to the [multidex-config.pro](http://multidex-config.pro) to the following lines:
+And, add to the `multidex-config.pro` to the following lines:
 
 ```
 -keep class io.sentry.android.core.SentryAndroidOptions

--- a/src/collections/_documentation/platforms/android/migrate.md
+++ b/src/collections/_documentation/platforms/android/migrate.md
@@ -160,7 +160,7 @@ Sentry.setExtra("extra", "thing");
 
 ### Multi-Dex support
 
-If you are using multi-dex and our SDK we would recommend you to update your multi dex configuration
+If you're using Multi-Dex and our SDK, we would recommend updating your Multi-Dex configuration:
 
 ```groovy
 release {
@@ -168,7 +168,7 @@ release {
 }
 ```
 
-and add to the [multidex-config.pro](http://multidex-config.pro) the following lines:
+And, add to the [multidex-config.pro](http://multidex-config.pro) to the following lines:
 
 ```
 -keep class io.sentry.android.core.SentryAndroidOptions


### PR DESCRIPTION
Our Android SDK had some updates that needed documenting for the GA release. Updates include new content for the Releases section and a new page for Migration.

![image](https://user-images.githubusercontent.com/25088225/74290323-5fb35a00-4ce6-11ea-9654-b98b9adf2b6f.png)

![image](https://user-images.githubusercontent.com/25088225/74290340-69d55880-4ce6-11ea-8b40-8bf61f7cf9a3.png)
