### PR TITLE
Remove alert from JS docs as they are now live

### DIFF
--- a/src/docs/sdks/javascript/index.mdx
+++ b/src/docs/sdks/javascript/index.mdx
@@ -2,10 +2,6 @@
 title: JavaScript
 ---
 
-<Alert title="Note" level="warning">
-  This set of documentation is under development.
-</Alert>
-
 On this page, we provide concise information to get you up and running with Sentry's JavaScript SDK, automatically reporting errors and exceptions in your application.
 
 **Note:** If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.


### PR DESCRIPTION
The alert label can come off, I think.