### PR TITLE
fix(apple): Add imports for Apple code samples

### DIFF
--- a/src/includes/before-breadcrumb/apple.mdx
+++ b/src/includes/before-breadcrumb/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.beforeBreadcrumb = { crumb in
         return crumb
@@ -7,6 +9,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.beforeBreadcrumb = ^SentryBreadcrumb * _Nullable(SentryBreadcrumb * _Nonnull crumb) {
         return crumb;

--- a/src/includes/breadcrumbs-example/apple.mdx
+++ b/src/includes/breadcrumbs-example/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 let crumb = Breadcrumb()
 crumb.level = SentryLevel.info
 crumb.category = "auth"
@@ -7,6 +9,8 @@ SentrySDK.addBreadcrumb(crumb: crumb)
 ```
 
 ```objc
+@import Sentry;
+
 SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] init];
 crumb.level = kSentryLevelInfo;
 crumb.category = @"auth";

--- a/src/includes/capture-error/apple.mdx
+++ b/src/includes/capture-error/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.capture(error: error)
 
 // Or
@@ -8,6 +10,8 @@ SentrySDK.capture(exception: exception)
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK captureError:error];
 
 // Or

--- a/src/includes/capture-message/apple.mdx
+++ b/src/includes/capture-message/apple.mdx
@@ -1,7 +1,11 @@
 ```swift
+import Sentry
+
 SentrySDK.capture(message: "My first test message")
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK captureMessage:@"My first test message"];
 ```

