### PR TITLE
cocoa sdk ios v9

### DIFF
--- a/src/platforms/cocoa/index.mdx
+++ b/src/platforms/cocoa/index.mdx
@@ -15,7 +15,7 @@ The SDK can be installed using [CocoaPods](http://cocoapods.org), [Carthage](htt
 
 Support for
 
-- iOS >= 8.0
+- iOS >= 9.0
 - tvOS >= 9.0
 - macOS >= 10.10
 - watchOS >= 2.0 with limited symbolication support and no hard crashes


### PR DESCRIPTION
We've bumped the min version to iOS v9 for the next release of Sentry cocoa (6.0

https://github.com/getsentry/sentry-cocoa/pull/669