### PR TITLE
Clarify canonical format used for Breadcrumbs, Exceptions and Threads

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/breadcrumbs.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/breadcrumbs.md
@@ -3,14 +3,16 @@ title: Breadcrumbs Interface
 sidebar_order: 6
 ---
 
-The breadcrumbs interface specifies a series of application events, or
-`breadcrumbs`, that occurred before the main event. Its canonical name is
-`breadcrumbs`.
+The Breadcrumbs Interface specifies a series of application events, or
+"breadcrumbs", that occurred before an event.
 
-This interface is an object with a single `values` key containing an ordered
-list of breadcrumb objects. The entries are ordered from oldest to newest.
-Consequently, the last entry in the array should be the last entry before the
-event occurred.
+An [event]({%- link _documentation/development/sdk-dev/event-payloads/index.md
+-%}) may contain one or more breadcrumbs in an attribute named `breadcrumbs`.
+
+This interface is an object with a single `values` attribute containing an
+ordered list of breadcrumb objects. The entries are ordered from oldest to
+newest. Consequently, the last entry in the list should be the last entry before
+the event occurred.
 
 Each breadcrumb has a few properties of which at least `timestamp` and
 `category` must be provided. The rest is optional, and depending on what is
@@ -142,6 +144,10 @@ Its `data` property has the following sub-properties:
 ```
 
 ## Examples
+
+The following example illustrates the breadcrumbs part of the [event
+payload]({%- link _documentation/development/sdk-dev/event-payloads/index.md
+-%}) and omits other attributes for simplicity.
 
 ```json
 {

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/exception.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/exception.md
@@ -3,19 +3,27 @@ title: Exception Interface
 sidebar_order: 2
 ---
 
-An exception consists of a list of values. In most cases, this list contains a
-single exception, with an optional stack trace interface. Multiple values
-represent a chained exception, and should be sent oldest to newest. That is, if
-your code does this:
+The Exception Interface specifies an exception or error that occurred in a program.
+
+An [event]({%- link _documentation/development/sdk-dev/event-payloads/index.md
+-%}) may contain one or more exceptions in an attribute named `exception`.
+
+The `exception` attribute should be an object with the attribute `values`
+containing a list of one or more values that are objects in the format described
+below.
+
+Multiple values represent chained exceptions and should be sorted oldest to
+newest. For example, consider this Python code snippet:
 
 ```python
 try:
     raise Exception
 except Exception as e:
-    raise ValueError() from e
+    raise ValueError from e
 ```
 
-The order of exceptions would be `Exception` and then `ValueError`.
+`Exception` would be described first in the `values` list, followed by a
+description of `ValueError`.
 
 ## Attributes
 
@@ -166,23 +174,29 @@ information.
 
 ## Examples
 
-The following examples illustrate payloads that may be sent by SDKs in various
-circumstances.
+The following examples illustrate multiple ways to send exceptions. Each example
+contains the exception part of the [event payload]({%- link
+_documentation/development/sdk-dev/event-payloads/index.md -%}) and omits other
+attributes for simplicity.
 
 A single exception:
 
 ```json
 {
   "exception": {
-    "type": "ValueError",
-    "value": "My exception value",
-    "module": "__builtins__",
-    "stacktrace": {},
+    "values": [
+      {
+        "type": "ValueError",
+        "value": "my exception value",
+        "module": "__builtins__",
+        "stacktrace": {}
+      }
+    ]
   }
 }
 ```
 
-A list of exceptions:
+Chained exceptions:
 
 ```json
 {
@@ -190,12 +204,12 @@ A list of exceptions:
     "values": [
       {
         "type": "Exception",
-        "value": "Wrapped exception value",
+        "value": "initial exception",
         "module": "__builtins__"
       },
       {
         "type": "ValueError",
-        "value": "Original Exception value",
+        "value": "chained exception",
         "module": "__builtins__"
       },
     ]
@@ -208,29 +222,33 @@ iOS native mach exception with mechanism:
 ```json
 {
   "exception": {
-    "type": "EXC_BAD_ACCESS",
-    "value": "Attempted to dereference a null pointer",
-    "mechanism": {
-      "type": "mach",
-      "handled": false,
-      "data": {
-        "relevant_address": "0x1"
-      },
-      "meta": {
-        "signal": {
-          "number": 10,
-          "code": 0,
-          "name": "SIGBUS",
-          "code_name": "BUS_NOOP"
-        },
-        "mach_exception": {
-          "code": 0,
-          "subcode": 8,
-          "exception": 1,
-          "name": "EXC_BAD_ACCESS"
+    "values": [
+      {
+        "type": "EXC_BAD_ACCESS",
+        "value": "Attempted to dereference a null pointer",
+        "mechanism": {
+          "type": "mach",
+          "handled": false,
+          "data": {
+            "relevant_address": "0x1"
+          },
+          "meta": {
+            "signal": {
+              "number": 10,
+              "code": 0,
+              "name": "SIGBUS",
+              "code_name": "BUS_NOOP"
+            },
+            "mach_exception": {
+              "code": 0,
+              "subcode": 8,
+              "exception": 1,
+              "name": "EXC_BAD_ACCESS"
+            }
+          }
         }
       }
-    }
+    ]
   }
 }
 ```
@@ -240,16 +258,20 @@ JavaScript unhandled promise rejection:
 ```json
 {
   "exception": {
-    "type": "TypeError",
-    "value": "Object [object Object] has no method 'foo'",
-    "mechanism": {
-      "type": "promise",
-      "description": "This error originated either by throwing inside of an ...",
-      "handled": false,
-      "data": {
-        "polyfill": "bluebird"
+    "values": [
+      {
+        "type": "TypeError",
+        "value": "Object [object Object] has no method 'foo'",
+        "mechanism": {
+          "type": "promise",
+          "description": "This error originated either by throwing inside of an ...",
+          "handled": false,
+          "data": {
+            "polyfill": "bluebird"
+          }
+        }
       }
-    }
+    ]
   }
 }
 ```
@@ -258,7 +280,17 @@ Generic unhandled crash:
 
 ```json
 {
-    "type": "generic",
-    "handled": false
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "An error occurred",
+        "mechanism": {
+          "type": "generic",
+          "handled": false
+        }
+      }
+    ]
+  }
 }
 ```

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/index.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/index.md
@@ -3,6 +3,36 @@ title: Event Payloads
 sidebar_order: 3
 ---
 
+Events are the fundamental data that clients, often through the use of an SDK, send
+to the Sentry server.
+
+The API endpoint on the Sentry server where event payloads are sent is
+`/api/{PROJECT_ID}/store/`.
+
+{% capture __alert_content -%}
+We strive to document the canonical format of an event and its additional
+interfaces. However, for backwards compatibility the server also
+understands events that are not in the canonical format described throughout the
+documentation.
+
+Existing SDKs may be using a historical format that is not recommended for new
+code.
+{%- endcapture -%}
+
+{%- include components/alert.html title="Note on backwards compatibility" content=__alert_content level="info"%}
+
+
+{% capture __alert_content -%}
+If documentation is lacking or outdated, please let us know by [opening an
+issue](https://github.com/getsentry/sentry-docs/issues/new).
+
+SDK developers might benefit from consulting the [source code defining the
+protocol as understood by the
+server](https://github.com/getsentry/relay/tree/master/relay-general/src/protocol).
+{%- endcapture -%}
+
+{%- include components/alert.html title="Found a problem?" content=__alert_content level="warning"%}
+
 ## Required Attributes
 
 Attributes are simple data that Sentry understands to provide the most basic

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/threads.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/threads.md
@@ -3,13 +3,19 @@ title: Threads Interface
 sidebar_order: 10
 ---
 
-The threads interface allows you to specify the threads that were running at the
-time an event happened. These threads can also contain stack traces. As per
-policy, the thread that crashed with an exception should not have a stack trace,
-but instead, the `thread_id` attribute should be set on the exception and Sentry
-will connect the two.
+The Threads Interface specifies threads that were running at the time an event
+happened. These threads can also contain stack traces.
 
-This interface supports multiple thread values in the `values` key.
+An [event]({%- link _documentation/development/sdk-dev/event-payloads/index.md
+-%}) may contain one or more threads in an attribute named `threads`.
+
+The `threads` attribute should be an object with the attribute `values`
+containing one or more values that are objects in the format described below.
+
+As per Sentry policy, the thread that crashed with an [exception]({%- link
+_documentation/development/sdk-dev/event-payloads/exception.md -%}) should not
+have a stack trace, but instead, the `thread_id` attribute should be set on the
+exception and Sentry will connect the two.
 
 ## Attributes
 
@@ -46,17 +52,21 @@ This interface supports multiple thread values in the `values` key.
 
 ## Examples
 
-A single thread wrapped in `values`:
+The following example illustrates the threads part of the [event payload]({%-
+link _documentation/development/sdk-dev/event-payloads/index.md -%}) and omits
+other attributes for simplicity.
 
 ```json
 {
   "threads": {
-    "values": [{
-      "id": "0",
-      "name": "main",
-      "crashed": true,
-      "stacktrace": {...}
-    }]
+    "values": [
+      {
+        "id": "0",
+        "name": "main",
+        "crashed": true,
+        "stacktrace": {}
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
The server accepts several formats and normalizes event payloads to use
the values list form.

To reduce ambiguity, focus the documentation on the canonical form.