### PR TITLE
ref(relay): Update wording and formatting

### DIFF
--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -10,13 +10,13 @@ your application and Sentry.io.
 
 <Alert level="info" title="Note">
 
-Relay is still work in progress. The default Relay mode is at the moment only
-supported for on-premise installations and beta testers. If you are using Relay
-to connect to Sentry and are not a beta tester you need to use `proxy` or
-`static` mode.
+Relay is still work in progress. The default Relay mode is currently supported
+only for on-premise installations and beta testers. If you are using Relay to
+connect to Sentry and are not a beta tester you need to use `proxy` or `static`
+mode.
 
 If you want to beta test the `managed` mode while connecting to Sentry, please
-get in touch with us. See [Relay Modes] for more information.
+contact us. See [Relay Modes] for more information.
 
 </Alert>
 
@@ -26,14 +26,18 @@ Relay is designed to help you in a few use cases:
 
 ### Scrubbing Personally Identifiable Information (PII)
 
-Sentry allows to scrub PII in two places: in the SDK before sending the event,
-and upon arrival on Sentry's infrastructure. Relay adds a third option that
-allows to scrub data in a central place before sending it to Sentry.
+Sentry scrubs PII in two places:
+
+1. In the SDK before sending the event
+2. Upon arrival on Sentry's infrastructure
+
+Relay adds a third option that scrubs data in a central place prior to sending
+it to Sentry.
 
 To choose the right place for data scrubbing, consider:
 
 - If you prefer to configure data scrubbing in a central place, you can let
-  Sentry handle data scrubbing. Upon arrival, Sentry immediatly applies
+  Sentry handle data scrubbing. Upon arrival, Sentry immediately applies
   [server-side scrubbing] and guarantees that personal information is never
   stored.
 
@@ -45,7 +49,7 @@ To choose the right place for data scrubbing, consider:
 - For the most strict data privacy requirements, you can configure SDKs to scrub
   PII using the [`before-send` hooks], which prevents data from being collected
   on the device. This may require you to replicate the same logic across your
-  applications and could lead to a performance impact.
+  applications and may impact performance.
 
 ### Improved Response Time
 
@@ -64,7 +68,7 @@ act as an opaque proxy that reliably forwards events to Sentry.
 ## Getting Started
 
 In this section we will create a simple setup using the default settings. Check
-the [Configuration Options] page for a detail discussion of various operating
+the [Configuration Options] page for a detailed discussion of various operating
 scenarious for Relay.
 
 The Relay server is called `relay`. Binaries can be downloaded from [GitHub
@@ -72,8 +76,9 @@ Releases] and a Docker image is provided on [DockerHub].
 
 ### Initializing Configuration
 
-In order to create the initial configuration, Relay provides the `relay config init` command. The command puts configuration files in the `.relay` folder under
-the current working directory:
+To create the initial configuration, Relay provides the `relay config init`
+command, which puts configuration files in the `.relay` folder under the current
+working directory:
 
 ```shell
 ❯ ./relay config init
@@ -86,20 +91,22 @@ Do you want to create a new config?:
 
 Selecting the default configuration will create a minimal configuration file.
 Alternatively, you can choose to override the default settings, by selecting
-_"create custom config"_. This allows you to customize the following basic
-parameters:
+_"create custom config"_ and customize the following basic parameters:
 
 - The `mode` setting configures the major mode in which Relay operates. For more
   information on available relay modes, refer to [Relay Modes].
 
-  **Right now, the only options supported by `sentry.io` are `proxy` and
-  `static` mode.**
+  <Alert level="warning">
+
+  Currently, only `proxy` and `static` mode are available to all organizations.
+
+  </Alert>
 
 - The `upstream` setting configures the server to which Relay will forward the
   events (by default the main `sentry.io` URL).
 
 - The `port` and `host` settings configure the TCP port at which Relay will
-  listen to. This is the address to which SDKs send events.
+  listen. This is the address to which SDKs send events.
 
 - The `tls` settings configure TLS support (HTTPS support), used for
   the cases where the communication between the SDK and Relay needs to be
@@ -133,8 +140,7 @@ Besides `config.yml`, the `init` command has also created a credentials file
 `credentials.json` in the same `.relay` directory. This file contains the a
 public and private key used by Relay to authenticate with the upstream server.
 
-**As such, it is important that this file should be adequatly protected from
-modification or viewing by unauthorized entities**.
+**As a result, this file must be protected from modification or view by unauthorized entities.**
 
 Here's an example of the contents of a typical credentials file:
 
@@ -162,8 +168,8 @@ filtering, and rate limiting from your organization and project settings at
 Sentry. Since these settings may contain sensitive information, their access is
 restricted by Sentry and requires authorization.
 
-In order to register Relay with Sentry, get the contents of the public key,
-either by inspecting the `credentials.json` file or by running:
+To register Relay with Sentry, get the contents of the public key, either by
+inspecting the `credentials.json` file or by running:
 
 ```shell
 ❯ ./relay credentials show
