### PR TITLE
Index page for Getting Started

### DIFF
--- a/src/includes/automatic-handlers/javascript.mdx
+++ b/src/includes/automatic-handlers/javascript.mdx
@@ -1,0 +1,3 @@
+By including and configuring Sentry, our JavaScript SDK automatically attaches global handlers to _capture_ uncaught exceptions and unhandled promise rejections, as described in the official ECMAScript 6 standard. You can disable this default behavior by changing the `onunhandledrejection` option to `false` in your GlobalHandlers integration and manually hook into each event handler, then call `Sentry.captureException` or `Sentry.captureMessage` directly.
+
+You may also need to manage your configuration if you are using a third-party library to implement promises. Also, remember that browsers often implement security measures that can block error reporting when serving script files from different origins.

--- a/src/platforms/common/configuration/capture.mdx
+++ b/src/platforms/common/configuration/capture.mdx
@@ -9,6 +9,8 @@ Sentry's SDK hooks into your runtime environment and automatically reports error
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception it can be captured. For some SDKs you can also omit the argument to `capture_exception` and Sentry will attempt to capture the current exception. It can also be useful to manually report errors or messages to Sentry.
 
+<PlatformContent includePath="automatic-handlers" />
+
 Separately to capturing you can also record the breadcrumbs that lead up to an event. Breadcrumbs are different from events: they will not create an event in Sentry, but will be buffered until the next event is sent. Learn more about breadcrumbs in our [Breadcrumbs documentation](/platforms/javascript/enriching-error-data/breadcrumbs/).
 
 ## Capturing Errors

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -45,7 +45,7 @@ If prefer to use CDN to install our SDK, please see our documentation for [insta
 
 `init` Sentry as soon as possible in your app, to make sure it can monitor everything that follows it. Once this is done, all unhandled exceptions are automatically captured by Sentry.
 
-The snippet below includes an intentional error, so you can test that everything is working as soon as you set it up. To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+The snippet below includes an intentional error, so you can test that everything is working as soon as you set it up.
 
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
@@ -54,6 +54,7 @@ Sentry.init({ dsn: "___PUBLIC_DSN___" });
 
 myUndefinedFunction(); // To test your setup
 ```
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 ## Capture Errors
 
@@ -69,17 +70,13 @@ Key terms:
 </markdown>
 </Note>
 
-By including and configuring Sentry, our JavaScript SDK automatically attaches global handlers to _capture_ uncaught exceptions and unhandled promise rejections, as described in the official ECMAScript 6 standard. You can disable this default behavior by changing the `onunhandledrejection` option to `false` in your GlobalHandlers integration and manually hook into each event handler, then call `Sentry.captureException` or `Sentry.captureMessage` directly.
+Our JavaScript SDK automatically attaches global handlers to capture uncaught exceptions and unhandled promise rejections, as described in the official ECMAScript 6 standard.
 
-You may also need to manage your configuration if you are using a third-party library to implement promises. Also, remember that browsers often implement security measures that can block error reporting when serving script files from different origins.
-
-Learn more about how to manually capture errors or enable message capture with Sentry's JavaScript SDK in [Capture Errors](/platforms/javascript/enriching-error-data/capture).
+To disable this default behavior, manually capture errors or messages, or manage your configuration for third-party libraries that implement promises, see our [documentation for Advanced Usage](/platforms/javascript/configuration/capture).
 
 ### Automatically Enrich Error Data
 
-Events sent by the JavaScript SDK to Sentry are enriched with data that helps identify the source of the event. Much of this data is sent automatically - including the error context and environment - as well as the trail of events that led up to the event, which we call breadcrumbs. You don't need to configure these, though you may modify them.
-
-Learn more about the data sent to with events in [Enrich Event Data](/platforms/javascript/enriching-error-data/additional-data/).
+Events sent to Sentry are enriched with data to help identify their source. Much of this data is sent automatically. Learn more about [what is sent automatically](/platforms/javascript/enriching-error-data/additional-data/).
 
 ### Set the Release Version
 


### PR DESCRIPTION
We're working toward an index page for Getting Started for our SDKs. I've edited to the JS index page further, which I think can serve as a model (also evaluated PHP as part of this creating this PR).

This is closer, though the section in Capture Errors regarding global handlers may not be common. 