### PR TITLE
Feat: partial algolia updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-instantsearch-dom": "^6.4.0",
     "react-select": "^3.1.0",
     "remark-deflist": "^0.2.1",
-    "sentry-global-search": "getsentry/sentry-global-search#0.0.17",
+    "sentry-global-search": "getsentry/sentry-global-search#0.0.18",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"
   },

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -38,6 +38,7 @@ const flatten = arr =>
         title: context.title,
         section: context.title,
         url: path,
+        // Do not remove until the global lib is in sentry. Removing will break sentry.
         content: context.excerpt,
         text: context.excerpt,
         platforms: context.platform ? extrapolate(slug, ".") : [],
@@ -57,7 +58,15 @@ const queries = [
     query: pageQuery,
     transformer: ({ data }) => flatten(data.pages.edges),
     indexName: `${indexPrefix}docs`,
-    settings: sentryAlgoliaIndexSettings,
+    settings: {
+      ...sentryAlgoliaIndexSettings,
+
+      // Do not remove until the global lib is in sentry
+      attributesToSnippet: [`content:15`, `text:15`],
+      searchableAttributes: ["content", "title", "text", "section"],
+      attributesToHighlight: ["content", "title", "section"],
+      attributesToRetrieve: ["content", "title", "url", "section", "text"],
+    },
     enablePartialUpdates: true,
     matchFields: ["text", "section", "title", "url", "legacy"],
   },

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -1,7 +1,7 @@
 const {
   standardSDKSlug,
   extrapolate,
-  sentryAlgoliaIndexSettings: { disableTypoToleranceOnWords },
+  sentryAlgoliaIndexSettings,
 } = require("sentry-global-search");
 
 const pageQuery = `{
@@ -51,24 +51,6 @@ const flatten = arr =>
     }))
     .filter(n => !n.draft);
 
-const settings = {
-  snippetEllipsisText: "…",
-  highlightPreTag: "<mark>",
-  highlightPostTag: "</mark>",
-  attributesToSnippet: [`content:15`, `text:15`],
-  attributesForFaceting: [
-    "filterOnly(platforms)",
-    "filterOnly(pathSegments)",
-    "filterOnly(legacy)",
-  ],
-  searchableAttributes: ["content", "title", "text", "section"],
-  attributesToHighlight: ["content", "title", "section"],
-  attributeForDistinct: "section",
-  attributesToRetrieve: ["content", "title", "url", "section", "text"],
-  disableTypoToleranceOnWords,
-  advancedSyntax: true,
-};
-
 const indexPrefix = process.env.GATSBY_ALGOLIA_INDEX_PREFIX;
 if (!indexPrefix) {
   throw new Error("`GATSBY_ALGOLIA_INDEX_PREFIX` must be configured!");
@@ -79,7 +61,7 @@ const queries = [
     query: pageQuery,
     transformer: ({ data }) => flatten(data.pages.edges),
     indexName: `${indexPrefix}docs`,
-    settings,
+    settings: sentryAlgoliaIndexSettings,
   },
 ];
 

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -30,25 +30,21 @@ const flatten = arr =>
       ({ node: { context } }) =>
         context && !context.draft && !context.noindex && context.title
     )
-    .map(({ node: { objectID, context, path } }) => ({
-      objectID,
-      title: context.title,
-      section: context.title,
-      url: path,
-      content: context.excerpt,
-      text: context.excerpt,
-
-      // https://github.com/getsentry/sentry-global-search#sorting-by-a-platform
-      platforms: context.platform
-        ? extrapolate(standardSDKSlug(context.platform.name).slug, ".")
-        : [],
-
-      // https://github.com/getsentry/sentry-global-search#sorting-by-path
-      pathSegments: extrapolate(path, "/").map(x => `/${x}/`),
-
-      // https://github.com/getsentry/sentry-global-search#sorting-by-legacy
-      legacy: context.legacy || false,
-    }))
+    .map(({ node: { objectID, context, path } }) => {
+      // https://github.com/getsentry/sentry-global-search#algolia-record-stategy
+      const { slug } = standardSDKSlug(context.platform.name);
+      return {
+        objectID,
+        title: context.title,
+        section: context.title,
+        url: path,
+        content: context.excerpt,
+        text: context.excerpt,
+        platforms: context.platform ? extrapolate(slug, ".") : [],
+        pathSegments: extrapolate(path, "/").map(x => `/${x}/`),
+        legacy: context.legacy || false,
+      };
+    })
     .filter(n => !n.draft);
 
 const indexPrefix = process.env.GATSBY_ALGOLIA_INDEX_PREFIX;

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -62,6 +62,8 @@ const queries = [
     transformer: ({ data }) => flatten(data.pages.edges),
     indexName: `${indexPrefix}docs`,
     settings: sentryAlgoliaIndexSettings,
+    enablePartialUpdates: true,
+    matchFields: ["text", "section", "title", "url", "legacy"],
   },
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15917,9 +15917,9 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-sentry-global-search@getsentry/sentry-global-search#0.0.17:
-  version "0.0.17"
-  resolved "https://codeload.github.com/getsentry/sentry-global-search/tar.gz/5d95a2e9d74f8810be8b0b54a8140646ef5025c8"
+sentry-global-search@getsentry/sentry-global-search#0.0.18:
+  version "0.0.18"
+  resolved "https://codeload.github.com/getsentry/sentry-global-search/tar.gz/c8beeb3a4f6af4817eb90b9fc64e53a827a1ef1c"
   dependencies:
     algoliasearch "^4.3.1"
     dompurify "^2.0.12"


### PR DESCRIPTION
I've left one last bit of legacy index stuff that is necessary to avoid breaking sentry in production. Once the global lib is there we can remove it.