### PR TITLE
fix: Clarify accepted timestamp formats

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/breadcrumbs.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/breadcrumbs.md
@@ -22,10 +22,13 @@ useful when it includes at least a `timestamp` and `type`, `category` or
 
 `timestamp`:
 
-: _Recommended_. A timestamp representing when the breadcrumb occurred. This can
-  be either an ISO DateTime string or a Unix timestamp. Breadcrumbs are most
-  useful when they include a timestamp, as it creates a timeline leading up to
-  an event.
+: _Recommended_. A timestamp representing when the breadcrumb occurred. The
+  format is either a string as defined in [RFC
+  3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float)
+  value representing the number of seconds that have elapsed since the [Unix
+  epoch](https://en.wikipedia.org/wiki/Unix_time).  
+  Breadcrumbs are most useful when they include a timestamp, as it creates a
+  timeline leading up to an event.
 
 `type`:
 
@@ -74,7 +77,7 @@ completely rendered as a key/value table.
 
 ```json
 {
-  "timestamp": 1461185753845,
+  "timestamp": "2016-04-20T20:55:53.845Z",
   "message": "Something happened",
   "category": "log",
   "data": {
@@ -100,7 +103,7 @@ Its `data` property has the following sub-properties:
 
 ```json
 {
-  "timestamp": 1461185753845,
+  "timestamp": "2016-04-20T20:55:53.845Z",
   "type": "navigation",
   "data": {
     "from": "/login",
@@ -135,7 +138,7 @@ Its `data` property has the following sub-properties:
 
 ```json
 {
-  "timestamp": 1461185753845,
+  "timestamp": "2016-04-20T20:55:53.845Z",
   "type": "http",
   "data": {
     "url": "http://example.com/api/1.0/users",
@@ -157,7 +160,7 @@ payload]({%- link _documentation/development/sdk-dev/event-payloads/index.md
   "breadcrumbs": {
     "values": [
       {
-        "timestamp": 1461185753845,
+        "timestamp": "2016-04-20T20:55:53.845Z",
         "message": "Something happened",
         "category": "log",
         "data": {

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/index.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/index.md
@@ -54,9 +54,10 @@ The following attributes are required for all events.
 
 `timestamp`
 
-: Indicates when the logging record was created (in the Sentry SDK). The Sentry
-  server assumes the time is in UTC. The timestamp should be in ISO 8601 format,
-  without a timezone.
+: Indicates when the event was created in the Sentry SDK. The format is either a
+  string as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a
+  numeric (integer or float) value representing the [number of seconds that have
+  elapsed since the Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
   ```json
   {
@@ -64,12 +65,9 @@ The following attributes are required for all events.
   }
   ```
 
-  Alternatively, the timestamp can be specified as floating-point UNIX
-  timestamp.
-
   ```json
   {
-    "timestamp": 1304358096000
+    "timestamp": 1304358096.0
   }
   ```
 


### PR DESCRIPTION
Fix examples that had numeric value as milliseconds instead of seconds (server only accepts seconds).

Update examples to use RFC3339 as a preferred format for readability.

Related to https://github.com/getsentry/sentry-go/issues/190.