### PR TITLE
ref(api-schema): Add new request body example

### DIFF
--- a/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
@@ -29,6 +29,7 @@ export type DeRefedOpenAPI = {
           content: {
             "application/json": {
               schema: RequestBodySchema;
+              example: any;
             };
           };
           required: boolean;
@@ -65,6 +66,7 @@ export type RequestBody = {
   content: {
     content_type: string;
     schema: string;
+    example: string;
   };
   required: boolean;
 };

--- a/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
@@ -2,7 +2,7 @@ export type RequestBodySchema = {
   required: string[];
   type: string;
   properties: {
-    [key: string]: { type: string; description: string; example: string };
+    [key: string]: { type: string; description: string; };
   };
 };
 

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -18,7 +18,7 @@ export default async () => {
     }
   }
   const response = await axios.get(
-    "https://raw.githubusercontent.com/getsentry/sentry-api-schema/d7eb0bf0dba8c4725f4514c81bacea39dad6a503/openapi-derefed.json"
+    "https://raw.githubusercontent.com/getsentry/sentry-api-schema/03ccef5d80c6e636994e0594312778e1186ba41c/openapi-derefed.json"
   );
   return response.data;
 };

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -80,10 +80,9 @@ export default props => {
   }
 
   if (bodyParameters) {
-    // rn bodyParameters doesn't have the example data
     const requestBodyExample =
       (requestBodyContent?.example && JSON.parse(requestBodyContent.example)) ||
-      {}; // this is where I need to put the example
+      {};
 
     if (contentType === "multipart/form-data") {
       Object.entries(requestBodyExample).map(

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -71,6 +71,9 @@ export default props => {
     ` -H 'Authorization: Bearer <auth_token>'`,
   ];
 
+  console.log("hi!");
+  console.log(data) // request example isn't in the data
+
   if (["put", "options", "delete"].includes(data.method.toLowerCase())) {
     apiExample.push(` -X ${data.method.toUpperCase()}`);
   }
@@ -79,8 +82,10 @@ export default props => {
     apiExample.push(` -H 'Content-Type: ${contentType}'`);
   }
 
-  if (bodyParameters) {
-    const body = {};
+  if (bodyParameters) { // rn bodyParameters doesn't have the example data
+    console.log("body params");
+    console.log(bodyParameters);
+    const body = {}; // this is where I need to put the example
     Object.entries(bodyParameters.properties).map(
       ([key, { example }]) => (body[key] = example)
     );


### PR DESCRIPTION
In [this PR](https://github.com/getsentry/sentry/pull/21149) the `requestBody` is refactored to move the `example` below the `schema` and thus, the template must be refactored to account for the change. This PR adds in the "new" example to continue to display it properly in the cURL example. 