### PR TITLE
ref: Remove middleware term from Go integrations

### DIFF
--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Echo Middleware
+title: Echo
 ---
 
 This page shows how to use the Echo framework with Sentry.

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: FastHTTP Middleware
+title: FastHTTP
 redirect_from:
   - /platforms/go/fasthttp/
 ---

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Gin Middleware
+title: Gin
 redirect_from:
   - /platforms/go/gin/
 ---

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: net/http Middleware
+title: net/http
 redirect_from:
   - /clients/go/integrations/http/
   - /platforms/go/http/

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Iris Middleware
+title: Iris
 redirect_from:
   - /platforms/go/iris/
 ---

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Martini Middleware
+title: Martini
 redirect_from:
   - /platforms/go/martini/
 ---

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Negroni Middleware
+title: Negroni
 redirect_from:
   - /platforms/go/negroni/
 ---


### PR DESCRIPTION
It's repetitive. We get it, it's all middleware.