### PR TITLE
ref: Add note about Help Center

### DIFF
--- a/src/collections/_documentation/support/index.md
+++ b/src/collections/_documentation/support/index.md
@@ -5,6 +5,12 @@ sidebar_order: 8
 
 As a paying customer of Sentry you have access to various forms of support; and if you are using the Open Source version you can get in contact with the Sentry community for questions. All Sentry repositories can be found on [GitHub](https://github.com/getsentry). 
 
+{% include components/alert.html
+  title="Note"
+  content="If you're unable to find the answer in our documentation, you can also check out our [Help Center](https://help.sentry.io/hc/en-us) for commonly asked questions."
+  level="warning"
+%}
+
 ## System Status
 
 The availability of the Sentry cloud hosted installation is independently monitored from outside the infrastructure. To monitor the availability, get notifications and read status updates about outdates you can visit the status page at [status.sentry.io](http://status.sentry.io/). There you can also subscribe to email and SMS notifications.
@@ -19,4 +25,4 @@ If you’re looking for support on a specific SDK, check the documentation speci
 
 ## Paid Support
 
-If you are a paid customer, you can contact support from within your Sentry organization. This can be found by going to the dropdown menu under your organization's name in the top left, and clicking "Support". We suggest reserving that for actual problems with the service, and when possible referring to our documentation and community support.
+If you're a paid customer, you can contact support from within your Sentry organization. This can be found by clicking on the "Help" button on the bottom left. We suggest reserving that for actual problems with the service, and when possible referring to our documentation, [Help Center](https://help.sentry.io/hc/en-us), and community support.


### PR DESCRIPTION
Add note about the Help Center if the answer can't be found in our docs. I also updated the Paid Support section to correctly point to where you can contact support.

<img width="775" alt="Screen Shot 2020-02-25 at 3 31 17 PM" src="https://user-images.githubusercontent.com/20312973/75297176-fe11e600-57e3-11ea-8f42-e3ab838e70f1.png">

Open to feedback on if this should actually be an alert "Note", wording, etc.