### PR TITLE
fix: HTML escapes in code

### DIFF
--- a/gatsby/src/docs/workflow/debug-files.mdx
+++ b/gatsby/src/docs/workflow/debug-files.mdx
@@ -461,7 +461,7 @@ The path schemas in the table above are defined as follows:
 
 **Breakpad**
 
-: Path: `&lt;DebugName&gt;/&lt;BREAKPADid&gt;/&lt;SymName&gt;`
+: Path: `<DebugName>/<BREAKPADid>/<SymName>`
 
   Breakpad always uses a _Breakpad ID_ to store symbols. These identifiers can
   be computed from _Debug Identifiers_ by removing dashes and applying the
@@ -526,7 +526,7 @@ The path schemas in the table above are defined as follows:
 
 **SSQP**
 
-: Path: `&lt;file_name&gt;/&lt;prefix&gt;-&lt;identifier&gt;/&lt;file_name&gt;`
+: Path: `<file_name>/<prefix>-<identifier>/<file_name>`
 
   [SSQP Key Conventions] are an extension to the original Microsoft Symbol
   Server protocol for .NET. It specifies lookup paths for PE, PDB, MachO and ELF
@@ -538,15 +538,15 @@ The path schemas in the table above are defined as follows:
   for more information. This results in the following paths for all possible
   file types:
 
-   - `&lt;code_name&gt;/&lt;timestamp&gt;&lt;size_of_image&gt;/&lt;code_name&gt;`
+   - `<code_name>/<timestamp><size_of_image>/<code_name>`
      (PE file)
