### PR TITLE
feat: Support full fallback path on platform content

### DIFF
--- a/src/components/__tests__/configKey.test.js
+++ b/src/components/__tests__/configKey.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 
 import ConfigKey from "../configKey";
-import usePlatform from "../hooks/usePlatform";
+import usePlatform, { getPlatformsWithFallback } from "../hooks/usePlatform";
 
 jest.mock("../hooks/usePlatform");
 
@@ -16,6 +16,7 @@ describe("ConfigKey", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "ruby"]);
     const tree = renderer
       .create(<ConfigKey name="my-option-name" />, {
         path: "/",

--- a/src/components/__tests__/platformSection.test.js
+++ b/src/components/__tests__/platformSection.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 
 import PlatformSection from "../platformSection";
-import usePlatform from "../hooks/usePlatform";
+import usePlatform, { getPlatformsWithFallback } from "../hooks/usePlatform";
 
 jest.mock("../hooks/usePlatform");
 
@@ -15,6 +15,8 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby"]);
+
     const tree = renderer
       .create(<PlatformSection supported={["python"]}>Test</PlatformSection>)
       .toJSON();
@@ -30,6 +32,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["python"]);
     const tree = renderer
       .create(<PlatformSection supported={["python"]}>Test</PlatformSection>)
       .toJSON();
@@ -45,6 +48,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "ruby"]);
     const tree = renderer
       .create(<PlatformSection supported={["ruby"]}>Test</PlatformSection>)
       .toJSON();
@@ -60,6 +64,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby"]);
     const tree = renderer
       .create(<PlatformSection notSupported={["ruby"]}>Test</PlatformSection>)
       .toJSON();
@@ -75,6 +80,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "ruby"]);
     const tree = renderer
       .create(<PlatformSection notSupported={["ruby"]}>Test</PlatformSection>)
       .toJSON();
@@ -90,6 +96,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["python"]);
     const tree = renderer
       .create(<PlatformSection notSupported={["ruby"]}>Test</PlatformSection>)
       .toJSON();
@@ -105,6 +112,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "ruby"]);
     const tree = renderer
       .create(
         <PlatformSection supported={["ruby.rails"]} notSupported={["ruby"]}>
@@ -125,6 +133,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "javascript"]);
     const tree = renderer
       .create(
         <PlatformSection notSupported={["javascript"]}>Test</PlatformSection>
@@ -143,6 +152,7 @@ describe("PlatformSection", () => {
       jest.fn(),
       false,
     ]);
+    getPlatformsWithFallback.mockReturnValue(["ruby.rails", "javascript"]);
     const tree = renderer
       .create(
         <PlatformSection supported={["javascript"]}>Test</PlatformSection>

--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -201,6 +201,18 @@ type SetPlatformOptions = {
   noQueryString?: boolean;
 };
 
+export const getPlatformsWithFallback = (
+  platform: Platform | Guide
+): string[] => {
+  const result = [platform.key];
+  let curPlatform = platform;
+  while (curPlatform.fallbackPlatform) {
+    result.push(curPlatform.fallbackPlatform);
+    curPlatform = getPlatform(curPlatform.fallbackPlatform);
+  }
+  return result;
+};
+
 /**
  * The usePlatform() hook will allow you to reference the currently active platform.
  *

--- a/src/components/platformContent.tsx
+++ b/src/components/platformContent.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import styled from "@emotion/styled";
 import { graphql, useStaticQuery } from "gatsby";
 
-import usePlatform, { getPlatform, Platform } from "./hooks/usePlatform";
+import usePlatform, {
+  getPlatform,
+  getPlatformsWithFallback,
+  Platform,
+} from "./hooks/usePlatform";
 import Content from "./content";
 import SmartLink from "./smartLink";
 
@@ -47,15 +51,11 @@ type Props = {
 const getFileForPlatform = (
   includePath: string,
   fileList: FileNode[],
-  platform: Platform,
-  fallbackPlatform?: string
+  platform: Platform
 ): FileNode | null => {
-  const platformsToSearch = [
-    platform.key,
-    platform.fallbackPlatform,
-    fallbackPlatform,
-    "_default",
-  ];
+  const platformsToSearch = getPlatformsWithFallback(platform);
+  platformsToSearch.push("_default");
+
   const contentMatch = platformsToSearch
     .map(name => name && fileList.find(m => slugMatches(m.name, name)))
     .find(m => m);

--- a/src/components/platformSection.tsx
+++ b/src/components/platformSection.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-import usePlatform, { Platform } from "./hooks/usePlatform";
+import usePlatform, {
+  Platform,
+  getPlatformsWithFallback,
+} from "./hooks/usePlatform";
 
 type Props = {
   supported?: string[];
@@ -35,11 +38,7 @@ export default ({
     return null;
   }
 
-  const platformsToSearch = [
-    currentPlatform.key,
-    currentPlatform.key.split(".", 2)[0],
-    currentPlatform.fallbackPlatform,
-  ];
+  const platformsToSearch = getPlatformsWithFallback(currentPlatform);
 
   let result: boolean | null = null;
   for (let platformKey, i = 0; (platformKey = platformsToSearch[i]); i++) {


### PR DESCRIPTION
This resolves an issue for guides which their base platform also includes a fallbackPlatform. For example, the `node.express` guide should fallback to `node`, then to `javascript`.