### PR TITLE
Rename troubleshooting due to naming conflict

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -1,5 +1,7 @@
 ---
 title: Troubleshooting
+redirect_from:
+- /platforms/javascript/sourcemaps/troubleshooting/
 ---
 
 Source maps can sometimes be tricky to get going. If you’re having trouble:

--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -1,7 +1,5 @@
 ---
 title: Troubleshooting
-sidebar_order: 1000
-notoc: true
 ---
 
 Source maps can sometimes be tricky to get going. If you’re having trouble:


### PR DESCRIPTION
The name of the JS file for troubleshooting appears to be causing aberrant behavior because it has the same name as the directory troubleshooting.

Renaming the file solves the conflict; tested this on my local.