### PR TITLE
feat: DevelopmentAPI Sidebar

### DIFF
--- a/src/components/developmentApiSidebar.tsx
+++ b/src/components/developmentApiSidebar.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { graphql, useStaticQuery, withPrefix } from "gatsby";
+import { graphql, useStaticQuery } from "gatsby";
 import { useLocation } from "@reach/router";
 
 import SidebarLink from "./sidebarLink";
-import DynamicNav, { toTree, EntityTree } from "./dynamicNav";
+import DynamicNav, { toTree } from "./dynamicNav";
 
 const query = graphql`
   query DevelopmentApiNavQuery {
@@ -24,17 +24,10 @@ const query = graphql`
 export default () => {
   const data = useStaticQuery(query);
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
-
-  let endpoints = tree[0].children.reduce((acc: EntityTree[], curr: EntityTree) => {
-    if (curr.children.length > 1) {
-      acc.push(curr);
-    }
-    return acc;
-  }, []);
-
+  const endpoints = tree[0].children.filter(curr => curr.children.length > 1);
   const location = useLocation();
-  const isActive = path =>
-    location && location.pathname.indexOf(withPrefix(path)) === 0;
+
+  const isActive = path => location && location.pathname.startsWith(path);
 
   return (
     <ul className="list-unstyled" data-sidebar-tree>

--- a/src/components/developmentApiSidebar.tsx
+++ b/src/components/developmentApiSidebar.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { graphql, useStaticQuery, withPrefix } from "gatsby";
+import { useLocation } from "@reach/router";
+
+import SidebarLink from "./sidebarLink";
+import DynamicNav, { toTree, EntityTree } from "./dynamicNav";
+
+const query = graphql`
+  query DevelopmentApiNavQuery {
+    allSitePage(
+      filter: { path: { regex: "//development-api//" } }
+      sort: { fields: path }
+    ) {
+      nodes {
+        path
+        context {
+          title
+        }
+      }
+    }
+  }
+`;
+
+export default () => {
+  const data = useStaticQuery(query);
+  const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
+
+  let endpoints = tree[0].children.reduce((acc: EntityTree[], curr: any) => {
+    if (curr.children.length > 1) {
+      acc.push(curr);
+    }
+    return acc;
+  }, []);
+
+  const location = useLocation();
+  const isActive = path =>
+    location && location.pathname.indexOf(withPrefix(path)) === 0;
+
+  return (
+    <ul className="list-unstyled" data-sidebar-tree>
+      <DynamicNav
+        root="development-api"
+        title="API Reference"
+        tree={tree}
+        exclude={endpoints.map(elem => elem.node.path)}
+      />
+      <li className="mb-3" data-sidebar-branch>
+        <div
+          className="sidebar-title d-flex align-items-center mb-0"
+          data-sidebar-link
+        >
+          <h6>Endpoints</h6>
+        </div>
+        <ul className="list-unstyled" data-sidebar-tree>
+          {endpoints.map(({ node: { path, context: { title } }, children }) => (
+            <React.Fragment key={path}>
+              <SidebarLink to={path}>{title}</SidebarLink>
+              {isActive(path) && (
+                <div style={{ paddingLeft: "0.5rem" }}>
+                  {children
+                    .filter(({ node }) => !!node)
+                    .map(({ node: { path, context: { title } } }) => (
+                      <SidebarLink key={path} to={path}>
+                        {title}
+                      </SidebarLink>
+                    ))}
+                </div>
+              )}
+            </React.Fragment>
+          ))}
+        </ul>
+      </li>
+    </ul>
+  );
+};

--- a/src/components/developmentApiSidebar.tsx
+++ b/src/components/developmentApiSidebar.tsx
@@ -25,7 +25,7 @@ export default () => {
   const data = useStaticQuery(query);
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
 
-  let endpoints = tree[0].children.reduce((acc: EntityTree[], curr: any) => {
+  let endpoints = tree[0].children.reduce((acc: EntityTree[], curr: EntityTree) => {
     if (curr.children.length > 1) {
       acc.push(curr);
     }

--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -16,13 +16,13 @@ type Node = {
   [key: string]: any;
 };
 
-type Entity<T> = {
+export type Entity<T> = {
   name: string;
   children: T[];
   node: Node | null;
 };
 
-interface EntityTree extends Entity<EntityTree> {}
+export interface EntityTree extends Entity<EntityTree> {}
 
 export const toTree = (nodeList: Node[]): EntityTree[] => {
   const result = [];

--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -16,7 +16,7 @@ type Node = {
   [key: string]: any;
 };
 
-export type Entity<T> = {
+type Entity<T> = {
   name: string;
   children: T[];
   node: Node | null;

--- a/src/gatsby/createPages/createDevelopmentApiReference.ts
+++ b/src/gatsby/createPages/createDevelopmentApiReference.ts
@@ -4,7 +4,7 @@ export default async ({ actions, graphql, reporter }) => {
   const data = await getDataOrPanic(
     `
           query {
-            allFile(filter: {absolutePath: {}, relativePath: {in: ["permissions.mdx", "auth.mdx", "index.mdx", "requests.mdx"]}, dir: {regex: "/api/"}}) {
+            allFile(filter: {absolutePath: {}, relativePath: {in: ["permissions.mdx", "auth.mdx", "index.mdx", "requests.mdx", "pagination.mdx"]}, dir: {regex: "/api/"}}) {
               nodes {
                 id
                 childMarkdownRemark {

--- a/src/templates/developmentAPI.js
+++ b/src/templates/developmentAPI.js
@@ -4,6 +4,7 @@ import Prism from "prismjs";
 
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
+import DevelopmentApiSidebar from "~src/components/developmentApiSidebar";
 
 import "prismjs/components/prism-json";
 
@@ -71,7 +72,7 @@ export default props => {
   }, []);
 
   return (
-    <BasePage {...props}>
+    <BasePage sidebar={<DevelopmentApiSidebar />} {...props}>
       <div className="row">
         <div className="col-6">
           {data.summary && <p>{data.summary}</p>}

--- a/src/templates/developmentApiDoc.js
+++ b/src/templates/developmentApiDoc.js
@@ -3,6 +3,7 @@ import { graphql } from "gatsby";
 
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
+import DevelopmentApiSidebar from "~src/components/developmentApiSidebar";
 
 export default props => {
   const {
@@ -10,7 +11,7 @@ export default props => {
   } = props;
 
   return (
-    <BasePage {...props}>
+    <BasePage sidebar={<DevelopmentApiSidebar />} {...props}>
       <ul>
         {allOpenApi.edges.map(({ node: { path } }) => (
           <li

--- a/src/templates/developmentApiReference.js
+++ b/src/templates/developmentApiReference.js
@@ -3,6 +3,7 @@ import { graphql } from "gatsby";
 
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
+import DevelopmentApiSidebar from "~src/components/developmentApiSidebar";
 
 export default props => {
   const {
@@ -19,7 +20,7 @@ export default props => {
   }, {});
 
   return (
-    <BasePage {...props}>
+    <BasePage sidebar={<DevelopmentApiSidebar />} {...props}>
       <h2>Endpoints</h2>
       <p>A full list of the currently supported API endpoints:</p>
       <ul>


### PR DESCRIPTION
## Objective:
We want to customize the sidebar of the OpenAPI docs and show something similar to the [Stripe docs](https://stripe.com/docs).
If a user wants to exit the OpenAPI Reference then they can use the breadcrumbs navigation.

## UI
<img width="1440" alt="Screen Shot 2020-09-08 at 11 45 16 AM" src="https://user-images.githubusercontent.com/10491193/92515837-17e7a900-f1c9-11ea-8374-57316fc1a303.png">
<img width="1440" alt="Screen Shot 2020-09-08 at 11 45 27 AM" src="https://user-images.githubusercontent.com/10491193/92515854-1cac5d00-f1c9-11ea-993a-73f855d0b1cb.png">
