### PR TITLE
fix: Extra `can` in fallback for ErrorBoundary

### DIFF
--- a/src/docs/platforms/javascript/react.mdx
+++ b/src/docs/platforms/javascript/react.mdx
@@ -99,7 +99,7 @@ Options that are passed into the Sentry User Feedback Widget. See all possible c
 
 #### `fallback` (React.ReactNode or Function)
 
-A fallback component that gets rendered when the error boundary encounters an error. You can can either provide a React Component, or a function that returns a React Component as a valid fallback prop. If you provide a function, Sentry will call the function with the error and the component stack at the time of the error.
+A fallback component that gets rendered when the error boundary encounters an error. You can either provide a React Component, or a function that returns a React Component as a valid fallback prop. If you provide a function, Sentry will call the function with the error and the component stack at the time of the error.
 
 #### `onError` (Function)
 


### PR DESCRIPTION
There is an extra `can` in the fallback description for the `ErrorBoundary`: https://docs.sentry.io/platforms/javascript/react/#fallback-reactreactnode-or-function