### PR TITLE
Fix: broken fragment URLs (anchor tags)

### DIFF
--- a/src/docs/accounts/quotas/index.mdx
+++ b/src/docs/accounts/quotas/index.mdx
@@ -26,7 +26,7 @@ Sentry completes a thorough evaluation of each event to determine if it counts t
 
 1. **SDK configuration**
 
-   The SDK configuration either allows the event or filters the event out. For more information, see [Outbound Filters in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#outbound-filters) or [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
+   The SDK configuration either allows the event or filters the event out. For more information, see [Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/) or [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
 
 2. **SDK sample rate**
 
@@ -151,7 +151,7 @@ Per-key rate limits allow you to set the maximum volume of error events a key wi
 
 For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
 
-To set up rate limits, navigate to **[Project] » Client Keys » Configure**. Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#4-rate-limiting).
+To set up rate limits, navigate to **[Project] » Client Keys » Configure**. Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to Manage Your Event Stream](/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
 
 <Alert>Per-key rate limiting is available only for Business plans.</Alert>
 
@@ -213,7 +213,7 @@ _The 24 hour window ends at the beginning of the current hour, not at the curren
 
 What this means is that if you experience a spike, we will temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually increase until Sentry finally accepts all events.
 
-### How Does Spike Protection Help? {#how-does-spike-protection-help}
+### How Does Spike Protection Help?
 
 Because Sentry bills on monthly event volume, spikes can consume your Sentry capacity for the rest of the month. If it really is a spike, spike protection drops events during the spike to try and conserve your capacity. We also send an email notification to the Owner when spike protection is activated.
 

--- a/src/docs/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/accounts/quotas/manage-event-stream-guide.mdx
@@ -39,7 +39,7 @@ For more information and code samples check out:
 
 #### GlobalHandlers
 
-The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default but can be disabled through configuration. For more information see [GlobalHandlers Integration](/platforms/javascript/#globalhandlers)
+The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default but can be disabled through configuration. For more information see [GlobalHandlers Integration](/platforms/javascript/integrations/default/#globalhandlers)
 
 Check out additional configuration options with the [TryCatch](/platforms/javascript/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/integrations/plugin/#reportingobserver) integrations.
 
@@ -47,13 +47,13 @@ Check out additional configuration options with the [TryCatch](/platforms/javasc
 
 **Java** - Sentry SDK provides integrations with common Java loggers through implemented _Handlers_ and _Appenders_. The configuration allows you to set a logging threshold determining the level under which all errors will be filtered. For more information see Java Integrations [java.util.logging](/platforms/java/guides/logging/), [Log4j 1.x](/platforms/java/guides/log4j/), [Log4j 2.x](/platforms/java/guides/log4j2/), and [Logback](/platforms/java/guides/logback/).
 
-**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. For more information see [PHP: error_types](/platforms/php/configuration/options/#error_types).
+**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. For more information see [PHP: Common Options](/platforms/php/configuration/options/#common-options).
 
 **Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. For more information see [Ruby Configuration](/platforms/ruby/configuration/options/#optional-settings)
 
 ## 3. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project under `[Project Settings] > Inbound Filters > Data Filters`. For more information, see [Inbound Filters](/accounts/quotas/#3-inbound-data-filters) and [Manage Your Flow of Errors Using Inbound Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters)
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project under `[Project Settings] > Inbound Filters > Data Filters`. For more information, see [Inbound Filters](/accounts/quotas/#inbound-data-filters) and [Manage Your Flow of Errors Using Inbound Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters)
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the Inbound Data Filters view.
 
@@ -63,7 +63,7 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 Proper event grouping is essential to maintain a meaningful Issue Stream and reduce redundant notifications. Sentry groups similar _Events_ into unique _Issues_ based on their _Fingerprint_. An event's fingerprint relies firstly on its **stack trace**.
 
-With **JavaScript** errors, a minified source code might result in a nondeterministic stack trace that could mess up associated event grouping. Make sure Sentry has access to your `Source Maps` and minified artifacts. For more information see [Uploading Source Maps](/platforms/javascript/#source-maps).
+With **JavaScript** errors, a minified source code might result in a nondeterministic stack trace that could mess up associated event grouping. Make sure Sentry has access to your `Source Maps` and minified artifacts. For more information see [Uploading Source Maps](/platforms/javascript/sourcemaps/).
 
 ![JavaScript stack trace without source maps](manage-event-stream-04.png)
 ![JavaScript stack trace with source maps](manage-event-stream-05.png)
@@ -102,7 +102,7 @@ Under `[Project Settings] » Client Keys » Configure`, you can create multiple 
 
 ![Per DSN Key rate limits](manage-event-stream-11.png)
 
-For more information see [Rate Limiting Projects](/accounts/quotas/#id1)
+For more information see [What Counts Toward My Quota](/accounts/quotas/#what-counts-toward-my-quota-table-view)
 
 ## 7. Spike Protection
 


### PR DESCRIPTION
Docs has many broken/dead fragment URLs because an anchored section of a page moved or was renamed.