### PR TITLE
fix: Remove infinite redirect loop

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -3,7 +3,6 @@ title: Source Maps
 sidebar_order: 3
 redirect_from:
   - /sdks/javascript/config/sourcemaps/
-  - /platforms/javascript/sourcemaps/
   - /platforms/javascript/sourcemaps/generation/
   - /platforms/javascript/sourcemaps/troubleshooting/
 description: "Learn more about the Sentry SDK's automatic fetching of source code and source maps by scraping the URLs within the stack trace."


### PR DESCRIPTION
/platforms/javascript/sourcemaps/ would forever redirect to itself.

## Before

https://docs.sentry.io/platforms/javascript/sourcemaps/

![infinite redirect loop](https://user-images.githubusercontent.com/88819/92965507-31f9e380-f476-11ea-93ae-7cf6520026bc.gif)
