### PR TITLE
feat: Migrate from @sentry/apm to @sentry/tracing

### DIFF
--- a/src/components/jsCdnTag.js
+++ b/src/components/jsCdnTag.js
@@ -5,7 +5,7 @@ import CodeTabs from "./codeTabs";
 
 let cachedVersionData = null;
 
-export default ({ apm = false }) => {
+export default ({ tracing = false }) => {
   const [versionData, setVersionData] = useState(cachedVersionData);
 
   if (!versionData && typeof fetch !== "undefined") {
@@ -19,7 +19,7 @@ export default ({ apm = false }) => {
     });
   }
 
-  const packageName = apm ? "bundle.apm.min.js" : "bundle.min.js";
+  const packageName = tracing ? "bundle.tracing.min.js" : "bundle.min.js";
   const packageData = versionData
     ? versionData
     : {

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -16,7 +16,7 @@ For most cases, just replacing your `@sentry/tracing` import is enough to switch
 +import "@sentry/tracing";
 ```
 
-If you were using the CDN use the tracing snippet instead:
+If you were using the Browser CDN bundle, switch to using the tracing snippet instead:
 
 ```html
 <script
@@ -25,6 +25,24 @@ If you were using the CDN use the tracing snippet instead:
   crossorigin="anonymous"
 ></script>
 ```
+
+### Node
+
+If you were using the Express integration for automatic instrumentation, be sure to update your imports.
+
+```diff
+import * as Sentry from "@sentry/node";
+-import { Integrations } from "@sentry/apm";
++import { Integrations } from "@sentry/tracing";
+
+ Sentry.init({
+   integrations: [
+     new Integrations.Express(),
+   ]
+ });
+```
+
+### Browser
 
 If you are using the automatic instrumentation for the _browser_, you should switch your imports from `Tracing` to `BrowserTracing`.
 

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -18,7 +18,13 @@ For most cases, just replacing your `@sentry/tracing` import is enough to switch
 
 If you were using the CDN use the tracing snippet instead:
 
-<JsCdnTag tracing />
+```html
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
 
 If you are using the automatic instrumentation for the _browser_, you should switch your imports from `Tracing` to `BrowserTracing`.
 

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -1,0 +1,101 @@
+---
+title: "Switching to @sentry/tracing"
+sidebar_order: 20
+---
+
+Our performance JavaScript SDK has been renamed from [`@sentry/apm`](https://www.npmjs.com/package/@sentry/apm) to [`@sentry/tracing`](https://www.npmjs.com/package/@sentry/tracing). The behaviour between `@sentry/apm` and `@sentry/tracing` is _identical_, but some imports and API have changed slightly.
+
+Although `@sentry/apm` is deprecated for `@sentry/tracing`, we will continue to support `@sentry/apm` with bug fixes for all `5.x.x` versions.
+
+## Migrating from @sentry/apm to @sentry/tracing
+
+For most cases, just replacing your `@sentry/tracing` import is enough to switch packages.
+
+```diff
+-import "@sentry/apm";
++import "@sentry/tracing";
+```
+
+If you were using the CDN use the tracing snippet instead:
+
+<JsCdnTag tracing />
+
+If you are using the automatic instrumentation for the _browser_, you should switch your imports from `Tracing` to `BrowserTracing`.
+
+```diff
+import * as Sentry from "@sentry/browser";
+-import { Integrations } from "@sentry/apm";
++import { Integrations } from "@sentry/tracing";
+
+ Sentry.init({
+   integrations: [
+-    new Integrations.Tracing(),
++    new Integrations.BrowserTracing(),
+   ]
+ });
+```
+
+If you were using the `beforeNavigate` option from the `Tracing` integration, the API for the `beforeNavigate` option in `BrowserTracing` has changed slightly. Instead of passing in a location and returning a string representing transaction name, `beforeNavigate` now accepts a transaction context and is expected to return transaction context. You can now add extra tags or change the op based on different parameters. If you want to access the location like before, you will have to manually look at `window.location`.
+
+For example, if you had a function like so that computed the a custom transaction name,
+
+```javascript
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/apm";
+
+Sentry.init({
+  integrations: [
+    new Integrations.Tracing({
+      beforeNavigate: location => {
+        return getTransactionName(location);
+      },
+    }),
+  ],
+});
+```
+
+You would know leverage the context to do the same thing.
+
+```javascript
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/tracing";
+
+Sentry.init({
+  integrations: [
+    new Integrations.BrowserTracing({
+      beforeNavigate: context => {
+        return {
+          ...context,
+          // Can even look at context tags or other data to adjust
+          // transaction name
+          name: getTransactionName(window.location),
+        };
+      },
+    }),
+  ],
+});
+```
+
+For the full diff:
+
+```diff
+import * as Sentry from "@sentry/browser";
+-import { Integrations } from "@sentry/apm";
++import { Integrations } from "@sentry/tracing";
+
+ Sentry.init({
+   integrations: [
+-    new Integrations.Tracing({
+-      beforeNavigate: (location) => {
+-        return getTransactionName(location)
++    new Integrations.BrowserTracing({
++      beforeNavigate: (ctx) => {
++        return {
++          ...ctx,
++          name: getTransactionName(ctx.name, window.location)
++        }
+       }
+     }),
+   ]
+});
+```

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -26,6 +26,15 @@ If you were using the Browser CDN bundle, switch from the old
 ></script>
 ```
 
+And then update `Sentry.init`:
+
+```diff
+ Sentry.init({
+-  integrations: [new Sentry.Integrations.Tracing()]
++  integrations: [new Sentry.Integrations.BrowserTracing()]
+ });
+```
+
 ### Browser (npm package)
 
 If you were using automatic instrumentation, update the import statement and

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -3,20 +3,20 @@ title: "Switching to @sentry/tracing"
 sidebar_order: 20
 ---
 
-Our performance JavaScript SDK has been renamed from [`@sentry/apm`](https://www.npmjs.com/package/@sentry/apm) to [`@sentry/tracing`](https://www.npmjs.com/package/@sentry/tracing). The behaviour between `@sentry/apm` and `@sentry/tracing` is _identical_, but some imports and API have changed slightly.
+The tracing integration for JavaScript SDKs has moved from
+[`@sentry/apm`](https://www.npmjs.com/package/@sentry/apm) to
+[`@sentry/tracing`](https://www.npmjs.com/package/@sentry/tracing). While the
+two packages are similar, some imports and APIs have changed slightly.
 
-Although `@sentry/apm` is deprecated for `@sentry/tracing`, we will continue to support `@sentry/apm` with bug fixes for all `5.x.x` versions.
+The old package `@sentry/apm` is deprecated in favor of `@sentry/tracing`.
+Future support for `@sentry/apm` is limited to bug fixes only.
 
 ## Migrating from @sentry/apm to @sentry/tracing
 
-For most cases, just replacing your `@sentry/tracing` import is enough to switch packages.
+### Browser (CDN bundle)
 
-```diff
--import "@sentry/apm";
-+import "@sentry/tracing";
-```
-
-If you were using the Browser CDN bundle, switch to using the tracing snippet instead:
+If you were using the Browser CDN bundle, switch from the old
+`bundle.apm.min.js` to the new tracing bundle:
 
 ```html
 <script
@@ -26,28 +26,13 @@ If you were using the Browser CDN bundle, switch to using the tracing snippet in
 ></script>
 ```
 
-### Node
+### Browser (npm package)
 
-If you were using the Express integration for automatic instrumentation, be sure to update your imports.
-
-```diff
-import * as Sentry from "@sentry/node";
--import { Integrations } from "@sentry/apm";
-+import { Integrations } from "@sentry/tracing";
-
- Sentry.init({
-   integrations: [
-     new Integrations.Express(),
-   ]
- });
-```
-
-### Browser
-
-If you are using the automatic instrumentation for the _browser_, you should switch your imports from `Tracing` to `BrowserTracing`.
+If you were using automatic instrumentation, update the import statement and
+update `Sentry.init` to use the new `BrowserTracing` integration:
 
 ```diff
-import * as Sentry from "@sentry/browser";
+ import * as Sentry from "@sentry/browser";
 -import { Integrations } from "@sentry/apm";
 +import { Integrations } from "@sentry/tracing";
 
@@ -59,9 +44,16 @@ import * as Sentry from "@sentry/browser";
  });
 ```
 
-If you were using the `beforeNavigate` option from the `Tracing` integration, the API for the `beforeNavigate` option in `BrowserTracing` has changed slightly. Instead of passing in a location and returning a string representing transaction name, `beforeNavigate` now accepts a transaction context and is expected to return transaction context. You can now add extra tags or change the op based on different parameters. If you want to access the location like before, you will have to manually look at `window.location`.
+If you were using the `beforeNavigate` option from the `Tracing` integration,
+the API in `BrowserTracing` has changed slightly. Instead of passing in a
+location and returning a string representing transaction name, `beforeNavigate`
+now accepts a transaction context and is expected to return a transaction
+context. You can now add extra tags or change the `op` based on different
+parameters. If you want to access the location like before, you can get it from
+`window.location`.
 
-For example, if you had a function like so that computed the a custom transaction name,
+For example, if you had a function like so that computed a custom transaction
+name:
 
 ```javascript
 import * as Sentry from "@sentry/browser";
@@ -78,7 +70,7 @@ Sentry.init({
 });
 ```
 
-You would now leverage the context to do the same thing.
+You would now leverage the context to do the same thing:
 
 ```javascript
 import * as Sentry from "@sentry/browser";
@@ -103,7 +95,7 @@ Sentry.init({
 For the full diff:
 
 ```diff
-import * as Sentry from "@sentry/browser";
+ import * as Sentry from "@sentry/browser";
 -import { Integrations } from "@sentry/apm";
 +import { Integrations } from "@sentry/tracing";
 
@@ -121,5 +113,22 @@ import * as Sentry from "@sentry/browser";
        }
      }),
    ]
-});
+ });
+```
+
+### Node
+
+If you were using the Express integration for automatic instrumentation, the
+only necessary change is to update the import statement:
+
+```diff
+ import * as Sentry from "@sentry/node";
+-import { Integrations } from "@sentry/apm";
++import { Integrations } from "@sentry/tracing";
+
+ Sentry.init({
+   integrations: [
+     new Integrations.Express(),
+   ]
+ });
 ```

--- a/src/docs/product/performance/apm-to-tracing.mdx
+++ b/src/docs/product/performance/apm-to-tracing.mdx
@@ -54,7 +54,7 @@ Sentry.init({
 });
 ```
 
-You would know leverage the context to do the same thing.
+You would now leverage the context to do the same thing.
 
 ```javascript
 import * as Sentry from "@sentry/browser";

--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -10,7 +10,7 @@ $ npm install @sentry/browser @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/)
 
 </markdown></Alert>
 

--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -142,14 +142,6 @@ span.finish(); // Remember that only finished spans will be sent with the transa
 transaction.finish(); // Finishing the transaction will send it to Sentry
 ```
 
-If you want the transaction to be associated with any global errors, or have integrations automatically add spans to your transaction, the transaction should be set on the scope.
-
-```javascript
-const transaction = Sentry.startTransaction({ name: "test-transaction" });
-
-Sentry.configureScope(scope => scope.setSpan(transaction));
-```
-
 Here is a different example. If you want to create a transaction for a user interaction on your page, you need to do the following:
 
 ```javascript

--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -1,7 +1,5 @@
 To get started with performance monitoring using Sentry's JavaScript SDK, first install the `@sentry/browser` and `@sentry/tracing` packages:
 
-> > > > > > > feat: Migrate from @sentry/apm to @sentry/tracing
-
 ```bash
 # Using yarn
 $ yarn add @sentry/browser @sentry/tracing

--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -10,7 +10,7 @@ $ npm install @sentry/browser @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -1,36 +1,44 @@
-To get started with performance monitoring using Sentry's JavaScript SDK, first install the `@sentry/browser` and `@sentry/apm` packages:
+To get started with performance monitoring using Sentry's JavaScript SDK, first install the `@sentry/browser` and `@sentry/tracing` packages:
+
+> > > > > > > feat: Migrate from @sentry/apm to @sentry/tracing
 
 ```bash
 # Using yarn
-$ yarn add @sentry/browser @sentry/apm
+$ yarn add @sentry/browser @sentry/tracing
 
 # Using npm
-$ npm install @sentry/browser @sentry/apm
+$ npm install @sentry/browser @sentry/tracing
 ```
+
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
 
 Next, initialize the integration in your call to `Sentry.init`:
 
 ```jsx
 import * as Sentry from "@sentry/browser";
-import { Integrations as ApmIntegrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   release: "my-project-name@" + process.env.npm_package_version,
-  integrations: [new ApmIntegrations.Tracing()],
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 ```
 
-Alternatively, instead of npm packages, you can use our pre-built CDN bundle that combines both `@sentry/browser` and `@sentry/apm`:
+Alternatively, instead of npm packages, you can use our pre-built CDN bundle that combines both `@sentry/browser` and `@sentry/tracing`:
 
-<JsCdnTag apm />
+<JsCdnTag tracing />
 
 Next, initialize the integration in your call to `Sentry.init`:
 
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.Integrations.Tracing()],
+  integrations: [new Sentry.Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 ```
@@ -41,21 +49,21 @@ Learn more about sampling in [Using Your SDK to Filter Events](/error-reporting/
 
 **Automatic Instrumentation**
 
-For `@sentry/browser`, we provide an integration called `Tracing` that does automatic instrumentation in the browser. The `Tracing` integration creates `pageload` and `navigation` transactions containing spans for XHR/fetch requests and Performance API entries such as marks, measures, and resource timings.
+For `@sentry/browser`, we provide an integration called `BrowserTracing` that does automatic instrumentation in the browser. The `BrowserTracing` integration creates `pageload` and `navigation` transactions containing spans for XHR/fetch requests and Performance API entries such as marks, measures, and resource timings.
 
-The `Tracing` integration is specific to `@sentry/browser` and does not work with `@sentry/node`.
+The `BrowserTracing` integration is specific to `@sentry/browser` and does not work with `@sentry/node`.
 
-The `Tracing` integration resides in the `@sentry/apm` package. You can add it to your `Sentry.init` call:
+The `BrowserTracing` integration resides in the `@sentry/tracing` package. You can add it to your `Sentry.init` call:
 
 ```javascript
 // Without CDN
 
 import * as Sentry from "@sentry/browser";
-import { Integrations as ApmIntegrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new ApmIntegrations.Tracing()],
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 
@@ -63,20 +71,20 @@ Sentry.init({
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.Integrations.Tracing()],
+  integrations: [new Sentry.Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 ```
 
-_NOTE:_ The `Tracing` integration is available under `Sentry.Integrations.Tracing` when using the CDN bundle.
+_NOTE:_ The `BrowserTracing` integration is available under `Sentry.Integrations.BrowserTracing` when using the CDN bundle.
 
 To send traces, you will need to set the `tracesSampleRate` to a nonzero value. The configuration above will capture 100% of your transactions.
 
 By default, the `pageload` and `navigation` transactions set a transaction name using `window.location.pathname`.
 
-You can pass many different options to the `Tracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box.
+You can pass many different options to the `BrowserTracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box.
 
-For all possible options, see [TypeDocs](https://getsentry.github.io/sentry-javascript/interfaces/apm.tracingoptions.html).
+For all possible options, see [TypeDocs](https://getsentry.github.io/sentry-javascript/interfaces/tracing.browsertracingoptions.html).
 
 **tracingOrigins Option**
 
@@ -87,30 +95,35 @@ _Example:_
 - A frontend application is served from `example.com`
 - A backend service is served from `api.example.com`
 - The frontend application makes API calls to the backend
-- Therefore, the option needs to be configured like this: `new ApmIntegrations.Tracing({tracingOrigins: ['api.example.com']})`
+- Therefore, the option needs to be configured like this: `new Integrations.BrowserTracing({tracingOrigins: ['api.example.com']})`
 - Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
 
 _NOTE:_ You need to make sure your web server CORS is configured to allow the `sentry-trace` header. The configuration might look like `"Access-Control-Allow-Headers: sentry-trace"`, but this depends a lot on your setup. If you do not allow the `sentry-trace` header, the request might be blocked.
 
-**beforeNavigation Option**
+**beforeNavigate Option**
 
-For `pageload` and `navigation` transactions, the `Tracing` integration uses the browser's `window.location` API to generate a transaction name. To customize the name of the `pageload` and `navigation` transactions, you can supply a `beforeNavigation` option to the `Tracing` integration. This option allows you to pass in a function that takes in the location at the time of navigation and returns a new transaction name.
+For `pageload` and `navigation` transactions, the `BrowserTracing` integration uses the browser's `window.location` API to generate a transaction name. To customize the name of the `pageload` and `navigation` transactions, you can supply a `beforeNavigate` option to the `BrowserTracing` integration. This option allows you to pass in a function that takes in the location at the time of navigation and returns a new transaction name.
 
-`beforeNavigation` is useful if you would like to leverage the routes from a custom routing library like `React Router` or if you want to reduce the cardinality of particular transactions.
+`beforeNavigate` is useful if you would like to leverage the routes from a custom routing library like `React Router` or if you want to reduce the cardinality of particular transactions.
 
 ```javascript
 import * as Sentry from "@sentry/browser";
-import { Integrations as ApmIntegrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
+
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    new ApmIntegrations.Tracing({
-      beforeNavigate: location => {
-        // Here we are doing some basic parameter replacements, but we recommend
-        // using your UI's routing library to find the matching route template here
-        return location.pathname
-          .replace(/\d+/g, "<digits>")
-          .replace(/[a-f0-9]{32}/g, "<hash>");
+    new Integrations.BrowserTracing({
+      beforeNavigate: context => {
+        return {
+          ...context,
+          // You could use your UI's routing library to find the matching
+          // route template here. We don't have one right now, so do some basic
+          // parameter replacements.
+          name: location.pathname
+            .replace(/\d+/g, "<digits>")
+            .replace(/[a-f0-9]{32}/g, "<hash>"),
+        };
       },
     }),
   ],
@@ -121,7 +134,7 @@ Sentry.init({
 **Manual Instrumentation**
 
 To manually instrument certain regions of your code, you can create a transaction to capture them.
-This is valid for both JavaScript Browser and Node and works independently of the `Tracing` integration.
+This is valid for both JavaScript Browser and Node and works independently of the `BrowserTracing` integration.
 
 ```javascript
 const transaction = Sentry.startTransaction({ name: "test-transaction" });
@@ -131,6 +144,14 @@ span.finish(); // Remember that only finished spans will be sent with the transa
 transaction.finish(); // Finishing the transaction will send it to Sentry
 ```
 
+If you want the transaction to be associated with any global errors, or have integrations automatically add spans to your transaction, the transaction should be set on the scope.
+
+```javascript
+const transaction = Sentry.startTransaction({ name: "test-transaction" });
+
+Sentry.configureScope(scope => scope.setSpan(transaction));
+```
+
 Here is a different example. If you want to create a transaction for a user interaction on your page, you need to do the following:
 
 ```javascript
@@ -138,6 +159,8 @@ Here is a different example. If you want to create a transaction for a user inte
 shopCheckout() {
   // This will create a new Transaction for you
   const transaction = Sentry.startTransaction('shopCheckout');
+  // set the transaction on the scope so it picks up any errors
+  hub.configureScope(scope => scope.setSpan(transaction));
 
   // Assume this function makes an xhr/fetch call
   const result = validateShoppingCartOnServer();
@@ -201,23 +224,26 @@ addGlobalEventProcess(event => {
 });
 ```
 
-For browser JavaScript applications using the `Tracing` integration, the `beforeNavigate` option can be used to better group navigation/pageload transactions together based on URL.
+For browser JavaScript applications using the `BrowserTracing` integration, the `beforeNavigate` option can be used to better group navigation/pageload transactions together based on URL.
 
 ```javascript
 import * as Sentry from "@sentry/browser";
-import { Integrations as ApmIntegrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   // ...
   integrations: [
-    new ApmIntegrations.Tracing({
-      beforeNavigate: location => {
-        // You could use your UI's routing library to find the matching
-        // route template here. We don't have one right now, so do some basic
-        // parameter replacements.
-        return location.pathname
-          .replace(/\d+/g, "<digits>")
-          .replace(/[a-f0-9]{32}/g, "<hash>");
+    new Integrations.BrowserTracing({
+      beforeNavigate: context => {
+        return {
+          ...context,
+          // You could use your UI's routing library to find the matching
+          // route template here. We don't have one right now, so do some basic
+          // parameter replacements.
+          name: location.pathname
+            .replace(/\d+/g, "<digits>")
+            .replace(/[a-f0-9]{32}/g, "<hash>"),
+        };
       },
     }),
   ],
@@ -226,7 +252,7 @@ Sentry.init({
 
 **Retrieving a Transaction**
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` in case there is a running Transaction otherwise it returns `undefined`. If you are using our Tracing integration by default we attach the Transaction to the Scope. So you could do something like this:
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` in case there is a running Transaction on the scope, otherwise it returns `undefined`. If you are using our BrowserTracing integration by default we attach the Transaction to the Scope. So you could do something like this:
 
 ```javascript
 function myJsFunction() {

--- a/src/includes/performance-monitoring/configuration/koa.mdx
+++ b/src/includes/performance-monitoring/configuration/koa.mdx
@@ -4,17 +4,23 @@ To get started with performance monitoring with Koa, first install these package
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node @sentry/apm
+$ yarn add @sentry/node @sentry/tracing
 
 # Using npm
-$ npm install @sentry/node @sentry/apm
+$ npm install @sentry/node @sentry/tracing
 ```
+
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
 
 Creates and attach a transaction to each context
 
 ```javascript
 const Sentry = require("@sentry/node");
-const { Span } = require("@sentry/apm");
+const { Span } = require("@sentry/tracing");
 const Koa = require("koa");
 const app = new Koa();
 const domain = require("domain");

--- a/src/includes/performance-monitoring/configuration/koa.mdx
+++ b/src/includes/performance-monitoring/configuration/koa.mdx
@@ -91,8 +91,8 @@ app.use(tracingMiddleWare);
 
 // usual error handler
 app.on("error", (err, ctx) => {
-  Sentry.withScope(function(scope) {
-    scope.addEventProcessor(function(event) {
+  Sentry.withScope((scope) => {
+    scope.addEventProcessor((event) => {
       return Sentry.Handlers.parseRequest(event, ctx.request);
     });
     Sentry.captureException(err);

--- a/src/includes/performance-monitoring/configuration/koa.mdx
+++ b/src/includes/performance-monitoring/configuration/koa.mdx
@@ -12,7 +12,7 @@ $ npm install @sentry/node @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/includes/performance-monitoring/configuration/node.mdx
+++ b/src/includes/performance-monitoring/configuration/node.mdx
@@ -16,7 +16,7 @@ $ npm install @sentry/node @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/includes/performance-monitoring/configuration/node.mdx
+++ b/src/includes/performance-monitoring/configuration/node.mdx
@@ -8,11 +8,17 @@ To get started with performance monitoring with Node.js, first install these pac
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node @sentry/apm
+$ yarn add @sentry/node @sentry/tracing
 
 # Using npm
-$ npm install @sentry/node @sentry/apm
+$ npm install @sentry/node @sentry/tracing
 ```
+
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
 
 **Sending Traces**
 
@@ -24,9 +30,9 @@ const Sentry = require("@sentry/node");
 // import * as Sentry from '@sentry/node';
 
 // This is required since it patches functions on the hub
-const Apm = require("@sentry/apm");
+const Tracing = require("@sentry/tracing");
 // or use es6 import statements
-// import * as Apm from '@sentry/apm';
+// import * as Tracing from '@sentry/tracing';
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -61,7 +67,7 @@ It’s possible to add tracing to all popular frameworks; however, we only provi
 
 ```javascript
 const Sentry = require("@sentry/node");
-const Apm = require("@sentry/apm");
+const Tracing = require("@sentry/tracing");
 const express = require("express");
 const app = express();
 
@@ -71,7 +77,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Apm.Integrations.Express({ app }),
+    new Tracing.Integrations.Express({ app }),
   ],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
@@ -100,7 +106,7 @@ By default, Sentry error events will not get trace context unless you configure 
 
 ```js
 const Sentry = require("@sentry/node");
-const Apm = require("@sentry/apm");
+const Tracing = require("@sentry/tracing");
 
 const http = require("http");
 
@@ -176,6 +182,7 @@ app.get("/success", function successHandler(req, res) {
   const transaction = Sentry.getCurrentHub()
     .getScope()
     .getTransaction();
+
   if (transaction) {
     let span = transaction.startChild({
       op: "encode",

--- a/src/includes/performance-monitoring/configuration/react.mdx
+++ b/src/includes/performance-monitoring/configuration/react.mdx
@@ -38,7 +38,7 @@ ReactDOM.render(<App />, rootNode);
 
 **`withProfiler` Higher-Order Component**
 
-`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/tracing` to add React-related spans to transactions.
+`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/tracing` package to add React-related spans to transactions.
 
 In the example below, the `withProfiler` higher-order component is used to instrument an App component.
 

--- a/src/includes/performance-monitoring/configuration/react.mdx
+++ b/src/includes/performance-monitoring/configuration/react.mdx
@@ -38,7 +38,7 @@ ReactDOM.render(<App />, rootNode);
 
 **`withProfiler` Higher-Order Component**
 
-`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/tracing` add React related spans to transactions.
+`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/tracing` to add React-related spans to transactions.
 
 In the example below, the `withProfiler` higher-order component is used to instrument an App component.
 

--- a/src/includes/performance-monitoring/configuration/react.mdx
+++ b/src/includes/performance-monitoring/configuration/react.mdx
@@ -1,24 +1,30 @@
 **React**
 
-To get started with performance monitoring using Sentry's React SDK, first install the `@sentry/react` and `@sentry/apm` packages:
+To get started with performance monitoring using Sentry's React SDK, first install the `@sentry/react` and `@sentry/tracing` packages:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/react @sentry/apm
+$ yarn add @sentry/react @sentry/tracing
 
 # Using npm
-$ npm install @sentry/react @sentry/apm
+$ npm install @sentry/react @sentry/tracing
 ```
+
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
 
 Next, initialize the integration in your call to `Sentry.init`. Make sure this happens before you mount your React component on the page.
 
 ```jsx
 import * as Sentry from "@sentry/react";
-import { Integrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   release: "my-project-name@" + process.env.npm_package_version,
-  integrations: [new Integrations.Tracing()],
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 
@@ -32,7 +38,7 @@ ReactDOM.render(<App />, rootNode);
 
 **`withProfiler` Higher-Order Component**
 
-`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/apm` Tracing integration to add React related spans to transactions. If the Tracing integration is not enabled, the Profiler will not work.
+`@sentry/react` exports a `withProfiler` higher-order component that leverages the `@sentry/tracing` add React related spans to transactions.
 
 In the example below, the `withProfiler` higher-order component is used to instrument an App component.
 

--- a/src/includes/performance-monitoring/configuration/react.mdx
+++ b/src/includes/performance-monitoring/configuration/react.mdx
@@ -12,7 +12,7 @@ $ npm install @sentry/react @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/includes/performance-monitoring/configuration/vue.mdx
+++ b/src/includes/performance-monitoring/configuration/vue.mdx
@@ -4,25 +4,31 @@ To get started with performance monitoring with Vue.js, first install these pack
 
 ```bash
 # Using yarn
-$ yarn add @sentry/browser @sentry/integrations @sentry/apm
+$ yarn add @sentry/browser @sentry/integrations @sentry/tracing
 
 # Using npm
-$ npm install @sentry/browser @sentry/integrations @sentry/apm
+$ npm install @sentry/browser @sentry/integrations @sentry/tracing
 ```
+
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
 
 The Vue Tracing Integration allows you to track rendering performance during an initial application load.
 
 Sentry injects a handler inside Vue's `beforeCreate` mixin, providing access to a Vue component during its life cycle stages.
-When Sentry encounters a component named `root`, which is a top-level Vue instance (as in `new Vue({})`), we use our AM Tracing integration,
-and create a new activity named `Vue Application Render`. Once the activity has been created, it will wait until all of its child components render, and there aren't new rendering events triggered within the configured `timeout`, before marking the activity as completed.
+When Sentry encounters a component named `root`, which is a top-level Vue instance (as in `new Vue({})`), we use our AM BrowserTracing integration,
+and create a new span named `Vue Application Render`. Once the span has been created, it will wait until all of its child components render, and there aren't new rendering events triggered within the configured `timeout`, before marking the span as finished.
 
 The described instrumentation functionality will give you very high-level information about the rendering performance of the Vue instance. However, the integration can also provide more fine-grained details about what actually happened during a specific activity.
 To do that, you need to specify which components to track and what hooks to listen to (you can find a list of all available hooks [here](https://vuejs.org/v2/api/#Options-Lifecycle-Hooks)). You can also turn on tracking for all the components. However, it may be rather noisy if your app consists of hundreds of components. We encourage being more specific. If you don't provide hooks, Sentry will track a component's `mount` and `update` hooks.
 
 Note that we don't use `before` and `-ed` pairs for hooks, and you should provide a simple verb instead. For example, `update` is correct. `beforeUpdate` and `updated` are incorrect.
 
-To set up the Vue Tracing Integration, you will first need to configure the AM Tracing integration itself. For details on how to do this, see the [JavaScript](/performance-monitoring/distributed-tracing/#javascript) section above.
-Once you've configured the Tracing integration, move on to configuring the Vue integration itself.
+To set up the Vue Tracing Integration, you will first need to configure the AM BrowserTracing integration itself. For details on how to do this, see the [JavaScript](/performance-monitoring/distributed-tracing/#javascript) section above.
+Once you've configured the BrowserTracing integration, move on to configuring the Vue integration itself.
 Sentry built the new tracing capabilities into the original Vue error handler integrations, so there is no need to add any new packages. You only need to provide an appropriate configuration.
 
 The most basic configuration for tracing your Vue app, which would track only the top-level component, looks like this:
@@ -30,13 +36,13 @@ The most basic configuration for tracing your Vue app, which would track only th
 ```js
 import * as Sentry from "@sentry/browser";
 import { Vue as VueIntegration } from "@sentry/integrations";
-import { Integrations } from "@sentry/apm";
+import { Integrations } from "@sentry/tracing";
 import Vue from "vue";
 
 Sentry.init({
   // ...
   integrations: [
-    new Integrations.Tracing(),
+    new Integrations.BrowserTracing(),
     new VueIntegration({
       Vue,
       tracing: true,

--- a/src/includes/performance-monitoring/configuration/vue.mdx
+++ b/src/includes/performance-monitoring/configuration/vue.mdx
@@ -20,12 +20,12 @@ The Vue Tracing Integration allows you to track rendering performance during an 
 
 Sentry injects a handler inside Vue's `beforeCreate` mixin, providing access to a Vue component during its life cycle stages.
 When Sentry encounters a component named `root`, which is a top-level Vue instance (as in `new Vue({})`), we use our AM BrowserTracing integration,
-and create a new span named `Vue Application Render`. Once the span has been created, it will wait until all of its child components render, and there aren't new rendering events triggered within the configured `timeout`, before marking the span as finished.
+and create a new span named `Vue Application Render`. Once the `Vue Application Render` span has been created, it will wait until all of its child components render before marking the span as finished.
 
 The described instrumentation functionality will give you very high-level information about the rendering performance of the Vue instance. However, the integration can also provide more fine-grained details about what actually happened during a specific activity.
 To do that, you need to specify which components to track and what hooks to listen to (you can find a list of all available hooks [here](https://vuejs.org/v2/api/#Options-Lifecycle-Hooks)). You can also turn on tracking for all the components. However, it may be rather noisy if your app consists of hundreds of components. We encourage being more specific. If you don't provide hooks, Sentry will track a component's `mount` and `update` hooks.
 
-Note that we don't use `before` and `-ed` pairs for hooks, and you should provide a simple verb instead. For example, `update` is correct. `beforeUpdate` and `updated` are incorrect.
+Note that when specifying hooks we use the simple verb rather than `before` and `-ed` pairs. For example, `destroy` is correct. `beforeDestroy` and `destroyed` are incorrect.
 
 To set up the Vue Tracing Integration, you will first need to configure the AM BrowserTracing integration itself. For details on how to do this, see the [JavaScript](/performance-monitoring/distributed-tracing/#javascript) section above.
 Once you've configured the BrowserTracing integration, move on to configuring the Vue integration itself.

--- a/src/includes/performance-monitoring/configuration/vue.mdx
+++ b/src/includes/performance-monitoring/configuration/vue.mdx
@@ -12,7 +12,7 @@ $ npm install @sentry/browser @sentry/integrations @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -127,7 +127,7 @@ $ npm install @sentry/browser @sentry/tracing
 
 <Alert level="warning" title="Note"><markdown>
 
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
 
 </markdown></Alert>
 

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -125,7 +125,12 @@ $ yarn add @sentry/browser @sentry/tracing
 $ npm install @sentry/browser @sentry/tracing
 ```
 
-<<<<<<< HEAD:src/platforms/javascript/index.mdx
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
+
 ```html {tabTitle: CDN}
 <script
   src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.apm.min.js"
@@ -133,17 +138,6 @@ $ npm install @sentry/browser @sentry/tracing
   crossorigin="anonymous"
 ></script>
 ```
-=======
-<Alert level="warning" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
-
-</markdown></Alert>
-
-Alternatively, instead of `npm` packages, you can use our pre-built CDN bundle that combines both `@sentry/browser` and `@sentry/tracing`:
-
-<JsCdnTag tracing />
->>>>>>> feat: Migrate from @sentry/apm to @sentry/tracing:src/docs/platforms/javascript/index.mdx
 
 Next, initialize the integration in your call to `Sentry.init`:
 

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -133,8 +133,8 @@ We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you wer
 
 ```html {tabTitle: CDN}
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.apm.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.apm.min.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```
@@ -156,7 +156,7 @@ Sentry.init({
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   release: "my-project-name@" + process.env.npm_package_version,
-  integrations: [new Integrations.BrowserTracing()],
+  integrations: [new Sentry.Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // Be sure to lower this in production
 });
 ```

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -125,6 +125,7 @@ $ yarn add @sentry/browser @sentry/tracing
 $ npm install @sentry/browser @sentry/tracing
 ```
 
+<<<<<<< HEAD:src/platforms/javascript/index.mdx
 ```html {tabTitle: CDN}
 <script
   src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.apm.min.js"
@@ -132,6 +133,17 @@ $ npm install @sentry/browser @sentry/tracing
   crossorigin="anonymous"
 ></script>
 ```
+=======
+<Alert level="warning" title="Note"><markdown>
+
+We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to the tracing package](/product/performance/apm-to-tracing/)
+
+</markdown></Alert>
+
+Alternatively, instead of `npm` packages, you can use our pre-built CDN bundle that combines both `@sentry/browser` and `@sentry/tracing`:
+
+<JsCdnTag tracing />
+>>>>>>> feat: Migrate from @sentry/apm to @sentry/tracing:src/docs/platforms/javascript/index.mdx
 
 Next, initialize the integration in your call to `Sentry.init`:
 

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -9,8 +9,8 @@ The quickest way to get started is to use the CDN hosted version of the JavaScri
 
 ```html
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.apm.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.apm.min.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```
@@ -19,12 +19,12 @@ You should `init` the Sentry Browser SDK as soon as possible during your page lo
 
 ```javascript
 import * as Sentry from '@sentry/browser';
-import { Integrations as ApmIntegrations } from '@sentry/apm';
+import { Integrations } from '@sentry/tracing';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: [
-    new ApmIntegrations.Tracing(),
+    new Integrations.BrowserTracing(),
   ],
   tracesSampleRate: 1.0,
 });

--- a/src/wizard/javascript/react.md
+++ b/src/wizard/javascript/react.md
@@ -14,10 +14,10 @@ Add the Sentry SDK as a dependency using yarn or npm:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/react @sentry/apm
+$ yarn add @sentry/react @sentry/tracing
 
 # Using npm
-$ npm install @sentry/react @sentry/apm
+$ npm install @sentry/react @sentry/tracing
 ```
 
 ## Connecting the SDK to Sentry
@@ -30,18 +30,21 @@ You should `init` the Sentry browser SDK as soon as possible during your applica
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as Sentry from '@sentry/react';
-import { Integrations } from '@sentry/apm';
+import { Integrations } from '@sentry/tracing';
 import App from './App';
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    new Integrations.Tracing(),
+    new Integrations.BrowserTracing(),
   ],
   tracesSampleRate: 1.0,
 });
 
 ReactDOM.render(<App />, document.getElementById("root"));
+
+// Can also use with React Concurrent Mode
+// ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 ```
 
 The above configuration captures both error and performance data. To reduce the volume of performance data captured, change `tracesSampleRate` to a value between 0 and 1.


### PR DESCRIPTION
Switch all references from `@sentry/apm` to `@sentry/tracing`.

Also add an upgrade guide detailing the changes.

