### PR TITLE
feat: Update Releases docs with new sentry-cli set-commits behaviour

### DIFF
--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -247,6 +247,7 @@ sentry-cli releases set-commits --local $VERSION
 ```
 
 ##### Using the API
+To tell Sentry about your commit metadata via the API use the [create release endpoint](/api/releases/post-organization-releases/).
 
 In order for Sentry to use your commits, you must format your commits to match this form:
 

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -227,6 +227,28 @@ When Sentry sees this commit, we’ll reference the commit in the issue, and whe
 
 If you don't want Sentry to connect to your repository, or you're using an unsupported repository provider or VCS (e.g. Perforce), you can alternatively tell Sentry about your raw commit metadata via the API using the [create release endpoint](/api/releases/post-organization-releases/).
 
+#### Using the CLI
+```bash
+# Assumes you're in a git repository
+export SENTRY_AUTH_TOKEN=...
+export SENTRY_ORG=my-org
+VERSION=$(sentry-cli releases propose-version)
+
+# Create a release
+sentry-cli releases new -p project1 -p project2 $VERSION
+
+# Associate commits with the release
+sentry-cli releases set-commits --auto $VERSION
+```
+If you do not have a repo-based integration associated with your sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release’s commit and the current head commit with the release. If this is the first release, we’ll use the latest 20 commits. This behaviour is configurable with the `--initial-depth` flag. 
+
+Alternatively, you can use the the `--local` flag to enable this behaviour by default.
+```bash
+sentry-cli releases set-commits --local $VERSION
+```
+
+
+
 ##### Formatting Commit Metadata
 
 In order for Sentry to use your commits, you must format your commits to match this form:

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -224,7 +224,7 @@ When Sentry sees this commit, we’ll reference the commit in the issue, and whe
 %}
 
 #### Alternatively: Without a Repository Integration
-If you don’t want Sentry to connect to your repository, or you’re using an unsupported repository provider or VCS (e.g. Perforce), you can tell Sentry about your raw commit metadata via the CLI or the API using the [create release endpoint](/api/releases/post-organization-releases/).
+If you don’t want Sentry to connect to your repository, or you’re using an unsupported repository provider or VCS (e.g. Perforce), you can tell Sentry about your raw commit metadata via the CLI or the API.
 
 ##### Using the CLI
 ```bash

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -242,7 +242,7 @@ sentry-cli releases set-commits --auto $VERSION
 ```
 If you do not have a repo-based integration associated with your sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release’s commit and the current head commit with the release. If this is the first release, we’ll use the latest 20 commits. This behaviour is configurable with the `--initial-depth` flag. 
 
-Alternatively, you can use the the `--local` flag to enable this behaviour by default.
+Alternatively, you can use the `--local` flag to enable this behavior by default.
 ```bash
 sentry-cli releases set-commits --local $VERSION
 ```

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -224,10 +224,9 @@ When Sentry sees this commit, we’ll reference the commit in the issue, and whe
 %}
 
 #### Alternatively: Without a Repository Integration
+If you don’t want Sentry to connect to your repository, or you’re using an unsupported repository provider or VCS (e.g. Perforce), you can tell Sentry about your raw commit metadata via the CLI or the API using the [create release endpoint](/api/releases/post-organization-releases/).
 
-If you don't want Sentry to connect to your repository, or you're using an unsupported repository provider or VCS (e.g. Perforce), you can alternatively tell Sentry about your raw commit metadata via the API using the [create release endpoint](/api/releases/post-organization-releases/).
-
-#### Using the CLI
+##### Using the CLI
 ```bash
 # Assumes you're in a git repository
 export SENTRY_AUTH_TOKEN=...
@@ -247,9 +246,7 @@ Alternatively, you can use the `--local` flag to enable this behavior by default
 sentry-cli releases set-commits --local $VERSION
 ```
 
-
-
-##### Formatting Commit Metadata
+##### Using the API
 
 In order for Sentry to use your commits, you must format your commits to match this form:
 

--- a/src/collections/_documentation/workflow/releases/index.md
+++ b/src/collections/_documentation/workflow/releases/index.md
@@ -240,7 +240,7 @@ sentry-cli releases new -p project1 -p project2 $VERSION
 # Associate commits with the release
 sentry-cli releases set-commits --auto $VERSION
 ```
-If you do not have a repo-based integration associated with your sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release’s commit and the current head commit with the release. If this is the first release, we’ll use the latest 20 commits. This behaviour is configurable with the `--initial-depth` flag. 
+If you don't have a repo-based integration associated with your sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's commit and the current head commit with the release. If this is the first release, Sentry will use the latest 20 commits. This behavior is configurable with the `--initial-depth` flag. 
 
 Alternatively, you can use the `--local` flag to enable this behavior by default.
 ```bash


### PR DESCRIPTION
## Objective
Inform users of new functionality and flags available in the sentry-cli for releases.

<img width="1440" alt="Screen Shot 2020-07-01 at 11 10 03 AM" src="https://user-images.githubusercontent.com/10491193/86277430-86860600-bb8b-11ea-8d1a-2a2189ca0378.png">



