### PR TITLE
fix: Fix wildcard usage in platforms

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,31 +48,31 @@
       "destination": "/platforms/apple/$1"
     },
     {
-      "source": "/platforms/(.*)/configuration/capture/",
+      "source": "/platforms/([^/]*)/configuration/capture/",
       "destination": "/platforms/$1/usage/"
     },
     {
-      "source": "/platforms/(.*)/configuration/install-cdn/",
+      "source": "/platforms/([^/]*)/configuration/install-cdn/",
       "destination": "/platforms/$1/install/cdn/"
     },
     {
-      "source": "/platforms/(.*)/enriching-error-data/set-level/",
+      "source": "/platforms/([^/]*)/enriching-error-data/set-level/",
       "destination": "/platforms/$1/usage/set-level/"
     },
     {
-      "source": "/platforms/(.*)/enriching-error-data/additional-data/manage-context/",
+      "source": "/platforms/([^/]*)/enriching-error-data/additional-data/manage-context/",
       "destination": "/platforms/$1/enriching-events/context/"
     },
     {
-      "source": "/platforms/(.*)/enriching-error-data/additional-data/adding-tags/",
+      "source": "/platforms/([^/]*)/enriching-error-data/additional-data/adding-tags/",
       "destination": "/platforms/$1/enriching-events/tags/"
     },
     {
-      "source": "/platforms/(.*)/enriching-error-data/additional-data/(.*)",
+      "source": "/platforms/([^/]*)/enriching-error-data/additional-data/(.*)",
       "destination": "/platforms/$1/enriching-events/"
     },
     {
-      "source": "/platforms/(.*)/enriching-error-data/(.*)",
+      "source": "/platforms/([^/]*)/enriching-error-data/(.*)",
       "destination": "/platforms/$1/enriching-events/$2"
     },
     {
@@ -265,7 +265,7 @@
       "destination": "/platforms/java/configuration/"
     },
     {
-      "source": "/platforms/(.*)/context/",
+      "source": "/platforms/([^/]*)/context/",
       "destination": "/platforms/$1/enriching-events/context/"
     },
     {


### PR DESCRIPTION
Currently this leads to an infinite redirect:

```
https://docs.sentry.io/platforms/native/context/
https://docs.sentry.io/platforms/native/enriching-events/context/
https://docs.sentry.io/platforms/native/enriching-events/enriching-events/context/
...
```