### PR TITLE
feat: Add documentation about Apache Airflow

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -357,6 +357,7 @@ Array [
   "platforms/php/laravel/index.html",
   "platforms/php/symfony/index.html",
   "platforms/python/aiohttp/index.html",
+  "platforms/python/airflow/index.html",
   "platforms/python/asgi/index.html",
   "platforms/python/aws_lambda/index.html",
   "platforms/python/beam/index.html",

--- a/src/collections/_documentation/platforms/python/airflow.md
+++ b/src/collections/_documentation/platforms/python/airflow.md
@@ -1,0 +1,29 @@
+---
+title: Apache Airflow
+sidebar_order: 9
+---
+
+[Apache Airflow](https://airflow.apache.org/) **1.10.6** and above can be setup to send errors to Sentry.
+
+## Installation
+
+Install the `apache-airflow` package with the `sentry` requirement.
+
+```py
+pip install 'apache-airflow[sentry]'
+```
+
+You can then add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.
+
+```ini
+[sentry]
+sentry_dsn = ___PUBLIC_DSN___
+```
+
+Now, Airflow should report errors to Sentry automatically. Airflow will also generate custom tags and breadcrumbs based on the current dag and tasks at time of error.
+
+Please see the official [Apache Airflow documentation](https://airflow.apache.org/docs/stable/errors.html) for more details.
+
+### Configuration
+
+Please see the official [Apache Airflow documentation](https://airflow.apache.org/docs/stable/configurations-ref.html#sentry) for the full list of configuration options available.

--- a/src/collections/_documentation/platforms/python/airflow.md
+++ b/src/collections/_documentation/platforms/python/airflow.md
@@ -20,7 +20,7 @@ Then, add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under t
 sentry_dsn = ___PUBLIC_DSN___
 ```
 
-Now, Airflow should report errors to Sentry automatically. Airflow will also generate custom tags and breadcrumbs based on the current dag and tasks at time of error.
+Now, Airflow should report errors to Sentry automatically. Airflow will also generate custom tags and breadcrumbs based on the current Directed Acyclic Graph (DAG) and tasks at the time of the error.
 
 Please see the official [Apache Airflow documentation](https://airflow.apache.org/docs/stable/errors.html) for more details.
 

--- a/src/collections/_documentation/platforms/python/airflow.md
+++ b/src/collections/_documentation/platforms/python/airflow.md
@@ -3,7 +3,7 @@ title: Apache Airflow
 sidebar_order: 9
 ---
 
-[Apache Airflow](https://airflow.apache.org/) **1.10.6** and above can be setup to send errors to Sentry.
+[Apache Airflow](https://airflow.apache.org/) **1.10.6** and above can be set up to send errors to Sentry.
 
 ## Installation
 

--- a/src/collections/_documentation/platforms/python/airflow.md
+++ b/src/collections/_documentation/platforms/python/airflow.md
@@ -13,7 +13,7 @@ Install the `apache-airflow` package with the `sentry` requirement.
 pip install 'apache-airflow[sentry]'
 ```
 
-You can then add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.
+Then, add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.
 
 ```ini
 [sentry]

--- a/src/collections/_documentation/platforms/python/index.md
+++ b/src/collections/_documentation/platforms/python/index.md
@@ -252,6 +252,7 @@ For more information, see:
 - [RQ (Redis Queue)](/platforms/python/rq/)
 
 #### Data
+- [Apache Airflow](/platforms/python/airflow)
 - [Apache Beam](/platforms/python/beam/)
 - [PySpark](/platforms/python/pyspark/)
 


### PR DESCRIPTION
As promised, here is the Apache Airflow documentation.

The idea here is that we can get them started sending errors, and then point them to the actual Airflow docs, which will be more update to date about configuration, usage, tags/breadcrumbs tracked etc.

Although there is no Python code here, Airflow uses the python SDK internally to send errors, so I figured it would be best to put it under Python for now. Please let me know if there is a better way to do this, I'd be happy to oblige.

<img src="https://user-images.githubusercontent.com/18689448/87204789-b93ea580-c2d3-11ea-952a-1cfd8f3bad73.png" alt="screenshot of new apache airflow docs" width="500" />