### PR TITLE
fix: Rewrite intro to Go integrations

### DIFF
--- a/src/docs/platforms/go/echo.mdx
+++ b/src/docs/platforms/go/echo.mdx
@@ -2,15 +2,19 @@
 draft: false
 categories: []
 toc: true
-title: Echo
+title: Echo middleware
 tags: []
 ---
 
-## Echo Handler for Sentry-go SDK
+This page shows how to use the Echo framework with Sentry.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/echo
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/echo) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/echo
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/echo) is also
+available.
 
 ### Installation
 

--- a/src/docs/platforms/go/fasthttp.mdx
+++ b/src/docs/platforms/go/fasthttp.mdx
@@ -2,13 +2,20 @@
 draft: false
 categories: []
 toc: true
-title: Fasthttp
+title: FastHTTP middleware
 tags: []
 ---
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/fasthttp
+This page shows how to add Sentry instrumentation to programs using the FastHTTP
+package.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/fasthttp
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/fasthttp)
+available directly at the Go SDK source code repository.
+
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/fasthttp) is also
+available.
 
 ## Installation
 

--- a/src/docs/platforms/go/gin.mdx
+++ b/src/docs/platforms/go/gin.mdx
@@ -2,15 +2,19 @@
 draft: false
 categories: []
 toc: true
-title: Gin
+title: Gin middleware
 tags: []
 ---
 
-## Gin Handler for Sentry-go SDK
+This page shows how to use the Gin framework with Sentry.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/gin
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/gin) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/gin
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/gin) is also
+available.
 
 ### Installation
 

--- a/src/docs/platforms/go/http.mdx
+++ b/src/docs/platforms/go/http.mdx
@@ -2,15 +2,20 @@
 draft: false
 categories: []
 toc: true
-title: net/http
+title: net/http middleware
 tags: []
 ---
 
-## net/http Handler for Sentry-go SDK
+This page shows how to add Sentry instrumentation to programs using the net/http
+package.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/http
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/http) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/http
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/http) is also
+available.
 
 ### Installation
 

--- a/src/docs/platforms/go/iris.mdx
+++ b/src/docs/platforms/go/iris.mdx
@@ -2,15 +2,19 @@
 draft: false
 categories: []
 toc: true
-title: Iris
+title: Iris middleware
 tags: []
 ---
 
-## Iris Handler for Sentry-go SDK
+This page shows how to use the Iris framework with Sentry.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/iris
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/iris) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/iris
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/iris) is also
+available.
 
 ### Installation
 

--- a/src/docs/platforms/go/martini.mdx
+++ b/src/docs/platforms/go/martini.mdx
@@ -2,15 +2,19 @@
 draft: false
 categories: []
 toc: true
-title: Martini
+title: Martini middleware
 tags: []
 ---
 
-## Martini Handler for Sentry-go SDK
+This page shows how to use the Martini framework with Sentry.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/martini
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/martini) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/martini
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/martini) is also
+available.
 
 ### Installation
 

--- a/src/docs/platforms/go/negroni.mdx
+++ b/src/docs/platforms/go/negroni.mdx
@@ -2,15 +2,19 @@
 draft: false
 categories: []
 toc: true
-title: Negroni
+title: Negroni middleware
 tags: []
 ---
 
-## Negroni Handler for Sentry-go SDK
+This page shows how to use the Negroni framework with Sentry.
 
-**Godoc:** https://godoc.org/github.com/getsentry/sentry-go/negroni
+For a quick reference, there is a [complete
+example](https://github.com/getsentry/sentry-go/tree/master/example/negroni) at the
+Go SDK source code repository.
 
-**Example:** https://github.com/getsentry/sentry-go/tree/master/example/negroni
+[GoDoc-style API
+documentation](https://godoc.org/github.com/getsentry/sentry-go/negroni) is also
+available.
 
 ### Installation
 


### PR DESCRIPTION
Main goal is to add context and make links clickable.