### PR TITLE
Fix: PHP option `excluded_app_paths` to `in_app_exclude`

### DIFF
--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -222,7 +222,7 @@ exclude some types of errors, you just need to apply the right bitmask.
 For example, if you want to get all errors but exclude notices and deprecations,
 the right bitmask to apply is `E_ALL & ~E_NOTICE & ~E_DEPRECATED`.
 
-##### excluded_app_paths
+##### in_app_exclude
 
 This option configures the list of paths to exclude from the `app_path` detection.
 

--- a/src/collections/_documentation/platforms/php/index.md
+++ b/src/collections/_documentation/platforms/php/index.md
@@ -222,7 +222,7 @@ exclude some types of errors, you just need to apply the right bitmask.
 For example, if you want to get all errors but exclude notices and deprecations,
 the right bitmask to apply is `E_ALL & ~E_NOTICE & ~E_DEPRECATED`.
 
-##### in_app_exclude
+##### excluded_app_paths
 
 This option configures the list of paths to exclude from the `app_path` detection.
 


### PR DESCRIPTION
The PHP option `excluded_app_paths` changed to `in_app_exclude`.