-   - `&lt;debug_name&gt;/&lt;signature&gt;&lt;AGE&gt;/&lt;debug_name&gt;` (PDB
+   - `<debug_name>/<signature><AGE>/<debug_name>` (PDB
      file)
-   - `&lt;code_name&gt;/elf-buildid-&lt;buildid&gt;/&lt;code_name&gt;` (ELF
+   - `<code_name>/elf-buildid-<buildid>/<code_name>` (ELF
      binary)
-   - `_.debug/elf-buildid-sym-&lt;buildid&gt;/_.debug` (ELF debug file)
-   - `&lt;code_name&gt;/mach-uuid-&lt;uuid&gt;/&lt;code_name&gt;` (MachO binary)
-   - `_.dwarf/mach-uuid-sym-&lt;uuid&gt;/_.dwarf` (MachO binary)
+   - `_.debug/elf-buildid-sym-<buildid>/_.debug` (ELF debug file)
+   - `<code_name>/mach-uuid-<uuid>/<code_name>` (MachO binary)
+   - `_.dwarf/mach-uuid-sym-<uuid>/_.dwarf` (MachO binary)
 
   SSQP specifies an additional lookup method by SHA1 checksum over the
   file contents, commonly used for source file lookups. _Sentry does not support
@@ -562,7 +562,7 @@ The path schemas in the table above are defined as follows:
 
 **SymStore**
 
-: Path: `&lt;FileName&gt;/&lt;SIGNATURE&gt;&lt;AGE&gt;/&lt;FileName&gt;`
+: Path: `<FileName>/<SIGNATURE><AGE>/<FileName>`
 
   The public symbol server provided by Microsoft used to only host PDBs for the
   Windows platform. These use a _signature-age_ debug identifier in addition to
@@ -585,7 +585,7 @@ The path schemas in the table above are defined as follows:
 
 **Index2**
 
-: Path: `&lt;Fi&gt;/&lt;FileName&gt;/&lt;SIGNATURE&gt;&lt;AGE&gt;/&lt;FileName&gt;`
+: Path: `<Fi>/<FileName>/<SIGNATURE><AGE>/<FileName>`
 
   This layout is identical to _SymStore_, except that the first two characters
   of the file name are prepended to the path as an additional folder.

--- a/gatsby/src/docs/workflow/integrations/azure-devops/index.mdx
+++ b/gatsby/src/docs/workflow/integrations/azure-devops/index.mdx
@@ -64,7 +64,7 @@ To configure Issue sync, navigate to Organization Settings > **Integrations**, a
 
 #### Resolve in Commit
 
-Once you send commit data, you can start resolving issues by including `fixes &lt;SENTRY-SHORT-ID&gt;` in your commit messages. For example, a commit message might look like:
+Once you send commit data, you can start resolving issues by including `fixes <SENTRY-SHORT-ID>` in your commit messages. For example, a commit message might look like:
 
 ```
 Prevent empty queries on users

--- a/gatsby/src/docs/workflow/integrations/bitbucket/index.mdx
+++ b/gatsby/src/docs/workflow/integrations/bitbucket/index.mdx
@@ -112,7 +112,7 @@ Once you’ve navigated to a specific issue, you’ll find the **Linked Issues**
 
 ## Resolving in Commit
 
-Once you are sending commit data, you can start resolving issues by including `fixes &lt;SENTRY-SHORT-ID&gt;` in your commit messages. For example, a commit message might look like:
+Once you are sending commit data, you can start resolving issues by including `fixes <SENTRY-SHORT-ID>` in your commit messages. For example, a commit message might look like:
 
 ```
 Prevent empty queries on users
@@ -136,7 +136,7 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 
 ## Resolving in Commit
 
-Once you are sending commit data, you can start resolving issues by including `fixes &lt;SENTRY-SHORT-ID&gt;` in your commit messages. For example, a commit message might look like:
+Once you are sending commit data, you can start resolving issues by including `fixes <SENTRY-SHORT-ID>` in your commit messages. For example, a commit message might look like:
 
 ```
 Prevent empty queries on users

--- a/gatsby/src/docs/workflow/integrations/github/index.mdx
+++ b/gatsby/src/docs/workflow/integrations/github/index.mdx
@@ -142,7 +142,7 @@ Once you’ve navigated to a specific issue, you’ll find the **Linked Issues**
 
 ## Resolving in Commit/Pull Request
 
-Once you are sending commit data, you can start resolving issues by including `fixes &lt;SENTRY-SHORT-ID&gt;` in your commit messages. For example, a commit message might look like:
+Once you are sending commit data, you can start resolving issues by including `fixes <SENTRY-SHORT-ID>` in your commit messages. For example, a commit message might look like:
 
 ```
 Prevent empty queries on users
@@ -150,7 +150,7 @@ Prevent empty queries on users
 Fixes MYAPP-317
 ```
 
-You can also resolve issues with pull requests by including `fixes &lt;SENTRY-SHORT-ID&gt;` in the title or description.
+You can also resolve issues with pull requests by including `fixes <SENTRY-SHORT-ID>` in the title or description.
 
 When Sentry sees this, we’ll automatically annotate the matching issue with a reference to the commit or pull request, and, later, when that commit or pull request is part of a release, we’ll mark the issue as resolved.
 

--- a/gatsby/src/docs/workflow/integrations/gitlab/index.mdx
+++ b/gatsby/src/docs/workflow/integrations/gitlab/index.mdx
@@ -107,9 +107,9 @@ Here is where you can find info for [suspect commit setup](/workflow/releases/#l
 
 ## Resolve via Commit or PR
 
-Once you've added a repository (see configuration step 8), you can start resolving issues by including `fixes &lt;SHORT-ID&gt;` in your commit messages. You might want to type something in the commit like: "this fixes MyApp-AB12" or "Fixes MyApp-317". The keyword to include is **fixes**. You can also resolve issues with pull requests by including `fixes &lt;SHORT-ID&gt;` in the title or description. This will automatically resolve the issue in the next release.
+Once you've added a repository (see configuration step 8), you can start resolving issues by including `fixes <SHORT-ID>` in your commit messages. You might want to type something in the commit like: "this fixes MyApp-AB12" or "Fixes MyApp-317". The keyword to include is **fixes**. You can also resolve issues with pull requests by including `fixes <SHORT-ID>` in the title or description. This will automatically resolve the issue in the next release.
 
-A `&lt;SHORT-ID&gt;` may look something like 'BACKEND-C' in the image below.
+A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
 ![Issue detail highlighting suspect commits](short-id.png)
 

--- a/gatsby/src/docs/workflow/integrations/integration-platform/index.mdx
+++ b/gatsby/src/docs/workflow/integrations/integration-platform/index.mdx
@@ -232,7 +232,7 @@ There is an option called Alert Rule Action for the integration platform. What t
 
 ![Dropdown menu of options for alert rules.](alert-rules.png)
 
-For your service to receive webhooks for alert rules, users must add to existing rules or create new ones that have `Send a notification via &lt;your service&gt;` as an action in the rule. Once that's set up, you'll start receiving webhook requests for triggered alerts. For more information about the request and payload, see the [full documentation on Webhooks](/workflow/integrations/integration-platform/webhooks/).
+For your service to receive webhooks for alert rules, users must add to existing rules or create new ones that have `Send a notification via <your service>` as an action in the rule. Once that's set up, you'll start receiving webhook requests for triggered alerts. For more information about the request and payload, see the [full documentation on Webhooks](/workflow/integrations/integration-platform/webhooks/).
 
 ### Published State
 


### PR DESCRIPTION
Gatsby interprets HTML escapes in code escapes literal, which means they need to be rewritten to angle brackets. Otherwise, they render as `&lt;` and `&gt;` on the page. Note that this does not apply outside of code quotes, where we need those HTML escapes.