### PR TITLE
Docs: Fix Error in JavaScript SDK Guide (EmberJS)

### DIFF
--- a/src/collections/_documentation/platforms/javascript/ember.md
+++ b/src/collections/_documentation/platforms/javascript/ember.md
@@ -4,13 +4,29 @@ sidebar_order: 50
 ---
 <!-- WIZARD -->
 To use Sentry with your Ember application, you will need to use Sentry’s browser JavaScript SDK: `@sentry/browser`.
+Install it via `npm` or `yarn`:
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+
+
+# Using npm
+npm install @sentry/browser
+```
 
 On its own, `@sentry/browser` will report any uncaught exceptions triggered from your application.
-In order to use ESM imports without any additional configuration, you can use `ember-auto-import`
-by installing it with `ember install ember-auto-import`.
 
-Starting with version `5.x` our `Ember` integration lives in it's own package `@sentry/integrations`.
-You can install it with `npm` / `yarn` like:
+In your Ember app, you can import Sentry via [ESM imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).
+In order to integrate Sentry with this import method, you can use the Ember addon [ember-auto-import](https://emberobserver.com/addons/ember-auto-import)
+If you aren't using `ember-auto-import` in your Ember app yet, install it as follows:
+
+```bash
+ember install ember-auto-import
+```
+
+Starting with version `5.x` our `Ember` integration lives in its own package `@sentry/integrations`.
+Please continue the Sentry integration process by installing the integrations package with `npm` / `yarn` as follows:
 
 ```bash
 # Using yarn


### PR DESCRIPTION
During a pairing session with a colleague who was integrating Sentry into an Ember app I realised that the

```js
import * as Sentry from '@sentry/browser'
```
statement mentioned in the Ember tutorial will error when following the guide, because the installation step for `@sentry/browser` is missing.

This PR adds installation instructions for installing `@sentry/browser` as an initial step, as well as more context for what ember-auto-import is used for during the integration process.