### PR TITLE
Add missing event properties to search docs

### DIFF
--- a/gatsby/src/docs/workflow/search/index.mdx
+++ b/gatsby/src/docs/workflow/search/index.mdx
@@ -195,11 +195,17 @@ When searching on Event properties within the Issues search, Issue Search will r
 
 Below is a list of Event-level tokens reserved and known to Sentry:
 
-`geo.country_code`
-`geo.region`
-`geo.city`
+`location`
 
-: Restrict results to events triggered by a geographic area.
+: Restrict results to the events with a matching location.
+
+`message`
+
+: Restrict results to a matching message
+
+`environment`
+
+: Restrict results to events tagged with the given environment.
 
 `release`
 
@@ -207,10 +213,26 @@ Below is a list of Event-level tokens reserved and known to Sentry:
 
   Exact match on the version of a release, or `release:latest` to pick the most recent release.
 
-`user.id`
-`user.email`
-`user.username`
-`user.ip`
+`transaction`
+
+: Restrict results to events tagged a URL template/job name.
+
+`geo.country_code`<br />
+`geo.region`<br />
+`geo.city`<br />
+
+: Restrict results to events triggered by a geographic area.
+
+`http.method`<br />
+`http.referer`<br />
+`http.url`<br />
+
+: Restrict results based on the HTTP request context.
+
+`user.id`<br />
+`user.email`<br />
+`user.username`<br />
+`user.ip`<br />
 
 : Restrict results to events affecting the given user.
 
@@ -233,28 +255,42 @@ Below is a list of Event-level tokens reserved and known to Sentry:
   - less than (`<`)
   - less than or equal (`<=`)
 
-`device.arch`
-`device.brand`
-`device.locale`
-`device.model_id`
-`device.orientation`
+`device.arch`<br />
+`device.battery_level`<br />
+`device.brand`<br />
+`device.charging`<br />
+`device.locale`<br />
+`device.model_id`<br />
+`device.name`<br />
+`device.online`<br />
+`device.orientation`<br />
+`device.simulator`<br />
 `device.uuid`
 
 : Restrict results to events tagged with a specific device attribute.
 
-`message`
-`os.build`
+`os.build`<br />
 `os.kernel_version`
 
 : Restrict results to events tagged with a specific operating system property.
 
-`stack.abs_path`
-`stack.filename`
-`stack.function`
-`stack.module`
-`stack.stack_level`
+`stack.abs_path`<br />
+`stack.filename`<br />
+`stack.function`<br />
+`stack.module`<br />
+`stack.package`<br />
+`stack.stack_level`<br />
+`stack.lineno`<br />
 
 : Restrict results to events with a matching stack property.
+
+`error.type`<br />
+`error.value`<br />
+`error.mechanism`<br />
+`error.handled`<br />
+
+: Restrict results to events with a matching error property.
+
 
 ### Custom Tags
 


### PR DESCRIPTION
These properties exist in both discover and issue search but weren't in
the documentation.