### PR TITLE
Correcting return type

### DIFF
--- a/src/includes/configuration/before-send/php.mdx
+++ b/src/includes/configuration/before-send/php.mdx
@@ -3,7 +3,7 @@ In PHP a function can be used to modify the event or return a completely new one
 ```php
 Sentry\init([
   'dsn' => '___PUBLIC_DSN___',
-  'before_send' => function (Sentry\Event $event): ?Event {
+  'before_send' => function (Sentry\Event $event): ?Sentry\Event {
     return $event;
   },
 ]);


### PR DESCRIPTION
Correcting the return type from Event to Sentry\Event in PHP before_send example.