### PR TITLE
fix: change back bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.1.4
+   1.16.6


### PR DESCRIPTION
revert the gemfile.lock change from: https://github.com/getsentry/sentry-docs/pull/1646