### PR TITLE
Docs: Fix Ruby `current_environment` config name

### DIFF
--- a/src/includes/set-environment/ruby.mdx
+++ b/src/includes/set-environment/ruby.mdx
@@ -1,5 +1,5 @@
 ```ruby
 Raven.configure do |config|
-  config.environment = 'production'
+  config.current_environment = 'production'
 end
 ```


### PR DESCRIPTION
Relevant URL: https://docs.sentry.io/platforms/ruby/guides/rails/configuration/environments/

`environment` isn't a valid config and causes the app to crash; I looked into the code and it seems like it's called `current_environment`.