### PR TITLE
ref: Bump and document attachment size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: This is running both the Jekyll (port 9001) and Gatsby (port 9002) servers
 
 ## The Great Gatsby Migration
 
-The repository currently contains a Jekyll site (`./`) as well as a Gatsby site (`./gatsby`). This is to aid with a progressive migratiopn over to Gatsby. There's a bit of magic that you need to understand in how this is deployed:
+The repository currently contains a Jekyll site (`./`) as well as a Gatsby site (`./gatsby`). This is to aid with a progressive migration over to Gatsby. There's a bit of magic that you need to understand in how this is deployed:
 
 - **Sidebar:** Jekyll and Gatsby _both_ control the sidebar. If you add a new page in Gatsby at the top level (aka `/docs/parent/THISLEVEL.md`) you will also need to add an empty page in Jekyll at the same location with the `title`, `sidebar_order`, and `gatsby` frontmatter elements:
 

--- a/gatsby/src/docs/accounts/quotas/index.mdx
+++ b/gatsby/src/docs/accounts/quotas/index.mdx
@@ -55,7 +55,7 @@ In addition, depending on your project’s configuration and the plan you subscr
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
 <Alert>
-If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB compressed or 50 MB decompressed for minidump uploads (all files combined), the event will be rejected.
+If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB compressed or 100MB decompressed for minidump uploads (all files combined), the event will be rejected.
 </Alert>
 
 ## What Counts Toward my Quota, Table View

--- a/gatsby/src/docs/enriching-error-data/attachments/index.mdx
+++ b/gatsby/src/docs/enriching-error-data/attachments/index.mdx
@@ -13,6 +13,12 @@ Besides crash reports, Sentry can optionally store additional files uploaded in 
 
 To receive symbolicated stack traces, you have to upload debug information to Sentry. Unless the option to store crash reports is enabled, Sentry will use the crash reports only to create the event, then will drop the files. For more information, see [Debug Information Files](/workflow/debug-files/).
 
