### PR TITLE
Docs: Fix links in java logging docs page

### DIFF
--- a/src/platforms/java/guides/logging/index.mdx
+++ b/src/platforms/java/guides/logging/index.mdx
@@ -4,7 +4,7 @@ redirect_from:
   - /clients/java/modules/jul/
 ---
 
-The `sentry` library provides a [java.util.logging Handler](https://docs.oracle.com/javase/7/docs/api/java/util/logging/Handler.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), in order to do things like record breadcrumbs, set the current user, or manually send events.
+The `sentry` library provides a [java.util.logging Handler](https://docs.oracle.com/javase/7/docs/api/java/util/logging/Handler.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](configuration/capture/), in order to do things like record breadcrumbs, set the current user, or manually send events.
 
 The source for `sentry` can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry).
 
@@ -51,7 +51,7 @@ When starting your application, add the `java.util.logging.config.file` to the s
 $ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](config/) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](configuration/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 


### PR DESCRIPTION
Fixed 2 broken links in /platforms/java/guides/logging/ page