### PR TITLE
Update webhook field names

### DIFF
--- a/src/docs/product/alerts-notifications/alerts.mdx
+++ b/src/docs/product/alerts-notifications/alerts.mdx
@@ -46,6 +46,7 @@ When an alert is created or changes status, the actions associated with the trig
 - Send an email (to a member or team). If sent to a member, the member's personal project alert opt-out settings are overridden.
 - Send a Slack notification.
 - Send a PagerDuty incident.
+- Send a request to a webhook (via internal integrations).
 
 ### Alert Stream
 

--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -231,7 +231,11 @@ For more information, see the [full documentation on Webhooks](/workflow/integra
 
 ### Alerts
 
-There is an option called Alert Rule Action for the integration platform. What this means is that, when enabled, your integration will show up as a service in the action section when creating a new alert rule. For more information, see the [full documentation on Alert Rules](/workflow/alerts-notifications/alerts/).
+You can make any integration available as an action in Issue Alert rules and
+Metric Alert rules by enabling the Alert Rule Action toggle. It will then show
+up as a service in the action section when creating or updating an alert rule.
+For more information, see the
+[full documentation on Alert Rules](/workflow/alerts-notifications/alerts/).
 
 ![Dropdown menu of options for alert rules.](alert-rules.png)
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -411,17 +411,17 @@ All webhook requests have some common elements.
 - type: object
 - description: the incident that triggered the alert rule
 
-**data['text']**
+**data['description_text']**
 
 - type: string
 - description: a human-readable description of the alert
 
-**data['title']**
+**data['description_title']**
 
 - type: string
 - description: a human-readable title for the alert
 
-**data['url']**
+**data['web_url']**
 
 - type: string
 - description: the api url for the incident

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -437,6 +437,8 @@ All webhook requests have some common elements.
     "type": "application"
   },
   "data": {
+    "description_text": "1000 events in the last 10 minutes\\nFilter: level:error",
+    "description_title": "Resolved: Too many errors",
     "metric_alert": {
       "alert_rule": {
         "aggregate": "count()",
@@ -476,9 +478,7 @@ All webhook requests have some common elements.
       "title": "Sacred Marmot",
       "type": 2
     },
-    "text": "1000 events in the last 10 minutes\\nFilter: level:error",
-    "title": "Resolved: Too many errors",
-    "url": "https://sentry.io/organizations/baz/alerts/1/",
+    "web_url": "https://sentry.io/organizations/baz/alerts/1/",
   },
   "installation": {
     "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"


### PR DESCRIPTION
Updating docs for Sentry App Metric Alerts.
I've updated the field names in https://github.com/getsentry/sentry/pull/20497.
