### PR TITLE
Fix/gcp python intall

### DIFF
--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -4,7 +4,7 @@ redirect_from:
   - /platforms/python/gcp_functions/
 ---
 
-_(New in version 0.17.0)_
+_(New in version 0.17.1)_
 
 ## Install
 
@@ -50,7 +50,7 @@ sentry_sdk.init(
 )
 ```
 
-The timeout warning is sent only if the "timeout" in the GCP Funtion configuration is set to a value greater than one second.
+The timeout warning is sent only if the "timeout" in the GCP Function configuration is set to a value greater than one second.
 
 ## Behavior
 

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -11,7 +11,7 @@ _(New in version 0.17.1)_
 Add the Sentry SDK to your `requirements.txt`:
 
 ```text {filename:requirements.txt}
- sentry_sdk>=0.17.1
+ sentry-sdk>=0.17.1
 ```
 
 ## Configure

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -8,10 +8,10 @@ _(New in version 0.17.1)_
 
 ## Install
 
-Install our Python SDK using `pip`:
+Install our Sentry SDK in the `requirements.txt` section:
 
-```bash
-$ pip install --upgrade sentry-sdk
+```text {filename:requirements.txt}
+ sentry_sdk>=0.17.1
 ```
 
 ## Configure

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -8,7 +8,7 @@ _(New in version 0.17.1)_
 
 ## Install
 
-Install our Sentry SDK in the `requirements.txt` section:
+Add the Sentry SDK to your `requirements.txt`:
 
 ```text {filename:requirements.txt}
  sentry_sdk>=0.17.1


### PR DESCRIPTION
Minor fix - instructions on how to setup sentry for gap integration