### PR TITLE
Document prohibition of forward slashes in environment name

### DIFF
--- a/src/docs/product/sentry-basics/environments/index.mdx
+++ b/src/docs/product/sentry-basics/environments/index.mdx
@@ -16,7 +16,7 @@ Environments are unique to each organization. Environment settings, however, are
 
 ## Creating Environments
 
-Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. The environment name can't contain newlines or spaces, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](#hidden-environments) them.
+Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. The environment name can't contain newlines, spaces or forward slashes, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](#hidden-environments) them.
 
 ```JavaScript
 Sentry.init({


### PR DESCRIPTION
Environment names with any forward slash characters in "/" will be rejected by Sentry, as per https://github.com/getsentry/sentry/issues/6595#issuecomment-349483277 .  

The forward slash is a natural delineator to use for hierarchical environment names, a new user who reads the documentation and submits environment names with forward slashes can be frustrated to discover later that they are not accepted.

This change extends the documentation to include the forward slash character along with the other documented forbidden characters in environment names.