### PR TITLE
feat: Better codepush release upload docs

### DIFF
--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -47,7 +47,7 @@ After updating your CodePush release, you have to upload the new assets to Sentr
 When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap_output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder
 
 ```bash
-$ appcenter codepush release-react --sourcemap-output --app {APP} --output-dir ./build
+$ appcenter codepush release-react --app {APP} --d {DEPLOYMENT} --sourcemap-output --output-dir ./build
 ```
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. The sentry-wizard install step should have generated this file for you. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
@@ -60,7 +60,7 @@ Upload the outputted bundle and source maps to Sentry.
 If you use custom deployment names in CodePush, you will need to use `--deployment` to specify the deployment.
 
 ```bash
-$ sentry-cli react-native appcenter {APP} ios ./build/CodePush --dist {DIST}
+$ sentry-cli react-native appcenter {APP} ios ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST}
 ```
 
 If you still have issues with CodePush source maps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload source maps to Sentry.

--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -44,7 +44,7 @@ codePush.getUpdateMetadata().then((update) => {
 
 After updating your CodePush release, you have to upload the new assets to Sentry:
 
-When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap_output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder.
+When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap-output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder.
 
 ```bash
 $ appcenter codepush release-react -a {APP} -d {DEPLOYMENT} --sourcemap-output --output-dir ./build

--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -44,12 +44,23 @@ codePush.getUpdateMetadata().then((update) => {
 
 After updating your CodePush release, you have to upload the new assets to Sentry:
 
+When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap_output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder
+
 ```bash
-$ appcenter codepush release-react --sourcemap-output --app YourApp --output-dir ./build
-$ export SENTRY_PROPERTIES=./ios/sentry.properties
-$ sentry-cli react-native appcenter YourApp ios ./build/CodePush --dist YourBuildNumber
+$ appcenter codepush release-react --sourcemap-output --app {APP} --output-dir ./build
 ```
 
-Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
+Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. The sentry-wizard install step should have generated this file for you. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
+
+```bash
+$ export SENTRY_PROPERTIES=./ios/sentry.properties
+```
+
+Upload the outputted bundle and source maps to Sentry.
+If you use custom deployment names in CodePush, you will need to use `--deployment` to specify the deployment.
+
+```bash
+$ sentry-cli react-native appcenter {APP} ios ./build/CodePush --dist {DIST}
+```
 
 If you still have issues with CodePush source maps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload source maps to Sentry.

--- a/src/docs/platforms/react-native/codepush.mdx
+++ b/src/docs/platforms/react-native/codepush.mdx
@@ -44,10 +44,10 @@ codePush.getUpdateMetadata().then((update) => {
 
 After updating your CodePush release, you have to upload the new assets to Sentry:
 
-When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap_output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder
+When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap_output` and `--output-dir ./build`. This will output to the `./build/CodePush ` folder.
 
 ```bash
-$ appcenter codepush release-react --app {APP} --d {DEPLOYMENT} --sourcemap-output --output-dir ./build
+$ appcenter codepush release-react -a {APP} -d {DEPLOYMENT} --sourcemap-output --output-dir ./build
 ```
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. The sentry-wizard install step should have generated this file for you. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).


### PR DESCRIPTION
Prior docs were unclear what these commands do and that a `--deployment` would need to be specified to upload to deployments that aren't the default Production or Staging.

<img width="861" alt="Screen Shot 2020-08-14 at 6 35 44 PM" src="https://user-images.githubusercontent.com/30991498/90245486-f8c15a00-de5c-11ea-8363-c40fd9a6000c.png">

https://github.com/getsentry/sentry-cli/issues/415#issuecomment-673325836