### PR TITLE
feat: Overhaul Java documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Returns the latest version of the given package.
 packages.version('sentry.javacript.browser')
 ```
 
+You may also optionally specify a fallback for if the package isnt found (or theres an upstream error):
+
+```javascript
+packages.version('sentry.javacript.browser', '1.0.0')
+```
+
 #### ``packages.checksum``
 
 Returns the checksum of a given file in a package.

--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -31,7 +31,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{version}'
+    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.android', '{version}') }}'
 }
 ```
 

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -11,7 +11,7 @@ The DSN is the first and most important thing to configure because it tells the 
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
-```{filename:sentry.properties}
+```text {filename:sentry.properties}
 dsn=___PUBLIC_DSN___
 ```
 

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -88,7 +88,7 @@ The SDK can also be configured by setting querystring parameters on the DSN itse
 Option names in the DSN exactly match the examples given below. For example, to enable sampling if you are setting your DSN via the environment:
 
 ```bash
-SENTRY_DSN=https://public:private@host:port/1?sample.rate=0.75 java -jar app.jar
+SENTRY_DSN={DSN}/1?sample.rate=0.75 java -jar app.jar
 ```
 
 You can, of course, pass this DSN in using the other methods described above.

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -11,7 +11,7 @@ The DSN is the first and most important thing to configure because it tells the 
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
-```text {filename:sentry.properties}
+```text {tabTitle:Properties File} {filename:sentry.properties}
 dsn=___PUBLIC_DSN___
 ```
 

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_order: 1
+sidebar_order: 2
 redirect_from:
   - /clients/java/config/
 ---
@@ -11,20 +11,20 @@ The DSN is the first and most important thing to configure because it tells the 
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
-```
-dsn=https://public:private@host:port/1
+```{filename:sentry.properties}
+dsn=___PUBLIC_DSN___
 ```
 
 Via the Java System Properties _(not available on Android)_:
 
-```bash
-java -Dsentry.dsn=https://public:private@host:port/1 -jar app.jar
+```bash {tabTitle:Java System Properties}
+java -Dsentry.dsn=___PUBLIC_DSN___ -jar app.jar
 ```
 
 Via a System Environment Variable _(not available on Android)_:
 
-```bash
-SENTRY_DSN=https://public:private@host:port/1 java -jar app.jar
+```bash {tabTitle:System Environment Variable}
+SENTRY_DSN=___PUBLIC_DSN___ java -jar app.jar
 ```
 
 In code:
@@ -32,7 +32,7 @@ In code:
 ```java
 import io.sentry.Sentry;
 
-Sentry.init("https://public:private@host:port/1");
+Sentry.init("___PUBLIC_DSN___");
 ```
 
 ## Configuration methods {#configuration-methods}

--- a/src/platforms/java/common/config.mdx
+++ b/src/platforms/java/common/config.mdx
@@ -76,7 +76,7 @@ The DSN itself can also be configured directly in code:
 ```java
 import io.sentry.Sentry;
 
-Sentry.init("https://public:private@host:port/1?option=value&other.option=othervalue");
+Sentry.init("___PUBLIC_DSN___");
 ```
 
 Sentry **will not** be able to do anything with events until this line is run, so this method of configuration is not recommended if you might have errors occur during startup. In addition, by passing a hardcoded DSN you are no longer able to override the DSN at runtime via Java System Properties or System Environment Variables.

--- a/src/platforms/java/common/migration.mdx
+++ b/src/platforms/java/common/migration.mdx
@@ -74,7 +74,7 @@ For example:
 
 ```properties
 # sentry.properties
