### PR TITLE
Update Ruby doc for latest 3.1 version

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -52,7 +52,7 @@ end
 
 `breadcrumbs_logger`
 
-: Sentry supports 2 breadcrumbs loggers in the Ruby SDK:
+: Sentry supports two breadcrumbs loggers in the Ruby SDK:
 - `SentryLogger` - A general breadcrumbs logger for all Ruby applications.
 - `ActiveSupportLogger` - Built on top of Rails ActiveSupport's instrumentation and provide many Rails-specific information.
 

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -40,6 +40,16 @@ end
 
 If the async callback raises an exception, Raven will attempt to send synchronously.
 
+`backtrace_cleanup_callback`
+
+: In case you want to clean up exceptions' backtrace before it's sent to Sentry, you can specify a callback with `backtrace_cleanup_callback` to do that. For example:
+
+```ruby
+config.backtrace_cleanup_callback = lambda do |backtrace|
+  Rails.backtrace_cleaner.clean(backtrace)
+end
+```
+
 `breadcrumbs_logger`
 
 : Sentry supports 2 breadcrumbs loggers in the Ruby SDK:

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -54,7 +54,7 @@ end
 
 : Sentry supports two breadcrumbs loggers in the Ruby SDK:
 - `SentryLogger` - A general breadcrumbs logger for all Ruby applications.
-- `ActiveSupportLogger` - Built on top of Rails ActiveSupport's instrumentation and provide many Rails-specific information.
+- `ActiveSupportLogger` - Built on top of Rails ActiveSupport's instrumentation and provides many Rails-specific information.
 
 And you can enable them with the `breadcrumbs_logger` option:
 

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -40,6 +40,20 @@ end
 
 If the async callback raises an exception, Raven will attempt to send synchronously.
 
+`breadcrumbs_logger`
+
+: Sentry supports 2 breadcrumbs loggers in the Ruby SDK:
+- `SentryLogger` - A general breadcrumbs logger for all Ruby applications.
+- `ActiveSupportLogger` - Built on top of Rails ActiveSupport's instrumentation and provide many Rails-specific information.
+
+And you can enable them with the `breadcrumbs_logger` option:
+
+```ruby
+config.breadcrumbs_logger = :sentry_logger
+config.breadcrumbs_logger = :active_support_logger
+config.breadcrumbs_logger = [:sentry_logger, :active_support_logger]
+```
+
 `encoding`
 
 : While unlikely that you’ll need to change it, by default Raven compresses outgoing messages with gzip. This has a slight impact on performance, but due to the size of many Ruby stack trace it’s required for the serve to accept the content.

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -247,8 +247,8 @@ config.tags = { foo: :bar }
 : If the transport fails to send an event to Sentry for any reason (either the Sentry server has returned a 4XX or 5XX response), this Proc or lambda will be called.
 
 ```ruby
-config.transport_failure_callback = lambda { |event|
-  AdminMailer.email_admins("Oh god, it's on fire!").deliver_later
+config.transport_failure_callback = lambda { |event, error|
+  AdminMailer.email_admins("Oh god, it's on fire because #{error.message}!", event).deliver_later
 }
 ```
 

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -42,7 +42,7 @@ If the async callback raises an exception, Raven will attempt to send synchronou
 
 `backtrace_cleanup_callback`
 
-: In case you want to clean up exceptions' backtrace before it's sent to Sentry, you can specify a callback with `backtrace_cleanup_callback` to do that. For example:
+: If you want to clean up exceptions' backtrace before it's sent to Sentry, you can specify a callback with `backtrace_cleanup_callback` to do that. For example:
 
 ```ruby
 config.backtrace_cleanup_callback = lambda do |backtrace|

--- a/src/platforms/ruby/common/integrations.mdx
+++ b/src/platforms/ruby/common/integrations.mdx
@@ -22,21 +22,21 @@ Integrations are automatically loaded by default. This can be problematic if the
 To explicitly include integrations:
 
 ```ruby
-require 'sentry-raven-without-integrations'
+require 'sentry_raven_without_integrations'
 Raven.inject_only(:railties, :rack, :rake)
 ```
 
 To deny integrations:
 
 ```ruby
-require 'sentry-raven-without-integrations'
+require 'sentry_raven_without_integrations'
 Raven.inject_without(:sidekiq, :delayed_job)
 ```
 
 If you’re using bundler, then in your gemfile:
 
 ```ruby
-gem 'sentry-raven', require: 'sentry-raven-without-integrations'
+gem 'sentry-raven', require: 'sentry_raven_without_integrations'
 ```
 
 And in some sort of initializer:


### PR DESCRIPTION
Hello 👋, Ruby SDK's latest version [`3.1.0`](https://github.com/getsentry/raven-ruby/releases/tag/3.1.0) was just released. And this PR updates the documents to reflect the changes.

