### PR TITLE
feat(api-docs): Update SHA to get latest schema

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -192,7 +192,7 @@ const getPlugins = () => {
         name: "openapi",
         resolve: async () => {
           const response = await axios.get(
-            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/fd63b135165bc5f8292291ecd69996a63f098f98/openapi-derefed.json"
+            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/2006eb13d297386585507f6f5c40e9a7306a2835/openapi-derefed.json"
           );
           return response.data;
         },


### PR DESCRIPTION
This PR updates the SHA for the sentry-api-schema repo to include the change from https://github.com/getsentry/sentry-api-schema/pull/27