### PR TITLE
Add: search conditions `OR` and `AND`

### DIFF
--- a/gatsby/src/docs/workflow/search/index.mdx
+++ b/gatsby/src/docs/workflow/search/index.mdx
@@ -32,6 +32,24 @@ The tokens `is:resolved` and `user.username:"Jane Doe"` are standard search toke
 
 The token `example error` is utilizing the optional raw search and is passed as part of the issue search query (which uses a CONTAINS match similar to SQL). When using the optional raw search, you can provide _one_ string, and the query uses that entire string.
 
+### Using `OR` and `AND`
+
+NOTE: `OR` and `AND` search conditions are only available for [Discover](/performance-monitoring/discover-queries/), [Performance](/performance-monitoring/performance/), and [Metric Alerts](/workflow/alerts-notifications/alerts/#metric-alerts).
+
+Use `OR` and `AND` between tokens, and use parentheses `()` to group conditions. `AND` can also be used between non-aggregates and aggregates. However, `or` cannot. 
+
+Some examples of using the `OR` condition:
+
+```
+# a valid `OR` query
+browser:Chrome OR browser:Opera
+
+# an invalid `OR` query
+user.username:janedoe OR count():>100
+```
+
+Also, the queries prioritize `AND` before `OR`. For example, "x `AND` y `OR` z" is the same as "(x `AND` y) `OR` z". Parentheses can be used to change the grouping. For example, "x `AND` (y `OR` z)".
+
 ### Explicit Tag Syntax
 
 We recommend you never use reserved keywords (such as `project_id`) as tags. But if you do, you must use the following syntax to search for it:

--- a/gatsby/src/docs/workflow/search/index.mdx
+++ b/gatsby/src/docs/workflow/search/index.mdx
@@ -36,7 +36,7 @@ The token `example error` is utilizing the optional raw search and is passed as 
 
 NOTE: `OR` and `AND` search conditions are only available for [Discover](/performance-monitoring/discover-queries/), [Performance](/performance-monitoring/performance/), and [Metric Alerts](/workflow/alerts-notifications/alerts/#metric-alerts).
 
-Use `OR` and `AND` between tokens, and use parentheses `()` to group conditions. `AND` can also be used between non-aggregates and aggregates. However, `or` cannot. 
+Use `OR` and `AND` between tokens, and use parentheses `()` to group conditions. `AND` can also be used between non-aggregates and aggregates. However, `OR` cannot. 
 
 Some examples of using the `OR` condition:
 

--- a/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
+++ b/src/collections/_documentation/performance-monitoring/discover-queries/query-builder.md
@@ -205,6 +205,8 @@ The Query Builder syntax is identical to [Sentry's Search syntax](/workflow/sear
 - Lower bounds (is more than or equal to): `count(id):>99` or `count(id):>=99`
 - Multiple bounds (is more and less than): `count(id):>10 count(id):<20`
 
+Use `OR` and `AND` search conditions between filters. However `OR` cannot be used between aggregate and non-aggregate filters. For more details about these conditions, see [Using `OR` & `AND` Conditions](/workflow/search/#using-or--and-conditions).
+
 **Tag Summary Filters**
 
 Every event has a list of tag values. The tag summary (or facet map) is a visualization of the top 10 keys sorted by frequency. The most common tag value is listed directly above the bar in the description and percentage. Hover over each section in a bar to see the exact distribution for that tag. 


### PR DESCRIPTION
Search now includes the conditions `OR` and `AND`. This PR is dependent on https://github.com/getsentry/sentry/pull/19718 AND replaces https://github.com/getsentry/sentry-docs/pull/1857 

![image](https://user-images.githubusercontent.com/25088225/87984459-dbcc7d80-ca8e-11ea-9908-2f2ba8f864ad.png)
