### PR TITLE
fix: Should be able to render despite missing data fields

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -184,7 +184,7 @@ const getPlugins = () => {
         name: "openapi",
         resolve: async () => {
           const response = await axios.get(
-            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/68bb79acfbbee062bd8d2f71ee3a07d43dc934c9/openapi-derefed.json"
+            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/7df643a694949f2151270545f095355e5eea498e/openapi-derefed.json"
           );
           return response.data;
         },

--- a/src/templates/developmentAPI.js
+++ b/src/templates/developmentAPI.js
@@ -41,7 +41,7 @@ const strFormat = str => {
 
 export default props => {
   const data = props.data?.openApi?.path || {};
-  const parameters =
+  const bodyParameters =
     (data.requestBody?.content?.schema &&
       JSON.parse(data.requestBody.content.schema)) ||
     null;
@@ -51,9 +51,9 @@ export default props => {
     ` -H "Authorization: Bearer <auth_token>" `,
   ];
 
-  if (parameters) {
+  if (bodyParameters) {
     const body = {};
-    Object.entries(parameters.properties).map(
+    Object.entries(bodyParameters.properties).map(
       ([key, { example }]) => (body[key] = example)
     );
 
@@ -82,35 +82,48 @@ export default props => {
               <p>{data.description}</p>
             </div>
           )}
-          {!!data.parameters.filter(param => param.in === "path").length && (
-            <div className="api-info-row">
-              <strong>Path Parameters:</strong>
-              <Params
-                params={data.parameters.filter(param => param.in === "path")}
-              />
-            </div>
+          {data.parameters && (
+            <React.Fragment>
+              {!!data.parameters.filter(param => param.in === "path")
+                .length && (
+                <div className="api-info-row">
+                  <strong>Path Parameters:</strong>
+                  <Params
+                    params={data.parameters.filter(
+                      param => param.in === "path"
+                    )}
+                  />
+                </div>
+              )}
+
+              {!!data.parameters.filter(param => param.in === "query")
+                .length && (
+                <div className="api-info-row">
+                  <strong>Query Parameters:</strong>
+
+                  <Params
+                    params={data.parameters.filter(
+                      param => param.in === "query"
+                    )}
+                  />
+                </div>
+              )}
+            </React.Fragment>
           )}
 
-          {!!data.parameters.filter(param => param.in === "query").length && (
-            <div className="api-info-row">
-              <strong>Query Parameters:</strong>
-
-              <Params
-                params={data.parameters.filter(param => param.in === "query")}
-              />
-            </div>
-          )}
-
-          {parameters && (
+          {bodyParameters && (
             <div className="api-info-row">
               <strong>Body Parameters:</strong>
               <Params
-                params={Object.entries(parameters.properties).map(
+                params={Object.entries(bodyParameters.properties).map(
                   ([name, { type, description }]) => ({
                     schema: { type },
                     description,
                     name,
-                    required: parameters.required.includes(name),
+                    required:
+                      (bodyParameters.required &&
+                        bodyParameters.required.includes(name)) ||
+                      false,
                   })
                 )}
               />

--- a/src/templates/developmentAPI.js
+++ b/src/templates/developmentAPI.js
@@ -45,7 +45,12 @@ export default props => {
     (data.requestBody?.content?.schema &&
       JSON.parse(data.requestBody.content.schema)) ||
     null;
-
+  const pathParameters = (data.parameters || []).filter(
+    param => param.in === "path"
+  );
+  const queryParameters = (data.parameters || []).filter(
+    param => param.in === "query"
+  );
   const apiExample = [
     `curl https://sentry.io${data.apiPath} `,
     ` -H "Authorization: Bearer <auth_token>" `,
@@ -82,33 +87,20 @@ export default props => {
               <p>{data.description}</p>
             </div>
           )}
-          {data.parameters && (
-            <React.Fragment>
-              {!!data.parameters.filter(param => param.in === "path")
-                .length && (
-                <div className="api-info-row">
-                  <strong>Path Parameters:</strong>
-                  <Params
-                    params={data.parameters.filter(
-                      param => param.in === "path"
-                    )}
-                  />
-                </div>
-              )}
 
-              {!!data.parameters.filter(param => param.in === "query")
-                .length && (
-                <div className="api-info-row">
-                  <strong>Query Parameters:</strong>
+          {!!pathParameters.length && (
+            <div className="api-info-row">
+              <strong>Path Parameters:</strong>
+              <Params params={pathParameters} />
+            </div>
+          )}
 
-                  <Params
-                    params={data.parameters.filter(
-                      param => param.in === "query"
-                    )}
-                  />
-                </div>
-              )}
-            </React.Fragment>
+          {!!queryParameters.length && (
+            <div className="api-info-row">
+              <strong>Query Parameters:</strong>
+
+              <Params params={queryParameters} />
+            </div>
           )}
 
           {bodyParameters && (


### PR DESCRIPTION
## Objective
Some pages was not rendering properly on docs.sentry.io/development-api/. This is because we assumed some data fields would be present, so in this PR we just made them conditionally render on the existence of those fields.

Also this PR will deploy the latest SHA of `getsentry/sentry-api-schema`