### PR TITLE
remove extra parenthesis

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -95,7 +95,7 @@ Available options:
   root: string;
 
   // function that takes the frame, applies a transformation, and returns it
-  iteratee: (frame) => frame);
+  iteratee: (frame) => frame;
 }
 ```
 


### PR DESCRIPTION
The example seems to be trying to provide an arrow function with an inferred return, if so - then the parenthesis here is in the way