### PR TITLE
misc: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+/src/docs/sdks/ @getsentry/team-webplatform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,19 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# -------------------------------------------------------------
+
 /src/docs/sdks/ @getsentry/team-webplatform
+
+# -------------------------------------------------------------
+
+/src/docs/platforms/ @getsentry/team-webplatform
+
+/src/docs/platforms/android/ @getsentry/team-mobile
+/src/docs/platforms/cocoa/ @getsentry/team-mobile
+/src/docs/platforms/flutter/ @getsentry/team-mobile
+
+/src/docs/platforms/dotnet/ @bruno-garcia
+
+/src/docs/platforms/native/ @getsentry/owners-native
+
+/src/docs/platforms/rust/ @Swatinem


### PR DESCRIPTION
Extracted from https://github.com/getsentry/sentry-docs/pull/1993#issue-466982710

> @AbhiPrasad 
> We should probably divide the docs into issue owners. I guess this is more of a meta level thing, but I think making sure the teams are at least pinged on PR is useful. I assume web platform would "own" the JS SDK for now.

---

For starters we can have the Web Team for all SDKs and override with more specific owners as needed.

This will cause the team to be pinged on PRs that touch files under the given path.