### PR TITLE
Remove: duplicated section in Transaction Summary

### DIFF
--- a/src/collections/_documentation/performance-monitoring/getting-started.md
+++ b/src/collections/_documentation/performance-monitoring/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 sidebar_order: 0
 ---
 
-After this quick setup, you'll have access to [Performance](/performance-monitoring/performance/) and [Discover](/performance-monitoring/discover-queries/). These tools will empower you to see everything from macro-level [metrics](/performance-monitoring/performance/metrics/) to micro-level [spans](/performance-monitoring/performance/event-detail/), but you'll be able to cross-reference [transactions with related issues](/performance-monitoring/performance/transaction-summary/), customize [queries](/performance-monitoring/discover-queries/query-builder/) based on your personal needs, and substantially more. 
+After this quick setup, you'll have access to [Performance](/performance-monitoring/performance/). This tool will empower you to see everything from macro-level [metrics](/performance-monitoring/performance/metrics/) to micro-level [spans](/performance-monitoring/performance/event-detail/), but you'll be able to cross-reference [transactions with related issues](/performance-monitoring/performance/transaction-summary/), customize [queries](/performance-monitoring/discover-queries/query-builder/) based on your personal needs, and substantially more. 
 
 {% capture __alert_content -%}
 - JavaScript Browser SDK ≥ 5.16.0

--- a/src/collections/_documentation/performance-monitoring/performance/transaction-summary.md
+++ b/src/collections/_documentation/performance-monitoring/performance/transaction-summary.md
@@ -38,6 +38,10 @@ When viewing transactions, you may want to create more curated views. Click "Ope
 
 _Note_: Currently, only transaction data - the transaction name and any attributes the transaction inherits from its root span - is searchable. Data contained in spans other than the root span is not indexed and therefore cannot be searched.
 
-## Related Issues
+## Sidebar
 
 The sidebar contains helpful supplementary information about this transaction's [User Misery](/performance-monitoring/performance/metrics/#user-misery), [Apdex](/performance-monitoring/performance/metrics/#apdex), [Throughput](/performance-monitoring/performance/metrics/#throughput-total-tpm-tps), [Latency](/performance-monitoring/performance/metrics/#latency), and more. You'll also find a Tag Summary (facet map) for a list of common tags related to this transaction.
+
+## Related Issues
+
+This table will show you all related issues. In other words, any errors that are associated with this transaction. Click "Open in Issues" to see the full list.

--- a/src/collections/_documentation/performance-monitoring/performance/transaction-summary.md
+++ b/src/collections/_documentation/performance-monitoring/performance/transaction-summary.md
@@ -41,7 +41,3 @@ _Note_: Currently, only transaction data - the transaction name and any attribu
 ## Related Issues
 
 The sidebar contains helpful supplementary information about this transaction's [User Misery](/performance-monitoring/performance/metrics/#user-misery), [Apdex](/performance-monitoring/performance/metrics/#apdex), [Throughput](/performance-monitoring/performance/metrics/#throughput-total-tpm-tps), [Latency](/performance-monitoring/performance/metrics/#latency), and more. You'll also find a Tag Summary (facet map) for a list of common tags related to this transaction.
-
-## Related Issues
-
-This table will show you all related issues. In other words, any errors that are associated with this transaction. Click "Open in Issues" to see the full list.


### PR DESCRIPTION
Removed duplicated section in Transaction Summary and updated first two sentences in Getting Started.