### PR TITLE
docs: force hashbangs in JS docs

### DIFF
--- a/src/docs/platforms/javascript/index.mdx
+++ b/src/docs/platforms/javascript/index.mdx
@@ -450,7 +450,7 @@ Additionally, you can provide arbitrary key/value pairs beyond the reserved
 names, and the Sentry SDK will store those with the user.
 
 
-### Tagging Events
+### Tagging Events {#tagging-events}
 Tags are key/value pairs assigned to events that can be used for breaking down
 issues or quick access to finding related events.
 
@@ -564,7 +564,7 @@ Sentry.setContext("character_attributes", {
 </markdown></Alert>
 
 
-### Passing Context Directly
+### Passing Context Directly {#passing-context-directly}
 
 Starting in version `5.16.0` of our JavaScript SDKs, some of the contextual data can be provided directly to `captureException` and `captureMessage` calls.
 Provided data will be merged with the one that is already stored inside the current scope, unless explicitly cleared using a callback method.
@@ -577,7 +577,7 @@ This functionality works in three different variations:
 
 We allow the following context keys to be passed: `tags`, `extra`, `contexts`, `user`, `level`, `fingerprint`.
 
-#### Example Usages
+#### Example Usages {#passing-context-directly-example}
 
 ```javascript
 Sentry.captureException(new Error("something went wrong"), {
@@ -666,7 +666,7 @@ Additionally, keep in mind to define a valid HTML doctype on top of your HTML pa
 
 ## Advanced Usage
 
-### Breadcrumbs
+### Breadcrumbs {#breadcrumbs}
 Sentry will automatically record certain events, such as changes to the URL and XHR requests to provide context to an error.
 
 You can manually add breadcrumbs on other events or disable breadcrumbs.
@@ -807,7 +807,7 @@ Sentry.withScope(function(scope) {
 ```
 For more information, see [Setting the Level](#setting-the-level).
 
-### Lazy Loading Sentry
+### Lazy Loading Sentry {#lazy-loading}
 We recommend using our bundled CDN version for the browser as explained [here](/error-reporting/quickstart/?platform=browser#pick-a-client-integration). As noted there, if you want to use `defer`, you can, though keep in mind that any errors which occur in scripts that execute before the browser SDK script executes won’t be caught (because the SDK won’t be initialized yet). Therefore, if you do this, you'll need to a) place the script tag for the browser SDK first, and b) mark it, and all of your other scripts, `defer` (but not `async`), which will guarantee that it’s executed before any of the others.
 
 We also offer an alternative we call the _Loader_. You install by just adding this script to your website instead of the SDK bundle. This line is everything you need; the script is <1kB gzipped and includes the `Sentry.init` call with your DSN.
@@ -881,7 +881,7 @@ For more information, see:
 - [Full documentation on User Feedback](/enriching-error-data/user-feedback/)
 - [Introducing User Feedback](https://blog.sentry.io/2016/04/21/introducing-user-feedback)
 
-### SDK Integrations
+### SDK Integrations {#sdk-integrations}
 All of Sentry's SDKs provide Integrations, which provide additional functionality.
 
 System integrations are integrations enabled by default that integrate into the
@@ -908,7 +908,7 @@ _Import name: `Sentry.Integrations.FunctionToString`_
 
 This integration allows the SDK to provide original functions and method names, even when our error or breadcrumbs handlers wrap them.
 
-#### Browser specific
+#### Browser specific {#browser-specific}
 
 ##### TryCatch
 
@@ -988,7 +988,7 @@ _Import name: `Sentry.Integrations.UserAgent`_
 
 This integration attaches user-agent information to the event, which allows us to correctly catalog and tag them with specific OS, Browser and version information.
 
-### Pluggable Integrations
+### Pluggable Integrations {#pluggable-integrations}
 Pluggable integrations are integrations that can be additionally enabled, to provide some very specific features. Sentry documents them so you can see what they do and that they can be enabled. To enable pluggable integrations, install @sentry/integrations package and provide a new instance with your config to `integrations` option. For example:
 ```js
 import * as Sentry from '@sentry/browser';
@@ -1000,7 +1000,7 @@ Sentry.init({
 });
 ```
 
-#### ExtraErrorData
+#### ExtraErrorData {#extra-error-data}
 
 _Import name: `Sentry.Integrations.ExtraErrorData`_
 
@@ -1027,7 +1027,7 @@ It then retriggers to preserve default native behaviour.
 }
 ```
 
-#### Dedupe
+#### Dedupe {#dedupe}
 
 _Import name: `Sentry.Integrations.Dedupe`_
 
@@ -1069,7 +1069,7 @@ Available options:
 
 #### Browser specific
 
-##### ReportingObserver
+##### ReportingObserver {#reporting-observer}
 
 _Import name: `Sentry.Integrations.ReportingObserver`_
 
@@ -1156,12 +1156,12 @@ Sentry.init({
 });
 ```
 
-### Hints
+### Hints {#hints}
 Event and Breadcrumb `hints` are objects containing various information used to put together an event or a breadcrumb. For events, those are things like `event_id`, `originalException`, `syntheticException` (used internally to generate cleaner stack trace), and any other arbitrary `data` that user attaches. For breadcrumbs, it's all implementation dependent. For XHR requests, the hint contains the xhr object itself, for user interactions it contains the DOM element and event name, etc.
 
 They are available in two places: `beforeSend`/`beforeBreadcrumb` and `eventProcessors`. Those are two ways we'll allow users to modify what we put together.
 
-#### Hints for Events
+#### Hints for Events {#hints-for-events}
 
 `originalException`
 


### PR DESCRIPTION
Currently, https://docs.sentry.io/platforms/javascript contains plenty headers whose links are pointing to wrong sections in the documentation. This is an attempt to force correct links, though the wrong link of just some headings points towards a bug in the mdx processing pipeline.