### PR TITLE
Remove Python Automatic Instrumentation section

### DIFF
--- a/src/platforms/python/common/performance/index.mdx
+++ b/src/platforms/python/common/performance/index.mdx
@@ -5,34 +5,6 @@ description: "Learn more about how to configure our Performance integrations to 
 
 Performance Monitoring helps you see everything from macro-level metrics to micro-level spans, and you’ll be able to cross-reference transactions with related issues, customize queries based on your personal needs, and substantially more and is avaliable for the Sentry Python SDK version ≥ 0.11.2.
 
-## Automatic Instrumentation
-
-Many integrations for popular frameworks automatically capture transactions. If you already have any of the following frameworks set up for Sentry error reporting, you will start to see traces immediately:
-
-- All WSGI-based web frameworks (Django, Flask, Pyramid, Falcon, Bottle)
-- Celery
-- AIOHTTP web apps
-- Redis Queue (RQ)
-
-Spans are instrumented for the following operations within a transaction:
-
-- Database queries that use SQLAlchemy or the Django ORM
-- HTTP requests made with `requests` or the `stdlib`
-- Spawned subprocesses
-- Redis operations
-
-If you want to automatically enable all relevant transactions, you can use this alternative configuration (currently in alpha):
-
-```python
-import sentry_sdk
-
-sentry_sdk.init(
-    "___PUBLIC_DSN___",
-    _experiments={"auto_enabling_integrations": True},
-    traces_sample_rate=1.0 # must be present and non-zero to see any results 
-)
-```
-
 ## Manual Instrumentation
 
 To manually instrument certain regions of your code, you can create a transaction to capture them.


### PR DESCRIPTION
`traces_sample_rate` is enabled by default:
https://github.com/getsentry/sentry-python/blob/d8c161fb289b44b5cd4b83d0bb31112031925713/sentry_sdk/consts.py#L35-L70