### PR TITLE
Fix typo in `errorboundary.mdx`

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -14,7 +14,7 @@ import * as Sentry from "@sentry/react";
 </Sentry.ErrorBoundary>;
 ```
 
-The Sentry Error Boundary is also avaliable as a higher order component.
+The Sentry Error Boundary is also available as a higher order component.
 
 ```jsx
 import React from "react";


### PR DESCRIPTION
The typo was "avaliable" instead of "available"