### PR TITLE
Fix: Capitalize the S in JavaScript

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -18,7 +18,7 @@ Supported SDKs for Tracing
 - JavaScript Browser SDK ≥ 5.16.0
 - JavaScript Node SDK ≥ 5.16.0
 - Python SDK version ≥ 0.11.2
-- Javascript React SDK ≥ 5.18.1
+- JavaScript React SDK ≥ 5.18.1
 
 </markdown>
 </Alert>

--- a/src/platforms/javascript/guides/angular/index.mdx
+++ b/src/platforms/javascript/guides/angular/index.mdx
@@ -49,7 +49,7 @@ Once this is done, all uncaught exceptions are automatically reported to Sentry.
 
 ### Automatically Send Errors with `ErrorHandler`
 
-`@sentry/angular` exports a function to instantiate an `ErrorHandler` provider that will automatically send Javascript errors captured by the Angular's error handler.
+`@sentry/angular` exports a function to instantiate an `ErrorHandler` provider that will automatically send JavaScript errors captured by the Angular's error handler.
 
 ```javascript
 import { NgModule, ErrorHandler } from "@angular/core";

--- a/src/wizard/javascript/angular.md
+++ b/src/wizard/javascript/angular.md
@@ -41,7 +41,7 @@ On its own, `@sentry/angular` will report any uncaught exceptions triggered by y
 
 ### ErrorHandler
 
-`@sentry/angular` exports a function to instantiate `ErrorHandler` provider that will automatically send Javascript errors captured by the Angular's error handler.
+`@sentry/angular` exports a function to instantiate `ErrorHandler` provider that will automatically send JavaScript errors captured by the Angular's error handler.
 
 ```javascript
 import { NgModule, ErrorHandler } from '@angular/core';


### PR DESCRIPTION
This is an arbitrary change (but an improvement) to trigger a clean vercel build.