### PR TITLE
misc: Add visibility team as codeowners to the product docs they should own.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@
 /src/platforms/native/ @getsentry/owners-native
 
 /src/platforms/rust/ @Swatinem
+
+/src/docs/product/discover-queries/ @getsentry/visibility
+/src/docs/product/performance/ @getsentry/visibility


### PR DESCRIPTION
Add the visibility team as codeowners to the product docs they should own:

- Performance product docs
- Discover product docs