### PR TITLE
Convert all links to standard markdown

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -22,6 +22,6 @@ layout: default
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
   <p class="text-center">
-    <a href="{% link _documentation/home/index.md %}" class="btn btn-primary">Go back to the docs</a>
+    <a href="/" class="btn btn-primary">Go back to the docs</a>
   </p>
 </div>

--- a/src/_includes/components/platform_content.html
+++ b/src/_includes/components/platform_content.html
@@ -76,7 +76,7 @@
           -%}
           <a class="dropdown-item{% if __is_default %} active{% endif %}" id="{{ __uniq }}-{{ __slug }}-tab" data-platform="{{ __slug }}" data-toggle="platform" href="#{{ __uniq }}-{{ __slug }}" role="tab" aria-controls="{{ __uniq }}-{{ __slug }}" aria-selected="{% if __is_default %}true{% else %}false{% endif %}" data-not-dynamic>{{ __platform.name }}</a>
         {%- endfor -%}
-        <a class="dropdown-item" href="{% link _documentation/platforms/index.md %}" data-toggle="tooltip" data-placement="right" title="Click to see other platforms we support but that don't follow the unified&nbsp;API"><em>Platform not listed?</em></a>
+        <a class="dropdown-item" href="/platforms/" data-toggle="tooltip" data-placement="right" title="Click to see other platforms we support but that don't follow the unified&nbsp;API"><em>Platform not listed?</em></a>
       </div>
     </div>
   </div>

--- a/src/collections/_documentation/clients/go/config.md
+++ b/src/collections/_documentation/clients/go/config.md
@@ -52,7 +52,7 @@ raven.SetEnvironment("staging")
 
 Sets the release. Release names are just strings, but the Sentry SDK may detect some formats,
 and the format might render differently.
