### PR TITLE
ref: Replace explicit robots control with explicit noindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ It will _not_ index documents with any of the following in their frontmatter:
 
 - `draft: true`
 - `noindex: true`
-- `robots: noindex`
 
 ## Notes on Markdown vs MDX
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -69,12 +69,8 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         redirect_from: {
           type: "[String!]",
         },
-        // TODO: we can probably combine noindex + robots
         noindex: {
           type: "Boolean",
-        },
-        robots: {
-          type: "String",
         },
         sidebar_order: {
           type: "Int",

--- a/src/components/pages/doc.js
+++ b/src/components/pages/doc.js
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
-          robots
+          noindex
         }
       }
       childMdx {
@@ -37,7 +37,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
-          robots
+          noindex
         }
       }
     }

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -20,78 +20,73 @@ function SEO({ description, lang, meta, keywords, title, file }) {
     <StaticQuery
       query={detailsQuery}
       render={data => {
-        const robots = (
-          (
-            file &&
-            file.childMarkdownRemark && 
-            file.childMarkdownRemark.frontmatter && 
-            file.childMarkdownRemark.frontmatter.robots) 
-          || 
-          (
-            file &&
-            file.childMdx && 
+        const noindex =
+          (file &&
+            file.childMarkdownRemark &&
+            file.childMarkdownRemark.frontmatter &&
+            file.childMarkdownRemark.frontmatter.noindex) ||
+          (file &&
+            file.childMdx &&
             file.childMdx.frontmatter &&
-            file.childMdx.frontmatter.robots
-            )
-          );
-          
+            file.childMdx.frontmatter.noindex);
+
         const metaDescription =
           description || data.site.siteMetadata.description;
         return (
           <Helmet
             htmlAttributes={{
-              lang
+              lang,
             }}
             title={title}
             titleTemplate={`%s | ${data.site.siteMetadata.title}`}
             meta={[
               {
                 name: "description",
-                content: metaDescription
+                content: metaDescription,
               },
               {
                 property: "og:title",
-                content: title
+                content: title,
               },
               {
                 property: "og:description",
-                content: metaDescription
+                content: metaDescription,
               },
               {
                 property: "og:type",
-                content: "website"
+                content: "website",
               },
               {
                 name: "twitter:card",
-                content: "summary"
+                content: "summary",
               },
               {
                 name: "twitter:creator",
-                content: data.site.siteMetadata.author
+                content: data.site.siteMetadata.author,
               },
               {
                 name: "twitter:title",
-                content: title
+                content: title,
               },
               {
                 name: "twitter:description",
-                content: metaDescription
-              }
+                content: metaDescription,
+              },
             ]
               .concat(
                 keywords.length > 0
                   ? {
                       name: "keywords",
-                      content: keywords.join(", ")
+                      content: keywords.join(", "),
                     }
                   : []
               )
               .concat(
-                robots
+                noindex
                   ? {
-                    property: "robots",
-                    content: robots
-                  }
+                      property: "robots",
+                      content: "noindex",
+                    }
                   : []
               )
               .concat(meta)}
@@ -105,7 +100,7 @@ function SEO({ description, lang, meta, keywords, title, file }) {
 SEO.defaultProps = {
   lang: "en",
   meta: [],
-  keywords: []
+  keywords: [],
 };
 
 SEO.propTypes = {
@@ -114,7 +109,7 @@ SEO.propTypes = {
   meta: PropTypes.array,
   file: PropTypes.object,
   keywords: PropTypes.arrayOf(PropTypes.string),
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
 };
 
 export default SEO;

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -6,7 +6,6 @@ import { StaticQuery, graphql } from "gatsby";
 import SmartLink from "./smartLink";
 import { sortBy } from "../utils";
 
-// TODO(dcramer): filter out drafts
 const navQuery = graphql`
   query NavQuery {
     allFile(filter: { sourceInstanceName: { in: ["docs", "api-docs"] } }) {
@@ -142,8 +141,6 @@ const renderChildren = children => {
 };
 
 const DynamicNav = ({ root, title, tree, collapse = false }) => {
-  // TODO(dcramer): this still needs to build the tree
-  // love that we cant use filters here...
   const node = tree.find(n => n.name === root);
   const parentNode = node.children
     ? node.children.find(n => n.name === "")

--- a/src/docs/clients/cocoa/advanced.mdx
+++ b/src/docs/clients/cocoa/advanced.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Advanced Usage
-robots: noindex
+noindex: true
 tags: []
 ---
 ## Capturing uncaught exceptions on macOS

--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Uploading Debug Symbols
-robots: noindex
+noindex: true
 tags: []
 ---
 A dSYM upload is required for Sentry to symbolicate your crash logs for viewing. The symbolication process unscrambles Apple’s crash logs to reveal the function, variables, file names, and line numbers of the crash. The dSYM file can be uploaded through the [sentry-cli](https://github.com/getsentry/sentry-cli) tool or through a [Fastlane](https://fastlane.tools/) action.

--- a/src/docs/clients/cocoa/index.mdx
+++ b/src/docs/clients/cocoa/index.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Cocoa
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/cocoa/migration.mdx
+++ b/src/docs/clients/cocoa/migration.mdx
@@ -3,30 +3,33 @@ draft: false
 categories: []
 toc: true
 title: Migration Guide
-robots: noindex
+noindex: true
 tags: []
 ---
+
 ## Upgrade from 2.x.x to 3.x.x {#upgrade-from-2-x-x-to-3-0-x}
 
--   CocoaPods Make sure to update your Podfile to include `:subspecs => ['Core', 'KSCrash']`
+- CocoaPods Make sure to update your Podfile to include `:subspecs => ['Core', 'KSCrash']`
 
-    ```ruby
-    source 'https://github.com/CocoaPods/Specs.git'
-    platform :ios, '8.0'
-    use_frameworks!
+  ```ruby
+  source 'https://github.com/CocoaPods/Specs.git'
+  platform :ios, '8.0'
+  use_frameworks!
 
-    target 'YourApp' do
-        pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :subspecs => ['Core', 'KSCrash'], :tag => '3.x.x'
-    end
-    ```
--   Carthage Make sure to remove KSCrash, we bundled KSCrash into Sentry in order to make it work.
+  target 'YourApp' do
+      pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :subspecs => ['Core', 'KSCrash'], :tag => '3.x.x'
+  end
+  ```
 
-    ```ruby
-    github "getsentry/sentry-cocoa" "3"
-    ```
--   Public API We changed a lot of the public API, please checkout [Advanced Usage](/clients/cocoa/advanced/#advanced) for more examples about that.
+- Carthage Make sure to remove KSCrash, we bundled KSCrash into Sentry in order to make it work.
+
+  ```ruby
+  github "getsentry/sentry-cocoa" "3"
+  ```
+
+- Public API We changed a lot of the public API, please checkout [Advanced Usage](/clients/cocoa/advanced/#advanced) for more examples about that.
 
 ## Upgrade from 3.x.x to 4.x.x {#upgrade-from-3-x-x-to-4-x-x}
 
 - We removed the external KSCrash dependency and migrated the code directly into our SDK.
-There shouldn't be any conflicts including KSCrash it's just not necessary anymore.
+  There shouldn't be any conflicts including KSCrash it's just not necessary anymore.

--- a/src/docs/clients/csharp/index.mdx
+++ b/src/docs/clients/csharp/index.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: C#
-robots: noindex
+noindex: true
 tags: []
 ---
 

--- a/src/docs/clients/go/config.mdx
+++ b/src/docs/clients/go/config.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Configuration
 sidebar_order: 1
-robots: noindex
+noindex: true
 tags: []
 ---
 

--- a/src/docs/clients/go/context.mdx
+++ b/src/docs/clients/go/context.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Context
 sidebar_order: 3
-robots: noindex
+noindex: true
 tags: []
 ---
 

--- a/src/docs/clients/go/index.mdx
+++ b/src/docs/clients/go/index.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Go
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Support"><markdown>

--- a/src/docs/clients/go/integrations.mdx
+++ b/src/docs/clients/go/integrations.mdx
@@ -3,9 +3,10 @@ draft: false
 categories: []
 toc: true
 title: Integrations
-robots: noindex
+noindex: true
 tags: []
 ---
+
 The Raven Go package currently comes with an integration for the native `net/http` module to make it easy to handle common scenarios. More frameworks will be coming soon.
 
 ## net/http
@@ -13,6 +14,7 @@ The Raven Go package currently comes with an integration for the native `net/htt
 Raven Go provides middleware that can be used with the stdlib `net/http` library to automatically handle panics that occur during an http request.
 
 <!-- WIZARD http -->
+
 ### Installation
 
 Simply install `raven-go` through `go get`:

--- a/src/docs/clients/go/usage.mdx
+++ b/src/docs/clients/go/usage.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Usage
 sidebar_order: 2
-robots: noindex
+noindex: true
 tags: []
 ---
 

--- a/src/docs/clients/javascript/config.mdx
+++ b/src/docs/clients/javascript/config.mdx
@@ -4,13 +4,14 @@ categories: []
 toc: true
 title: Configuration
 sidebar_order: 1
-robots: noindex
+noindex: true
 tags: []
 ---
+
 To get started, you need to configure Raven.js to use your Sentry DSN:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___').install()
+Raven.config("___PUBLIC_DSN___").install();
 ```
 
 At this point, Raven is ready to capture any uncaught exception.
@@ -20,9 +21,9 @@ At this point, Raven is ready to capture any uncaught exception.
 `Raven.config()` can optionally be passed an additional argument for extra configuration:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
-    release: 'myapp@1.3.0'
-}).install()
+Raven.config("___PUBLIC_DSN___", {
+  release: "myapp@1.3.0",
+}).install();
 ```
 
 Those configuration options are documented below:
@@ -31,156 +32,158 @@ Those configuration options are documented below:
 
 : The name of the logger used by Sentry. Default: `javascript`
 
-  ```javascript
-  {
-    logger: 'javascript'
-  }
-  ```
+```javascript
+{
+  logger: "javascript";
+}
+```
 
 `release`
 
 : Track the version of your application in Sentry.
 
-  ```javascript
-  {
-    release: '721e41770371db95eee98ca2707686226b993eda'
-  }
-  ```
+```javascript
+{
+  release: "721e41770371db95eee98ca2707686226b993eda";
+}
+```
 
-  Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. To learn more about configuring releases and deploys, click [here](/workflow/releases/).
+Can also be defined with `Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')`. To learn more about configuring releases and deploys, click [here](/workflow/releases/).
 
 `environment`
 
 : Track the environment name inside Sentry.
 
-  ```javascript
-  {
-    environment: 'production'
-  }
-  ```
+```javascript
+{
+  environment: "production";
+}
+```
 
 `serverName`
 
-: *(New in version 1.3.0.)*
+: _(New in version 1.3.0.)_
 
-  Typically this would be the server name, but that doesn’t exist on all platforms. Instead, you may use something like the device ID, as it indicates the host which the client is running on.
+Typically this would be the server name, but that doesn’t exist on all platforms. Instead, you may use something like the device ID, as it indicates the host which the client is running on.
 
-  ```javascript
-  {
-    serverName: device.uuid
-  }
-  ```
+```javascript
+{
+  serverName: device.uuid;
+}
+```
 
 `tags`
 
 : Additional [tags](/enriching-error-data/additional-data/#tags) to assign to each event.
 
-  ```javascript
-  {
-    tags: {git_commit: 'c0deb10c4'}
+```javascript
+{
+  tags: {
+    git_commit: "c0deb10c4";
   }
-  ```
+}
+```
 
 `whitelistUrls`
 
 : The inverse of `ignoreUrls`. Only report errors from whole URLs matching a regex pattern or an exact string. `whitelistUrls` should match the URL of your actual JavaScript files. It should match the URL of your site if and only if you are inlining code inside `&lt;script&gt;` tags. Not setting this value is equivalent to a catch-all and will not filter out any values.
 
-  ```javascript
-  {
-    whitelistUrls: [/getsentry\.com/]
-  }
-  ```
+```javascript
+{
+  whitelistUrls: [/getsentry\.com/];
+}
+```
 
 `ignoreErrors`
 
 : Very often, you will come across specific errors that are a result of something other than your application, or errors that you’re completely not interested in. _ignoreErrors_ is a list of these messages to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the messages, so if you need to achieve an exact match, use RegExp patterns instead.
 
-  ```javascript
-  {
-    ignoreErrors: ['fb_xd_fragment', /^Exact Match Message$/]
-  }
-  ```
+```javascript
+{
+  ignoreErrors: ["fb_xd_fragment", /^Exact Match Message$/];
+}
+```
 
 `ignoreUrls`
 
 : The inverse of `whitelistUrls` and similar to `ignoreErrors`, but will ignore errors from whole URLs matching a regex pattern or an exact string.
 
-  ```javascript
-  {
-    ignoreUrls: [/graph\.facebook\.com/, 'http://example.com/script2.js']
-  }
-  ```
+```javascript
+{
+  ignoreUrls: [/graph\.facebook\.com/, "http://example.com/script2.js"];
+}
+```
 
 `includePaths`
 
 : An array of regex patterns to indicate which URLs are a part of your app in the stack trace. All other frames will appear collapsed inside Sentry to make it easier to discern between frames that happened in your code vs other code. It’d be suggested to add the current page URL, and the host for your CDN.
 
-  ```javascript
-  {
-      includePaths: [/https?:\/\/getsentry\.com/, /https?:\/\/cdn\.getsentry\.com/]
-  }
-  ```
+```javascript
+{
+  includePaths: [/https?:\/\/getsentry\.com/, /https?:\/\/cdn\.getsentry\.com/];
+}
+```
 
 `sampleRate`
 
 : A sampling rate to apply to events. A value of 0.0 will send no events, and a value of 1.0 will send all events (default).
 
-  ```javascript
-  {
-      sampleRate: 0.5 // send 50% of events, drop the other half
-  }
-  ```
+```javascript
+{
+  sampleRate: 0.5; // send 50% of events, drop the other half
+}
+```
 
 `sanitizeKeys`
 
-: An array of strings or regex patterns representing keys that should be scrubbed from the payload sent to Sentry. We’ll go through every field in the payload and mask the values with simple _********_ string instead. This will match _only_ keys of the object, not the values. Sentry also sanitizes all events sent to it on the server-side, but this allows you to strip the payload before it gets to the server.
+: An array of strings or regex patterns representing keys that should be scrubbed from the payload sent to Sentry. We’ll go through every field in the payload and mask the values with simple _**\*\*\*\***_ string instead. This will match _only_ keys of the object, not the values. Sentry also sanitizes all events sent to it on the server-side, but this allows you to strip the payload before it gets to the server.
 
-  ```javascript
-  {
-      sanitizeKeys: [/_token$/, /password/i, 'someHideousKey']
-  }
-  ```
+```javascript
+{
+  sanitizeKeys: [/_token$/, /password/i, "someHideousKey"];
+}
+```
 
 `dataCallback`
 
 : A function that allows mutation of the data payload right before being sent to Sentry.
 
-  ```javascript
-  {
-      dataCallback: function(data) {
-        // do something to data
-        return data;
-      }
-  }
-  ```
+```javascript
+{
+    dataCallback: function(data) {
+      // do something to data
+      return data;
+    }
+}
+```
 
 `breadcrumbCallback`
 
 : A function that allows filtering or mutating breadcrumb payloads. Return false to throw away the breadcrumb.
 
-  ```javascript
-  {
-      breadcrumbCallback: function(crumb) {
-        if (crumb.type === 'http') {
-          return crumb;
-        }
-
-        return false;
+```javascript
+{
+    breadcrumbCallback: function(crumb) {
+      if (crumb.type === 'http') {
+        return crumb;
       }
-  }
-  ```
+
+      return false;
+    }
+}
+```
 
 `shouldSendCallback`
 
 : A callback function that allows you to apply your own filters to determine if the message should be sent to Sentry.
 
-  ```javascript
-  {
-      shouldSendCallback: function(data) {
-        return false;
-      }
-  }
-  ```
+```javascript
+{
+    shouldSendCallback: function(data) {
+      return false;
+    }
+}
+```
 
 `maxMessageLength`
 
@@ -194,19 +197,19 @@ Those configuration options are documented below:
 
 : Enables/disables automatic collection of breadcrumbs. Possible values are:
 
-  -   _true_ (default)
-  -   _false_ - all breadcrumb collection disabled
-  -   A dictionary of individual breadcrumb types that can be enabled/disabled:
+- _true_ (default)
+- _false_ - all breadcrumb collection disabled
+- A dictionary of individual breadcrumb types that can be enabled/disabled:
 
-  ```javascript
-  autoBreadcrumbs: {
-      'xhr': false,      // XMLHttpRequest
-      'console': false,  // console logging
-      'dom': true,       // DOM interactions, i.e. clicks/typing
-      'location': false, // url changes, including pushState/popState
-      'sentry': true     // sentry events
-  }
-  ```
+```javascript
+autoBreadcrumbs: {
+    'xhr': false,      // XMLHttpRequest
+    'console': false,  // console logging
+    'dom': true,       // DOM interactions, i.e. clicks/typing
+    'location': false, // url changes, including pushState/popState
+    'sentry': true     // sentry events
+}
+```
 
 `maxBreadcrumbs`
 
@@ -220,33 +223,33 @@ Those configuration options are documented below:
 
 : Override the default HTTP data transport handler.
 
-  Alternatively, can be specified using `Raven.setTransport(myTransportFunction)`.
+Alternatively, can be specified using `Raven.setTransport(myTransportFunction)`.
 
-  ```javascript
-  {
-      transport: function (options) {
-          // send data
-      }
-  }
-  ```
+```javascript
+{
+    transport: function (options) {
+        // send data
+    }
+}
+```
 
-  The provided function receives a single argument, `options`, with the following properties:
+The provided function receives a single argument, `options`, with the following properties:
 
-  url
+url
 
-  : The target url where the data is sent.
+: The target url where the data is sent.
 
-  data
+data
 
-  : The outbound exception data.
+: The outbound exception data.
 
     For POST requests, this should be JSON-encoded and set as the HTTP body (and transferred as Content-type: application/json).
 
     For GET requests, this should be JSON-encoded and passed over the query string with key `sentry_data`.
 
-  auth
+auth
 
-  : An object representing authentication data. This should be converted to urlencoded key/value pairs and passed as part of the query string, for both GET and POST requests.
+: An object representing authentication data. This should be converted to urlencoded key/value pairs and passed as part of the query string, for both GET and POST requests.
 
     The auth object has the following properties:
 
@@ -262,64 +265,64 @@ Those configuration options are documented below:
 
     : Your public client key (DSN).
 
-  options
+options
 
-  : Include all top-level options described.
+: Include all top-level options described.
 
-  onSuccess
+onSuccess
 
-  : Callback to be invoked upon a successful request.
+: Callback to be invoked upon a successful request.
 
-  onError
+onError
 
-  : Callback to be invoked upon a failed request.
+: Callback to be invoked upon a failed request.
 
 `headers`
 
 : Pass custom headers to server requests for `fetch` or `XMLHttpRequest`.
 
-  ```javascript
-  {
-      headers: {
-          'CSRF-TOKEN': '12345'
-      }
-  }
-  ```
+```javascript
+{
+    headers: {
+        'CSRF-TOKEN': '12345'
+    }
+}
+```
 
-  Headers value can be in the form of a function, to the compute value in time of a request:
+Headers value can be in the form of a function, to the compute value in time of a request:
 
-  ```javascript
-  {
-      headers: {
-          'CSRF-TOKEN': function() {
-              // custom logic that will be computed on every request
-              return new Date();
-          }
-      }
-  }
-  ```
+```javascript
+{
+    headers: {
+        'CSRF-TOKEN': function() {
+            // custom logic that will be computed on every request
+            return new Date();
+        }
+    }
+}
+```
 
 `fetchParameters`
 
 : `fetch()` init parameters ([https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)).
 
-  Setting `keepalive: true` parameter will allow SDK to send events in `unload` and `beforeunload` handlers.
-  However, it'll also restrict the size of a single event to 64kB, per [fetch specification](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) (point 8.5).
+Setting `keepalive: true` parameter will allow SDK to send events in `unload` and `beforeunload` handlers.
+However, it'll also restrict the size of a single event to 64kB, per [fetch specification](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) (point 8.5).
 
-  Defaults:
+Defaults:
 
-  ```javascript
-  {
-      method: 'POST',
-      referrerPolicy: 'origin'
-  }
-  ```
+```javascript
+{
+    method: 'POST',
+    referrerPolicy: 'origin'
+}
+```
 
 `allowDuplicates`
 
 : By default, Raven.js attempts to suppress duplicate captured errors and messages that occur back-to-back. Such events are often triggered by rogue code (e.g. from a _setInterval_ callback in a browser extension), are not actionable, and eat up your event quota.
 
-  To disable this behavior (for example, when testing), set `allowDuplicates: true` during configuration.
+To disable this behavior (for example, when testing), set `allowDuplicates: true` during configuration.
 
 `allowSecretKey`
 
@@ -333,46 +336,40 @@ Those configuration options are documented below:
 
 : Enables/disables instrumentation of globals. Possible values are:
 
-  -   _true_ (default)
-  -   _false_ - all instrumentation disabled
-  -   A dictionary of individual instrumentation types that can be enabled/disabled:
+- _true_ (default)
+- _false_ - all instrumentation disabled
+- A dictionary of individual instrumentation types that can be enabled/disabled:
 
-  ```javascript
-  instrument: {
-      'tryCatch': true, // Instruments timers and event targets
-  }
-  ```
+```javascript
+instrument: {
+    'tryCatch': true, // Instruments timers and event targets
+}
+```
 
 ## Putting it all together
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
+  <head>
     <title>Awesome stuff happening here</title>
-</head>
-<body>
+  </head>
+  <body>
     ...
     <script src="jquery.min.js"></script>
-    <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js"
-        crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.ravenjs.com/3.26.4/raven.min.js"
+      crossorigin="anonymous"
+    ></script>
     <script>
-        Raven.config('___PUBLIC_DSN___', {
-            logger: 'my-logger',
-            whitelistUrls: [
-                /disqus\.com/,
-                /getsentry\.com/
-            ],
-            ignoreErrors: [
-                'fb_xd_fragment',
-                /ReferenceError:.*/
-            ],
-            includePaths: [
-                /https?:\/\/(www\.)?getsentry\.com/
-            ]
-        }).install();
+      Raven.config("___PUBLIC_DSN___", {
+        logger: "my-logger",
+        whitelistUrls: [/disqus\.com/, /getsentry\.com/],
+        ignoreErrors: ["fb_xd_fragment", /ReferenceError:.*/],
+        includePaths: [/https?:\/\/(www\.)?getsentry\.com/],
+      }).install();
     </script>
     <script src="myapp.js"></script>
-</body>
+  </body>
 </html>
 ```

--- a/src/docs/clients/javascript/index.mdx
+++ b/src/docs/clients/javascript/index.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: JavaScript
 sidebar_order: 7
-robots: noindex
+noindex: true
 tags: []
 ---
 Raven.js is the official browser JavaScript client for Sentry. It automatically reports uncaught JavaScript exceptions triggered from a browser environment, and provides a rich API for reporting your own errors.

--- a/src/docs/clients/javascript/install.mdx
+++ b/src/docs/clients/javascript/install.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Installation
-robots: noindex
+noindex: true
 tags: []
 ---
 Raven is distributed in a few different methods, and should get included after any other libraries are included, but before your own scripts.

--- a/src/docs/clients/javascript/integrations.mdx
+++ b/src/docs/clients/javascript/integrations.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Integrations
-robots: noindex
+noindex: true
 tags: []
 ---
 Integrations extend the functionality of Raven.js to cover common libraries and environments automatically using simple plugins.

--- a/src/docs/clients/javascript/sourcemaps.mdx
+++ b/src/docs/clients/javascript/sourcemaps.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: Source Maps
 sidebar_order: 3
-robots: noindex
+noindex: true
 tags: []
 ---
+
 Sentry supports un-minifying JavaScript via [Source Maps](http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
 
 Most of the process is the same whether you're using this SDK or the [new unified JavaScript Browser SDK](/platforms/javascript/), so the main docs for dealing with source maps can be found [there](/platforms/javascript/sourcemaps/). The one difference is how you specify the release in your SDK configuration.
@@ -16,10 +17,11 @@ Most of the process is the same whether you're using this SDK or the [new unifie
 If you are uploading source map artifacts yourself, you must specify the release in your Raven.js client configuration. Sentry will use the release name to associate digested event data with the files you’ve uploaded via the [releases API](/api/releases/), [sentry-cli](/cli/) or [sentry-webpack-plugin](https://github.com/getsentry/sentry-webpack-plugin). This step is optional if you are hosting source maps on the remote server, but still recommended.
 
 ```javascript
-Raven.config('your-dsn', {
-  release: '1.2.3-beta'
+Raven.config("your-dsn", {
+  release: "1.2.3-beta",
 }).install();
 ```
+
 ## Next Steps
 
 Now that you've specified the release in your SDK config, head on over to [our main source maps docs](/platforms/javascript/sourcemaps/) to learn how to [create your source maps](/platforms/javascript/sourcemaps/) and [make them available to Sentry](/platforms/javascript/sourcemaps/). There you'll also find a [troubleshooting guide](/platforms/javascript/sourcemaps/).

--- a/src/docs/clients/javascript/tips.mdx
+++ b/src/docs/clients/javascript/tips.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Tips and Tricks
 sidebar_order: 4
-robots: noindex
+noindex: true
 tags: []
 ---
 These are some general recommendations and tips for how to get the most out of Raven.js and Sentry.

--- a/src/docs/clients/javascript/usage.mdx
+++ b/src/docs/clients/javascript/usage.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Usage
 sidebar_order: 2
-robots: noindex
+noindex: true
 tags: []
 ---
 By default, Raven makes a few efforts to try its best to capture meaningful stack traces, but browsers make it pretty difficult.

--- a/src/docs/clients/node/coffeescript.mdx
+++ b/src/docs/clients/node/coffeescript.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: CoffeeScript
 sidebar_order: 4
-robots: noindex
+noindex: true
 tags: []
 ---
+
 In order to use raven-node with coffee-script or another library which overwrites Error.prepareStackTrace you might run into the exception “Traceback does not support Error.prepareStackTrace being defined already.”
 
 In order to not have raven-node (and the underlying raw stack trace library) require Traceback you can pass your own stackFunction in the options. For example:

--- a/src/docs/clients/node/config.mdx
+++ b/src/docs/clients/node/config.mdx
@@ -3,14 +3,15 @@ draft: false
 categories: []
 toc: true
 title: Configuration
-robots: noindex
+noindex: true
 tags: []
 ---
+
 To get started, you need to configure Raven to use your Sentry DSN:
 
 ```javascript
-var Raven = require('raven');
-Raven.config('___PUBLIC_DSN___').install();
+var Raven = require("raven");
+Raven.config("___PUBLIC_DSN___").install();
 ```
 
 At this point, Raven is ready to capture any uncaught exceptions.
@@ -18,7 +19,7 @@ At this point, Raven is ready to capture any uncaught exceptions.
 Note that the `install` method can optionally take a callback function that is invoked if a fatal, non-recoverable error occurs. You can use this callback to perform any cleanup that should occur before the Node process exits.
 
 ```javascript
-Raven.config('___PUBLIC_DSN___').install(function (err, initialErr, eventId) {
+Raven.config("___PUBLIC_DSN___").install(function(err, initialErr, eventId) {
   console.error(err);
   process.exit(1);
 });
@@ -29,8 +30,8 @@ Raven.config('___PUBLIC_DSN___').install(function (err, initialErr, eventId) {
 `Raven.config()` can optionally be passed an additional argument for extra configuration:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
-  release: '1.3.0'
+Raven.config("___PUBLIC_DSN___", {
+  release: "1.3.0",
 }).install();
 ```
 
@@ -40,185 +41,191 @@ Those configuration options are documented below:
 
 : The name of the logger used by Sentry.
 
-  ```javascript
-  {
-    logger: 'default'
-  }
-  ```
+```javascript
+{
+  logger: "default";
+}
+```
 
 `name`
 
 : Set the server name for the client to use. Default: `require('os').hostname()` Optionally, use `SENTRY_NAME` environment variable.
 
-  ```javascript
-  {
-    name: 'primary'
-  }
-  ```
+```javascript
+{
+  name: "primary";
+}
+```
 
 `release`
 
 : Track the version of your application in Sentry. Optionally, use `SENTRY_RELEASE` environment variable.
 
-  ```javascript
-  {
-    release: '721e41770371db95eee98ca2707686226b993eda'
-  }
-  ```
+```javascript
+{
+  release: "721e41770371db95eee98ca2707686226b993eda";
+}
+```
 
-  This is usually a Git SHA hash, which can be obtained using various npm packages, e.g.
+This is usually a Git SHA hash, which can be obtained using various npm packages, e.g.
 
-  ```javascript
-  var git = require('git-rev-sync');
+```javascript
+var git = require("git-rev-sync");
 
-  {
-    // this will return 40 characters long hash
-    // eg. '75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef'
-    release: git.long()
-  }
-  ```
+{
+  // this will return 40 characters long hash
+  // eg. '75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef'
+  release: git.long();
+}
+```
 
 `environment`
 
 : Track the environment name inside Sentry. Optionally, use `SENTRY_ENVIRONMENT` environment variable.
 
-  ```javascript
-  {
-    environment: 'staging'
-  }
-  ```
+```javascript
+{
+  environment: "staging";
+}
+```
 
 `tags`
 
 : Additional tags to assign to each event.
 
-  ```javascript
-  {
-    tags: {git_commit: 'c0deb10c4'}
+```javascript
+{
+  tags: {
+    git_commit: "c0deb10c4";
   }
-  ```
+}
+```
 
 `extra`
 
 : Arbitrary data to associate with the event.
 
-  ```javascript
-  {
-      extra: {planet: {name: 'Earth'}}
+```javascript
+{
+  extra: {
+    planet: {
+      name: "Earth";
+    }
   }
-  ```
+}
+```
 
 `parseUser`
 
 : Controls how Raven tries to parse user context when parsing a request object.
 
-  An array of strings will serve as a whitelist for fields to grab from `req.user`. `true` will collect all keys from `req.user`. `false` will collect nothing.
+An array of strings will serve as a whitelist for fields to grab from `req.user`. `true` will collect all keys from `req.user`. `false` will collect nothing.
 
-  Defaults to `['id', 'username', 'email']`.
+Defaults to `['id', 'username', 'email']`.
 
-  Alternatively, a function can be provided for fully custom parsing:
+Alternatively, a function can be provided for fully custom parsing:
 
-  ```javascript
-  {
-      parseUser: function (req) {
-          // custom user parsing logic
-          return {
-              username: req.specialUserField.username,
-              id: req.specialUserField.getId()
-          };
-      }
-  }
-  ```
+```javascript
+{
+    parseUser: function (req) {
+        // custom user parsing logic
+        return {
+            username: req.specialUserField.username,
+            id: req.specialUserField.getId()
+        };
+    }
+}
+```
 
 `sampleRate`
 
 : A sampling rate to apply to events. A value of 0.0 will send no events, and a value of 1.0 will send all events (default).
 
-  ```javascript
-  {
-      sampleRate: 0.5 // send 50% of events, drop the other half
-  }
-  ```
+```javascript
+{
+  sampleRate: 0.5; // send 50% of events, drop the other half
+}
+```
 
 `sendTimeout`
 
 : The time to wait to connect to the server or receive a response when capturing an exception, in seconds.
 
-  If it takes longer, the transport considers it a failed request and will pass back a timeout error.
+If it takes longer, the transport considers it a failed request and will pass back a timeout error.
 
-  Defaults to 1 second. Make it longer if you run into timeout problems when sending exceptions to Sentry.
+Defaults to 1 second. Make it longer if you run into timeout problems when sending exceptions to Sentry.
 
-  ```javascript
-  {
-      sendTimeout: 5 // wait 5 seconds before considering the capture to have failed
-  }
-  ```
+```javascript
+{
+  sendTimeout: 5; // wait 5 seconds before considering the capture to have failed
+}
+```
 
 `dataCallback`
 
 : A function that allows mutation of the data payload right before being sent to Sentry.
 
-  ```javascript
-  {
-      dataCallback: function(data) {
-          // add a user context
-          data.user = {
-              id: 1337,
-              name: 'janedoe',
-              email: 'janedoe@example.com'
-          };
-          return data;
-      }
-  }
-  ```
+```javascript
+{
+    dataCallback: function(data) {
+        // add a user context
+        data.user = {
+            id: 1337,
+            name: 'janedoe',
+            email: 'janedoe@example.com'
+        };
+        return data;
+    }
+}
+```
 
 `shouldSendCallback`
 
 : A callback function that allows you to apply your own filters to determine if the event should be sent to Sentry.
 
-  ```javascript
-  {
-      shouldSendCallback: function (data) {
-          // randomly omit half of events
-          return Math.random() > 0.5;
-      }
-  }
-  ```
+```javascript
+{
+    shouldSendCallback: function (data) {
+        // randomly omit half of events
+        return Math.random() > 0.5;
+    }
+}
+```
 
 `autoBreadcrumbs`
 
 : Enables/disables automatic collection of breadcrumbs. Possible values are:
 
-  -   _false_ - all automatic breadcrumb collection disabled (default)
-  -   _true_ - all automatic breadcrumb collection enabled
-  -   A dictionary of individual breadcrumb types that can be enabled/disabled:
+- _false_ - all automatic breadcrumb collection disabled (default)
+- _true_ - all automatic breadcrumb collection enabled
+- A dictionary of individual breadcrumb types that can be enabled/disabled:
 
-  ```javascript
-  autoBreadcrumbs: {
-      'console': false,  // console logging
-      'http': true,     // http and https requests
-  }
-  ```
+```javascript
+autoBreadcrumbs: {
+    'console': false,  // console logging
+    'http': true,     // http and https requests
+}
+```
 
 `maxBreadcrumbs`
 
 : Raven captures up to 30 breadcrumb entries by default. You can increase this to be as high as 100, or reduce it if you find 30 is too noisy, by setting _maxBreadcrumbs_.
 
-  Note that in very high-concurrency situations where you might have a large number of long-lived contexts each with a large number of associated breadcrumbs, there is potential for significant memory usage. 10,000 contexts with 10kB of breadcrumb data each will use around 120mB of memory. Most applications will be nowhere close to either of these numbers, but if yours might be, you can use the _maxBreadcrumbs_ parameter to limit the amount of breadcrumb data each context will keep around.
+Note that in very high-concurrency situations where you might have a large number of long-lived contexts each with a large number of associated breadcrumbs, there is potential for significant memory usage. 10,000 contexts with 10kB of breadcrumb data each will use around 120mB of memory. Most applications will be nowhere close to either of these numbers, but if yours might be, you can use the _maxBreadcrumbs_ parameter to limit the amount of breadcrumb data each context will keep around.
 
 `transport`
 
 : Override the default HTTP data transport handler.
 
-  ```javascript
-  {
-      transport: function (options) {
-          // send data
-      }
-  }
-  ```
+```javascript
+{
+    transport: function (options) {
+        // send data
+    }
+}
+```
 
-  Please see the raven-node source code to see [how transports are implemented](https://github.com/getsentry/sentry-javascript/blob/master/packages/raven-node/lib/transports.js).
+Please see the raven-node source code to see [how transports are implemented](https://github.com/getsentry/sentry-javascript/blob/master/packages/raven-node/lib/transports.js).
 
 `maxReqQueueCount`
 

--- a/src/docs/clients/node/index.mdx
+++ b/src/docs/clients/node/index.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Node.js
 sidebar_order: 9
-robots: noindex
+noindex: true
 tags: []
 ---
 raven-node is the official Node.js client for Sentry.

--- a/src/docs/clients/node/integrations.mdx
+++ b/src/docs/clients/node/integrations.mdx
@@ -3,60 +3,60 @@ draft: false
 categories: []
 toc: true
 title: Integrations
-robots: noindex
+noindex: true
 tags: []
 ---
 
 ## Connect
 
 ```javascript
-var connect = require('connect');
-var Raven = require('raven');
+var connect = require("connect");
+var Raven = require("raven");
 
 // Must configure Raven before doing anything else with it
-Raven.config('___PUBLIC_DSN___').install();
+Raven.config("___PUBLIC_DSN___").install();
 
 function mainHandler(req, res) {
-    throw new Error('Broke!');
+  throw new Error("Broke!");
 }
 
 function onError(err, req, res, next) {
-    // The error id is attached to `res.sentry` to be returned
-    // and optionally displayed to the user for support.
-    res.statusCode = 500;
-    res.end(res.sentry + '\n');
+  // The error id is attached to `res.sentry` to be returned
+  // and optionally displayed to the user for support.
+  res.statusCode = 500;
+  res.end(res.sentry + "\n");
 }
 
 connect(
-    // The request handler be the first item
-    Raven.requestHandler(),
+  // The request handler be the first item
+  Raven.requestHandler(),
 
-    connect.bodyParser(),
-    connect.cookieParser(),
-    mainHandler,
+  connect.bodyParser(),
+  connect.cookieParser(),
+  mainHandler,
 
-    // The error handler must be before any other error middleware
-    Raven.errorHandler(),
+  // The error handler must be before any other error middleware
+  Raven.errorHandler(),
 
-    // Optional fallthrough error handler
-    onError,
+  // Optional fallthrough error handler
+  onError
 ).listen(3000);
 ```
 
 ## Express
 
 ```javascript
-var app = require('express')();
-var Raven = require('raven');
+var app = require("express")();
+var Raven = require("raven");
 
 // Must configure Raven before doing anything else with it
-Raven.config('__DSN__').install();
+Raven.config("__DSN__").install();
 
 // The request handler must be the first middleware on the app
 app.use(Raven.requestHandler());
 
-app.get('/', function mainHandler(req, res) {
-    throw new Error('Broke!');
+app.get("/", function mainHandler(req, res) {
+  throw new Error("Broke!");
 });
 
 // The error handler must be before any other error middleware
@@ -64,10 +64,10 @@ app.use(Raven.errorHandler());
 
 // Optional fallthrough error handler
 app.use(function onError(err, req, res, next) {
-    // The error id is attached to `res.sentry` to be returned
-    // and optionally displayed to the user for support.
-    res.statusCode = 500;
-    res.end(res.sentry + '\n');
+  // The error id is attached to `res.sentry` to be returned
+  // and optionally displayed to the user for support.
+  res.statusCode = 500;
+  res.end(res.sentry + "\n");
 });
 
 app.listen(3000);
@@ -76,16 +76,16 @@ app.listen(3000);
 ## Koa
 
 ```javascript
-var koa = require('koa');
-var Raven = require('raven');
+var koa = require("koa");
+var Raven = require("raven");
 
 var app = koa();
-Raven.config('___PUBLIC_DSN___').install();
+Raven.config("___PUBLIC_DSN___").install();
 
-app.on('error', function (err) {
-    Raven.captureException(err, function (err, eventId) {
-        console.log('Reported error ' + eventId);
-    });
+app.on("error", function(err) {
+  Raven.captureException(err, function(err, eventId) {
+    console.log("Reported error " + eventId);
+  });
 });
 
 app.listen(3000);
@@ -100,8 +100,8 @@ Configure `raven-node` as early as possible:
 ```javascript
 // server/server.js
 
-const Raven = require('raven');
-Raven.config('__DSN__').install();
+const Raven = require("raven");
+Raven.config("__DSN__").install();
 ```
 
 Add `Raven.errorHandler` as a Loopback middleware:
@@ -123,8 +123,8 @@ Add `Raven.errorHandler` as a Loopback middleware:
 ```javascript
 // config/http.js
 
-var Raven = require('raven');
-Raven.config('__DSN__').install();
+var Raven = require("raven");
+Raven.config("__DSN__").install();
 
 module.exports.http = {
   middleware: {
@@ -135,13 +135,13 @@ module.exports.http = {
     // And they have to be added in a correct order to middlewares list
     order: [
       // The request handler must be the very first one
-      'requestHandler',
+      "requestHandler",
       // ...more middlewares
-      'router',
+      "router",
       // The error handler must be after router, but before any other error middleware
-      'errorHandler',
+      "errorHandler",
       /// ...remaining middlewares
-    ]
-  }
-}
+    ],
+  },
+};
 ```

--- a/src/docs/clients/node/sourcemaps.mdx
+++ b/src/docs/clients/node/sourcemaps.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: Source Maps
 sidebar_order: 2
-robots: noindex
+noindex: true
 tags: []
 ---
+
 Sentry supports un-minifying JavaScript via [Source Maps](http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
 
 ## Generating a Source Map
@@ -20,19 +21,19 @@ Webpack is a powerful build tool that resolves and bundles your JavaScript modul
 Webpack can be configured to output source maps by editing `webpack.config.js`.
 
 ```javascript
-const path = require('path');
+const path = require("path");
 
 module.exports = {
-    // ... other config above ...
-    target: 'node',
-    devtool: 'source-map',
-    entry: {
-      "app": './src/app.js'
-    },
-    output: {
-      path: path.join(__dirname, 'dist'),
-      filename: '[name].js'
-    }
+  // ... other config above ...
+  target: "node",
+  devtool: "source-map",
+  entry: {
+    app: "./src/app.js",
+  },
+  output: {
+    path: path.join(__dirname, "dist"),
+    filename: "[name].js",
+  },
 };
 ```
 
@@ -46,23 +47,23 @@ Sentry provides an abstraction called **Releases** which you can attach source a
 
 It can be easily done with a help of the `sentry-webpack-plugin`, which internally uses our Sentry CLI.
 
--   Start by creating a new authentication token under **[Account] > API**.
--   Ensure you you have `project:write` selected under scopes.
--   Install `@sentry/webpack-plugin` using `npm`
--   Create `.sentryclirc` file with necessary config (see Sentry Webpack Plugin docs below)
--   Update your `webpack.config.json`
+- Start by creating a new authentication token under **[Account] > API**.
+- Ensure you you have `project:write` selected under scopes.
+- Install `@sentry/webpack-plugin` using `npm`
+- Create `.sentryclirc` file with necessary config (see Sentry Webpack Plugin docs below)
+- Update your `webpack.config.json`
 
 ```javascript
-const SentryPlugin = require('@sentry/webpack-plugin');
+const SentryPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
-    // ... other config above ...
-    plugins: [
-      new SentryPlugin({
-        release: process.env.RELEASE,
-        include: './dist'
-      })
-    ]
+  // ... other config above ...
+  plugins: [
+    new SentryPlugin({
+      release: process.env.RELEASE,
+      include: "./dist",
+    }),
+  ],
 };
 ```
 
@@ -71,8 +72,8 @@ You can take a look at [Sentry Webpack Plugin documentation](https://github.com/
 Additionally, you’ll need to configure the client to send the `release`:
 
 ```javascript
-Raven.config('your-dsn', {
-    release: process.env.RELEASE
+Raven.config("your-dsn", {
+  release: process.env.RELEASE,
 });
 ```
 

--- a/src/docs/clients/node/typescript.mdx
+++ b/src/docs/clients/node/typescript.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: TypeScript
 sidebar_order: 3
-robots: noindex
+noindex: true
 tags: []
 ---
+
 Please read [Source Maps docs](/clients/node/sourcemaps/) first to learn how to configure Raven SDK, upload artifacts to our servers or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).
 
 Using Raven and Source Maps with TypeScript unfortunatelly requires slightly more configuration.
@@ -24,16 +25,14 @@ Assuming you already have a _tsconfig.json_ file similar to this:
 
 ```json
 {
-    "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
-        "allowJs": true,
-        "moduleResolution": "node",
-        "outDir": "dist"
-    },
-    "include": [
-        "./src/**/*"
-    ]
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "allowJs": true,
+    "moduleResolution": "node",
+    "outDir": "dist"
+  },
+  "include": ["./src/**/*"]
 }
 ```
 
@@ -41,12 +40,12 @@ create a new one called _tsconfig.production.json_ and paste the snippet below:
 
 ```json
 {
-    "extends": "./tsconfig",
-    "compilerOptions": {
-        "sourceMap": true,
-        "inlineSources": true,
-        "sourceRoot": "/"
-    }
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/"
+  }
 }
 ```
 
@@ -56,7 +55,7 @@ The second step is changing events frames, so that Sentry can link stack traces 
 
 This can be done using _dataCallback_, in a very similar manner as we do with a single entrypoint described in Source Maps docs, with one, very important difference. Instead of using _basename_, we have to somehow detect and pass the root directory of our project.
 
-Unfortunately, Node is very fragile in that manner and doesn’t have a very reliable way to do this. The easiest and the most reliable way we found, is to store the ___dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This _has to be done_ as the first thing in your code and from the entrypoint, otherwise the path will be incorrect.
+Unfortunately, Node is very fragile in that manner and doesn’t have a very reliable way to do this. The easiest and the most reliable way we found, is to store the _\_\_dirname_ or _process.cwd()_ in the global variable and using it in other places of your app. This _has to be done_ as the first thing in your code and from the entrypoint, otherwise the path will be incorrect.
 
 If you want, you can set this value by hand to something like _/var/www/html/some-app_ if you can get this from some external source or you know it won’t ever change.
 
@@ -78,25 +77,25 @@ global.__rootdir__ = __dirname || process.cwd();
 ```
 
 ```javascript
-import * as path from 'path';
+import * as path from "path";
 const root = global.__rootdir__;
 
-Raven.config('your-dsn', {
+Raven.config("your-dsn", {
   // the rest of configuration
 
-  dataCallback: function (data) {
+  dataCallback: function(data) {
     var stacktrace = data.exception && data.exception[0].stacktrace;
 
     if (stacktrace && stacktrace.frames) {
       stacktrace.frames.forEach(function(frame) {
-        if (frame.filename.startsWith('/')) {
+        if (frame.filename.startsWith("/")) {
           frame.filename = "app:///" + path.relative(root, frame.filename);
         }
       });
     }
 
     return data;
-  }
+  },
 }).install();
 ```
 

--- a/src/docs/clients/node/usage.mdx
+++ b/src/docs/clients/node/usage.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: Usage
 sidebar_order: 1
-robots: noindex
+noindex: true
 tags: []
 ---
+
 ## Capturing Errors
 
 You can use `captureException` to manually report errors:
@@ -16,12 +17,12 @@ try {
   throw new Error();
 } catch (e) {
   // You can get eventId either as the synchronous return value, or via the callback
-  var eventId = Raven.captureException(e, function (sendErr, eventId) {
+  var eventId = Raven.captureException(e, function(sendErr, eventId) {
     // This callback fires once the report has been sent to Sentry
     if (sendErr) {
-      console.error('Failed to send captured exception to Sentry');
+      console.error("Failed to send captured exception to Sentry");
     } else {
-      console.log('Captured exception and send to Sentry successfully');
+      console.log("Captured exception and send to Sentry successfully");
     }
   });
 }
@@ -30,10 +31,10 @@ try {
 The recommended usage pattern, though, is to run your entire program inside a Raven context:
 
 ```javascript
-var Raven = require('raven');
+var Raven = require("raven");
 
-Raven.config('___PUBLIC_DSN___').install();
-Raven.context(function () {
+Raven.config("___PUBLIC_DSN___").install();
+Raven.context(function() {
   // all your stuff goes here
 });
 ```
@@ -45,19 +46,19 @@ Raven will automatically catch and report any unhandled errors originating insid
 `Raven.context` allows you to wrap any function to be immediately executed. Behind the scenes, this uses [domains](https://nodejs.org/api/domain.html) to wrap, catch, and record any exceptions originating from the function.
 
 ```javascript
-Raven.context(function () {
-    doSomething(a[0])
+Raven.context(function() {
+  doSomething(a[0]);
 });
 ```
 
 `Raven.wrap` wraps a function in a similar way to `Raven.context`, but instead of invoking the function, it returns another function. This is especially useful when passing around a callback.
 
 ```javascript
-var doIt = function () {
-    // doing cool stuff
-}
+var doIt = function() {
+  // doing cool stuff
+};
 
-setTimeout(Raven.wrap(doIt), 1000)
+setTimeout(Raven.wrap(doIt), 1000);
 ```
 
 We refer to code wrapped via `Raven.context` or `Raven.wrap` as being inside a context. Code inside a context has access to the `setContext`, `mergeContext`, and `getContext` methods for associating data with that context.
@@ -65,14 +66,14 @@ We refer to code wrapped via `Raven.context` or `Raven.wrap` as being inside a c
 ```javascript
 Raven.setContext({
   user: {
-    username: 'lewis'
-  }
+    username: "lewis",
+  },
 });
 
 Raven.mergeContext({
   tags: {
-    component: 'api'
-  }
+    component: "api",
+  },
 });
 
 console.log(Raven.getContext());
@@ -92,9 +93,9 @@ While a user is logged in, you can tell Sentry to associate errors with user dat
 ```javascript
 Raven.setContext({
   user: {
-    email: 'matt@example.com',
-    id: '123'
-  }
+    email: "matt@example.com",
+    id: "123",
+  },
 });
 ```
 
@@ -103,8 +104,8 @@ This data is then included with any errors or messages, allowing you to see whic
 ## Capturing Messages
 
 ```javascript
-client.captureMessage('Broken!', function (err, eventId) {
-    // The message has now been sent to Sentry
+client.captureMessage("Broken!", function(err, eventId) {
+  // The message has now been sent to Sentry
 });
 ```
 
@@ -116,80 +117,86 @@ All optional attributes are passed as part of the options to `captureException` 
 
 : User context for this event. Must be a mapping. Children can be any native JSON type.
 
-  ```javascript
-  {
-      user: { name: 'matt' }
+```javascript
+{
+  user: {
+    name: "matt";
   }
-  ```
+}
+```
 
-  If you’re inside a context and your context data includes a `user` key, that data will be merged into this.
+If you’re inside a context and your context data includes a `user` key, that data will be merged into this.
 
 `request`
 
 : Alias: `req`. The `request` object associated with this event, from a Node http server, Express, Koa, or similar. Will be parsed for request details and user context from `request.user` if present. It will only pull out the data that’s handled by the server: `headers`, `method`, `host`, `protocol`, `url`, `query`, `cookies`, `body`, `ip` and `user`.
 
-  ```javascript
-  app.use(function (req, res, next) {
-      if (someError) {
-          Raven.captureException(someError, { req: req });
-      }
-  });
-  ```
+```javascript
+app.use(function(req, res, next) {
+  if (someError) {
+    Raven.captureException(someError, { req: req });
+  }
+});
+```
 
-  Note that the `Raven.requestHandler()` Express middleware adds the `req` object to the context for you automatically, so you won’t need to provide it manually.
+Note that the `Raven.requestHandler()` Express middleware adds the `req` object to the context for you automatically, so you won’t need to provide it manually.
 
 `tags`
 
 : Tags to index with this event. Must be a mapping of strings.
 
-  ```javascript
-  {
-      tags: { key: 'value' }
+```javascript
+{
+  tags: {
+    key: "value";
   }
-  ```
+}
+```
 
-  If you’re inside a context and your context data includes a _tags_ key, that data will be merged into this. You can also set tags data globally to be merged with all events by passing a `tags` option to `config`.
+If you’re inside a context and your context data includes a _tags_ key, that data will be merged into this. You can also set tags data globally to be merged with all events by passing a `tags` option to `config`.
 
 `extra`
 
 : Additional context for this event. Must be a mapping. Children can be any native JSON type.
 
-  ```javascript
-  {
-      extra: { key: 'value' }
+```javascript
+{
+  extra: {
+    key: "value";
   }
-  ```
+}
+```
 
-  If you’re inside a context and your context data includes an _extra_ key, that data will be merged into this. You can also set extra data globally to be merged with all events by passing an `extra` option to `config`.
+If you’re inside a context and your context data includes an _extra_ key, that data will be merged into this. You can also set extra data globally to be merged with all events by passing an `extra` option to `config`.
 
 `fingerprint`
 
 : The fingerprint for grouping this event. Learn more how [Sentry groups errors](/data-management/event-grouping/).
 
-  ```javascript
-  {
-      // don't group events from the same NODE_ENV together
-      fingerprint: ['{{ default }}', process.env.NODE_ENV]
-  }
-  ```
+```javascript
+{
+  // don't group events from the same NODE_ENV together
+  fingerprint: ["{{ default }}", process.env.NODE_ENV];
+}
+```
 
 `level`
 
 : The level of the event. Defaults to `error`.
 
-  ```javascript
-  {
-      level: 'warning'
-  }
-  ```
+```javascript
+{
+  level: "warning";
+}
+```
 
-  Sentry is aware of the following levels:
+Sentry is aware of the following levels:
 
-  -   debug (the least serious)
-  -   info
-  -   warning
-  -   error
-  -   fatal (the most serious)
+- debug (the least serious)
+- info
+- warning
+- error
+- fatal (the most serious)
 
 ## Recording Breadcrumbs {#raven-recording-breadcrumbs}
 
@@ -198,13 +205,13 @@ Breadcrumbs are records of server and application lifecycle events that can be h
 We can capture breadcrumbs and associate them with a context, and then send them along with any errors captured from that context:
 
 ```javascript
-Raven.context(function () {
+Raven.context(function() {
   Raven.captureBreadcrumb({
-    message: 'Received payment confirmation',
-    category: 'payment',
+    message: "Received payment confirmation",
+    category: "payment",
     data: {
-       amount: 312,
-    }
+      amount: 312,
+    },
   });
   // errors thrown here will have breadcrumb attached
 });
@@ -214,25 +221,25 @@ To learn more about what types of data can be collected via breadcrumbs, see the
 
 Raven can be configured to automatically capture breadcrubs for certain events including:
 
-> -   http/https requests
-> -   console log statements
-> -   postgres queries
+> - http/https requests
+> - console log statements
+> - postgres queries
 
 Automatic breadcrumb collection is disabled by default. You can enable it with a config option:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
-  autoBreadcrumbs: true
+Raven.config("___PUBLIC_DSN___", {
+  autoBreadcrumbs: true,
 });
 ```
 
 Or just enable specific types of automatic breadcrumbs:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
+Raven.config("___PUBLIC_DSN___", {
   autoBreadcrumbs: {
-    http: true
-  }
+    http: true,
+  },
 });
 ```
 
@@ -243,7 +250,7 @@ For more on configuring breadcrumbs, see [_Configuration_](/clients/node/config/
 To make referencing an event easy (both by the developer and customer), you can get an event ID from any captured message or exception. It’s provided both as the synchronous return value of the capture method and as an argument to the callback:
 
 ```javascript
-var eventId = Raven.captureException(e, function (sendErr, eventId2) {
+var eventId = Raven.captureException(e, function(sendErr, eventId2) {
   // eventId === eventId2
 });
 ```
@@ -253,8 +260,8 @@ var eventId = Raven.captureException(e, function (sendErr, eventId2) {
 By default, Raven does not capture unhandled promise rejections. You can have it do so automatically:
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
-  captureUnhandledRejections: true
+Raven.config("___PUBLIC_DSN___", {
+  captureUnhandledRejections: true,
 }).install();
 ```
 
@@ -269,12 +276,14 @@ The fatal error handler callback will be the last thing called before the proces
 After catching a fatal exception, Raven will make a best-effort attempt to send it to Sentry before it calls the fatal exception handler. If sending fails, a `sendErr` error object will be passed, and otherwise the `eventId` will be provided. In either case, the error object resulting in the shutdown is passed as the first parameter.
 
 ```javascript
-Raven.install(function (err, sendErr, eventId) {
+Raven.install(function(err, sendErr, eventId) {
   if (!sendErr) {
-    console.log('Successfully sent fatal error with eventId ' + eventId + ' to Sentry:');
+    console.log(
+      "Successfully sent fatal error with eventId " + eventId + " to Sentry:"
+    );
     console.error(err.stack);
   }
-  console.log('This is thy sheath; there rust, and let me die.');
+  console.log("This is thy sheath; there rust, and let me die.");
   process.exit(1);
 });
 ```
@@ -284,11 +293,11 @@ Raven.install(function (err, sendErr, eventId) {
 If you want to know if an event was logged or errored out, Raven instances emit two events, _logged_ and _error_:
 
 ```javascript
-Raven.on('logged', function () {
-  console.log('Yay, it worked!');
+Raven.on("logged", function() {
+  console.log("Yay, it worked!");
 });
 
-Raven.on('error', function (e) {
+Raven.on("error", function(e) {
   // The event contains information about the failure:
   //   e.reason -- raw response body
   //   e.statusCode -- response status code
@@ -297,14 +306,14 @@ Raven.on('error', function (e) {
   console.log("uh oh, couldn't record the event");
 });
 
-Raven.captureMessage('Boom');
+Raven.captureMessage("Boom");
 ```
 
 ## Configuring the HTTP Transport
 
 ```javascript
-Raven.config('___PUBLIC_DSN___', {
-  transport: new raven.transports.HTTPSTransport({rejectUnauthorized: false})
+Raven.config("___PUBLIC_DSN___", {
+  transport: new raven.transports.HTTPSTransport({ rejectUnauthorized: false }),
 });
 ```
 
@@ -313,7 +322,7 @@ Raven.config('___PUBLIC_DSN___', {
 Passing any falsey value as the DSN will disable sending events upstream:
 
 ```javascript
-Raven.config(process.env.NODE_ENV === 'production' && '___PUBLIC_DSN___');
+Raven.config(process.env.NODE_ENV === "production" && "___PUBLIC_DSN___");
 ```
 
 ## Disable Console Alerts
@@ -331,7 +340,7 @@ Raven.disableConsoleAlerts();
 Normally there is just one instance of Raven:
 
 ```javascript
-var Raven = require('raven');
+var Raven = require("raven");
 // Raven is already a Raven instance, and we do everything based on that instance
 ```
 

--- a/src/docs/clients/php/config.mdx
+++ b/src/docs/clients/php/config.mdx
@@ -3,9 +3,10 @@ draft: false
 categories: []
 toc: true
 title: Configuration
-robots: noindex
+noindex: true
 tags: []
 ---
+
 Several options exist that allow you to configure the behavior of the `Raven_Client`. These are passed as the second parameter of the constructor, and is expected to be an array of key value pairs:
 
 ```php
@@ -22,157 +23,157 @@ The following settings are available for the client:
 
 : A string to override the default value for the server’s hostname.
 
-  Defaults to `Raven_Compat::gethostname()`.
+Defaults to `Raven_Compat::gethostname()`.
 
 `tags`
 
 : An array of tags to apply to events in this context.
 
-  ```php
-  'tags' => array(
-      'php_version' => phpversion(),
-  )
-  ```
+```php
+'tags' => array(
+    'php_version' => phpversion(),
+)
+```
 
-  ```php
-  $client->tags_context(array(
-      'php_version' => phpversion(),
-  ));
-  ```
+```php
+$client->tags_context(array(
+    'php_version' => phpversion(),
+));
+```
 
 `release`
 
 : The version of your application (e.g. git SHA)
 
-  ```php
-  'release' => MyApp::getReleaseVersion(),
-  ```
+```php
+'release' => MyApp::getReleaseVersion(),
+```
 
-  ```php
-  $client->setRelease(MyApp::getReleaseVersion());
-  ```
+```php
+$client->setRelease(MyApp::getReleaseVersion());
+```
 
 `environment`
 
 : The environment your application is running in.
 
-  ```php
-  'environment' => 'production',
-  ```
+```php
+'environment' => 'production',
+```
 
-  ```php
-  $client->setEnvironment('production');
-  ```
+```php
+$client->setEnvironment('production');
+```
 
 `app_path`
 
 : The root path to your application code.
 
-  ```php
-  'app_path' => app_root(),
-  ```
+```php
+'app_path' => app_root(),
+```
 
-  ```php
-  $client->setAppPath(app_root());
-  ```
+```php
+$client->setAppPath(app_root());
+```
 
 `excluded_app_paths`
 
 : Paths to exclude from app_path detection.
 
-  ```php
-  'excluded_app_paths' => array(app_root() . '/cache'),
-  ```
+```php
+'excluded_app_paths' => array(app_root() . '/cache'),
+```
 
-  ```php
-  $client->setExcludedAppPaths(array(app_root() . '/cache'));
-  ```
+```php
+$client->setExcludedAppPaths(array(app_root() . '/cache'));
+```
 
 `prefixes`
 
 : Prefixes which should be stripped from filenames to create relative paths.
 
-  ```php
-  'prefixes' => array(
-      '/www/php/lib',
-  ),
-  ```
+```php
+'prefixes' => array(
+    '/www/php/lib',
+),
+```
 
-  ```php
-  $client->setPrefixes(array(
-      '/www/php/lib',
-  ));
-  ```
+```php
+$client->setPrefixes(array(
+    '/www/php/lib',
+));
+```
 
 `sample_rate`
 
 : The sampling factor to apply to events. A value of 0.00 will deny sending any events, and a value of 1.00 will send 100% of events.
 
-  ```php
-  // send 50% of events
-  'sample_rate' => 0.5,
-  ```
+```php
+// send 50% of events
+'sample_rate' => 0.5,
+```
 
 `send_callback`
 
 : A function which will be called whenever data is ready to be sent. Within the function you can mutate the data, or alternatively return `false` to instruct the SDK to not send the event.
 
-  ```php
-  'send_callback' => function(&$data) {
-      // strip HTTP data
-      @unset($data['request']);
-  },
-  ```
+```php
+'send_callback' => function(&$data) {
+    // strip HTTP data
+    @unset($data['request']);
+},
+```
 
-  ```php
-  $client->setSendCallback(function($data) {
-      // don't send events if POST
-      if ($_SERVER['REQUEST_METHOD'] === 'POST')
-      {
-          return false;
-      }
-  });
-  ```
+```php
+$client->setSendCallback(function($data) {
+    // don't send events if POST
+    if ($_SERVER['REQUEST_METHOD'] === 'POST')
+    {
+        return false;
+    }
+});
+```
 
 `curl_method`
 
 : Defaults to ‘sync’.
 
-  Available methods:
+Available methods:
 
-  -   `sync` (default): send requests immediately when they’re made
-  -   `async`: uses a curl_multi handler for best-effort asynchronous submissions
-  -   `exec`: asynchronously send events by forking a curl process for each item
+- `sync` (default): send requests immediately when they’re made
+- `async`: uses a curl_multi handler for best-effort asynchronous submissions
+- `exec`: asynchronously send events by forking a curl process for each item
 
 `curl_path`
 
 : Defaults to ‘curl’.
 
-  Specify the path to the curl binary to be used with the ‘exec’ curl method.
+Specify the path to the curl binary to be used with the ‘exec’ curl method.
 
 `transport`
 
 : Set a custom transport to override how Sentry events are sent upstream.
 
-  ```php
-  'transport' => function($client, $data) {
-      $myHttpClient->send(array(
-          'url'     => $client->getServerEndpoint(),
-          'method'  => 'POST',
-          'headers' => array(
-              'Content-Encoding' => 'gzip',
-              'Content-Type'     => 'application/octet-stream',
-              'User-Agent'       => $client->getUserAgent(),
-              'X-Sentry-Auth'    => $client->getAuthHeader(),
-          ),
-          'body'    => gzcompress(jsonEncode($data)),
-      ))
-  },
-  ```
+```php
+'transport' => function($client, $data) {
+    $myHttpClient->send(array(
+        'url'     => $client->getServerEndpoint(),
+        'method'  => 'POST',
+        'headers' => array(
+            'Content-Encoding' => 'gzip',
+            'Content-Type'     => 'application/octet-stream',
+            'User-Agent'       => $client->getUserAgent(),
+            'X-Sentry-Auth'    => $client->getAuthHeader(),
+        ),
+        'body'    => gzcompress(jsonEncode($data)),
+    ))
+},
+```
 
-  ```php
-  $client->setTransport(...);
-  ```
+```php
+$client->setTransport(...);
+```
 
 `trace`
 
@@ -182,18 +183,18 @@ The following settings are available for the client:
 
 : Adjust the default logger name for messages.
 
-  Defaults to `php`.
+Defaults to `php`.
 
 `ca_cert`
 
 : The path to the CA certificate bundle.
 
-  Defaults to the common bundle which includes getsentry.com: ./data/cacert.pem
+Defaults to the common bundle which includes getsentry.com: ./data/cacert.pem
 
-  Caveats:
+Caveats:
 
-  -   The CA bundle is ignored unless curl throws an error suggesting it needs a cert.
-  -   The option is only currently used within the synchronous curl transport.
+- The CA bundle is ignored unless curl throws an error suggesting it needs a cert.
+- The option is only currently used within the synchronous curl transport.
 
 `curl_ssl_version`
 
@@ -203,7 +204,7 @@ The following settings are available for the client:
 
 : Defaults to 1024 characters.
 
-  This value is used to truncate message and frame variables. However it is not guarantee that length of whole message will be restricted by this value.
+This value is used to truncate message and frame variables. However it is not guarantee that length of whole message will be restricted by this value.
 
 `processors`
 
@@ -213,50 +214,50 @@ The following settings are available for the client:
 
 : Options that will be passed on to a `setProcessorOptions()` function in a `Raven_Processor` sub-class before that Processor is added to the list of processors used by `Raven_Client`
 
-  An example of overriding the regular expressions in `Raven_Processor_SanitizeDataProcessor` is below:
+An example of overriding the regular expressions in `Raven_Processor_SanitizeDataProcessor` is below:
 
-  ```php
-  'processorOptions' => array(
-      'Raven_Processor_SanitizeDataProcessor' => array(
-                  'fields_re' => '/(user_password|user_token|user_secret)/i',
-                  'values_re' => '/^(?:\d[ -]*?){15,16}$/'
-              )
-  )
-  ```
+```php
+'processorOptions' => array(
+    'Raven_Processor_SanitizeDataProcessor' => array(
+                'fields_re' => '/(user_password|user_token|user_secret)/i',
+                'values_re' => '/^(?:\d[ -]*?){15,16}$/'
+            )
+)
+```
 
 `timeout`
 
 : The timeout for sending requests to the Sentry server in seconds, default is 2 seconds.
 
-  ```php
-  'timeout' => 2,
-  ```
+```php
+'timeout' => 2,
+```
 
 `excluded_exceptions`
 
 : Exception that should not be reported, exceptions extending exceptions in this list will also be excluded, default is an empty array.
 
-  In the example below, when you exclude `LogicException` you will also exclude `BadFunctionCallException` since it extends `LogicException`.
+In the example below, when you exclude `LogicException` you will also exclude `BadFunctionCallException` since it extends `LogicException`.
 
-  ```php
-  'excluded_exceptions' => array('LogicException'),
-  ```
+```php
+'excluded_exceptions' => array('LogicException'),
+```
 
 `ignore_server_port`
 
 : By default the server port will be added to the logged URL when it is a non standard port (80, 443). Setting this to `true` will ignore the server port altogether and will result in the server port never getting appended to the logged URL.
 
-  ```php
-  'ignore_server_port' => true,
-  ```
+```php
+'ignore_server_port' => true,
+```
 
 ## Providing Request Context {#sentry-php-request-context}
 
 Most of the time you’re not actually calling out to Raven directly, but you still want to provide some additional context. This lifecycle generally constists of something like the following:
 
--   Set some context via a middleware (e.g. the logged in user)
--   Send all given context with any events during the request lifecycle
--   Cleanup context
+- Set some context via a middleware (e.g. the logged in user)
+- Send all given context with any events during the request lifecycle
+- Cleanup context
 
 There are three primary methods for providing request context:
 

--- a/src/docs/clients/php/index.mdx
+++ b/src/docs/clients/php/index.mdx
@@ -4,12 +4,14 @@ categories: []
 toc: true
 title: PHP
 sidebar_order: 11
-robots: noindex
+noindex: true
 tags: []
 ---
+
 The PHP SDK for Sentry supports PHP 5.3 and higher. It’s available as a BSD licensed Open Source library.
 
 ## Getting Started
+
 Getting started with Sentry is a three step process:
 
 1.  [Sign up for an account](https://sentry.io/signup/)
@@ -17,6 +19,7 @@ Getting started with Sentry is a three step process:
 3.  [Configure it](#configure)
 
 <!-- WIZARD installation -->
+
 ## Installation {#install}
 
 There are various ways to install the PHP integration for Sentry. The recommended way is to use [Composer](http://getcomposer.org/):
@@ -35,8 +38,8 @@ Alternatively you can manually install it:
     Raven_Autoloader::register();
     ```
 
-
 <!-- WIZARD configuration -->
+
 ## Configuration {#configure}
 
 The most important part is the creation of the raven client. Create it once and reference it from anywhere you want to interface with Sentry:
@@ -54,7 +57,6 @@ $error_handler->registerErrorHandler();
 $error_handler->registerShutdownFunction();
 ```
 
-
 ## Adding Context
 
 Much of the usefulness of Sentry comes from additional context data with the events. The PHP client makes this very convenient by providing methods to set thread local context data that is then submitted automatically with all events. For instance you can use the `user_context` method to add information about the current user:
@@ -71,14 +73,14 @@ For more information see [Providing Request Context](/clients/php/config/#sentry
 
 Want more? Have a look at the full documentation for more information.
 
--   [Usage](/clients/php/usage/)
--   [Configuration](/clients/php/config/)
--   [Integrations](/clients/php/integrations/)
-    -   [Laravel](/clients/php/integrations/#laravel)
-    -   [Monolog](/clients/php/integrations/#monolog)
-    -   [Symfony](/clients/php/integrations/#symfony2)
+- [Usage](/clients/php/usage/)
+- [Configuration](/clients/php/config/)
+- [Integrations](/clients/php/integrations/)
+  - [Laravel](/clients/php/integrations/#laravel)
+  - [Monolog](/clients/php/integrations/#monolog)
+  - [Symfony](/clients/php/integrations/#symfony2)
 
 Resources:
 
--   [Bug Tracker](http://github.com/getsentry/sentry-php/issues)
--   [GitHub Project](http://github.com/getsentry/sentry-php)
+- [Bug Tracker](http://github.com/getsentry/sentry-php/issues)
+- [GitHub Project](http://github.com/getsentry/sentry-php)

--- a/src/docs/clients/php/integrations.mdx
+++ b/src/docs/clients/php/integrations.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Integrations
-robots: noindex
+noindex: true
 tags: []
 ---
 ## Laravel

--- a/src/docs/clients/php/usage.mdx
+++ b/src/docs/clients/php/usage.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Usage
 sidebar_order: 1
-robots: noindex
+noindex: true
 tags: []
 ---
 Using Sentry with PHP is straightforward. After installation of the library you can directly interface with the client and start submitting data.

--- a/src/docs/clients/python/advanced.mdx
+++ b/src/docs/clients/python/advanced.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: Advanced Usage
 sidebar_order: 1
-robots: noindex
+noindex: true
 tags: []
 ---
+
 This covers some advanced usage scenarios for raven Python.
 
 ## Alternative Installations
@@ -60,7 +61,7 @@ client = raven.Client(
 )
 ```
 
-*(New in version 5.2.0: The `fetch_package_version` and `fetch_git_sha` helpers.)*
+_(New in version 5.2.0: The `fetch_package_version` and `fetch_git_sha` helpers.)_
 
 ## Client Arguments
 
@@ -179,7 +180,8 @@ If an iterable is longer than the specified length, the left-most elements up to
 ```python
 list_max_length = 50
 
-````
+```
+
 `string_max_length`
 
 : The maximum characters of a string that should be stored.
@@ -188,7 +190,7 @@ If a string is longer than the given length, it will be truncated down to the sp
 
 ```python
 string_max_length = 200
-````
+```
 
 `auto_log_stacks`
 

--- a/src/docs/clients/python/api.mdx
+++ b/src/docs/clients/python/api.mdx
@@ -3,20 +3,21 @@ draft: false
 categories: []
 toc: true
 title: API Reference
-robots: noindex
+noindex: true
 tags: []
 ---
+
 This gives you an overview of the public API that raven-python exposes.
 
 ## Client
 
-{: #raven.Client}_class_ `raven.``Client`(_dsn=None_, _**kwargs_)
+{: #raven.Client}_class_ ` raven.``Client `(_dsn=None_, _\*\*kwargs_)
 
 : The client needs to be instantiated once and can then be used for submitting events to the Sentry server. For information about the configuration of that client and which parameters are accepted see [Configuring the Client](/clients/python/advanced/#python-client-config).
 
-  {: #raven.Client.capture}`capture`(_event_type_, _data=None_, _date=None_, _time_spent=None_, _extra=None_, _stack=False_, _tags=None_, _**kwargs_)
+{: #raven.Client.capture}`capture`(_event_type_, _data=None_, _date=None_, _time_spent=None_, _extra=None_, _stack=False_, _tags=None_, _\*\*kwargs_)
 
-  : This method is the low-level method for reporting events to Sentry. It captures and processes an event and pipes it via the configured transport to Sentry.
+: This method is the low-level method for reporting events to Sentry. It captures and processes an event and pipes it via the configured transport to Sentry.
 
     Example:
 
@@ -36,9 +37,9 @@ This gives you an overview of the public API that raven-python exposes.
 
     <table class="table"><tbody valign="top"><tr><th>Parameters:</th><td><ul><li><strong>event_type</strong> – the module path to the Event class. Builtins can use shorthand class notation and exclude the full module path.</li><li><strong>data</strong> – the data base, useful for specifying structured data interfaces. Any key which contains a ‘.’ will be assumed to be a data interface.</li><li><strong>date</strong> – the datetime of this event. If not supplied the current timestamp is used.</li><li><strong>time_spent</strong> – a integer value representing the duration of the event (in milliseconds)</li><li><strong>extra</strong> – a dictionary of additional standard metadata.</li><li><strong>stack</strong> – If set to <cite>True</cite> a stack frame is recorded together with the event.</li><li><strong>tags</strong> – dict of extra tags</li><li><strong>sample_rate</strong> – a float in the range [0, 1] to sample this message. This overrides the Client object’s sample_rate</li><li><strong>kwargs</strong> – extra keyword arguments are handled specific to the reported event type.</li></ul></td></tr><tr><th>Returns:</th><td>a tuple with a 32-length string identifying this event</td></tr></tbody></table>
 
-  {: #raven.Client.captureMessage}`captureMessage`(_message_, _**kwargs_)
+{: #raven.Client.captureMessage}`captureMessage`(_message_, _\*\*kwargs_)
 
-  : This is a shorthand to reporting a message via [`capture()`](#raven.Client.capture "raven.Client.capture"). It passes `'raven.events.Message'` as _event_type_ and the message along. All other keyword arguments are regularly forwarded.
+: This is a shorthand to reporting a message via [`capture()`](#raven.Client.capture "raven.Client.capture"). It passes `'raven.events.Message'` as _event_type_ and the message along. All other keyword arguments are regularly forwarded.
 
     Example:
 
@@ -46,9 +47,9 @@ This gives you an overview of the public API that raven-python exposes.
     client.captureMessage('This just happened!')
     ```
 
-  {: #raven.Client.captureException}`captureException`(_exc_info=None_, _**kwargs_)
+{: #raven.Client.captureException}`captureException`(_exc_info=None_, _\*\*kwargs_)
 
-  : This is a shorthand to reporting an exception via [`capture()`](#raven.Client.capture "raven.Client.capture"). It passes `'raven.events.Exception'` as _event_type_ and the traceback along. All other keyword arguments are regularly forwarded.
+: This is a shorthand to reporting an exception via [`capture()`](#raven.Client.capture "raven.Client.capture"). It passes `'raven.events.Exception'` as _event_type_ and the traceback along. All other keyword arguments are regularly forwarded.
 
     If exc_info is not provided, or is set to True, then this method will perform the `exc_info = sys.exc_info()` and the requisite clean-up for you.
 
@@ -61,23 +62,23 @@ This gives you an overview of the public API that raven-python exposes.
         client.captureException()
     ```
 
-  `captureBreadcrumb(message=None, timestamp=None,`
-  `level=None, category=None, data=None,`
-  `type=None, processor=None)`
+`captureBreadcrumb(message=None, timestamp=None,`
+`level=None, category=None, data=None,`
+`type=None, processor=None)`
 
-  : Manually captures a breadcrumb in the internal buffer for the current client’s context. Instead of using this method you are encouraged to instead use the [`raven.breadcrumbs.record()`](/clients/python/breadcrumbs/#raven.breadcrumbs.record "raven.breadcrumbs.record") function which records to the correct client automatically.
+: Manually captures a breadcrumb in the internal buffer for the current client’s context. Instead of using this method you are encouraged to instead use the [`raven.breadcrumbs.record()`](/clients/python/breadcrumbs/#raven.breadcrumbs.record "raven.breadcrumbs.record") function which records to the correct client automatically.
 
-  {: #raven.Client.send}`send`(_**data_)
+{: #raven.Client.send}`send`(_\*\*data_)
 
-  : Accepts all data parameters and serializes them, then sends then onwards via the transport to Sentry. This can be used as to send low-level protocol data to the server.
+: Accepts all data parameters and serializes them, then sends then onwards via the transport to Sentry. This can be used as to send low-level protocol data to the server.
 
-  {: #raven.Client.context}`context`
+{: #raven.Client.context}`context`
 
-  : Returns a reference to the thread local context object. See [`raven.context.Context`](#raven.context.Context "raven.context.Context") for more information.
+: Returns a reference to the thread local context object. See [`raven.context.Context`](#raven.context.Context "raven.context.Context") for more information.
 
-  {: #raven.Client.user_context}`user_context`(_data_)
+{: #raven.Client.user*context}`user_context`(\_data*)
 
-  : Updates the user context for future events.
+: Updates the user context for future events.
 
     Equivalent to this:
 
@@ -85,9 +86,9 @@ This gives you an overview of the public API that raven-python exposes.
     client.context.merge({'user': data})
     ```
 
-  {: #raven.Client.http_context}`http_context`(_data_)
+{: #raven.Client.http*context}`http_context`(\_data*)
 
-  : Updates the HTTP context for future events.
+: Updates the HTTP context for future events.
 
     Equivalent to this:
 
@@ -95,9 +96,9 @@ This gives you an overview of the public API that raven-python exposes.
     client.context.merge({'request': data})
     ```
 
-  {: #raven.Client.extra_context}`extra_context`(_data_)
+{: #raven.Client.extra*context}`extra_context`(\_data*)
 
-  : Update the extra context for future events.
+: Update the extra context for future events.
 
     Equivalent to this:
 
@@ -105,9 +106,9 @@ This gives you an overview of the public API that raven-python exposes.
     client.context.merge({'extra': data})
     ```
 
-  {: #raven.Client.tags_context}`tags_context`(_data_)
+{: #raven.Client.tags*context}`tags_context`(\_data*)
 
-  : Update the tags context for future events.
+: Update the tags context for future events.
 
     Equivalent to this:
 
@@ -117,28 +118,28 @@ This gives you an overview of the public API that raven-python exposes.
 
 ## Context
 
-{: #raven.context.Context}_class_ `raven.context.``Context`
+{: #raven.context.Context}_class_ ` raven.context.``Context `
 
 : The context object works similar to a dictionary and is used to record information that should be submitted with events automatically. It is available through [`raven.Client.context`](#raven.Client.context "raven.Client.context") and is thread local. This means that you can modify this object over time to feed it with more appropriate information.
 
-  {: #raven.context.Context.activate}`activate`()
+{: #raven.context.Context.activate}`activate`()
 
-  : Binds the context to the current thread. This normally happens automatically on first usage but if the context was deactivated then this needs to be called again to bind it again. Only if a context is bound to the thread breadcrumbs will be recorded.
+: Binds the context to the current thread. This normally happens automatically on first usage but if the context was deactivated then this needs to be called again to bind it again. Only if a context is bound to the thread breadcrumbs will be recorded.
 
-  {: #raven.context.Context.deactivate}`deactivate`()
+{: #raven.context.Context.deactivate}`deactivate`()
 
-  : This deactivates the thread binding of the context. In particular it means that breadcrumbs of the current thread are no longer recorded to this context.
+: This deactivates the thread binding of the context. In particular it means that breadcrumbs of the current thread are no longer recorded to this context.
 
-  {: #raven.context.Context.merge}`merge`(_data_, _activate=True_)
+{: #raven.context.Context.merge}`merge`(_data_, _activate=True_)
 
-  : Performs a merge of the current data in the context and the new data provided. This also automatically activates the context by default.
+: Performs a merge of the current data in the context and the new data provided. This also automatically activates the context by default.
 
-  {: #raven.context.Context.clear}`clear`(_deactivate=None_)
+{: #raven.context.Context.clear}`clear`(_deactivate=None_)
 
-  : Clears the context. It’s important that you make sure to call this when you reuse the thread for something else. For instance for web frameworks it’s generally a good idea to call this at the end of the HTTP request.
+: Clears the context. It’s important that you make sure to call this when you reuse the thread for something else. For instance for web frameworks it’s generally a good idea to call this at the end of the HTTP request.
 
     Otherwise you run at risk of seeing incorrect information after the first use of the thread.
 
     Optionally _deactivate_ parameter controls if the context should automatically be deactivated. The default behavior is to deactivate if the context was not created for the main thread.
 
-  The context can also be used as a context manager. In that case [`activate()`](#raven.context.Context.activate "raven.context.Context.activate") is called on enter and [`deactivate()`](#raven.context.Context.deactivate "raven.context.Context.deactivate") is called on exit.
+The context can also be used as a context manager. In that case [`activate()`](#raven.context.Context.activate "raven.context.Context.activate") is called on enter and [`deactivate()`](#raven.context.Context.deactivate "raven.context.Context.deactivate") is called on exit.

--- a/src/docs/clients/python/breadcrumbs.mdx
+++ b/src/docs/clients/python/breadcrumbs.mdx
@@ -4,9 +4,10 @@ categories: []
 toc: true
 title: Logging Breadcrumbs
 sidebar_order: 2
-robots: noindex
+noindex: true
 tags: []
 ---
+
 Newer Sentry versions support logging of breadcrumbs in addition of errors. This means that whenever an error or other Sentry event is submitted to the system, breadcrumbs that were logged before are sent along to make it easier to reproduce what lead up to an error.
 
 In the default configuration the Python client instruments the logging framework and a few popular libraries to emit crumbs.
@@ -27,26 +28,26 @@ When a sentry client is constructed then the raven library will by default autom
 
 : This is a list of libraries that you want to hook. The default is to hook all libraries that we have integrations for. If this is set to an empty list then no libraries are hooked.
 
-  The following libraries are supported currently:
+The following libraries are supported currently:
 
-  -   `'requests'`: hooks the Python requests library.
-  -   `'httplib'`: hooks the stdlib http library (also hooks urllib in the process)
+- `'requests'`: hooks the Python requests library.
+- `'httplib'`: hooks the stdlib http library (also hooks urllib in the process)
 
 Additionally framework integration will hook more things automatically. For instance when you use Django, database queries will be recorded.
 
 Another option to control what happens is to register special handlers for the logging system or to disable loggers entirely. For this you can use the [`ignore_logger()`](#raven.breadcrumbs.ignore_logger "raven.breadcrumbs.ignore_logger") and [`register_special_log_handler()`](#raven.breadcrumbs.register_special_log_handler "raven.breadcrumbs.register_special_log_handler") functions:
 
-{: #raven.breadcrumbs.ignore_logger}`raven.breadcrumbs.``ignore_logger`(_name_or_logger_, _allow_level=None_)
+{: #raven.breadcrumbs.ignore*logger}` raven.breadcrumbs.``ignore_logger `(\_name_or_logger*, _allow_level=None_)
 
 : If called with the name of a logger, this will ignore all messages that come from that logger. For instance if you have a very spammy logger you can disable it this way.
 
-{: #raven.breadcrumbs.register_special_log_handler}`raven.breadcrumbs.``register_special_log_handler`(_name_or_logger_, _callback_)
+{: #raven.breadcrumbs.register*special_log_handler}` raven.breadcrumbs.``register_special_log_handler `(\_name_or_logger*, _callback_)
 
 : Registers a callback for log handling. The callback is invoked with given arguments: _logger_, _level_, _msg_, _args_ and _kwargs_ which are the values passed to the logging system. If the callback returns true value the default handling is disabled. Only one callback can be registered per one logger name. Logger tree is not traversed so calling this method with _spammy_module_ argument will not silence messages from _spammy_module.child_.
 
-  Typically it makes sense to invoke [`record()`](#raven.breadcrumbs.record "raven.breadcrumbs.record") from it unless you want to silence a message based on its attributes other than _level_.
+Typically it makes sense to invoke [`record()`](#raven.breadcrumbs.record "raven.breadcrumbs.record") from it unless you want to silence a message based on its attributes other than _level_.
 
-{: #raven.breadcrumbs.register_logging_handler}`raven.breadcrumbs.``register_logging_handler`(_callback_)
+{: #raven.breadcrumbs.register*logging_handler}` raven.breadcrumbs.``register_logging_handler `(\_callback*)
 
 : This is similar to [`register_special_log_handler()`](#raven.breadcrumbs.register_special_log_handler "raven.breadcrumbs.register_special_log_handler") but it adds a global callback that is invoked for all log entries. Otherwise it works the same but multiple handlers can be registered.
 
@@ -54,27 +55,27 @@ Another option to control what happens is to register special handlers for the l
 
 If you want to manually record breadcrumbs the most convenient way to do that is to use the `record()` function which will automatically record the crumbs with the clients that are working with the current thread. This is more convenient than to call the _captureBreadcrumb_ method on the client itself as you need to hold a reference to that.
 
-{: #raven.breadcrumbs.record}`raven.breadcrumbs.``record`(_**options_)
+{: #raven.breadcrumbs.record}` raven.breadcrumbs.``record `(_\*\*options_)
 
 : This function accepts keyword arguments matching the attributes of a breadcrumb. For more information see [_Event Payloads_](https://develop.sentry.dev/sdk/event-payloads/). Additionally, a _processor_ callback can be passed which will be invoked to process the data if the crumb was not rejected.
 
-  The most important parameters:
+The most important parameters:
 
-  _message_:
+_message_:
 
-  : the message that should be recorded.
+: the message that should be recorded.
 
-  _data_:
+_data_:
 
-  : a data dictionary that should be recorded with the event.
+: a data dictionary that should be recorded with the event.
 
-  _category_:
+_category_:
 
-  : The category for this error. This can be a module name, or just a string that clearly identifies the crumb (eg: _http_, _rpc_, etc.)
+: The category for this error. This can be a module name, or just a string that clearly identifies the crumb (eg: _http_, _rpc_, etc.)
 
-  _type_:
+_type_:
 
-  : can override the type if a special type should be sent to Sentry.
+: can override the type if a special type should be sent to Sentry.
 
 Example:
 

--- a/src/docs/clients/python/index.mdx
+++ b/src/docs/clients/python/index.mdx
@@ -4,7 +4,7 @@ categories: []
 toc: true
 title: Python
 sidebar_order: 12
-robots: noindex
+noindex: true
 tags: []
 ---
 

--- a/src/docs/clients/python/integrations.mdx
+++ b/src/docs/clients/python/integrations.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Integrations
-robots: noindex
+noindex: true
 tags: []
 ---
 The Raven Python module also comes with integration for some commonly used libraries to automatically capture errors from common environments. This means that once you have such an integration configured you typically do not need to report errors manually.

--- a/src/docs/clients/python/platform-support.mdx
+++ b/src/docs/clients/python/platform-support.mdx
@@ -3,14 +3,15 @@ draft: false
 categories: []
 toc: true
 title: Supported Platforms
-robots: noindex
+noindex: true
 tags: []
 ---
--   Python 2.6
--   Python 2.7
--   Python 3.2
--   Python 3.3
--   Python 3.5
--   Python 3.6
--   PyPy
--   Google App Engine
+
+- Python 2.6
+- Python 2.7
+- Python 3.2
+- Python 3.3
+- Python 3.5
+- Python 3.6
+- PyPy
+- Google App Engine

--- a/src/docs/clients/python/transports.mdx
+++ b/src/docs/clients/python/transports.mdx
@@ -3,9 +3,10 @@ draft: false
 categories: []
 toc: true
 title: Transports
-robots: noindex
+noindex: true
 tags: []
 ---
+
 A transport is the mechanism in which Raven sends the HTTP request to the Sentry server. By default, Raven uses a threaded asynchronous transport, but you can easily adjust this by passing your own transport class.
 
 The transport class is passed via the `transport` parameter on `Client`:

--- a/src/docs/clients/react-native/cocoapods.mdx
+++ b/src/docs/clients/react-native/cocoapods.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Setup With CocoaPods
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/codepush.mdx
+++ b/src/docs/clients/react-native/codepush.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Using Sentry with CodePush
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/config.mdx
+++ b/src/docs/clients/react-native/config.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Additional Configuration
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/expo.mdx
+++ b/src/docs/clients/react-native/expo.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Using Sentry with Expo
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/index.mdx
+++ b/src/docs/clients/react-native/index.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: React Native
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/manual-setup.mdx
+++ b/src/docs/clients/react-native/manual-setup.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Manual Setup
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/ram-bundles.mdx
+++ b/src/docs/clients/react-native/ram-bundles.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Using RAM Bundles
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/react-native/sourcemaps.mdx
+++ b/src/docs/clients/react-native/sourcemaps.mdx
@@ -3,7 +3,7 @@ draft: false
 categories: []
 toc: true
 title: Source Maps for Other Platforms
-robots: noindex
+noindex: true
 tags: []
 ---
 <Alert level="warning" title="Note"><markdown>

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -12,7 +12,6 @@ const pageQuery = `{
               title
               draft
               noindex
-              robots
             }
             fields {
               slug
@@ -25,7 +24,6 @@ const pageQuery = `{
               title
               draft
               noindex
-              robots
             }
             fields {
               slug
@@ -49,10 +47,7 @@ const flatten = arr =>
       objectID,
     ])
     .filter(
-      ([child, _]) =>
-        !child.frontmatter.noindex &&
-        !child.frontmatter.draft &&
-        child.frontmatter.robots !== "noindex"
+      ([child, _]) => !child.frontmatter.noindex && !child.frontmatter.draft
     )
     .map(([child, objectID]) => ({
       objectID,


### PR DESCRIPTION
This merges `robots: noindex` into `noindex: true`, and removes the ability to explicitly override granular robots control on a given page.

Note: noindex implies both `robots:noindex` as well as disabling Algolia indexing.