### PR TITLE
Correcting markdown note

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -246,11 +246,11 @@ when you only release some of the builds you are creating).
 
 <Note><markdown>
 
-You need to specify the organization and project you are working with because
+You need to specify the organization and project you are working with 
+because ProGuard files work on projects. For more information about this refer to 
+[Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
 </markdown></Note>
-ProGuard files work on projects. For more information about this refer to
-[Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
 The `upload-proguard` command is the one to use for uploading ProGuard files. It
 takes the path to one or more ProGuard mapping files and will upload them to


### PR DESCRIPTION
Correcting markdown note under ProGuard Mapping Upload, part of the note text was outside the markdown block.