-dsn=https://host:port/1?options
+dsn={DSN}?options
 release=1.0.0
 ```
 

--- a/src/platforms/java/guides/google-app-engine/index.mdx
+++ b/src/platforms/java/guides/google-app-engine/index.mdx
@@ -21,7 +21,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/google-app-engine/index.mdx
+++ b/src/platforms/java/guides/google-app-engine/index.mdx
@@ -12,29 +12,23 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-appengine</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry-appengine:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry-appengine" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-appengine" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-appengine%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-appengine).
 
 ### Usage
 

--- a/src/platforms/java/guides/google-app-engine/index.mdx
+++ b/src/platforms/java/guides/google-app-engine/index.mdx
@@ -43,7 +43,7 @@ The queue size and thread options will not be used as they are specific to the d
 By default, the default task queue will be used, but it’s possible to specify which one will be used with the `sentry.async.gae.queuename` option:
 
 ```
-http://public:private@host:port/1?async.gae.queuename=MyQueueName
+___PUBLIC_DSN___?async.gae.queuename=MyQueueName
 ```
 
 ### Connection Name
@@ -51,5 +51,5 @@ http://public:private@host:port/1?async.gae.queuename=MyQueueName
 As the queued tasks are sent across different instances of the application, it’s important to be able to identify which connection should be used when processing the event. To do so, the GAE module will identify each connection based on an identifier either automatically generated or user defined. To manually set the connection identifier (only used internally) use the option `sentry.async.gae.connectionid`:
 
 ```
-http://public:private@host:port/1?async.gae.connectionid=MyConnection
+___PUBLIC_DSN___?async.gae.connectionid=MyConnection
 ```

--- a/src/platforms/java/guides/google-app-engine/index.mdx
+++ b/src/platforms/java/guides/google-app-engine/index.mdx
@@ -43,7 +43,7 @@ The queue size and thread options will not be used as they are specific to the d
 By default, the default task queue will be used, but it’s possible to specify which one will be used with the `sentry.async.gae.queuename` option:
 
 ```
-___PUBLIC_DSN___?async.gae.queuename=MyQueueName
+{DSN}?async.gae.queuename=MyQueueName
 ```
 
 ### Connection Name
@@ -51,5 +51,5 @@ ___PUBLIC_DSN___?async.gae.queuename=MyQueueName
 As the queued tasks are sent across different instances of the application, it’s important to be able to identify which connection should be used when processing the event. To do so, the GAE module will identify each connection based on an identifier either automatically generated or user defined. To manually set the connection identifier (only used internally) use the option `sentry.async.gae.connectionid`:
 
 ```
