### PR TITLE
fix(links): Move performance sampling page to common

### DIFF
--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -2,6 +2,7 @@
 title: Filtering and Sampling Events
 sidebar_order: 5
 description: "Learn more about how to configure your SDK to filter and sample events reported to Sentry."
+notoc: true
 notSupported:
   - perl
 ---
@@ -93,7 +94,7 @@ To send a representative sample of your errors to Sentry, set the `sampleRate` o
 
 **Note:** The error sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-<PlatformSection supported={["javascript", "node"]}><markdown>
+<PlatformSection supported={["javascript", "node"]} notSupported={["react-native"]}><markdown>
 
 ## Filtering Transaction Events
 
@@ -113,7 +114,7 @@ tracesSampler: samplingContext => {
 };
 ```
 
-To learn more about the `tracesSampler` option, please see [Sampling Transactions](/platforms/javascript/performance/sampling/).
+To learn more about the `tracesSampler` option, please see <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
 
 </markdown></PlatformSection>
 

--- a/src/platforms/common/performance/sampling.mdx
+++ b/src/platforms/common/performance/sampling.mdx
@@ -2,6 +2,9 @@
 title: Sampling Transactions
 sidebar_order: 20
 description: "Learn how to configure the volume of transactions sent to Sentry."
+supported:
+  - javascript
+  - node
 ---
 
 You can control the volume of transactions sent to Sentry in two ways.

--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -82,7 +82,7 @@ Sentry.init({
 });
 ```
 
-If either of these options is set, tracing will be enabled in your app. (They are meant to be mutually exclusive, but if you do set both, `tracesSampler` will take precedence.) You can learn more about how they work in [Sampling Transactions](/platforms/javascript/performance/sampling/).
+If either of these options is set, tracing will be enabled in your app. (They are meant to be mutually exclusive, but if you do set both, `tracesSampler` will take precedence.) You can learn more about how they work in <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
 
 <Alert level="info" title="Note"><markdown>
 

--- a/src/platforms/javascript/index.mdx
+++ b/src/platforms/javascript/index.mdx
@@ -127,7 +127,7 @@ Sentry.init({
 
 Performance data is transmitted using a new event type called “transactions,” which you can learn about in [Distributed Tracing](/product/performance/distributed-tracing/). To begin capturing transactions, install the tracing package and set either `tracesSampleRate` or `tracesSampler` in your [SDK configuration](/platforms/javascript/configuration/options/#common-options). These determine what percentage of potential transactions get sent to Sentry; we recommend capturing only a sample, as one way to adjust your overall Sentry volume to meet your needs.
 
-Learn more about `tracesSampleRate` and `tracesSampler` in [Sampling Transactions](/performance/sampling).
+Learn more about `tracesSampleRate` and `tracesSampler` in [Sampling Transactions](/platforms/javascript/performance/sampling/).
 
 ## Next Steps
 


### PR DESCRIPTION
Switch to using a `PlatformLink`, and move the sampling page to `common` to fix a broken link on the filtering page.

Now that the file is common, more parts will need to be "platform-ized" but this should fix the broken links for now and that can come in a follow-up PR.