### PR TITLE
feat(API docs): Parse markdown links

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { sortPages, parseBackticks } from "../utils";
+import { sortPages, parseMarkdown } from "../utils";
 
 const PAGE_ONE = { context: { title: "Test", sidebar_order: 5 } };
 const PAGE_TWO = { context: { title: "Test Two", sidebar_order: 10 } };
@@ -23,9 +23,9 @@ describe("sortPages", () => {
   });
 });
 
-describe("parseBackticks", () => {
+describe("parseMarkdown", () => {
   it("converts a single code formatted string in a string", () => {
-    const result = parseBackticks(
+    const result = parseMarkdown(
       "The `quick` brown fox jumps over the lazy dog."
     );
     expect(result).toBe(
@@ -34,7 +34,7 @@ describe("parseBackticks", () => {
   });
 
   it("coverts multiple code formatted strings in a string", () => {
-    const result = parseBackticks(
+    const result = parseMarkdown(
       "The `quick` `brown` fox `jumps` over the lazy dog."
     );
     expect(result).toBe(
@@ -43,7 +43,7 @@ describe("parseBackticks", () => {
   });
 
   it("converts multiple backticks as code element", () => {
-    const result = parseBackticks(
+    const result = parseMarkdown(
       'Possible values are: ``""`` (disable),``"24h"``, ``"14d"``'
     );
 

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -51,4 +51,22 @@ describe("parseMarkdown", () => {
       'Possible values are: <code>""</code> (disable),<code>"24h"</code>, <code>"14d"</code>'
     );
   });
+  it("converts markdown link to html", () => {
+    const result = parseMarkdown(
+      "This can be retrieved from the [beforeSend callback](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend)."
+    );
+
+    expect(result).toBe(
+      'This can be retrieved from the <a href="https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend">beforeSend callback</a>.'
+    );
+  });
+  it("converts markdown link and code formatted strings to html", () => {
+    const result = parseMarkdown(
+      "This `example` can be retrieved from the [beforeSend callback](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend)."
+    );
+
+    expect(result).toBe(
+      'This <code>example</code> can be retrieved from the <a href="https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend">beforeSend callback</a>.'
+    );
+  });
 });

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
-import { parseBackticks } from "~src/utils";
+import { parseMarkdown } from "~src/utils";
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
 import ApiSidebar from "~src/components/apiSidebar";
@@ -29,7 +29,7 @@ const Params = ({ params }) => (
         {!!param.description && (
           <dd
             dangerouslySetInnerHTML={{
-              __html: parseBackticks(param.description),
+              __html: parseMarkdown(param.description),
             }}
           ></dd>
         )}
@@ -113,7 +113,7 @@ export default props => {
 
           {data.description && (
             <div className="pb-3 content-flush-bottom">
-              <p>{parseBackticks(data.description)}</p>
+              <p>{parseMarkdown(data.description)}</p>
             </div>
           )}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,9 +80,10 @@ export const sortPages = (
 // - a code block containing a single backtick
 // But I don't think this case will occur in the OpenAPI schema.
 // We assume that individuals will always close out their code blocks, as they have done in the markdown files.
-export const parseBackticks = (str: string) => {
+export const parseMarkdown = (str: string) => {
   let i = 0;
   return str
+    .replace(/\[([^\]]+)\]\(([^\)]+)\)/, '<a href="$2">$1</a>') // format markdown links into a hrefs
     .replace(/\`+/g, "`") // Squash backticks for code blocks with multiple backticks
     .split("")
     .map(c => {


### PR DESCRIPTION
In order for the API docs to be able to use links in the path and body param descriptions, we must parse markdown links into html links

![Screen Shot 2020-10-14 at 4 32 08 PM](https://user-images.githubusercontent.com/29959063/96056431-6547dd80-0e3b-11eb-9fa6-e1d29a9746d8.png)