### PR TITLE
fix: wrong link to context documentation

### DIFF
--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -24,7 +24,7 @@ blank scope are created on it. That hub is then associated with the current
 thread and will internally hold a stack of scopes.
 
 The scope will hold useful information that should be sent along with the
-event. For instance [contexts](../additional-data/) or
+event. For instance [contexts](../context/) or
 [breadcrumbs](../breadcrumbs/) are stored on
 the scope. When a scope is pushed, it inherits all data from the parent scope
 and when it pops all modifications are reverted.
@@ -40,7 +40,7 @@ of the box. The hub you are unlikely to be interacting with directly unless you
 are writing an integration or you want to create or destroy scopes. Scopes on the
 other hand are more user facing. You can at any point in time call
 `configure-scope` to modify data stored on the scope. This is for instance
-used to [modify the context](../additional-data/).
+used to [modify the context](../context/).
 
 <Alert>
 If you are very curious about how thread locality works: On platforms such as .NET
@@ -69,7 +69,7 @@ This can also be applied when unsetting a user at logout:
 <PlatformContent includePath="unset-user" />
 
 To learn what useful information can be associated with scopes see
-[the context documentation](../additional-data/).
+[the context documentation](../context/).
 
 ## Local Scopes
 


### PR DESCRIPTION
additional-data is 404, so I'm guessing these links should lead to the context page?

link to the direct page:
https://sentry-docs-git-fork-id0sch-patch-1.sentry.dev/platforms/javascript/enriching-events/scopes/