### PR TITLE
chore: Update linkchecker to show markdown filenames

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,17 +35,17 @@ jobs:
         id: cache-linkchecker
         with:
           path: ~/.cargo/bin/hyperlink
-          key: ${{ runner.os }}-linkchecker-bin
+          key: ${{ runner.os }}-linkchecker-bin2
       - uses: actions-rs/toolchain@v1
         if: steps.cache-linkchecker.outputs.cache-hit != 'true'
         with:
           toolchain: stable
       - name: Install link checker
         if: steps.cache-linkchecker.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/untitaker/hyperlink --branch main
+        run: cargo install --git https://github.com/untitaker/hyperlink --rev 422d51f1dae067af25d491c06889814f7b088c87
 
       - name: Run linkchecker
-        run: hyperlink public/
+        run: hyperlink public/ --sources src/
 
   job_lint:
     name: Lint


### PR DESCRIPTION
https://github.com/untitaker/hyperlink/commit/422d51f1dae067af25d491c06889814f7b088c87#diff-04c6e90faac2675aa89e2176d2eec7d8R46

That commit will show the filenames of the original markdown files *additionally*.

We're bumping cache name and pin by rev to make sure to get a commit that contains the new option.