### PR TITLE
fix: Add note about depreacted react-native

### DIFF
--- a/src/collections/_documentation/clients/react-native/cocoapods.md
+++ b/src/collections/_documentation/clients/react-native/cocoapods.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/cocoapods.md
+++ b/src/collections/_documentation/clients/react-native/cocoapods.md
@@ -3,6 +3,15 @@ title: 'Setup With CocoaPods'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
+
 In order to use Sentry with CocoaPods you have to install the packages with `npm` or `yarn` and link them locally in your `Podfile`.
 
 ```bash

--- a/src/collections/_documentation/clients/react-native/codepush.md
+++ b/src/collections/_documentation/clients/react-native/codepush.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/codepush.md
+++ b/src/collections/_documentation/clients/react-native/codepush.md
@@ -3,6 +3,14 @@ title: 'Using Sentry with CodePush'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 If you want to use sentry together with CodePush you have to send us the CodePush version:
 
 ```javascript

--- a/src/collections/_documentation/clients/react-native/config.md
+++ b/src/collections/_documentation/clients/react-native/config.md
@@ -3,6 +3,14 @@ title: 'Additional Configuration'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 These are functions you can call in your JavaScript code:
 
 ```javascript

--- a/src/collections/_documentation/clients/react-native/config.md
+++ b/src/collections/_documentation/clients/react-native/config.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/expo.md
+++ b/src/collections/_documentation/clients/react-native/expo.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/expo.md
+++ b/src/collections/_documentation/clients/react-native/expo.md
@@ -3,6 +3,14 @@ title: 'Using Sentry with Expo'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 [Expo](https://expo.io/) is an excellent way to quickly create and play around with your React Native app. Now you can also use Sentry together with Expo:
 
 ```bash

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -3,6 +3,14 @@ title: 'React Native'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 This is the documentation for our React-Native SDK. The React-Native SDK uses a native extension for iOS and Android but will fall back to a pure JavaScript version if necessary.
 
 ## Getting Started

--- a/src/collections/_documentation/clients/react-native/index.md
+++ b/src/collections/_documentation/clients/react-native/index.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/manual-setup.md
+++ b/src/collections/_documentation/clients/react-native/manual-setup.md
@@ -3,6 +3,14 @@ title: 'Manual Setup'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 If you can’t (or don’t want) to run the linking step you can see here what is happening on each platform.
 
 ## General

--- a/src/collections/_documentation/clients/react-native/ram-bundles.md
+++ b/src/collections/_documentation/clients/react-native/ram-bundles.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/ram-bundles.md
+++ b/src/collections/_documentation/clients/react-native/ram-bundles.md
@@ -3,6 +3,14 @@ title: 'Using RAM Bundles'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 The [RAM bundle](https://facebook.github.io/react-native/docs/performance#ram-bundles-inline-requires) format is a new approach to packaging React Native apps that optimizes your app's startup time. With RAM bundles, it is possible to load to memory only those modules that are needed for specific functionality, and only when needed.
 
 All the existing RAM bundle formats are explained in detail in the [Metro Bundler documentation](https://facebook.github.io/metro/docs/en/bundling).

--- a/src/collections/_documentation/clients/react-native/sourcemaps.md
+++ b/src/collections/_documentation/clients/react-native/sourcemaps.md
@@ -4,7 +4,7 @@ robots: noindex
 ---
 
 {% capture __alert_content -%}
-A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
 {%- include components/alert.html
     title="Note"
     content=__alert_content

--- a/src/collections/_documentation/clients/react-native/sourcemaps.md
+++ b/src/collections/_documentation/clients/react-native/sourcemaps.md
@@ -3,6 +3,14 @@ title: 'Source Maps for Other Platforms'
 robots: noindex
 ---
 
+{% capture __alert_content -%}
+A new React Native SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.{%- endcapture -%}
+{%- include components/alert.html
+    title="Note"
+    content=__alert_content
+    level="warning"
+%}
+
 Currently automatic source map handling is only implemented for iOS with Xcode and Android with gradle. If you manually invoke the [react-native packager](https://github.com/facebook/metro) you can however get source maps anyways by passing _–sourcemap-output_ to it.
 
 If you do get source maps you can upload them with `sentry-cli`. However make sure to pass `--rewrite` to the `upload-sourcemaps` command which will fix up the source maps before upload (inlines sources etc.).


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/363802/86916035-40005080-c123-11ea-88fc-24a39bf6bb2d.png)

I couldn't figure out how to add the layout header we have everywhere else so I added it manually.

Fixes https://github.com/getsentry/sentry-docs/issues/1744