+## Size Limits
+
+Sentry allows at most 100MB of attachments per event, including the crash report file. Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
+
+Usually, native crash reports range from a few kilobytes to a few megabytes. This leaves sufficient space to add custom attachments. In case your application generates particularly large crash reports, consider to limit or avoid adding additional attachments in the SDK.
+
 ## Storage and Quota Impact
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -178,6 +178,30 @@ sentry_value_t event = sentry_value_new_message_event(
 );
 ```
 
+### Application Crashes
+
+By default, the Native SDK intercepts crash signals and unhandled exceptions and
+sends crash reports to Sentry. Depending on the [backend](#integrations), the
+crash report is sent as a conventional event, or as a native crash report file.
+On Windows, Linux, and macOS, the default backends send binary Minidump files.
+Sentry processes them to extract stack traces and exception information into a
+readable crash report.
+
+For more information on and the limits that apply, see
+[What is a Minidump](/platforms/native/minidumps#what-is-a-minidump).
+
+{% capture __alert_content -%}
+The size of Minidumps can vary greatly from a few kilobytes to many megabytes.
+Contributing factors are the number of threads, size of stack space, and the
+number of heap memory regions referenced from the stack. Sentry limits Minidump
+uploads to _100MB_ and rejects all larger files.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Size Limits"
+  content=__alert_content
+  level="warning"
+%}
+
 ## Uploading Debug Information
 
 {% include platforms/upload-debug-info.md %}
@@ -364,7 +388,7 @@ For more information, see:
   Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters).
 
 {% capture __alert_content -%}
-The Crashpad Backend sends minidumps with an additional event payload
+The Crashpad Backend sends Minidumps with an additional event payload
 out-of-process. `before_send` hooks are not invoked when capturing crashes
 using Crashpad.
 {%- endcapture -%}
@@ -439,7 +463,7 @@ CMake option, with support for the following options:
 [Crashpad](https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md)
 is an open-source multiplatform crash reporting system written in C++ by Google.
 It supports macOS, Windows, and Linux, and features an uploader to
-submit minidumps to a configured URL right when the process crashes.
+submit Minidumps to a configured URL right when the process crashes.
 
 To use the Crashpad backend with the Native SDK, configure the CMake build
 with the `SENTRY_BACKEND=crashpad` option. This will automatically create a

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -193,8 +193,10 @@ For more information on Minidumps and the limits that apply, see
 {% capture __alert_content -%}
 The size of Minidumps can vary between a few kilobytes and many megabytes.
 Contributing factors are the number of threads, size of stack space, and the
-number of heap memory regions referenced from the stack. Sentry limits Minidump
-uploads to _100MB_ and drops all larger requests.
+number of heap memory regions referenced from the stack. As Minidumps often
+contain large regions of empty memory, the SDK compresses Minidumps before
+uploading. Sentry drops requests with a body larger than _20MB_, or if they
+contain files larger than _100MB_.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Size Limits"

--- a/src/collections/_documentation/platforms/native/index.md
+++ b/src/collections/_documentation/platforms/native/index.md
@@ -180,21 +180,21 @@ sentry_value_t event = sentry_value_new_message_event(
 
 ### Application Crashes
 
-By default, the Native SDK intercepts crash signals and unhandled exceptions and
-sends crash reports to Sentry. Depending on the [backend](#integrations), the
-crash report is sent as a conventional event, or as a native crash report file.
-On Windows, Linux, and macOS, the default backends send binary Minidump files.
-Sentry processes them to extract stack traces and exception information into a
-readable crash report.
+By default, the Native SDK intercepts crash signals and unhandled exceptions to
+send crash reports to Sentry. Depending on the [backend](#integrations), the
+crash report can be sent as a conventional event or as a native crash report
+file. On Windows, Linux, and macOS, the default backends send binary Minidump
+files. Sentry processes them to extract stack traces and exception information
+into a readable crash report.
 
-For more information on and the limits that apply, see
+For more information on Minidumps and the limits that apply, see
 [What is a Minidump](/platforms/native/minidumps#what-is-a-minidump).
 
 {% capture __alert_content -%}
-The size of Minidumps can vary greatly from a few kilobytes to many megabytes.
+The size of Minidumps can vary between a few kilobytes and many megabytes.
 Contributing factors are the number of threads, size of stack space, and the
 number of heap memory regions referenced from the stack. Sentry limits Minidump
-uploads to _100MB_ and rejects all larger files.
+uploads to _100MB_ and drops all larger requests.
 {%- endcapture -%}
 {%- include components/alert.html
   title="Size Limits"

--- a/src/collections/_documentation/platforms/native/minidump.md
+++ b/src/collections/_documentation/platforms/native/minidump.md
@@ -139,7 +139,7 @@ Event ingestion imposes limits on the size and number of fields in multipart
 uploads. These limits are subject to future change and defined currently as:
 
 - *20MB* for a compressed minidump request
-- *50MB* for the full body after decompression
-- *50MB* for all files combined
-- *50MB* for each file individually
+- *100MB* for the full body after decompression
+- *100MB* for all files combined
+- *100MB* for each file individually
 - *1MB* for event payloads

--- a/src/collections/_documentation/platforms/native/ue4.md
+++ b/src/collections/_documentation/platforms/native/ue4.md
@@ -95,4 +95,4 @@ Event ingestion imposes limits on the size of UE4 crash reports. These limits
 are subject to future change and defined currently as:
 
 - *20MB* for a compressed request
-- *50MB* for the full crash report after decompression
+- *100MB* for the full crash report after decompression


### PR DESCRIPTION
Size limits for attachments are now at 100MB. Additionally, this PR adds more information on size limits to the Native SDK and Attachments page.

See https://github.com/getsentry/relay/pull/671
See https://github.com/getsentry/develop/pull/90