### PR TITLE
Remove not relevant community supported SDKs

### DIFF
--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -24,7 +24,6 @@ These SDKs are maintained and supported by [the Sentry community](https://forum.
 - [_C++_](https://github.com/nlohmann/crow)
 - [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 - [_Crystal_](https://github.com/Sija/raven.cr)
-- [_Flutter_](/platforms/flutter/)
 - [_Grails_](https://github.com/agorapulse/grails-sentry)
 - [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
 - [_Lua_](https://github.com/cloudflare/raven-lua)

--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -21,7 +21,6 @@ If your use-case is very specific, or not covered by Sentry, you'll find documen
 These SDKs are maintained and supported by [the Sentry community](https://forum.sentry.io). While generally our community does a great job at responding to issues, it's important to understand that Sentry staff cannot help you with issues using a community-supported SDK
 
 - [_AdonisJS_](https://github.com/Perafan18/adonis-sentry)
-- [_C++_](https://github.com/nlohmann/crow)
 - [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 - [_Crystal_](https://github.com/Sija/raven.cr)
 - [_Grails_](https://github.com/agorapulse/grails-sentry)
@@ -32,7 +31,6 @@ These SDKs are maintained and supported by [the Sentry community](https://forum.
 - [_Scrapy_](https://github.com/llonchj/scrapy-sentry)
 - [_Terraform_](https://github.com/jianyuan/terraform-provider-sentry)
 - [_Wordpress_](https://github.com/stayallive/wp-sentry)
-- [_Zend_](https://github.com/cloud-solutions/zend-sentry)
 
 ## Other platforms
 


### PR DESCRIPTION
The C++ one hasn't had updates in 2 years and we have sentry-native
Flutter is supported by our team
Zend has a discontinued notice on the readme