### PR TITLE
update before send doc with error spam prevention

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/filtering.md
+++ b/src/collections/_documentation/error-reporting/configuration/filtering.md
@@ -29,6 +29,8 @@ been caught:
 
 {% include components/platform_content.html content_dir='before-send-hint' %}
 
+This is useful to stop error spam. If you are getting thousands of errors that should really just be one error, you can set a custom fingerprint for that error to group them together. Then you can snooze/ignore that one issue.
+
 ### Before Breadcrumb
 
 Similar to `before-send` hints are also supported in `before-breadcrumb`.  This is particularly useful when


### PR DESCRIPTION
Hopefully this makes it clear to the reader that before_send can be used to prevent error spam.
Related issue: https://github.com/getsentry/sentry-python/issues/149

Thanks to @untitaker for the tip