### PR TITLE
fix(slack): Deleting legacy slack plugin is not part of the upgrade process

### DIFF
--- a/src/docs/workflow/integrations/slack/index.mdx
+++ b/src/docs/workflow/integrations/slack/index.mdx
@@ -72,13 +72,13 @@ In the next section, we'll walk you through configuring your notification settin
 
     ![](slack-alert-message.png)
 
-## Upgrading Slack
-
-### Deleting the legacy project-based Slack integration
+## Deleting the legacy project-based Slack integration
 
 We recommend disabling the legacy project-based integration after setting up the global integration.
 
 Once you configure the global Slack integration and Alert Rules, you can disable the old project-based Slack integration. Go to each project that has the old project-based Slack enabled and disable it. If you're looking to upgrade your global integration, please refer to the information below under **Upgrading Slack**.
+
+## Upgrading Slack
 
 ### How do I know if I need to upgrade?
 


### PR DESCRIPTION
So, move it to its own section, as [before](https://github.com/getsentry/sentry-docs/pull/1696/files#r427689427).

## Screenshot
![Screen Shot 2020-08-07 at 10 08 04 AM](https://user-images.githubusercontent.com/1417849/89670358-f0ce4c80-d895-11ea-9c47-a967c278b8e8.png)