### PR TITLE
fix: android version placeholder

### DIFF
--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -31,7 +31,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.android', '{version}') }}'
+    implementation 'io.sentry:sentry-android:{version}'
 }
 ```
 

--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -31,7 +31,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
+    implementation 'io.sentry:sentry-android:{version}'
 }
 ```
 
@@ -549,7 +549,7 @@ compileOptions {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android-core:{{% packages.version('sentry.android', '{version}') }}'
+    implementation 'io.sentry:sentry-android-core:{version}'
 }
 ```
 

--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -31,7 +31,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{version}'
+    implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
 }
 ```
 

--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -549,7 +549,7 @@ compileOptions {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android-core:{version}'
+    implementation 'io.sentry:sentry-android-core:{{% packages.version('sentry.android', '{version}') }}'
 }
 ```
 

--- a/src/platforms/android/timber.mdx
+++ b/src/platforms/android/timber.mdx
@@ -20,8 +20,8 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-android/
    Using Gradle:
 
    ```groovy
-   implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
-   implementation 'io.sentry:sentry-android-timber:{{% packages.version('sentry.android', '{version}') }}' // version >= 2.2.0
+   implementation 'io.sentry:sentry-android:{version}'
+   implementation 'io.sentry:sentry-android-timber:{version}' // version >= 2.2.0
    ```
 
 3. Initialize and add the `SentryTimberIntegration`

--- a/src/platforms/android/timber.mdx
+++ b/src/platforms/android/timber.mdx
@@ -20,8 +20,8 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-android/
    Using Gradle:
 
    ```groovy
-   implementation 'io.sentry:sentry-android:{version}'
-   implementation 'io.sentry:sentry-android-timber:{version}' // version >= 2.2.0
+   implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
+   implementation 'io.sentry:sentry-android-timber:{{% packages.version('sentry.android', '{version}') }}' // version >= 2.2.0
    ```
 
 3. Initialize and add the `SentryTimberIntegration`

--- a/src/wizard/java/android.md
+++ b/src/wizard/java/android.md
@@ -28,7 +28,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{version}'
+    implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
 }
 ```
 

--- a/src/wizard/java/android.md
+++ b/src/wizard/java/android.md
@@ -28,7 +28,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{{% packages.version('sentry.android', '{version}') }}'
+    implementation 'io.sentry:sentry-android:{version}'
 }
 ```
 

--- a/src/wizard/java/android.md
+++ b/src/wizard/java/android.md
@@ -28,7 +28,7 @@ android {
 // ADD SENTRY ANDROID AS A DEPENDENCY
 dependencies {
     // https://github.com/getsentry/sentry-android/releases
-    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.android', '{version}') }}'
+    implementation 'io.sentry:sentry-android:{version}'
 }
 ```
 


### PR DESCRIPTION
the expression implementation 'io.sentry:sentry-android:`{{% packages.version('sentry.android', '{version}') }}'` is not being executed, so the dependency is wrong like the plain text mentioned above, the syntax looks good though, not sure what's happening, it should take the 2nd argument which is `{version}`.