### PR TITLE
Fixing package name

### DIFF
--- a/src/collections/_documentation/platforms/node/aws_lambda.md
+++ b/src/collections/_documentation/platforms/node/aws_lambda.md
@@ -8,7 +8,7 @@ Create a deployment package on your local machine and install the required depen
 Install our Node.js SDK using `npm`:
 
 ```basic
-npm install sentry_sdk
+npm install @sentry/node
 ```
 
 To set up Sentry error logging for a Lambda function, build a wrapper:


### PR DESCRIPTION
installing `sentry_sdk` gives the following error:
```
error An unexpected error occurred: "https://registry.yarnpkg.com/sentry_sdk: Not found".
````
Fixed to `@sentry/node`