@@ -199,8 +205,8 @@ Relay:
  DEBUG relay::server::upstream > relay successfully registered with upstream
 ```
 
-If you moved your config folder somewhere else (e.g. for security reasons), you
-can use the `--config` option to specify the location:
+If you moved your config folder somewhere else (for example, for security
+reasons), you can use the `--config` option to specify the location:
 
 ```shell
 ❯ relay run --config ./my/custom/relay_folder/
@@ -211,11 +217,11 @@ can use the `--config` option to specify the location:
 As an alternative to directly running the Relay binary, Sentry also provides a
 Docker image that can be used to run Relay. It can be found on [DockerHub].
 
-Similar to directly running the `relay` binary, running the docker image needs a
+Similar to directly running the `relay` binary, running the Docker image needs a
 directory in which it can find the configuration and credentials files
 (`config.yml` and `credentials.json`). Providing the configuration directory can
-be done with the standard mechanisms offered by docker, either by mounting
-[docker volumes] or by building a new container and copying the files in.
+be done with the standard mechanisms offered by Docker, either by mounting
+[Docker volumes] or by building a new container and copying the files in.
 
 For example, you can start the latest version of `relay` as follows:
 
@@ -228,23 +234,25 @@ This example command assumes that Relay's configuration files, `config.yml` and
 
 ## Logging and Healthcheck
 
-Now you have a running relay, you might have noticed that relay displays some
-`INFO` messages, including:
+With Relay now running, you will receive `INFO` messages, such as:
 
 ```shell
+INFO  relay::setup > launching relay from config folder .relay
+INFO  relay::setup >   relay mode: managed
+INFO  relay::setup >   relay id: f2119bc9-9a9b-4531-826b-24e9794902f2
 INFO  relay::setup >   log level: INFO
 ```
 
-This is the default logging level and you can change this to show more or less
+This is the default logging level, which you can change to show more or less
 info. For details about configuring logging please see [Logging] on the options
 page.
 
-Relay provides two URLs for checking liveness and readyness of the service:
+Relay provides two URLs for checking system status:
 
 - `GET /api/relay/healthcheck/live/`: Tests if Relay is running and listening to
-  HTTP requests. - `GET /api/relay/healthcheck/ready/`: Tests if Relay is
-  authenticated with the upstream and
-  operating normally.
+  HTTP requests.
+- `GET /api/relay/healthcheck/ready/`: Tests if Relay is authenticated with the
+  upstream and operating normally.
 
 In case of success, both endpoints return a _200 OK_ response:
 
@@ -256,12 +264,10 @@ In case of success, both endpoints return a _200 OK_ response:
 
 ### Sending a Test Event
 
-Once Relay is running and authenticated with Sentry, it is time to send a test
-event.
+Once Relay is running and authenticated with Sentry, send a test event.
 
-Get the DSN of your project by navigating to your _Project Settings > Client
-Keys (DSN)_. From the _Client Keys_ page, get the DSN, which looks something
-like:
+Get the DSN of your project by navigating to _Project Settings > Client Keys
+(DSN)_, which looks similar to:
 
 ```
 https://12345abcdb1e4c123490ecec89c1f199@o1.ingest.sentry.io/2244

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -75,7 +75,7 @@ Releases] and a Docker image is provided on [DockerHub].
 In order to create the initial configuration, Relay provides the `relay config init` command. The command puts configuration files in the `.relay` folder under
 the current working directory:
 
-```sh
+```shell
 ❯ ./relay config init
 Initializing relay in /<current_directory>/.relay
 Do you want to create a new config?:
@@ -165,7 +165,7 @@ restricted by Sentry and requires authorization.
 In order to register Relay with Sentry, get the contents of the public key,
 either by inspecting the `credentials.json` file or by running:
 
-```sh
+```shell
 ❯ ./relay credentials show
 Credentials:
   relay id: 8cd24a0e-384d-4052-9010-68a21392b33c
@@ -189,7 +189,7 @@ Now your Relay is registered with Sentry and ready to send messages. See
 Once you have registered your Relay with Sentry, you are ready to run your
 Relay:
 
-```sh
+```shell
 ❯ relay run
  INFO  relay::setup > launching relay from config folder .relay
  INFO  relay::setup >   relay mode: managed
@@ -202,7 +202,7 @@ Relay:
 If you moved your config folder somewhere else (e.g. for security reasons), you
 can use the `--config` option to specify the location:
 
-```sh
+```shell
 ❯ relay run --config ./my/custom/relay_folder/
 ```
 
