### PR TITLE
Clarify WPF initialization instructions

### DIFF
--- a/src/platforms/dotnet/wpf.mdx
+++ b/src/platforms/dotnet/wpf.mdx
@@ -13,6 +13,12 @@ Sentry's .NET SDK works with Windows Presentation Foundation applications throug
 
 In addition to [initializing the SDK with `SentrySdk.Init`](/platforms/dotnet/), you must configure the WPF specific error handler.
 
+<Alert level="info" title="Note"><markdown>
+
+The SDK should be initialized in the constructor of your application class (usually `App.xaml.cs`). Do not initialize the SDK in the `OnStartup()` event of the application or the `Hub` will not be initialized correctly.
+
+</markdown></Alert>
+
 The SDK automatically handles `AppDomain.UnhandledException`. On WPF, for production apps (when no debugger is attached), WPF catches exception to show the dialog to the user. You can also configure your app to capture those exceptions before the dialog shows up:
 
 ```csharp

--- a/src/platforms/dotnet/wpf.mdx
+++ b/src/platforms/dotnet/wpf.mdx
@@ -13,7 +13,7 @@ Sentry's .NET SDK works with Windows Presentation Foundation applications throug
 
 In addition to [initializing the SDK with `SentrySdk.Init`](/platforms/dotnet/), you must configure the WPF specific error handler.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Important"><markdown>
 
 The SDK should be initialized in the constructor of your application class (usually `App.xaml.cs`). Do not initialize the SDK in the `OnStartup()` event of the application or the `Hub` will not be initialized correctly.
 


### PR DESCRIPTION
Add a note to clarify that the SentrySDK should be initialized in the application constructor and not the `OnStartup()` event.

This is valuable to specify explicitly because it is not common to have a constructor in a WPF `Application` class. App initialization is usually all done in the `OnStartup()` event, but attempting to initialize the Sentry SDK in the `OnStartup()` event leads to obscure issues with Hub and Scope stack initialization as outlined in the [community forum](https://forum.sentry.io/t/user-context-not-submitting-consistently/10806/4?u=senti.mark.monteiro)