### PR TITLE
fix: React native docs

### DIFF
--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -49,6 +49,7 @@ To this:
 
 ```bash
 export NODE_BINARY=node
+export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"
 export SENTRY_PROPERTIES=../sentry.properties
 
 # If you are using RN 0.46+

--- a/src/collections/_documentation/platforms/react-native/manual-setup.md
+++ b/src/collections/_documentation/platforms/react-native/manual-setup.md
@@ -34,6 +34,7 @@ To this:
 
 ```bash
 export NODE_BINARY=node
+export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"
 export SENTRY_PROPERTIES=../sentry.properties
 
 # If you are using RN 0.46+


### PR DESCRIPTION
Add docs for ppl to add `EXTRA_PACKAGER_ARGS` to Xcode build script to make sure source maps are not bundled with the app.