--- a/src/includes/cocoa/integrations/apple.mdx
+++ b/src/includes/cocoa/integrations/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start(options: [
     //...
     "integrations": Sentry.Options.defaultIntegrations().filter { (name) -> Bool in
@@ -9,6 +11,8 @@ SentrySDK.start(options: [
 ```
 
 ```objc
+@import Sentry;
+
 NSMutableArray *integrations = [SentryOptions defaultIntegrations].mutableCopy;
 [integrations removeObject:@"SentryAutoBreadcrumbTrackingIntegration"];
 [SentrySDK startWithOptions:@{

--- a/src/includes/cocoa/pass-scope/apple.mdx
+++ b/src/includes/cocoa/pass-scope/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: nil)
 let scope = Scope()
 scope.setLevel(.fatal)
@@ -10,6 +12,8 @@ SentrySDK.capture(exception: exception, scope: scope)
 ```
 
 ```objc
+@import Sentry;
+
 NSException *exception = [[NSException alloc] initWithName:@"My Custom exception" reason:@"User clicked the button" userInfo:nil];
 SentryScope *scope = [[SentryScope alloc] init];
 [scope setLevel:kSentryLevelFatal];

--- a/src/includes/cocoa/scope-callback/apple.mdx
+++ b/src/includes/cocoa/scope-callback/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 let userInfo = [NSLocalizedDescriptionKey : "Object does not exist"]
 let error = NSError(domain: "YourErrorDomain", code: 0, userInfo: userInfo)
 SentrySDK.capture(error: error) { (scope) in
@@ -10,6 +12,8 @@ SentrySDK.capture(error: error) { (scope) in
 ```
 
 ```objc
+@import Sentry;
+
 NSDictionary *userInfo = @ { NSLocalizedDescriptionKey : @"Object does not exist" };
 NSError *error = [NSError errorWithDomain:@"YourErrorDomain"
                                    code:0

--- a/src/includes/configuration/auto-session-tracking/apple.mdx
+++ b/src/includes/configuration/auto-session-tracking/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     // If you prefer NOT to track release health.
@@ -7,6 +9,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithOptions:@{
     @"dsn": @"___PUBLIC_DSN___",
     // If you prefer NOT to track release health.

--- a/src/includes/configuration/before-send/apple.mdx
+++ b/src/includes/configuration/before-send/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.beforeSend = { event in
@@ -9,6 +11,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.beforeSend = ^SentryEvent * _Nullable(SentryEvent * _Nonnull event) {

--- a/src/includes/configuration/sample-rate/apple.mdx
+++ b/src/includes/configuration/sample-rate/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.sampleRate = 0.25
 }
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.sampleRate = @0.25;
 }];

--- a/src/includes/configuration/session-tracking-interval/apple.mdx
+++ b/src/includes/configuration/session-tracking-interval/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.sessionTrackingIntervalMillis = 60000
@@ -6,6 +8,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithOptions:@{
     @"dsn": @"___PUBLIC_DSN___",
     @"sessionTrackingIntervalMillis": @60000

--- a/src/includes/configure-scope/apple.mdx
+++ b/src/includes/configure-scope/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.configureScope { scope in
     scope.setTag(value: "my-tag", key: "my value")
     let user = User()
@@ -8,6 +10,8 @@ SentrySDK.configureScope { scope in
 ```
 
 ```objc
+import Sentry
+
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
     [scope setTagValue:@"my-tag" forKey:@"my value"];
     SentryUser *user = [[SentryUser alloc] init];

--- a/src/includes/getting-started-verify/apple.mdx
+++ b/src/includes/getting-started-verify/apple.mdx
@@ -1,9 +1,13 @@
 One way to verify your setup is by intentionally causing an error that breaks your application.
 
 ```swift
+import Sentry
+
 SentrySDK.crash()
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK crash];
 ```

--- a/src/includes/set-context/apple.mdx
+++ b/src/includes/set-context/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.configureScope { scope in
     scope.setExtra(value: "Mighty Fighter", key: "character.name")
 }
 ```
 
 ```objc
+import Sentry
+
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
     [scope setExtraValue:@"Mighty Fighter" forKey:@"character.name"];
 }];

--- a/src/includes/set-environment/apple.mdx
+++ b/src/includes/set-environment/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.environment = "production"
@@ -6,6 +8,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.environment = @"production";

--- a/src/includes/set-extra/apple.mdx
+++ b/src/includes/set-extra/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.configureScope { scope in
     scope.setExtra(value: "Mighty Fighter", key: "character.name")
 }
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
     [scope setExtraValue:@"Mighty Fighter" forKey:@"character.name"];
 }];

--- a/src/includes/set-fingerprint/basic/apple.mdx
+++ b/src/includes/set-fingerprint/basic/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.beforeSend = { event in
         event.fingerprint = ["my-view-function"]
@@ -8,6 +10,8 @@ SentrySDK.start { options in
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.beforeSend = ^SentryEvent * _Nullable(SentryEvent * _Nonnull event) {
         event.fingerprint = @[@"my-view-function"];

--- a/src/includes/set-level/apple.mdx
+++ b/src/includes/set-level/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.logLevel = SentryLogLevel.error
 }
 ```
 
 ``` objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.logLevel = kSentryLogLevelError;
 }

--- a/src/includes/set-release/apple.mdx
+++ b/src/includes/set-release/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.start { options in
     options.releaseName = "1.0.0"
 }
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.releaseName = @"1.0.0;"
 }

--- a/src/includes/set-tag/apple.mdx
+++ b/src/includes/set-tag/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 SentrySDK.configureScope { scope in
     scope.setTag(value: "page_locale", key: "de-at")
 }
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
     [scope setTagValue:@"page_locale" forKey:@"de-at"];
 }];

--- a/src/includes/set-user/apple.mdx
+++ b/src/includes/set-user/apple.mdx
@@ -1,10 +1,14 @@
 ```swift
+import Sentry
+
 let user = User()
 user.email = "john.doe@example.com"
 SentrySDK.setUser(user)
 ```
 
 ```objc
+@import Sentry;
+
 SentryUser *user = [[SentryUser alloc] init];
 user.email = @"john.doe@example.com";
 [SentrySDK setUser:user];

--- a/src/includes/trigger-crash/apple.mdx
+++ b/src/includes/trigger-crash/apple.mdx
@@ -1,7 +1,11 @@
 ```swift
+import Sentry
+
 SentrySDK.crash()
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK crash];
 ```

--- a/src/includes/unset-user/apple.mdx
+++ b/src/includes/unset-user/apple.mdx
@@ -1,7 +1,11 @@
 ```swift
+import Sentry
+
 SentrySDK.setUser(nil)
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK setUser:nil];
 ```

--- a/src/includes/with-scope/apple.mdx
+++ b/src/includes/with-scope/apple.mdx
@@ -1,4 +1,6 @@
 ```swift
+import Sentry
+
 SentrySDK.capture(error: error) { scope in
     // will be tagged with my-tag="my value"
     scope.setTag(value: "my-tag", key: "my value")
@@ -9,6 +11,8 @@ SentrySDK.capture(error: error)
 ```
 
 ```objc
+@import Sentry;
+
 [SentrySDK captureError:error withScopeBlock:^(SentryScope * _Nonnull scope) {
     // will be tagged with my-tag="my value"
     [scope setTagValue:@"my-tag" forKey:@"my value"];


### PR DESCRIPTION
Other platforms all display the import statement at the top of code samples,
because it is in our philosophy to assume novice developers.