### PR TITLE
fix: API docs column widths

### DIFF
--- a/src/gatsby/createPages/createApiPages.ts
+++ b/src/gatsby/createPages/createApiPages.ts
@@ -28,6 +28,7 @@ export default async ({ actions, graphql, reporter }) => {
         context: {
           id: node.id,
           title: node.path.operationId,
+          notoc: true
         },
       });
     })


### PR DESCRIPTION
## UI
**Before**
<img width="1440" alt="Screen Shot 2020-10-06 at 2 06 35 PM" src="https://user-images.githubusercontent.com/10491193/95260857-4a8fbc00-07de-11eb-9c84-92c6dae00a9b.png">

**After**
<img width="1440" alt="Screen Shot 2020-10-06 at 2 13 20 PM" src="https://user-images.githubusercontent.com/10491193/95260877-50859d00-07de-11eb-9956-c00ff0ef3df1.png">
