### PR TITLE
Update: Add JS code example for sampling

### DIFF
--- a/src/collections/_documentation/performance/distributed-tracing.md
+++ b/src/collections/_documentation/performance/distributed-tracing.md
@@ -180,18 +180,17 @@ Sentry.init({
 To send any traces, set the `tracesSampleRate` to a nonzero value. The following configuration will capture 10% of all your transactions:
 
 ```javascript
-const tracesSampleRate = config ? config.apmSampling : 0.1;
-	 
-const integrations = [
-    new ExtraErrorData({
-        // 6 is arbitrary, seems like a nice number
-        depth: 6,
-    }),
-    new Integrations.Tracing({
-        tracingOrigins: ['localhost', 'sentry.io', /^\//],
-        tracesSampleRate,
-    }),
-];
+import * as Sentry from '@sentry/browser';
+import { Integrations as ApmIntegrations } from '@sentry/apm';
+
+Sentry.init({
+    dsn: '___PUBLIC_DSN___',
+    integrations: [
+        new Integrations.Tracing({
+            tracesSampleRate: 0.1,
+        }),
+    ],
+});
 ```
 
 You can pass many different options to tracing, but it comes with reasonable defaults out of the box.

--- a/src/collections/_documentation/performance/distributed-tracing.md
+++ b/src/collections/_documentation/performance/distributed-tracing.md
@@ -177,6 +177,23 @@ Sentry.init({
 });
 ```
 
+To send any traces, set the `tracesSampleRate` to a nonzero value. The following configuration will capture 10% of all your transactions:
+
+```javascript
+const tracesSampleRate = config ? config.apmSampling : 0.1;
+	 
+const integrations = [
+    new ExtraErrorData({
+        // 6 is arbitrary, seems like a nice number
+        depth: 6,
+    }),
+    new Integrations.Tracing({
+        tracingOrigins: ['localhost', 'sentry.io', /^\//],
+        tracesSampleRate,
+    }),
+];
+```
+
 You can pass many different options to tracing, but it comes with reasonable defaults out of the box.
 [Spans]({%- link _documentation/performance/performance-glossary.md -%}#span) are instrumented for the following operations within a [transaction]({%- link _documentation/performance/performance-glossary.md -%}#transaction):
 

--- a/src/collections/_documentation/performance/distributed-tracing.md
+++ b/src/collections/_documentation/performance/distributed-tracing.md
@@ -12,7 +12,7 @@ Sentry's Performance features are currently in beta. For more details about acce
     level="warning"
 %}
 
-Enabling tracing data collection augments your existing error data to capture interactions between your software systems. This lets Sentry tell you valuable metrics about your software health like throughput and latency, as well as expose the impact of errors across multiple systems. Tracing makes Sentry a more complete monitoring solution to diagnose and measure your application health.
+Enabling tracing data collection augments your existing error data to capture interactions among your software systems. This lets Sentry tell you valuable metrics about your software health like throughput and latency, as well as expose the impact of errors across multiple systems. Tracing makes Sentry a more complete monitoring solution to diagnose and measure your application health.
 
 ## Tracing & Distributed Tracing
 


### PR DESCRIPTION
Distributed Tracing doc was missing a code example for sampling. This adds the code example.

Before:
![image](https://user-images.githubusercontent.com/25088225/76666172-e78abf00-6545-11ea-9ad2-3d992ded647f.png)


After:
![image](https://user-images.githubusercontent.com/25088225/76666462-0721e780-6546-11ea-929e-1de95af012f4.png)

