### PR TITLE
"default" does not show up for fingerprint example

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -447,7 +447,7 @@ The following example will split up the default group Sentry would create (repre
 function makeRequest(path, options) {
     return fetch(path, options).catch(function(err) {
         Sentry.withScope(function(scope) {
-          scope.setFingerprint(['{{default}}', path]);
+          scope.setFingerprint(['{{{{default}}}}', path]);
           Sentry.captureException(err);
         });
     });

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -447,7 +447,7 @@ The following example will split up the default group Sentry would create (repre
 function makeRequest(path, options) {
     return fetch(path, options).catch(function(err) {
         Sentry.withScope(function(scope) {
-          scope.setFingerprint(['{{{{default}}}}', path]);
+          scope.setFingerprint(['{{ "{{default"}}}}', path]);
           Sentry.captureException(err);
         });
     });


### PR DESCRIPTION
The example for fingerprints to [split up a group into more groups](https://docs.sentry.io/platforms/javascript/#example-split-up-a-group-into-more-groups-groups-are-too-big) is missing the `{{default}}` keyword. It is missing from the page source, as well, so I assume it is due to server-side processing trying to replace the double curly braces with a variable.

```javascript
scope.setFingerprint(['', path]);
```
...should be...
```javascript
scope.setFingerprint(['{{default}}', path]);
```

NOTE: I did not make a change to the last line, nor is it necessary, and I'm not sure why Github is showing a change. The addition it shows is something that already exists in the docs, so I don't know why GIthub shows it as an addition when viewing the "Preview."