### PR TITLE
Update JavaScript capture errors sections

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -69,40 +69,6 @@ By including and configuring Sentry, the SDK will automatically attach global ha
 [{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
 
 Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure CORS headers, and add appropriate script attributes. 
-
-**CORS Attributes and Headers**
-
-To gain visibility into a JavaScript exception thrown from scripts originating from different origins, do two things:
-
-1. Add a `crossorigin=”anonymous”` script attribute
-
-    ```javascript
-    <script src="http://another-domain.com/app.js" crossorigin="anonymous"></script>
-    ```
-
-    The script attribute tells the browser to fetch the target file "anonymously." Potentially user-identifying information like cookies or HTTP credentials won't be transmitted by the browser to the server when requesting this file.
-
-2. Add a Cross-Origin HTTP header
-
-    ```javascript
-    Access-Control-Allow-Origin: *
-    ```
-    Cross-Origin Resource Sharing (CORS) is a set of APIs (mostly HTTP headers) that dictate how files ought to be downloaded and served across origins.
-    
-    By setting `Access-Control-Allow-Origin: *`, the server is indicating to browsers that any origin can fetch this file. Alternatively, you can restrict it to a known origin you control:
-    
-    ```javascript
-    Access-Control-Allow-Origin: https://www.example.com
-    ```
-    
-    Most community CDNs properly set an Access-Control-Allow-Origin header.
-
-    ```bash
-    $ curl --head https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.js | \
-    grep -i "access-control-allow-origin"
-
-    Access-Control-Allow-Origin: *
-    ```
     
 ### Manually Capture Errors
 In most situations, you can capture errors manually with `captureException()`.
@@ -1023,6 +989,42 @@ basic stack trace. This exception is stored here for further data extraction.
 `xhr`
 
 : For breadcrumbs created from HTTP requests done via the legacy `XMLHttpRequest` API. This holds the original xhr object.
+
+## Troubleshooting
+
+### CORS Attributes and Headers
+
+To gain visibility into a JavaScript exception thrown from scripts originating from different origins, do two things:
+
+1. Add a `crossorigin=”anonymous”` script attribute
+
+    ```javascript
+    <script src="http://another-domain.com/app.js" crossorigin="anonymous"></script>
+    ```
+
+    The script attribute tells the browser to fetch the target file "anonymously." Potentially user-identifying information like cookies or HTTP credentials won't be transmitted by the browser to the server when requesting this file.
+
+2. Add a Cross-Origin HTTP header
+
+    ```javascript
+    Access-Control-Allow-Origin: *
+    ```
+    Cross-Origin Resource Sharing (CORS) is a set of APIs (mostly HTTP headers) that dictate how files ought to be downloaded and served across origins.
+    
+    By setting `Access-Control-Allow-Origin: *`, the server is indicating to browsers that any origin can fetch this file. Alternatively, you can restrict it to a known origin you control:
+    
+    ```javascript
+    Access-Control-Allow-Origin: https://www.example.com
+    ```
+    
+    Most community CDNs properly set an Access-Control-Allow-Origin header.
+
+    ```bash
+    $ curl --head https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.js | \
+    grep -i "access-control-allow-origin"
+
+    Access-Control-Allow-Origin: *
+    ```
 
 ## Additional Resources
 - [Optimizing the Sentry Workflow](https://blog.sentry.io/2018/03/06/the-sentry-workflow)

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -68,7 +68,7 @@ By including and configuring Sentry, the SDK will automatically attach global ha
 
 [{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
 
-Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure the CORS headers, and add script attributes. 
+Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure CORS headers, and add appropriate script attributes. 
 
 **CORS Attributes and Headers**
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -68,9 +68,7 @@ By including and configuring Sentry, the SDK will automatically attach global ha
 
 [{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
 
-Keep in mind; browsers are taking some security measures when serving script files from different origins. For errors to always make their way to Sentry, make sure that you configure CORS headers and add appropriate script attributes. 
-
-For more details, see Sentry's blog post: [What the heck is "Script error"?](https://blog.sentry.io/2016/05/17/what-is-script-error#the-fix-cors-attributes-and-headers).
+Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure the CORS headers, and add script attributes. 
 
 ### Manually Capture Errors
 In most situations, you can capture errors manually with `captureException()`.

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -990,7 +990,7 @@ basic stack trace. This exception is stored here for further data extraction.
 
 : For breadcrumbs created from HTTP requests done via the legacy `XMLHttpRequest` API. This holds the original xhr object.
 
-## Troubleshooting
+## Troubleshoot
 
 ### CORS Attributes and Headers
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -70,6 +70,40 @@ By including and configuring Sentry, the SDK will automatically attach global ha
 
 Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure the CORS headers, and add script attributes. 
 
+**CORS Attributes and Headers**
+
+To gain visibility into a JavaScript exception thrown from scripts originating from different origins, do two things:
+
+1. Add a `crossorigin=”anonymous”` script attribute
+
+    ```javascript
+    <script src="http://another-domain.com/app.js" crossorigin="anonymous"></script>
+    ```
+
+    The script attribute tells the browser to fetch the target file "anonymously." Potentially user-identifying information like cookies or HTTP credentials won't be transmitted by the browser to the server when requesting this file.
+
+2. Add a Cross-Origin HTTP header
+
+    ```javascript
+    Access-Control-Allow-Origin: *
+    ```
+    Cross-Origin Resource Sharing (CORS) is a set of APIs (mostly HTTP headers) that dictate how files ought to be downloaded and served across origins.
+    
+    By setting `Access-Control-Allow-Origin: *`, the server is indicating to browsers that any origin can fetch this file. Alternatively, you can restrict it to a known origin you control:
+    
+    ```javascript
+    Access-Control-Allow-Origin: https://www.example.com
+    ```
+    
+    Most community CDNs properly set an Access-Control-Allow-Origin header.
+
+    ```bash
+    $ curl --head https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.js | \
+    grep -i "access-control-allow-origin"
+
+    Access-Control-Allow-Origin: *
+    ```
+    
 ### Manually Capture Errors
 In most situations, you can capture errors manually with `captureException()`.
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -68,7 +68,7 @@ By including and configuring Sentry, the SDK will automatically attach global ha
 
 [{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
 
-Browsers take security measures when serving script files from different origins. To ensure errors are routed to Sentry, configure CORS headers, and add appropriate script attributes. 
+Note: Browsers may take security measures when serving script files from different origins that can block error reporting. If you find errors are not being reported accurately, please see the troubleshooting section on [Cross-Origin Resource Sharing (CORS)](#cors-attributes-and-headers).
     
 ### Manually Capture Errors
 In most situations, you can capture errors manually with `captureException()`.
@@ -990,7 +990,7 @@ basic stack trace. This exception is stored here for further data extraction.
 
 : For breadcrumbs created from HTTP requests done via the legacy `XMLHttpRequest` API. This holds the original xhr object.
 
-## Troubleshoot
+## Troubleshooting
 
 ### CORS Attributes and Headers
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -89,7 +89,7 @@ By default, Sentry for JavaScript captures unhandled promise rejections, as desc
 
 Configuration may be required if you are using a third-party library to implement promises.
 
-Most promise libraries have a global hook for capturing unhandled errors. You may want to disable default behavior by changing the `onunhandledrejection` option to `false` in your [GlobalHandlers]({%- link _documentation/platforms/javascript/index.md -%}#globalhandlers) integration and manually hook into such event handler and call `Sentry.captureException` or `Sentry.captureMessage` directly.
+Most promise libraries have a global hook for capturing unhandled errors. Disable default behavior by changing the `onunhandledrejection` option to `false` in your [GlobalHandlers]({%- link _documentation/platforms/javascript/index.md -%}#globalhandlers) integration and manually hook into each event handler and call `Sentry.captureException` or `Sentry.captureMessage` directly.
 
 ## Releases
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -61,7 +61,19 @@ Then, you can see the error in your dashboard:
 [{% asset js-index/error-message.png alt="Error in Unresolved Issues with title This is my fake error message" %}]({% asset js-index/error-message.png @path %})
 
 ## Capturing Errors
-In most situations, you can capture errors automatically with `captureException()`.
+Automatically and manually capture errors, exceptions, and rejections.
+
+### Automatically Capture Errors
+By including and configuring Sentry, the SDK will automatically attach global handlers to capture uncaught exceptions and unhandled rejections.
+
+[{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
+
+Keep in mind; browsers are taking some security measures when serving script files from different origins. For errors to always make their way to Sentry, make sure that you configure CORS headers and add appropriate script attributes. 
+
+For more details, see Sentry's blog post: [What the heck is "Script error"?](https://blog.sentry.io/2016/05/17/what-is-script-error#the-fix-cors-attributes-and-headers).
+
+### Manually Capture Errors
+In most situations, you can capture errors manually with `captureException()`.
 
 ```javascript
 try {
@@ -72,19 +84,12 @@ try {
 ```
 For additional functionality, see [SDK Integrations](#sdk-integrations).
 
-### Automatically Capturing Errors
-By including and configuring Sentry, the SDK will automatically attach global handlers to capture uncaught exceptions and unhandled rejections.
-
-[{% asset js-index/automatically-capture-errors.png alt="Stack trace of a captured error" %}]({% asset js-index/automatically-capture-errors.png @path %})
-
-Keep in mind; browsers are taking some security measures when serving script files from different origins. For errors to always make their way to Sentry, make sure that you configure CORS headers and add appropriate script attributes. For more information, refer to our [What the heck is "Script error"?](https://blog.sentry.io/2016/05/17/what-is-script-error#the-fix-cors-attributes-and-headers) blog post.
-
 ### Automatically Capturing Errors with Promises
-By default, Sentry for JavaScript captures unhandled promise rejections as described in the official ECMAScript 6 standard.
+By default, Sentry for JavaScript captures unhandled promise rejections, as described in the official ECMAScript 6 standard.
 
 Configuration may be required if you are using a third-party library to implement promises.
 
-Most promise libraries have a global hook for capturing unhandled errors. You may want to disable default behavior by changing `onunhandledrejection` option to `false` in your [GlobalHandlers]({%- link _documentation/platforms/javascript/index.md -%}#globalhandlers) integration and manually hook into such event handler and call `Sentry.captureException` or `Sentry.captureMessage` directly.
+Most promise libraries have a global hook for capturing unhandled errors. You may want to disable default behavior by changing the `onunhandledrejection` option to `false` in your [GlobalHandlers]({%- link _documentation/platforms/javascript/index.md -%}#globalhandlers) integration and manually hook into such event handler and call `Sentry.captureException` or `Sentry.captureMessage` directly.
 
 ## Releases
 

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -84,7 +84,7 @@ try {
 ```
 For additional functionality, see [SDK Integrations](#sdk-integrations).
 
-### Automatically Capturing Errors with Promises
+### Automatically Capture Errors with Promises
 By default, Sentry for JavaScript captures unhandled promise rejections, as described in the official ECMAScript 6 standard.
 
 Configuration may be required if you are using a third-party library to implement promises.


### PR DESCRIPTION
Switched the automatic and manual sections on the JS page.

**BEFORE**:
![image](https://user-images.githubusercontent.com/25088225/80520576-7a3cbd00-893e-11ea-80cf-a4211225dde0.png)



**AFTER**:
![image](https://user-images.githubusercontent.com/25088225/80521077-42824500-893f-11ea-8096-7213d853a785.png)
