### PR TITLE
Add missing note to guide

### DIFF
--- a/src/docs/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/accounts/quotas/manage-event-stream-guide.mdx
@@ -80,6 +80,10 @@ You've been alerted on a new error in your code? Jump into the issue page to get
 
 ### Delete & Discard
 
+<Alert level="info">
+  Delete and Discard is available on the Business plan.
+</Alert>
+
 If there is an irrelevant reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the issue details page by clicking `Delete and discard future events`. This will remove the issue and event data from Sentry and filter out future matching events.
 
 ![Delete and Discard](manage-event-stream-06.png)


### PR DESCRIPTION
Delete and discard is available only for business plan users; the guide is not clear about this.