### PR TITLE
fix: suggest importing just init rather than all

### DIFF
--- a/src/platforms/javascript/guides/angular/index.mdx
+++ b/src/platforms/javascript/guides/angular/index.mdx
@@ -34,11 +34,11 @@ yarn add @sentry/angular
 ```javascript
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import * as Sentry from "@sentry/angular";
+import { init as initSentry } from "@sentry/angular";
 
 import { AppModule } from "./app/app.module";
 
-Sentry.init({ dsn: "___PUBLIC_DSN___" });
+initSentry({ dsn: "___PUBLIC_DSN___" });
 
 enableProdMode();
 platformBrowserDynamic()


### PR DESCRIPTION
To ensure proper treeshaking, do not import all from `@sentry/angular`