### PR TITLE
Added --dist argument

### DIFF
--- a/src/collections/_documentation/platforms/react-native/codepush.md
+++ b/src/collections/_documentation/platforms/react-native/codepush.md
@@ -21,7 +21,7 @@ After updating your CodePush release, you have to upload the new assets to Sentr
 ```bash
 $ appcenter codepush release-react --sourcemap-output --app YourApp --output-dir ./build
 $ export SENTRY_PROPERTIES=./ios/sentry.properties
-$ sentry-cli react-native appcenter YourApp ios ./build/CodePush
+$ sentry-cli react-native appcenter YourApp ios ./build/CodePush --dist YourBuildNumber
 ```
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects]({%- link _documentation/cli/configuration.md -%}#sentry-cli-working-with-projects).


### PR DESCRIPTION
My understanding is if the --dist doesn't get explicitly declared then it'll just be None which can present problems with the deminification of source maps

see merge where this was added: https://github.com/getsentry/sentry-cli/commit/ee81633876c1f19b27724dcb70cadb88ff05e7e2