### PR TITLE
Additional Gatsby functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ yarn start
 
 You will now be able to access docs via http://localhost:3000.
 
-Note: This is running both the Jekyll (port 9001) and Gatsby (port 8000) servers, with a proxy routing requests between the two. 
+Note: This is running both the Jekyll (port 9001) and Gatsby (port 8000) servers, with a proxy routing requests between the two.
 
 ## The Great Gatsby Migration
 
@@ -43,6 +43,28 @@ The repository currently contains a Jekyll site (`./`) as well as a Gatsby site 
 - This is likely brittle. We want to move away from Jekyll as quickly as possible, so ideally all new content is done in Gatsby.
 
 - You can determine which engine is used by viewing source and looking for `"Rendered with"` in the HTML.
+
+## MDX Components + Markdown
+
+:pray: that MDX v2 fixes this.
+
+MDX has its flaws. When rendering components, any text inside of them is treated as raw text (_not_ markdown). To work around this you can use the `<markdown>` tag, but it also has its issues. Generally speaking, put an empty after the opening tag, and before the closing tag.
+
+```jsx
+// dont do this as parsing will hit weird breakages
+<markdown>
+foo bar
+</markdown>
+```
+
+```jsx
+// do this@
+<markdown>
+
+foo bar
+
+</markdown>
+```
 
 ## Development mode (Gatsby-specific)
 

