### PR TITLE
feat: Add robots meta header

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -36,7 +36,7 @@ export default ({
   const hasToc = child && !!child.tableOfContents.items;
   return (
     <div className="document-wrapper">
-      <SEO title={title} />
+      <SEO title={title} file={file} />
       <div className="sidebar">
         <Header
           siteTitle={siteMetadata.title}

--- a/src/components/pages/doc.js
+++ b/src/components/pages/doc.js
@@ -33,6 +33,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
+          robots
         }
       }
       childMdx {
@@ -43,6 +44,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
+          robots
         }
       }
     }

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -15,11 +15,24 @@ const detailsQuery = graphql`
   }
 `;
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ description, lang, meta, keywords, title, file }) {
   return (
     <StaticQuery
       query={detailsQuery}
       render={data => {
+        const robots = (
+          (
+            file.childMarkdownRemark && 
+            file.childMarkdownRemark.frontmatter && 
+            file.childMarkdownRemark.frontmatter.robots) 
+          || 
+          (
+            file.childMdx && 
+            file.childMdx.frontmatter &&
+            file.childMdx.frontmatter.robots
+            )
+          );
+          
         const metaDescription =
           description || data.site.siteMetadata.description;
         return (
@@ -71,6 +84,14 @@ function SEO({ description, lang, meta, keywords, title }) {
                     }
                   : []
               )
+              .concat(
+                robots
+                  ? {
+                    property: "robots",
+                    content: robots
+                  }
+                  : []
+              )
               .concat(meta)}
           />
         );
@@ -89,6 +110,7 @@ SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
+  file: PropTypes.object,
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired
 };

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -22,11 +22,13 @@ function SEO({ description, lang, meta, keywords, title, file }) {
       render={data => {
         const robots = (
           (
+            file &&
             file.childMarkdownRemark && 
             file.childMarkdownRemark.frontmatter && 
             file.childMarkdownRemark.frontmatter.robots) 
           || 
           (
+            file &&
             file.childMdx && 
             file.childMdx.frontmatter &&
             file.childMdx.frontmatter.robots


### PR DESCRIPTION
Adds a meta header for robots to tell bots not to index old pages.

![image](https://user-images.githubusercontent.com/363802/89892103-732c7880-dbd6-11ea-89e4-f41e7d49814d.png)
