### PR TITLE
Add minimum Spring Boot version to docs.

### DIFF
--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -10,7 +10,7 @@ The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/jav
 
 <Note><markdown>
 
-We support Spring Boot 2.1.0 or newer. Still on an older version? You can use [our legacy SDK](/platforms/java/legacy/spring/).
+We support Spring Boot 2.1.0 and above. Still on an older version? You can use [our legacy SDK](/platforms/java/legacy/spring/).
 
 </markdown></Note>
 

--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -8,7 +8,11 @@ The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/jav
 - automatically setting the release on `SentryEvent` when [Spring Boot Git integration is configured](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-git-info)
 - automatically registering `BeforeSendCallback`, `BeforeBreadcrumbCallback`, `EventProcessor`, `Integration` beans
 
-We support Spring Boot 2.1.0 or newer.
+<Note><markdown>
+
+We support Spring Boot 2.1.0 or newer. Still on an older version? You can use [our legacy SDK](/platforms/java/legacy/spring/).
+
+</markdown></Note>
 
 For the best experience we recommend using Sentry Spring Boot integration together with one of the logging framework integrations as they seamlessly work together:
 

--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -8,6 +8,8 @@ The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/jav
 - automatically setting the release on `SentryEvent` when [Spring Boot Git integration is configured](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-git-info)
 - automatically registering `BeforeSendCallback`, `BeforeBreadcrumbCallback`, `EventProcessor`, `Integration` beans
 
+We support Spring Boot 2.1.0 or newer.
+
 For the best experience we recommend using Sentry Spring Boot integration together with one of the logging framework integrations as they seamlessly work together:
 
 - [Logback](/platforms/java/guides/logback/)


### PR DESCRIPTION
To avoid issues like https://github.com/getsentry/sentry-java/issues/970 this change makes it clear what's the minimum supported Spring Boot version.