### PR TITLE
misc(CODEOWNERS): Comment out web platform team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-/src/platforms/ @getsentry/team-webplatform
+#/src/platforms/ @getsentry/team-webplatform
 
 /src/platforms/android/ @getsentry/team-mobile
 /src/platforms/cocoa/ @getsentry/team-mobile


### PR DESCRIPTION
Adding the team to CODEOWNERS considerably increased the number of
GitHub notifications the team is getting on a daily basis, while most of
it ends up being noise, rather than PRs that are really waiting for an
approval or other input from the team.

A negative effect of excessive noise is that PRs that really need the
team's attention might accidentally be ignored, lost in the middle of
other unimportant notifications.

From now on we'd like to experiment with manually and explicitly
requiring our review on PRs that genuinely require it, leaving the
initial triage for the docs team that owns the repo as a whole.