### PR TITLE
Update: CLI for creating source bundles

### DIFF
--- a/gatsby/src/docs/cli/dif.mdx
+++ b/gatsby/src/docs/cli/dif.mdx
@@ -59,13 +59,23 @@ To create a source bundle, use the `difutil bundle-sources` command on a list of
 debug information files:
 
 ```bash
+# on the build machine:
 $ sentry-cli difutil bundle-sources /path/to/files...
+
+# at any later time:
+$ sentry-cli upload-dif --type sourcebundle /path/to/bundles...
 ```
 
 To create multiple source bundles for all debug information files, use the
 command on each file individually.
 
-Alternatively, specify the `--include-sources` parameter to use the upload-dif command, which generates source bundles on the fly during the upload. This requires that the upload is performed on the same machine as the application build.
+Alternatively, add the `--include-sources` option to the `upload-dif` command,
+which generates source bundles on the fly during the upload. This requires that
+the upload is performed on the same machine as the application build:
+
+```bash
+$ sentry-cli upload-dif --include-sources /path/to/files...
+```
 
 ## Uploading Files
 

--- a/gatsby/src/docs/cli/dif.mdx
+++ b/gatsby/src/docs/cli/dif.mdx
@@ -65,9 +65,7 @@ $ sentry-cli difutil bundle-sources /path/to/files...
 To create multiple source bundles for all debug information files, use the
 command on each file individually.
 
-Alternatively, specify the `--include-sources` parameter to the upload command,
-which generates source bundles on the fly during the upload. This requires that
-the upload is performed on the same machine as the application build.
+Alternatively, specify the `--include-sources` parameter to use the upload-dif command, which generates source bundles on the fly during the upload. This requires that the upload is performed on the same machine as the application build.
 
 ## Uploading Files
 


### PR DESCRIPTION
We need to update the CLI docs to improve this statement in creating source bundles:

Currently:
"Alternatively, specify the --include-sources parameter to the upload command, which generates source bundles on the fly during the upload. This requires that the upload is performed on the same machine as the application build."

It should say: 
"Alternatively, specify the --include-sources parameter to use the upload-dif command, which generates source bundles on the fly during the upload. This requires that the upload is performed on the same machine as the application build."