### PR TITLE
feat: Add redirects for legacy pages which no longer exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ Something that applies to all platforms, but not javascript or node.
 
 Note: This currently causes issues with tableOfContents generation, so its recommended to disable the TOC when using it.
 
+### PlatformRedirectLink
+
+Useful for linking to platform-specific content when there's not a specific platform already selected.
+
+```javascript
+
+<PlatformRedirectLink to="/enriching-error-data/" />
+```
+
+This will direct them to a page where they can choose the platform, and then to the appropriate link.
+
 ## Linting
 
 We use prettier to format our code. Run prettier if you get linting errors in CI.

--- a/src/components/__tests__/__snapshots__/platformRedirectLink.test.js.snap
+++ b/src/components/__tests__/__snapshots__/platformRedirectLink.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlatformRedirectLink renders with to 1`] = `
+<a
+  className=""
+  href="/platform-redirect/?next=%2Fenriching-error-data%2F"
+/>
+`;
+
+exports[`PlatformRedirectLink renders without to 1`] = `
+<a
+  className=""
+  href="/platform-redirect/"
+/>
+`;

--- a/src/components/__tests__/platformRedirectLink.test.js
+++ b/src/components/__tests__/platformRedirectLink.test.js
@@ -1,0 +1,20 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import PlatformRedirectLink from "../platformRedirectLink";
+
+describe("PlatformRedirectLink", () => {
+  it("renders with to", () => {
+    const tree = renderer
+      .create(<PlatformRedirectLink to="/enriching-error-data/" />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders without to", () => {
+    const tree = renderer.create(<PlatformRedirectLink />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -48,21 +48,23 @@ export const Breadcrumbs = ({
   let currentPath = location.pathname;
   if (currentPath.substr(currentPath.length - 1) !== "/")
     currentPath = currentPath += "/";
-  let rootNode = nodes.find(n => n.path === currentPath);
+  const rootNode = nodes.find(n => n.path === currentPath);
   if (!rootNode) {
     console.warn(`Cant find root node for breadcrumbs: ${currentPath}`);
     return null;
   }
-  let trailNodes = nodes.filter(n => rootNode.path.indexOf(n.path) === 0);
+  const trailNodes = nodes.filter(n => rootNode.path.indexOf(n.path) === 0);
 
   return (
     <ul className="breadcrumb" style={{ margin: 0 }}>
       {trailNodes
         .sort((a, b) => a.path.localeCompare(b.path))
         .map(n => {
+          const title = getTitle(n);
+          if (!title) return null;
           return (
             <li className="breadcrumb-item" key={n.id}>
-              <SmartLink to={n.path}>{getTitle(n)}</SmartLink>
+              <SmartLink to={n.path}>{title}</SmartLink>
             </li>
           );
         })}

--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -130,13 +130,12 @@ const getPlatformFromLocation = (
 
   if (!location) return [null, false];
 
-  const qsPlatform = parse(location.search).platform;
-  let qsMatch: [string, string | null];
-  if (qsPlatform instanceof Array) {
-    qsMatch = normalizeSlug(qsPlatform[0]).split(".", 2) as [string, null];
-  } else {
-    qsMatch = normalizeSlug(qsPlatform || "").split(".", 2) as [string, null];
-  }
+  const qsPlatform = parse(location.search, { arrayFormat: "none" })
+    .platform as string | null;
+  const qsMatch = normalizeSlug(qsPlatform || "").split(".", 2) as [
+    string,
+    null
+  ];
 
   return [qsMatch ?? null, false];
 };

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -15,6 +15,7 @@ import JsCdnTag from "./jsCdnTag";
 import PageGrid from "./pageGrid";
 import ParamTable from "./paramTable";
 import PlatformContent from "./platformContent";
+import PlatformRedirectLink from "./platformRedirectLink";
 import PlatformSection from "./platformSection";
 
 const mdxComponents = {
@@ -30,6 +31,7 @@ const mdxComponents = {
   PageGrid,
   ParamTable,
   PlatformContent,
+  PlatformRedirectLink,
   PlatformSection,
 };
 

--- a/src/components/platformGrid.tsx
+++ b/src/components/platformGrid.tsx
@@ -1,28 +1,9 @@
 import React from "react";
-import { useStaticQuery, graphql } from "gatsby";
 import styled from "@emotion/styled";
 
 import PlatformIcon from "./platformIcon";
 import SmartLink from "./smartLink";
-
-const query = graphql`
-  query PlatformGridQuery {
-    allPlatform {
-      nodes {
-        key
-        name
-        title
-        url
-        guides {
-          key
-          name
-          title
-          url
-        }
-      }
-    }
-  }
-`;
+import { usePlatformList } from "./hooks/usePlatform";
 
 const PlatformCell = styled.div`
   display: flex;
@@ -79,10 +60,12 @@ const GuideList = styled.div`
   }
 `;
 
