### PR TITLE
fix: Typos

### DIFF
--- a/src/platforms/javascript/common/performance/capturing/automatic.mdx
+++ b/src/platforms/javascript/common/performance/capturing/automatic.mdx
@@ -4,7 +4,7 @@ sidebar_order: 20
 description: "Learn how to configure what performance data is automatically captured."
 ---
 
-The `@sentry/tracing` package provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications. By default, this integration will create a new transaction for each pageload and navigation event, and will create a child span for every `XMLHttpRequest` or `fetch` request which occurs while those transactions are open.
+The `@sentry/tracing` package provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications. By default, this integration will create a new transaction for each page load and navigation event, and will create a child span for every `XMLHttpRequest` or `fetch` request which occurs while those transactions are open.
 
 To enable this automatic tracing, include the `BrowserTracing` integration in your SDK configuration options. (Note that when using ESM modules, the main `@sentry/*` import must come before the `@sentry/tracing` import.)
 

--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -96,9 +96,9 @@ Without sampling, our atomatic instrumenation will send a transaction any time a
 
 ## Connecting Backend and Frontend Transactions
 
-To connect backend and frontend transactions into a single choherent trace, Sentry uses a `trace_id` value which is propagated between frontend and backend. Depending on the circumstance, this id is transmitted either in a request/response header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible for you to navigate between them in the Sentry UI, so you can better understand how the different parts of your system are affecting each other.
+To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value which is propagated between frontend and backend. Depending on the circumstance, this id is transmitted either in a request/response header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible for you to navigate between them in the Sentry UI, so you can better understand how the different parts of your system are affecting each other.
 
-### Pageload
+### Page load
 
 When enabling tracing in both frontend and backend and taking advantage of the automatic frontend instrumentation, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.
 


### PR DESCRIPTION
Note that we use `pageload` when referring to a specific type of transaction (by
its "op" value), and page load otherwise.