### PR TITLE
fix: Transactions have spans

### DIFF
--- a/src/includes/performance-monitoring/configuration/koa.mdx
+++ b/src/includes/performance-monitoring/configuration/koa.mdx
@@ -101,9 +101,11 @@ app.on("error", (err, ctx) => {
 // the rest of your app
 ```
 
-**Subsequent manual child transactions**
+**Subsequent manual child spans**
 
-The following example creates a transaction for a part of the code that contains an expensive operation, and sends the result to Sentry, you will need to use the transaction stored in the context
+The following example creates a span for a part of the code that contains an
+expensive operation and sends the result to Sentry. You will need to use the
+transaction stored in the context.
 
 ```javascript
 const myMiddleware = async (ctx, next) => {


### PR DESCRIPTION
This is a terminology fix. The children of a transaction are spans, not
transaction themselves.