### PR TITLE
feat: Update Release Management docs with new sentry-cli set-commits behaviour

### DIFF
--- a/src/collections/_documentation/cli/releases.md
+++ b/src/collections/_documentation/cli/releases.md
@@ -72,6 +72,14 @@ If you also want to set a previous commit instead of letting the server use the 
 sentry-cli releases set-commits "$VERSION" --commit "my-repo@from..to"
 ```
 
+### Alternatively: Without a Repository Integration
+You can still use the `--auto` flag and the cli will automatically use the git tree of your local repo, and associate commits between the previous release's commit and the current head commit with the release. If this is the first release, Sentry will use the latest 20 commits. This behavior is configurable with the `--initial-depth` flag. 
+
+You can use the `--local` flag to enable this behavior by default.
+```bash
+sentry-cli releases set-commits --local $VERSION
+```
+
 {% include components/alert.html
   title='Troubleshooting'
   content='If you receive an "Unable to Fetch Commits" email, take a look at our [Help Center Article](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-).'


### PR DESCRIPTION
## Objective
Inform users of new functionality and flags available in the sentry-cli for releases.

It is pretty much the same as https://github.com/getsentry/sentry-docs/pull/1813

<img width="1440" alt="Screen Shot 2020-07-01 at 1 32 35 AM" src="https://user-images.githubusercontent.com/10491193/86222390-0637b480-bb3b-11ea-9e48-8f45ac9559e8.png">