@@ -219,7 +219,7 @@ be done with the standard mechanisms offered by docker, either by mounting
 
 For example, you can start the latest version of `relay` as follows:
 
-```sh
+```shell
 ❯ docker run -v $(pwd)/configs/:/work/.relay/ getsentry/relay run
 ```
 
@@ -231,7 +231,7 @@ This example command assumes that Relay's configuration files, `config.yml` and
 Now you have a running relay, you might have noticed that relay displays some
 `INFO` messages, including:
 
-```sh
+```shell
 INFO  relay::setup >   log level: INFO
 ```
 
@@ -278,7 +278,7 @@ http://12345abcdb1e4c123490ecec89c1f199@localhost:3000/2244
 Use the new DSN in your SDK configuration. To test this, you can send a message
 with `sentry-cli`:
 
-```sh
+```shell
 ❯ export SENTRY_DSN='http://12345abcdb1e4c123490ecec89c1f199@127.0.0.1:3000/2244'
 ❯ sentry-cli send-event -m 'A test event'
 ```

--- a/src/docs/product/relay/metrics.mdx
+++ b/src/docs/product/relay/metrics.mdx
@@ -16,8 +16,8 @@ sentry:
 
 ## Configuration
 
-Stats can be submitted to a statsd server by configuring `metrics` key. It can
-be put to a `ip:port` tuple:
+Stats can be submitted to a StatsD server by configuring the `metrics` key. It
+can be set to an `ip:port` tuple:
 
 ```yaml
 metrics:
@@ -25,27 +25,29 @@ metrics:
   prefix: mycompany.relay
 ```
 
-### `statsd`
+`statsd`
 
-Configures the host and port of the statsd client. We recommend to run a statsd
-client on the same host as Relay for performance reasons.
+: Configures the host and port of the StatsD client. We recommend running a
+  StatsD client on the same host as Relay for performance reasons.
 
-### `prefix`
+`prefix`
 
-Configures a prefix that is prepended to all reported metrics. By default, all
-metrics are reported with a `"sentry.relay"` prefix.
+: Configures a prefix that is prepended to all reported metrics. By default, all
+  metrics are reported with a `"sentry.relay"` prefix.
 
-### `hostname_tag`
+`hostname_tag`
 
-Adds a tag of the given name and sets it to the hostname of the machine that is running Relay. This is useful to separate multiple Relays. For example, setting this to:
+: Adds a tag of the given name and sets it to the hostname of the machine that
+  is running Relay. This is useful to separate multiple Relays. For example,
+  setting this to:
 
-```yaml
-metrics:
-  hostname_tag: pod_name
-```
+  ```yaml
+  metrics:
+    hostname_tag: pod_name
+  ```
 
-The above example adds a `"pod_name"` tag that is set to the host name to every
-metric.
+  The above example adds a `"pod_name"` tag that is set to the host name to
+  every metric.
 
 ## Metrics
 

--- a/src/docs/product/relay/modes.mdx
+++ b/src/docs/product/relay/modes.mdx
@@ -3,17 +3,19 @@ title: Relay Modes
 sidebar_order: 1
 ---
 
-When configuring a Relay server, the most important thing it is to understand
-the major modes in which it can operate.
+When configuring a Relay server, it is key to understand the major modes in
+which Relay can operate.
 
-As seen in the introduction, the configuration file contains a `relay.mode`
-field. Currently, there are three modes that can be specified: `managed`,
-`static`, `proxy`.
+As discussed in the introduction, the configuration file contains a `relay.mode`
+field. Currently, you can specify one of three modes: `managed`, `static`,
+`proxy`.
 
-Event processing in Sentry can be configured using a two level hierachical
-configuration. At the top level, there are organization wide settings. An
-organization contains projects and event processing can be controlled with
-settings at project level.
+Event processing in Sentry is configured according to settings defined for the
+organization and project. Some settings, such as privacy controls, are set at
+the organization level and inherited by all projects in that organization; other
+settings are specified per project. For Relay, events are processed according to
+the inherited project settings to which the event belongs. The Relay mode
+controls the way Relay obtains these project settings.
 
 From Relay's point of view, events are processed according to the settings of
 the project it belongs to. Sentry includes all organization settings, such as
@@ -34,9 +36,9 @@ Since configuration is obtained from Sentry, authentication is required in this
 mode. If authentication fails, no events will be accepted by Relay.
 
 As Relay receives events from applications, it will request project
-configurations from Sentry in order to process the events. If Sentry is unable
-to provide the configuration for a particular project, all messages for that
-project will be discared.
+configurations from Sentry to process the events. If Sentry is unable to provide
+the configuration for a particular project, all messages for that project will
+be discarded.
 
 Configuration is refreshed in regular intervals. See [Configuration Options] for ways to configure intervals, timeouts and retries.
 
@@ -50,7 +52,7 @@ relay:
 ```
 
 In static configuration, Relay will process events only for statically
