### PR TITLE
Go documentation: split consecutive code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Description of send-default-pii
 
 ### Code Blocks
 
-Consecutively code blocks will be automatically collapsed into a tabulated container.  This behavior is generally useful if you want to define an example in multiple languages:
+Consecutive code blocks will be automatically collapsed into a tabulated container.  This behavior is generally useful if you want to define an example in multiple languages:
 
 
 ````markdown
@@ -213,6 +213,7 @@ function foo() { return 'bar' }
 ```python
 def foo():
   return 'bar'
+```
 ````
 
 Some times you may not want this behavior. To solve this you can either break up the code blocks with some additional text, or you can use the ``<Break />`` component.

--- a/src/docs/platforms/go/echo.mdx
+++ b/src/docs/platforms/go/echo.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/echo
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/fasthttp.mdx
+++ b/src/docs/platforms/go/fasthttp.mdx
@@ -16,6 +16,8 @@ tags: []
 go get github.com/getsentry/sentry-go/fasthttp
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/gin.mdx
+++ b/src/docs/platforms/go/gin.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/gin
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/http.mdx
+++ b/src/docs/platforms/go/http.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/http
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/iris.mdx
+++ b/src/docs/platforms/go/iris.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/iris
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/martini.mdx
+++ b/src/docs/platforms/go/martini.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/martini
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"

--- a/src/docs/platforms/go/negroni.mdx
+++ b/src/docs/platforms/go/negroni.mdx
@@ -18,6 +18,8 @@ tags: []
 $ go get github.com/getsentry/sentry-go/negroni
 ```
 
+<Break />
+
 ```go
 import (
 	"fmt"


### PR DESCRIPTION
## Broken 

![image](https://user-images.githubusercontent.com/88819/90800420-f35c8780-e314-11ea-9ba8-c92cd508e8ee.png)

## Fix

