### PR TITLE
fix(cocoa): Remove memory warning integration

### DIFF
--- a/src/collections/_documentation/platforms/cocoa/integrations/objc.md
+++ b/src/collections/_documentation/platforms/cocoa/integrations/objc.md
@@ -1,6 +1,6 @@
 ```objc
 NSMutableArray *integrations = [SentryOptions defaultIntegrations].mutableCopy;
-[integrations removeObject:@"SentryUIKitMemoryWarningIntegration"];
+[integrations removeObject:@"SentryAutoBreadcrumbTrackingIntegration"];
 [SentrySDK startWithOptions:@{
     // ...
     @"integrations": integrations

--- a/src/collections/_documentation/platforms/cocoa/integrations/swift.md
+++ b/src/collections/_documentation/platforms/cocoa/integrations/swift.md
@@ -2,7 +2,7 @@
 SentrySDK.start(options: [
     //...
     "integrations": Sentry.Options.defaultIntegrations().filter { (name) -> Bool in
-        return name != "SentryUIKitMemoryWarningIntegration" // This will disable  SentryUIKitMemoryWarningIntegration
+        return name != "SentryAutoBreadcrumbTrackingIntegration" // This will disable  SentryAutoBreadcrumbTrackingIntegration
     }
     //...
 ])

--- a/src/collections/_documentation/platforms/cocoa/usage.md
+++ b/src/collections/_documentation/platforms/cocoa/usage.md
@@ -43,10 +43,6 @@ The SDK enables all integrations by default. To disable any of them:
 
 This integration is the core part of the SDK. It hooks into all signal and exception handlers to capture uncaught errors or crashes. This integration is also responsible for adding most of the device information to events. If it is disabled, you will not receive crash reports, nor will events contain much device data.
 
-#### SentryUIKitMemoryWarningIntegration
-
-This integration only functions in apps where UIKit is available. The integration will send an event to Sentry when `UIApplicationDidReceiveMemoryWarningNotification` is received.
-
 #### SentryAutoBreadcrumbTrackingIntegration
 
 This integration will swizzle some methods to create breadcrumbs e.g.: for `UIApplicationDidReceiveMemoryWarningNotification`, `sendAction:to:from:forEvent:` (UI interactions) or `viewDidAppear:` those breadcrumbs will be attached to your events.


### PR DESCRIPTION
The SentryUIKitMemoryWarningIntegration is obsolete since Cocoa 5.0.0 since
we have breadcrumbs now. Therefore we remove this integration from the docs.
The integration itself is going to be removed with Cocoa 5.1.0.