### PR TITLE
moved Integrations in main nav sidebar

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -44,8 +44,9 @@ export const Sidebar = ({ data }: ChildProps): JSX.Element => {
         root="product"
         title="Product"
         tree={tree}
-        exclude={["/product/relay/"]}
+        exclude={["/product/relay/", "/product/integrations/"]}
       />
+      <DynamicNav root="product/integrations" title="Integrations" tree={tree} />
       <DynamicNav root="accounts" title="Account Management" tree={tree} />
       <DynamicNav root="cli" title="sentry-cli" tree={tree} />
       <DynamicNav root="meta" title="Security and Legal" tree={tree} />

--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -13,6 +13,11 @@ description: "Learn more about the wide variety of apps and services integrated 
 
 Sentry integrates with your favorite apps and services. Each integration offers features that help track and triage your errors.
 
+## Integration Platform
+Sentry’s Integration Platform provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public](/product/integrations/integration-platform/#public-integrations) as well as [internal](/product/integrations/integration-platform/#internal-integrations) use cases.
+
+For more details, see the [full Integration Platform documentation](/product/integrations/integration-platform/).
+
 ## Notification & Incidents
 
 | Integration                                   | Alerts | Link Unfurling |

--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -14,7 +14,7 @@ description: "Learn more about the wide variety of apps and services integrated 
 Sentry integrates with your favorite apps and services. Each integration offers features that help track and triage your errors.
 
 ## Integration Platform
-Sentry’s Integration Platform provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public](/product/integrations/integration-platform/#public-integrations) as well as [internal](/product/integrations/integration-platform/#internal-integrations) use cases.
+Sentry’s Integration Platform provides a way for external services to interact with Sentry. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public](/product/integrations/integration-platform/#public-integrations) as well as [internal](/product/integrations/integration-platform/#internal-integrations) use cases.
 
 For more details, see the [full Integration Platform documentation](/product/integrations/integration-platform/).
 

--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -5,7 +5,7 @@ redirect_from:
   - /workflow/integrations/integration-platform/
 ---
 
-Sentry’s Integration Platform provides a way for external services to interact with the Sentry SaaS service using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public](#public-integrations) as well as [internal](#internal-integrations) use cases.
+Sentry’s Integration Platform provides a way for external services to interact with Sentry using the REST API and webhooks. Integrations utilizing this platform are first-class actors within Sentry, and you can build them for [public](#public-integrations) as well as [internal](#internal-integrations) use cases.
 
 ## Creating an Integration
 

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -5,10 +5,10 @@ redirect_from:
   - /workflow/search/
   - /product/search/
   - /learn/search/
-description: "Learn more about Search, which is available on several major Sentry views: Issues and Events."
+description: "Learn more about Search, which is available on several major Sentry views: Issues, Events, and Releases."
 ---
 
-Search is available on several major Sentry views: Issues and Events.
+Search is available on several major Sentry views: Issues, Events, and Releases.
 
 <Alert title="Looking for information on Discover?" level="info"><markdown>
 

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -5,10 +5,10 @@ redirect_from:
   - /workflow/search/
   - /product/search/
   - /learn/search/
-description: "Learn more about Search, which is available on several major Sentry views: Issues, Events, and Releases."
+description: "Learn more about Search, which is available on several major Sentry views: Issues and Events."
 ---
 
-Search is available on several major Sentry views: Issues, Events, and Releases.
+Search is available on several major Sentry views: Issues and Events.
 
 <Alert title="Looking for information on Discover?" level="info"><markdown>
 


### PR DESCRIPTION
Moved Integrations into its own top tier section in the main navigation sidebar.