### PR TITLE
fix(jira): Link should be link, not markdown

### DIFF
--- a/src/docs/product/integrations/jira/index.mdx
+++ b/src/docs/product/integrations/jira/index.mdx
@@ -109,7 +109,9 @@ To configure Issue sync, navigate to **Organization Settings** > **Integrations*
 ![](jira-sync.png)
 
 <Alert title="Note" level="info">
+
 If you hit a 4xx or 5xx error during or after setting up the Jira Server integration, please take a look at this [Help Center article](https://help.sentry.io/hc/en-us/articles/360034547794-Why-am-I-receiving-a-4xx-5xx-error-for-the-Jira-Server-Integration-).
+
 </Alert>
 
 ## Issue Notifications


### PR DESCRIPTION
From: https://docs.sentry.io/product/integrations/jira/

**Before**
<img width="757" alt="Screen Shot 2020-08-10 at 3 52 55 PM" src="https://user-images.githubusercontent.com/1417849/89839058-a95bf080-db21-11ea-92a3-2c528b89aecd.png">

**After**
<img width="759" alt="Screen Shot 2020-08-10 at 3 34 03 PM" src="https://user-images.githubusercontent.com/1417849/89838081-33568a00-db1f-11ea-9d9d-a1e7d75af67c.png">