### PR TITLE
Resized images for Alerts and Notifications

### DIFF
--- a/src/collections/_documentation/workflow/alerts-notifications/alerts.md
+++ b/src/collections/_documentation/workflow/alerts-notifications/alerts.md
@@ -168,13 +168,13 @@ Use the "default project alerts" setting to set your default preference across a
 
 Note that this setting does not affect alerts you've configured to send to your email explicitly.
 
-[{% asset notifications/default_project_alerts.png alt="A toggle for turning on or off all project alerts." %}]({% asset notifications/default_project_alerts.png @path %})
+[{% asset notifications/default_project_alerts.png alt="A toggle for turning on or off all project alerts." width="300" %}]({% asset notifications/default_project_alerts.png @path %})
 
 After selecting the appropriate alert setting, selectively change it by project in **User Settings > Account > Fine tune alerts by project**.
 
 Each project has three options: Default, On, or Off. Selecting default uses your default preference from the previous step.
 
-[{% asset notifications/specific_project_alert.png alt="Dropdown indicating a choice between default, on, or off." %}]({% asset notifications/specific_project_alert.png @path %})
+[{% asset notifications/specific_project_alert.png alt="Dropdown indicating a choice between default, on, or off." width="300" %}]({% asset notifications/specific_project_alert.png @path %})
 
 ## **FAQs**
 

--- a/src/collections/_documentation/workflow/alerts-notifications/notifications.md
+++ b/src/collections/_documentation/workflow/alerts-notifications/notifications.md
@@ -77,7 +77,7 @@ Each project has three options: Default, On, or Off. Selecting default uses your
 
 To opt-out of workflow notifications for a specific issue, click "Unsubscribe" at the bottom right of the issue’s page.
 
-[{% asset notifications/unsubscribe.png alt="An unsubscribe button to stop notifications." %}]({% asset notifications/unsubscribe.png @path %})
+[{% asset notifications/unsubscribe.png alt="An unsubscribe button to stop notifications." width="300" %}]({% asset notifications/unsubscribe.png @path %})
 
 ### Deploy Notifications
 


### PR DESCRIPTION
A few images were too big and now they're more consistent with the other screenshots.

**BEFORE:**

![image](https://user-images.githubusercontent.com/25088225/77678843-01b59b80-6f4f-11ea-9eff-398e20c85662.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/25088225/77678962-2a3d9580-6f4f-11ea-9dda-5ecdaa8f1b40.png)
