### PR TITLE
Fix SentrySdk.Init link in WPF documentation

### DIFF
--- a/src/platforms/dotnet/wpf.mdx
+++ b/src/platforms/dotnet/wpf.mdx
@@ -11,7 +11,7 @@ Sentry's .NET SDK works with Windows Presentation Foundation applications throug
 
 ## Configuration
 
-In addition to [initializing the SDK with `SentrySdk.Init`](/platforms/dotnet/), you must configure the WPF specific error handler.
+In addition to [initializing the SDK with `SentrySdk.Init`](/error-reporting/quickstart/?platform=csharp#configure-the-sdk), you must configure the WPF specific error handler.
 
 The SDK automatically handles `AppDomain.UnhandledException`. On WPF, for production apps (when no debugger is attached), WPF catches exception to show the dialog to the user. You can also configure your app to capture those exceptions before the dialog shows up:
 


### PR DESCRIPTION
The existing link went to a page that does not have any documentation on the `SentrySdk.Init()` method. The new link goes to the correct location that describes how to initialize the SDK