### PR TITLE
Highlight event argument for filtering documentation

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/filtering.md
+++ b/src/collections/_documentation/error-reporting/configuration/filtering.md
@@ -19,7 +19,7 @@ instance.  For better customization SDKs send these objects to certain callbacks
 
 ### Before Send
 
-The `before-send` callback is passed the event and a second argument `hint` which holds one or more
+The `before-send` callback is passed the `event` and a second argument `hint` which holds one or more
 hints.  Typically this hint holds the original exception so that additional data can be extracted
 or grouping is affected.
 `before-send` will be called right before the event is sent to the server, so it's the last place where you can edit its data.


### PR DESCRIPTION
Highlighting `event` because it's also an argument, same as `hint`.