-___PUBLIC_DSN___?async.gae.connectionid=MyConnection
+{DSN}?async.gae.connectionid=MyConnection
 ```

--- a/src/platforms/java/guides/log4j/index.mdx
+++ b/src/platforms/java/guides/log4j/index.mdx
@@ -19,7 +19,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry-log4j:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-log4j:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/log4j/index.mdx
+++ b/src/platforms/java/guides/log4j/index.mdx
@@ -10,29 +10,23 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry-log4j:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry-log4j:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry-log4j" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-log4j" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-log4j).
 
 ### Usage
 

--- a/src/platforms/java/guides/log4j2/index.mdx
+++ b/src/platforms/java/guides/log4j2/index.mdx
@@ -10,29 +10,23 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j2</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry-log4j2:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry-log4j2" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-log4j2" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j2%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-log4j2).
 
 ### Usage
 

--- a/src/platforms/java/guides/log4j2/index.mdx
+++ b/src/platforms/java/guides/log4j2/index.mdx
@@ -19,7 +19,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/logback/index.mdx
+++ b/src/platforms/java/guides/logback/index.mdx
@@ -10,29 +10,23 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-logback</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry-logback:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-logback" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-logback%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-logback).
 
 ### Usage
 

--- a/src/platforms/java/guides/logback/index.mdx
+++ b/src/platforms/java/guides/logback/index.mdx
@@ -19,7 +19,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/logging/index.mdx
+++ b/src/platforms/java/guides/logging/index.mdx
@@ -10,29 +10,23 @@ The source for `sentry` can be found [on GitHub](https://github.com/getsentry/se
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry).
 
 ### Usage
 

--- a/src/platforms/java/guides/logging/index.mdx
+++ b/src/platforms/java/guides/logging/index.mdx
@@ -19,7 +19,7 @@ The source for `sentry` can be found [on GitHub](https://github.com/getsentry/se
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/spring/index.mdx
+++ b/src/platforms/java/guides/spring/index.mdx
@@ -17,7 +17,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry-spring:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-spring:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/guides/spring/index.mdx
+++ b/src/platforms/java/guides/spring/index.mdx
@@ -8,29 +8,23 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tre
 
 ### Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
-compile 'io.sentry:sentry-spring:1.7.30'
+```groovy {tabTitle:Gradle}
+compile 'io.sentry:sentry-spring:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
-Using SBT:
-
-```scala
-libraryDependencies += "io.sentry" % "sentry-spring" % "1.7.30"
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-spring" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-spring%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-spring).
 
 ### Usage
 

--- a/src/platforms/java/index.mdx
+++ b/src/platforms/java/index.mdx
@@ -1,64 +1,16 @@
 ---
 title: Java
+sidebar_order: 0
 redirect_from:
   - /clients/java/
 ---
 
 Sentry for Java is a collection of modules provided by Sentry. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage](/platform/java/usage/) is another option.
 
-Using a framework or library? Take a look at our specific guides to get started.
-
 <GuideGrid platform="java" />
-
-## Configuration {#config}
-
-Use the configuration below in combination with any of the integrations from above. The configuration will only work after an integration is installed. After that, [set your DSN](#setting-the-dsn).
-
-### Setting the DSN (Data Source Name) {#setting-the-dsn}
-
-The DSN is the first and most important thing to configure because it tells the SDK where to send events. You can find your project’s DSN in the “Client Keys” section of your “Project Settings” in Sentry.
-
-In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
-
-```
-dsn=https://public:private@host:port/1
-```
-
-Via the Java System Properties _(not available on Android)_:
-
-```bash
-java -Dsentry.dsn=https://public:private@host:port/1 -jar app.jar
-```
-
-Via a System Environment Variable _(not available on Android)_:
-
-```bash
-SENTRY_DSN=https://public:private@host:port/1 java -jar app.jar
-```
-
-In code:
-
-```java
-import io.sentry.Sentry;
-
-Sentry.init("https://public:private@host:port/1");
-```
-
-### Configuration Methods
-
-There are multiple ways to configure the Java SDK, but all of them take the same options. See the [configuration methods documentation](/platforms/java/config/) for how to use each configuration method and how the option names might differ between them.
-
-## Next Steps
-
-- [Context & Breadcrumbs](/platforms/java/context/)
-- [Manual Usage](/platforms/java/usage/)
-- [Migration from Raven Java](/platforms/java/migration/)
 
 ## Resources
 
 - [Examples](https://github.com/getsentry/examples)
 - [Bug Tracker](http://github.com/getsentry/sentry-java/issues)
 - [Code](http://github.com/getsentry/sentry-java)
-- [Mailing List](https://groups.google.com/group/getsentry)
-- [IRC](irc://irc.freenode.net/sentry) (irc.freenode.net, #sentry)
-- [Travis CI](http://travis-ci.org/getsentry/sentry-java)

--- a/src/platforms/java/usage.mdx
+++ b/src/platforms/java/usage.mdx
@@ -1,15 +1,13 @@
 ---
 title: Manual Usage
-sidebar_order: 5
+sidebar_order: 1
 redirect_from:
   - /clients/java/usage/
 ---
 
 ## Installation
 
-Using Maven:
-
-```xml
+```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
@@ -17,19 +15,15 @@ Using Maven:
 </dependency>
 ```
 
