### PR TITLE
feat: Add docs for @sentry/gatsby

### DIFF
--- a/__tests__/__snapshots__/documentation.js.snap
+++ b/__tests__/__snapshots__/documentation.js.snap
@@ -336,6 +336,7 @@ Array [
   "platforms/javascript/cordova/index.html",
   "platforms/javascript/electron/index.html",
   "platforms/javascript/ember/index.html",
+  "platforms/javascript/gatsby/index.html",
   "platforms/javascript/index.html",
   "platforms/javascript/ionic/index.html",
   "platforms/javascript/react/index.html",

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -4,9 +4,9 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.1",
     "@mdx-js/react": "^1.6.1",
-    "@sentry/apm": "^5.18.0",
-    "@sentry/gatsby": "^5.18.0",
-    "@sentry/react": "^5.18.0",
+    "@sentry/apm": "^5.20.0",
+    "@sentry/gatsby": "^5.20.0",
+    "@sentry/react": "^5.20.0",
     "add": "^2.0.6",
     "algoliasearch": "^4.2.0",
     "babel-preset-gatsby": "^0.4.1",

--- a/gatsby/yarn.lock
+++ b/gatsby/yarn.lock
@@ -2092,87 +2092,88 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@sentry/apm@^5.18.0":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.18.1.tgz#2736ea6cc30ffe093850a2c9ef3b7801a2873a74"
-  integrity sha512-UcfEgECz7/X9l/3OoUwVCIpSb0RqyUAd/yRCRGF5Lh7kaqaYi1HbatkYUTDEnhOhaEXYtXUvRXPmRD1zMukqsw==
+"@sentry/apm@^5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.20.0.tgz#14c1900ce83582c988c7620ab41d0d2d95956059"
+  integrity sha512-6zfMRYXG/9VzsmgQqYqFFvg/5XJYOimY/KIrJAijemMLb0Xhwu3xw/2eelWxkWilTBXUWO+dQel5P7JBA8QsKw==
   dependencies:
-    "@sentry/browser" "5.18.1"
-    "@sentry/hub" "5.18.1"
-    "@sentry/minimal" "5.18.1"
-    "@sentry/types" "5.18.1"
-    "@sentry/utils" "5.18.1"
+    "@sentry/browser" "5.20.0"
+    "@sentry/hub" "5.20.0"
+    "@sentry/minimal" "5.20.0"
+    "@sentry/types" "5.20.0"
+    "@sentry/utils" "5.20.0"
     tslib "^1.9.3"
 
-"@sentry/browser@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.18.1.tgz#6a2ebe8f4ba88b2e98ccc91442e1dcb37b2df988"
-  integrity sha512-U1w0d5kRMsfzMYwWn4+awDKfBEI5lxhHa0bMChSpj5z/dWiz/e0mikZ9gCoF+ZNqkXJ92l/3r9gRz+SIsn5ZoA==
+"@sentry/browser@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.20.0.tgz#010ae9a09060ca1859dcc1dbfa186798db82ef7e"
+  integrity sha512-xVPL7/RuAPcemfSzXiyPHAt4M+0BfzkdTlN+PZb6frCEo4k6E0UiN6WLsGj/iwa2gXhyfTQXtbTuP+tDuNPEJw==
   dependencies:
-    "@sentry/core" "5.18.1"
-    "@sentry/types" "5.18.1"
-    "@sentry/utils" "5.18.1"
+    "@sentry/core" "5.20.0"
+    "@sentry/types" "5.20.0"
+    "@sentry/utils" "5.20.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.18.1.tgz#c2aa7ef9054e372d006d32234969711234d2bb02"
-  integrity sha512-nC2aK6gwVIBVysmtdFHxYJyuChIHtkv7TnvmwgA5788L/HWo7E3R+Rd8Tf2npvp/aP+kmNITNbc5CIIqwGPaqQ==
+"@sentry/core@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.20.0.tgz#4c6daad108af94cd0ec5a13fd20b2bfe61ccd586"
+  integrity sha512-fzzWKEolc0O6H/phdDenzKs7JXDSb0sooxVn0QCUkwWSzACALQh+NR/UciOXyhyuoUiqu4zthYQx02qtGqizeQ==
   dependencies:
-    "@sentry/hub" "5.18.1"
-    "@sentry/minimal" "5.18.1"
-    "@sentry/types" "5.18.1"
-    "@sentry/utils" "5.18.1"
+    "@sentry/hub" "5.20.0"
+    "@sentry/minimal" "5.20.0"
+    "@sentry/types" "5.20.0"
+    "@sentry/utils" "5.20.0"
     tslib "^1.9.3"
 
-"@sentry/gatsby@^5.18.0":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/gatsby/-/gatsby-5.18.1.tgz#a466ce2e52abc454a3ecc1843849a8900da3d2c6"
-  integrity sha512-d0cvNbj0P3mefq+tQXStH0prhdxYd2mH+PhFY+GK4SrPCNSSqIN8DQXNSVPRi/mDNNmFq52tUrnps+2Z2Fl6Vg==
+"@sentry/gatsby@^5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/gatsby/-/gatsby-5.20.0.tgz#edcd97b321b2d36f8d78d40629eedd8d2007deba"
+  integrity sha512-DvVlKYpFexLZ3zLK+IvNd3GU+KctQvbR6pnb73xDyXtzt5sDfdOBDX/MSp9y516Bzzne83cXbRkEo1U0SE5K7g==
   dependencies:
-    "@sentry/react" "5.18.1"
-    "@sentry/types" "5.18.1"
+    "@sentry/react" "5.20.0"
+    "@sentry/types" "5.20.0"
 
-"@sentry/hub@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.18.1.tgz#4c2f642e29a320885692b902fba89e57a9906e64"
-  integrity sha512-dFnaj1fQRT74EhoF8MXJ23K3svt11zEF6CS3cdMrkSzfRbAHjyza7KT2AJHUeF6gtH2BZzqsSw+FnfAke0HGIg==
+"@sentry/hub@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.20.0.tgz#3c8ceb29debaea4184bca210cfa7fdd4aad639cb"
+  integrity sha512-DiU8fpjAAMOgSx5tsTekMtHPCAtSNWSNS91FFkDCqPn6fYG+/aK/hB5kTlJwr+GTM1815+WWrtXP6y2ecSmZuA==
   dependencies:
-    "@sentry/types" "5.18.1"
-    "@sentry/utils" "5.18.1"
+    "@sentry/types" "5.20.0"
+    "@sentry/utils" "5.20.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.18.1.tgz#8de01e87c5f5c6e74b707849202150cd4b316ee0"
-  integrity sha512-St2bjcZ5FFiH+bYkWoEPlEb0w38YSvftnjJTvZyk05SCdsF7HkGfoBeFmztwBf1VLQPYt3ojny14L6KDAvOTpw==
+"@sentry/minimal@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.20.0.tgz#309ab4159b44ce3350698294e47da97903593dad"
+  integrity sha512-oA+0g7p3bapzjgGKQIkSjcjA85VG1HPmjxBD9wpRvNjmYuVmm80Cl1H/P+xg/hupw/kNmASAX4IOd5Z9pEeboA==
   dependencies:
-    "@sentry/hub" "5.18.1"
-    "@sentry/types" "5.18.1"
+    "@sentry/hub" "5.20.0"
+    "@sentry/types" "5.20.0"
     tslib "^1.9.3"
 
-"@sentry/react@5.18.1", "@sentry/react@^5.18.0":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.18.1.tgz#6121645e4098ee6dfe56d126f2a5dd88406815c9"
-  integrity sha512-tXqspQ8+1Fj1pL6ZQnyL6PdvuWRroplo5wKZelBT1eZRWg0IbvJJrhof+zK0kq+p8hFkvuqj8YPIhf8SKIFePw==
+"@sentry/react@5.20.0", "@sentry/react@^5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.20.0.tgz#3b85b474f1bc527e7808c41382c2c86c69c683ea"
+  integrity sha512-T+/diXX/+5jxQLxzVzWcEW9bizxzMfwS+V/UYvtWL0r3KiaJjzqloa9wuoOyTS99lk5yLWU533c/SJ8yDgr9Vg==
   dependencies:
-    "@sentry/browser" "5.18.1"
-    "@sentry/types" "5.18.1"
-    "@sentry/utils" "5.18.1"
+    "@sentry/browser" "5.20.0"
+    "@sentry/minimal" "5.20.0"
+    "@sentry/types" "5.20.0"
+    "@sentry/utils" "5.20.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/types@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.18.1.tgz#9d72254262f28e966b06371c5b3833de8f0253b8"
-  integrity sha512-y5YTkRFC4Y7r4GHrvin6aZLBpQIGdMZRq78f/s7IIEZrmWYbVKsK4dyJht6pOsUdEaxeYpsu3okIA0bqmthSJA==
+"@sentry/types@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.20.0.tgz#0bccbc96ce6fabd115545ec4e70c78ba6c506644"
+  integrity sha512-/9tiGiXBRsOKM66HeCpt0iSF0vnAIqHzXgC97icNQIstx/ZA8tcLs9540cHDeaN0cyZUyZF1o8ECqcLXGNODWQ==
 
-"@sentry/utils@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.18.1.tgz#c9880056793ae77d651db0dae76a08a8a0b31eac"
-  integrity sha512-P4lt6NauCBWASaP6R5kfOmc24imbD32G5FeWqK7vHftIphOJ0X7OZfh93DJPs3e5RIvW3YCywUsa7MpTH5/ClA==
+"@sentry/utils@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.20.0.tgz#d67636d83a3001008ad442e3a13f6cc88d48aaf6"
+  integrity sha512-w0AeAzWEf35h9U9QL/4lgS9MqaTPjeSmQYNU/n4ef3FKr+u8HP68Ra7NZ0adiKgi67Yxr652kWopOLPl7CxvZg==
   dependencies:
-    "@sentry/types" "5.18.1"
+    "@sentry/types" "5.20.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":

--- a/src/collections/_documentation/platforms/javascript/gatsby.md
+++ b/src/collections/_documentation/platforms/javascript/gatsby.md
@@ -78,7 +78,7 @@ The Gatsby SDK will set certain options automatically based on environmental var
 
 : Defaults to certain environmental variables based on the platform
 
-- Github Actions: `process.env.GITHUB_SHA`
+- GitHub Actions: `process.env.GITHUB_SHA`
 - Netlify: `process.env.COMMIT_REF`
 - Vercel: `process.env.VERCEL_GITHUB_COMMIT_SHA` or `process.env.VERCEL_GITLAB_COMMIT_SHA` or `process.env.VERCEL_BITBUCKET_COMMIT_SHA`
 

--- a/src/collections/_documentation/platforms/javascript/gatsby.md
+++ b/src/collections/_documentation/platforms/javascript/gatsby.md
@@ -27,7 +27,7 @@ $ npm install @sentry/gatsby
 
 ## Connecting the SDK to Sentry
 
-You can register the plugin your gatsby configuration file (typically `gatsby-config.js`).
+You can register the plugin in your Gatsby configuration file (typically `gatsby-config.js`).
 
 ```js
 {
@@ -81,4 +81,3 @@ The Gatsby SDK will set certain options automatically based on environmental var
 - GitHub Actions: `process.env.GITHUB_SHA`
 - Netlify: `process.env.COMMIT_REF`
 - Vercel: `process.env.VERCEL_GITHUB_COMMIT_SHA` or `process.env.VERCEL_GITLAB_COMMIT_SHA` or `process.env.VERCEL_BITBUCKET_COMMIT_SHA`
-

--- a/src/collections/_documentation/platforms/javascript/gatsby.md
+++ b/src/collections/_documentation/platforms/javascript/gatsby.md
@@ -1,0 +1,84 @@
+---
+title: Gatsby
+sidebar_order: 30
+keywords: ["gatsby", "gatsbyjs"]
+---
+<!-- WIZARD -->
+To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK).
+
+{% capture __alert_content -%}
+`@sentry/gatsby` is a wrapper around the `@sentry/react` package, with added functionality related to Gatsby. All methods available in the `@sentry/react` package can also be imported from `@sentry/gatsby`.
+{%- endcapture -%}
+{%- include components/alert.html
+  title="Note"
+  content=__alert_content
+  level="info"
+%}
+
+Add the Sentry SDK as a dependency using yarn or npm:
+
+```bash
+# Using yarn
+$ yarn add @sentry/gatsby
+
+# Using npm
+$ npm install @sentry/gatsby
+```
+
+## Connecting the SDK to Sentry
+
+You can register the plugin your gatsby configuration file (typically `gatsby-config.js`).
+
+```js
+{
+  // ...
+  plugins: [
+    {
+      resolve: "@sentry/gatsby",
+      options: {
+          dsn: ___PUBLIC_DSN___,
+      }
+    },
+    // ...
+  ]
+}
+```
+<!-- ENDWIZARD -->
+
+## Options
+
+The options field in the plugin configuration is passed directly to `Sentry.init`. Check our configuration docs for a [full list of the avaliable options](/error-reporting/configuration/?platform=javascript).
+
+For example, the configuration below adjusts the `sampleRate` and  `maxBreadcrumbs` options.
+
+```js
+{
+  // ...
+  plugins: [
+    {
+      resolve: "@sentry/gatsby",
+      options: {
+          dsn: ___PUBLIC_DSN___,
+          maxBreadcrumbs: 80,
+          sampleRate: 0.7,
+      }
+    },
+    // ...
+  ]
+}
+```
+
+The Gatsby SDK will set certain options automatically based on environmental variables, but these can be overridden by setting custom options in the plugin configuration.
+
+`environment` (string)
+
+: Defaults to `process.env.NODE_ENV` or `development`
+
+`release` (boolean)
+
+: Defaults to certain environmental variables based on the platform
+
+- Github Actions: `process.env.GITHUB_SHA`
+- Netlify: `process.env.COMMIT_REF`
+- Vercel: `process.env.VERCEL_GITHUB_COMMIT_SHA` or `process.env.VERCEL_GITLAB_COMMIT_SHA` or `process.env.VERCEL_BITBUCKET_COMMIT_SHA`
+


### PR DESCRIPTION
We've run `@sentry/gatsby` for a couple days on develop, and we've tested it with multiple versions, so I think we are good to add documentation for it.

This PR adds documentation to add and configure `@sentry/gatsby` in your gatsby projects.

See the package here: https://github.com/getsentry/sentry-javascript/tree/master/packages/gatsby.

Also bumps `@sentry/gatsby` to `5.20.0` cause `5.18.0` tracing was broken.