### PR TITLE
fix: Remove redirects

### DIFF
--- a/src/platforms/javascript/common/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/lazy-load-sentry.mdx
@@ -1,8 +1,6 @@
 ---
 title: Lazy Loading Sentry
 sidebar_order: 11
-redirect_from:
-  - /platforms/javascript/common/
 excerpt: ""
 description: "We recommend using our bundled CDN version for the browser. If you use `defer`, learn more about its effect on capturing errors."
 ---

--- a/src/platforms/javascript/common/sourcemaps/hosting-publicly.mdx
+++ b/src/platforms/javascript/common/sourcemaps/hosting-publicly.mdx
@@ -1,7 +1,5 @@
 ---
 title: Hosting Publicly
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/
 ---
 
 By default, Sentry will look for source map directives in your compiled JavaScript files, which are located on the last line and have the following format:

--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -6,7 +6,6 @@ redirect_from:
   - /platforms/javascript/sourcemaps/
   - /platforms/javascript/sourcemaps/generation/
   - /platforms/javascript/sourcemaps/troubleshooting/
-  - /platforms/javascript/common/sourcemaps/
 description: "Learn more about the Sentry SDK's automatic fetching of source code and source maps by scraping the URLs within the stack trace."
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/multiple-origins.mdx
+++ b/src/platforms/javascript/common/sourcemaps/multiple-origins.mdx
@@ -1,7 +1,5 @@
 ---
 title: Multiple Origins
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/
 ---
 
 It’s not uncommon for a web application to be accessible at multiple origins. For example:

--- a/src/platforms/javascript/common/sourcemaps/tools/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/index.mdx
@@ -1,7 +1,5 @@
 ---
 title: Tools
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/tools/
 ---
 
 <PageGrid />

--- a/src/platforms/javascript/common/sourcemaps/tools/systemjs.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/systemjs.mdx
@@ -1,7 +1,5 @@
 ---
 title: SystemJS
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/tools/
 description: "SystemJS is the default module loader for Angular 2 projects."
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/tools/typescript.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/typescript.mdx
@@ -1,7 +1,5 @@
 ---
 title: TypeScript
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/tools/
 description: "The TypeScript compiler can be configured to output source maps."
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/tools/uglifyjs.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/uglifyjs.mdx
@@ -1,7 +1,5 @@
 ---
 title: UglifyJS
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/tools/
 description: "UglifyJS is a popular tool for minifying your source code for production."
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -1,7 +1,5 @@
 ---
 title: Webpack
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/tools/
 description: "Webpack is a powerful build tool that resolves, bundles, and compresses your JavaScript modules."
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/troubleshooting.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting.mdx
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting
 sidebar_order: 1000
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/
 notoc: true
 ---
 

--- a/src/platforms/javascript/common/sourcemaps/validating.mdx
+++ b/src/platforms/javascript/common/sourcemaps/validating.mdx
@@ -1,7 +1,5 @@
 ---
 title: Validating Files
-redirect_from:
-  - /platforms/javascript/common/sourcemaps/
 ---
 
 It can be quite challenging to ensure that source maps are actually valid themselves and uploaded correctly. To help with this, we maintain an online validation tool that can be used to test your source maps against your **hosted** source: [sourcemaps.io](https://sourcemaps.io).

--- a/src/platforms/javascript/common/supported-browsers.mdx
+++ b/src/platforms/javascript/common/supported-browsers.mdx
@@ -1,7 +1,5 @@
 ---
 title: Supported Browsers
-redirect_from:
-  - /platforms/javascript/common/
 excerpt: ""
 description: "We support a variety of browsers; check out our list."
 ---


### PR DESCRIPTION
It does not make sense to have the same URL in the 'redirect_from' list
of multiple pages, because visiting the given URL can only redirect to
one location, not multiple.

AFAIK the has never been content in those URLs we are redirecting from,
so either we need different redirects or none (the content under the
"common" directory is used to generate pages, but "common" is not part
of the resulting URLs).

Updates 84d8a9375bfa997632fe792655a6a1bc004c2a46