### PR TITLE
fix(performance): Pull platform-specific content into includes

### DIFF
--- a/src/includes/performance/always-inherit-sampling-decision/javascript.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/javascript.mdx
@@ -1,0 +1,11 @@
+```javascript
+tracesSampler: samplingContext => {
+  // always inherit
+  if (samplingContext.parentSampled !== undefined) {
+    return samplingContext.parentSampled
+  }
+
+  ...
+  // rest of sampling logic here
+}
+```

--- a/src/includes/performance/always-inherit-sampling-decision/node.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/node.mdx
@@ -1,0 +1,11 @@
+```javascript
+tracesSampler: samplingContext => {
+  // always inherit
+  if (samplingContext.parentSampled !== undefined) {
+    return samplingContext.parentSampled
+  }
+
+  ...
+  // rest of sampling logic here
+}
+```

--- a/src/includes/performance/dynamic-sampling-function/javascript.mdx
+++ b/src/includes/performance/dynamic-sampling-function/javascript.mdx
@@ -1,0 +1,17 @@
+```javascript
+tracesSampler: samplingContext => {
+  // Examine provided context data (including parent decision, if any) along
+  // with anything in the global namespace to compute the sample rate or
+  // sampling decision for this transaction
+
+  if ("...") {
+    return 0.5; // These are important - take a big sample
+  } else if ("...") {
+    return 0.01; // These are less important or happen much more frequently - only take 1% of them
+  } else if ("...") {
+    return 0; // These aren't something worth tracking - drop all transactions like this
+  } else {
+    return 0.1; // Default sample rate
+  }
+};
+```

--- a/src/includes/performance/dynamic-sampling-function/node.mdx
+++ b/src/includes/performance/dynamic-sampling-function/node.mdx
@@ -1,0 +1,17 @@
+```javascript
+tracesSampler: samplingContext => {
+  // Examine provided context data (including parent decision, if any) along
+  // with anything in the global namespace to compute the sample rate or
+  // sampling decision for this transaction
+
+  if ("...") {
+    return 0.5; // These are important - take a big sample
+  } else if ("...") {
+    return 0.01; // These are less important or happen much more frequently - only take 1% of them
+  } else if ("...") {
+    return 0; // These aren't something worth tracking - drop all transactions like this
+  } else {
+    return 0.1; // Default sample rate
+  }
+};
+```

--- a/src/includes/performance/force-sampling-decision/javascript.mdx
+++ b/src/includes/performance/force-sampling-decision/javascript.mdx
@@ -1,0 +1,6 @@
+```javascript
+Sentry.startTransaction({
+  name: "Search from navbar",
+  sampled: true,
+});
+```

--- a/src/includes/performance/force-sampling-decision/node.mdx
+++ b/src/includes/performance/force-sampling-decision/node.mdx
@@ -1,0 +1,6 @@
+```javascript
+Sentry.startTransaction({
+  name: "Search from navbar",
+  sampled: true,
+});
+```

--- a/src/includes/performance/uniform-sample-rate/javascript.mdx
+++ b/src/includes/performance/uniform-sample-rate/javascript.mdx
@@ -1,0 +1,35 @@
+```javascript {tabTitle: ESM}
+// If you're using one of our integration packages, like `@sentry/react` or
+// `@sentry/angular`, substitute its name for `@sentry/browser` here
+import * as Sentry from "@sentry/browser";
+
+// If taking advantage of automatic instrumentation (highly recommended)
+import { Integrations as TracingIntegrations } from "@sentry/tracing";
+// Or, if only doing manual tracing
+// import * as _ from "@sentry/tracing"
+// Note: You MUST import the package in some way for tracing to work
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // This enables automatic instrumentation (highly recommeneded), but is not
+  // necessary for purely manual usage
+  integrations: [new TracingIntegrations.BrowserTracing()],
+
+  // Each transaction has a 20% chance of being sent to Sentry
+  tracesSampleRate: 0.2,
+});
+```
+
+```javascript {tabTitle: CDN}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // This enables automatic instrumentation (highly recommeneded), but is not
+  // necessary for purely manual usage
+  integrations: [new Sentry.Integrations.BrowserTracing()],
+
+  // Each transaction has a 20% chance of being sent to Sentry
+  tracesSampleRate: 0.2,
+});
+```

--- a/src/includes/performance/uniform-sample-rate/node.mdx
+++ b/src/includes/performance/uniform-sample-rate/node.mdx
@@ -1,0 +1,22 @@
+```javascript
+// If you're using one of our integration packages, like `@sentry/serverless`,
+// substitute its name for `@sentry/node` here
+import * as Sentry from "@sentry/node";
+
+// Importing the package initializes tracing
+import * as _ from "@sentry/tracing";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // This enables automatic instrumentation (highly recommeneded), but is not
+  // necessary for purely manual usage
+  integrations: [
+    // enable HTTP calls tracing
+    new Sentry.Integrations.Http({ tracing: true }),
+  ],
+
+  // Each transaction has a 20% chance of being sent to Sentry
+  tracesSampleRate: 0.2,
+});
+```

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -118,6 +118,8 @@ To learn more about the `tracesSampler` option, please see <PlatformLink to="/pe
 
 </markdown></PlatformSection>
 
