### PR TITLE
feat: Add support for sidebar_title

### DIFF
--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -11,6 +11,7 @@ type Node = {
   context: {
     title?: string | null;
     sidebar_order?: number | null;
+    sidebar_title?: string | null;
     [key: string]: any;
   };
   [key: string]: any;
@@ -70,7 +71,7 @@ export const renderChildren = (
       <SidebarLink
         to={node.path}
         key={node.path}
-        title={node.context.title}
+        title={node.context.sidebar_title || node.context.title}
         collapsed={depth >= showDepth}
       >
         {renderChildren(children, exclude, showDepth, depth + 1)}
@@ -135,7 +136,8 @@ export default ({
     currentTree = entity.children;
   });
   if (!entity) return null;
-  if (!title && entity.node) title = entity.node.context.title;
+  if (!title && entity.node)
+    title = entity.node.context.sidebar_title || entity.node.context.title;
   const parentNode = entity.children
     ? entity.children.find((n: EntityTree) => n.name === "")
     : null;

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -15,6 +15,7 @@ const navQuery = graphql`
         path
         context {
           title
+          sidebar_title
           sidebar_order
           platform {
             name
@@ -30,6 +31,7 @@ type Node = {
   context: {
     title: string;
     sidebar_order?: number;
+    sidebar_title?: string;
     platform: {
       name: string;
     };

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -13,6 +13,7 @@ const navQuery = graphql`
           draft
           title
           sidebar_order
+          sidebar_title
         }
       }
     }
@@ -25,6 +26,7 @@ type NavNode = {
     draft: boolean;
     title: string;
     sidebar_order: number;
+    sidebar_title?: string;
   };
 };
 

--- a/src/gatsby/createPages/createApiReference.ts
+++ b/src/gatsby/createPages/createApiReference.ts
@@ -14,6 +14,7 @@ export default async ({ actions, graphql, reporter }) => {
                     draft
                     noindex
                     sidebar_order
+                    sidebar_title
                     redirect_from
                     keywords
                   }
@@ -30,6 +31,7 @@ export default async ({ actions, graphql, reporter }) => {
                     draft
                     noindex
                     sidebar_order
+                    sidebar_title
                     redirect_from
                     keywords
                   }

--- a/src/gatsby/createPages/createDocPages.ts
+++ b/src/gatsby/createPages/createDocPages.ts
@@ -15,6 +15,7 @@ export default async ({ actions, graphql, reporter }) => {
                     noindex
                     notoc
                     sidebar_order
+                    sidebar_title
                     redirect_from
                     keywords
                   }
@@ -32,6 +33,7 @@ export default async ({ actions, graphql, reporter }) => {
                     noindex
                     notoc
                     sidebar_order
+                    sidebar_title
                     redirect_from
                     keywords
                   }

--- a/src/gatsby/createPages/createInternalDocPages.ts
+++ b/src/gatsby/createPages/createInternalDocPages.ts
@@ -14,6 +14,7 @@ export default async ({ actions, graphql, reporter }) => {
                 draft
                 noindex
                 sidebar_order
+                sidebar_title
                 redirect_from
                 keywords
               }
@@ -30,6 +31,7 @@ export default async ({ actions, graphql, reporter }) => {
                 draft
                 noindex
                 sidebar_order
+                sidebar_title
                 redirect_from
                 keywords
               }

--- a/src/gatsby/createPages/createPlatformPages.ts
+++ b/src/gatsby/createPages/createPlatformPages.ts
@@ -147,6 +147,7 @@ export default async ({ actions, graphql, reporter, getNode }) => {
               noindex
               notoc
               sidebar_order
+              sidebar_title
               redirect_from
               supported
               notSupported
@@ -162,6 +163,7 @@ export default async ({ actions, graphql, reporter, getNode }) => {
               noindex
               notoc
               sidebar_order
+              sidebar_title
               redirect_from
               supported
               notSupported

--- a/src/gatsby/createSchemaCustomization/index.ts
+++ b/src/gatsby/createSchemaCustomization/index.ts
@@ -10,6 +10,7 @@ export default ({ actions, schema }) => {
     type PageContext {
       title: String
       sidebar_order: Int
+      sidebar_title: String
       draft: Boolean
       redirect_from: [String!]
 
@@ -63,6 +64,9 @@ export default ({ actions, schema }) => {
         },
         noindex: {
           type: "Boolean",
+        },
+        sidebar_title: {
+          type: "String",
         },
         sidebar_order: {
           type: "Int",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,7 @@ export const sortBy = (arr: any[], comp: (any) => any): any[] => {
 type Page = {
   context: {
     title?: string;
+    sidebar_title?: string;
     sidebar_order?: number;
   };
 };
@@ -69,7 +70,9 @@ export const sortPages = (
     const bso = b.context.sidebar_order >= 0 ? b.context.sidebar_order : 10;
     if (aso > bso) return 1;
     else if (bso > aso) return -1;
-    return a.context.title.localeCompare(b.context.title);
+    return (a.context.sidebar_title || a.context.title).localeCompare(
+      b.context.sidebar_title || b.context.title
+    );
   });
 };
 


### PR DESCRIPTION
Allow specifying sidebar_title in frontmatter to override the value in generated sidebar trees.