### PR TITLE
Edited "environment name can't contain" sentence

### DIFF
--- a/src/collections/_documentation/enriching-error-data/environments.md
+++ b/src/collections/_documentation/enriching-error-data/environments.md
@@ -14,7 +14,7 @@ Environments are unique to each organization. Environment settings, however, are
 
 ## Creating Environments
 
-Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. The environment name can't contain newlines or spaces, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](#hidden-environments) them.
+Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. The environment name can't contain newlines or spaces, can't be the string "None", a URL or exceed 64 characters. You can't delete environments, but you can [hide](#hidden-environments) them.
 
 ```python
 import sentry_sdk


### PR DESCRIPTION
When I tried to name an environment with my host URL that contained protocol, hostname, and port, there wasn't created an environment in the same way as when the name contained space character. Sentry just ignored the invalid env name. 
So I believe the URL format is not available and should be specified in the documentation as well.