### PR TITLE
fix(saml2): Fix typo in URL for SAML endpoint

### DIFF
--- a/src/collections/_documentation/accounts/saml2.md
+++ b/src/collections/_documentation/accounts/saml2.md
@@ -24,7 +24,7 @@ Sentry supports the following SAML services:
 ## 1. Register Sentry with IdP
 Before connecting Sentry to the Identity Provider (IdP), it’s important to first register Sentry as an application on the IdP’s side. Sentry’s SAML endpoints are as follows, where the `{organization_slug}` is substituted for your organization slug:
 
-<table class="table"><tbody valign="top"><tr><th>ACS:</th><td><code class="docutils literal">https://sentry.io/saml/acs/{organization_slug}/</code></td></tr><tr><th>SLS:</th><td><code class="docutils literal">https://sentry.io/saml/SLS/{organization_slug}/</code></td></tr><tr><th>Metadata:</th><td><code class="docutils literal">https://sentry.io/saml/metadata/{organization_slug}/</code></td></tr></tbody></table>
+<table class="table"><tbody valign="top"><tr><th>ACS:</th><td><code class="docutils literal">https://sentry.io/saml/acs/{organization_slug}/</code></td></tr><tr><th>SLS:</th><td><code class="docutils literal">https://sentry.io/saml/sls/{organization_slug}/</code></td></tr><tr><th>Metadata:</th><td><code class="docutils literal">https://sentry.io/saml/metadata/{organization_slug}/</code></td></tr></tbody></table>
 
 **What are these three things?**
 * `ACS` means *Assertion Consumer Service*, and is used for establishing a session based on rules made between your IdP and the service provider it is integrating with. _Please note: Sentry’s ACS endpoint uses HTTP-POST bindings_

--- a/src/collections/_documentation/accounts/sso.md
+++ b/src/collections/_documentation/accounts/sso.md
@@ -55,7 +55,7 @@ Sentry’s Assertion Consumer Service uses the HTTP-POST bindings.
 
 Sentry’s SAML endpoints are as follows, where the `{organization_slug}` is substituted for your organization slug:
 
-<table class="table"><tbody valign="top"><tr><th>ACS:</th><td><code class="docutils literal">https://sentry.io/saml/acs/{organization_slug}/</code></td></tr><tr><th>SLS:</th><td><code class="docutils literal">https://sentry.io/saml/SLS/{organization_slug}/</code></td></tr><tr><th>Metadata:</th><td><code class="docutils literal">https://sentry.io/saml/metadata/{organization_slug}/</code></td></tr></tbody></table>
+<table class="table"><tbody valign="top"><tr><th>ACS:</th><td><code class="docutils literal">https://sentry.io/saml/acs/{organization_slug}/</code></td></tr><tr><th>SLS:</th><td><code class="docutils literal">https://sentry.io/saml/sls/{organization_slug}/</code></td></tr><tr><th>Metadata:</th><td><code class="docutils literal">https://sentry.io/saml/metadata/{organization_slug}/</code></td></tr></tbody></table>
 
 {% capture __alert_content -%}
 SAML2 SSO requires a Business or Enterprise Plan.


### PR DESCRIPTION
Hi @MimiDumpling!!

This is my first PR on docs. I found that `.../SLS/...` should be in small letters (see this [line of code in getsentry/sentry](https://github.com/getsentry/sentry/blob/f7febb2015585d4f1d0a9070d7ffef5c6ffa8541/src/sentry/web/urls.py#L157)). I don't think this affects anything but it's a small change and I'm in favor of accuracy in docs.