### PR TITLE
docs(laravel): More straight-forward performance onboarding

### DIFF
--- a/src/wizard/php/laravel.md
+++ b/src/wizard/php/laravel.md
@@ -47,11 +47,16 @@ Create the Sentry configuration file (`config/sentry.php`) with this command:
 $ php artisan sentry:publish
 ```
 
-Add your DSN to `.env`:
+Add your DSN to `.env` and set a sample rate for capturing performance data (tracing):
 
 ```shell
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
+
+SENTRY_TRACES_SAMPLE_RATE=1
 ```
+
+The above configuration captures both error and performance data. To reduce the volume of performance data captured, or disable it entirely, change tracesSampleRate to a value between 0 and 1.
+
 
 You can easily verify that Sentry is capturing errors in your Laravel application by creating a debug route that will throw an exception:
 
@@ -62,17 +67,3 @@ Route::get('/debug-sentry', function () {
 ```
 
 Visiting this route will trigger an exception that will be captured by Sentry.
-
-**Monitor Performane**
-
-Set `traces_sample_rate` to a value greater than `0.0` (`config/sentry.php`) after that, Performance Monitoring will be enabled.
-
-```php
-'traces_sample_rate' => 1.0 # be sure to lower this in production to prevent quota issues
-```
-
-or in the `.env` file:
-
-```shell
-SENTRY_TRACES_SAMPLE_RATE=1
-```

--- a/src/wizard/php/laravel.md
+++ b/src/wizard/php/laravel.md
@@ -55,7 +55,7 @@ SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
 SENTRY_TRACES_SAMPLE_RATE=1
 ```
 
-The above configuration captures both error and performance data. To reduce the volume of performance data captured, or disable it entirely, change tracesSampleRate to a value between 0 and 1.
+The above configuration captures both error and performance data. To reduce the volume of performance data captured, or disable it entirely, change `tracesSampleRate` to a value between 0 and 1.
 
 
 You can easily verify that Sentry is capturing errors in your Laravel application by creating a debug route that will throw an exception:


### PR DESCRIPTION
Instead of having a separate block for Performance, include it in the environment variable guide for DSN and add a note about reducing volume or even opting out.

I also suggest here strictly using the environment variable configuration method, since we already do that for DSN. If there's a reason we should show the alternate setup (which, fwiw, I didn't even know where to put), please let me know @HazAT.

After:

![image](https://user-images.githubusercontent.com/2153/94499840-90cb9680-01b2-11eb-8395-907f780070ff.png)
