### PR TITLE
ref(AM): Change names of `rps` and `rpm` functions

### DIFF
--- a/src/collections/_documentation/performance/distributed-tracing.md
+++ b/src/collections/_documentation/performance/distributed-tracing.md
@@ -297,8 +297,8 @@ The following functions aggregate transaction counts and the rate at which trans
 
 - count
 - count unique values (for a given field)
-- average requests (transactions) per second
-- average requests (transactions) per minute
+- average events (transactions) per second (eps)
+- average event (transactions) per minute (epm)
 
 Each of these functions is calculated with respect to the collection of transactions within the given row, which means the numbers will change as you filter your data or change the time window. Also, if you have set up your SDK to [sample your data](#data-sampling), remember that only the transactions that are sent to Sentry are counted. So if a row containing transactions representing requests to a given endpoint is calculated to be receiving 5 requests per second, and you've got a 25% sampling rate enabled, in reality you're getting approximately 20 requests to that endpoint each second. (20 because you're collecting 25% - or 1/4 - of your data, so your real volume is 4 times what you're seeing in Sentry.)
 
@@ -328,7 +328,7 @@ Clicking on a row in the span view expands the details of that span. From here, 
 
 [{% asset performance/span-detail-view.png alt="Span detail view shows the span id, trace id, parent span id, and other data such as tags." %}]({% asset performance/span-detail-view.png @path %})
 
-_Search by Trace ID_
+_Searching by Trace ID_
 
 You can search for all of the transactions in a given trace by expanding any of the span details and clicking on "Search by Trace".
 

--- a/src/collections/_documentation/performance/distributed-tracing.md
+++ b/src/collections/_documentation/performance/distributed-tracing.md
@@ -298,7 +298,7 @@ The following functions aggregate transaction counts and the rate at which trans
 - count
 - count unique values (for a given field)
 - average events (transactions) per second (eps)
-- average event (transactions) per minute (epm)
+- average events (transactions) per minute (epm)
 
 Each of these functions is calculated with respect to the collection of transactions within the given row, which means the numbers will change as you filter your data or change the time window. Also, if you have set up your SDK to [sample your data](#data-sampling), remember that only the transactions that are sent to Sentry are counted. So if a row containing transactions representing requests to a given endpoint is calculated to be receiving 5 requests per second, and you've got a 25% sampling rate enabled, in reality you're getting approximately 20 requests to that endpoint each second. (20 because you're collecting 25% - or 1/4 - of your data, so your real volume is 4 times what you're seeing in Sentry.)
 

--- a/src/collections/_documentation/performance/performance-metrics.md
+++ b/src/collections/_documentation/performance/performance-metrics.md
@@ -27,8 +27,8 @@ The P95 Threshold indicates that 5% of transaction durations are greater than th
 ## P99 Threshold
 The P99 Threshold indicates that 1% of transaction durations are greater than the threshold. For example, if the P99 threshold is 5 seconds, then 1% of transactions exceeded that threshold, taking longer than 5 seconds.
 
-## Throughput (Total, RPM, RPS)
-Throughput indicates the number of requests over a given time range (Total), requests per minute (RPM), or requests per second (RPS).
+## Throughput (Total, TPM, TPS)
+Throughput indicates the number of transactions over a given time range (Total), average transactions per minute (EPM), or average transactions per second (EPS).
     
 ## User Misery
 User Misery is a user-weighted performance metric to assess the relative magnitude of your application performance. While you can examine the ratio of various response time threshold levels with [Apdex](#apdex), User Misery counts the number of unique users who were frustrated based on the specified response time threshold. User Misery highlights transactions that have the highest impact on users.

--- a/src/collections/_documentation/performance/performance-metrics.md
+++ b/src/collections/_documentation/performance/performance-metrics.md
@@ -28,7 +28,7 @@ The P95 Threshold indicates that 5% of transaction durations are greater than th
 The P99 Threshold indicates that 1% of transaction durations are greater than the threshold. For example, if the P99 threshold is 5 seconds, then 1% of transactions exceeded that threshold, taking longer than 5 seconds.
 
 ## Throughput (Total, TPM, TPS)
-Throughput indicates the number of transactions over a given time range (Total), average transactions per minute (EPM), or average transactions per second (EPS).
+Throughput indicates the number of transactions over a given time range (Total), average transactions per minute (TPM), or average transactions per second (TPS).
     
 ## User Misery
 User Misery is a user-weighted performance metric to assess the relative magnitude of your application performance. While you can examine the ratio of various response time threshold levels with [Apdex](#apdex), User Misery counts the number of unique users who were frustrated based on the specified response time threshold. User Misery highlights transactions that have the highest impact on users.


### PR DESCRIPTION
Updating the docs to reflect the changes made [here](https://github.com/getsentry/sentry/pull/18917) and [here](https://github.com/getsentry/sentry/pull/19007).

(I also fixed a typo that's been bothering me.)

