### PR TITLE
Fix: Remove unnecessary redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -214,10 +214,6 @@ server {
   location = /workflow/integrations/global-integrations/slack/ {
     return 302 /workflow/integrations/global-integrations/;
   }
-  
-  location = /workflow/releases/ {
-    return 302 /workflow/releases/index;
-  }
 
   location = /sitemap/ {
     return 301 /sitemap.xml$is_args$args;


### PR DESCRIPTION
Removing a 302 from nginx.conf because it's unnecessary and incorrect.