### PR TITLE
fix: Markdown for image instead of link

### DIFF
--- a/src/platforms/javascript/common/configuration/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/configuration/lazy-load-sentry.mdx
@@ -48,7 +48,7 @@ It can take a few minutes until the change is visible in the code, since it’s 
 
 </markdown></Note>
 
-[](js-loader-settings.png)
+![JavaScript Loader Settings](js-loader-settings.png)
 
 ## **Current limitations**
 


### PR DESCRIPTION
Also add an 'alt' for the image.

See https://docs.sentry.io/platforms/javascript/configuration/lazy-load-sentry/#additional-configuration


---

### Before

![image](https://user-images.githubusercontent.com/88819/92603448-9c145c00-f2af-11ea-86ff-a24c2766ed93.png)

---

### After

![image](https://user-images.githubusercontent.com/88819/92603482-a6365a80-f2af-11ea-9140-afc4e0f6c1ac.png)
