### PR TITLE
fix: Broken links

### DIFF
--- a/src/platforms/java/guides/log4j/index.mdx
+++ b/src/platforms/java/guides/log4j/index.mdx
@@ -81,7 +81,7 @@ Alternatively, using the `log4j.xml` format:
 </log4j:configuration>
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](config/) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 

--- a/src/platforms/java/guides/log4j2/index.mdx
+++ b/src/platforms/java/guides/log4j2/index.mdx
@@ -55,7 +55,7 @@ Example configuration using the `log4j2.xml` format:
 </configuration>
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](config/) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 

--- a/src/platforms/java/guides/logging/index.mdx
+++ b/src/platforms/java/guides/logging/index.mdx
@@ -51,7 +51,7 @@ When starting your application, add the `java.util.logging.config.file` to the s
 $ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 ```
 
-Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](config/) for ways you can do this.
+Next, **you’ll need to configure your DSN** (client key) and optionally other values such as `environment` and `release`. [See the configuration page](configuration/options/) for ways you can do this.
 
 <!-- TODO-ADD-VERIFICATION-EXAMPLE -->
 

--- a/src/platforms/ruby/guides/rails/index.mdx
+++ b/src/platforms/ruby/guides/rails/index.mdx
@@ -18,7 +18,7 @@ gem "sentry-raven"
 
 ### Configuration
 
-Open up `config/application.rb` and configure the DSN, and any other [_settings_](config/) you need:
+Open up `config/application.rb` and configure the DSN, and any other [settings](configuration/options/) you need:
 
 ```ruby
 Raven.configure do |config|


### PR DESCRIPTION
Updates `.../config/` to `.../configuration/options/`, as that's where we talk about DSN and other init options.

Closes #2296.

Thanks to @bago2k4 for sending the original PR.