-configured projects and rejects events for all other projects. This is useful
+configured projects and reject events for all other projects. This is useful
 when you know the projects sending events upfront, and you wish to explicitly
 control the projects that are allowed to send events through this Relay.
 

--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -13,7 +13,7 @@ All configuration keys are `snake_case`.
 
 ## Relay
 
-General relay settings for Relay's operation.
+General settings for Relay's operation.
 
 ### `relay.mode`
 
@@ -245,13 +245,13 @@ The maximum payload size for file uploads and chunks.
 
 _String, default: `100MiB`_
 
-The maximum payload size for chunks
+The maximum payload size for chunks.
 
 ### `limits.max_thread_count`
 
 _Integer, default: number of cpus_
 
-The maximum number of threads to spawn for CPU and web worker, each.
+The maximum number of threads to spawn for each CPU and web worker.
 
 The total number of threads spawned will roughly be `2 * limits.max_thread_count + N`, where `N` is a fixed set of management threads.
 
@@ -372,10 +372,9 @@ errors are sent, but still logged.
 
 _String, optional_
 
-DSN to report internal Relay failures to.
+Sentry DSN to which to report internal Relay failures.
 
-It is not a good idea to set this to a value that will make the Relay send
-errors to itself. Ideally this should just send errors to Sentry directly, not
-another Relay.
+We recommend setting this to a value that will not send Relay errors to itself.
+Ideally, this value should send errors to Sentry directly, not another Relay.
 
 [relay modes]: /product/relay/modes/

--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -15,161 +15,167 @@ All configuration keys are `snake_case`.
 
 General settings for Relay's operation.
 
-### `relay.mode`
+`relay.mode`
 
-_String, default: `managed`_, possible values: `managed`, `static`, `proxy` and `capture`
+: _String, default: `managed`_, possible values: `managed`, `static`, `proxy`
+  and `capture`
 
-Controls how Relay obtains the project configuration for events. For detailed explanation of the modes, see [Relay Modes].
+  Controls how Relay obtains the project configuration for events. For detailed
+  explanation of the modes, see [Relay Modes].
 
-### `relay.upstream`
+`relay.upstream`
 
-_String, default: `https://sentry.io`_
+: _String, default: `https://sentry.io`_
 
-Fully qualified URL of the upstream Relay or Sentry instance.
+  Fully qualified URL of the upstream Relay or Sentry instance.
+  
+  <Alert level="warning" title="Important">
 
-**Important**: Relay does not check for cycles. Ensure this option is not set
-to an endpoint that will cause events to be cycled back here.
+  Relay does not check for cycles. Ensure this option is not set to an endpoint
+  that will cause events to be cycled back here.
+  
+  </Alert>
 
-### `relay.host`
+`relay.host`
 
-_String, default: `0.0.0.0` in Docker, otherwise `127.0.0.1`_
+: _String, default: `0.0.0.0` in Docker, otherwise `127.0.0.1`_
 
-The host, the Relay should bind to (network interface). Example: `0.0.0.0`
+  The host, the Relay should bind to (network interface). Example: `0.0.0.0`
 
-### `relay.port`
+`relay.port`
 
-_Integer, default: `3000`_
+: _Integer, default: `3000`_
 
-The port to bind for the unencrypted Relay HTTP server. Example: `3000`
+  The port to bind for the unencrypted Relay HTTP server. Example: `3000`
 
-### `relay.tls_port`
+`relay.tls_port`
 
-_Integer, optional_
+: _Integer, optional_
 
