### PR TITLE
Docs: Fixes minor typo in user-feedback-example(django.mdx)

### DIFF
--- a/gatsby/src/includes/user-feedback-example/django.mdx
+++ b/gatsby/src/includes/user-feedback-example/django.mdx
@@ -10,7 +10,7 @@ def handler500(request, *args, **argv):
     }, status=500)
 ```
 
-Make sure you've got have the JavaScript SDK available:
+Make sure you've got the JavaScript SDK available:
 
 <JsCdnTag />
 


### PR DESCRIPTION
- I think there's a grammatical mistake in the following line `Make sure you've got have the JavaScript SDK available:`.
- This PR fixes this typo in django.mdx file.
- If this is a typo, I can fix this typo in other examples as well, please let me know.
