### PR TITLE
fix(gcf): add trailing list bracket to examples

### DIFF
--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -11,7 +11,7 @@ _(New in version 0.17.0)_
 Install our Sentry SDK in the `requirements.txt` section:
 
 ```text {filename:requirements.txt}
-sentry_sdk
+sentry_sdk>=0.17.0
 ```
 
 ## Configure
@@ -27,7 +27,7 @@ sentry_sdk.init(
     integrations=[GcpIntegration()],
 )
 
-def my_function(event, context):
+def http_function_entrypoint(request):
     # ...
 ```
 

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -8,10 +8,10 @@ _(New in version 0.17.0)_
 
 ## Install
 
-Install our Sentry SDK in the `requirements.txt` section:
+Install our Python SDK using `pip`:
 
-```text {filename:requirements.txt}
-sentry_sdk>=0.17.0
+```bash
+$ pip install --upgrade sentry-sdk
 ```
 
 ## Configure

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -24,7 +24,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 def my_function(event, context):
@@ -46,7 +46,7 @@ Timeout warning reports an issue when function execution time is about to expire
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    integrations=[GcpIntegration(timeout_warning=True)]
+    integrations=[GcpIntegration(timeout_warning=True)],
 )
 ```
 

--- a/src/wizard/python/pythongcpfunctions.md
+++ b/src/wizard/python/pythongcpfunctions.md
@@ -19,7 +19,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 def my_function(event, context):
@@ -33,7 +33,7 @@ Update the sentry initialization to set ```timeout_warning``` to ```true```
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    integrations=[GcpIntegration(timeout_warning=True)]
+    integrations=[GcpIntegration(timeout_warning=True)],
 )
 ```
 The timeout warning is sent only if the "timeout" in the GCP Funtion configuration is set to a value greater than one second.

--- a/src/wizard/python/pythongcpfunctions.md
+++ b/src/wizard/python/pythongcpfunctions.md
@@ -5,10 +5,10 @@ support_level: production
 type: framework
 ---
 
-Install our Sentry SDK in the `requirements.txt` section:
+Install our Python SDK using `pip`:
 
-```python
-sentry_sdk>=0.17.0
+```bash
+$ pip install --upgrade sentry-sdk
 ```
 
 You can use the GCP Functions integration for the Python SDK like this:

--- a/src/wizard/python/pythongcpfunctions.md
+++ b/src/wizard/python/pythongcpfunctions.md
@@ -8,7 +8,7 @@ type: framework
 Install our Sentry SDK in the `requirements.txt` section:
 
 ```python
-sentry_sdk
+sentry_sdk>=0.17.0
 ```
 
 You can use the GCP Functions integration for the Python SDK like this:
@@ -22,7 +22,7 @@ sentry_sdk.init(
     integrations=[GcpIntegration()],
 )
 
-def my_function(event, context):
+def http_function_entrypoint(request):
     ...
 ```
 


### PR DESCRIPTION
See https://github.com/getsentry/examples/pull/54.

Also, `event, context` is the pubsub entrypoint signature, which isn't what most people use. I changed it to http for a more popular example.

And pinned `sentry_sdk>=0.17.0` just to be extra correct.