### PR TITLE
Remove "on this page" list

### DIFF
--- a/src/docs/sdks/javascript/index.mdx
+++ b/src/docs/sdks/javascript/index.mdx
@@ -17,16 +17,6 @@ In the right place? We also offer documentation for:
 - [React](/platforms/javascript/react/)
 - [Vue](/platforms/javascript/vue/)
 
-On this page:
-
-- [Install](#install)
-- [Configure](#configure)
-- [Verify Setup](#verify-setup)
-- [Capture Errors](#capture-errors)
-  1. [Enrich Error Data](#enrich-error-data)
-  2. [Set the Release Version](#set-the-release-version)
-- [Monitor Performance](#monitor-performance)
-
 ## Install
 
 Sentry captures data by using an SDK within your application’s runtime. Add the Sentry SDK as a dependency using `yarn` or `npm`:


### PR DESCRIPTION
The links for "on this page" are duplicated in the RH sidebar, so no need for them. And mobile is not a rational use case for maintaining this list.