### PR TITLE
Update releases.mdx

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -15,7 +15,9 @@ Because releases work on projects you will need to specify the organization and 
 
 Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
 
-- use a forward slash ("/")
+- be (".") ,  (".."), or forward slash ("/") 
+- be the string ("latest")
+- contain a forward slash ("/")
 - exceed 200 characters
 
 The value can be arbitrary, but for certain platforms, recommendations exist:

--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -15,8 +15,7 @@ Because releases work on projects you will need to specify the organization and 
 
 Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
 
-- contain newlines or spaces
-- use a forward slash ("/"), back slash ("\"), period ("."), or double period ("..")
+- use a forward slash ("/")
 - exceed 200 characters
 
 The value can be arbitrary, but for certain platforms, recommendations exist:

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -26,7 +26,9 @@ Include a release ID (often called a "version") when you configure your client S
 The release name cannot:
 
 - contain newlines or spaces
-- use a forward slash ("/"), back slash ("\\"), period ("."), or double period ("..")
+- be (".") ,  (".."), or forward slash ("/")
+- be the string ("latest")
+- contain a forward slash ("/")
 - exceed 200 characters
 
 <Note><markdown>


### PR DESCRIPTION
It appears that forward slash is the only one that isn’t allowed. All others characters can easily make their way into a release name.
<img width="220" alt="Screen Shot 2020-10-05 at 3 52 29 PM" src="https://user-images.githubusercontent.com/66752128/95140066-cf1d0480-0722-11eb-9dc6-98cc60b33092.png">
