### PR TITLE
ref: Remove unused markdown tableOfContents

### DIFF
--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -33,7 +33,6 @@ type Props = {
   data?: {
     file?: {
       childMarkdownRemark?: {
-        tableOfContents?: any;
         [key: string]: any;
       };
       childMdx?: {

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -20,7 +20,6 @@ export const pageQuery = graphql`
       sourceInstanceName
       childMarkdownRemark {
         html
-        tableOfContents
         internal {
           type
         }

--- a/src/templates/platform.js
+++ b/src/templates/platform.js
@@ -50,7 +50,6 @@ export const pageQuery = graphql`
       sourceInstanceName
       childMarkdownRemark {
         html
-        tableOfContents
         internal {
           type
         }


### PR DESCRIPTION
It returns a string - which is unexpected and incompatible with our TOC component.