### PR TITLE
feat: Provide deprecation warnings for raven clients

### DIFF
--- a/src/docs/clients/csharp/index.mdx
+++ b/src/docs/clients/csharp/index.mdx
@@ -9,7 +9,7 @@ tags: []
 
 <Alert level="warning" title="Note"><markdown>
 
-For .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4 or higher we recommend using the new [.NET SDK](/platforms/dotnet). Raven is still recommended for .NET Framework 3.5 to 4.6.0.
+For .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4, or higher we recommend using the new [.NET SDK](/platforms/dotnet). Raven is still recommended for .NET Framework 3.5 to 4.6.0.
 
 </markdown></Alert>
 

--- a/src/docs/clients/csharp/index.mdx
+++ b/src/docs/clients/csharp/index.mdx
@@ -7,6 +7,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note"><markdown>
+
+For .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4 or higher we recommend using the new [.NET SDK](/platforms/dotnet). Raven is still recommended for .NET Framework 3.5 to 4.6.0.
+
+</markdown></Alert>
+
 Raven is the C# client for Sentry. Raven relies on the most popular logging libraries to capture and convert logs before sending details to a Sentry instance.
 
 ## Installation

--- a/src/docs/clients/javascript/index.mdx
+++ b/src/docs/clients/javascript/index.mdx
@@ -7,6 +7,13 @@ sidebar_order: 7
 noindex: true
 tags: []
 ---
+
+<Alert level="warning" title="Note"><markdown>
+
+A new JavaScript SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated JavaScript SDK](/sdks/javascript) for new projects.
+
+</markdown></Alert>
+
 Raven.js is the official browser JavaScript client for Sentry. It automatically reports uncaught JavaScript exceptions triggered from a browser environment, and provides a rich API for reporting your own errors.
 
 <Alert level="warning" title="Node.js"><markdown>

--- a/src/docs/clients/node/index.mdx
+++ b/src/docs/clients/node/index.mdx
@@ -7,6 +7,13 @@ sidebar_order: 9
 noindex: true
 tags: []
 ---
+
+<Alert level="warning" title="Note"><markdown>
+
+A new Node SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Node SDK](/platforms/node) for new projects.
+
+</markdown></Alert>
+
 raven-node is the official Node.js client for Sentry.
 
 <Alert level="warning" title="Note"><markdown>

--- a/src/docs/clients/php/index.mdx
+++ b/src/docs/clients/php/index.mdx
@@ -8,6 +8,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note"><markdown>
+
+A new PHP SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. If you are using PHP 7.1 or later, we recommend using the [updated PHP SDK](/platforms/php) for new projects.
+
+</markdown></Alert>
+
 The PHP SDK for Sentry supports PHP 5.3 and higher. It’s available as a BSD licensed Open Source library.
 
 ## Getting Started

--- a/src/docs/clients/python/index.mdx
+++ b/src/docs/clients/python/index.mdx
@@ -8,6 +8,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note"><markdown>
+
+A new Python SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Python SDK](/platforms/python/) for new projects.
+
+</markdown></Alert>
+
 For pairing Sentry up with Python you can use the Raven for Python (raven-python) library. It is the official standalone Python client for Sentry. It can be used with any modern Python interpreter be it CPython 2.x or 3.x, PyPy or Jython. It’s an Open Source project and available under a very liberal BSD license.
 
 ## Installation


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/1995

We should point customers toward using our new SDKs. This PR adds deprecation warnings to all raven clients that did not have them before.

As a side note, we should try to avoid our deprecated SDKs superseding our new SDKs in search results, not sure if there is an easy way around that though.

I used messaging we have from https://docs.sentry.io/clients/cocoa/, but let me know if there is anything more appropriate.