### PR TITLE
fix(dotnet): sample wouldn't compile

### DIFF
--- a/src/platforms/dotnet/index.mdx
+++ b/src/platforms/dotnet/index.mdx
@@ -57,7 +57,7 @@ Verify Sentry is capturing unhandled exceptions by raising an exception. For exa
 ```csharp
 using (SentrySdk.Init("___PUBLIC_DSN___"))
 {
-    Console.WriteLine(1 / 0);
+    throw null;
 }
 ```
 

--- a/src/platforms/dotnet/index.mdx
+++ b/src/platforms/dotnet/index.mdx
@@ -52,7 +52,7 @@ using (SentrySdk.Init("___PUBLIC_DSN___"))
 
 ## Verify
 
-Verify Sentry is capturing unhandled exceptions by raising an exception. For example, you can use the following snippet to raise a `DivideByZeroException`:
+Verify Sentry is capturing unhandled exceptions by raising an exception. For example, you can use the following snippet to raise a `NullReferenceException`:
 
 ```csharp
 using (SentrySdk.Init("___PUBLIC_DSN___"))


### PR DESCRIPTION
C# compile won't be happy with `1/0`. There must be at least a variable involved.