-Optional port to bind for the encrypted Relay HTTPS server. Example: `3001`
+  Optional port to bind for the encrypted Relay HTTPS server. Example: `3001`
 
-This is in addition to the `port` option: If you set up a HTTPS server at
-`tls_port`, the HTTP server at `port` still exists.
+  This is in addition to the `port` option: If you set up a HTTPS server at
+  `tls_port`, the HTTP server at `port` still exists.
 
-### `relay.tls_identity_path`
+`relay.tls_identity_path`
 
-_String, optional_
+: _String, optional_
 
-The filesystem path to the identity (DER-encoded PKCS12) to use for the HTTPS
-server. Relative paths are evaluated in the current working directory. Example:
-`relay_dev.pfx`
+  The filesystem path to the identity (DER-encoded PKCS12) to use for the HTTPS
+  server. Relative paths are evaluated in the current working directory.
+  Example: `relay_dev.pfx`
 
-### `relay.tls_identity_password`
+`relay.tls_identity_password`
 
-_String, optional_
+: _String, optional_
 
-Password for the PKCS12 archive in `relay.tls_identity_path`.
+  Password for the PKCS12 archive in `relay.tls_identity_path`.
 
 ## HTTP
 
 Set various network-related settings.
 
-### `http.timeout`
+`http.timeout`
 
-_Integer, default: `5`_
+: _Integer, default: `5`_
 
-Timeout for upstream requests in seconds.
+  Timeout for upstream requests in seconds.
 
-This timeout covers the time from sending the request until receiving response
-headers. Neither the connection process and handshakes, nor reading the response
-body is covered in this timeout.
+  This timeout covers the time from sending the request until receiving response
+  headers. Neither the connection process and handshakes, nor reading the
+  response body is covered in this timeout.
 
-### `http.connection_timeout`
+`http.connection_timeout`
 
-_Integer, default: `3`_
+: _Integer, default: `3`_
 
-Timeout for establishing connections with the upstream in seconds.
+  Timeout for establishing connections with the upstream in seconds.
 
-This includes SSL handshakes. Relay reuses connections when the upstream
-supports connection keep-alive. Connections are retained for a maximum 75
-seconds, or 15 seconds of inactivity.
+  This includes SSL handshakes. Relay reuses connections when the upstream
+  supports connection keep-alive. Connections are retained for a maximum 75
+  seconds, or 15 seconds of inactivity.
 
-### `http.max_retry_interval`
+`http.max_retry_interval`
 
-_Integer, default: `60`_
+: _Integer, default: `60`_
 
-Maximum interval between failed request retries in seconds.
+  Maximum interval between failed request retries in seconds.
 
-### `host.header`
+`host.header`
 
-string, default: `null`
+: _String, default: `null`_
 
-The custom HTTP Host header to be sent to the upstream.
+  The custom HTTP Host header to be sent to the upstream.
 
 ## Caching
 
 Fine-tune caching of project state.
 
-### `cache.project_expiry`
+`cache.project_expiry`
 
-_Integer, default: `300` (5 minutes)_
+: _Integer, default: `300` (5 minutes)_
 
-The cache timeout for project configurations in seconds. Irrelevant if you use
-the "simple proxy mode", where your project config is stored in local files.
+  The cache timeout for project configurations in seconds. Irrelevant if you use
+  the "simple proxy mode", where your project config is stored in local files.
 
-### `cache.project_grace_period`
+`cache.project_grace_period`
 
-_Integer, default: `0` (seconds)_
+: _Integer, default: `0` (seconds)_
 
-Number of seconds to continue using this project configuration after cache
-expiry while a new state is being fetched. This is added on top of `cache.project_expiry`
-and `cache.miss_expiry`.
+  Number of seconds to continue using this project configuration after cache
+  expiry while a new state is being fetched. This is added on top of
+  `cache.project_expiry` and `cache.miss_expiry`.
 
-### `cache.relay_expiry`
+`cache.relay_expiry`
 
-_Integer, default: `3600` (1 hour)_
+: _Integer, default: `3600` (1 hour)_
 
-The cache timeout for downstream Relay info (public keys) in seconds. This is
-only relevant, if you plan to connect further Relays to this one.
+  The cache timeout for downstream Relay info (public keys) in seconds. This is
+  only relevant, if you plan to connect further Relays to this one.
 
-### `cache.event_expiry`
+`cache.event_expiry`
 
-_Integer, default: `600` (10 minutes)_
+: _Integer, default: `600` (10 minutes)_
 
