### PR TITLE
fix(urls): Use relative URLs instead of linking to docs.sentry.io

### DIFF
--- a/src/docs/accounts/quotas/index.mdx
+++ b/src/docs/accounts/quotas/index.mdx
@@ -15,7 +15,7 @@ Sentry’s flexibility means you can exercise fine-grained control over which ev
 Let’s clarify a few terms to start:
 
 - Event - an event is one instance of you sending Sentry data. Generally, this data is an error. Every event has a set of characteristics, called its fingerprint.
-- Issue - an issue is a grouping of similar events, which all share the same fingerprint. For example, Sentry groups events together when they are triggered by the same part of your code. For more information, see [Grouping & Fingerprinting](https://docs.sentry.io/data-management/event-grouping/).
+- Issue - an issue is a grouping of similar events, which all share the same fingerprint. For example, Sentry groups events together when they are triggered by the same part of your code. For more information, see [Grouping & Fingerprinting](/data-management/event-grouping/).
 - Attachment - Attachments are files uploaded in the same request, such as log files. Unless the option to store crash reports is enabled, Sentry will use the files only to create the event, and then drop the files.
 - Transaction - A transaction represents a single instance of a service being called to support an operation you want to measure or track, like a page load.
 - Quota - your quota is the monthly number of events - errors, attachments, and transactions - you pay Sentry to track.

--- a/src/docs/accounts/quotas/index.mdx
+++ b/src/docs/accounts/quotas/index.mdx
@@ -15,7 +15,7 @@ Sentry’s flexibility means you can exercise fine-grained control over which ev
 Let’s clarify a few terms to start:
 
 - Event - an event is one instance of you sending Sentry data. Generally, this data is an error. Every event has a set of characteristics, called its fingerprint.
-- Issue - an issue is a grouping of similar events, which all share the same fingerprint. For example, Sentry groups events together when they are triggered by the same part of your code. For more information, see [Grouping & Fingerprinting](/data-management/event-grouping/).
+- Issue - an issue is a grouping of similar events, which all share the same fingerprint. For example, Sentry groups events together when they are triggered by the same part of your code. For more information, see [Grouping & Fingerprinting](/product/sentry-basics/guides/grouping-and-fingerprints/).
 - Attachment - Attachments are files uploaded in the same request, such as log files. Unless the option to store crash reports is enabled, Sentry will use the files only to create the event, and then drop the files.
 - Transaction - A transaction represents a single instance of a service being called to support an operation you want to measure or track, like a page load.
 - Quota - your quota is the monthly number of events - errors, attachments, and transactions - you pay Sentry to track.

--- a/src/docs/clients/javascript/usage.mdx
+++ b/src/docs/clients/javascript/usage.mdx
@@ -258,7 +258,7 @@ Raven.isSetup();
 Raven and Sentry support [Source Maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/).
 
 For more information, please read the [Source Map
-docs](https://docs.sentry.io/clients/javascript/sourcemaps/). Also, check
+docs](/clients/javascript/sourcemaps/). Also, check
 out our
 [Gruntfile](https://github.com/getsentry/raven-js/blob/master/packages/raven-js/Gruntfile.js)
 for a good example of what we’re doing.

--- a/src/docs/clients/node/index.mdx
+++ b/src/docs/clients/node/index.mdx
@@ -18,7 +18,7 @@ raven-node is the official Node.js client for Sentry.
 
 <Alert level="warning" title="Note"><markdown>
 
-If you’re using JavaScript in the browser, you’ll need [raven-js](https://docs.sentry.io/clients/javascript).
+If you’re using JavaScript in the browser, you’ll need [raven-js](/clients/javascript).
 
 </markdown></Alert>
 

--- a/src/docs/product/integrations/gcp-cloud-run/index.mdx
+++ b/src/docs/product/integrations/gcp-cloud-run/index.mdx
@@ -9,7 +9,7 @@ Cloud Run helps developers save time in building and deploying their application
 
     ![Sentry Choose Platform](sentry-choose-platform.png)
 
-3. Follow instructions to instrument your Cloud Run application. Detailed platform docs [here](http://docs.sentry.io/platforms/).
+3. Follow instructions to instrument your Cloud Run application. Detailed platform docs [here](/platforms/).
 4. Deploy your Cloud Run application with GCP.
 
 That's it! Sentry will now report all issues from your Cloud Run application.

--- a/src/docs/product/sentry-basics/environments/index.mdx
+++ b/src/docs/product/sentry-basics/environments/index.mdx
@@ -31,7 +31,7 @@ Also, the environment filter affects all issue-related metrics, such as the coun
 
 A release by itself is not associated with an environment but can be deployed to different environments. When you select an environment on the releases page, it shows releases that were deployed to that environment. For example, a release deployed to the `QA` and `Prod` environment will appear in your view when filtering by `QA`, as well as `Prod`. All issue-related metrics within a given release will be affected by the environment filter. A deploy must have an environment.
 
-For more details about configuring releases and deploys, see the [full documentation on Releases](https://docs.sentry.io/workflow/releases/).
+For more details about configuring releases and deploys, see the [full documentation on Releases](/workflow/releases/).
 
 ## Hidden Environments
 

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
@@ -16,7 +16,7 @@ In this section, we will:
 
 <Note><markdown>
 
-As part of the **CI/CD workflow** for this app demo, we're using a `Makefile` to handle the `sentry-cli` related tasks through `make` targets. If you're using a different code base, you can still apply the settings and commands described below to your specific setup or run them directly in a command-line shell as part of your build process. For more information, see [Command Line Interface](https://docs.sentry.io/cli/).
+As part of the **CI/CD workflow** for this app demo, we're using a `Makefile` to handle the `sentry-cli` related tasks through `make` targets. If you're using a different code base, you can still apply the settings and commands described below to your specific setup or run them directly in a command-line shell as part of your build process. For more information, see [Command Line Interface](/cli/).
 
 </markdown></Note>
 

--- a/src/includes/getting-started-install/dotnet.mdx
+++ b/src/includes/getting-started-install/dotnet.mdx
@@ -10,4 +10,4 @@ dotnet add package Sentry
 
 **Using .NET Framework prior to 4.6.1?**
 
-[Our legacy SDK](https://docs.sentry.io/clients/csharp/) supports .NET Framework as early as 3.5.
+[Our legacy SDK](/clients/csharp/) supports .NET Framework as early as 3.5.

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -56,7 +56,7 @@ Please note that the new SDK will send with each event a release version in a di
 
 If you are using the [GitHub](/workflow/integrations/github/) or [GitLab](/workflow/integrations/gitlab/) integrations, you need to do one of the following:
 
-- Use the new format LINK: ([https://docs.sentry.io/platforms/android/#releases](https://docs.sentry.io/platforms/android/#releases))
+- Use the new format LINK: ([https://docs.sentry.io/platforms/android/#releases](/platforms/android/#releases))
 - Set the release in your `AndroidManifest.xml`
 - Change your code as described in the configuration section
 

--- a/src/platforms/android/timber.mdx
+++ b/src/platforms/android/timber.mdx
@@ -13,7 +13,7 @@ The source can be found [on GitHub](https://github.com/getsentry/sentry-android/
 
 ### Installation
 
-1. In order to add the Timber integration, you have to do a [manual initialization](https://docs.sentry.io/platforms/android/#manual-initialization) of the Android SDK.
+1. In order to add the Timber integration, you have to do a [manual initialization](/platforms/android/#manual-initialization) of the Android SDK.
 
 2. Add the `sentry-android-timber` dependency
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -32,7 +32,7 @@ The screenshot below provides an example of the User Feedback widget, though you
 
 To integrate the widget, you'll need to be running version 2.1 or newer of our JavaScript SDK. The widget authenticates with your public DSN, then passes in the Event ID that was generated on your backend.
 
-**If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use the [User Feedback API](/api/projects/post-project-user-reports/).**
+**If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use the [User Feedback API](https://docs.sentry.io/api/projects/post-project-user-reports/).**
 
 <PlatformContent includePath="user-feedback-example" />
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -32,7 +32,7 @@ The screenshot below provides an example of the User Feedback widget, though you
 
 To integrate the widget, you'll need to be running version 2.1 or newer of our JavaScript SDK. The widget authenticates with your public DSN, then passes in the Event ID that was generated on your backend.
 
-**If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use the [User Feedback API](https://docs.sentry.io/api/projects/post-project-user-reports/).**
+**If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use the [User Feedback API](/api/projects/post-project-user-reports/).**
 
 <PlatformContent includePath="user-feedback-example" />
 

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -50,7 +50,7 @@ In the example above, the `SendIdentity` flag was switched on. The SDK then will
 Also in the example above, you can find the DSN being set. That will instruct the `SentryAppender` to initialize the SDK.
 
 This is only one of the ways to initialize the SDK. If you wish to configure the SDK programatically, you could **leave the DSN out** from the appender configuration section. The SDK needs to be initialized only **once** and since other integrations (like ASP.NET) are also able to initialize the SDK, you only need to pass the DSN to one of these integrations.
-One common case to not add the DSN to the XML configuration file (which would initialize it via the log4net integration) is to have full access to the [SDK option](/error-reporting/configuration/?platform=csharp).
+One common case to not add the DSN to the XML configuration file (which would initialize it via the log4net integration) is to have full access to the [SDK option](/platforms/dotnet/guides/log4net/configuration/options/).
 
 ### Sample
 

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -37,7 +37,7 @@ This can be done, for example, via the `app.config` for console and desktop apps
 
 <Note><markdown>
 
-Only a subset of the options are exposed via the log4net appender configuration. If you wish to access an [SDK option](https://docs.sentry.io/platforms/dotnet/configuration/options/) which is not listed below, you'll need to initialize the SDK via [SentrySdk.Init](https://docs.sentry.io/platforms/dotnet/) instead of doing it via this integration as described below.
+Only a subset of the options are exposed via the log4net appender configuration. If you wish to access an [SDK option](/platforms/dotnet/configuration/options/) which is not listed below, you'll need to initialize the SDK via [SentrySdk.Init](https://docs.sentry.io/platforms/dotnet/) instead of doing it via this integration as described below.
 
 </markdown></Note>
 
@@ -50,7 +50,7 @@ In the example above, the `SendIdentity` flag was switched on. The SDK then will
 Also in the example above, you can find the DSN being set. That will instruct the `SentryAppender` to initialize the SDK.
 
 This is only one of the ways to initialize the SDK. If you wish to configure the SDK programatically, you could **leave the DSN out** from the appender configuration section. The SDK needs to be initialized only **once** and since other integrations (like ASP.NET) are also able to initialize the SDK, you only need to pass the DSN to one of these integrations.
-One common case to not add the DSN to the XML configuration file (which would initialize it via the log4net integration) is to have full access to the [SDK option](https://docs.sentry.io/error-reporting/configuration/?platform=csharp).
+One common case to not add the DSN to the XML configuration file (which would initialize it via the log4net integration) is to have full access to the [SDK option](/error-reporting/configuration/?platform=csharp).
 
 ### Sample
 

--- a/src/platforms/dotnet/index.mdx
+++ b/src/platforms/dotnet/index.mdx
@@ -23,7 +23,7 @@ Of those, we run our unit/integration tests against:
 
 <Alert level="info" title="Using an older version of .NET Framework or Mono?"><markdown>
 
-[Our legacy SDK](https://docs.sentry.io/clients/csharp/) supports .NET Framework as early as 3.5.
+[Our legacy SDK](/clients/csharp/) supports .NET Framework as early as 3.5.
 
 </markdown></Alert>
 

--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -38,7 +38,7 @@ $ npm install --save-dev @sentry/webpack-plugin
 $ yarn add --dev @sentry/webpack-plugin
 ```
 
-Next you need to generate an access token for our API. Within your organization's settings, navigate to Developer Settings, [create a new internal integration](https://docs.sentry.io/product/integrations/integration-platform/#internal-integrations), and provide a name appropriate to your organization. **Important:** Select **Releases -> Admin** for Permissions.
+Next you need to generate an access token for our API. Within your organization's settings, navigate to Developer Settings, [create a new internal integration](/product/integrations/integration-platform/#internal-integrations), and provide a name appropriate to your organization. **Important:** Select **Releases -> Admin** for Permissions.
 
 <Note><markdown>
 


### PR DESCRIPTION
Replaces any absolute URL in a markdown file that pointed to docs.sentry.io and instead uses a relative URL. This way I can navigate links on a local development build without being transported to the production website.