### PR TITLE
fix: capitalization mismatch for `testKit` vs `testkit`

### DIFF
--- a/src/collections/_documentation/platforms/javascript/sentry-testkit.md
+++ b/src/collections/_documentation/platforms/javascript/sentry-testkit.md
@@ -31,8 +31,8 @@ Sentry.init({
 
 // then run any scenario that should call Sentry.catchException(...)
 
-expect(testKit.reports()).toHaveLength(1)
-const report = testKit.reports()[0]
+expect(testkit.reports()).toHaveLength(1)
+const report = testkit.reports()[0]
 expect(report).toHaveProperty(/*...*/)
 ```
 


### PR DESCRIPTION
Currently the typed result of `sentryTestKit()` is the following:
```typescript
  export interface TestkitResult {
    testkit: Testkit;
    sentryTransport: {
      new (options: TransportOptions): Transport;
    };
    initNetworkInterceptor<T>(dsn: string, initCallback: (baseUrl: string, handleRequestBody: (requestBody: { [key: string]: any }) => void) => T): T;
    localServer: LocalServer
  }
```

Notice that `testkit` is all lower case.  

In the example above this is imported and used with inconsistent naming.  This is simply a fix for that.