### PR TITLE
fix: Infinite redirect loop

### DIFF
--- a/src/platforms/node/common/sourcemaps.mdx
+++ b/src/platforms/node/common/sourcemaps.mdx
@@ -1,8 +1,6 @@
 ---
 title: Source Maps
 sidebar_order: 400
-redirect_from:
-  - /platforms/node/sourcemaps/
 ---
 
 Sentry supports un-minifying JavaScript via [Source Maps](http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).

--- a/src/platforms/node/common/typescript.mdx
+++ b/src/platforms/node/common/typescript.mdx
@@ -2,8 +2,6 @@
 toc: true
 title: TypeScript
 sidebar_order: 500
-redirect_from:
-  - /platforms/node/typescript/
 ---
 
 Please read the [Source Maps docs](/platforms/node/sourcemaps/) first to learn how to configure Sentry SDK, upload artifacts to our servers, or use Webpack (if you’re willing to use _ts-loader_ for your TypeScript compilation).


### PR DESCRIPTION
https://docs.sentry.io/platforms/node/sourcemaps/ would redirect to itself.

Same problem in https://docs.sentry.io/platforms/node/typescript/.