### PR TITLE
fix: weird visual glitch with Resources autoclicking

### DIFF
--- a/src/_includes/sidebar.html
+++ b/src/_includes/sidebar.html
@@ -13,7 +13,7 @@
 
 <ul class="list-unstyled" data-sidebar-tree>
   <li class="mb-3" data-sidebar-branch>
-    <a class="sidebar-title d-flex align-items-center mb-0 active" data-sidebar-link>
+    <a class="sidebar-title d-flex align-items-center mb-0" href="#" data-sidebar-link>
       <h6>Resources</h6>
     </a>
     <ul class="list-unstyled" data-sidebar-tree>


### PR DESCRIPTION
Discussion: https://sentry.slack.com/archives/C8H0BQRDJ/p1589612596369400

Don't know any frontend at all, but managed to fix it by removing this "active" thing, whatever that is. Also, I added a bogus href so `Resources` looks like every other section header in the sidebar. It was basically invisible before, which was inconsistent.

Also, the live reloader didn't work for me @dcramer. Another good reason to move the build system + framework to something better.
