### PR TITLE
feat(redirects): Semi magical redirects

### DIFF
--- a/src/platforms/common/data-management/event-grouping/index.mdx
+++ b/src/platforms/common/data-management/event-grouping/index.mdx
@@ -2,8 +2,8 @@
 title: "Grouping Events into Issues"
 sidebar_order: 0
 redirect_from:
-  - /data-management/rollups/
-  - /learn/rollups/
+  - platform:/data-management/rollups/
+  - platform:/learn/rollups/
 ---
 
 All events have a fingerprint. Events with the same fingerprint are grouped together into an issue. By default, Sentry will run one of our built-in grouping algorithms to generate a fingerprint based on information available within the event such as `stacktrace`, `exception`, and `message`. To extend the default grouping behavior or change it completely, you can use a combination of the following options:


### PR DESCRIPTION
Still magical but slightly less magical redirects.  If we use them everywhere
we should be able to cut down on the uses of the vercel redirects.

This should fix for instance this link: https://docs.sentry.io/learn/rollups/