### PR TITLE
fix: Remove unecessary config

### DIFF
--- a/src/collections/_documentation/platforms/cocoa/index.md
+++ b/src/collections/_documentation/platforms/cocoa/index.md
@@ -102,7 +102,6 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     _ = SentrySDK(options: [
            "dsn": “YOUR_SENTRY_DSN”,
            "enableAutoSessionTracking": true
-           "sessionTrackingIntervalMillis": 30000
     ])
     return true
 }


### PR DESCRIPTION
`sessionTrackingIntervalMillis` is used as an override. 30000 is already the default and causes noise in the doc/configuration