### PR TITLE
feat: improvements to code tabs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "git.ignoreLimitWarning": true
 }

--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -169,15 +169,25 @@ function SpanWrapper(props): JSX.Element {
 
 type Props = {
   filename?: string;
+  language?: string;
+  title?: string;
   children: JSX.Element;
 };
 
-export default ({ filename, children }: Props): JSX.Element => {
+export default ({ filename, language, children }: Props): JSX.Element => {
   const [showCopied, setShowCopied] = useState(false);
   const codeRef = useRef(null);
 
   function copyCode() {
-    copy(codeRef.current.innerText);
+    let code = codeRef.current.innerText;
+    // don't copy leading prompt for bash
+    if (language === "bash" || language === "shell") {
+      const match = code.match(/^\$\s*/);
+      if (match) {
+        code = code.substr(match[0].length);
+      }
+    }
+    copy(code);
     setShowCopied(true);
     setTimeout(() => setShowCopied(false), 1200);
   }

--- a/src/css/_includes/code-blocks.scss
+++ b/src/css/_includes/code-blocks.scss
@@ -12,7 +12,7 @@
     border-radius: 3px 3px 0 0;
 
     button {
-      color: $white;
+      color: $desatPurple8;
       padding: 3px 6px;
       display: inline-block;
       cursor: pointer;
@@ -22,13 +22,10 @@
       outline: none;
 
       &.active,
-      &:focus {
-        color: $linkColor;
-      }
-
+      &:focus,
       &.only-choice {
-        color: $mediumPurple;
-        cursor: normal;
+        color: $white;
+        font-weight: 500;
       }
     }
   }

--- a/src/platforms/javascript/common/config/sourcemaps.mdx
+++ b/src/platforms/javascript/common/config/sourcemaps.mdx
@@ -34,8 +34,11 @@ Webpack is a powerful build tool that resolves and bundles your JavaScript modul
 
 We have created a convenient [Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) that configures source maps and uploads them to Sentry during the build. This process is the recommended one for uploading sources to Sentry:
 
-```shell
+```shell {tabTitle:npm}
 $ npm install --save-dev @sentry/webpack-plugin
+```
+
+```shell {tabTitle:yarn}
 $ yarn add --dev @sentry/webpack-plugin
 ```
 


### PR DESCRIPTION
This adds a few small improvements to code tabs:

* code blocks that are shell/bash now chop off the leading `$` for copy paste
* made the active selection less confusing (gray/white bold)
* separate a use of yarn/npm into tabs.

![image](https://user-images.githubusercontent.com/7396/91348382-f7d8e280-e7e3-11ea-9b54-e02bce87541f.png)
