### PR TITLE
feat: Simplify Laravel onboarding

### DIFF
--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -34,15 +34,13 @@ public function report(Throwable $exception)
 
 ## Configure
 
-Run:
+Setup Sentry with this command:
 
 ```shell
-$ php artisan sentry:publish
+php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
-that creates the Sentry configuration file (`config/sentry.php`).
-
-Afterwards, add your DSN to `.env`:
+It creates (`config/sentry.php`) and adds the `DSN` to your `.env` file.
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/src/wizard/php/laravel.md
+++ b/src/wizard/php/laravel.md
@@ -41,17 +41,13 @@ public function report(Exception $exception)
 }
 ```
 
-Create the Sentry configuration file (`config/sentry.php`) with this command:
+Setup Sentry with this command:
 
 ```shell
-$ php artisan sentry:publish
+php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
-Add your DSN to `.env`:
-
-```shell
-SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
-```
+It creates (`config/sentry.php`) and adds the `DSN` to your `.env` file.
 
 You can easily verify that Sentry is capturing errors in your Laravel application by creating a debug route that will throw an exception:
 


### PR DESCRIPTION
Once we merge this PR
https://github.com/getsentry/sentry-laravel/pull/392

It's one command the user needs to run to setup everything:

`php artisan sentry:publish --dsn=___PUBLIC_DSN___`

In case the user doesn't paste it with `--dsn` the command will prompt for the DSN.