### PR TITLE
Fix links in quotas and guide

### DIFF
--- a/src/docs/accounts/quotas/index.mdx
+++ b/src/docs/accounts/quotas/index.mdx
@@ -50,11 +50,11 @@ In addition, depending on your project’s configuration and the plan you subscr
 
 6. **Rate limit for the project**
 
-   If the error event rate limit for the project has been exceeded, and your subscription allows, the event will not be counted. For more information, see [Rate Limiting in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#4-rate-limiting) or [Rate Limiting Projects](/accounts/quotas/#id1).
+   If the error event rate limit for the project has been exceeded, and your subscription allows, the event will not be counted. For more information, see [Rate Limiting in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or [Error Event Limits](/accounts/quotas/#error-event-limits).
 
 7. **Inbound filters**
 
-   If any inbound filter is set for this type of error event, and your subscription allows, the event will not be counted. For more information, see [Inbound Filters in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#inbound-data-filters) or [Inbound Data Filter](/accounts/quotas/#inbound-data-filters).
+   If any inbound filter is set for this type of error event, and your subscription allows, the event will not be counted. For more information, see [Inbound Filters in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#3-inbound-data-filters) or [Inbound Data Filter](/accounts/quotas/#inbound-data-filters).
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 

--- a/src/docs/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/accounts/quotas/manage-event-stream-guide.mdx
@@ -52,7 +52,7 @@ Check out additional configuration options with the [TryCatch](/platforms/javasc
 
 ## 3. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project under `[Project Settings] > Inbound Filters > Data Filters`. For more information, see [Inbound Filters](/accounts/quotas/#inbound-data-filters) and [Manage Your Flow of Errors Using Inbound Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters)
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project under `[Project Settings] > Inbound Filters > Data Filters`. For more information, see [Inbound Filters](/accounts/quotas/#3-inbound-data-filters) and [Manage Your Flow of Errors Using Inbound Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters)
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the Inbound Data Filters view.
 


### PR DESCRIPTION
The links between the guide and the quotas content weren't quite correct. This PR fixes the links Tony identified as broken.