### PR TITLE
fix: Use Sentry to refer to the product, sentry.io to the URL

### DIFF
--- a/src/docs/accounts/sso/saml2.mdx
+++ b/src/docs/accounts/sso/saml2.mdx
@@ -33,10 +33,10 @@ Before connecting Sentry to the Identity Provider (IdP), it’s important to fir
 * `SLS` stands for *Single Logout Service*, and is used to address logout requests from the IdP.
 * `Metadata`, alternatively referred to as the `entityID`  in some systems, refers to the configuration data for an IdP or an SP. In this case, the Metadata endpoint in Sentry refers to your Sentry organization’s metadata on the Service Provider end.
 
-When setting these values up on the IdP end, it’s important to remember that Sentry.io does not need to provide a signing certificate for the integration to work.
+When setting these values up on the IdP end, it’s important to remember that Sentry does not need to provide a signing certificate for the integration to work.
 
 ## Register IdP with Sentry
-There are three distinct methods for registering your IdP with Sentry.io: Metadata, XML, and data fields. Each method is broken down below, and will produce the same end result.
+There are three distinct methods for registering your IdP with Sentry: Metadata, XML, and data fields. Each method is broken down below, and will produce the same end result.
 
 ### Using Metadata URL
 
@@ -46,7 +46,7 @@ This method only requires a Metadata URL provided by the IdP platform. After it 
 
 ### Using Provider XML
 
-For this method to work, an administrator needs to provide the contents of the IdP’s generated metadata file. Once the contents are pasted directly into the text field, Sentry will do the rest. _Sentry.io does not require a signing certificate._
+For this method to work, an administrator needs to provide the contents of the IdP’s generated metadata file. Once the contents are pasted directly into the text field, Sentry will do the rest. _Sentry does not require a signing certificate._
 
 ![](saml2-provider-xml.png)
 
@@ -113,12 +113,12 @@ Because Sentry uses Just-In-Time (JIT) provisioning, new members are registered 
 **What is the process for adding new members to a SAML2-enabled Sentry organization?**
 Sentry makes use of Just-In-Time provisioning for member accounts; any new member created within an Identity Provider will have an account automatically created in Sentry when that member attempts to sign into Sentry for the first time.
 
-**What happens to Sentry.io accounts that exist prior to SAML being enabled/enforced?**
+**What happens to Sentry accounts that exist prior to SAML being enabled/enforced?**
 Existing members will receive an email notifying them of the new SAML authentication option once it is turned on (regardless of enforcement) and they'll be able to link the accounts in the IdP system with their Sentry memberships.
 
 **Does Sentry deprovision members if they are no longer present in the Identity Provider?**
 At this time, Sentry's SAML2 integration does not automatically deprovision inactive user accounts.
-Instead, the member remains inside of Sentry.io without any means to log in, as they can no longer access the IdP platform for sign-on. For now, inactive member accounts will need to be removed manually by a Manager or an Owner in Sentry.
+Instead, the member remains inside of Sentry without any means to log in, as they can no longer access the IdP platform for sign-on. For now, inactive member accounts will need to be removed manually by a Manager or an Owner in Sentry.
 
 **Attempting to set up SAML2 SSO with an IdP results in a failure with the message “The provider did not return a valid user identity.” What is happening here?**
 The crux of the problem here is that different IdP platforms (Okta, Azure AD, etc) use different terms and conventions for the fields necessary for the integration to work. As a result, it’s possible to map up incorrect values into Sentry, causing SSO to fail with this error message.

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
@@ -19,7 +19,7 @@ Now that the Demo App is up and running on your local environment integrated wit
     Notice that:
     * An error message **Something went wrong** displays in the app
     * The error appears in the browser console
-    * An alert sent to your email address configured on Sentry.io notifying you about an error that occurred in your app
+    * An alert sent to your email address configured on Sentry notifying you about an error that occurred in your app
 
         ![Import and Configure SDK](generate-first-error-03.png)
 

--- a/src/docs/sdks/javascript/index.mdx
+++ b/src/docs/sdks/javascript/index.mdx
@@ -8,7 +8,7 @@ This set of documentation is under development.
 
 On this page, we provide concise information to get you up and running with Sentry's JavaScript SDK, automatically reporting errors and exceptions in your application.
 
-**Note:** If you don't already have an account and Sentry project established, head over to [Sentry.io](https://sentry.io/signup/), then return to this page.
+**Note:** If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
 In the right place? We also offer documentation for:
 


### PR DESCRIPTION
As per our brand guidelines.