-The cache timeout for events (store) before dropping them.
+  The cache timeout for events (store) before dropping them.
 
-### `cache.miss_expiry`
+`cache.miss_expiry`
 
-_Integer, default: `60` (1 minute)_
+: _Integer, default: `60` (1 minute)_
 
-The cache timeout for non-existing entries.
+  The cache timeout for non-existing entries.
 
-### `cache.batch_interval`
+`cache.batch_interval`
 
-_Integer, default: `100` (100 milliseconds)_
+: _Integer, default: `100` (100 milliseconds)_
 
-The buffer timeout for batched queries before sending them upstream **in
-milliseconds**.
+  The buffer timeout for batched queries before sending them upstream **in
+  milliseconds**.
 
-### `cache.batch_size`
+`cache.batch_size`
 
-_Integer, default: `500`_
+: _Integer, default: `500`_
 
-The maximum number of project configs to fetch from Sentry at once.
+  The maximum number of project configs to fetch from Sentry at once.
 
-### `cache.file_interval`
+`cache.file_interval`
 
-_Integer, default: `10` (10 seconds)_
+: _Integer, default: `10` (10 seconds)_
 
-Interval for watching local cache override files in seconds.
+  Interval for watching local cache override files in seconds.
 
-### `cache.event_buffer_size`
+`cache.event_buffer_size`
 
-_Integer, default: `1000`_
+: _Integer, default: `1000`_
 
-The maximum number of events that are buffered in case of network issues or high
-rates of incoming events.
+  The maximum number of events that are buffered in case of network issues or
+  high rates of incoming events.
 
-### `cache.eviction_interval`
+`cache.eviction_interval`
 
-_Integer, default: `60` (seconds)_
+: _Integer, default: `60` (seconds)_
 
-Interval for evicting outdated project configs from memory.
+  Interval for evicting outdated project configs from memory.
 
 ## Size Limits
 
@@ -182,199 +188,209 @@ human-readable strings of a number and a human-readable unit, such as:
 - `1MB` (_1,000,000_ bytes)
 - `1MiB` (_1,048,576_ bytes)
 
-### `limits.max_concurrent_requests`
+`limits.max_concurrent_requests`
 
-_Integer, default: `100`_
+: _Integer, default: `100`_
 
-The maximum number of concurrent connections to the upstream. If supported by the upstream, Relay supports connection keepalive.
+  The maximum number of concurrent connections to the upstream. If supported by
+  the upstream, Relay supports connection keepalive.
 
-### `limits.max_concurrent_queries`
+`limits.max_concurrent_queries`
 
-_Integer, default: `5`_
+: _Integer, default: `5`_
 
-The maximum number of queries that can be sent concurrently from Relay to the
-upstream before Relay starts buffering requests. Queries are all requests made
-to the upstream for obtaining information and explicitly exclude event
-submission.
+  The maximum number of queries that can be sent concurrently from Relay to the
+  upstream before Relay starts buffering requests. Queries are all requests made
+  to the upstream for obtaining information and explicitly exclude event
+  submission.
 
-The concurrency of queries is additionally constrained by `max_concurrent_requests`.
+  The concurrency of queries is additionally constrained by
+  `max_concurrent_requests`.
 
-### `limits.max_event_size`
+`limits.max_event_size`
 
-_String, default: `1MiB`_
+: _String, default: `1MiB`_
 
-The maximum payload size for events.
+  The maximum payload size for events.
 
-### `limits.max_attachment_size`
+`limits.max_attachment_size`
 
-_String, default: `50MiB`_
+: _String, default: `50MiB`_
 
-The maximum size for each attachment.
+  The maximum size for each attachment.
 
-### `limits.max_attachments_size`
+`limits.max_attachments_size`
 
-_String, default: `50MiB`_
+: _String, default: `50MiB`_
 
-The maximum combined size for all attachments in an envelope or request.
+  The maximum combined size for all attachments in an envelope or request.
 
-### `limits.max_envelope_size`
+`limits.max_envelope_size`
 
-_String, default: `50MiB`_
+: _String, default: `50MiB`_
 
-The maximum payload size for an entire envelopes. Individual limits still apply.
+  The maximum payload size for an entire envelopes. Individual limits still
+  apply.
 
-### `limits.max_session_count`
+`limits.max_session_count`
 
-_Integer, default: `100`_
+: _Integer, default: `100`_
 
-The maximum number of session items per envelope.
+  The maximum number of session items per envelope.
 
