### PR TITLE
feat(koa-guide): koa guide set the transaction on scope

### DIFF
--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -109,6 +109,10 @@ const tracingMiddleWare = async (ctx, next) => {
     traceId,
     sampled,
   });
+  
+  // put the transaction on the scope so that you can retrieve it with Sentry.getCurrentHub().getScope().getTransaction();
+  Sentry.getCurrentHub().configureScope(scope => scope.setSpan(transaction));
+  // put the transaction on the context to retrieve it from there (where possible)
   ctx.__sentry_transaction = transaction;
   await next();
 

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -110,7 +110,8 @@ const tracingMiddleWare = async (ctx, next) => {
     sampled,
   });
   
-  // put the transaction on the scope so that you can retrieve it with Sentry.getCurrentHub().getScope().getTransaction();
+  // put the transaction on the scope so that you can retrieve it 
+  // with Sentry.getCurrentHub().getScope().getTransaction();
   Sentry.getCurrentHub().configureScope(scope => scope.setSpan(transaction));
   // put the transaction on the context to retrieve it from there (where possible)
   ctx.__sentry_transaction = transaction;


### PR DESCRIPTION
This enables the transaction retrieval for koa described by the [performance monitoring docs of nodejs](https://docs.sentry.io/platforms/node/performance/).
With that the usage for koa is the same like for express.js.