### PR TITLE
fix: Show custom sidebar on "/development-api"

### DIFF
--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -3,10 +3,19 @@ import { graphql } from "gatsby";
 
 import BasePage from "~src/components/basePage";
 import Content from "~src/components/content";
+import DevelopmentApiSidebar from "~src/components/developmentApiSidebar";
 
 export default props => {
+  console.log({ props });
   return (
-    <BasePage {...props}>
+    <BasePage
+      sidebar={
+        props.path.startsWith("/development-api") ? (
+          <DevelopmentApiSidebar />
+        ) : null
+      }
+      {...props}
+    >
       <Content file={props.data.file} />
     </BasePage>
   );

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -6,7 +6,6 @@ import Content from "~src/components/content";
 import DevelopmentApiSidebar from "~src/components/developmentApiSidebar";
 
 export default props => {
-  console.log({ props });
   return (
     <BasePage
       sidebar={


### PR DESCRIPTION
## Objective
OpenAPI docs sidebar not showing up on `/development-api/` in production

## UI
<img width="1374" alt="Screen Shot 2020-09-09 at 10 46 56 AM" src="https://user-images.githubusercontent.com/10491193/92635035-0b775500-f28a-11ea-91da-69e8bde98741.png">
