### PR TITLE
fix: Remove language about @sentry/apm

### DIFF
--- a/src/includes/performance-monitoring/configuration/javascript.mdx
+++ b/src/includes/performance-monitoring/configuration/javascript.mdx
@@ -8,12 +8,6 @@ $ yarn add @sentry/browser @sentry/tracing
 $ npm install --save @sentry/browser @sentry/tracing
 ```
 
-<Note><markdown>
-
-The integration name was updated from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-</markdown></Note>
-
 Next, initialize the integration in your call to `Sentry.init`:
 
 ```jsx

--- a/src/includes/performance-monitoring/configuration/koa.mdx
+++ b/src/includes/performance-monitoring/configuration/koa.mdx
@@ -10,12 +10,6 @@ $ yarn add @sentry/node @sentry/tracing
 $ npm install --save @sentry/node @sentry/tracing
 ```
 
-<Alert level="warning" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-</markdown></Alert>
-
 Creates and attach a transaction to each context
 
 ```javascript

--- a/src/includes/performance-monitoring/configuration/node.mdx
+++ b/src/includes/performance-monitoring/configuration/node.mdx
@@ -14,12 +14,6 @@ $ yarn add @sentry/node @sentry/tracing
 $ npm install --save @sentry/node @sentry/tracing
 ```
 
-<Alert level="warning" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-</markdown></Alert>
-
 **Sending Traces**
 
 To send traces, set the `tracesSampleRate` to a nonzero value. The following configuration will capture 100% of all your transactions:

--- a/src/includes/performance-monitoring/configuration/react.mdx
+++ b/src/includes/performance-monitoring/configuration/react.mdx
@@ -10,12 +10,6 @@ $ yarn add @sentry/react @sentry/tracing
 $ npm install --save @sentry/react @sentry/tracing
 ```
 
-<Alert level="warning" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-</markdown></Alert>
-
 Next, initialize the integration in your call to `Sentry.init`. Make sure this happens before you mount your React component on the page.
 
 ```jsx

--- a/src/includes/performance-monitoring/configuration/vue.mdx
+++ b/src/includes/performance-monitoring/configuration/vue.mdx
@@ -10,12 +10,6 @@ $ yarn add @sentry/browser @sentry/integrations @sentry/tracing
 $ npm install --save @sentry/browser @sentry/integrations @sentry/tracing
 ```
 
-<Alert level="warning" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-</markdown></Alert>
-
 The Vue Tracing Integration allows you to track rendering performance during an initial application load.
 
 Sentry injects a handler inside Vue's `beforeCreate` mixin, providing access to a Vue component during its life cycle stages.

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -112,14 +112,6 @@ $ yarn add @sentry/browser @sentry/tracing
 $ npm install --save @sentry/browser @sentry/tracing
 ```
 
-<Alert level="note" title="Note"><markdown>
-
-We switched our package name from `@sentry/apm` to `@sentry/tracing`. If you were previously using `@sentry/apm`, please see [Switching to @sentry/tracing](/product/performance/apm-to-tracing/).
-
-If you are using our CDN, please see our documentation for [installing with CDN](/platforms/javascript/configuration/install-cdn).
-
-</markdown></Alert>
-
 Initialize the integration in your call to `Sentry.init`:
 
 ```javascript {tabTitle: ESM}


### PR DESCRIPTION
Most folks don't know what this means, and folks who might can probably figure it out.