### PR TITLE
fix: ruby environment config

### DIFF
--- a/src/includes/set-environment/ruby.mdx
+++ b/src/includes/set-environment/ruby.mdx
@@ -1,5 +1,5 @@
 ```ruby
 Raven.configure do |config|
-  config.environment = 'production'
+  config.current_environment = 'production'
 end
 ```


### PR DESCRIPTION
`environment=` does not exist. Use `current_environment=` instead. See
https://github.com/getsentry/sentry-ruby/blob/94138234bdca8bd1cb44b36990b84b0ab5c0ff02/lib/raven/configuration.rb#L24.