### PR TITLE
fix(apple): CocoaPods Installation Podfile

### DIFF
--- a/src/includes/getting-started-install/apple.ios.mdx
+++ b/src/includes/getting-started-install/apple.ios.mdx
@@ -1,12 +1,7 @@
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby {filename:Podfile}
-platform :ios, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/includes/getting-started-install/apple.macos.mdx
+++ b/src/includes/getting-started-install/apple.macos.mdx
@@ -1,12 +1,7 @@
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby {filename:Podfile}
-platform :macos, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/includes/getting-started-install/apple.mdx
+++ b/src/includes/getting-started-install/apple.mdx
@@ -1,12 +1,7 @@
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby {filename:Podfile}
-platform :ios, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/includes/getting-started-install/apple.tvos.mdx
+++ b/src/includes/getting-started-install/apple.tvos.mdx
@@ -1,12 +1,7 @@
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby {filename:Podfile}
-platform :tvos, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/includes/getting-started-install/apple.watchos.mdx
+++ b/src/includes/getting-started-install/apple.watchos.mdx
@@ -1,12 +1,7 @@
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
-```ruby
-platform :watchos, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+```ruby {filename:Podfile}
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/platforms/apple/common/install/cocoapods.mdx
+++ b/src/platforms/apple/common/install/cocoapods.mdx
@@ -4,13 +4,8 @@ title: Cocoapods
 
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
-```ruby
-platform :ios, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+```ruby {filename:Podfile}
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/wizard/apple/index.md
+++ b/src/wizard/apple/index.md
@@ -7,13 +7,8 @@ type: language
 
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
-```ruby
-platform :ios, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+```ruby {filename:Podfile}
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -7,13 +7,8 @@ type: language
 
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
-```ruby
-platform :ios, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+```ruby {filename:Podfile}
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.

--- a/src/wizard/apple/macos.md
+++ b/src/wizard/apple/macos.md
@@ -7,13 +7,8 @@ type: language
 
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
-```ruby
-platform :macos, '8.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
-end
+```ruby {filename:Podfile}
+pod 'Sentry', '~> {{ packages.version('sentry.cocoa') }}'
 ```
 
 Afterwards run `pod install`.


### PR DESCRIPTION
The Podfile for how to install Sentry with CocoaPods displayed the placeholder
for the version instead of the version. This is fixed now and the Podfile is
cleaned up so it only contains the line to add Sentry instead of a template
for a Podfile.