### PR TITLE
feat: Reuse existing API reference pages

### DIFF
--- a/src/gatsby/createPages/createDevelopmentApiReference.ts
+++ b/src/gatsby/createPages/createDevelopmentApiReference.ts
@@ -1,12 +1,65 @@
+import { getChild, getDataOrPanic } from "../helpers";
+
 export default async ({ actions, graphql, reporter }) => {
-  const component = require.resolve(
-    `../../templates/developmentApiReference.js`
+  const data = await getDataOrPanic(
+    `
+          query {
+            allFile(filter: {absolutePath: {}, relativePath: {in: ["permissions.mdx", "auth.mdx", "index.mdx", "requests.mdx"]}, dir: {regex: "/api/"}}) {
+              nodes {
+                id
+                childMarkdownRemark {
+                  frontmatter {
+                    title
+                    description
+                    draft
+                    noindex
+                    sidebar_order
+                    redirect_from
+                  }
+                  fields {
+                    slug
+                    legacy
+                  }
+                  excerpt(pruneLength: 5000)
+                }
+                childMdx {
+                  frontmatter {
+                    title
+                    description
+                    draft
+                    noindex
+                    sidebar_order
+                    redirect_from
+                  }
+                  fields {
+                    slug
+                    legacy
+                  }
+                  excerpt(pruneLength: 5000)
+                }
+              }
+            }
+          }
+        `,
+    graphql,
+    reporter
   );
-  await actions.createPage({
-    path: `/development-api/`,
-    component,
-    context: {
-      title: "API Reference"
-    },
+
+  const component = require.resolve(`../../templates/doc.tsx`);
+  data.allFile.nodes.map((node: any) => {
+    const child = getChild(node);
+    if (child && child.fields) {
+      console.log({ path: child.fields.slug });
+      actions.createPage({
+        path: `development-api${child.fields.slug}`,
+        component,
+        context: {
+          excerpt: child.excerpt,
+          ...child.frontmatter,
+          id: node.id,
+          legacy: child.fields.legacy,
+        },
+      });
+    }
   });
 };

--- a/src/gatsby/createPages/createDevelopmentApiReference.ts
+++ b/src/gatsby/createPages/createDevelopmentApiReference.ts
@@ -49,7 +49,6 @@ export default async ({ actions, graphql, reporter }) => {
   data.allFile.nodes.map((node: any) => {
     const child = getChild(node);
     if (child && child.fields) {
-      console.log({ path: child.fields.slug });
       actions.createPage({
         path: `development-api${child.fields.slug}`,
         component,


### PR DESCRIPTION
## Objective
We can reuse the pages in the following routes and route them under `route.replace(/api/g, "development-api")` for each route:
- `/api/`
- `/api/auth/`
- `/api/requests/`
- `/api/permissions/`
- `/api/pagination/`

## UI
<img width="1440" alt="Screen Shot 2020-09-03 at 3 49 34 PM" src="https://user-images.githubusercontent.com/10491193/92181002-2450b800-edfd-11ea-88c9-ede5501ab1ec.png">
