### PR TITLE
feat: Template variables in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ redirect_from:
 
 These will be generated as both client-side (using an empty page with a meta tag) and server-side (nginx rules).
 
+## Template Variables
+
+A transformation is exposed to both Markdown and MDX files which supports processing variables in a Django/Jekyll-style way. The variables available are globally scoped and configured within `gatsby-config.js` (via `gatsby-remark-variables`).
+
+For example:
+
+```markdown
+JavaScript SDK: {{ packages.version('sentry.browser.javascript') }}
+```
+
+In this case, we expose ``packages`` as an instance of ``PackageRegistry`` which is why there is a `packages.version` function available.
+
+When a function call is invalid, or doesn't match something in the known scope, it will simple render it as a literal value instead. So for example:
+
+```markdown
+setFingerprint('{{ default }}')
+```
+
+Will render as:
+
+```markdown
+setFingerprint('{{ default }}')
+```
+
+This is because there is no entity scoped to ``default`` in the template renderer. Additionally - in this case - we also add the ``default`` expression to the exclusion list in our configuration, as it is commonly use in our documentation.
+
 ## Wizard Pages
 
 A number of pages exist to provide content within Sentry installations. We refer to this system as the _Wizard_. These pages are found in Gatsby's `wizard` content directory, and are rendered and exported to a JSON file for use within the `getsentry/sentry` application.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ For example:
 JavaScript SDK: {{ packages.version('sentry.browser.javascript') }}
 ```
 
-In this case, we expose ``packages`` as an instance of ``PackageRegistry`` which is why there is a `packages.version` function available.
+In this case, we expose ``packages`` as an instance of ``PackageRegistry`` which is why there is a `packages.version` function available. Additional, we expose a default context variable of ``page`` which contains the frontmatter of the given markdown node. For example, ``{{ page.title }}``.
 
-When a function call is invalid, or doesn't match something in the known scope, it will simple render it as a literal value instead. So for example:
+When a function call is invalid (or errors), or doesn't match something in the known scope, it will simple render it as a literal value instead. So for example:
 
 ```markdown
 setFingerprint('{{ default }}')

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,10 +12,22 @@ if (process.env.BRANCH_NAME === "master" && process.env.ALGOLIA_ADMIN_KEY) {
   process.env.ALGOLIA_INDEX = "1";
 }
 
+const IS_DEV = activeEnv === "development";
+
 const queries = require("./src/utils/algolia");
