### PR TITLE
feat: Hide framework list from guides

### DIFF
--- a/src/components/platformSection.tsx
+++ b/src/components/platformSection.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-import usePlatform from "./hooks/usePlatform";
+import usePlatform, { Platform } from "./hooks/usePlatform";
 
 type Props = {
   supported?: string[];
   notSupported?: string[];
   platform?: string;
+  noGuides?: boolean;
   children?: React.ReactNode;
 };
 
@@ -26,9 +27,13 @@ export default ({
   supported = [],
   notSupported = [],
   platform,
+  noGuides,
   children,
 }: Props): JSX.Element => {
   const [currentPlatform] = usePlatform(platform);
+  if (noGuides && !(currentPlatform as Platform).guides) {
+    return null;
+  }
 
   const platformsToSearch = [
     currentPlatform.key,

--- a/src/docs/contributing/pages/components.mdx
+++ b/src/docs/contributing/pages/components.mdx
@@ -167,6 +167,7 @@ Attributes:
 - `platform` (string) - defaults to the `platform` value from the page context or querystring
 - `supported` (string[])
 - `notSupported` (string[])
+- `noGuides` (boolean) - hide this on all guides (takes precedence over `supported`/`notSupported`)
 
 Note: This currently causes issues with tableOfContents generation, so we recommend disabling the TOC when using it.
 

--- a/src/includes/framework-list/_default.mdx 
+++ b/src/includes/framework-list/_default.mdx 
@@ -1,1 +1,3 @@
-<GuideGrid />
+<PlatformSection noGuides>
+    <GuideGrid />
+</PlatformSection>

--- a/src/includes/framework-list/javascript.mdx
+++ b/src/includes/framework-list/javascript.mdx
@@ -1,3 +1,7 @@
+<PlatformSection noGuides><markdown>
+
 Using a framework? Take a look at our specific guides to get started.
 
 <GuideGrid platform="javascript" />
+
+</markdown></PlatformSection>


### PR DESCRIPTION
Introduce `noGuides` attribute on `PlatformContent` to enable hiding content from guide pages.