### PR TITLE
node: Unify imports syntax across all pages

### DIFF
--- a/src/collections/_documentation/enriching-error-data/set-environment/node.md
+++ b/src/collections/_documentation/enriching-error-data/set-environment/node.md
@@ -1,5 +1,7 @@
 ```javascript
-const Sentry = require('@sentry/node');
+import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
 
 Sentry.init({
   environment: '{{ page.example_environment }}',

--- a/src/collections/_documentation/error-reporting/getting-started-config/node.md
+++ b/src/collections/_documentation/error-reporting/getting-started-config/node.md
@@ -1,6 +1,9 @@
 You need to inform the Sentry Node SDK about your DSN:
 
 ```javascript
-const Sentry = require('@sentry/node');
+import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
+
 Sentry.init({ dsn: '___PUBLIC_DSN___' });
 ```

--- a/src/collections/_documentation/platforms/javascript/angular.md
+++ b/src/collections/_documentation/platforms/javascript/angular.md
@@ -64,14 +64,14 @@ npm install @sentry/browser @sentry/integrations
 ```javascript
 import angular from 'angular';
 import * as Sentry from '@sentry/browser';
-import * as Integrations from '@sentry/integrations';
+import { Angular as AngularIntegration } from '@sentry/integrations';
 
 // Make sure to call Sentry.init after importing AngularJS. 
 // You can also pass {angular: AngularInstance} to the Integrations.Angular() constructor.
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: [
-    new Integrations.Angular(),
+    new AngularIntegration(),
   ],
 });
 

--- a/src/collections/_documentation/platforms/javascript/ember.md
+++ b/src/collections/_documentation/platforms/javascript/ember.md
@@ -24,11 +24,11 @@ Then add this to your `app.js`:
 
 ```javascript
 import * as Sentry from '@sentry/browser'
-import * as Integrations from '@sentry/integrations';
+import { Ember as EmberIntegration } from '@sentry/integrations';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [new Integrations.Ember()]
+  integrations: [new EmberIntegration()]
 });
 ```
 

--- a/src/collections/_documentation/platforms/javascript/getting-started-dsn/node.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-dsn/node.md
@@ -1,6 +1,8 @@
 
 ```javascript
 import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
 
 // All integrations that come with an SDK can be found on the Sentry.Integrations object
 // Custom integrations must conform Integration interface: https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/index.ts

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -784,11 +784,11 @@ This integration attaches user-agent information to the event, which allows us t
 Pluggable integrations are integrations that can be additionally enabled, to provide some very specific features. Sentry documents them so you can see what they do and that they can be enabled. To enable pluggable integrations, install @sentry/integrations package and provide a new instance with your config to `integrations` option. For example: 
 ```js
 import * as Sentry from '@sentry/browser';
-import * as Integrations from '@sentry/integrations';
+import { ReportingObserver as ReportingObserverIntegration } from '@sentry/integrations';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [new Integrations.ReportingObserver()]
+  integrations: [new ReportingObserverIntegration()]
 });
 ```
 
@@ -894,12 +894,12 @@ All pluggable / optional integrations do live inside `@sentry/integrations`.
 
 ```js
 import * as Sentry from '@sentry/browser';
