### PR TITLE
Fix: Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,10 @@ require("dotenv").config({
   path: `.env.${activeEnv}`,
 });
 
-if (process.env.BRANCH_NAME === "master" && process.env.ALGOLIA_ADMIN_KEY) {
+if (
+  process.env.VERCEL_GITHUB_COMMIT_REF === "master" &&
+  process.env.ALGOLIA_ADMIN_KEY
+) {
   process.env.ALGOLIA_INDEX = "1";
 }
 


### PR DESCRIPTION
Algolia was previously configured to use a Freight variable, but now that we're on Vercel we need to use the current git ref they provide.