### PR TITLE
fix: Missing closing ``` in redux section on react page

### DIFF
--- a/src/collections/_documentation/platforms/javascript/react.md
+++ b/src/collections/_documentation/platforms/javascript/react.md
@@ -213,6 +213,7 @@ Sentry.init({
   dsn: '___DSN___',
   normalizeDepth: 10 // Or however deep you want your state context to be.
 })
+```
 
 ### Redux Enhancer Options
 


### PR DESCRIPTION
Missing a closing \``` causing code block to not be closed. Probably caused when merging in a suggestion and missed the \```