### PR TITLE
Add: search conditions `or` and `and`

### DIFF
--- a/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
+++ b/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
@@ -205,21 +205,8 @@ The Query Builder syntax is identical to [Sentry's Search syntax](/workflow/sear
 - Lower bounds (is more than or equal to): `count(id):>99` or `count(id):>=99`
 - Multiple bounds (is more and less than): `count(id):>10 count(id):<20`
 
-**Using `or` & `and` Conditions**
+Use `or` and `and` conditions between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. For more details about these conditions, see [Using `or` & `and` Conditions](/workflow/search/#using-or--and-conditions).
 
-Use `or` and `and` between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. 
-
-Some examples of using the `or` condition:
-
-```
-# a valid `or` query
-[ add `or` example here ]
-
-# an invalid `or` query
-[ add invalid example here ]
-```
-
-Also, the queries prioritize `and` before `or`. For example, "x `and` y `or` z" is the same as "[x `and` y] `or` z".
 
 **Tag Summary Filters**
 

--- a/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
+++ b/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
@@ -205,7 +205,7 @@ The Query Builder syntax is identical to [Sentry's Search syntax](/workflow/sear
 - Lower bounds (is more than or equal to): `count(id):>99` or `count(id):>=99`
 - Multiple bounds (is more and less than): `count(id):>10 count(id):<20`
 
-Use `or` and `and` conditions between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. For more details about these conditions, see [Using `or` & `and` Conditions](/workflow/search/#using-or--and-conditions).
+Use `OR` and `AND` conditions between filters. However `OR` cannot be used between aggregate and non-aggregate filters. For more details about these conditions, see [Using `OR` & `AND` Conditions](/workflow/search/#using-or--and-conditions).
 
 
 **Tag Summary Filters**

--- a/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
+++ b/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
@@ -205,6 +205,22 @@ The Query Builder syntax is identical to [Sentry's Search syntax](/workflow/sear
 - Lower bounds (is more than or equal to): `count(id):>99` or `count(id):>=99`
 - Multiple bounds (is more and less than): `count(id):>10 count(id):<20`
 
+**Using `or` & `and` Conditions**
+
+Use `or` and `and` between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. 
+
+Some examples of using the `or` condition:
+
+```
+# a valid `or` query
+[ add `or` example here ]
+
+# an invalid `or` query
+[ add invalid example here ]
+```
+
+Also, the queries prioritize `and` before `or`. For example, "x `and` y `or` z" is the same as "[x `and` y] `or` z".
+
 **Tag Summary Filters**
 
 Every event has a list of tag values. The tag summary (or facet map) is a visualization of the top 10 keys sorted by frequency. The most common tag value is listed directly above the bar in the description and percentage. Hover over each section in a bar to see the exact distribution for that tag. 

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -37,6 +37,22 @@ The tokens `is:resolved` and `user.username:"Jane Doe"` are standard search toke
 
 The token `example error` is utilizing the optional raw search and is passed as part of the issue search query (which uses a CONTAINS match similar to SQL). When using the optional raw search, you can provide _one_ string, and the query uses that entire string.
 
+### Using `or` & `and` Conditions
+
+Use `or` and `and` between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. 
+
+Some examples of using the `or` condition:
+
+```
+# a valid `or` query
+[ add `or` example here ]
+
+# an invalid `or` query
+[ add invalid example here ]
+```
+
+Also, the queries prioritize `and` before `or`. For example, "x `and` y `or` z" is the same as "[x `and` y] `or` z".
+
 ### Explicit Tag Syntax
 
 We recommend you never use reserved keywords (such as `project_id`) as tags. But if you do, you must use the following syntax to search for it:

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -37,21 +37,21 @@ The tokens `is:resolved` and `user.username:"Jane Doe"` are standard search toke
 
 The token `example error` is utilizing the optional raw search and is passed as part of the issue search query (which uses a CONTAINS match similar to SQL). When using the optional raw search, you can provide _one_ string, and the query uses that entire string.
 
-### Using `or` & `and` Conditions
+### Using `OR` & `AND` Conditions
 
-Use `or` and `and` between aggregate filters. `and` can also handle queries between non-aggregates and aggregates. However, `or` cannot. 
+Use `OR` and `AND` between tokens, and use parentheses `()` to group conditions. `AND` can also be used between non-aggregates and aggregates. However, `or` cannot. 
 
-Some examples of using the `or` condition:
+Some examples of using the `OR` condition:
 
 ```
 # a valid `or` query
-[ add `or` example here ]
+browser:Chrome OR browser:Opera
 
 # an invalid `or` query
-[ add invalid example here ]
+user.username:janedoe OR count():>100
 ```
 
-Also, the queries prioritize `and` before `or`. For example, "x `and` y `or` z" is the same as "[x `and` y] `or` z".
+Also, the queries prioritize `AND` before `OR`. For example, "x `AND` y `OR` z" is the same as "(x `AND` y) `OR` z". Parentheses can be used to change the grouping. For example, "x `AND` (y `OR` z)".
 
 ### Explicit Tag Syntax
 


### PR DESCRIPTION
Discover queries now include the conditions `or` and `and`.

![image](https://user-images.githubusercontent.com/25088225/86825735-92b70b00-c044-11ea-8891-0433aa278bff.png)
