### PR TITLE
feat(api-docs): Update api-schema SHA

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -192,7 +192,7 @@ const getPlugins = () => {
         name: "openapi",
         resolve: async () => {
           const response = await axios.get(
-            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/2006eb13d297386585507f6f5c40e9a7306a2835/openapi-derefed.json"
+            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/d7eb0bf0dba8c4725f4514c81bacea39dad6a503/openapi-derefed.json"
           );
           return response.data;
         },


### PR DESCRIPTION
This PR updates the api-schema SHA again to include the changes from https://github.com/getsentry/sentry-api-schema/pull/28