### PR TITLE
Document backtrace option for capture_messsage

### DIFF
--- a/src/platforms/ruby/common/usage.mdx
+++ b/src/platforms/ruby/common/usage.mdx
@@ -88,6 +88,18 @@ With calls to `capture_exception` or `capture_message` additional data can be su
 }
 ```
 
+`backtrace`
+
+: Stack trace to attach to this event.  Must be an array of strings; usually `caller` (the current stack trace).
+
+```ruby
+{
+    :backtrace => caller # (or any other array of strings representing a backtrace)
+}
+```
+
+Note: `capture_exception` will take the backtrace from the exception, by default, if available.
+
 `fingerprint`
 
 : The fingerprint for grouping this event.


### PR DESCRIPTION
This is a PR to replace #766 which is outdated.

Documents solution to the issue in getsentry/raven-ruby#139

(Hoping someone can merge it before this one rots! 🙏 🤞 )