### PR TITLE
 ref(onpremise): Point people to the latest release 

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -75,7 +75,7 @@ export default () => {
                 <SidebarLink to="https://develop.sentry.dev">
                   Developer Documentation
                 </SidebarLink>
-                <SidebarLink to="https://github.com/getsentry/onpremise">
+                <SidebarLink to="https://github.com/getsentry/onpremise/releases/latest">
                   Self-Hosting Sentry
                 </SidebarLink>
               </ul>

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -11,7 +11,7 @@ To get you started, you might find some of these links relevant:
 - New to Sentry? Have a look at [_Getting Started_](/error-reporting/quickstart/).
 - No account yet? You can sign up for one at [sentry.io](https://sentry.io/signup/).
 - Stuck? Feel free to contact [Support](/support/).
-- Self-hosting the Sentry server? See [_On-Premise Installation_](https://github.com/getsentry/onpremise/releases/latest).
+- Self-hosting the Sentry server? See [our documentation for On-Premise Installations](https://github.com/getsentry/onpremise/releases/latest).
 
 ## Contributing
 

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -11,7 +11,7 @@ To get you started, you might find some of these links relevant:
 - New to Sentry? Have a look at [_Getting Started_](/error-reporting/quickstart/).
 - No account yet? You can sign up for one at [sentry.io](https://sentry.io/signup/).
 - Stuck? Feel free to contact [Support](/support/).
-- Self-hosting the Sentry server? See [_Installation_](https://github.com/getsentry/onpremise).
+- Self-hosting the Sentry server? See [_On-Premise Installation_](https://github.com/getsentry/onpremise/releases/latest).
 
 ## Contributing
 


### PR DESCRIPTION
We used to point people to the homepage of on-premise, advocating for the nightly builds. With this patch, we point them to the latest release.

Rel: https://app.asana.com/0/1169344595888357/1190341230301201/f