### PR TITLE
Change link from Django 2.0 docs to Django 3.0

### DIFF
--- a/src/collections/_documentation/platforms/python/django.md
+++ b/src/collections/_documentation/platforms/python/django.md
@@ -117,4 +117,4 @@ def my_custom_page_not_found_view(*args, **kwargs):
 
 The error message you send to Sentry will have the usual request data attached.
 
-Refer to [Customizing Error Views](https://docs.djangoproject.com/en/2.0/topics/http/views/#customizing-error-views) from the Django documentation for more information.
+Refer to [Customizing Error Views](https://docs.djangoproject.com/en/3.0/topics/http/views/#customizing-error-views) from the Django documentation for more information.


### PR DESCRIPTION
I don't know if you'd like this changed, but I click the `Help us fix it` anyway :)

If Django 2.0 is still the major version being used, feel free to close this PR