### PR TITLE
fix(relay): Update links after moving to product

### DIFF
--- a/src/docs/product/relay/best-practices.mdx
+++ b/src/docs/product/relay/best-practices.mdx
@@ -10,22 +10,22 @@ This page reviews our guidelines for operation when self-hosting external Relays
 
 ## General Considerations
 
-* We recommend running Relay using the officially provided Docker image (`getsentry/relay`) found on [DockerHub] and tagged with its Git revision identifier, rather than building from source.
+- We recommend running Relay using the officially provided Docker image (`getsentry/relay`) found on [DockerHub](https://hub.docker.com/r/getsentry/relay/) and tagged with its Git revision identifier, rather than building from source.
 
-* We recommend running at least two Relay instances (containers) with a reverse proxy (such as [HAProxy] or [Nginx]) in front of them for both improved availability and simplified Relay updates.
+- We recommend running at least two Relay instances (containers) with a reverse proxy (such as [HAProxy](https://www.haproxy.org/) or [Nginx](https://nginx.org)) in front of them for both improved availability and simplified Relay updates.
 
-* To monitor your Relay setup, configure both [Logging] and [Metrics].
+- To monitor your Relay setup, configure both [Logging](/product/relay/#logging-and-healthcheck) and [Metrics](/product/relay/metrics/).
 
 ## System Requirements and Recommendations
 
 - CPU
-    - x86-64 (amd64) CPU architecture
-    - Relay is a multi-threaded application that tries to leverage all available CPU cores. As a result, Sentry highly recommends running Relay on multi-core CPUs. If your set up is expected to handle more than 100 requests per second, we recommend running running Relay on at least four (4) CPU cores.
-        - By default, every Relay instance will use the total number of available cores to adjust the sizes of its thread pools. Adjust this behavior by configuring the `limits.max_thread_count`.
+  - x86-64 (amd64) CPU architecture
+  - Relay is a multi-threaded application that tries to leverage all available CPU cores. As a result, Sentry highly recommends running Relay on multi-core CPUs. If your set up is expected to handle more than 100 requests per second, we recommend running running Relay on at least four (4) CPU cores.
+    - By default, every Relay instance will use the total number of available cores to adjust the sizes of its thread pools. Adjust this behavior by configuring the `limits.max_thread_count`.
 - Memory
-    - At least 2GB of RAM per Relay container is recommended.
+  - At least 2GB of RAM per Relay container is recommended.
 - Storage
-    - Relay does not currently require disk storage.
+  - Relay does not currently require disk storage.
 
 ## Example Configuration
 
@@ -58,11 +58,4 @@ cache:
   event_expiry: 1800
 ```
 
-See the [Configuration Options] page for detailed descriptions of all available options.
-
-[metrics]: /meta/relay/metrics/
-[logging]: /meta/relay/#logging-and-healthcheck
-[dockerhub]: https://hub.docker.com/r/getsentry/relay/
-[haproxy]: https://www.haproxy.org/
-[nginx]: https://nginx.org
-[configuration options]: /meta/relay/options/
+See the [Configuration Options](/product/relay/options/) page for detailed descriptions of all available options.

--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -5,13 +5,14 @@ sidebar_order: 1
 redirect_from:
   - /meta/relay/getting-started/
 ---
-Getting started with Relay is as simple as using the default settings. You can also configure Relay to suit your organization's needs. Check the [Configuration Options] page for a detailed discussion of operating scenarios.
+
+Getting started with Relay is as simple as using the default settings. You can also configure Relay to suit your organization's needs. Check the [Configuration Options](/product/relay/options/) page for a detailed discussion of operating scenarios.
 
 <Note>
 <markdown>
 
 The Relay server is called `relay`. Download binaries from [GitHub
-Releases]. A Docker image is provided on [DockerHub].
+Releases](https://github.com/getsentry/relay/releases). A Docker image is provided on [DockerHub](https://hub.docker.com/r/getsentry/relay/).
 
 </markdown>
 </Note>
@@ -33,7 +34,7 @@ Select the default configuration to create a minimal configuration file.
 You can choose to override the default settings by selecting
 _"create custom config"_ and customizing these parameters:
 
-- The `mode` setting, which configures the major mode in which Relay operates. For more information on available Relay modes, refer to [Relay Modes].
+- The `mode` setting, which configures the major mode in which Relay operates. For more information on available Relay modes, refer to [Relay Modes](/product/relay/modes/).
 
   <Alert level="warning">
 
@@ -63,7 +64,7 @@ relay:
   tls_identity_password: ~
 ```
 
-Configurations are fully documented in [Configuration Options].
+Configurations are fully documented in [Configuration Options](/product/relay/options/).
 
 ## Creating Credentials
 
@@ -106,12 +107,12 @@ To register Relay with Sentry:
 
 1. Copy the contents of the public key, either by inspecting the `credentials.json` file or by running:
 
-```shell
-❯ ./relay credentials show
-Credentials:
-  relay id: 8cd24a0e-384d-4052-9010-68a21392b33c
-  public key: nDJl79SbEYH9-8NEJAI7ezrgYfolPW3Bnkg00k1zOfA
-```
+  ```shell
+  ❯ ./relay credentials show
+  Credentials:
+    relay id: 8cd24a0e-384d-4052-9010-68a21392b33c
+    public key: nDJl79SbEYH9-8NEJAI7ezrgYfolPW3Bnkg00k1zOfA
+  ```
 
 2. Click on _Settings_ in the main navigation for Sentry, then select _Relays_.
 
@@ -122,7 +123,7 @@ Credentials:
   ![](edit-relay-key.png)
 
 This process registers Relay with Sentry so it is ready to send messages. See
-[Configuration Options] to learn more about Relay configuration options.
+[Configuration Options](/product/relay/options/) to learn more about Relay configuration options.
 
 ## Running Relay
 
@@ -151,12 +152,12 @@ If you moved your config folder (for example, for security reasons), use the `--
 ### Running Relay in Docker
 
 As an alternate to running the Relay binary directly, Sentry provides a
-Docker image that can be used to run Relay. It can be found on [DockerHub].
+Docker image that can be used to run Relay. It can be found on [DockerHub](https://hub.docker.com/r/getsentry/relay/).
 
 Similar to running the `relay` binary directly, running the Docker image needs a
 directory in which it can find the configuration and credentials files
 (`config.yml` and `credentials.json`). Provide the configuration directory using the standard mechanisms offered by Docker, either by mounting
-[Docker volumes] or by building a new container and copying in the files.
+[Docker volumes](https://docs.docker.com/storage/volumes/) or by building a new container and copying in the files.
 
 For example, you can start the latest version of `relay` as follows:
 
@@ -178,7 +179,7 @@ INFO  relay::setup >   relay id: f2119bc9-9a9b-4531-826b-24e9794902f2
 INFO  relay::setup >   log level: INFO
 ```
 
-This example displays the default logging level, which you can modify so it displays either more or less information. For details about configuring logging please see [Logging] on the options page.
+This example displays the default logging level, which you can modify so it displays either more or less information. For details about configuring logging please see [Logging](/product/relay/options/#logging) on the options page.
 
 Relay provides two URLs for checking system status:
 
@@ -228,12 +229,3 @@ project.
 ## Advanced Configuration
 
 <PageGrid />
-
-
-
-[github releases]: https://github.com/getsentry/relay/releases
-[configuration options]: /meta/relay/options/
-[relay modes]: /meta/relay/modes/
-[dockerhub]: https://hub.docker.com/r/getsentry/relay/
-[docker volumes]: https://docs.docker.com/storage/volumes/
-[logging]: /meta/relay/options/#logging

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -23,7 +23,7 @@ connect to Sentry and are not a beta tester, you need to use `proxy` or `static`
 mode.
 
 If you want to beta test the `managed` mode while connecting to Sentry, please
-contact us. See [Relay Modes] for more information.
+contact us. See [Relay Modes](/product/relay/modes/) for more information.
 
 </Alert>
 
@@ -45,14 +45,14 @@ To choose the right place for data scrubbing, consider:
 
 - If you prefer to configure data scrubbing in a central place, you can let
   Sentry handle data scrubbing. Upon arrival, Sentry immediately applies
-  [server-side scrubbing] and guarantees that personal information is never
+  [server-side scrubbing](/platform-redirect/?next=/data-management/sensitive-data/%23server-side-scrubbing) and guarantees that personal information is never
   stored.
 
 - If you cannot send PII outside your infrastructure, but you still prefer to
   configure data scrubbing in a centralized place, configure your SDK to send events to Relay. Relay uses the privacy settings configured in Sentry, and scrubs PII before forwarding data to Sentry.
 
 - If you must enforce strict data privacy requirements, you can configure SDKs to
-  scrub PII using the [`before-send` hooks], which prevents data from being
+  scrub PII using the [`before-send` hooks](/platform-redirect/?next=configuration/options/%23hooks), which prevents data from being
   collected on the device. This may require you to replicate the same logic across
   your applications, but may impact performance.
 
@@ -67,7 +67,3 @@ By default, SDKs need to be configured with a Data Source Name (DSN) that points
 ## Configuration
 
 <PageGrid />
-
-
-[`before-send` hooks]: /platform-redirect/?next=configuration/options/%23hooks
-[server-side scrubbing]: /platform-redirect/?next=/data-management/sensitive-data/%23server-side-scrubbing

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relay
 description: "Learn more about Relay, Sentry's data security solution."
-sidebar_order: 1
+sidebar_order: 7
 redirect_from:
   - /meta/relay/
 ---
@@ -13,7 +13,6 @@ Relay is specifically designed to:
 - Scrub personal information in a central place prior to sending it to Sentry, adding to the places Sentry already scrubs PII
 - Improve event response time in regions with low bandwidth or limited connectivity
 - Act as an opaque proxy for organizations that restrict all HTTP communication to a custom domain name
-
 
 <Alert level="info" title="Note">
 

--- a/src/docs/product/relay/modes.mdx
+++ b/src/docs/product/relay/modes.mdx
@@ -12,7 +12,7 @@ The mode is stored in the configuration file, which contains the `relay.mode` fi
 
 In Sentry, event processing is configured according to both project and organization settings. Some settings, such as privacy controls, are set at the organization level, then inherited by all projects in that organization; other settings are specified per project. For Relay, events are processed according to the inherited project settings to which the event is sent.
 
-Configuration for Relay is refreshed in regular intervals by polling Sentry. Sentry does not need line-of-sight to your Relays. See [Configuration Options] regarding configuration of intervals, timeouts, and retries.
+Configuration for Relay is refreshed in regular intervals by polling Sentry. Sentry does not need line-of-sight to your Relays. See [Configuration Options](/product/relay/options/) regarding configuration of intervals, timeouts, and retries.
 
 ## Managed Mode
 
@@ -53,7 +53,7 @@ relay:
 ```
 
 To configure projects, add files using the format `projects/<PROJECT_ID>.json` to your Relay configuration folder. For a description of the contents of this file,
-refer to [Project Configuration].
+refer to [Project Configuration](/product/relay/projects/).
 
 ## Proxy Mode
 
@@ -76,6 +76,3 @@ To activate proxy mode, set this configuration:
 relay:
   mode: proxy
 ```
-
-[configuration options]: /meta/relay/options/
-[project configuration]: /meta/relay/projects/

--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -24,7 +24,7 @@ The following document the general settings for Relay:
   and `capture`
 
   Controls how Relay obtains the project configuration for events. For detailed
-  explanation of these modes, see [Relay Modes].
+  explanation of these modes, see [Relay Modes](/product/relay/modes/).
 
 `relay.upstream`
 
@@ -394,5 +394,3 @@ default.
   We recommend setting this to a value that will not send Relay errors to
   itself. Ideally, this value should send errors to Sentry directly, not another
   Relay.
-
-[relay modes]: /meta/relay/modes/

--- a/src/docs/product/relay/projects.mdx
+++ b/src/docs/product/relay/projects.mdx
@@ -47,63 +47,60 @@ The public key (`<DSN_KEY>`) is the key of the project's DSN and is unrelated to
 `slug`
 
 : The short name of the project, displayed in Sentry. This value is currently
-  required for Relay to accept events.
+required for Relay to accept events.
 
-  ```json
-  {
+```json
+{
   "slug": "my-project"
-  }
-  ```
+}
+```
 
 `disabled`
 
 : Whether the project is disabled. If set to `true`, the Relay will drop all
-  events sent to this project.
+events sent to this project.
 
-  ```json
-  {
-    "disabled": false
-  }
-  ```
+```json
+{
+  "disabled": false
+}
+```
 
 `publicKeys`
 
 : A list of known public keys (the public key in a DSN) and whether events using
-  that key should be accepted.
+that key should be accepted.
 
-  ```json
-  {
-    "publicKeys": [
-      {
-        "publicKey": "12345abcdb1e4c123490ecec89c1f199",
-        "isEnabled": true
-      }
-    ]
-  }
-  ```
+```json
+{
+  "publicKeys": [
+    {
+      "publicKey": "12345abcdb1e4c123490ecec89c1f199",
+      "isEnabled": true
+    }
+  ]
+}
+```
 
-  You can obtain the key by going into the _Sentry > Project Settings > Client Keys (DSN)_ . The public key can be extracted from the DSN. In this DSN, for example, `https://12345abcdb1e4c123490ecec89c1f199@o1.ingest.sentry.io/2244`, the key is `12345abcdb1e4c123490ecec89c1f199`.
+You can obtain the key by going into the _Sentry > Project Settings > Client Keys (DSN)_ . The public key can be extracted from the DSN. In this DSN, for example, `https://12345abcdb1e4c123490ecec89c1f199@o1.ingest.sentry.io/2244`, the key is `12345abcdb1e4c123490ecec89c1f199`.
 
-  A project may contain multiple public keys, but only messages using enabled project keys will be processed. Likewise, keys can be disabled using the `isEnabled` flag.
+A project may contain multiple public keys, but only messages using enabled project keys will be processed. Likewise, keys can be disabled using the `isEnabled` flag.
 
 `config.allowedDomains`
 
 : Configure _Origin_ or _Referer_ URLs from which Sentry should accept events.
-  This is corresponds to the _Allowed Domains_ setting in the Sentry UI.
+This is corresponds to the _Allowed Domains_ setting in the Sentry UI.
 
   <Alert level="warning" title="Warning">
 
-  An empty list rejects all origins. Use the default `["*"]` to allow all origins.
+An empty list rejects all origins. Use the default `["*"]` to allow all origins.
 
   </Alert>
 
-  ```json
-  {
-    "config": {
-      "allowedDomains": ["mycompany.com"]
-    }
+```json
+{
+  "config": {
+    "allowedDomains": ["mycompany.com"]
   }
-  ```
-
-
-[getting started]: /meta/relay/getting-started/
+}
+```


### PR DESCRIPTION
- Also reverts the sidebar order back to original.
- This also inlines links so that they no longer get out of sync with the page. 
- Finally, this reformats the best practices page.

Follow-up to https://github.com/getsentry/sentry-docs/pull/2331