### PR TITLE
Add: note about stack frame order

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -428,6 +428,8 @@ All webhook requests have some common elements.
 
 #### Payload
 
+Note: The webhook payload stack frame order lists the oldest frame to the most recent (where the exception happened).
+
 ```json
 {
   "action": "resolved",

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -427,8 +427,11 @@ All webhook requests have some common elements.
 - description: the api url for the incident
 
 #### Payload
-
-Note: The webhook payload stack frame order lists the oldest frame to the most recent (where the exception happened).
+<Note>
+  <markdown>
+    Note: The webhook payload stack frame order lists the oldest frame to the most recent (where the exception happened).
+  </markdown>
+</Note>
 
 ```json
 {


### PR DESCRIPTION
We needed a small note about how the stack frame order lists the oldest frame to the most recent.