### PR TITLE
Fix: typo in Ruby "Context" link

### DIFF
--- a/src/platforms/ruby/index.mdx
+++ b/src/platforms/ruby/index.mdx
@@ -98,7 +98,7 @@ Raven.tags_context interesting: 'yes'
 Raven.extra_context happiness: 'very'
 ```
 
-For more information, see [_Context_](/platform/ruby/context/).
+For more information, see [_Context_](/platforms/ruby/context/).
 
 Resources:
 


### PR DESCRIPTION
`/platforms/` plural.