### PR TITLE
ref: Move resolve function and implement support for local OpenAPI paths

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -1,7 +1,6 @@
-import axios from "axios";
-
 import queries from "./utils/algolia";
 import PackageRegistry from "./utils/packageRegistry";
+import resolveOpenAPI from "./utils/resolveOpenAPI";
 
 const packages = new PackageRegistry();
 
@@ -189,13 +188,8 @@ const getPlugins = () => {
       resolve: `./src/gatsby/plugins/gatsby-plugin-openapi`,
       options: {
         name: "openapi",
-        resolve: async () => {
-          const response = await axios.get(
-            "https://raw.githubusercontent.com/getsentry/sentry-api-schema/d7eb0bf0dba8c4725f4514c81bacea39dad6a503/openapi-derefed.json"
-          );
-          return response.data;
-        },
-        // required, function which returns a Promise resolving Swagger JSON
+        // resolve: required, function which returns a Promise resolving OpenAPI JSON
+        resolve: resolveOpenAPI,
       },
     },
     // used to generate clident-side redirects for markdown redirect_from

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -5,7 +5,7 @@ const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
 
 export default async () => {
-  if (activeEnv && process.env.OPENAPI_LOCAL_PATH) {
+  if (activeEnv === "development" && process.env.OPENAPI_LOCAL_PATH) {
     try {
       console.log(`Fetching from ${process.env.OPENAPI_LOCAL_PATH}`);
       let data = await fs.readFile(process.env.OPENAPI_LOCAL_PATH, "utf8");

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+import { promises as fs } from "fs";
+
+const activeEnv =
+  process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
+
+export default async () => {
+  if (activeEnv && process.env.OPENAPI_LOCAL_PATH) {
+    try {
+      console.log(`Fetching from ${process.env.OPENAPI_LOCAL_PATH}`);
+      let data = await fs.readFile(process.env.OPENAPI_LOCAL_PATH, "utf8");
+      return data;
+    } catch (error) {
+      console.log(
+        `Failed to connect to  ${process.env.OPENAPI_LOCAL_PATH}. Continuing to fetch versioned schema from Github.
+        ${error}`
+      );
+    }
+  }
+  const response = await axios.get(
+    "https://raw.githubusercontent.com/getsentry/sentry-api-schema/d7eb0bf0dba8c4725f4514c81bacea39dad6a503/openapi-derefed.json"
+  );
+  return response.data;
+};


### PR DESCRIPTION
## Objective
We want to work locally with API docs so that people can make changes to the OpenAPI spec in Sentry but also be able to see what it would look like in docs.sentry.io/api/.

In this PR, I have implemented support for developers to set an environment variable `OPENAPI_LOCAL_PATH` that can be lead to their locally generated `openapi-derefed.json`. 

If it is able to resolve the path, `gatsby-plugin-openapi` will generate its' graphql nodes from the local `openapi-derefed.json`, else it defaults to fetching the `openapi-derefed.json` from the versioned commit in `getsentry/sentry-api-schema`.

ex: `OPENAPI_LOCAL_PATH=/Users/nisanthan.nanthankumar/Documents/sentry-api-schema/openapi-derefed.json yarn start`

## Future Improvements (Not this PR)
 - Support Hot-Reload. Maybe we can watch the file from the env variable. **Need to look into this**