### PR TITLE
ref: Added a yarn remove step to react-native upgrade docs

### DIFF
--- a/src/collections/_documentation/platforms/react-native/index.md
+++ b/src/collections/_documentation/platforms/react-native/index.md
@@ -71,10 +71,18 @@ The following changes will be performed:
 If you are upgrading from an earlier version of react-native-sentry you should unlink the package to ensure the generated code is updated to the latest version:
 
 ```bash
-$ react-native unlink react-native-sentry
+react-native unlink react-native-sentry
 ```
 
-After that remove `react-native-sentry` from your `package.json` and follow the installation instructions.
+After that remove `react-native-sentry` from your `package.json`:
+
+```bash
+npm uninstall react-native-sentry --save
+# or
+yarn remove react-native-sentry
+```
+
+You can then follow the installation instructions above.
 
 ## iOS Specifics
 


### PR DESCRIPTION
Added a yarn remove step for when upgrading in react native from `react-native-sentry` to `@sentry/react-native` instead of having the user just remove from the package.json.