### PR TITLE
fix redirection to releases

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -216,7 +216,7 @@ server {
   }
   
   location = /workflow/releases/ {
-    return 302 /workflow/releases/index/;
+    return 302 /workflow/releases/index;
   }
 
   location = /sitemap/ {


### PR DESCRIPTION
In the current version the link to the https://docs.sentry.io/workflow/releases doesnt work.
https://docs.sentry.io/workflow/releases/index works so I hope that change of the redirection will help.