### PR TITLE
Update serverless.md

### DIFF
--- a/src/collections/_documentation/platforms/node/serverless.md
+++ b/src/collections/_documentation/platforms/node/serverless.md
@@ -23,7 +23,7 @@ function sentryHandler(lambdaHandler) {
     } catch (error) {
       Sentry.captureException(error);
       await Sentry.flush(2000);
-      return error;
+      throw error;
     }
   };
 }


### PR DESCRIPTION
I found `return error` doesn't act same as default lambdaHandler. 
I think `throw error` acts as same.