### PR TITLE
feat(apple): Set installation id as user id

### DIFF
--- a/src/includes/set-user/apple.mdx
+++ b/src/includes/set-user/apple.mdx
@@ -9,3 +9,6 @@ SentryUser *user = [[SentryUser alloc] init];
 user.email = @"john.doe@example.com";
 [SentrySDK setUser:user];
 ```
+
+Since 6.0.1: If no user is set the SDK uses the installation id of the SDK as the
+user id of the event before queuing it for submission.

--- a/src/includes/set-user/apple.mdx
+++ b/src/includes/set-user/apple.mdx
@@ -10,5 +10,4 @@ user.email = @"john.doe@example.com";
 [SentrySDK setUser:user];
 ```
 
-Since 6.0.1: If no user is set the SDK uses the installation id of the SDK as the
-user id of the event before queuing it for submission.
+Since 6.0.1: Sentry will by fallback to `installationId` if you do not provide a user identity.


### PR DESCRIPTION
Add a comment to set-user on Apple about setting the installation id of
the SDK as the userId of an event before queuing it for submission.

Only merge when https://github.com/getsentry/sentry-cocoa/pull/757 is released.