### PR TITLE
add unsupported to frontmatter for breakpad, crashpad, and minidumps

### DIFF
--- a/src/platforms/common/configuration/index.mdx
+++ b/src/platforms/common/configuration/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-notSupported: ["native.ue4", "native.breakpad", "native.crashpad"]
+notSupported: ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps"]
 sidebar_order: 5
 ---
 

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -6,6 +6,10 @@ notoc: true
 supported:
   - native
   - javascript
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 Sentry can augment your crash reports by storing additional files alongside the event, such as log files, as attachments. Attachments allow the files within a crash to not only upload to Sentry, but also persist for further investigation. You can use a higher-level SDK for platforms with built-in support for native crashes, or generate and upload attachments using the API:

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -10,6 +10,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 Sentry can augment your crash reports by storing additional files alongside the event, such as log files, as attachments. Attachments allow the files within a crash to not only upload to Sentry, but also persist for further investigation. You can use a higher-level SDK for platforms with built-in support for native crashes, or generate and upload attachments using the API:

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -6,6 +6,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an issue. These events are very similar to traditional logs, but can record more rich structured data.

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -2,6 +2,10 @@
 title: Breadcrumbs
 sidebar_order: 102
 description: "Learn more about what Sentry uses to create a trail of events (breadcrumbs) that happened prior to an issue."
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an issue. These events are very similar to traditional logs, but can record more rich structured data.

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -1,6 +1,10 @@
 ---
 title: Add Context
 sidebar_order: 1
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries) to an event. You cannot search these, but they are viewable on the issue page:

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -5,6 +5,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries) to an event. You cannot search these, but they are viewable on the issue page:

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -5,6 +5,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 Users consist of a few critical pieces of information that construct a unique identity in Sentry. Each of these is optional, but one **must** be present for the Sentry SDK to capture the user:

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -1,6 +1,10 @@
 ---
 title: Identify Users
 sidebar_order: 2
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 Users consist of a few critical pieces of information that construct a unique identity in Sentry. Each of these is optional, but one **must** be present for the Sentry SDK to capture the user:

--- a/src/platforms/common/enriching-events/index.mdx
+++ b/src/platforms/common/enriching-events/index.mdx
@@ -1,5 +1,9 @@
 ---
 title: Enriching Events
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 <PageGrid />

--- a/src/platforms/common/enriching-events/index.mdx
+++ b/src/platforms/common/enriching-events/index.mdx
@@ -4,6 +4,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 <PageGrid />

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -4,6 +4,10 @@ sidebar_order: 200
 redirect_from:
   - /learn/scopes/
 description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -8,6 +8,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra

--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -5,6 +5,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 **Tags** are key/value string pairs that are both indexed and searchable. Tags power UI features such as filters and tag-distribution maps. Tags help you quickly access related events and view the tag distribution for a set of events. Common uses for tags include hostname, platform version, and user language.

--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -1,6 +1,10 @@
 ---
 title: Customize Tags
 sidebar_order: 3
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 **Tags** are key/value string pairs that are both indexed and searchable. Tags power UI features such as filters and tag-distribution maps. Tags help you quickly access related events and view the tag distribution for a set of events. Common uses for tags include hostname, platform version, and user language.

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -17,6 +17,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. This type of feedback is useful when you may typically render a plain error page (the classic `500.html`).

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -14,6 +14,9 @@ notSupported:
   - dotnet.serilog
   - dotnet.nlog
   - dotnet.wpf
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. This type of feedback is useful when you may typically render a plain error page (the classic `500.html`).

--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -7,6 +7,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.ue4
 ---
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, exceptions, and rejections.

--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -3,6 +3,10 @@ title: Usage
 sidebar_order: 10
 excerpt: ""
 description: "Learn more about automatically reporting errors, exceptions, and rejections as well as how to manually capture errors and enable message capture."
+notSupported:
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
 ---
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, exceptions, and rejections.


### PR DESCRIPTION
This PR ensures that breakpad, crashpad, and minidumps don't display information that is not pertinent to their audience.