### PR TITLE
fix: Link to DSN config option

### DIFF
--- a/src/platforms/java/guides/spring/index.mdx
+++ b/src/platforms/java/guides/spring/index.mdx
@@ -49,7 +49,7 @@ public HandlerExceptionResolver sentryExceptionResolver() {
 }
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](config/#setting-the-dsn) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](configuration/options/#setting-the-dsn) for ways you can do this.
 
 #### Spring Boot HTTP Data
 


### PR DESCRIPTION
the original link was only a 404, this should fix it

before: https://docs.sentry.io/platforms/java/guides/spring/config/#setting-the-dsn
after: https://docs.sentry.io/platforms/java/configuration/options/#setting-the-dsn