-import * as Integrations from '@sentry/integrations';
+import { Vue as VueIntegration } from '@sentry/integrations';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: [
-    new Integrations.Vue({
+    new VueIntegration({
       Vue,
       attachProps: true,
     }),

--- a/src/collections/_documentation/platforms/javascript/vue.md
+++ b/src/collections/_documentation/platforms/javascript/vue.md
@@ -34,11 +34,11 @@ Then add this to your `app.js`:
 ```javascript
 import Vue from 'vue'
 import * as Sentry from '@sentry/browser';
-import * as Integrations from '@sentry/integrations';
+import { Vue as VueIntegration } from '@sentry/integrations';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [new Integrations.Vue({Vue, attachProps: true})],
+  integrations: [new VueIntegration({Vue, attachProps: true})],
 });
 ```
 

--- a/src/collections/_documentation/platforms/node/connect.md
+++ b/src/collections/_documentation/platforms/node/connect.md
@@ -15,8 +15,12 @@ $ npm install @sentry/node@{% sdk_version sentry.javascript.node %}
 ```
 
 ```javascript
-const connect = require('connect');
-const Sentry = require('@sentry/node');
+import connect from 'connect';
+import * as Sentry from '@sentry/node';
+
+// or using CommonJS
+// const connect = require('connect');
+// const Sentry = require('@sentry/node');
 
 // Must configure Sentry before doing anything else with it
 Sentry.init({ dsn: '___PUBLIC_DSN___' });

--- a/src/collections/_documentation/platforms/node/express.md
+++ b/src/collections/_documentation/platforms/node/express.md
@@ -17,9 +17,14 @@ $ npm install @sentry/node@{% sdk_version sentry.javascript.node %}
 Sentry should be initialized as early in your app as possible.
 
 ```javascript
-const express = require('express');
+import express from 'express';
+import * as Sentry from '@sentry/node';
+
+// or using CommonJS
+// const express = require('express');
+// const Sentry = require('@sentry/node');
+
 const app = express();
-const Sentry = require('@sentry/node');
 
 Sentry.init({ dsn: '___PUBLIC_DSN___' });
 

--- a/src/collections/_documentation/platforms/node/index.md
+++ b/src/collections/_documentation/platforms/node/index.md
@@ -24,6 +24,8 @@ One thing that is the same across all our JavaScript SDKs --- how you add or rem
 
 ```javascript
 import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
 
 // All integrations that come with an SDK can be found on the Sentry.Integrations object
 // Custom integrations must conform Integration interface: https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/index.ts
@@ -40,6 +42,8 @@ In this example, we will remove the by default enabled integration for adding br
 
 ```javascript
 import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
@@ -56,6 +60,8 @@ Sentry.init({
 
 ```javascript
 import * as Sentry from '@sentry/node';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
@@ -72,12 +78,15 @@ All pluggable / optional integrations do live inside `@sentry/integrations`.
 
 ```js
 import * as Sentry from '@sentry/node';
-import * as Integrations from '@sentry/integrations';
+import { Dedupe as DedupeIntegration } from '@sentry/integrations';
+// or using CommonJS
+// const Sentry = require('@sentry/node');
+// const { Dedupe: DedupeIntegration } = require('@sentry/integrations');
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: [
-    new Integrations.Dedupe(),
+    new DedupeIntegration(),
   ],
 });
 ```

--- a/src/collections/_documentation/platforms/node/koa.md
+++ b/src/collections/_documentation/platforms/node/koa.md
@@ -8,9 +8,14 @@ sidebar_order: 1011
 Our Koa integration only requires the installation of `@sentry/node`, and then you can use it like this:
 
 ```javascript
-const Koa = require('koa');
+import Koa from 'koa';
+import * as Sentry from '@sentry/node';
+
+// or using CommonJS
+// const Koa = require('koa');
+// const Sentry = require('@sentry/node');
+
 const app = new Koa();
-const Sentry = require('@sentry/node');
 
 Sentry.init({ dsn: '___PUBLIC_DSN___' });
 


### PR DESCRIPTION
Some people may get confused without providing both ways. See: https://github.com/getsentry/sentry-javascript/issues/1647

I verified that frameworks are imported correctly as well:

![Screenshot 2020-04-17 at 11 31 21](https://user-images.githubusercontent.com/1523305/79555019-37a5f580-809f-11ea-82c7-54d1808014a6.png)
![Screenshot 2020-04-17 at 11 31 30](https://user-images.githubusercontent.com/1523305/79555023-383e8c00-809f-11ea-8a94-7211c1f1ce5c.png)


Also changed how integrations are imported to make it more obvious that they are completely independent from each other.