### PR TITLE
ref(tracing): Reorganize and rename tracing sections in SDK docs

### DIFF
--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -85,9 +85,7 @@ export const PlatformSidebar = ({
       <DynamicNav
         root={`/${pathRoot}/performance`}
         title="Performance Monitoring"
-        prependLinks={[
-          [`/${pathRoot}/performance/`, "Enabling Performance Monitoring"],
-        ]}
+        prependLinks={[[`/${pathRoot}/performance/`, "Enabling Tracing"]]}
         suppressMissing
         tree={tree}
       />

--- a/src/platforms/common/performance/sampling.mdx
+++ b/src/platforms/common/performance/sampling.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sampling Transactions
+sidebar_title: Sampling
 sidebar_order: 20
 description: "Learn how to configure the volume of transactions sent to Sentry."
 supported:

--- a/src/platforms/javascript/common/performance/capturing/automatic.mdx
+++ b/src/platforms/javascript/common/performance/capturing/automatic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Capturing Transactions Automatically
+title: Automatic Capture
 sidebar_order: 20
 description: "Learn how to configure what performance data is automatically captured."
 ---

--- a/src/platforms/javascript/common/performance/capturing/index.mdx
+++ b/src/platforms/javascript/common/performance/capturing/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Capturing Transactions
+sidebar_order: 20
+description: "Learn how to capture transactions both automatically and manually."
+---
+
+<PageGrid />

--- a/src/platforms/javascript/common/performance/capturing/manual.mdx
+++ b/src/platforms/javascript/common/performance/capturing/manual.mdx
@@ -1,5 +1,5 @@
 ---
-title: Capturing Transactions Manually
+title: Manual Capture
 sidebar_order: 20
 description: "Learn how to capture performance data on any action in your app."
 ---

--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 
 Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
-Once tracing is enabled, certain types of operations will be measured automatically, and you can also choose to manually measure any operation you like. To learn more, see [Capturing Transactions Automatically](/platforms/javascript/performance/automatic/) and [Capturing Transactions Manually](/platforms/javascript/performance/manual/).
+Once tracing is enabled, certain types of operations will be measured automatically, and you can also choose to manually measure any operation you like. To learn more, see [Capturing Transactions Automatically](/platforms/javascript/performance/capturing/automatic/) and [Capturing Transactions Manually](/platforms/javascript/performance/capturing/manual/).
 
 ## Enabling Tracing
 


### PR DESCRIPTION
Primarily with the purpose of making each heading one line.