### PR TITLE
Update docs to reflect new change to setting release and dist in React Native

### DIFF
--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -5,19 +5,40 @@ toc: true
 title: Using Sentry with CodePush
 tags: []
 ---
-If you want to use Sentry together with CodePush you have to send us the CodePush version:
+If you want to use Sentry together with CodePush you will have to pass `release` and `dist` to `Sentry.init`. Our suggestion is to store them in an `app.json`, or you can just use the `package.json`. These values need to be unique to each version of your codebase and match the version on the sourcemaps exactly or they might not be symbolicated.
+
+```javascript
+import { release, dist } from 'app.json'
+
+Sentry.init({
+  // ...
+  release,
+  dist
+});
+```
+
+If you need to use `codePush.getUpdateMetadata`, you will have to wait to initialize the Sentry SDK until the Promise is resolved.
+<Alert level="warning" title="Warning"><markdown>
+
+This method is not recommended as any errors or crashes that happen before the Sentry SDK is initialized will not be caught. 
+
+</markdown></Alert>
+
 
 ```javascript
 import codePush from "react-native-code-push";
 
 codePush.getUpdateMetadata().then((update) => {
   if (update) {
-    Sentry.setRelease(update.appVersion + '-codepush:' + update.label);
+    Sentry.init({
+      // ...
+      release: `${update.appVersion}-codepush:${update.label}`
+    });
   }
 });
 ```
 
-Put this somewhere in your code where you already use CodePush. This makes sure that we can associate crashes with the right source maps. `Sentry.setRelease` sets the release to `version`. This works for iOS as well as Android. Make sure that you call this function otherwise Sentry is not able to symbolicate your crashes correctly.
+## Making Releases
 
 After updating your CodePush release, you have to upload the new assets to Sentry:
 
@@ -28,3 +49,5 @@ $ sentry-cli react-native appcenter YourApp ios ./build/CodePush --dist YourBuil
 ```
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
+
+If you still have issues with CodePush sourcemaps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload sourcemaps to Sentry.

--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -5,7 +5,7 @@ toc: true
 title: Using Sentry with CodePush
 tags: []
 ---
-If you want to use Sentry together with CodePush you will have to pass `release` and `dist` to `Sentry.init`. Our suggestion is to store them in an `app.json`, or you can just use the `package.json`. These values need to be unique to each version of your codebase and match the version on the sourcemaps exactly or they might not be symbolicated.
+If you want to use Sentry together with CodePush you will have to pass `release` and `dist` to `Sentry.init`. Our suggestion is to store them in an `app.json`, or you can just use the `package.json`. These values need to be unique to each version of your codebase and match the version on the source maps exactly, or they might not be symbolicated.
 
 ```javascript
 import { release, dist } from 'app.json'
@@ -20,7 +20,7 @@ Sentry.init({
 If you need to use `codePush.getUpdateMetadata`, you will have to wait to initialize the Sentry SDK until the Promise is resolved.
 <Alert level="warning" title="Warning"><markdown>
 
-This method is not recommended as any errors or crashes that happen before the Sentry SDK is initialized will not be caught. 
+This method is not recommended as any errors or crashes that happen before the initialization of the Sentry SDK will not be caught.  
 
 </markdown></Alert>
 
@@ -50,4 +50,4 @@ $ sentry-cli react-native appcenter YourApp ios ./build/CodePush --dist YourBuil
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
 
-If you still have issues with CodePush sourcemaps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload sourcemaps to Sentry.
+If you still have issues with CodePush source maps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload source maps to Sentry.

--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -7,6 +7,8 @@ tags: []
 ---
 If you want to use Sentry together with CodePush you will have to pass `release` and `dist` to `Sentry.init`. Our suggestion is to store them in an `app.json`, or you can just use the `package.json`. These values need to be unique to each version of your codebase and match the version on the source maps exactly, or they might not be symbolicated.
 
+We recommend using the format `${BUNDLE_ID}@${APP_VERSION}+codepush:${DIST}` for release names.
+
 ```javascript
 import { release, dist } from 'app.json'
 
@@ -32,7 +34,7 @@ codePush.getUpdateMetadata().then((update) => {
   if (update) {
     Sentry.init({
       // ...
-      release: `${update.appVersion}-codepush:${update.label}`
+      release: `${update.appVersion}+codepush:${update.label}`
     });
   }
 });

--- a/src/docs/platforms/react-native/sourcemaps.mdx
+++ b/src/docs/platforms/react-native/sourcemaps.mdx
@@ -41,7 +41,10 @@ is set for your release. For instance, `com.example.myapp-1.0`.
 If you set the release name within your app, the `RELEASE_NAME` should be the same value. For example:
 
 ```js
-Sentry.setRelease(RELEASE_NAME)
+Sentry.init({
+  // ...
+  release: RELEASE_NAME
+});
 ```
 
 `DISTRIBUTION_NAME`:
@@ -49,5 +52,8 @@ Sentry.setRelease(RELEASE_NAME)
 : This is the version code or build ID depending on your platform. So for instance just set this to whatever is set in your _Info.plist_ or what your Gradle setup generates (For example, `52`).
 
 ```js
-Sentry.setDist(DISTRIBUTION_NAME);
+Sentry.init({
+  // ...
+  dist: DISTRIBUTION_NAME
+});
 ```


### PR DESCRIPTION
The `Sentry.setRelease` and `Sentry.setDist` have been deprecated and setting these values have been moved to just passing them to `Sentry.init`

https://github.com/getsentry/sentry-react-native/pull/1009