### PR TITLE
Add GitHub Actions to release automation docs

### DIFF
--- a/gatsby/src/docs/workflow/releases/release-automation/github-actions/index.mdx
+++ b/gatsby/src/docs/workflow/releases/release-automation/github-actions/index.mdx
@@ -1,0 +1,7 @@
+---
+title: GitHub Actions
+---
+
+The [Sentry Release GitHub Action](https://github.com/marketplace/actions/sentry-release) automates Sentry release management in GitHub with just one step. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
+
+For more details about Sentry release management concepts, see the full documentation on [releases](/workflow/releases/).

--- a/gatsby/src/docs/workflow/releases/release-automation/index.md
+++ b/gatsby/src/docs/workflow/releases/release-automation/index.md
@@ -9,6 +9,7 @@ Sentry release management can be automated using any continuous integration and 
 ### Release Management Automation Guides
 - [Bitbucket Pipelines](/workflow/releases/release-automation/bitbucket-pipelines/)
 - [CircleCI](/workflow/releases/release-automation/circleci/)
+- [GitHub Actions](/workflow/releases/release-automation/github-actions/)
 - [Jenkins](/workflow/releases/release-automation/jenkins/)
 - [Netlify](/workflow/releases/release-automation/netlify/)
 - [Travis CI](/workflow/releases/release-automation/travis-ci/)


### PR DESCRIPTION
Add GitHub Actions to release automation docs.
![screencapture-localhost-9002-workflow-releases-release-automation-github-actions-2020-07-24-17_35_46](https://user-images.githubusercontent.com/7978631/88461572-80690980-ce59-11ea-8403-6ddb60be0447.png)
