### PR TITLE
Revert "fix: Run single request for SDKs"

### DIFF
--- a/src/gatsby/utils/packageRegistry.ts
+++ b/src/gatsby/utils/packageRegistry.ts
@@ -13,16 +13,18 @@ type VersionData = {
   };
   main_docs_url: string;
   name: string;
-  package_url?: string;
+  package_url: string;
   repo_url: string;
   version: string;
 };
 
 export default class PackageRegistry {
   indexCache: { [name: string]: VersionData } | null;
+  cache: { [name: string]: VersionData | {} };
 
   constructor() {
     this.indexCache = null;
+    this.cache = {};
   }
 
   getList = async () => {
@@ -43,16 +45,28 @@ export default class PackageRegistry {
   };
 
   getData = async (name: string) => {
-    await this.getList();
-    return this.indexCache[name]
+    if (!this.cache[name]) {
+      console.info(`Fetching release registry for ${name}`);
+      try {
+        const result = await axios({
+          url: `https://release-registry.services.sentry.io/sdks/${name}/latest`,
+        });
+        this.cache[name] = result.data;
+      } catch (err) {
+        console.error(`Unable to fetch registry for ${name}: ${err.message}`);
+        this.cache[name] = {};
+      }
+    }
+
+    return this.cache[name];
   };
 
-  version = async (name: string, defaultValue: string = "") => {
+  version = async (name, defaultValue: string = "") => {
     const data = (await this.getData(name)) as VersionData;
-    return data && data.version || defaultValue;
+    return data.version || defaultValue;
   };
 
-  checksum = async (name: string, fileName: string, checksum: string) => {
+  checksum = async (name, fileName: string, checksum: string) => {
     const data = (await this.getData(name)) as VersionData;
     if (!data.files) return "";
     return data.files[fileName].checksums[checksum] || "";


### PR DESCRIPTION
Reverts getsentry/sentry-docs#2225

the registry is instantiated multiple times (per-call), so this doesn't actually cache as much