### PR TITLE
ref(wizard): Remove pinned versions

### DIFF
--- a/src/platforms/node/express.mdx
+++ b/src/platforms/node/express.mdx
@@ -9,10 +9,10 @@ If you are using `yarn` or `npm`, you can add our package as a dependency:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node@5.20.1
+$ yarn add @sentry/node
 
 # Using npm
-$ npm install @sentry/node@5.20.1
+$ npm install @sentry/node
 ```
 
 Sentry should be initialized as early in your app as possible.

--- a/src/wizard/node/connect.md
+++ b/src/wizard/node/connect.md
@@ -9,10 +9,10 @@ If you are using `yarn` or `npm`, you can add our package as a dependency:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node@5.20.1
+$ yarn add @sentry/node
 
 # Using npm
-$ npm install @sentry/node@5.20.1
+$ npm install @sentry/node
 ```
 
 ```javascript

--- a/src/wizard/node/express.md
+++ b/src/wizard/node/express.md
@@ -9,10 +9,10 @@ If you are using `yarn` or `npm`, you can add our package as a dependency:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node@5.20.1
+$ yarn add @sentry/node
 
 # Using npm
-$ npm install @sentry/node@5.20.1
+$ npm install @sentry/node
 ```
 
 Sentry should be initialized as early in your app as possible.

--- a/src/wizard/node/index.md
+++ b/src/wizard/node/index.md
@@ -9,10 +9,10 @@ If you are using `yarn` or `npm` you can add our package as a dependency:
 
 ```bash
 # Using yarn
-$ yarn add @sentry/node@5.20.1
+$ yarn add @sentry/node
 
 # Using npm
-$ npm install @sentry/node@5.20.1
+$ npm install @sentry/node
 ```
 
 You need to inform the Sentry Node SDK about your DSN:


### PR DESCRIPTION
Don't pin a specific version to wizard docs -  we want to make sure that users are installing versions as recent as possible.