### PR TITLE
feat(relay): Remove WIP notice

### DIFF
--- a/src/docs/product/performance/event-detail.mdx
+++ b/src/docs/product/performance/event-detail.mdx
@@ -56,11 +56,9 @@ The trace view may be limited to one project at a time if you're on the [Team pl
 Some spans within a transaction may be the parent of another transaction. Under these circumstances, some Span IDs will have a "View Child" or "View Children" button. These will potentially lead to another transaction or a list of transactions.
 
 <Alert>
-  <markdown>
 
-    Traversing between parent and child transactions is only available on the [Business plan](https://sentry.io/pricing/). Further, project permissions may affect access to some of these transactions.
+Traversing between parent and child transactions is only available on the [Business plan](https://sentry.io/pricing/). Further, project permissions may affect access to some of these transactions.
 
-</markdown>
 </Alert>
 
 **Adding Query Information and Parameters to Spans**

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -15,15 +15,9 @@ Relay is specifically designed to:
 - Improve event response time in regions with low bandwidth or limited connectivity
 - Act as an opaque proxy for organizations that restrict all HTTP communication to a custom domain name
 
-<Alert level="info" title="Note">
+<Alert>
 
-Relay is a work in progress. The default Relay mode is currently supported
-only for on-premise installations and beta testers. If you are using Relay to
-connect to Sentry and are not a beta tester, you need to use `proxy` or `static`
-mode.
-
-If you want to beta test the `managed` mode while connecting to Sentry, please
-contact us. See [Relay Modes](/product/relay/modes/) for more information.
+Relay in `managed` mode is available on the [Business and Enterprise plans](https://sentry.io/pricing/).
 
 </Alert>
 


### PR DESCRIPTION
Instead, link to the pricing page.

This also fixes an unrelated rendering bug on the Performance Event Detail page:

![image](https://user-images.githubusercontent.com/1433023/95718599-f7e75180-0c6e-11eb-969b-1301943c302d.png)
