### PR TITLE
Add: restriction for release naming

### DIFF
--- a/src/docs/cli/releases.mdx
+++ b/src/docs/cli/releases.mdx
@@ -13,7 +13,7 @@ Because releases work on projects you will need to specify the organization and 
 
 ## Creating Releases
 
-Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot contain newlines, spaces, or "\\\", be ".", "..", or exceed 200 characters. The value can be arbitrary, but for certain platforms, recommendations exist:
+Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot contain newlines, spaces, "/" or "\\\", be ".", "..", or exceed 200 characters. The value can be arbitrary, but for certain platforms, recommendations exist:
 
 - for mobile devices use `package-name@version-number` or `package-name@version-number+build-number`. **Do not** use `VERSION_NUMBER (BUILD_NUMBER)` as the parenthesis are used for display purposes (foo@1.0+2 becomes 1.0 (2)), so invoking them will cause an error.
 - if you use a DVCS we recommed using the identifying hash (eg: the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let sentry-cli automatically determine this hash for supported version control systems with `sentry-cli releases propose-version`.

--- a/src/docs/cli/releases.mdx
+++ b/src/docs/cli/releases.mdx
@@ -13,7 +13,13 @@ Because releases work on projects you will need to specify the organization and 
 
 ## Creating Releases
 
-Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot contain newlines, spaces, "/" or "\\\", be ".", "..", or exceed 200 characters. The value can be arbitrary, but for certain platforms, recommendations exist:
+Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
+
+- contain newlines or spaces
+- use a forward slash ("/"), back slash "\\\", period ("."), or double period ("..")
+- exceed 200 characters
+
+The value can be arbitrary, but for certain platforms, recommendations exist:
 
 - for mobile devices use `package-name@version-number` or `package-name@version-number+build-number`. **Do not** use `VERSION_NUMBER (BUILD_NUMBER)` as the parenthesis are used for display purposes (foo@1.0+2 becomes 1.0 (2)), so invoking them will cause an error.
 - if you use a DVCS we recommed using the identifying hash (eg: the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let sentry-cli automatically determine this hash for supported version control systems with `sentry-cli releases propose-version`.

--- a/src/docs/cli/releases.mdx
+++ b/src/docs/cli/releases.mdx
@@ -16,7 +16,7 @@ Because releases work on projects you will need to specify the organization and 
 Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
 
 - contain newlines or spaces
-- use a forward slash ("/"), back slash "\\\", period ("."), or double period ("..")
+- use a forward slash ("/"), back slash ("\"), period ("."), or double period ("..")
 - exceed 200 characters
 
 The value can be arbitrary, but for certain platforms, recommendations exist:

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -23,7 +23,11 @@ Additionally, releases are used for applying [source maps](/platforms/javascript
 
 Include a release ID (often called a "version") when you configure your client SDK. This ID is commonly a git SHA or a custom version number.
 
-The release name cannot contain newlines, spaces, "/" or "\\\", be ".", "..", or exceed 200 characters.
+The release name cannot:
+
+- contain newlines or spaces
+- use a forward slash ("/"), back slash "\\\", period ("."), or double period ("..")
+- exceed 200 characters
 
 <Note><markdown>
 

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -26,7 +26,7 @@ Include a release ID (often called a "version") when you configure your client S
 The release name cannot:
 
 - contain newlines or spaces
-- use a forward slash ("/"), back slash "\\\", period ("."), or double period ("..")
+- use a forward slash ("/"), back slash ("\\"), period ("."), or double period ("..")
 - exceed 200 characters
 
 <Note><markdown>

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -23,7 +23,7 @@ Additionally, releases are used for applying [source maps](/platforms/javascript
 
 Include a release ID (often called a "version") when you configure your client SDK. This ID is commonly a git SHA or a custom version number.
 
-The release name cannot contain newlines, spaces, or "\\\", be ".", "..", or exceed 200 characters.
+The release name cannot contain newlines, spaces, "/" or "\\\", be ".", "..", or exceed 200 characters.
 
 <Note><markdown>
 


### PR DESCRIPTION
We need to let customers know that "/" is unavailable for release ids.