### PR TITLE
fix: Gatsby guide advanced configuration link

### DIFF
--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -45,7 +45,7 @@ You can register the plugin in your Gatsby configuration file (typically `gatsby
 
 ## Options
 
-The options field in the plugin configuration is passed directly to `Sentry.init`. Check our configuration docs for a [full list of the available options](/error-reporting/configuration/?platform=javascript).
+The options field in the plugin configuration is passed directly to `Sentry.init`. Check our configuration docs for a [full list of the available options](/platforms/javascript/configuration/options/).
 
 For example, the configuration below adjusts the `sampleRate` and `maxBreadcrumbs` options.
 


### PR DESCRIPTION
The link to direct a user from the Gatsby guide to the general Javascript Sentry config documentation is broken in section:
[https://docs.sentry.io/platforms/javascript/guides/gatsby/#options](https://docs.sentry.io/platforms/javascript/guides/gatsby/#options)

Changed link from redirecting from:
`/error-reporting/configuration/?platform=javascript`
to:
`/platforms/javascript/configuration/options/`

Which will bring the user directly to:
[https://docs.sentry.io/platforms/javascript/configuration/options/](https://docs.sentry.io/platforms/javascript/configuration/options/)