-For more information have a look at [the releases documentation]({% link _documentation/workflow/releases/index.md %}).
+For more information have a look at [the releases documentation](/workflow/releases/).
 
 ```go
 raven.SetRelease("h3ll0w0rld")

--- a/src/collections/_documentation/data-management/advanced-datascrubbing.md
+++ b/src/collections/_documentation/data-management/advanced-datascrubbing.md
@@ -4,7 +4,7 @@ sidebar_order: 4
 keywords: ["pii", "gdpr", "personally identifiable data", "compliance"]
 ---
 
-In addition to using [`beforeSend`]({% link _documentation/data-management/sensitive-data.md %}#custom-event-processing-in-the-sdk) in your SDK or our [server-side data scrubbing features]({% link _documentation/data-management/sensitive-data.md %}#server-side-scrubbing) to redact sensitive data, we are currently beta-testing ways to give you more granular control over server-side data scrubbing of your events. Additional functionality includes:
+In addition to using [`beforeSend`](/data-management/sensitive-data/#custom-event-processing-in-the-sdk) in your SDK or our [server-side data scrubbing features](/data-management/sensitive-data/#server-side-scrubbing) to redact sensitive data, we are currently beta-testing ways to give you more granular control over server-side data scrubbing of your events. Additional functionality includes:
 
 * Define custom regular expressions to match on sensitive data
 * Detailed tuning on which parts of an event to scrub
@@ -164,7 +164,7 @@ Select known parts of the schema using the following:
 * `$logentry` matches the `logentry` attribute of an event.
 * `$thread` matches a single thread instance in `{"threads": {"values": [...]}}`
 * `$breadcrumb` matches a single breadcrumb in `{"breadcrumbs": {"values": [...]}}`
-* `$span` matches a [trace span]({% link _documentation/performance/distributed-tracing.md %}#traces-transactions-and-spans)
+* `$span` matches a [trace span](/performance/distributed-tracing/#traces-transactions-and-spans)
 * `$sdk` matches the SDK context in `{"sdk": ...}`
 
 ### Escaping Special Characters

--- a/src/collections/_documentation/data-management/event-grouping/server-side-fingerprinting.md
+++ b/src/collections/_documentation/data-management/event-grouping/server-side-fingerprinting.md
@@ -4,7 +4,7 @@ sidebar_order: 1
 ---
 
 Server-side fingerprinting is also configured with a config similar to
-[grouping enhancements]({% link _documentation/data-management/event-grouping/grouping-enhancements.md %}),
+[grouping enhancements](/data-management/event-grouping/grouping-enhancements/),
 but the syntax is slightly different. The matchers are the same
 but instead of flipping flags, a fingerprint is assigned that overrides the
 default grouping entirely.
@@ -24,7 +24,7 @@ The matchers are:
 - `value`: matches on an exception value
 - `message`: matches on a log message
 
-The matchers also include the following from Custom Grouping Enhancements. See [grouping enhancements]({% link _documentation/data-management/event-grouping/grouping-enhancements.md %}#rules) for more info on how they work:
+The matchers also include the following from Custom Grouping Enhancements. See [grouping enhancements](/data-management/event-grouping/grouping-enhancements/#rules) for more info on how they work:
 
 - `family`
 - `path`

--- a/src/collections/_documentation/data-management/sensitive-data.md
+++ b/src/collections/_documentation/data-management/sensitive-data.md
@@ -132,7 +132,7 @@ As mentioned earlier, configure scrubbing within SDK if possible so that sensiti
 
 ### Advanced server-side data scrubbing
 
-We are currently betatesting additional features around server-side data scrubbing. For more information see [_Advanced Data Scrubbing_]({% link _documentation/data-management/advanced-datascrubbing.md %}).
+We are currently betatesting additional features around server-side data scrubbing. For more information see [_Advanced Data Scrubbing_](/data-management/advanced-datascrubbing/).
 
 ## Restricting Emails
 

--- a/src/collections/_documentation/enriching-error-data/breadcrumbs.md
+++ b/src/collections/_documentation/enriching-error-data/breadcrumbs.md
@@ -67,4 +67,4 @@ hint.  The function can modify the breadcrumb or decide to discard it entirely:
 
 {% include components/platform_content.html content_dir='before-breadcrumb' %}
 
-For information about what can be done with the hint see [_Filtering Events_]({% link _documentation/error-reporting/configuration/filtering.md %}#before-breadcrumb).
+For information about what can be done with the hint see [_Filtering Events_](/error-reporting/configuration/filtering/#before-breadcrumb).

--- a/src/collections/_documentation/enriching-error-data/error-tracing.md
+++ b/src/collections/_documentation/enriching-error-data/error-tracing.md
@@ -6,7 +6,7 @@ sidebar_order: 5
 With error tracing, you can correlate errors from multiple services and uncover a significant story surrounding a break. Using a unique identifier allows you to trace an error and pinpoint the service and code behaving unexpectedly. 
 
 ## Error Tracing and Sentry Configuration
-The following steps demonstrate a potential use-case that involves an example web application with a JavaScript front-end and a Node.js server. The examples assume that both services are already configured with Sentry's [JavaScript SDK]({% link _documentation/platforms/javascript/index.md %}).
+The following steps demonstrate a potential use-case that involves an example web application with a JavaScript front-end and a Node.js server. The examples assume that both services are already configured with Sentry's [JavaScript SDK](/platforms/javascript/).
 
 #### Step 1: Generate a unique transaction ID
 Generate a unique transaction identifier and set as a Sentry tag in the service issuing the request. This unique identifier could be a transaction ID or a session ID created when the web application first loads. Set this value as a Sentry tag using the Sentry SDK. Below, the example uses a `transactionId` as a unique identifier:

--- a/src/collections/_documentation/enriching-error-data/scopes.md
+++ b/src/collections/_documentation/enriching-error-data/scopes.md
@@ -16,8 +16,8 @@ blank scope are created on it.  That hub is then associated with the current
 thread and will internally hold a stack of scopes.
 
 The scope will hold useful information that should be sent along with the
-event.  For instance [contexts]({% link _documentation/enriching-error-data/additional-data.md %}) or
-[breadcrumbs]({% link _documentation/enriching-error-data/breadcrumbs.md %}) are stored on
+event.  For instance [contexts](/enriching-error-data/additional-data/) or
+[breadcrumbs](/enriching-error-data/breadcrumbs/) are stored on
 the scope.  When a scope is pushed, it inherits all data from the parent scope
 and when it pops all modifications are reverted.
 
@@ -32,7 +32,7 @@ of the box.  The hub you are unlikely to be interacting with directly unless you
 are writing an integration or you want to create or destroy scopes.  Scopes on the
 other hand are more user facing.  You can at any point in time call
 `configure-scope` to modify data stored on the scope.  This is for instance
-used to [modify the context]({% link _documentation/enriching-error-data/additional-data.md %}).
+used to [modify the context](/enriching-error-data/additional-data/).
 
 {% capture __alert_content -%}
 If you are very curious about how this thread locality thing works here are the
@@ -65,7 +65,7 @@ This can also be applied when unsetting a user at logout:
 {% include components/platform_content.html content_dir='unset-user' %}
 
 To learn what useful information can be associated with scopes see
-[the context documentation]({% link _documentation/enriching-error-data/additional-data.md %}).
+[the context documentation](/enriching-error-data/additional-data/).
 
 ## Local Scopes
 

--- a/src/collections/_documentation/error-reporting/capturing.md
+++ b/src/collections/_documentation/error-reporting/capturing.md
@@ -11,7 +11,7 @@ issue group or be added to an already existing one based on Sentry's grouping
 algorithm.  Separately to capturing you can also record "breadcrumbs" that lead
 up to an event.  Breadcrumbs are different in that they will not create an event
 in Sentry but will be buffered until the next event is sent.  For more information
-have a look at [the breadcrumbs documentation]({% link _documentation/enriching-error-data/breadcrumbs.md %}).
+have a look at [the breadcrumbs documentation](/enriching-error-data/breadcrumbs/).
 
 ## Capturing Errors / Exceptions
 
@@ -38,9 +38,6 @@ into.  For more information about that consult the API documentation of the SDK.
 
 ## Next Steps
 
-* Need to add extra data to your events? Have a look at [our context
-  documentation]({% link _documentation/enriching-error-data/additional-data.md %}).
+* Need to add extra data to your events? Have a look at [our context documentation](/enriching-error-data/additional-data/).
 
-* Captured too much data? Have a look at [filtering]({% link
-  _documentation/error-reporting/configuration/filtering.md %}) to remove spam
-  or sensitive information from your events.
+* Captured too much data? Have a look at [filtering](/error-reporting/configuration/filtering/) to remove spam or sensitive information from your events.

--- a/src/collections/_documentation/error-reporting/configuration/before-breadcrumb-hint/javascript.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-breadcrumb-hint/javascript.md
@@ -15,4 +15,4 @@ Sentry.init({
 });
 ```
 
