### PR TITLE
Fix typo on Configuration page

### DIFF
--- a/src/collections/_documentation/clients/ruby/config.md
+++ b/src/collections/_documentation/clients/ruby/config.md
@@ -119,7 +119,7 @@ end
   You can also provide regex-like strings to the sanitizer:
 
   ```ruby
-  config.sanitize_fields = ["my_field", "foo(.*)?bar]
+  config.sanitize_fields = ["my_field", "foo(.*)?bar"]
   ```
 
   It’s also possible to remove HTTP header values which match a list:


### PR DESCRIPTION
Seems missing `"`