### PR TITLE
Fix: text in alert page

### DIFF
--- a/src/collections/_documentation/workflow/alerts-notifications/alerts.md
+++ b/src/collections/_documentation/workflow/alerts-notifications/alerts.md
@@ -110,15 +110,6 @@ In the example, the alert will not fire because an event cannot satisfy both of 
 The following actions are available:
 
 - Send an email
-<<<<<<< HEAD
-    - Send email to either [Issue Owners](/workflow/issue-owners/), Team, or [Member](/accounts/membership/#member)
-- Send a notification to all legacy integrations
-    - [Legacy integrations](/workflow/integrations/legacy-integrations/), also known as Plugins, are configured per project 
-- Send a notification via an integration
-    - This includes:
-        - Legacy integrations
-        - Integrations built using the [Integration platform](/workflow/integrations/integration-platform/) (includes published integrations, internal integrations, unpublished integrations)
-=======
     - Send email to either [Issue Owners](/workflow/issue-owners), Team, or [Member](/accounts/membership/#member)
 - Send a notification to all legacy integrations
     - [Legacy integrations](/workflow/integrations/legacy-integrations), also known as Plugins, are configured per project 
@@ -126,7 +117,6 @@ The following actions are available:
     - This includes:
         - Legacy integrations
         - Integrations built using the [Integration platform](/workflow/integrations/integration-platform/index) (includes published integrations, internal integrations, unpublished integrations)
->>>>>>> updated alerts page to new link structure
     -  If no legacy integrations or integrations built using the integration platform are enabled, this option is hidden.
 - Send a notification to a global integration, which includes
     - [PagerDuty](/workflow/integrations/global-integrations/#pagerduty)
@@ -134,11 +124,7 @@ The following actions are available:
 
 [{% asset notifications/alert-actions2.png alt="The alert condition in this example shows the conditions are conflicting with each other." %}]({% asset notifications/alert-actions2.png @path %})
 
-<<<<<<< HEAD
-For more details, see [Legacy Integrations](/workflow/integrations/legacy-integrations/) (via “Service” as any individual integration) that can send Notifications.
-=======
 For more details, see [Legacy Integrations](/workflow/integrations/legacy-integrations) (via “Service” as any individual integration) that can send Notifications.
->>>>>>> updated alerts page to new link structure
 
 By default, [issue owners](/workflow/alerts-notifications/alerts/#issue-owners) receive alert emails. If an issue owner is not configured or not found, the email will either not send or send to all project members as defined in **Project Settings > Issue Owners**.
 


### PR DESCRIPTION
Alert page had strange behavior with some text. This PR fixes them. Looks like leftover merge conflict resolution.