### PR TITLE
ref(css): Shrink `h4` to differentiate it from `h3` 

### DIFF
--- a/src/_assets/css/_includes/bootstrap-overrides.scss
+++ b/src/_assets/css/_includes/bootstrap-overrides.scss
@@ -5,7 +5,7 @@ $small-font-size: 85%;
 $h1-font-size: 2em;
 $h2-font-size: 1.5em;
 $h3-font-size: 1.125em;
-$h4-font-size: 1.075em;
+$h4-font-size: 1em;
 $h5-font-size: 1em;
 $h6-font-size: 1em;
 


### PR DESCRIPTION
As @rhcarvalho correctly points out [here](https://github.com/getsentry/sentry-docs/pull/1667#discussion_r422048896), actually headings have many advantages over text made to look like a heading by bolding it and putting it on its own line.

In markdown, it's the difference between `#### Dogs Rule` and `**Dogs Rule**`. In HTML it means anchor links, consistent styling, and better accessibility (vs. lack of all of those things).

So, a clear win for headings, right? It would be, except that with our current CSS, it's next to impossible to tell an `h4` (`#### Dogs Rule`) from an `h3` (`### Dogs Rule`), because the difference is only a 4% reduction in size. Since using `h4`s breaks the document's visual hierarchy, folks in many cases choose to use the fake heading in spite of its drawbacks, because it _is_ visually distinct from an `h3`.

This PR shrinks the size of `h4`s so that you get the look of the fake heading, with all of the advantages of the real one.