### PR TITLE
ref(node): Small tweaks to Default Integrations page

### DIFF
--- a/src/platforms/node/common/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/integrations/default-integrations.mdx
@@ -5,12 +5,18 @@ redirect_from:
   - /platforms/node/default-integrations/
 ---
 
-System integrations are integrations enabled by default that combine into the
+System integrations are integrations enabled by default that hook into the
 standard library or the interpreter itself. They're documented so you can see
-what they do and that they can be disabled if they cause issues. To disable
-system integrations set `defaultIntegrations: false` when calling `init()`.
-To override their settings, provide a new instance with your config
-to `integrations` option. For example: to change fatal error handler
+what they do and know how to disable them if they cause issues. 
+
+To disable _all_ default integrations, set `defaultIntegrations: false` when calling `init()`.
+
+To disable just one integration, provide a filtered list to the `integrations` option when calling `init()`.
+For example, to disable the `Console` integration:
+`integrations: defaults => defaults.filter(integration => integration.name !== 'Console')`.
+
+To override an integration's settings, provide a new instance to the `integrations` option when calling `init()`.
+For example, to change the fatal error handler:
 `integrations: [new Sentry.Integrations.OnUncaughtException({ onFatalError: () => { /** your implementation */ } })]`.
 
 ## Core
@@ -19,30 +25,40 @@ to `integrations` option. For example: to change fatal error handler
 
 _Import name: `Sentry.Integrations.InboundFilters`_
 
-This integration allows developers to ignore specific errors based on the type of message, as well as deny/allow URLs from which the exception originated.
-Keep in mind that denyUrl and allowUrl work only for captured exceptions, not raw message events.
+This integration allows developers to ignore specific errors based on the error message or the URL from which the exception originated.
 
-To configure it, use `ignoreErrors`, `denyUrls` and `allowUrls` SDK options directly.
+To configure it, use the `ignoreErrors`, `denyUrls`, and `allowUrls` SDK options directly. 
+(Keep in mind that `denyUrls` and `allowUrls` only work for captured exceptions, not raw message events.)
 
 ### FunctionToString
 
 _Import name: `Sentry.Integrations.FunctionToString`_
 
-This integration allows the SDK to provide original functions and method names, even when they are wrapped by our error or breadcrumbs handlers.
+This integration allows the SDK to provide original function and method names, even when those functions or methods 
+are wrapped by our error or breadcrumb handlers.
 
-## Node specific
+## Node-specific
 
 ### Console
 
 _Import name: `Sentry.Integrations.Console`_
 
-This integration wraps the `console` module to treat all its calls as breadcrumbs.
+This integration wraps the `console` module in order to record all of its calls as breadcrumbs.
 
 ### Http
 
 _Import name: `Sentry.Integrations.Http`_
 
-This integration wraps `http` and `https` modules to capture all network requests as breadcrumbs.
+This integration wraps `http` and `https` modules to capture all network requests as breadcrumbs and/or tracing spans.
+
+Available options:
+
+```js
+{
+  breadcrumbs: boolean; // default: true
+  tracing: boolean; // default: false
+}
+```
 
 ### OnUncaughtException
 
@@ -62,13 +78,13 @@ Available options:
 
 _Import name: `Sentry.Integrations.OnUnhandledRejection`_
 
-This integration attaches global unhandled rejection handlers. By default, all unhandled rejections trigger a warning and log the error. You can change this behavior using the `mode` option, which is in line with Node's CLI options: https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+This integration attaches a global unhandled rejection handler. By default, all unhandled rejections trigger a warning and log the error. You can change this behavior using the `mode` option, which is in line with Node's CLI options: https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode.
 
 Available options:
 
 ```js
 {
-  mode: "none" | "warn" | "strict";
+  mode: "none" | "warn" | "strict"; // default: "warn"
 }
 ```
 
@@ -76,13 +92,13 @@ Available options:
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows you to configure linked errors. They'll be recursively read up to a specified limit and lookup will be performed by a specific key. By default, the limit sets to 5 and the key used is `cause`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit and lookup will be performed by a specific key. By default, the limit is set to 5 and the key used is `"cause"`.
 
 Available options:
 
 ```js
 {
-  key: string;
-  limit: number;
+  key: string; // default: "cause"
+  limit: number; // default: 5
 }
 ```

--- a/src/platforms/node/common/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/integrations/default-integrations.mdx
@@ -11,7 +11,10 @@ what they do and know how to disable them if they cause issues.
 
 To disable _all_ default integrations, set `defaultIntegrations: false` when calling `init()`.
 
-To disable just one integration, provide a filtered list to the `integrations` option when calling `init()`.
+To disable one or more of the default integrations, pass in a function to the
+`integrations` option when calling `init()`. The function should take an array
+of default integrations and return a filtered array, excluding the integrations
+you do not want to use.
 For example, to disable the `Console` integration:
 `integrations: defaults => defaults.filter(integration => integration.name !== 'Console')`.
 


### PR DESCRIPTION
The only substantive changes here are:

1) To list out the options for the `http` integration
2) To provide default option values as comments in the code
3) To demonstrate how to disable a single integration

Other than that, it's just cleaning up the language a bit.