--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -36,7 +36,7 @@ const getPlugins = () => {
       resolve: `gatsby-remark-images`,
       options: {
         maxWidth: 1200,
-        linkImagesToOriginal: false
+        linkImagesToOriginal: true
       }
     },
     {

--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -29,6 +29,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       slug: String!
       jekyllOnly: Boolean
       gatsbyOnly: Boolean
+      gatsby: Boolean
     }
   `,
     schema.buildObjectType({

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -27,7 +27,7 @@
     "gatsby-remark-autolink-headers": "^2.3.1",
     "gatsby-remark-check-links": "^2.1.0",
     "gatsby-remark-copy-linked-files": "^2.3.2",
-    "gatsby-remark-images": "^3.3.1",
+    "gatsby-remark-images": "^3.3.16",
     "gatsby-remark-prismjs": "^3.5.1",
     "gatsby-source-filesystem": "^2.3.1",
     "gatsby-transformer-remark": "^2.8.7",

--- a/gatsby/src/components/alert.js
+++ b/gatsby/src/components/alert.js
@@ -1,39 +1,44 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-const Alert = ({ title, children, level, deepLink, dismiss }) => (
-  <div
-    className={`alert ${level && `alert-${level}`}`}
-    role="alert"
-    id={deepLink}
-  >
-    {dismiss && (
-      <button
-        type="button"
-        className="close"
-        data-dismiss="alert"
-        aria-label="Close"
-      >
-        <span aria-hidden="true">&times;</span>
-      </button>
-    )}
-    {title && <h5 className="no_toc">{title}</h5>}
-    <div className="alert-body content-flush-bottom">{children}</div>
-  </div>
-);
+const Alert = ({ title, children, level, deepLink, dismiss }) => {
+  let className = "alert";
+  if (level) {
+    className += ` alert-${level}`;
+  }
+  if (children.props && typeof children.props.children === "string") {
+    className += " markdown-text-only";
+  }
+  return (
+    <div className={className} role="alert" id={deepLink}>
+      {dismiss && (
+        <button
+          type="button"
+          className="close"
+          data-dismiss="alert"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      )}
+      {title && <h5 className="no_toc">{title}</h5>}
+      <div className="alert-body content-flush-bottom">{children}</div>
+    </div>
+  );
+};
 
 Alert.propTypes = {
   title: PropTypes.string,
   level: PropTypes.string,
   deepLink: PropTypes.string,
-  dismiss: PropTypes.bool,
+  dismiss: PropTypes.bool
 };
 
 Alert.defaultProps = {
   title: null,
   level: "",
   deepLink: null,
-  dismiss: false,
+  dismiss: false
 };
 
 export default Alert;

--- a/gatsby/src/components/codeBlock.js
+++ b/gatsby/src/components/codeBlock.js
@@ -6,7 +6,7 @@ import { Clipboard } from "react-feather";
 import { useOnClickOutside, useRefWithCallback } from "../utils";
 import CodeContext from "./codeContext";
 
-const KEYWORDS_REGEX = /\b___([A-Z_][A-Z0-9_]*)___\b/g;
+const KEYWORDS_REGEX = /\b___(?:([A-Z_][A-Z0-9_]*)\.)?([A-Z_][A-Z0-9_]*)___\b/g;
 
 function makeKeywordsClickable(children) {
   if (!Array.isArray(children)) {
@@ -31,8 +31,8 @@ function makeKeywordsClickable(children) {
       }
       arr.push(
         Selector({
-          group: "PROJECT",
-          keyword: match[1],
+          group: match[1] || "PROJECT",
+          keyword: match[2],
           key: lastIndex
         })
       );

--- a/gatsby/src/components/content.js
+++ b/gatsby/src/components/content.js
@@ -10,6 +10,8 @@ import SmartLink from "./smartLink";
 import CodeBlock from "./codeBlock";
 import CodeTabs from "./codeTabs";
 import CodeContext, { useCodeContextState } from "./codeContext";
+import JsCdnTag from "./jsCdnTag";
+import ParamTable from "./paramTable";
 import PlatformContent from "./platformContent";
 
 const mdxComponents = {
@@ -19,7 +21,9 @@ const mdxComponents = {
   CodeBlock,
   CodeTabs,
   Break,
-  PlatformContent
+  ParamTable,
+  PlatformContent,
+  JsCdnTag
 };
 
 export default ({ file }) => {

--- a/gatsby/src/components/jsCdnTag.js
+++ b/gatsby/src/components/jsCdnTag.js
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+
+export default ({ apm = false }) => {
+  const [versionData, setVersionData] = useState(null);
+
+  fetch(
+    "https://release-registry.services.sentry.io/sdks/sentry.javascript.browser/latest"
+  ).then(data => setVersionData(data));
+
+  const packageName = apm ? "bundle.apm.min.js" : "bundle.min.js";
+  const packageData =
+    versionData && versionData[packageName]
+      ? versionData[packageName]
+      : { version: "{VERSION}", checksums: { "sha384-base64": "{CHECKSUM}" } };
+
+  return (
+    <pre className="language-js">{`<script src="https://browser.sentry-cdn.com/${packageData.version}/${packageName}" integrity="${packageData.checksums["sha384-base64"]}" crossorigin="anonymous"></script>`}</pre>
+  );
+};

--- a/gatsby/src/components/paramTable.js
+++ b/gatsby/src/components/paramTable.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+export default ({ fields }) => (
+  <table className="table">
+    {fields.map(([name, paramList]) => (
+      <tr key={name}>
+        <td>
+          <strong>{name}</strong>
+        </td>
+        <td class="content-flush-bottom">
+          <ul class="api-params">
+            {paramList.map(param => (
+              <li key={param.name}>
+                <code>{param.name}</code>
+                {!!param.type && <em> ({param.type})</em>}
+                {!!param.description && ` — ${param.description}`}
+              </li>
+            ))}
+          </ul>
+        </td>
+      </tr>
+    ))}
+  </table>
+);

--- a/gatsby/src/components/sidebar.js
+++ b/gatsby/src/components/sidebar.js
@@ -18,6 +18,7 @@ const navQuery = graphql`
           frontmatter {
             title
             sidebar_order
+            gatsby
           }
           fields {
             slug
@@ -148,12 +149,11 @@ const Sidebar = () => {
         const tree = toTree(
           sortBy(
             data.allFile.nodes
-              .filter(n => {
-                return !!(n.childMdx || n.childMarkdownRemark);
-              })
-              .map(n => {
-                return n.childMdx || n.childMarkdownRemark;
-              }),
+              .filter(n => !!(n.childMdx || n.childMarkdownRemark))
+              .map(n => n.childMdx || n.childMarkdownRemark)
+              // hide jekyll docs which indicate they're converted to gatsby
+              // this avoids duplicating urls (which filter out in the tree, but might be the wrong node)
+              .filter(n => !n.frontmatter.gatsby),
             n => n.fields.slug
           )
         );

--- a/gatsby/src/css/_includes/alert.scss
+++ b/gatsby/src/css/_includes/alert.scss
@@ -1,6 +1,14 @@
 .alert {
   border-color: $border-color;
-  padding-bottom: 0;
+
+  markdown:last-child {
+    display: block;
+    margin-bottom: -1rem !important;
+  }
+
+  &.markdown-text-only markdown:last-child {
+    margin-bottom: 0 !important;
+  }
 
   > h5 {
     font-size: 1em;

--- a/gatsby/yarn.lock
+++ b/gatsby/yarn.lock
@@ -7459,6 +7459,18 @@ gatsby-cli@^2.12.51:
     yargs "^15.3.1"
     yurnalist "^1.1.2"
 
+gatsby-core-utils@^1.3.10:
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.10.tgz#f283b9c0c5281e678d3b8b77cf46ef3992971d3f"
+  integrity sha512-JtGP7lrbJanatO1j04mECRP7CHlnlexhS3KYUROQdcwxBvyIikkHYOt4FqS4FAQ6y6MqOvM1/uvpkbQbBx154Q==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-core-utils@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.8.tgz#e6d15d8cb24fa7e16a0af01a5e262ac9c4f31913"
@@ -7760,15 +7772,15 @@ gatsby-remark-copy-linked-files@^2.3.2:
     probe-image-size "^4.1.1"
     unist-util-visit "^1.4.1"
 
-gatsby-remark-images@^3.3.1:
-  version "3.3.13"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.13.tgz#ccd050d31d26c314b6f4388bd220dd70c5694d4c"
-  integrity sha512-vM2oqGAKmomNiHlw9a+oK3T5df66X12ReYDly6Ye61nWbDmOuEq2ibES6SqTx73Kv8VKiT9+5/ejz9MDfbVtQA==
+gatsby-remark-images@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.16.tgz#101b6b1ebe03b03e4b38712746be1d26eca80320"
+  integrity sha512-xts1nLBfgch1z9DcmogFS7HkV76nJX5+ZRHxRLjIU7Qhseu6ciUGlXhHLJKqjFEiIxRAVbYNhR6f8MyS21IufA==
   dependencies:
     "@babel/runtime" "^7.10.3"
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.3"
-    gatsby-core-utils "^1.3.8"
+    gatsby-core-utils "^1.3.10"
     is-relative-url "^3.0.0"
     lodash "^4.17.15"
     mdast-util-definitions "^1.2.5"


### PR DESCRIPTION
- Fix whitespace when markdown is used with alerts
- Add JsCdnTag for embedding version-based sentry-javascript script tag
- Add ParamTable component for rendering parameterized tables
- Ignore gatsby migrated files (via frontmatter) in gatsby sidebar generation
- Re-add support for prefix in code blocks (unused)