### PR TITLE
fix: add extra documentation for RN about configureondemand Gradle's feature

### DIFF
--- a/src/collections/_documentation/platforms/react-native/index.md
+++ b/src/collections/_documentation/platforms/react-native/index.md
@@ -92,7 +92,7 @@ When you use Xcode, you can hook directly into the build process to upload debug
 
 For Android, we hook into Gradle for the source map build process. When you run `react-native link`, the Gradle files are automatically updated. When you run `./gradlew assembleRelease` source maps are automatically built and uploaded to Sentry.
 
-If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build or to disable this feature in order to upload the source map on every build.
+If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build.
 
 To disable this feature, set `org.gradle.configureondemand=false` or remove it as it's default value is disabled, do this in the `gradle.properties` file.
 

--- a/src/collections/_documentation/platforms/react-native/index.md
+++ b/src/collections/_documentation/platforms/react-native/index.md
@@ -94,7 +94,7 @@ For Android, we hook into Gradle for the source map build process. When you run 
 
 If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build.
 
-To disable this feature, set `org.gradle.configureondemand=false` or remove it as it's default value is disabled, do this in the `gradle.properties` file.
+To disable this feature, set `org.gradle.configureondemand=false` or remove it as its default value is disabled, do this in the `gradle.properties` file.
 
 <!-- WIZARD -->
 ## Connecting the SDK to Sentry

--- a/src/collections/_documentation/platforms/react-native/index.md
+++ b/src/collections/_documentation/platforms/react-native/index.md
@@ -92,6 +92,10 @@ When you use Xcode, you can hook directly into the build process to upload debug
 
 For Android, we hook into Gradle for the source map build process. When you run `react-native link`, the Gradle files are automatically updated. When you run `./gradlew assembleRelease` source maps are automatically built and uploaded to Sentry.
 
+If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build or to disable this feature in order to upload the source map on every build.
+
+To disable this feature, set `org.gradle.configureondemand=false` or remove it as it's default value is disabled, do this in the `gradle.properties` file.
+
 <!-- WIZARD -->
 ## Connecting the SDK to Sentry
 


### PR DESCRIPTION
Fix: getsentry/sentry-react-native/issues/841