### PR TITLE
docs(sourcemaps): update webpack config filename extension

### DIFF
--- a/src/docs/clients/node/sourcemaps.mdx
+++ b/src/docs/clients/node/sourcemaps.mdx
@@ -51,7 +51,7 @@ It can be easily done with a help of the `sentry-webpack-plugin`, which internal
 - Ensure you you have `project:write` selected under scopes.
 - Install `@sentry/webpack-plugin` using `npm`
 - Create `.sentryclirc` file with necessary config (see Sentry Webpack Plugin docs below)
-- Update your `webpack.config.json`
+- Update your `webpack.config.js`
 
 ```javascript
 const SentryPlugin = require("@sentry/webpack-plugin");

--- a/src/docs/platforms/node/sourcemaps.mdx
+++ b/src/docs/platforms/node/sourcemaps.mdx
@@ -61,7 +61,7 @@ You can do this with the help of the `sentry-webpack-plugin`, which internally u
 - Ensure you have `project:write` selected under scopes.
 - Install `@sentry/webpack-plugin` using `npm`
 - Create `.sentryclirc` file with necessary config (see Sentry Webpack Plugin docs below)
-- Update your `webpack.config.json`
+- Update your `webpack.config.js`
 
 ```javascript
 const SentryPlugin = require("@sentry/webpack-plugin");


### PR DESCRIPTION
This PR updates the filename used for webpack configuration. It appears to be a typo.

https://webpack.js.org/concepts/configuration/