### PR TITLE
Fix table formatting on /api/permissions

### DIFF
--- a/src/docs/api/permissions.mdx
+++ b/src/docs/api/permissions.mdx
@@ -14,15 +14,19 @@ If you're looking for information on membership roles please visit the
 
 ### Organizations
 
+|               |             |
+| :-:           | :-:         |
 | **GET**       | `org:read`  |
 | **PUT/POST**  | `org:write` |
 | **DELETE**    | `org:admin` |
 
 ### Projects
 
-| GET      | `project:read`  |
-| PUT/POST | `project:write` |
-| DELETE   | `project:admin` |
+|              |                 |
+| :-:          | :-:             |
+| **GET**      | `project:read`  |
+| **PUT/POST** | `project:write` |
+| **DELETE**   | `project:admin` |
 
 
 <Alert level="warning" title="Note"><markdown>
@@ -38,18 +42,24 @@ and **organization** release endpoints. The available endpoints are listed in th
 
 ### Teams
 
+|              |              |
+| :-:          | :-:          |
 | **GET**      | `team:read`  |
 | **PUT/POST** | `team:write` |
 | **DELETE**   | `team:admin` |
 
 ### Members
 
+|              |                |
+| :-:          | :-:            |
 | **GET**      | `member:read`  |
 | **PUT/POST** | `member:write` |
 | **DELETE**   | `member:admin` |
 
 ### Issues & Events
 
+|             |               |
+| :-:         | :-:           |
 | **GET**     | `event:read`  |
 | **PUT**     | `event:write` |
 | **DELETE**  | `event:admin` |
@@ -67,6 +77,8 @@ Events in sentry are immutable and can only be deleted by deleting the whole iss
 
 ### Releases
 
+|                          |                    |
+| :-:                      | :-:                |
 | **GET/PUT/POST/DELETE**  | `project:releases` |
 
 


### PR DESCRIPTION
This is my first PR here, so please let me know if I'm missing anything!

I believe that these rows are meant to be tables. They didn't get formatted as such because they were missing a header row. So I added a header row. Additionally, I made the methods under the **Projects** heading bold to match the rest of the documentation.

The [current state](https://docs.sentry.io/api/permissions/) looks like this: 
![current: unformatted tables](https://user-images.githubusercontent.com/1696960/90055497-0632e480-dca3-11ea-8f3f-e6c7fd41b93d.png)

This PR fixes the table formatting so that it looks like this:
![new: formatted tables](https://user-images.githubusercontent.com/1696960/90055591-2f537500-dca3-11ea-9426-d7cb326dc5e1.png)