+<PlatformSection supported={["javascript", "node", "python", "PHP"]} notSupported={["react-native"]}><markdown>
+
 ## Sampling Transaction Events
 
 For Sentry's Performance Monitoring, we recommend sampling your data for two reasons. First, though capturing a single trace involves minimal overhead, capturing traces for every single page load, or every single API request, has the potential to add an undesirable amount of load to your system. Second, enabling sampling allows you to better manage the number of events sent to Sentry, so you can tailor it to your organization's needs.
@@ -125,3 +127,5 @@ For Sentry's Performance Monitoring, we recommend sampling your data for two re
 When choosing a sampling rate, the goal is not to collect *too* much data, but to collect sufficient data so you can draw meaningful conclusions. If you’re not sure what rate to choose, start with a low value and gradually increase it as you learn more about your traffic patterns and volume, until you’ve found a rate that balances performance and volume concerns with data accuracy.
 
 To set a sample rate for your transactions, provide a number between `0` (0% of transactions sent) and `1` (100% of transactions sent) to the `tracesSampleRate` configuration option. For example, including `tracesSampleRate: 0.2` in your SDK config will cause the SDK to only send 20% of possible transaction events.
+
+</markdown></PlatformSection>

--- a/src/platforms/common/performance/sampling.mdx
+++ b/src/platforms/common/performance/sampling.mdx
@@ -15,41 +15,7 @@ Setting a uniform sample rate is a good option if you want an even cross-section
 
 To do this, set the `tracesSampleRate` option in your `Sentry.init()` to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. (So, for example, if you set `tracesSampleRate` to `0.2`, approximately 20% of your transactions will get recorded and sent.) That looks like this:
 
-```javascript {tabTitle: ESM}
-// If you're using one of our integration packages, like `@sentry/react` or `@sentry/angular`,
-// substitute its name for `@sentry/browser` here
-import * as Sentry from "@sentry/browser";
-
-// If taking advantage of automatic instrumentation (highly recommended)
-import { Integrations as TracingIntegrations } from "@sentry/tracing";
-// Or, if only doing manual tracing
-// import * as _ from "@sentry/tracing"
-// Note: You MUST import the package in some way for tracing to work
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // This enables automatic instrumentation (highly recommeneded), but is not
-  // necessary for purely manual usage
-  integrations: [new TracingIntegrations.BrowserTracing()],
-
-  // Each transaction has a 20% chance of being sent to Sentry
-  tracesSampleRate: 0.2,
-});
-```
-
-```javascript {tabTitle: CDN}
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // This enables automatic instrumentation (highly recommeneded), but is not
-  // necessary for purely manual usage
-  integrations: [new Sentry.Integrations.BrowserTracing()],
-
-  // Each transaction has a 20% chance of being sent to Sentry
-  tracesSampleRate: 0.2,
-});
-```
+<PlatformContent includePath="performance/uniform-sample-rate" />
 
 ## Dynamic Sampling Function
 
@@ -61,22 +27,7 @@ Providing a sampling function is a good option if you:
 
 To sample dynamically, set the `tracesSampler` option in your `Sentry.init()` to a function that will accept a `samplingContext` object and return a sample rate between 0 and 1. For example:
 
-```javascript
-tracesSampler: samplingContext => {
-  // Examine provided context data (including parent decision, if any) along with anything
-  // in the global namespace to compute the sample rate or sampling decision for this transaction.
-
-  if ("...") {
-    return 0.5; // These are important - take a big sample
-  } else if ("...") {
-    return 0.01; // These are less important or happen much more frequently - only take 1% of them
-  } else if ("...") {
-    return 0; // These aren't something worth tracking - drop all transactions like this
-  } else {
-    return 0.1; // Default sample rate
-  }
-};
-```
+<PlatformContent includePath="performance/dynamic-sampling-function" />
 
 For convenience, the function can also return a boolean. Returning `true` is equivalent to returning `1`, and will guarantee the transaction will be sent to Sentry. Returning `false` is equivalent to returning `0` and will guarantee the transaction will **not** be sent to Sentry.
 
@@ -100,17 +51,7 @@ If the transaction currently being created is one of those subsequent transactio
 
 For convenience, the `tracesSampler` function can return a boolean, so that a parent's decision can be returned directly if that's the desired behavior.
 
-```javascript
-tracesSampler: samplingContext => {
-  // always inherit
-  if (samplingContext.parentSampled !== undefined) {
-    return samplingContext.parentSampled
-  }
-
-  ...
-  // rest of sampling logic here
-}
-```
+<PlatformContent includePath="performance/always-inherit-sampling-decision" />
 
 If you're using a `tracesSampleRate` rather than a `tracesSampler`, the decision will always be inherited.
 
@@ -118,12 +59,7 @@ If you're using a `tracesSampleRate` rather than a `tracesSampler`, the decision
 
 If you know at transaction creation time whether or not you want the transaction sent to Sentry, you also have the option of passing a sampling decision directly to the transaction in the `transactionContext` object (note, not the `customSamplingContext` object). If you do that, the transaction won't be subject to the `tracesSampleRate`, nor will `tracesSampler` be run, so you can count on the decision that's passed not to be overwritten.
 
-```javascript
-Sentry.startTransaction({
-  name: "Search from navbar",
-  sampled: true,
-});
-```
+<PlatformContent includePath="performance/force-sampling-decision" />
 
 ## Precedence
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-docs/pull/2401.

Now that the sampling page is in `/common`, anything language-specific needs to be pulled out into includes so it can be swapped out.