### PR TITLE
fix: behaviour => behavior

### DIFF
--- a/src/docs/clients/csharp/index.mdx
+++ b/src/docs/clients/csharp/index.mdx
@@ -148,7 +148,7 @@ public class ExampleController : ApiController
 
 ## Debugging SharpRaven
 
-If an exception is raised internally to `RavenClient` it is logged to the `Console`. To extend this behaviour use the property `ErrorOnCapture`:
+If an exception is raised internally to `RavenClient` it is logged to the `Console`. To extend this behavior use the property `ErrorOnCapture`:
 
 ```csharp
 ravenClient.ErrorOnCapture = exception =>

--- a/src/docs/clients/javascript/usage.mdx
+++ b/src/docs/clients/javascript/usage.mdx
@@ -289,7 +289,7 @@ Both of these steps need to be done or your scripts might not even get executed
 
 By default, Raven.js capture unhandled promise rejections as described in official ECMAScript 6 standard.
 
-Most Promise libraries however, have a global hook for capturing unhandled errors. You may want to disable default behaviour by setting `captureUnhandledRejections` option to `false` and manually hook into such event handler and call `Raven.captureException` or `Raven.captureMessage` directly.
+Most Promise libraries however, have a global hook for capturing unhandled errors. You may want to disable default behavior by setting `captureUnhandledRejections` option to `false` and manually hook into such event handler and call `Raven.captureException` or `Raven.captureMessage` directly.
 
 For example, the [RSVP.js library](https://github.com/tildeio/rsvp.js/) (used by Ember.js) allows you to bind an event handler to a [global error event](https://github.com/tildeio/rsvp.js#error-handling):
 

--- a/src/platforms/elixir/config.mdx
+++ b/src/platforms/elixir/config.mdx
@@ -71,11 +71,11 @@ The backend can also be configured to capture Logger metadata, which is detailed
 
 `client`
 
-: If you need different functionality for the HTTP client, you can define your own module that implements the `Sentry.HTTPClient` behaviour and set `client` to that module. Defaults to `Sentry.HackneyClient`.
+: If you need different functionality for the HTTP client, you can define your own module that implements the `Sentry.HTTPClient` [`behaviour`](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours) and set `client` to that module. Defaults to `Sentry.HackneyClient`.
 
 `filter`
 
-: Set this to a module that implements the `Sentry.EventFilter` behaviour if you would like to prevent certain exceptions from being sent. See below for further documentation. Defaults to excluding exceptions from `Sentry.PlugCapture` that match route not found exceptions from Phoenix and Plug.
+: Set this to a module that implements the `Sentry.EventFilter` [`behaviour`](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours) if you would like to prevent certain exceptions from being sent. See below for further documentation. Defaults to excluding exceptions from `Sentry.PlugCapture` that match route not found exceptions from Phoenix and Plug.
 
 `hackney_pool_max_connections`
 

--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -102,7 +102,7 @@ config :logger,
 
 ## Filtering Events
 
-If you would like to prevent certain exceptions, the `:filter` configuration option allows you to implement the `Sentry.EventFilter` behaviour. The first argument is the exception to be sent, and the second is the source of the event. `Sentry.PlugCapture` will have a source of `:plug`, and `Sentry.LoggerBackend` will have a source of `:logger`. If an exception does not come from either of those sources, the source will be nil unless the `:event_source` option is passed to `Sentry.capture_exception/2`.
+If you would like to prevent certain exceptions, the `:filter` configuration option allows you to implement the `Sentry.EventFilter` [`behaviour`](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours). The first argument is the exception to be sent, and the second is the source of the event. `Sentry.PlugCapture` will have a source of `:plug`, and `Sentry.LoggerBackend` will have a source of `:logger`. If an exception does not come from either of those sources, the source will be nil unless the `:event_source` option is passed to `Sentry.capture_exception/2`.
 
 A configuration like below will prevent sending `Phoenix.Router.NoRouteError` from `Sentry.PlugCapture`, but allows other exceptions to be sent.
 

--- a/src/platforms/elixir/usage.mdx
+++ b/src/platforms/elixir/usage.mdx
@@ -77,7 +77,7 @@ user: %{
 
 `event_source`
 
-: The source of the event. Used by the `Sentry.EventFilter` behaviour.
+: The source of the event. Used by the `Sentry.EventFilter` [`behaviour`](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours).
 
 ## Breadcrumbs
 

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -204,7 +204,7 @@ Caused by: LowLevelException
 
 Some frames are replaced by the `... N more` line as they are the same frames as in the enclosing exception.
 
-Similar behaviour is enabled by default in Sentry. To disable it, use the `stacktrace.hidecommon` option.
+A similar behavior is enabled by default in Sentry. To disable it, use the `stacktrace.hidecommon` option.
 
 ```
 stacktrace.hidecommon=false
@@ -268,7 +268,7 @@ The `ShutdownHook` could lead to memory leaks in an environment where the life c
 
 An example would be in a JEE environment where the application using Sentry could be deployed and undeployed regularly.
 
-To avoid this behaviour, it is possible to disable the graceful shutdown by setting the `buffer.gracefulshutdown` option:
+To avoid this behavior, it is possible to disable the graceful shutdown by setting the `buffer.gracefulshutdown` option:
 
 ```
 buffer.gracefulshutdown=false
@@ -298,7 +298,7 @@ The `ShutdownHook` could lead to memory leaks in an environment where the life c
 
 An example would be in a JEE environment where the application using Sentry could be deployed and undeployed regularly.
 
-To avoid this behaviour, it is possible to disable the graceful shutdown. This might lead to some log entries being lost if the log application doesn’t shut down the `SentryClient` instance nicely.
+To avoid this behavior, it is possible to disable the graceful shutdown. This might lead to some log entries being lost if the log application doesn’t shut down the `SentryClient` instance nicely.
 
 The option to do so is `async.gracefulshutdown`:
 

--- a/src/platforms/node/common/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/integrations/pluggable-integrations.mdx
@@ -14,7 +14,7 @@ Pluggable integrations are integrations that can be additionally enabled, to pro
 _Import name: `Sentry.Integrations.CaptureConsole`_
 
 This integration captures all `Console API` calls and redirects them to Sentry using `captureMessage` call.
-It then retriggers to preserve default native behaviour.
+It then retriggers to preserve default native behavior.
 
 Available options:
 

--- a/src/wizard/javascript/angular.md
+++ b/src/wizard/javascript/angular.md
@@ -62,7 +62,7 @@ import * as Sentry from '@sentry/angular';
 export class AppModule {}
 ```
 
-Additionally, `createErrorHandler` accepts a set of options that allows you to configure its behaviour. For more details see `ErrorHandlerOptions` interface in [our repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
+Additionally, `createErrorHandler` accepts a set of options that allows you to configure its behavior. For more details see `ErrorHandlerOptions` interface in [our repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
 
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->


### PR DESCRIPTION
We use US spelling in docs.

Note that for Elixir 'behaviour' is used as a technical term and thus preserved with a link to its definition.