### PR TITLE
Add Sentry Netlify build plugin to release automation docs

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -400,6 +400,7 @@ Array [
   "workflow/releases/release-automation/circleci/index.html",
   "workflow/releases/release-automation/index.html",
   "workflow/releases/release-automation/jenkins/index.html",
+  "workflow/releases/release-automation/netlify/index.html",
   "workflow/search/index.html",
   "workflow/user-settings/index.html",
 ]

--- a/src/collections/_documentation/workflow/releases/release-automation/bitbucket-pipelines/index.md
+++ b/src/collections/_documentation/workflow/releases/release-automation/bitbucket-pipelines/index.md
@@ -1,6 +1,6 @@
 ---
 title: Bitbucket Pipelines
-sidebar_order: 2
+sidebar_order: 0
 
 ---
 

--- a/src/collections/_documentation/workflow/releases/release-automation/index.md
+++ b/src/collections/_documentation/workflow/releases/release-automation/index.md
@@ -7,7 +7,8 @@ sidebar_order: 2
 Sentry release management can be automated using any continuous integration and delivery (CI/CD) platform or automation server.
 
 ### Release Management Automation Guides
-- [Jenkins]({%- link _documentation/workflow/releases/release-automation/jenkins/index.md -%})
-- [CircleCI]({%- link _documentation/workflow/releases/release-automation/circleci/index.md -%})
 - [Bitbucket Pipelines]({%- link _documentation/workflow/releases/release-automation/bitbucket-pipelines/index.md -%})
+- [CircleCI]({%- link _documentation/workflow/releases/release-automation/circleci/index.md -%})
+- [Jenkins]({%- link _documentation/workflow/releases/release-automation/jenkins/index.md -%})
+- [Netlify]({%- link _documentation/workflow/releases/release-automation/netlify/index.md -%})
 - [CLI]({%- link _documentation/workflow/releases/index.md -%}#create-release)

--- a/src/collections/_documentation/workflow/releases/release-automation/jenkins/index.md
+++ b/src/collections/_documentation/workflow/releases/release-automation/jenkins/index.md
@@ -1,6 +1,6 @@
 ---
 title: Jenkins
-sidebar_order: 0
+sidebar_order: 2
 
 ---
 

--- a/src/collections/_documentation/workflow/releases/release-automation/netlify/index.md
+++ b/src/collections/_documentation/workflow/releases/release-automation/netlify/index.md
@@ -1,0 +1,9 @@
+---
+title: Netlify
+sidebar_order: 3
+
+---
+
+The [Sentry Netlify build plugin](https://github.com/getsentry/sentry-netlify-build-plugin) automates Sentry release management in Netlify with just one step. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. You'll also be able to apply source maps to see the original code in Sentry.
+
+For more details about Sentry release management concepts, see the full documenation on [releases]({%- link _documentation/workflow/releases/index.md -%}).


### PR DESCRIPTION
Add Sentry Netlify build plugin to release automation docs.

![netlify-docs-page](https://user-images.githubusercontent.com/7978631/82838686-d03f4a80-9e81-11ea-9b27-b9c2bd8f8e21.png)
