### PR TITLE
sdk-dev: Document sending of default integrations

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/sdk.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/sdk.md
@@ -21,8 +21,10 @@ and transmit an event.
 
 `integrations`:
 
-: _Optional_. A list of integrations with the platform or a framework that was
-  explicitly activated by the user. This does not include default integrations.
+: _Optional_. A list of names identifying enabled integrations. The list should
+  have all enabled integrations, including default integrations. Default
+  integrations are included because different SDK releases may contain different
+  default integrations.
 
 `packages`:
 


### PR DESCRIPTION
Some SDKs today already send a complete list of enabled SDKs, while the
docs suggested otherwise.

Updating the suggestion to have SDKs always send a full list, because
otherwise it is harder to provide insights in Sentry as we'd need to
maintain a mapping of default integrations for each SDK for each
released version.