### PR TITLE
Fix: redirects for Slack and Jira

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -227,6 +227,14 @@ server {
   location = /workflow/integrations/global-integrations/slack/ {
     return 302 /workflow/integrations/global-integrations/;
   }
+  
+  location = /workflow/integrations/slack/ {
+    return 302 /workflow/integrations/global-integrations/;
+  }
+  
+  location = /workflow/integrations/jira/ {
+    return 302 /workflow/integrations/global-integrations/;
+  }
 
   location = /sitemap/ {
     return 301 /sitemap.xml$is_args$args;


### PR DESCRIPTION
This PR redirects these broken links:
https://docs.sentry.io/workflow/integrations/slack/
https://docs.sentry.io/workflow/integrations/jira/