### PR TITLE
feat: React Native SDK 2.x migration docs

### DIFF
--- a/src/platforms/react-native/advanced-setup.mdx
+++ b/src/platforms/react-native/advanced-setup.mdx
@@ -123,7 +123,7 @@ dependencies {
 Please make sure your `MainApplication.java` looks something like this (only necessary for react-native versions `< 0.60`):
 
 ```java
-import io.sentry.RNSentryPackage;
+import io.sentry.react.RNSentryPackage;
 
 public class MainApplication extends Application implements ReactApplication {
 

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -1,8 +1,39 @@
 ---
-title: Migrating from react-native-sentry
+title: Migration
 ---
 
-If you are upgrading from an earlier version of react-native-sentry you should unlink the package to ensure the generated code is updated to the latest version:
+## From 1.x to 2.x
+
+In `@sentry/react-native` version `2.x`, release health and native stack traces are now enabled by default.
+
+### iOS/MacOS
+
+There are no immediate breaking changes for iOS/MacOS on the React Native side, just make sure you run `pod install` after the upgrade.
+
+If you use the `sentry-cocoa` SDK directly, you should follow its [migration guide for 5.x to 6.x](/platforms/apple/migration/#migrating-from-5x-to-6x).
+
+### Android
+
+If you are on React Native <0.60, you will need to update this line in your `MainApplication.java`:
+
+
+Old:
+
+```java
+import io.sentry.RNSentryPackage;
+```
+
+New:
+```java
+import io.sentry.react.RNSentryPackage;
+```
+
+Otherwise, there should be no other immediate breaking changes on the React Native side. If you use the `sentry-andoid` SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration/#migrating-from-sentry-android-2x-to-sentry-android-3x).
+
+
+## From 0.x to 1.x
+
+If you are upgrading from an earlier version of `react-native-sentry` you should unlink the package to ensure the generated code is updated to the latest version:
 
 ```bash
 react-native unlink react-native-sentry

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -1,33 +1,34 @@
 ---
 title: Migration
+description: "Learn more about migrating from 1.x to 2.x to enable release health tracking and native stack traces by default."
 ---
 
 ## From 1.x to 2.x
 
-In `@sentry/react-native` version `2.x`, release health and native stack traces are now enabled by default.
+Sentry's most recent version of our React Native SDK enables release health tracking and native stack traces by default.
 
-This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/).
-If you are using an on-premise installation it requires Sentry version
-`>= v20.6.0` to work. If you are using sentry.io nothing will change and
-no action is needed.
+This version of the SDK uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are using an on-premise installation, the SDK requires Sentry version 20.6.0 and above. If you are using our SaaS product (`sentry.io`), there is no change and no action is required.
 
 ### iOS/MacOS
 
-There are no immediate breaking changes for iOS/MacOS on the React Native side, just make sure you run `pod install` after the upgrade.
+While the migration does not introduce breaking changes for iOS/MacOS on the React Native side, we recommend that you run `pod install` after the upgrade.
 
-If you use the `sentry-cocoa` SDK directly, you should follow its [migration guide for 5.x to 6.x](/platforms/apple/migration/#migrating-from-5x-to-6x).
+<Note>
+<markdown>
 
-On iOS/MacOS, we now cache events in envelopes on the disk.
-We decided not to take the effort to migrate these few cached events from 5.x to 6.x into
-envelopes. Instead we remove them from the disk. This means you might lose a few cached
-events of your users when upgrading.
+If you are using our Cocoa SDK directly, follow that [migration guide for 5.x to 6.x](/platforms/apple/migration/#migrating-from-5x-to-6x).
+
+</markdown>
+</Note>
+
+On iOS/MacOS, we now cache events in envelopes on the disk. As a result, you might lose a few cached events during the migration. Due to the effort involved, the migration from 5.x to 6.x does not move these few cached events into envelopes.
 
 ### Android
 
 If you are on React Native <0.60, you will need to update this line in your `MainApplication.java`:
 
 
-Old:
+From (earlier version):
 
 ```java
 import io.sentry.RNSentryPackage;
@@ -38,12 +39,20 @@ New:
 import io.sentry.react.RNSentryPackage;
 ```
 
-Otherwise, there should be no other immediate breaking changes on the React Native side. If you use the `sentry-andoid` SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration/#migrating-from-sentry-android-2x-to-sentry-android-3x).
+Other than the one line change noted above, the migration should not cause breaking changes on the React Native side. 
+
+<Note>
+<markdown>
+
+If you use our Android SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration/#migrating-from-sentry-android-2x-to-sentry-android-3x).
+
+</markdown>
+</Note>
 
 
 ## From 0.x to 1.x
 
-If you are upgrading from an earlier version of `react-native-sentry` you should unlink the package to ensure the generated code is updated to the latest version:
+If you are upgrading from an earlier version of Sentry's React Native SDK, you should unlink the package to ensure the generated code is updated to the latest version:
 
 ```bash
 react-native unlink react-native-sentry

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -6,11 +6,21 @@ title: Migration
 
 In `@sentry/react-native` version `2.x`, release health and native stack traces are now enabled by default.
 
+This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/).
+If you are using an on-premise installation it requires Sentry version
+`>= v20.6.0` to work. If you are using sentry.io nothing will change and
+no action is needed.
+
 ### iOS/MacOS
 
 There are no immediate breaking changes for iOS/MacOS on the React Native side, just make sure you run `pod install` after the upgrade.
 
 If you use the `sentry-cocoa` SDK directly, you should follow its [migration guide for 5.x to 6.x](/platforms/apple/migration/#migrating-from-5x-to-6x).
+
+On iOS/MacOS, we now cache events in envelopes on the disk.
+We decided not to take the effort to migrate these few cached events from 5.x to 6.x into
+envelopes. Instead we remove them from the disk. This means you might lose a few cached
+events of your users when upgrading.
 
 ### Android
 


### PR DESCRIPTION
Docs for users migrating to the 2.x version of the React Native SDK.

- Changes android package name from `io.sentry.RNSentryPackage` to `io.sentry.react.RNSentryPackage`
- Migration docs for users moving from 1.x to 2.x.

Linked PR:
https://github.com/getsentry/sentry-react-native/pull/1131