### PR TITLE
fix: Remove unintentional trailing whitespace

### DIFF
--- a/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/browser.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 Calling an undefined function will throw an exception:
 

--- a/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/cordova.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 Calling an undefined function will throw an exception:
 

--- a/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/electron.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 Calling an undefined function will throw an exception:
 

--- a/src/collections/_documentation/error-reporting/getting-started-verify/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/node.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 Calling an undefined function will throw an exception:
 

--- a/src/collections/_documentation/error-reporting/getting-started-verify/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/php.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 You can throw an exception in your PHP application:
 

--- a/src/collections/_documentation/error-reporting/getting-started-verify/python.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/python.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 Raise an unhandled Python exception by inserting a divide by zero expression
 into your application:

--- a/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
+++ b/src/collections/_documentation/error-reporting/getting-started-verify/rust.md
@@ -1,4 +1,4 @@
-One way to verify your setup is by intentionally sending an event that breaks your application. 
+One way to verify your setup is by intentionally sending an event that breaks your application.
 
 The quickest way to verify Sentry in your Rust application is to cause a panic:
 


### PR DESCRIPTION
Accidentally added through GitHub code change suggestions during code
review (in #1513).