### PR TITLE
added link to Sentry's page about Flutter

### DIFF
--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -23,7 +23,7 @@ These SDKs are [maintained and supported](https://forum.sentry.io) by the Sentry
 * [_C++_](https://github.com/nlohmann/crow)
 * [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 * [_Crystal_](https://github.com/Sija/raven.cr)
-* [_Flutter_](https://flutter.dev/docs/cookbook/maintenance/error-reporting)
+* [_Flutter_]({% link _documentation/platforms/flutter/index.md %})
 * [_Grails_](https://github.com/agorapulse/grails-sentry)
 * [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
 * [_Lua_](https://github.com/cloudflare/raven-lua)


### PR DESCRIPTION
@bruno-garcia created some lovely docs about Flutter and I thought it appropriate to link to them from the Platforms index page. 

![image](https://user-images.githubusercontent.com/25088225/74789946-09589500-526b-11ea-9e15-0d2a7b1eb611.png)
