### PR TITLE
fix: event.level fatal is not a crashed session

### DIFF
--- a/src/docs/product/releases/health.mdx
+++ b/src/docs/product/releases/health.mdx
@@ -143,7 +143,7 @@ Number of users that started the application at least once in the specified time
 #### Crash
 
 The fatal error that caused the crash of the application. Errors that did not cause the end of the application should not be included.
-Sentry considers every error event with the field `level` set to `fatal` or the field `handled` set to `false` as a Crashed state.
+Sentry considers every error event with the field `handled` set to `false` as a Crashed state.
 
 #### Crash Free User
 


### PR DESCRIPTION
opening this one to continue https://github.com/getsentry/sentry-docs/pull/1923, too much conflicts