### PR TITLE
fix(spring-boot): Clarify meaning in `CustomEventProcessor` and related sections

### DIFF
--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -118,7 +118,7 @@ sentry:
 
 ### Registering Custom Event Processor
 
-A Spring bean implementing `EventProcessor` will be automatically set on `SentryOptions` during Sentry SDK auto-configuration. There can be multiple event processors registered in single application.
+Any Spring bean implementing `EventProcessor` will be automatically set on `SentryOptions` during Sentry SDK auto-configuration. There can be multiple event processors registered in single application.
 
 ```java
 import io.sentry.SentryEvent;
@@ -137,7 +137,7 @@ public class CustomEventProcessor implements EventProcessor {
 
 ### Registering Custom Before Send Callback
 
-A Spring bean implementing the `BeforeSendCallback` will be automatically set on `SentryOptions` during the SDK's auto-configuration. Note that there can be only a single bean set this way.
+Any Spring bean implementing the `BeforeSendCallback` will be automatically set on `SentryOptions` during the SDK's auto-configuration. Note that there can be only a single bean set this way.
 
 ```java
 import io.sentry.SentryEvent;
@@ -157,7 +157,7 @@ public class CustomBeforeSendCallback implements SentryOptions.BeforeSendCallbac
 
 ### Registering Custom Before Breadcrumb Callback
 
-A Spring bean implementing the `BeforeBreadcrumbCallback` will be automatically set on `SentryOptions` during the SDK's auto-configuration. Note that there can be only a single bean set this way.
+Any Spring bean implementing the `BeforeBreadcrumbCallback` will be automatically set on `SentryOptions` during the SDK's auto-configuration. Note that there can be only a single bean set this way.
 
 ```java
 import io.sentry.Breadcrumb;


### PR DESCRIPTION
Nothing wrong with it grammatically, but as it stands the meaning is ambiguous.