### PR TITLE
Update: Alerts page

### DIFF
--- a/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
+++ b/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
@@ -36,7 +36,7 @@ As mentioned [above](#for-errors), a metric is the value of an aggregate functio
 
 A metric alert has, at most, two triggers. The first is a critical trigger, which is required. The second is a warning trigger, which is optional. Triggers are independent of one another; however, the warning (optional) must be reached before the critical (required) trigger.
 
-Sentry evaluates triggers approximately every minute from the highest severity to lowest. Sentry creates an alert with the severity of the matched trigger (warning or critical). If an alert is already active, its status is updated. If no resolution threshold is specified and the alert is neither a warning nor critical, the alert will automatically resolve. You can also resolve alerts manually.
+Sentry evaluates triggers approximately every minute from the highest severity to lowest. Sentry creates an alert with the severity of the matched trigger (warning or critical). If an alert is already active, its status is updated. If no resolution threshold is specified, the alert will automatically resolve when it's no longer violating the critical or warning conditions. You can also resolve alerts manually.
 
 When an alert is created or changes status, the actions associated with the trigger are executed. The available actions are:
 

--- a/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
+++ b/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
@@ -189,8 +189,6 @@ Each project has three options: Default, On, or Off. Selecting default uses your
 
 - Can I copy an alert rule to another project?
     - This feature will be available in a future release.
-- Can I set different default alert rules?
-    - This feature will be available in a future release.
 - Are there issue-level filters other than environment?
     - No, all filters are event-based. For example, configurations don't exist for alerting only if an issue is X days old, or assigned to Y, or alerted-on-before, etc.
 - What is the difference between Delete, Delete & Discard, and Ignore?

--- a/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
+++ b/gatsby/src/docs/workflow/alerts-notifications/alerts.mdx
@@ -36,7 +36,7 @@ As mentioned [above](#for-errors), a metric is the value of an aggregate functio
 
 A metric alert has, at most, two triggers. The first is a critical trigger, which is required. The second is a warning trigger, which is optional. Triggers are independent of one another; however, the warning (optional) must be reached before the critical (required) trigger.
 
-Sentry evaluates triggers approximately every minute from the highest severity to lowest. Sentry creates an alert with the severity of the matched trigger (warning or critical). If an alert is already active, its status is updated. Admins can resolve alerts manually or automatically by setting the resolution threshold.
+Sentry evaluates triggers approximately every minute from the highest severity to lowest. Sentry creates an alert with the severity of the matched trigger (warning or critical). If an alert is already active, its status is updated. If no resolution threshold is specified and the alert is neither a warning nor critical, the alert will automatically resolve. You can also resolve alerts manually.
 
 When an alert is created or changes status, the actions associated with the trigger are executed. The available actions are:
 
@@ -149,7 +149,7 @@ If you select "All Environments", Sentry checks individually for each environmen
 
 The digests feature works only for **issue alert emails** and limits alerts across projects. This project-level setting allows you to batch issue alerts to limit the total number of emails you receive for that project. Use the sliders to control the frequency.
 
-[A sliding adjustment scale for the frequency of alert emails.](notifications/alert_digest.png)
+![A sliding adjustment scale for the frequency of alert emails.](notifications/alert_digest.png)
 
 ## Alert Listing
 


### PR DESCRIPTION
A few fixes for the Alert page. Includes updating the FAQ, fixing a sentence, and a broken image.