### PR TITLE
created redirect for error tracing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -486,6 +486,10 @@ server {
   location = /workflow/notifications/workflow/ {
     return 302 /workflow/alerts-notifications/notifications/;
   }
+  
+  location = /enriching-error-data/tracing/ {
+    return 302 /enriching-error-data/error-tracing/;
+  }
 
   location / {
     try_files $uri $uri.html $uri/ $uri/index.html =404;

--- a/src/collections/_documentation/error-reporting/quickstart.md
+++ b/src/collections/_documentation/error-reporting/quickstart.md
@@ -11,7 +11,7 @@ Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
 2.  [Install your SDK](#pick-a-client-integration)
-2.  [Configure it](#configure-the-sdk)
+2.  [Configure your SDK](#configure-the-sdk)
 
 ## Install an SDK {#pick-a-client-integration}
 


### PR DESCRIPTION
The Error Tracing page was originally called Tracing. This fix redirects Tracing links to Error Tracing.