### PR TITLE
Parameter debug not supported on SentryTarget

### DIFF
--- a/src/collections/_documentation/platforms/dotnet/nlog.md
+++ b/src/collections/_documentation/platforms/dotnet/nlog.md
@@ -112,7 +112,6 @@ The SDK can also be configured via `NLog.config` XML file:
     <target xsi:type="Sentry" name="sentry"
             dsn="___PUBLIC_DSN___"
             layout="${message}"
-            debug="true"
             breadcrumbLayout="${message}"
             minimumBreadcrumbLevel="Debug"
             minimumEventLevel="Error">


### PR DESCRIPTION
I copied the sent configuration for nlog from the documentation and found that the sentry documentation has an unsupported parameter.

debug="true" in the target is not supported by the sentry target. 

System.Configuration.ConfigurationErrorsException
  HResult=0x80131902
  Message=An error occurred creating the configuration section handler for nlog: Exception when parsing ..\web.config line 67)
  Source=<Cannot evaluate the exception source>
  StackTrace:
<Cannot evaluate the exception stack trace>

  This exception was originally thrown at this call stack:
    [External Code]

Inner Exception 1:
NLogConfigurationException: Exception when parsing ..\web.config. 

Inner Exception 2:
NotSupportedException: Parameter debug not supported on SentryTarget