### PR TITLE
docs: Add Native Release Health sections

### DIFF
--- a/gatsby/src/docs/workflow/releases/health.mdx
+++ b/gatsby/src/docs/workflow/releases/health.mdx
@@ -86,6 +86,13 @@ To benefit from the health data you must use at least version 1.4.0 of the React
 
 For more details, see the [full documentation on using Release Health with React Native](/platforms/react-native/#release-health).
 
+### Native (C/C++)
+
+To benefit from the health data you must use at least version 0.4.0 of the Native SDK.
+The collection of release health metrics is enabled by default unless specifically disabled in the initialization options of the SDK.
+
+For more details, see the [full documentation on using Release Health on Native](/platforms/native/#release-health).
+
 ## Data Filtering
 
 Sentry has inbound data filters. These filters are exclusively applied at ingest time and not later in processing. This, for instance, lets one discard an error by error message when the error is ingested through the JSON API. On the other hand, this filter doesn't apply to ingested minidumps.

--- a/gatsby/src/docs/workflow/releases/health.mdx
+++ b/gatsby/src/docs/workflow/releases/health.mdx
@@ -70,26 +70,26 @@ Currently, we support the health functionality for Android, iOS and React Native
 
 ### Android
 
-To benefit from the health data you must use at least version 2.1.0 of the Android SDK, and enable the collection of release health metrics in the AndroidManifest.xml file.
+To benefit from the health data, you must use at least version 2.1.0 of the Android SDK, and enable the collection of release health metrics in the AndroidManifest.xml file.
 
 For more details, see the [full documentation on using Release Health with Android](/platforms/android/#release-health).
 
 ### iOS
 
-To benefit from the health data you must use at least version 5.0.0 of the Cocoa SDK and enable the collection of the release health metrics in the initialization options of the SDK.
+To benefit from the health data, you must use at least version 5.0.0 of the Cocoa SDK and enable the collection of the release health metrics in the initialization options of the SDK.
 
 For more details, see the [full documentation on using Release Health with iOS](/platforms/cocoa/#release-health).
 
 ### React Native
 
-To benefit from the health data you must use at least version 1.4.0 of the React Native SDK and enable the collection of the release health metrics in the initialization options of the SDK.
+To benefit from the health data, you must use at least version 1.4.0 of the React Native SDK and enable the collection of the release health metrics in the initialization options of the SDK.
 
 For more details, see the [full documentation on using Release Health with React Native](/platforms/react-native/#release-health).
 
 ### Native (C/C++)
 
-To benefit from the health data you must use at least version 0.4.0 of the Native SDK.
-The collection of release health metrics is enabled by default unless specifically disabled in the initialization options of the SDK.
+To benefit from the health data, you must use at least version 0.4.0 of the Native SDK.
+Metrics collection for release health is, by default, enabled, unless you specifically disabled collecting in the initialization options for the SDK.
 
 For more details, see the [full documentation on using Release Health on Native](/platforms/native/#release-health).
 

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -198,8 +198,8 @@ initialization:
 
 Monitor the [health of releases](/workflow/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/workflow/releases/health/#crash), and [session data](/workflow/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the release details, graphs, and filters.
 
-To benefit from the health data you must use at least version 0.4.0 of the Native SDK.
-The collection of release health metrics is enabled by default unless specifically disabled in the initialization options of the SDK.
+To benefit from the health data, you must use at least version 0.4.0 of the Native SDK.
+Metrics collection for release health is, by default, enabled, unless you specifically disabled collecting in the initialization options for the SDK.
 
 ```c
 sentry_options_t *options = sentry_options_new();
@@ -209,13 +209,13 @@ sentry_init(options);
 ```
 
 The SDK automatically starts a new session when it is initialized via `sentry_init`, and will end that session automatically when the SDK is shut down via `sentry_shutdown`, or explicitly by calling `sentry_end_session`.
-The SDK currently only tracks one concurrent session and will also end the running session when using `sentry_start_session`.
+The SDK currently tracks only one concurrent session and will end the running session when using `sentry_start_session`.
 
 For more details, see the [full documentation on Release Health](/workflow/releases/health/).
 
 ### Identification of the User
 
-By default, the SDK will try to use the `id`, `email` or `username` properties of the object set via `sentry_set_user` as the sessions distinct identifier. While this ID does contain personally identifiable information and is transmitted to the sentry backend, it will not be persisted server-side.
+By default, the SDK will try to use the `id`, `email`, or `username` properties of the object set via `sentry_set_user` as the session’s distinct identifier. While this ID contains personally identifiable information, and is transmitted to the sentry backend, the ID will not persist server-side.
 
 ### Known Limitations
 

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -194,6 +194,33 @@ initialization:
   sentry_options_set_release(options, "my-unique-release-1.0.0");
 ```
 
+### Release Health
+
+Monitor the [health of releases](/workflow/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/workflow/releases/health/#crash), and [session data](/workflow/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the release details, graphs, and filters.
+
+To benefit from the health data you must use at least version 0.4.0 of the Native SDK.
+The collection of release health metrics is enabled by default unless specifically disabled in the initialization options of the SDK.
+
+```c
+sentry_options_t *options = sentry_options_new();
+// Session tracking is enabled by default. To disable:
+sentry_options_set_auto_session_tracking(options, 0);
+sentry_init(options);
+```
+
+The SDK automatically starts a new session when it is initialized via `sentry_init`, and will end that session automatically when the SDK is shut down via `sentry_shutdown`, or explicitly by calling `sentry_end_session`.
+The SDK currently only tracks one concurrent session and will also end the running session when using `sentry_start_session`.
+
+For more details, see the [full documentation on Release Health](/workflow/releases/health/).
+
+### Identification of the User
+
+By default, the SDK will try to use the `id`, `email` or `username` properties of the object set via `sentry_set_user` as the sessions distinct identifier. While this ID does contain personally identifiable information and is transmitted to the sentry backend, it will not be persisted server-side.
+
+### Known Limitations
+
+When using the Crashpad backend on macOS, the duration and status of crashes sessions can not be reliably determined, and may be classified as [`abnormal`](/workflow/releases/health/#release-details) exits instead.
+
 ## Context
 
 {% include platforms/event-contexts.md %}


### PR DESCRIPTION
Adds a section about release health to the Native docs, and links to it from the main Release Health documentation as well. Most of the text is copied from other platforms.