### PR TITLE
removed process.exit() from normal javascript

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/drain-example/javascript.md
+++ b/src/collections/_documentation/error-reporting/configuration/drain-example/javascript.md
@@ -4,7 +4,7 @@ in.
 
 ```javascript
 Sentry.close(2000).then(function() {
-  process.exit();
+  // perform something after close
 });
 ```
 


### PR DESCRIPTION
process.exit() created confusion with browser javascript and NodeJS scripts