### PR TITLE
fix: Child markdown node interception

### DIFF
--- a/src/components/relayMetrics.tsx
+++ b/src/components/relayMetrics.tsx
@@ -11,7 +11,7 @@ const query = graphql`
         type
         features
 
-        childrenRelayMetricDescription {
+        childRelayMetricDescription {
           childMarkdownRemark {
             html
           }
@@ -41,7 +41,7 @@ function RelayFeatures({ features }) {
 
 function Metric({ metric }) {
   const descriptionHtml =
-    metric.childrenRelayMetricDescription[0].childMarkdownRemark.html;
+    metric.childRelayMetricDescription.childMarkdownRemark.html;
 
   return (
     <>

--- a/src/gatsby/onCreateNode.ts
+++ b/src/gatsby/onCreateNode.ts
@@ -8,7 +8,10 @@ export default ({
   createNodeId,
 }) => {
   const { createNodeField, createNode } = actions;
-  if (node.internal.type === "Mdx" || node.internal.type === "MarkdownRemark") {
+  if (
+    (node.internal.type === "Mdx" || node.internal.type === "MarkdownRemark") &&
+    node.fileAbsolutePath
+  ) {
     const value = createFilePath({ node, getNode });
     createNodeField({
       name: "slug",

--- a/src/gatsby/sourceNodes/relayMetricsNodes.ts
+++ b/src/gatsby/sourceNodes/relayMetricsNodes.ts
@@ -8,18 +8,6 @@ export const relayMetricsNodes = async ({
   const { createNode, createParentChildLink } = actions;
 
   metrics.forEach(metric => {
-    const descriptionNode = {
-      id: createNodeId(metric.name + "_description"),
-      internal: {
-        content: metric.description,
-        contentDigest: createContentDigest(metric.description),
-        mediaType: "text/markdown",
-        type: "RelayMetricDescription",
-      },
-    };
-
-    createNode(descriptionNode);
-
     const metricNode = {
       ...metric,
       id: createNodeId(metric.name),
@@ -30,6 +18,19 @@ export const relayMetricsNodes = async ({
     };
 
     createNode(metricNode);
+
+    const descriptionNode = {
+      id: createNodeId(metric.name + "_description"),
+      parent: metricNode.id,
+      internal: {
+        content: metric.description,
+        contentDigest: createContentDigest(metric.description),
+        mediaType: "text/markdown",
+        type: "RelayMetricDescription",
+      },
+    };
+
+    createNode(descriptionNode);
 
     createParentChildLink({
       parent: metricNode,


### PR DESCRIPTION
Fixes onCreateNode to skip nodes that do not have an absolute file path set. For
such nodes, the `gatsby-source-filesystem` has a buggy resovler that throws an
error while trying to retrieve file information.

It seems that the intention of this hook was to inject attributes on markdown
pages. However, markdown snippet nodes, such as in Relay metrics, do not need 
the `slug` and `legacy` fields.

Along with this fix, the relationship between `RelayMetric` and
`RelayMetricDescription` was changed to many-to-one by adding a reference to the
`parent` id.

