### PR TITLE
fix: More broken links

### DIFF
--- a/src/docs/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/accounts/quotas/manage-event-stream-guide.mdx
@@ -34,7 +34,7 @@ The integration is enabled by default and adds the following configuration optio
 
 For more information and code samples check out:
 
-- [Integrating the SDK: Filtering Events Reported to Sentry](/platforms/javascript/config/filter/)
+- [Integrating the SDK: Filtering Events Reported to Sentry](/platforms/javascript/configuration/filtering/)
 - [Enriching Error Data](/platforms/javascript/enriching-error-data/additional-data/)
 
 #### GlobalHandlers
@@ -49,7 +49,7 @@ Check out additional configuration options with the [TryCatch](/platforms/javasc
 
 **PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. For more information see [PHP: error_types](/error-reporting/configuration/?platform=php#error_types).
 
-**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. For more information see [Ruby Configuration](/platforms/ruby/config/#optional-settings)
+**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. For more information see [Ruby Configuration](/platforms/ruby/configuration/options/#optional-settings)
 
 ## 3. Inbound Data Filters
 

--- a/src/platforms/go/common/migration.mdx
+++ b/src/platforms/go/common/migration.mdx
@@ -78,7 +78,7 @@ sentry.Init(sentry.ClientOptions{
 })
 ```
 
-Available options: see [Configuration](/platforms/go/config/) section.
+Available options: see [Configuration](/platforms/go/configuration/options/) section.
 
 #### Providing SSL Certificates
 

--- a/src/platforms/go/index.mdx
+++ b/src/platforms/go/index.mdx
@@ -29,7 +29,7 @@ $ go get github.com/getsentry/sentry-go
 
 To use `sentry-go`, you’ll need to import the `sentry-go` package and initialize it with the client options that will include your DSN. If you specify the `SENTRY_DSN` environment variable, you can omit this value from options and it will be picked up automatically for you. The release and environment can also be specified in the environment variables `SENTRY_RELEASE` and `SENTRY_ENVIRONMENT` respectively.
 
-More on this in [Configuration](/platforms/go/config/) section.
+More on this in [Configuration](/platforms/go/configuration/options/) section.
 
 ## Usage {#usage}
 

--- a/src/platforms/java/common/migration.mdx
+++ b/src/platforms/java/common/migration.mdx
@@ -59,7 +59,7 @@ For example, the `logback` appender is now referenced in configuration by using 
 
 This is because appenders are initialized only when the first message (at or above the threshold) is sent to them, which means Sentry has no idea how to initialize and configure itself until the first event is sent. This may seem OK, but it prevented users from being able to do things before an error was sent, such as: record breadcrumbs, set the current user, and more.
 
-For this reason, all configuration is now done “outside” of the logging integration itself. You may configure Sentry using a properties file (default: `sentry.properties`) if you preferred the old style, [more information can be found on the configuration page](/platforms/java/config/#configuration).
+For this reason, all configuration is now done “outside” of the logging integration itself. You may configure Sentry using a properties file (default: `sentry.properties`) if you preferred the old style, [more information can be found on the configuration page](/platforms/java/configuration/options/#configuration-methods).
 
 For example:
 
@@ -153,4 +153,4 @@ In addition, as noted above, the underlying client class `Raven` became `SentryC
 
 `Now (sentry-java)`
 
-: To do customization users subclass `DefaultSentryClientFactory` and then call out that class with the `factory` option, like `factory=my.company.MySentryClientFactory`. [See the configuration page](/platforms/java/config/#configuration) for more information.
+: To do customization users subclass `DefaultSentryClientFactory` and then call out that class with the `factory` option, like `factory=my.company.MySentryClientFactory`. [See the configuration page](/platforms/java/configuration/options/#custom-functionality) for more information.

--- a/src/platforms/php/guides/symfony/config.mdx
+++ b/src/platforms/php/guides/symfony/config.mdx
@@ -2,7 +2,7 @@
 title: Config
 ---
 
-In addition to the [configuration available in the PHP SDK](/platforms/php/config/), there are some Symfony-specific options.
+In addition to the [configuration available in the PHP SDK](/platforms/php/configuration/options/), there are some Symfony-specific options.
 
 All configuration for Symfony is done in `app/config/config.yml`.
 

--- a/src/wizard/java/log4j.md
+++ b/src/wizard/java/log4j.md
@@ -82,6 +82,6 @@ Alternatively, using the `log4j.xml` format:
 </log4j:configuration>
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](/platforms/java/guides/log4j/config/#configuration) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration options page](/platforms/java/guides/log4j/configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->

--- a/src/wizard/java/log4j2.md
+++ b/src/wizard/java/log4j2.md
@@ -56,6 +56,6 @@ Example configuration using the `log4j2.xml` format:
 </configuration>
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](/platforms/java/guides/lgo4j2/config/#configuration) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration options page](/platforms/java/guides/log4j2/configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->

--- a/src/wizard/java/logging.md
+++ b/src/wizard/java/logging.md
@@ -52,6 +52,6 @@ When starting your application, add the `java.util.logging.config.file` to the s
 $ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](/platforms/java/guides/logging/config/#configuration) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration options page](/platforms/java/guides/logging/configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->

--- a/src/wizard/ruby/rails.md
+++ b/src/wizard/ruby/rails.md
@@ -19,7 +19,7 @@ gem "sentry-raven"
 
 ### Configuration
 
-Open up `config/application.rb` and configure the DSN, and any other [_settings_](/platforms/ruby/guides/rails/config/) you need:
+Open up `config/application.rb` and configure the DSN, and any other [_settings_](/platforms/ruby/guides/rails/configuration/options/) you need:
 
 ```ruby
 Raven.configure do |config|


### PR DESCRIPTION
- `/platforms/.*/config/` doesn't exist anymore, thanks to @joergi for reporting in https://github.com/getsentry/sentry-docs/pull/2199#issuecomment-689424309
- lgo4j2 => log4j2
- Fixed some anchors

---

Hacky way of checking the URLs involved:

```
for url in $(git diff --cached -U0 | rg '^\+[^+]' | rg --only-matching '\]\(([^)]+)\)' -r '$1'); do curl -LIso /dev/null -w "%{url_effective} %{http_code}\n" https://docs.sentry.io$url ; done | sort -u 
```