### PR TITLE
Add note that DSN can be public

### DIFF
--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -24,6 +24,9 @@ events.
 
 In runtimes without a process environment (such as the browser) that fallback does not apply.
 
+The DSN does not need to be kept private. If it is abused, the worst case is that another 
+application could send events to your account.
+
 {:.config-key}
 ### `debug`
 


### PR DESCRIPTION
One of the first questions I had while integrating Sentry is whether the DSN needed to kept private. I'm not sure the wording here is perfect, but this should help clarify for future people.

Details here: https://forum.sentry.io/t/dsn-private-public/6297/3