-Using Gradle:
-
-```groovy
+```groovy {tabTitle:Gradle}
 compile 'io.sentry:sentry:1.7.30'
 ```
 
-Using SBT:
-
-```scala
+```scala {tabTitle:SBT}
 libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-spring).
 
 ## Capture an Error
 

--- a/src/platforms/java/usage.mdx
+++ b/src/platforms/java/usage.mdx
@@ -16,7 +16,7 @@ redirect_from:
 ```
 
 ```groovy {tabTitle:Gradle}
-compile 'io.sentry:sentry:1.7.30'
+implementation 'io.sentry:sentry:1.7.30'
 ```
 
 ```scala {tabTitle:SBT}

--- a/src/utils/packageRegistry.js
+++ b/src/utils/packageRegistry.js
@@ -8,19 +8,23 @@ module.exports = class PackageRegistry {
   getData = async name => {
     if (!this.cache[name]) {
       console.info(`Fetching release registry for ${name}`);
-      const result = await axios({
-        url: `https://release-registry.services.sentry.io/sdks/${name}/latest`,
-      });
-
-      this.cache[name] = result.data;
+      try {
+        const result = await axios({
+          url: `https://release-registry.services.sentry.io/sdks/${name}/latest`,
+        });
+        this.cache[name] = result.data;
+      } catch (err) {
+        console.error(`Unable to fetch registry for ${name}: ${err.message}`);
+        this.cache[name] = {};
+      }
     }
 
     return this.cache[name];
   };
 
-  version = async name => {
+  version = async (name, defaultValue = "") => {
     const data = await this.getData(name);
-    return data.version || "";
+    return data.version || defaultValue;
   };
 
   checksum = async (name, fileName, checksum) => {

--- a/src/wizard/java/android.md
+++ b/src/wizard/java/android.md
@@ -28,7 +28,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{version}'
+    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.android', '{version}') }}'
 }
 ```
 

--- a/src/wizard/java/appengine.md
+++ b/src/wizard/java/appengine.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-appengine</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-appengine:1.7.30'
+compile 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-appengine" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry-appengine" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-appengine%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/wizard/java/appengine.md
+++ b/src/wizard/java/appengine.md
@@ -20,7 +20,7 @@ Using Maven:
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-appengine:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -20,7 +20,7 @@ Using Maven:
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:1.7.30'
+compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
 
 ## Capture an Error
 

--- a/src/wizard/java/log4j.md
+++ b/src/wizard/java/log4j.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-log4j:1.7.30'
+compile 'io.sentry:sentry-log4j:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-log4j" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry-log4j" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/wizard/java/log4j2.md
+++ b/src/wizard/java/log4j2.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-log4j2</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-log4j2:1.7.30'
+compile 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-log4j2" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry-log4j2" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-log4j2%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/wizard/java/log4j2.md
+++ b/src/wizard/java/log4j2.md
@@ -20,7 +20,7 @@ Using Maven:
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:

--- a/src/wizard/java/logback.md
+++ b/src/wizard/java/logback.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-logback</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-logback:1.7.30'
+compile 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry-logback" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry-logback%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/wizard/java/logback.md
+++ b/src/wizard/java/logback.md
@@ -20,7 +20,7 @@ Using Maven:
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry-logback:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:

--- a/src/wizard/java/logging.md
+++ b/src/wizard/java/logging.md
@@ -13,23 +13,21 @@ Using Maven:
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
-    <version>1.7.30</version>
+    <version>{{ packages.version('sentry.java', '1.7.30') }}</version>
 </dependency>
 ```
 
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:1.7.30'
+compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:
 
 ```scala
-libraryDependencies += "io.sentry" % "sentry" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.java', '1.7.30') }}"
 ```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/#artifactdetails%7Cio.sentry%7Csentry%7C1.7.30%7Cjar).
 
 ### Usage
 

--- a/src/wizard/java/logging.md
+++ b/src/wizard/java/logging.md
@@ -20,7 +20,7 @@ Using Maven:
 Using Gradle:
 
 ```groovy
-compile 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
+implementation 'io.sentry:sentry:{{ packages.version('sentry.java', '1.7.30') }}'
 ```
 
 Using SBT:


### PR DESCRIPTION
- Support dynamic versions when available
- Remove invalid instructions on index - you need to use an integration
- Move manual usage under core Java (its the same as a guide)
- Add DSN placeholders
- Similar tweaks to Android
- Modernize Gradle instructions