### PR TITLE
feat: change platform redirect wording to be used for non legacy redirects

### DIFF
--- a/src/pages/platform-redirect.tsx
+++ b/src/pages/platform-redirect.tsx
@@ -16,10 +16,11 @@ const PlatformRedirect = ({ path = "/" }: Props) => {
 
   return (
     <Layout>
-      <h1>Content Moved</h1>
+      <h1>Platform Specific Content</h1>
       <p>
-        The page you are looking for has been moved. Select your platform below
-        and we&apos;ll direct you to the most up-to-date documentation on it.
+        The page you are looking for is customized for each platform. Select
+        your platform below and we&apos;ll direct you to the most specific
+        documentation on it.
       </p>
 
       <ul>


### PR DESCRIPTION
This changes the platform redirect text so it also covers cases that are not
legacy redirects.  This comes in useful when trying to link to the docs for
grouping from the Sentry settings where the platform is not known.