### PR TITLE
fix: Fix bad example for setContext in js SDK

### DIFF
--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -422,10 +422,14 @@ Sentry.withScope(function(scope) {
 ```
 
 ### Extra Context {#extra-context}
-In addition to the structured context that Sentry understands, you can send arbitrary key/value pairs of data which the Sentry SDK will store alongside the event. These are not indexed, and the Sentry SDK uses them to add additional information about what might be happening:
+In addition to the structured context that Sentry understands, you can send a key paired with a data object which the Sentry SDK will store alongside the event. These are not indexed, and the Sentry SDK uses them to add additional information about what might be happening:
 
 ```javascript
-Sentry.setContext("character_name", "Mighty Fighter");
+Sentry.setContext("character_attributes", {
+  name: "Mighty Fighter",
+  age: 19,
+  attack_type: "melee"
+});
 ```
 
 {% capture __alert_content -%}


### PR DESCRIPTION
In the js SDK, the `Sentry.setContext` method's second parameter takes in
an object only and not a string as per http://getsentry.github.io/sentry-javascript/classes/hub.scope.html#setcontext.

Users will attempt to pass a string:
https://github.com/getsentry/sentry-react-native/issues/694#issuecomment-640069758

Attempting to pass a string in the second parameter will encounter an error when processing the event:
<img width="781" alt="Screen Shot 2020-06-06 at 10 33 22 PM" src="https://user-images.githubusercontent.com/30991498/83948619-8f174500-a848-11ea-8e4e-bee900cbbead.png">
