### PR TITLE
fixed release example for rust

### DIFF
--- a/src/collections/_documentation/workflow/releases/set-release/rust.md
+++ b/src/collections/_documentation/workflow/releases/set-release/rust.md
@@ -1,7 +1,12 @@
 ```rust
 use sentry;
 
-sentry::init(sentry::ClientOptions {
-    release: "{{ page.release_identifier }}@{{ page.release_version }}"
-});
+let _guard = sentry::init((
+    "___PUBLIC_DSN___",
+    sentry::ClientOptions {
+        release: Some("{{ page.release_identifier }}@{{ page.release_version }}".into()),
+        ..Default::default()
+    },
+));
+
 ```


### PR DESCRIPTION
I fixed up the rust example as it requires `Option<String>`. I also added the DSN in the example, as it took me a while to realize how this works with the `sentry::ClientOptions` passed in `init(`.