### PR TITLE
ref: Add simple migration guide for Python

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -350,6 +350,7 @@ Array [
   "platforms/python/gnu_backtrace/index.html",
   "platforms/python/index.html",
   "platforms/python/logging/index.html",
+  "platforms/python/migration/index.html",
   "platforms/python/pyramid/index.html",
   "platforms/python/pyspark/index.html",
   "platforms/python/redis/index.html",

--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -132,6 +132,7 @@
       wizard_parent: python
       wizard: true
       case_style: snake_case
+      doc_link: /platforms/python/
 -
       slug: python-legacy
       support_level: production

--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -20,6 +20,10 @@ The SDK provides support for Python 2.7 and 3.4 or later. [Integrations](#integr
   level="info"
 %}
 
+### Migrating from Raven
+
+If you are migrating from [raven-python](https://github.com/getsentry/raven-python), have a look at [our migration guide]({%- link _documentation/platforms/python/migration.md -%}) before continuing.
+
 ### Connecting the SDK to Sentry
 
 After you’ve completed setting up a project in Sentry, Sentry will give you a value which we call a DSN or Data Source Name. It looks a lot like a standard URL, but it’s just a representation of the configuration required by the Sentry SDKs. It consists of a few pieces, including the protocol, public key, the server address, and the project identifier.

--- a/src/collections/_documentation/platforms/python/migration.md
+++ b/src/collections/_documentation/platforms/python/migration.md
@@ -1,0 +1,117 @@
+---
+title: Migrating from Raven to Sentry-Python
+sidebar_order: 1
+---
+
+If you want to move to the new sentry-python SDK we provided a short guide here of the most common patterns:
+
+## Installation
+
+The installation is now the same regardless of framework or library you integrate with. There are no alternative initialization routines other than `sentry_sdk.init`. For integration-specific instructions please refer to [our list of integrations for the new SDK]({%- link _documentation/platforms/python/index.md -%}#integrations).
+
+**Old**:
+
+```python
+import raven
+client = raven.Client('___PUBLIC_DSN___', release="1.3.0")
+```
+
+**New**:
+
+```python
+import sentry_sdk
+sentry_sdk.init('___PUBLIC_DSN___', release='1.3.0')
+```
+
+## Set a global tag
+
+**Old**:
+
+```python
+client.tags_context({'key': 'value'})
+```
+
+**New**:
+
+```python
+sentry_sdk.set_tag('key', 'value')
+```
+
+## Capture custom exception
+
+**Old**:
+
+```python
+try:
+    throwing_function()
+except Exception:
+    client.captureException(extra={'debug': False})
+```
+
+**New**:
+
+```python
+with sentry_sdk.push_scope() as scope:
+    scope.set_extra('debug', False)
+
+    try:
+        throwing_function()
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+```
+
+## Capture a message
+
+**Old**:
+
+```python
+client.captureMessage('test', level='info', extra={'debug': False})
+```
+
+**New**:
+
+```python
+with sentry_sdk.push_scope() as scope:
+    scope.set_extra('debug', False)
+    sentry_sdk.capture_message('test', 'info')
+```
+
+## Breadcrumbs
+
+**Old**:
+
+```python
+from raven import breadcrumbs import
+
+breadcrumbs.record(
+    message='Item added to shopping cart',
+    category='action',
+    data={
+        'isbn': '978-1617290541',
+        'cartSize': '3'
+    }
+)
+```
+
+**New**:
+
+```python
+sentry_sdk.add_breadcrumb(
+  message='Item added to shopping cart',
+  category='action',
+  data={
+    'isbn': '978-1617290541',
+    'cartSize': '3'
+  }
+)
+```
+
+## Filtering sensitive data
+
+Raven used to have a few built-in heuristics to detect password fields and
+creditcard numbers. Since those heuristics were the same for everybody, it was
+impossible to further improve them for a usecase without breaking somebody
+else's usecase. There is no easy search-and-replace type solution in the new
+SDK.
+
+We encourage you to consider alternative options outlined at [_Filtering Events_]({%- link _documentation/error-reporting/configuration/filtering.md -%}).


### PR DESCRIPTION
This is https://forum.sentry.io/t/switching-to-sentry-python/4733 with some touch-ups. Paging cramer on this one because he's the other person who underwent a migration at sentry (for zeus)