### PR TITLE
Fix typo in Getting Started

### DIFF
--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -5,7 +5,7 @@ sidebar_order: 0
 
 For an overview of what Sentry does, take a look at the Sentry [workflow](https://blog.sentry.io/2018/03/06/the-sentry-workflow).
 
-Sentry is designed to be very simple to get off the ground, yet powerful to grow into. If you have never used Sentry before, this tutorial will help you getting started.
+Sentry is designed to be both simple to get off the ground and powerful to grow into. If you have never used Sentry before, this tutorial helps you get started.
 
 Getting started with Sentry is a three step process:
 


### PR DESCRIPTION
Testing the Git workflow with a minor grammar and typo fix in the quickstart.md file.