+const packages = new (require("./src/utils/packageRegistry"))();
 
 const getPlugins = () => {
   const remarkPlugins = [
+    {
+      resolve: require.resolve("./plugins/gatsby-remark-variables"),
+      options: {
+        scope: {
+          packages,
+        },
+        excludeExpr: ["default"],
+      },
+    },
     {
       resolve: `gatsby-remark-copy-linked-files`,
     },
@@ -54,8 +66,8 @@ const getPlugins = () => {
         tracesSampleRate: activeEnv === "development" ? 0 : 1,
       },
     },
-    "gatsby-plugin-sass",
     "gatsby-plugin-sharp",
+    "gatsby-plugin-sass",
     "gatsby-plugin-zeit-now",
     {
       resolve: `gatsby-transformer-remark`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -178,16 +178,18 @@ exports.createPages = async function({ actions, graphql, reporter }) {
       reporter.panicOnBuild('🚨  ERROR: Loading "createApi" query');
     }
     const component = require.resolve(`./src/components/pages/api.js`);
-    data.allApiDoc.nodes.forEach(node => {
-      actions.createPage({
-        path: node.fields.slug,
-        component,
-        context: {
-          id: node.id,
-          title: node.title,
-        },
-      });
-    });
+    await Promise.all(
+      data.allApiDoc.nodes.map(async node => {
+        actions.createPage({
+          path: node.fields.slug,
+          component,
+          context: {
+            id: node.id,
+            title: node.title,
+          },
+        });
+      })
+    );
   };
 
   const createDocs = async () => {
@@ -221,21 +223,22 @@ exports.createPages = async function({ actions, graphql, reporter }) {
       reporter.panicOnBuild('🚨  ERROR: Loading "createDocs" query');
     }
     const component = require.resolve(`./src/components/pages/doc.js`);
-    data.allFile.nodes.forEach(node => {
-      const child = node.childMarkdownRemark || node.childMdx;
-      if (child && child.fields) {
-        actions.createPage({
-          path: child.fields.slug,
-          component,
-          context: {
-            id: node.id,
-            title: child.frontmatter.title,
-          },
-        });
-      }
-    });
+    await Promise.all(
+      data.allFile.nodes.map(async node => {
+        const child = node.childMarkdownRemark || node.childMdx;
+        if (child && child.fields) {
+          actions.createPage({
+            path: child.fields.slug,
+            component,
+            context: {
+              id: node.id,
+              title: child.frontmatter.title,
+            },
+          });
+        }
+      })
+    );
   };
 
-  await createApi();
-  await createDocs();
+  await Promise.all([createApi(), createDocs()]);
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "remark-deflist": "^0.2.1"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
     "sdk:copy": "node scripts/sdk-symlink",
     "develop": "gatsby develop -p 3000",
     "start": "npm run develop",

--- a/plugins/gatsby-plugin-sentry-wizard/gatsby-node.js
+++ b/plugins/gatsby-plugin-sentry-wizard/gatsby-node.js
@@ -27,7 +27,7 @@ exports.createPages = async ({ graphql }, { source, output }) => {
       }
     `,
     {
-      source: source
+      source: source,
     }
   );
 
@@ -58,7 +58,7 @@ const writeJson = async (path, nodes) => {
       type: n.frontmatter.type,
       details: sub ? `${main}/${sub}.json` : `${main}.json`,
       doc_link: n.frontmatter.doc_link,
-      name: n.frontmatter.name
+      name: n.frontmatter.name,
     };
     if (sub) platforms[main][sub] = data;
     else platforms[main]["_self"] = data;
@@ -68,26 +68,28 @@ const writeJson = async (path, nodes) => {
   fs.mkdirSync(path, { recursive: true });
   fs.writeFileSync(`${path}/_index.json`, JSON.stringify({ platforms }));
 
-  nodes.forEach(node => {
-    const pathMatch = node.fields.slug.match(/^\/([^\/]+)(?:\/([^\/]+))?\/$/);
-    const [_, main, sub] = pathMatch;
+  Promise.all(
+    nodes.map(async node => {
+      const pathMatch = node.fields.slug.match(/^\/([^\/]+)(?:\/([^\/]+))?\/$/);
+      const [_, main, sub] = pathMatch;
 
-    console.info(`Writing '${sub ? `${main}/${sub}.json` : `${main}.json`}'`);
-    if (sub) {
-      fs.mkdirSync(`${path}/${main}`, { recursive: true });
-    }
+      console.info(`Writing '${sub ? `${main}/${sub}.json` : `${main}.json`}'`);
+      if (sub) {
+        fs.mkdirSync(`${path}/${main}`, { recursive: true });
+      }
 
-    writeNode(
-      sub ? `${path}/${main}/${sub}.json` : `${path}/${main}.json`,
-      node
-    );
-  });
+      writeNode(
+        sub ? `${path}/${main}/${sub}.json` : `${path}/${main}.json`,
+        node
+      );
+    })
+  );
   console.log(`Wizard recorded ${nodes.length} platform snippets`);
 };
 
 const writeNode = (path, node) => {
   const dom = new jsdom.JSDOM(node.html, {
-    url: "https://docs.sentry.io/"
+    url: "https://docs.sentry.io/",
   });
   // remove anchor svgs
   dom.window.document.querySelectorAll("a.anchor svg").forEach(node => {
@@ -111,7 +113,7 @@ const writeNode = (path, node) => {
       support_level: node.frontmatter.support_level,
       doc_link: node.frontmatter.doc_link,
       name: node.frontmatter.name,
-      body: dom.window.document.body.innerHTML
+      body: dom.window.document.body.innerHTML,
     })
   );
 };

--- a/plugins/gatsby-remark-variables/index.js
+++ b/plugins/gatsby-remark-variables/index.js
@@ -1,0 +1,63 @@
+const visit = require("unist-util-visit");
+
+function scopedEval(expr, context = {}) {
+  const evaluator = Function.apply(null, [
+    ...Object.keys(context),
+    "expr",
+    "return eval(expr)",
+  ]);
+  return evaluator.apply(null, [...Object.values(context), expr]);
+}
+
+const matchEach = (text, pattern, callback) => {
+  let match, rv;
+  let promises = [];
+  while ((match = pattern.exec(text)) !== null) {
+    rv = callback(match);
+    if (rv instanceof Promise) {
+      promises.push(rv);
+    }
+  }
+  return Promise.all(promises);
+};
+
+module.exports = async ({ markdownAST }, options) => {
+  visit(
+    markdownAST,
+    () => true,
+    async node => {
+      // XXX(dcramer): by far the worst template language of all time
+
+      if (!node.value) {
+        return;
+      }
+
+      // TODO(dcramer): this could be improved by parsing the string piece by piece so you can
+      // safely quote template literals e.g. {{ '{{ foo }}' }}
+      matchEach(node.value, /\{\{\s*([^}]+)\s*\}\}/gi, async match => {
+        const expr = match[1].replace(/\s+$/, "");
+
+        // Known common value, lets just make life easy
+        if (options.excludeExpr.indexOf(expr) !== -1) {
+          return;
+        }
+
+        // YOU CAN EXECUTE CODE HERE JUST FYI
+        let result;
+        try {
+          result = scopedEval(expr, options.scope);
+          if (result instanceof Promise) result = await result;
+        } catch (err) {
+          console.warn(
+            `Error executing variable-like construct: ${match[0]}`,
+            err
+          );
+        }
+        if (result) {
+          node.value = node.value.replace(match[0], result);
+        }
+      });
+    }
+  );
+  return markdownAST;
+};

--- a/plugins/gatsby-remark-variables/index.js
+++ b/plugins/gatsby-remark-variables/index.js
@@ -21,7 +21,9 @@ const matchEach = (text, pattern, callback) => {
   return Promise.all(promises);
 };
 
-module.exports = async ({ markdownAST }, options) => {
+module.exports = async ({ markdownAST, markdownNode }, options) => {
+  const page = markdownNode.frontmatter;
+
   visit(
     markdownAST,
     () => true,
@@ -45,7 +47,10 @@ module.exports = async ({ markdownAST }, options) => {
         // YOU CAN EXECUTE CODE HERE JUST FYI
         let result;
         try {
-          result = scopedEval(expr, options.scope);
+          result = scopedEval(expr, {
+            ...options.scope,
+            page,
+          });
           if (result instanceof Promise) result = await result;
         } catch (err) {
           console.warn(

--- a/plugins/gatsby-remark-variables/package.json
+++ b/plugins/gatsby-remark-variables/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gatsby-plugin-include",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "peerDependencies": {
+    "gatsby": "^2.0.0",
+    "remark-variables": "*"
+  },
+  "dependencies": {
+    "unist-util-visit": "^1.4.1"
+  }
+}

--- a/plugins/gatsby-remark-variables/package.json
+++ b/plugins/gatsby-remark-variables/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "gatsby-plugin-include",
+  "name": "gatsby-remark-variables",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0",
-    "remark-variables": "*"
+    "gatsby": "^2.0.0"
   },
   "dependencies": {
     "unist-util-visit": "^1.4.1"

--- a/src/docs/platforms/angular/index.mdx
+++ b/src/docs/platforms/angular/index.mdx
@@ -177,16 +177,18 @@ In case you're using the CDN version or the Loader, Sentry provides a standalone
 
 ```html
 <!-- Note that we now also provide a es6 build only -->
-<!-- <script src="https://browser.sentry-cdn.com/5.20.1/bundle.es6.min.js" integrity="sha384-vX2xdItiRzNmed/VJFb8J4h2p35hYqkdTI9+xNOueKEcr7iipZy17fplNS0ikHL0" crossorigin="anonymous"></script> -->
+<!-- <script src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.es6.min.js" integrity="{{ packages.checksum('sentry.javascript.browser', 'bundle.es6.min.js', 'sha384-base64') }}" crossorigin="anonymous"></script> -->
+</script>
 <script
-  src="https://browser.sentry-cdn.com/5.20.1/bundle.min.js"
-  integrity="sha384-O8HdAJg1h8RARFowXd2J/r5fIWuinSBtjhwQoPesfVILeXzGpJxvyY/77OaPPXUo"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 
 <!-- If you include the integration it will be available under Sentry.Integrations.Angular -->
 <script
-  src="https://browser.sentry-cdn.com/5.20.1/angular.min.js"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/angular.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'angular.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 

--- a/src/includes/set-environment/cordova.mdx
+++ b/src/includes/set-environment/cordova.mdx
@@ -2,7 +2,7 @@
 onDeviceReady: function() {
     var Sentry = cordova.require("sentry-cordova.Sentry");
     Sentry.init({
-        environment: '{{ page.example_environment }}',
+        environment: 'production',
     });
 }
 ```

--- a/src/includes/set-environment/csharp.mdx
+++ b/src/includes/set-environment/csharp.mdx
@@ -1,5 +1,5 @@
 ```csharp
 using Sentry;
 
-SentrySdk.Init(o => o.Environment = "{{ page.example_environment }}");
+SentrySdk.Init(o => o.Environment = "production");
 ```

--- a/src/includes/set-environment/electron.mdx
+++ b/src/includes/set-environment/electron.mdx
@@ -1,7 +1,7 @@
 ```javascript
-import * as Sentry from '@sentry/electron';
+import * as Sentry from "@sentry/electron";
 
 Sentry.init({
-  environment: '{{ page.example_environment }}',
-})
+  environment: "production",
+});
 ```

--- a/src/includes/set-environment/go.mdx
+++ b/src/includes/set-environment/go.mdx
@@ -1,5 +1,5 @@
 ```go
 sentry.Init(sentry.ClientOptions{
-	Environment: "{{ page.example_environment }}",
+	Environment: "production",
 })
 ```

--- a/src/includes/set-environment/javascript.mdx
+++ b/src/includes/set-environment/javascript.mdx
@@ -1,9 +1,9 @@
 Options are passed to the `init()` as object:
 
 ```javascript
