### PR TITLE
fix: /platform/ -> /platforms/

### DIFF
--- a/src/platforms/java/index.mdx
+++ b/src/platforms/java/index.mdx
@@ -4,7 +4,7 @@ redirect_from:
   - /clients/java/
 ---
 
-Sentry for Java is a collection of modules provided by Sentry. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage](/platform/java/usage/) is another option.
+Sentry for Java is a collection of modules provided by Sentry. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the library or framework integrations listed under Installation. Otherwise, [manual usage](/platforms/java/usage/) is another option.
 
 <GuideGrid platform="java" />
 

--- a/src/platforms/ruby/index.mdx
+++ b/src/platforms/ruby/index.mdx
@@ -20,8 +20,6 @@ Sentry captures data by using an SDK within your application’s runtime. Sentry
 gem "sentry-raven"
 ```
 
-For other means of installation see [_Installation_](/platform/ruby/install/).
-
 ### Development Version
 
 To install the development version from GitHub:
@@ -60,9 +58,9 @@ end
 
 ## Reporting Failures
 
-If you use Rails, Rake, Sidekiq, etc, you’re already done - no more configuration required! Check [_Integrations_](/platform/ruby/integrations/) for more details on other gems Sentry integrates with automatically.
+If you use Rails, Rake, Sidekiq, etc, you’re already done - no more configuration required! Check [_Integrations_](/platforms/ruby/integrations/) for more details on other gems Sentry integrates with automatically.
 
-Rack requires a little more setup: [_Rack (Sinatra etc.)_](/platform/ruby/guides/rack/)
+Rack requires a little more setup: [_Rack (Sinatra etc.)_](/platforms/ruby/guides/rack/)
 
 Otherwise, Raven supports two methods of capturing exceptions:
 

--- a/src/wizard/ruby/index.md
+++ b/src/wizard/ruby/index.md
@@ -1,6 +1,6 @@
 ---
 name: Ruby
-doc_link: https://docs.sentry.io/platform/ruby/
+doc_link: https://docs.sentry.io/platforms/ruby/
 support_level: production
 type: language
 ---
@@ -12,8 +12,6 @@ Raven Ruby comes as a gem and is straightforward to install. If you are using Bu
 ```ruby
 gem "sentry-raven"
 ```
-
-For other means of installation see [_Installation_](/platform/ruby/install/).
 
 ## Configuration {#configure}
 
@@ -27,9 +25,9 @@ end
 
 ## Reporting Failures
 
-If you use Rails, Rake, Sidekiq, etc, you’re already done - no more configuration required! Check [_Integrations_](/platform/ruby/integrations/) for more details on other gems Sentry integrates with automatically.
+If you use Rails, Rake, Sidekiq, etc, you’re already done - no more configuration required! Check [_Integrations_](/platforms/ruby/integrations/) for more details on other gems Sentry integrates with automatically.
 
-Rack requires a little more setup: [_Rack (Sinatra etc.)_](/platform/ruby/integrations/#rack-sinatra-etc)
+Rack requires a little more setup: [_Rack (Sinatra etc.)_](/platforms/ruby/guides/rack/)
 
 Otherwise, Raven supports two methods of capturing exceptions:
 

--- a/src/wizard/ruby/rack.md
+++ b/src/wizard/ruby/rack.md
@@ -1,6 +1,6 @@
 ---
 name: Rack
-doc_link: https://docs.sentry.io/platform/ruby/guides/rack/
+doc_link: https://docs.sentry.io/platforms/ruby/guides/rack/
 support_level: production
 type: framework
 ---

--- a/src/wizard/ruby/rails.md
+++ b/src/wizard/ruby/rails.md
@@ -1,6 +1,6 @@
 ---
 name: Rails
-doc_link: https://docs.sentry.io/platform/ruby/guides/rails/
+doc_link: https://docs.sentry.io/platforms/ruby/guides/rails/
 support_level: production
 type: framework
 ---
@@ -19,7 +19,7 @@ gem "sentry-raven"
 
 ### Configuration
 
-Open up `config/application.rb` and configure the DSN, and any other [_settings_](/platform/ruby/guides/rails/config/) you need:
+Open up `config/application.rb` and configure the DSN, and any other [_settings_](/platforms/ruby/guides/rails/config/) you need:
 
 ```ruby
 Raven.configure do |config|


### PR DESCRIPTION
This was incorrectly changed from `/clients/` to `/platform/` in e9462c722de66c8485681755dd0502c987293b8c, missing the 's'.

Links to `.../ruby/install/` are removed because the content apparently doesn't exist.

Follows up on #2128.