### PR TITLE
feat: Parse backticks as html code elements

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -41,4 +41,14 @@ describe("parseBackticks", () => {
       "The <code>quick</code> <code>brown</code> fox <code>jumps</code> over the lazy dog."
     );
   });
+
+  it("converts multiple backticks as code element", () => {
+    const result = parseBackticks(
+      'Possible values are: ``""`` (disable),``"24h"``, ``"14d"``'
+    );
+
+    expect(result).toBe(
+      'Possible values are: <code>""</code> (disable),<code>"24h"</code>, <code>"14d"</code>'
+    );
+  });
 });

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { sortPages } from "../utils";
+import { sortPages, parseBackticks } from "../utils";
 
 const PAGE_ONE = { context: { title: "Test", sidebar_order: 5 } };
 const PAGE_TWO = { context: { title: "Test Two", sidebar_order: 10 } };
@@ -20,5 +20,25 @@ describe("sortPages", () => {
     expect(result[0].node).toBe(PAGE_ONE);
     expect(result[1].node).toBe(PAGE_THREE);
     expect(result[2].node).toBe(PAGE_TWO);
+  });
+});
+
+describe("parseBackticks", () => {
+  it("converts a single code formatted string in a string", () => {
+    const result = parseBackticks(
+      "The `quick` brown fox jumps over the lazy dog."
+    );
+    expect(result).toBe(
+      "The <code>quick</code> brown fox jumps over the lazy dog."
+    );
+  });
+
+  it("coverts multiple code formatted strings in a string", () => {
+    const result = parseBackticks(
+      "The `quick` `brown` fox `jumps` over the lazy dog."
+    );
+    expect(result).toBe(
+      "The <code>quick</code> <code>brown</code> fox <code>jumps</code> over the lazy dog."
+    );
   });
 });

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -114,7 +114,7 @@ export default props => {
 
           {data.description && (
             <div className="pb-3 content-flush-bottom">
-              <p>{data.description}</p>
+              <p>{parseBackticks(data.description)}</p>
             </div>
           )}
 

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
+import {parseBackticks} from "~src/utils";
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
 import ApiSidebar from "~src/components/apiSidebar";
@@ -12,37 +13,6 @@ import {
 } from "~src/gatsby/plugins/gatsby-plugin-openapi/types.ts";
 
 import "prismjs/components/prism-json";
-
-const parseBackticks = (str: string) => {
-  let arr = str.split("");
-  let i = 0;
-  let j = arr.length - 1;
-
-  const forward = () => {
-    for (i <= j; i++; ) {
-      if (arr[i] === "`") {
-        arr[i] = "<code>";
-        break;
-      }
-    }
-  };
-
-  const reverse = () => {
-    for (j >= i; j--; ) {
-      if (arr[j] === "`") {
-        arr[j] = "</code>";
-        break;
-      }
-    }
-  };
-
-  while (i <= j) {
-    forward();
-    reverse();
-  }
-
-  return arr.join("");
-};
 
 const Params = ({ params }) => (
   <dl className="api-params">

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -13,6 +13,37 @@ import {
 
 import "prismjs/components/prism-json";
 
+const parseBackticks = (str: string) => {
+  let arr = str.split("");
+  let i = 0;
+  let j = arr.length - 1;
+
+  const forward = () => {
+    for (i <= j; i++; ) {
+      if (arr[i] === "`") {
+        arr[i] = "<code>";
+        break;
+      }
+    }
+  };
+
+  const reverse = () => {
+    for (j >= i; j--; ) {
+      if (arr[j] === "`") {
+        arr[j] = "</code>";
+        break;
+      }
+    }
+  };
+
+  while (i <= j) {
+    forward();
+    reverse();
+  }
+
+  return arr.join("");
+};
+
 const Params = ({ params }) => (
   <dl className="api-params">
     {params.map(param => (
@@ -25,7 +56,13 @@ const Params = ({ params }) => (
 
           {!!param.required && <div className="required">REQUIRED</div>}
         </dt>
-        <dd>{!!param.description && param.description}</dd>
+        {!!param.description && (
+          <dd
+            dangerouslySetInnerHTML={{
+              __html: parseBackticks(param.description),
+            }}
+          ></dd>
+        )}
       </React.Fragment>
     ))}
   </dl>

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
-import {parseBackticks} from "~src/utils";
+import { parseBackticks } from "~src/utils";
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
 import ApiSidebar from "~src/components/apiSidebar";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,3 +72,13 @@ export const sortPages = (
     return a.context.title.localeCompare(b.context.title);
   });
 };
+
+export const parseBackticks = (str: string) => {
+  let i = 0;
+  return str
+    .split("")
+    .map(c => {
+      return c === "`" ? (i++ % 2 ? "</code>" : "<code>") : c;
+    })
+    .join("");
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,7 @@ export const sortPages = (
 export const parseBackticks = (str: string) => {
   let i = 0;
   return str
+    .replace(/\`+/g, "`")
     .split("")
     .map(c => {
       return c === "`" ? (i++ % 2 ? "</code>" : "<code>") : c;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,10 +73,14 @@ export const sortPages = (
   });
 };
 
+// Does not cover the following edge cases:
+// - a code block containing a single backtick
+// But I don't think this case will occur in the OpenAPI schema.
+// We assume that individuals will always close out their code blocks, as they have done in the markdown files.
 export const parseBackticks = (str: string) => {
   let i = 0;
   return str
-    .replace(/\`+/g, "`")
+    .replace(/\`+/g, "`") // Squash backticks for code blocks with multiple backticks
     .split("")
     .map(c => {
       return c === "`" ? (i++ % 2 ? "</code>" : "<code>") : c;


### PR DESCRIPTION
## Objective
All code formatted strings are formatted properly.

Naive parsing function should be O(n). **Can this be improved?**

## UI
*BEFORE*
<img width="1440" alt="Screen Shot 2020-09-25 at 1 01 23 PM" src="https://user-images.githubusercontent.com/10491193/94311057-78981500-ff2f-11ea-9423-84bba613bf1b.png">

*AFTER*
<img width="1440" alt="Screen Shot 2020-09-25 at 1 03 05 PM" src="https://user-images.githubusercontent.com/10491193/94311076-7fbf2300-ff2f-11ea-9373-c2a457aee3fb.png">