-import * as Sentry from '@sentry/browser';
+import * as Sentry from "@sentry/browser";
 
 Sentry.init({
-  environment: '{{ page.example_environment }}',
-})
+  environment: "production",
+});
 ```

--- a/src/includes/set-environment/native.mdx
+++ b/src/includes/set-environment/native.mdx
@@ -1,5 +1,5 @@
 ```c
 sentry_options_t *options = sentry_options_new();
-sentry_options_set_environment(options, "{{ page.example_environment }}");
+sentry_options_set_environment(options, "production");
 sentry_init(options);
 ```

--- a/src/includes/set-environment/node.mdx
+++ b/src/includes/set-environment/node.mdx
@@ -1,9 +1,9 @@
 ```javascript
-import * as Sentry from '@sentry/node';
+import * as Sentry from "@sentry/node";
 // or using CommonJS
 // const Sentry = require('@sentry/node');
 
 Sentry.init({
-  environment: '{{ page.example_environment }}',
-})
+  environment: "production",
+});
 ```

--- a/src/includes/set-environment/python.mdx
+++ b/src/includes/set-environment/python.mdx
@@ -1,5 +1,5 @@
 ```python
 import sentry_sdk
 
-sentry_sdk.init(environment="{{ page.example_environment }}")
+sentry_sdk.init(environment="production")
 ```

--- a/src/includes/set-environment/rust.mdx
+++ b/src/includes/set-environment/rust.mdx
@@ -1,6 +1,6 @@
 ```rust
 sentry::init(sentry::ClientOptions {
-    environment: Some("{{ page.example_environment }}".into()),
+    environment: Some("production".into()),
     ..Default::default()
 });
 ```

--- a/src/utils/packageRegistry.js
+++ b/src/utils/packageRegistry.js
@@ -1,0 +1,30 @@
+const axios = require("axios");
+
+module.exports = class PackageRegistry {
+  constructor() {
+    this.cache = {};
+  }
+
+  getData = async name => {
+    if (!this.cache[name]) {
+      console.info(`Fetching release registry for ${name}`);
+      const result = await axios({
+        url: `https://release-registry.services.sentry.io/sdks/${name}/latest`,
+      });
+
+      this.cache[name] = result.data;
+    }
+
+    return this.cache[name];
+  };
+
+  version = async name => {
+    const data = await this.getData(name);
+    return data.version || "";
+  };
+
+  checksum = async (name, fileName, checksum) => {
+    const data = await this.getData(name);
+    return data.files[fileName].checksums[checksum] || "";
+  };
+};

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -7,7 +7,7 @@ type: language
 The quickest way to get started is to use the CDN hosted version of the JavaScript browser SDK:
 
 ```html
-<script src="https://browser.sentry-cdn.com/5.20.1/bundle.min.js" integrity="sha384-O8HdAJg1h8RARFowXd2J/r5fIWuinSBtjhwQoPesfVILeXzGpJxvyY/77OaPPXUo" crossorigin="anonymous">
+<script src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js" integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}" crossorigin="anonymous">
 </script>
 ```
 


### PR DESCRIPTION
This primarily adds support for template variables (or otherwise javascript functions) executable within any markdown content. An example is found in the ``README.md``. Generally speaking, its the same as Django or Liquid: ``{{ scoped_variable }}``.

Using the system it implements the PackageRegistry and adds it to the scope as ``packages``, thus making them callable with e.g. ``packages.version()``.

Additionally this makes a few small changes to other various Gatsby configurations to improve performance.