### PR TITLE
Fix: consistent naming of tracingOrigins option

### DIFF
--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -89,7 +89,7 @@ For all possible options, see [TypeDocs](https://getsentry.github.io/sentry-java
 
 **tracingOrigins Option**
 
-The default value of `tracingOrigins` is `['localhost', /^\//]`. The JavaScript SDK will attach the `sentry-trace` header to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you will need to add it there to propagate the `sentry-trace` header to the backend services, which is required to link transactions together as part of a single trace. **One important thing to note is that the `traceOrigins` option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL can help make sure that requests do not unnecessarily have the `sentry-trace` header attached.**
+The default value of `tracingOrigins` is `['localhost', /^\//]`. The JavaScript SDK will attach the `sentry-trace` header to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you will need to add it there to propagate the `sentry-trace` header to the backend services, which is required to link transactions together as part of a single trace. **One important thing to note is that the `tracingOrigins` option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL can help make sure that requests do not unnecessarily have the `sentry-trace` header attached.**
 
 *Example:*
 


### PR DESCRIPTION
The `tracingOrigins` option is referenced as `traceOrigins` in the performance "getting started" documentation. 