### PR TITLE
feat: Tell Vercel to use trailing slash on URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,7 @@
       ]
     }
   ],
+  "trailingSlash": true,
   "redirects": [
     { "source": "/(hosted|on-premise)/(.*)", "destination": "/$2" },
     { "source": "/internal/(.*)", "destination": "https://develop.sentry.dev" },


### PR DESCRIPTION
That's what we had pre-Vercel and Gatsby, so keep canonical URLs with a
trailing slash.

Reference and explanation why the default value 'undefined' is harmful
(double indexing harming SEO):

https://vercel.com/docs/configuration#project/trailingslash/true