-### `limits.max_api_payload_size`
+`limits.max_api_payload_size`
 
-_String, default: `20MiB`_
+: _String, default: `20MiB`_
 
-The maximum payload size for general API requests.
+  The maximum payload size for general API requests.
 
-### `limits.max_api_file_upload_size`
+`limits.max_api_file_upload_size`
 
-_String, default: `40MiB`_
+: _String, default: `40MiB`_
 
-The maximum payload size for file uploads and chunks.
+  The maximum payload size for file uploads and chunks.
 
-### `limits.max_api_chunk_upload_size`
+`limits.max_api_chunk_upload_size`
 
-_String, default: `100MiB`_
+: _String, default: `100MiB`_
 
-The maximum payload size for chunks.
+  The maximum payload size for chunks.
 
-### `limits.max_thread_count`
+`limits.max_thread_count`
 
-_Integer, default: number of cpus_
+: _Integer, default: number of cpus_
 
-The maximum number of threads to spawn for each CPU and web worker.
+  The maximum number of threads to spawn for each CPU and web worker.
 
-The total number of threads spawned will roughly be `2 * limits.max_thread_count + N`, where `N` is a fixed set of management threads.
+  The total number of threads spawned will roughly be `2 *
+  limits.max_thread_count + N`, where `N` is a fixed set of management threads.
 
-### `limits.query_timeout`
+`limits.query_timeout`
 
-_Integer, default: `30` (seconds)_
+: _Integer, default: `30` (seconds)_
 
-The maximum number of seconds a query is allowed to take across retries.
-Individual requests have lower timeouts.
+  The maximum number of seconds a query is allowed to take across retries.
+  Individual requests have lower timeouts.
 
-### `limits.max_connection_rate`
+`limits.max_connection_rate`
 
-_Integer, default: `256`_
+: _Integer, default: `256`_
 
-The maximum number of connections to Relay that can be created at once.
+  The maximum number of connections to Relay that can be created at once.
 
-### `limits.max_pending_connections`
+`limits.max_pending_connections`
 
 _Integer, default: `2048`_
 
-The maximum number of pending connects to Relay. This corresponds to the backlog param of
-`listen(2)` in POSIX.
+: The maximum number of pending connects to Relay. This corresponds to the
+  backlog param of `listen(2)` in POSIX.
 
-### `limits.max_connections`
+`limits.max_connections`
 
-_Integer: default: `25_000`_
+: _Integer: default: `25_000`_
 
-The maximum number of open incoming connections to Relay.
+  The maximum number of open incoming connections to Relay.
 
-### `limits.shutdown_timeout`
+`limits.shutdown_timeout`
 
 _Integer, default:L `10` (seconds)_
 
-The maximum number of seconds to wait for pending events after receiving a
-shutdown signal.
+: The maximum number of seconds to wait for pending events after receiving a
+  shutdown signal.
 
 ## Logging
 
-### `logging.level`
+`logging.level`
 
-_String, default: `info`_
+: _String, default: `info`_
 
-The log level for the relay. One of:
+  The log level for the relay. One of:
 
-- `off`
-- `error`
-- `warn`
-- `info`
-- `debug`
-- `trace`
+  - `off`
+  - `error`
+  - `warn`
+  - `info`
+  - `debug`
+  - `trace`
 
-**Warning**: On `debug` and `trace` levels, Relay emits extremely verbose
-messages which can have severe impact on application performance.
+  <Alert level="warning" title="Warning">
+  
+  On `debug` and `trace` levels, Relay emits extremely verbose messages which
+  can have severe impact on application performance.
+  
+  </Alert>
 
-### `logging.log_failed_payloads`
+`logging.log_failed_payloads`
 
-_boolean, default: `false`_
+: _boolean, default: `false`_
 
-Logs full event payloads of failed events to the log stream.
+  Logs full event payloads of failed events to the log stream.
 
-### `logging.format`
+`logging.format`
 
-_String, default: `auto`_
+: _String, default: `auto`_
 
-Controls the log format. One of:
+  Controls the log format. One of:
 
-- `auto`: Auto detect (pretty for TTY, simplified for other)
-- `pretty`: Human readable format with colors
-- `simplified`: Simplified human readable log output
-- `json`: JSON records, suitable for logging software
+  - `auto`: Auto detect (pretty for TTY, simplified for other)
+  - `pretty`: Human readable format with colors
+  - `simplified`: Simplified human readable log output
+  - `json`: JSON records, suitable for logging software
 
