### PR TITLE
Update index.mdx

### DIFF
--- a/src/platforms/python/common/performance/index.mdx
+++ b/src/platforms/python/common/performance/index.mdx
@@ -28,7 +28,8 @@ import sentry_sdk
 
 sentry_sdk.init(
     "___PUBLIC_DSN___",
-    _experiments={"auto_enabling_integrations": True}
+    _experiments={"auto_enabling_integrations": True},
+    traces_sample_rate=1.0 # must be present and non-zero to see any results 
 )
 ```
 


### PR DESCRIPTION
Without the `traces_sample_rate` explicitly set, there won't be any output in Performance Monitor as the default rate is 0