### PR TITLE
[WIP] Fix: integrations issue alerts link

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -145,6 +145,8 @@ All webhook requests have some common elements.
 
 ### Issue Alerts
 
+[Metric Alerts test](#metric-alerts)
+
 `'Sentry-Hook-Resource': 'event_alert'`
 
 **Attributes**
@@ -396,6 +398,8 @@ All webhook requests have some common elements.
 ```
 
 ### Metric Alerts
+
+[Issue Alerts test](#issue-alerts)
 
 `'Sentry-Hook-Resource': 'metric_alert'`
 


### PR DESCRIPTION
There's some wonky behavior with this link: https://docs.sentry.io/product/integrations/integration-platform/webhooks/#issue-alerts

Observations for live docs:
- if I **click** the link above, it redirects me to the Metric Alerts section of the page, but the url stays the same -- with the #issue-alerts tag
- Sometimes, when I **manually write** in #issue-alerts into the url, it behaves correctly and takes me to the Issue Alerts section of the page. Other times, it takes me to Metric Alerts. **WARNING**: This behavior is super inconsistent.

Observations for localhost:
- everything is working as it should
- no issues with manually writing the tags into the url
-  created test links (as seen in this PR) and they are working as they should