### PR TITLE
fix: Duplicate redirects for guide-level

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,10 @@
       "destination": "/platforms/$1/usage/"
     },
     {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/configuration/capture/",
+      "destination": "/platforms/$1/guides/$2/usage/"
+    },
+    {
       "source": "/platforms/([^/]*)/configuration/install-cdn/",
       "destination": "/platforms/$1/install/cdn/"
     },
@@ -60,20 +64,40 @@
       "destination": "/platforms/$1/usage/set-level/"
     },
     {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/enriching-error-data/set-level/",
+      "destination": "/platforms/$1/guides/$2/usage/set-level/"
+    },
+    {
       "source": "/platforms/([^/]*)/enriching-error-data/additional-data/manage-context/",
       "destination": "/platforms/$1/enriching-events/context/"
+    },
+    {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/enriching-error-data/additional-data/manage-context/",
+      "destination": "/platforms/$1/guides/$2/enriching-events/context/"
     },
     {
       "source": "/platforms/([^/]*)/enriching-error-data/additional-data/adding-tags/",
       "destination": "/platforms/$1/enriching-events/tags/"
     },
     {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/enriching-error-data/additional-data/adding-tags/",
+      "destination": "/platforms/$1/guides/$2/enriching-events/tags/"
+    },
+    {
       "source": "/platforms/([^/]*)/enriching-error-data/additional-data/(.*)",
       "destination": "/platforms/$1/enriching-events/"
     },
     {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/enriching-error-data/additional-data/(.*)",
+      "destination": "/platforms/$1/guides/$2/enriching-events/"
+    },
+    {
       "source": "/platforms/([^/]*)/enriching-error-data/(.*)",
       "destination": "/platforms/$1/enriching-events/$2"
+    },
+    {
+      "source": "/platforms/([^/]*)/guides/([^/]*)/enriching-error-data/(.*)",
+      "destination": "/platforms/$1/guides/$2/enriching-events/$3"
     },
     {
       "source": "/platforms/javascript/config/sourcemaps/",


### PR DESCRIPTION
Instead of using `.*` and causing infinite redirects because of too
liberal matchers, use `[^/]` and just duplicate.