-export default (): JSX.Element => {
-  const {
-    allPlatform: { nodes: platformList },
-  } = useStaticQuery(query);
+type Props = {
+  noGuides: boolean;
+};
+
+export default ({ noGuides = false }: Props): JSX.Element => {
+  const platformList = usePlatformList();
   return (
     <div className="row">
       {platformList
@@ -104,15 +87,17 @@ export default (): JSX.Element => {
                     <h4>{platform.title}</h4>
                   </SmartLink>
 
-                  <GuideList>
-                    {platform.guides.map(guide => {
-                      return (
-                        <SmartLink to={guide.url} key={guide.key}>
-                          {guide.title}
-                        </SmartLink>
-                      );
-                    })}
-                  </GuideList>
+                  {!noGuides && (
+                    <GuideList>
+                      {platform.guides.map(guide => {
+                        return (
+                          <SmartLink to={guide.url} key={guide.key}>
+                            {guide.title}
+                          </SmartLink>
+                        );
+                      })}
+                    </GuideList>
+                  )}
                 </PlatformCellContent>
               </PlatformCell>
             </div>

--- a/src/components/platformRedirectLink.tsx
+++ b/src/components/platformRedirectLink.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import SmartLink from "./smartLink";
+
+type Props = {
+  to?: string;
+  children: JSX.Element;
+};
+
+export default ({ children, to }: Props): JSX.Element => {
+  let path = `/platform-redirect/`;
+  if (to) path += `?next=${encodeURIComponent(to)}`;
+  return <SmartLink to={path}>{children}</SmartLink>;
+};

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -74,6 +74,11 @@ export const PlatformSidebar = ({
         title={`Sentry for ${(guide || platform).title}`}
         showDepth={1}
         prependLinks={[[`/${pathRoot}/`, "Getting Started"]]}
+        exclude={[
+          `/${pathRoot}/enriching-error-data/`,
+          `/${pathRoot}/data-management/`,
+          `/${pathRoot}/guides/`,
+        ]}
       />
       <DynamicNav
         root={`/${pathRoot}/enriching-error-data`}

--- a/src/pages/platform-redirect.tsx
+++ b/src/pages/platform-redirect.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from "react";
+import { useNavigate, useLocation } from "@reach/router";
+import { parse } from "query-string";
+
+import Layout from "../components/layout";
+import PlatformIcon from "../components/platformIcon";
+import SmartLink from "../components/smartLink";
+import { usePlatformList } from "../components/hooks/usePlatform";
+
+type Props = {
+  path?: string;
+};
+
+const PlatformRedirect = ({ path = "/" }: Props) => {
+  const platformList = usePlatformList();
+
+  return (
+    <Layout>
+      <h1>Content Moved</h1>
+      <p>
+        The page you are looking for has been moved. Select your platform below
+        and we&apos;ll direct you to the most up-to-date documentation on it.
+      </p>
+
+      <ul>
+        {platformList.map(platform => (
+          <li key={platform.key}>
+            <SmartLink to={`/platforms/${platform.key}${path}`}>
+              <PlatformIcon
+                size={16}
+                platform={platform.key}
+                style={{ marginRight: "0.5rem" }}
+              />
+              <h4 style={{ display: "inline-block" }}>{platform.title}</h4>
+            </SmartLink>
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+};
+
+export default () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const queryString = parse(location.search, { arrayFormat: "none" });
+  const path = (queryString.next as string | null) || "";
+  const platform = queryString.platform as string | null;
+
+  if (platform) {
+    useEffect(() => {
+      navigate(`/platforms/${platform}${path}`);
+    });
+    return null;
+  }
+
+  return <PlatformRedirect path={path || ""} />;
+};

--- a/src/platforms/common/data-management/index.mdx
+++ b/src/platforms/common/data-management/index.mdx
@@ -1,0 +1,5 @@
+---
+title: Data Management
+---
+
+<PageGrid />

--- a/src/platforms/common/enriching-error-data/index.mdx
+++ b/src/platforms/common/enriching-error-data/index.mdx
@@ -1,0 +1,5 @@
+---
+title: Enriching Error Data
+---
+
+<PageGrid />

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,16 @@
     { "source": "/(hosted|on-premise)/(.*)", "destination": "/$2" },
     { "source": "/internal/(.*)", "destination": "https://develop.sentry.dev" },
     {
+      "source": "/(enriching-error-data|data-management)(.*)",
+      "destination": "/platform-redirect/?next=/$1$2",
+      "permanent": false
+    },
+    {
+      "source": "/error-reporting/(.*)",
+      "destination": "/platform-redirect/",
+      "permanent": false
+    },
+    {
       "source": "/development/(contribute|server)/(.*)",
       "destination": "https://develop.sentry.dev"
     },


### PR DESCRIPTION
- /enriching-error-data/ and /data-management/ will help you get to the platform specific content
- /error-reporting/ will get you to platform root

If the `platform` value is passed to `/redirect-page/` it will automatically forward you.

Fixes #2180 
Fixes #2181