-For information about which hints are available see [hints in JavaScript]({% link _documentation/platforms/javascript/index.md %}#hints).
+For information about which hints are available see [hints in JavaScript](/platforms/javascript/#hints).

--- a/src/collections/_documentation/error-reporting/configuration/before-breadcrumb-hint/python.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-breadcrumb-hint/python.md
@@ -9,4 +9,4 @@ def before_breadcrumb(crumb, hint):
 sentry_sdk.init(before_breadcrumb=before_breadcrumb)
 ```
 
-For information about which hints are available see [hints in Python]({% link _documentation/platforms/python/index.md %}#hints).
+For information about which hints are available see [hints in Python](/platforms/python/#hints).

--- a/src/collections/_documentation/error-reporting/configuration/before-send-hint/javascript.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-send-hint/javascript.md
@@ -12,4 +12,4 @@ init({
 });
 ```
 
-For information about which hints are available see [hints in JavaScript]({% link _documentation/platforms/javascript/index.md %}#hints).
+For information about which hints are available see [hints in JavaScript](/platforms/javascript/#hints).

--- a/src/collections/_documentation/error-reporting/configuration/before-send-hint/python.md
+++ b/src/collections/_documentation/error-reporting/configuration/before-send-hint/python.md
@@ -11,4 +11,4 @@ def before_send(event, hint):
 sentry_sdk.init(before_send=before_send)
 ```
 
-For information about which hints are available see [hints in Python]({% link _documentation/platforms/python/index.md %}#hints).
+For information about which hints are available see [hints in Python](/platforms/python/#hints).

--- a/src/collections/_documentation/error-reporting/configuration/config-intro/php.md
+++ b/src/collections/_documentation/error-reporting/configuration/config-intro/php.md
@@ -8,7 +8,7 @@ Sentry\init([
 ```
 
 {% capture __alert %}
-Some of the options listed below that are marked as _not available_ may be available in another form; see [PHP specific documentation]({% link _documentation/workflow/releases/index.md %}).
+Some of the options listed below that are marked as _not available_ may be available in another form; see [PHP specific documentation](/workflow/releases/).
 {% endcapture %}
 
 {% include components/alert.html

--- a/src/collections/_documentation/error-reporting/configuration/index.md
+++ b/src/collections/_documentation/error-reporting/configuration/index.md
@@ -42,7 +42,7 @@ if you have the chance it's a better idea to manually set it.  That way it's gua
 in sync with your deploy integrations or source map uploads.
 
 Release names are just strings but some formats are detected by Sentry and might be rendered
-differently.  For more information have a look at [the releases documentation]({% link _documentation/workflow/releases/index.md %}).
+differently.  For more information have a look at [the releases documentation](/workflow/releases/).
 
 By default the SDK will try to read this value from the `SENTRY_RELEASE` environment
 variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/csharp.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/csharp.md
@@ -1,1 +1,1 @@
--  [_integrating with the .NET ecosystem_]({% link _documentation/platforms/dotnet/index.md %})
+-  [_integrating with the .NET ecosystem_](/platforms/dotnet/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/go.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/go.md
@@ -1,1 +1,1 @@
--  [_integrating with the Go ecosystem_]({% link _documentation/platforms/go/index.md %})
+-  [_integrating with the Go ecosystem_](/platforms/go/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/javascript.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/javascript.md
@@ -1,1 +1,1 @@
--  [_integrating with the JavaScript ecosystem_]({% link _documentation/platforms/javascript/index.md %})
+-  [_integrating with the JavaScript ecosystem_](/platforms/javascript/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/native.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/native.md
@@ -1,3 +1,3 @@
--  [_adding Google Breakpad_]({% link _documentation/platforms/native/index.md %}#google-breakpad)
--  [_adding Google Crashpad_]({% link _documentation/platforms/native/index.md %}#google-crashpad)
--  [_integrating with Unreal Engine 4_]({%- link _documentation/platforms/native/ue4.md -%})
+-  [_adding Google Breakpad_](/platforms/native/#google-breakpad)
+-  [_adding Google Crashpad_](/platforms/native/#google-crashpad)
+-  [_integrating with Unreal Engine 4_](/platforms/native/ue4/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/php.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/php.md
@@ -1,1 +1,1 @@
--  [_integrating with the PHP ecosystem_]({% link _documentation/platforms/php/index.md %})
+-  [_integrating with the PHP ecosystem_](/platforms/php/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/python.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/python.md
@@ -1,1 +1,1 @@
--  [_integrating with the Python ecosystem_]({% link _documentation/platforms/python/index.md %})
+-  [_integrating with the Python ecosystem_](/platforms/python/)

--- a/src/collections/_documentation/error-reporting/getting-started-next-steps/rust.md
+++ b/src/collections/_documentation/error-reporting/getting-started-next-steps/rust.md
@@ -1,1 +1,1 @@
--  [_integrating with the Rust ecosystem_]({% link _documentation/platforms/rust/index.md %})
+-  [_integrating with the Rust ecosystem_](/platforms/rust/)

--- a/src/collections/_documentation/performance/getting-started.md
+++ b/src/collections/_documentation/performance/getting-started.md
@@ -7,10 +7,10 @@ Performance monitoring helps developers measure Apdex, Throughput, and trace slo
 
 Learn more about performance monitoring in:
 
-- [Homepage]({% link _documentation/performance/performance-homepage.md %}): displays a high-level report of application health, including problematic transactions and both Apdex and Throughput graphs
-- [Distributed Tracing]({% link _documentation/performance/distributed-tracing.md %}): diagnose problems and view interactions across your software systems
-- [Metrics]({% link _documentation/performance/performance-metrics.md %}): provides insight into user experience of your application based on custom thresholds
-- [Discover]({% link _documentation/performance/discover/index.md %}): view data across environments with pre-built queries. Customers subscribed to the Team or Business plan can use Discover to view comprehensive information sent to Sentry.
+- [Homepage](/performance/performance-homepage/): displays a high-level report of application health, including problematic transactions and both Apdex and Throughput graphs
+- [Distributed Tracing](/performance/distributed-tracing/): diagnose problems and view interactions across your software systems
+- [Metrics](/performance/performance-metrics/): provides insight into user experience of your application based on custom thresholds
+- [Discover](/performance/discover/): view data across environments with pre-built queries. Customers subscribed to the Team or Business plan can use Discover to view comprehensive information sent to Sentry.
 
 ## Install
 
@@ -20,15 +20,15 @@ Learn more about performance monitoring in:
 
 Sentry provides several tools to explore your application's performance data and uncover problems.
 
-The **Performance homepage** is our center for monitoring how your application is doing. Here, you can view a list of all your endpoints and transactions and view a summary of any transaction in your application. Learn more about the [Homepage]({% link _documentation/performance/performance-homepage.md %}).
+The **Performance homepage** is our center for monitoring how your application is doing. Here, you can view a list of all your endpoints and transactions and view a summary of any transaction in your application. Learn more about the [Homepage](/performance/performance-homepage/).
 
 [{% asset performance/performance-homepage-main-example.png alt="Example of Performance in Product UI" %}]({% asset performance/performance-homepage-main-example.png @path %})
 
-**Discover** is our custom business intelligence query builder that can help you answer questions about your data and analyze metrics. Learn more about [Discover]({% link _documentation/performance/discover/index.md %}).
+**Discover** is our custom business intelligence query builder that can help you answer questions about your data and analyze metrics. Learn more about [Discover](/performance/discover/).
 
 [{% asset performance/discover-main-page-example.png alt="Discover page" %}]({% asset performance/discover-main-page-example.png @path %})
 
 
-**Transaction Details** lets you examine an individual transaction event in detail. Here spans are visualized to help you identify slow HTTP requests, slow database queries, and other bottlenecks. You can also jump to other transactions within the trace, and identify associated errors. Learn more about [Distributed Tracing]({% link _documentation/performance/distributed-tracing.md %}) and the [Transaction Details page]({% link _documentation/performance/distributed-tracing.md %}#transaction-detail-viewpage).
+**Transaction Details** lets you examine an individual transaction event in detail. Here spans are visualized to help you identify slow HTTP requests, slow database queries, and other bottlenecks. You can also jump to other transactions within the trace, and identify associated errors. Learn more about [Distributed Tracing](/performance/distributed-tracing/) and the [Transaction Details page](/performance/distributed-tracing/#transaction-detail-viewpage).
 
 [{% asset performance/transaction-detail-main-example.png alt="Discover page" %}]({% asset performance/transaction-detail-main-example.png @path %})

--- a/src/collections/_documentation/platforms/dotnet/entityframework.md
+++ b/src/collections/_documentation/platforms/dotnet/entityframework.md
@@ -29,7 +29,7 @@ This package extends `Sentry` main SDK. That means that besides the EF features,
 * Queries as breadcrumbs
 * Validation errors
 
-All queries executed are added as breadcrumbs and are sent with any event which happens on the same [scope]({% link _documentation/enriching-error-data/scopes.md %}). Besides that, validation errors are also included as `Extra`.
+All queries executed are added as breadcrumbs and are sent with any event which happens on the same [scope](/enriching-error-data/scopes/). Besides that, validation errors are also included as `Extra`.
 
 
 ## Configuration

--- a/src/collections/_documentation/platforms/dotnet/index.md
+++ b/src/collections/_documentation/platforms/dotnet/index.md
@@ -8,12 +8,12 @@ This section will describe features, configurations and general functionality wh
 
 ## Integrations
 
-- [_ASP.NET Core_]({% link _documentation/platforms/dotnet/aspnetcore.md %})
-- [_EntityFramework_]({% link _documentation/platforms/dotnet/entityframework.md %})
-- [_log4net_]({% link _documentation/platforms/dotnet/log4net.md %})
-- [_Microsoft.Extensions.Logging_]({% link _documentation/platforms/dotnet/microsoft-extensions-logging.md %})
-- [_Serilog_]({% link _documentation/platforms/dotnet/serilog.md %})
-- [_NLog_]({% link _documentation/platforms/dotnet/nlog.md %})
+- [_ASP.NET Core_](/platforms/dotnet/aspnetcore/)
+- [_EntityFramework_](/platforms/dotnet/entityframework/)
+- [_log4net_](/platforms/dotnet/log4net/)
+- [_Microsoft.Extensions.Logging_](/platforms/dotnet/microsoft-extensions-logging/)
+- [_Serilog_](/platforms/dotnet/serilog/)
+- [_NLog_](/platforms/dotnet/nlog/)
 
 ## Compatibility
 
@@ -69,7 +69,7 @@ If that's your case, you can use 2 abstractions:
 
 The `ISentryClient` exposes the `CaptureEvent` method and its implementation `SentryClient` is responsible for queueing the event to be sent to Sentry. It also abstracts away the internal transport.
 
-The `IHub` on the other hand, holds a client and the current [scope]({% link _documentation/enriching-error-data/scopes.md %}). In fact, it extends `ISentryClient` and is able to dispatch calls to the right client depending on the current scope.
+The `IHub` on the other hand, holds a client and the current [scope](/enriching-error-data/scopes/). In fact, it extends `ISentryClient` and is able to dispatch calls to the right client depending on the current scope.
 
 In order to allow different events to hold different contextual data, you need to know in which scope you are in.
 That's the job of the [`Hub`](https://github.com/getsentry/sentry-dotnet/blob/master/src/Sentry/Internal/Hub.cs). It holds the scope management as well as a client.

--- a/src/collections/_documentation/platforms/dotnet/microsoft-extensions-logging.md
+++ b/src/collections/_documentation/platforms/dotnet/microsoft-extensions-logging.md
@@ -35,7 +35,7 @@ Messages logged from assemblies with the name starting with `Sentry` will not ge
 * Store log messages as breadcrumbs
 * Send events to sentry
 
-Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope]({% link _documentation/enriching-error-data/scopes.md %}).
+Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope](/enriching-error-data/scopes/).
 
 By default, any message with log level `Information` or higher will be kept as a `Breadcrumb`.
 

--- a/src/collections/_documentation/platforms/dotnet/nlog.md
+++ b/src/collections/_documentation/platforms/dotnet/nlog.md
@@ -35,7 +35,7 @@ Messages logged from assemblies with the name starting with `Sentry` will not ge
 * Store log messages as breadcrumbs
 * Send events to sentry
 
-Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope]({% link _documentation/enriching-error-data/scopes.md %}).
+Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope](/enriching-error-data/scopes/).
 
 By default, Sentry will keep any message with log level `Info` or higher as a `Breadcrumb`.
 

--- a/src/collections/_documentation/platforms/dotnet/serilog.md
+++ b/src/collections/_documentation/platforms/dotnet/serilog.md
@@ -35,7 +35,7 @@ Messages logged from assemblies with the name starting with `Sentry` will not ge
 * Store log messages as breadcrumbs
 * Send events to sentry
 
-Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope]({% link _documentation/enriching-error-data/scopes.md %}).
+Two separate settings define the minimum log level to keep the log entry as a `Breadcrumb` and to send an `Event` to Sentry. The events include any stored breadcrumb on that [scope](/enriching-error-data/scopes/).
 
 By default, any message with log level `Information` or higher will be kept as a `Breadcrumb`.
 

--- a/src/collections/_documentation/platforms/index.md
+++ b/src/collections/_documentation/platforms/index.md
@@ -23,7 +23,7 @@ These SDKs are [maintained and supported](https://forum.sentry.io) by the Sentry
 * [_C++_](https://github.com/nlohmann/crow)
 * [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 * [_Crystal_](https://github.com/Sija/raven.cr)
-* [_Flutter_]({% link _documentation/platforms/flutter/index.md %})
+* [_Flutter_](/platforms/flutter/)
 * [_Grails_](https://github.com/agorapulse/grails-sentry)
 * [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
 * [_Lua_](https://github.com/cloudflare/raven-lua)
@@ -36,6 +36,6 @@ These SDKs are [maintained and supported](https://forum.sentry.io) by the Sentry
 
 ## Other platforms
 
-Some platforms have been phased out or have been replaced with new SDKs. For those legacy integrations head over to the [legacy clients]({% link _documentation/clients/index.md %}) page.
+Some platforms have been phased out or have been replaced with new SDKs. For those legacy integrations head over to the [legacy clients](/clients/) page.
 
 Your favorite language or framework still cannot be found? Then we encourage you to start a discussion about supporting it on our [community forum](https://forum.sentry.io).

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/angular.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/angular.md
@@ -1,4 +1,4 @@
-The Angular integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Angular integration page]({% link _documentation/platforms/javascript/angular.md %})
+The Angular integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Angular integration page](/platforms/javascript/angular/)
 
 {% wizard hide %}
 You can also [NPM install our browser library](?platform=browsernpm).

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/ember.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/ember.md
@@ -1,4 +1,4 @@
-The Ember integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Ember integration page]({% link _documentation/platforms/javascript/ember.md %})
+The Ember integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Ember integration page](/platforms/javascript/ember/)
 
 {% wizard hide %}
 You can also [NPM install our browser library](?platform=browsernpm).

--- a/src/collections/_documentation/platforms/javascript/getting-started-install/vue.md
+++ b/src/collections/_documentation/platforms/javascript/getting-started-install/vue.md
@@ -1,4 +1,4 @@
-The Vue integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Vue integration page]({% link _documentation/platforms/javascript/vue.md %})
+The Vue integration requires our [Browser SDK](?platform=browsernpm) in addition see our in depth [Vue integration page](/platforms/javascript/vue/)
 
 {% wizard hide %}
 You can also [NPM install our browser library](?platform=browsernpm).

--- a/src/collections/_documentation/platforms/javascript/index.md
+++ b/src/collections/_documentation/platforms/javascript/index.md
@@ -690,7 +690,7 @@ Sentry.withScope(function(scope) {
 For more information, see [Setting the Level](#setting-the-level).
 
 ### Lazy Loading Sentry
-We recommend using our bundled CDN version for the browser as explained [here]({% link _documentation/error-reporting/quickstart.md %}?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer`, you can, though keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
+We recommend using our bundled CDN version for the browser as explained [here](/error-reporting/quickstart/?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer`, you can, though keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
 
 We also offer an alternative we call the _Loader_. You install by just adding this script to your website instead of the SDK bundle. This line is everything you need; the script is <1kB gzipped and includes the `Sentry.init` call with your DSN.
 
@@ -714,7 +714,7 @@ It's a small wrapper around our SDK. The _Loader_ does a few things:
 - It lazy injects our SDK into your website.
 - After you've loaded the SDK, the Loader will send everything to Sentry.
 
-By default, the _Loader_ contains all information needed for our SDK to function, like the `DSN`.  In case you want to set additional [options]({% link _documentation/error-reporting/configuration/index.md %}) you have to set them like this:
+By default, the _Loader_ contains all information needed for our SDK to function, like the `DSN`.  In case you want to set additional [options](/error-reporting/configuration/) you have to set them like this:
 
 
 ```javascript

--- a/src/collections/_documentation/platforms/php/symfony.md
+++ b/src/collections/_documentation/platforms/php/symfony.md
@@ -65,7 +65,7 @@ If you're using the Symfony Flex plugin, you'll find this file already created f
 
 ## Customization
 
-The [Sentry 2.0 SDK]({% link _documentation/platforms/php/index.md %}#php-specific-options) uses the 
+The [Sentry 2.0 SDK](/platforms/php/#php-specific-options) uses the 
 [Unified API](https://develop.sentry.dev/sdk/unified-api/), hence it uses the concept of `Scope`s to 
 hold information about the current state of the app, and attach it to any event that is reported. 
 This bundle has three listeners (`RequestListener`, `SubRequestListener`, and `ConsoleListener`) that add some easy 
@@ -133,8 +133,8 @@ disable it in the `test` and `dev` environments.
 
 ### Options
 All the possibile configurations under the `options` key map directly to the correspondent options from the base SDK;
-you can read more about those in the [Unified API configuration docs]({% link _documentation/error-reporting/configuration/index.md %}),
-and on the [PHP specific SDK docs]({% link _documentation/platforms/php/index.md %}#php-specific-options).
+you can read more about those in the [Unified API configuration docs](/error-reporting/configuration/),
+and on the [PHP specific SDK docs](/platforms/php/#php-specific-options).
 
 Below you can find additional documentation that is specific to the bundle usage, or information about the sensible default
 values that you can use in some cases.

--- a/src/collections/_documentation/platforms/python/aiohttp.md
+++ b/src/collections/_documentation/platforms/python/aiohttp.md
@@ -58,5 +58,5 @@ Framework](https://docs.aiohttp.org/en/stable/web.html). A Python version of
   issue](https://github.com/getsentry/sentry-python/issues/220).
 
 * Logging with any logger will create breadcrumbs when
-  the [Logging]({% link _documentation/platforms/python/logging.md %})
+  the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).

--- a/src/collections/_documentation/platforms/python/aws_lambda.md
+++ b/src/collections/_documentation/platforms/python/aws_lambda.md
@@ -22,7 +22,7 @@ def my_function(event, context):
 ```
 
 {% capture __alert_content -%}
-If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*]({% link _documentation/platforms/python/index.md %}#integrations) for more information.
+If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*](/platforms/python/#integrations) for more information.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Note"
@@ -41,4 +41,4 @@ With the AWS Lambda integration enabled, the Python SDK will:
 
 * {% include platforms/python/request-data.md %}
 
-* Generally the behavior is quite similar to the [generic serverless integration]({% link _documentation/platforms/python/serverless.md %}).
+* Generally the behavior is quite similar to the [generic serverless integration](/platforms/python/serverless/).

--- a/src/collections/_documentation/platforms/python/default-integrations.md
+++ b/src/collections/_documentation/platforms/python/default-integrations.md
@@ -68,7 +68,7 @@ Adds `sys.argv` as an `extra` attribute to each event.
 ## Logging
 *Import name: `sentry_sdk.integrations.logging.LoggingIntegration`*
 
-See [_Logging_]({% link _documentation/platforms/python/logging.md %})
+See [_Logging_](/platforms/python/logging/)
 
 ## Threading
 *Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`*

--- a/src/collections/_documentation/platforms/python/django.md
+++ b/src/collections/_documentation/platforms/python/django.md
@@ -49,7 +49,7 @@ Visiting this route will trigger an error that will be captured by Sentry.
 
 A Django application using [Channels 2.0](https://channels.readthedocs.io/en/latest/) will be correctly instrumented under Python 3.7. For older versions of Python you'll have to install `aiocontextvars` from PyPI or your application will not start.
 
-If you experience memory leaks in your channels consumers while using the SDK, you need to wrap your entire application in Sentry's [ASGI middleware]({% link _documentation/platforms/python/asgi.md %}).
+If you experience memory leaks in your channels consumers while using the SDK, you need to wrap your entire application in Sentry's [ASGI middleware](/platforms/python/asgi/).
 
 Unfortunately the SDK is not able to do so by itself, as [Channels is missing some hooks for instrumentation](https://github.com/django/channels/issues/1348).
 
@@ -63,7 +63,7 @@ Unfortunately the SDK is not able to do so by itself, as [Channels is missing so
 
 * The Sentry Python SDK will attach SQL queries as breadcrumbs.
 
-* Logging with any logger will create breadcrumbs when the [Logging]({% link _documentation/platforms/python/logging.md %})
+* Logging with any logger will create breadcrumbs when the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).
 
 ## Options
@@ -90,7 +90,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 ## User Feedback
 
-You can use the user feedback feature with this integration.  For more information see [User Feedback]({% link _documentation/enriching-error-data/user-feedback.md %}?platform=django).
+You can use the user feedback feature with this integration.  For more information see [User Feedback](/enriching-error-data/user-feedback/?platform=django).
 
 ## Reporting other status codes
 

--- a/src/collections/_documentation/platforms/python/flask.md
+++ b/src/collections/_documentation/platforms/python/flask.md
@@ -52,7 +52,7 @@ Visiting this route will trigger an error that will be captured by Sentry.
   object to capture some more data.
 
 * Logging with `app.logger` or *any* logger will create breadcrumbs when
-  the [Logging]({% link _documentation/platforms/python/logging.md %})
+  the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).
 
 ## Options
@@ -76,4 +76,4 @@ You can pass the following keyword arguments to `FlaskIntegration()`:
 
 ## User Feedback
 
-You can use the user feedback feature with this integration.  For more information see [User Feedback]({% link _documentation/enriching-error-data/user-feedback.md %}?platform=flask).
+You can use the user feedback feature with this integration.  For more information see [User Feedback](/enriching-error-data/user-feedback/?platform=flask).

--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -275,7 +275,7 @@ For more information, see full documentation on [Default Integrations]({%- link 
 
 ## Hints
 
-The Python SDK provides some common [hints]({% link _documentation/error-reporting/configuration/filtering.md %}#event-hints) for breadcrumbs and events.  These hints are passed as the `hint` parameter to `before_send` and `before_breadcrumb` (as well as event processors) as a dictionary.  More than one hint can be supplied, but this is rare.
+The Python SDK provides some common [hints](/error-reporting/configuration/filtering/#event-hints) for breadcrumbs and events.  These hints are passed as the `hint` parameter to `before_send` and `before_breadcrumb` (as well as event processors) as a dictionary.  More than one hint can be supplied, but this is rare.
 
 `exc_info`
 
@@ -295,4 +295,4 @@ This section contains various gotchas that are inherent to the Python SDK's
 design, do not necessarily affect the majority of users and do not really fit
 anywhere else.
 
-- [Contextvars vs thread locals]({% link _documentation/platforms/python/contextvars.md %})
+- [Contextvars vs thread locals](/platforms/python/contextvars/)

--- a/src/collections/_documentation/platforms/python/pyramid.md
+++ b/src/collections/_documentation/platforms/python/pyramid.md
@@ -48,7 +48,7 @@ Framework](https://trypyramid.com/).
 * {% include platforms/python/request-data.md %}
 
 * Logging with *any* logger will create breadcrumbs when
-  the [Logging]({% link _documentation/platforms/python/logging.md %})
+  the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).
 
 ## Options

--- a/src/collections/_documentation/platforms/python/sanic.md
+++ b/src/collections/_documentation/platforms/python/sanic.md
@@ -57,5 +57,5 @@ A Python version of 3.6 or greater is also required.
 * {% include platforms/python/request-data.md %}
 
 * Logging with any logger will create breadcrumbs when
-  the [Logging]({% link _documentation/platforms/python/logging.md %})
+  the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).

--- a/src/collections/_documentation/platforms/python/serverless.md
+++ b/src/collections/_documentation/platforms/python/serverless.md
@@ -6,7 +6,7 @@ sidebar_order: 9
 {% version_added 0.7.3 %}
 
 <!-- WIZARD -->
-It is recommended to use an [integration for your particular serverless environment if available]({% link _documentation/platforms/python/index.md %}#serverless), as those are easier to use and capture more useful information.
+It is recommended to use an [integration for your particular serverless environment if available](/platforms/python/#serverless), as those are easier to use and capture more useful information.
 
 If you use a serverless provider not directly supported by the SDK, you can use this generic integration.
 
@@ -33,6 +33,6 @@ def my_function(...):
 
   When there are no events to be sent, this will not add a delay. However, if there are errors, this will delay the return of your serverless function until the events are sent. This is necessary as serverless environments typically reserve the right to kill the runtime/VM when they consider it unused.
 
-  The maximum amount of time to block overall is set by the [`shutdown_timeout` client option]({% link _documentation/error-reporting/configuration/index.md %}?platform=python#shutdown-timeout).
+  The maximum amount of time to block overall is set by the [`shutdown_timeout` client option](/error-reporting/configuration/?platform=python#shutdown-timeout).
 
   You can disable this aspect by decorating with `@serverless_function(flush=False)` instead.

--- a/src/collections/_documentation/platforms/python/tornado.md
+++ b/src/collections/_documentation/platforms/python/tornado.md
@@ -50,5 +50,5 @@ Python 3.6 or greater is required.
 * {% include platforms/python/request-data.md %}
 
 * Logging with any logger will create breadcrumbs when
-  the [Logging]({% link _documentation/platforms/python/logging.md %})
+  the [Logging](/platforms/python/logging/)
   integration is enabled (done by default).

--- a/src/collections/_documentation/platforms/python/wsgi.md
+++ b/src/collections/_documentation/platforms/python/wsgi.md
@@ -6,7 +6,7 @@ sidebar_order: 8
 {% version_added 0.6.0 %}
 
 <!-- WIZARD -->
-It is recommended to use an [integration for your particular WSGI framework if available]({% link _documentation/platforms/python/index.md %}#web-frameworks), as those are easier to use and capture more useful information.
+It is recommended to use an [integration for your particular WSGI framework if available](/platforms/python/#web-frameworks), as those are easier to use and capture more useful information.
 
 If you use a WSGI framework not directly supported by the SDK, or wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.
 

--- a/src/collections/_documentation/platforms/rust/index.md
+++ b/src/collections/_documentation/platforms/rust/index.md
@@ -9,8 +9,7 @@ protocol for Rust and provides convenient helpers for sending common types of
 events to Sentry.
 
 The Rust SDK follows the new unified SDK architecture.  To get started have a
-look at the [quickstart]({% link _documentation/error-reporting/quickstart.md
-%}?platform=rust) docs.
+look at the [quickstart](/error-reporting/quickstart/?platform=rust) docs.
 
 ## Integrations
 
@@ -21,25 +20,25 @@ and libraries.
 
 Sentry-Rust supports the following application frameworks:
 
-* [actix-web]({% link _documentation/platforms/rust/actix.md %})
+* [actix-web](/platforms/rust/actix/)
 
 ### Error handling integrations
 
 Sentry-Rust supports the most commonly used libraries for advanced error management:
 
-* [failure]({% link _documentation/platforms/rust/failure.md %})
-* [error-chain]({% link _documentation/platforms/rust/error_chain.md %})
+* [failure](/platforms/rust/failure/)
+* [error-chain](/platforms/rust/error_chain/)
 
 Additionally you can catch panics using the panic integration:
 
-* [panic]({% link _documentation/platforms/rust/panic.md %})
+* [panic](/platforms/rust/panic/)
 
 ### Logging integrations
 
 Logs can be automatically converted into breadcrumbs.
 
-* [env_logger]({% link _documentation/platforms/rust/env_logger.md %})
-* [log]({% link _documentation/platforms/rust/log.md %})
+* [env_logger](/platforms/rust/env_logger/)
+* [log](/platforms/rust/log/)
 
 ## More Information
 

--- a/src/collections/_documentation/workflow/integrations/global-integrations.md
+++ b/src/collections/_documentation/workflow/integrations/global-integrations.md
@@ -180,7 +180,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with re
 
 ### Bitbucket Server
 
-You can use the data from your Bitbucket Server commits to help find and fix bugs faster. [Troubleshooting]({% link _documentation/workflow/integrations/global-integrations.md %}#troubleshooting-2)
+You can use the data from your Bitbucket Server commits to help find and fix bugs faster. [Troubleshooting](/workflow/integrations/global-integrations/#troubleshooting-2)
 
 #### Installing Bitbucket Server with Sentry
 
@@ -443,7 +443,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 ### GitHub Enterprise
 
-You can use the data from your GitHub Enterprise commits to help find and fix bugs faster. [Troubleshooting]({% link _documentation/workflow/integrations/global-integrations.md %}#troubleshooting-2)
+You can use the data from your GitHub Enterprise commits to help find and fix bugs faster. [Troubleshooting](/workflow/integrations/global-integrations/#troubleshooting-2)
 
 #### Configure GitHub Enterprise
 
@@ -568,7 +568,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 ### GitLab
 
-Sentry’s GitLab integration helps you find and fix bugs faster by using data from your GitLab commits. Additionally, you can streamline your triaging process by creating a GitLab issue directly from Sentry. [Troubleshooting]({% link _documentation/workflow/integrations/global-integrations.md %}#troubleshooting-2)
+Sentry’s GitLab integration helps you find and fix bugs faster by using data from your GitLab commits. Additionally, you can streamline your triaging process by creating a GitLab issue directly from Sentry. [Troubleshooting](/workflow/integrations/global-integrations/troubleshooting-2)
 
 #### Configure GitLab
 

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -113,7 +113,7 @@ You need to make sure you’re using [Auth Tokens]({%- link _documentation/api/a
   level="warning"
 %}
 
-In the above example, first, we're using environment variables to configure the CLI (see [_Working with Projects_]({% link _documentation/cli/configuration.md %}#sentry-cli-working-with-projects) for other possible ways), and then the `propose-version` sub-command to determine a release ID automatically. Next, we’re creating a release tagged `VERSION` for the organization `my-org` for projects `project1` and `project2`. Finally, we’re using the `--auto` flag to determine the repository name automatically, and associate commits between the previous release’s commit and the current head commit with the release. If the previous release doesn't have any commits associated with it, we’ll use the latest 20 commits.
+In the above example, first, we're using environment variables to configure the CLI (see [_Working with Projects_](/cli/configuration/#sentry-cli-working-with-projects) for other possible ways), and then the `propose-version` sub-command to determine a release ID automatically. Next, we’re creating a release tagged `VERSION` for the organization `my-org` for projects `project1` and `project2`. Finally, we’re using the `--auto` flag to determine the repository name automatically, and associate commits between the previous release’s commit and the current head commit with the release. If the previous release doesn't have any commits associated with it, we’ll use the latest 20 commits.
 
 If you want more control over which commits to associate, or are unable to execute the command inside the repository, you can manually specify a repository and range:
 


### PR DESCRIPTION
This will ease the transition to Gatsby, at the cost of no automatic link checking.