### PR TITLE
fix(platforms): Let sub-platform list overflow

### DIFF
--- a/src/components/platformGrid.tsx
+++ b/src/components/platformGrid.tsx
@@ -9,7 +9,6 @@ const PlatformCell = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  height: 116px;
 
   overflow: hidden;
 
@@ -42,8 +41,6 @@ const PlatformCellContent = styled.div`
 const GuideList = styled.div`
   font-size: 0.8em;
   width: 100%;
-  height: 54px;
-  overflow: hidden;
   text-overflow: ellipsis;
 
   a {


### PR DESCRIPTION
I was bothered that a number of the Python integrations get cut off. This makes it so that the cards are no longer uniform, but I think it looks fine having Python as the one outlier (everything else lines up fine).

Before:

![image](https://user-images.githubusercontent.com/2153/94514038-0ea09980-01d5-11eb-91d2-f91c3ef10337.png)

After:

![image](https://user-images.githubusercontent.com/2153/94514022-05173180-01d5-11eb-98ad-250432e24053.png)
