### PR TITLE
Update basics.mdx

### DIFF
--- a/src/platforms/javascript/common/config/basics.mdx
+++ b/src/platforms/javascript/common/config/basics.mdx
@@ -85,7 +85,24 @@ Transports are used to send events to Sentry. Transports can be customized to so
 
 `transport`
 
-: Switches out the transport used to send events. In JavaScript for example, it can be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
+: Switches out the transport used to send events. In JavaScript for example, it can be used to capture events.
+
+`transportOptions`
+
+: Can be used for a more complex setup such as a custom header or when you require a proxy for outbound requests.
+
+For example setting an authorization header in the `init()` method:
+
+```js
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  transportOptions: {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  },
+});
+```
 
 `shutdownTimeout`
 


### PR DESCRIPTION
This is my first contribution.

I had some trouble finding out how to set a custom header for an authorization token. As it seemed it was just an option that could be set I initially tried:

```js
// wrong example
Sentry.init({
  dsn: "___PUBLIC_DSN___",
  headers: {
      Authorization: `Bearer ${token}`,
    },
});
```
But that was not working.

Reading the documentation it seemed that 'transportation' can be used. However, in de code the following methods are available:

[transport](https://github.com/getsentry/sentry-javascript/blob/b7baedd94c960aa05db2f5bc8318335e18965ea1/packages/core/src/transports/noop.ts)
- sendEvent
- close

Instead, the transportOptions allow for changing the headers or proxy settings:

[transportOptions (typings)](https://github.com/getsentry/sentry-javascript/blob/b7baedd94c960aa05db2f5bc8318335e18965ea1/packages/types/src/transport.ts#L26)
- dsn
- headers
- httpProxy
- httpsProxy
- caCerts
- fetchParameters

So I added an example with the transportObjects object. 

What still would be a nice addition is a way for a user reading the documentation to find out what kind of options are available.