-### `logging.enable_backtraces`
+`logging.enable_backtraces`
 
-_boolean, default: `true`_
+: _boolean, default: `true`_
 
-Writes back traces for all internal errors to the log stream and includes them in Sentry errors, if enabled.
+  Writes back traces for all internal errors to the log stream and includes them
+  in Sentry errors, if enabled.
 
-## Statsd Metrics
+## StatsD Metrics
 
-### `metrics.statsd`
+`metrics.statsd`
 
-_String, optional_
+: _String, optional_
 
-If set to a host/port string then metrics will be reported to this statsd
-instance.
+  If set to a host/port string then metrics will be reported to this StatsD
+  instance.
 
-### `metrics.prefix`
+`metrics.prefix`
 
-_String, default: `sentry.relay`_
+: _String, default: `sentry.relay`_
 
-The prefix that should be added to all metrics.
+  The prefix that should be added to all metrics.
 
-### `metrics.default_tags`
+`metrics.default_tags`
 
-_Map of strings to strings, default empty_
+: _Map of strings to strings, default empty_
 
-A set of default tags that should be attached to all outgoing statsd metrics.
+  A set of default tags that should be attached to all outgoing StatsD metrics.
 
-### `metrics.hostname_tag`
+`metrics.hostname_tag`
 
-_String, optional_
+: _String, optional_
 
-If set, reports the current hostname under the given tag name for all metrics.
+  If set, reports the current hostname under the given tag name for all metrics.
 
 ## Internal Error Reporting
 
 Configures error reporting for errors happening within Relay. Disabled by
 default.
 
-### `sentry.enabled`
+`sentry.enabled`
 
-_boolean, default: `false`_
+: _boolean, default: `false`_
 
-Whether to report internal errors to a separate DSN. `false` means no internal
-errors are sent, but still logged.
+  Whether to report internal errors to a separate DSN. `false` means no internal
+  errors are sent, but still logged.
 
-### `sentry.dsn`
+`sentry.dsn`
 
-_String, optional_
+: _String, optional_
 
-Sentry DSN to which to report internal Relay failures.
+  Sentry DSN to which to report internal Relay failures.
 
-We recommend setting this to a value that will not send Relay errors to itself.
-Ideally, this value should send errors to Sentry directly, not another Relay.
+  We recommend setting this to a value that will not send Relay errors to
+  itself. Ideally, this value should send errors to Sentry directly, not another
+  Relay.
 
 [relay modes]: /product/relay/modes/

--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -5,7 +5,7 @@ sidebar_order: 2
 
 The base configuration for Relay lives in the file `.relay/config.yml`. To change this location, pass the `--config` option to any Relay command:
 
-```sh
+```shell
 ❯ ./relay run --config /path/to/folder
 ```
 

--- a/src/docs/product/relay/projects.mdx
+++ b/src/docs/product/relay/projects.mdx
@@ -3,9 +3,11 @@ title: Project Configuration
 sidebar_order: 4
 ---
 
-In `static` and `proxy` mode, you can configure project settings on the file system.
+In `static` and `proxy` mode, you can configure project settings on the file
+system.
 
-Static project configurations are found under the `projects` subdirectory of the Relay configuration directory, By default, this is located at `.relay/projects`.
+Static project configurations are found under the `projects` subdirectory of the
+Relay configuration directory, By default, this is located at `.relay/projects`.
 
 To configure projects, add files named `<PROJECT_ID>.json` in that location:
 
@@ -37,8 +39,8 @@ fields. The minimal configuration **must** contain the following fields:
 
 <Alert level="warning" title="Public Key">
 
-The public key (`<DSN_KEY>`) is the key of the project's DSN and it has nothing
-to do with the Relay public key that is used for Relay registration.
+The public key (`<DSN_KEY>`) is the key of the project's DSN and has nothing to
+do with the Relay public key used for Relay registration.
 
 </Alert>
 
@@ -96,9 +98,9 @@ the key is:
 12345abcdb1e4c123490ecec89c1f199
 ```
 
-A project may contain multiple public keys, only messages using enabled project
-keys will be processed. Likewise, keys can be disabled using the `isEnabled`
-flag.
+A project may contain multiple public keys, but only messages using enabled
+project keys will be processed. Likewise, keys can be disabled using the
+`isEnabled` flag.
 
 ## `config.allowedDomains`
 


### PR DESCRIPTION
Updates wording as suggested by @PeloWriter in https://github.com/getsentry/sentry-docs/pull/2197, and applies standard definition list formatting to options docs.

