### PR TITLE
List matchers from grouping enhancements

### DIFF
--- a/src/collections/_documentation/data-management/event-grouping/server-side-fingerprinting.md
+++ b/src/collections/_documentation/data-management/event-grouping/server-side-fingerprinting.md
@@ -18,12 +18,22 @@ These rules can be configured on a per-project basis under *Project Settings > G
 All values are matched against, and in the case of stack traces, all frames are considered.
 If all matches in a line match then the fingerprint is applied.
 
-The matchers are [the same as for grouping enhancements]({% link _documentation/data-management/event-grouping/grouping-enhancements.md %}#rules)
-but some extra ones are available:
+The matchers are:
 
 - `type`: matches on an exception type
 - `value`: matches on an exception value
 - `message`: matches on a log message
+
+The matchers also include the following from Custom Grouping Enhancements. See [grouping enhancements]({% link _documentation/data-management/event-grouping/grouping-enhancements.md %}#rules) for more info on how they work:
+
+- `family`
+- `path`
+- `module`
+- `function`
+- `package`
+- `app`
+
+
 
 Don't forget that you can also use variables like `{% raw %}{{ function }}{% endraw %}` to
 customize fingerprinting like you can do if the client submits them.


### PR DESCRIPTION
I found myself constantly thinking that Server Side Fingerprinting was only available for:
```
- `type`: matches on an exception type
- `value`: matches on an exception value
- `message`: matches on a log message
```
I always forgot to go check in:
```
The matchers are the same as for grouping enhancements (https://docs.sentry.io/data-management/event-grouping/grouping-enhancements/#rules) 
but some extra ones are available:
```
**I didn't like how this was phrased, "same as x but here are extras y"** and upon leaving server side fingerprinting, it's overwhelming the amount of info on Custom Grouping Enhancements page. That's a separate area of documentation.

However **I do like** that the other types are listed under Examples:
https://docs.sentry.io/data-management/event-grouping/server-side-fingerprinting/#examples
my bad for missing that the first time

I'd rather see all the 'matchers' listed in 1 unified list, as done in the File Diff