### PR TITLE
chore: No more manual version bumps sentry-cocoa

### DIFF
--- a/src/collections/_documentation/platforms/cocoa/index.md
+++ b/src/collections/_documentation/platforms/cocoa/index.md
@@ -31,7 +31,7 @@ platform :ios, '8.0'
 use_frameworks! # This is important
 
 target 'YourApp' do
-    pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '5.0.0-beta.5'
+    pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{% sdk_version sentry.cocoa %}'
 end
 ```
 <!-- {% sdk_version sentry.cocoa %} -->
@@ -43,7 +43,7 @@ Afterwards run `pod install`.
 To integrate Sentry into your Xcode project using Carthage, specify it in your _Cartfile_:
 
 ```ruby
-github "getsentry/sentry-cocoa" "5.0.0-beta.5"
+github "getsentry/sentry-cocoa" "{% sdk_version sentry.cocoa %}"
 ```
 
 Run `carthage update` to download the framework and drag the built _Sentry.framework_ into your Xcode project.


### PR DESCRIPTION
The recent change to the `.craft.yml` makes it so that we also publish the beta version to the registry
https://github.com/getsentry/sentry-cocoa/commit/bbcefde128cdb0d4718dfe2b40b7f2805f50dc52#diff-5d0582c415804fb1a47d79260b3faffb

This change updates the docs so we no longer have to manually bump the version here.

Please only merge this after the next publish with `craft` in `sentry-cocoa`