### PR TITLE
feat(protocol): Document image_vmaddr

### DIFF
--- a/src/collections/_documentation/development/sdk-dev/event-payloads/debugmeta.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/debugmeta.md
@@ -92,7 +92,7 @@ Attributes:
   still choose to place it at a different address. 
   
   If this value is non-zero, all symbols and addresses declared in the native
-  image start at this address, rather than `0`. In contrast, Sentry deals with
+  image start at this address, rather than `0`. By contrast, Sentry deals with
   addresses relative to the start of the image. For example, with
   `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address
   of `0x1000`.
@@ -188,7 +188,7 @@ Attributes:
   still choose to place it at a different address. 
   
   If this value is non-zero, all symbols and addresses declared in the native
-  image start at this address, rather than `0`. In contrast, Sentry deals with
+  image start at this address, rather than `0`. By contrast, Sentry deals with
   addresses relative to the start of the image. For example, with
   `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address
   of `0x1000`.

--- a/src/collections/_documentation/development/sdk-dev/event-payloads/debugmeta.md
+++ b/src/collections/_documentation/development/sdk-dev/event-payloads/debugmeta.md
@@ -85,6 +85,21 @@ Attributes:
 : _Optional_. The absolute path to the dynamic library or executable. This helps
   to locate the file if it is missing on Sentry.
 
+`image_vmaddr`:
+
+: _Optional_: Preferred load address of the image in virtual memory, as declared
+  in the headers of the image. When loading an image, the operating system may
+  still choose to place it at a different address. 
+  
+  If this value is non-zero, all symbols and addresses declared in the native
+  image start at this address, rather than `0`. In contrast, Sentry deals with
+  addresses relative to the start of the image. For example, with
+  `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address
+  of `0x1000`.
+  
+  Relative addresses used in Apple Crash Reports and `addr2line` are usually in
+  the preferred address space, and not relative address space.
+  
 `arch`:
 
 : _Optional_: Architecture of the module. If missing, this will be backfilled by
@@ -100,6 +115,7 @@ Example:
   "code_file": "/usr/lib/libDiagnosticMessagesClient.dylib",
   "image_addr": "0x7fffe668e000",
   "image_size": 8192,
+  "image_vmaddr": "0x40000",
   "arch": "x86_64",
 }
 ```
@@ -165,6 +181,21 @@ Attributes:
 : _Optional_. The absolute path to the dynamic library or executable. This helps
   to locate the file if it is missing on Sentry.
 
+`image_vmaddr`:
+
+: _Optional_: Preferred load address of the image in virtual memory, as declared
+  in the headers of the image. When loading an image, the operating system may
+  still choose to place it at a different address. 
+  
+  If this value is non-zero, all symbols and addresses declared in the native
+  image start at this address, rather than `0`. In contrast, Sentry deals with
+  addresses relative to the start of the image. For example, with
+  `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address
+  of `0x1000`.
+  
+  Relative addresses used in `addr2line` are usually in the preferred address
+  space, and not relative address space.
+
 `arch`:
 
 : _Optional_: Architecture of the module. If missing, this will be backfilled by
@@ -180,6 +211,7 @@ Example:
   "debug_id": "e20a2268-5dc6-c165-b6aa-a12fa6765a6e",
   "image_addr": "0x7f5140527000",
   "image_size": 90112,
+  "image_vmaddr": "0x40000",
   "arch": "x86_64"
 }
 ```
@@ -247,6 +279,16 @@ debugging. Their structure is identical to other native images.
   the file if it is missing on Sentry. The code file should be provided to allow
   server-side stack walking of binary crash reports, such as Minidumps.
 
+`image_vmaddr`:
+
+: _Optional_: Preferred load address of the image in virtual memory, as declared
+  in the headers of the image. When loading an image, the operating system may
+  still choose to place it at a different address. 
+  
+  Symbols and addresses in the native image are always relative to the start of
+  the image and do not consider the preferred load address. It is merely a hint
+  to the loader.
+
 `arch`:
 
 : _Optional_: Architecture of the module. If missing, this will be backfilled by
@@ -263,6 +305,7 @@ Example:
   "debug_file": "dbghelp.pdb",
   "image_addr": "0x70850000",
   "image_size": "1331200",
+  "image_vmaddr": "0x40000",
   "arch": "x86"
 }
 ```

--- a/src/collections/_documentation/enriching-error-data/additional-data.md
+++ b/src/collections/_documentation/enriching-error-data/additional-data.md
@@ -90,7 +90,7 @@ Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries
 
 In the past, custom context was called "extra" and set via a method like setExtra(), which is deprecated.
 
-Custom data set using `setExtra` appears in the "Additional Data" section of an event. In contrast, each key set using `setContext` gets its own section on the issue page, with the section title being the key name.
+Custom data set using `setExtra` appears in the "Additional Data" section of an event. By contrast, each key set using `setContext` gets its own section on the issue page, with the section title being the key name.
 
 For more details about predefined and custom contexts, see the [full documentation on Context Interface]({%- link _documentation/development/sdk-dev/event-payloads/contexts.md -%}). 
 

--- a/src/collections/_documentation/workflow/releases/health.md
+++ b/src/collections/_documentation/workflow/releases/health.md
@@ -42,7 +42,7 @@ When you change the date range, Sentry recalculates the values. Sentry doesn't p
 
 Let's say you selected the 24-hour time range, have seven users that are using your application for seven days, and each day one of them experiences a crash. The Release Index page will show you that every day there were 85.7% crash-free users on the release.
 
-In contrast, let's say you selected the seven-day time range, have seven users, and each day a different user experiences a crash. By the end of the week, the Release Index page will show you the project had 0% crash-free users.
+By contrast, let's say you selected the seven-day time range, have seven users, and each day a different user experiences a crash. By the end of the week, the Release Index page will show you the project had 0% crash-free users.
 
 ## Release Details
 


### PR DESCRIPTION
This was originally deprecated and thus undocumented. However, to render proper apple crash reports and addresses that can be fed into `addr2line`, it is useful to retain the original load address as `image_vmaddr`. 

Note that the description for the three platforms varies slightly.