### PR TITLE
fix: Render markdown formatting in description

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { sortPages, parseBackticks } from "../utils";
+import { sortPages } from "../utils";
 
 const PAGE_ONE = { context: { title: "Test", sidebar_order: 5 } };
 const PAGE_TWO = { context: { title: "Test Two", sidebar_order: 10 } };
@@ -20,35 +20,5 @@ describe("sortPages", () => {
     expect(result[0].node).toBe(PAGE_ONE);
     expect(result[1].node).toBe(PAGE_THREE);
     expect(result[2].node).toBe(PAGE_TWO);
-  });
-});
-
-describe("parseBackticks", () => {
-  it("converts a single code formatted string in a string", () => {
-    const result = parseBackticks(
-      "The `quick` brown fox jumps over the lazy dog."
-    );
-    expect(result).toBe(
-      "The <code>quick</code> brown fox jumps over the lazy dog."
-    );
-  });
-
-  it("coverts multiple code formatted strings in a string", () => {
-    const result = parseBackticks(
-      "The `quick` `brown` fox `jumps` over the lazy dog."
-    );
-    expect(result).toBe(
-      "The <code>quick</code> <code>brown</code> fox <code>jumps</code> over the lazy dog."
-    );
-  });
-
-  it("converts multiple backticks as code element", () => {
-    const result = parseBackticks(
-      'Possible values are: ``""`` (disable),``"24h"``, ``"14d"``'
-    );
-
-    expect(result).toBe(
-      'Possible values are: <code>""</code> (disable),<code>"24h"</code>, <code>"14d"</code>'
-    );
   });
 });

--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -23,6 +23,29 @@ export const getApiTypeDefs = () => {
         query_parameters: [ApiParam]
         warning: String
       }
+      
+      type ApiParameterSchema {
+        enum: [String]
+        format: String
+        type: String
+      }
+      
+      type openApiPathDescription implements Node @childOf(types: ["openAPI"], ) {
+        id: ID!
+      }
+      
+      type openApiPathParameter implements Node @childOf(types: ["openAPI"], many: true) {
+        id: ID!
+        schema: ApiParameterSchema
+        name: String
+        in: String
+        description: String
+        required: Boolean
+      }
+      
+      type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter"], mimeTypes: ["text/markdown"]) {
+        body: String
+      }
       `,
   ];
 };

--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -126,3 +126,49 @@ export const sourceNodes = async (
     console.log(error);
   }
 };
+
+export const onCreateNode = async ({
+  node,
+  actions,
+  createNodeId,
+  createContentDigest,
+}) => {
+  if (node.internal.type === "openAPI") {
+    const descriptionNode = {
+      id: createNodeId(`openApiPathDescription-${node.id}`),
+      parent: node.id,
+      children: [],
+      internal: {
+        type: "openApiPathDescription",
+        content: node.path.description,
+        mediaType: "text/markdown",
+        contentDigest: createContentDigest(node.path.description),
+      },
+    };
+    actions.createNode(descriptionNode);
+    actions.createParentChildLink({
+      parent: node,
+      child: descriptionNode,
+    });
+
+    node.path.parameters.map((param, index) => {
+      const paramNode = {
+        id: createNodeId(`openApiPathParameter-${node.id}-${index}`),
+        parent: node.id,
+        children: [],
+        ...param,
+        internal: {
+          type: "openApiPathParameter",
+          content: param.description,
+          mediaType: "text/markdown",
+          contentDigest: createContentDigest(param),
+        },
+      };
+      actions.createNode(paramNode);
+      actions.createParentChildLink({
+        parent: node,
+        child: paramNode,
+      });
+    })
+  }
+};

--- a/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
@@ -2,7 +2,7 @@ export type RequestBodySchema = {
   required: string[];
   type: string;
   properties: {
-    [key: string]: { type: string; description: string; };
+    [key: string]: { type: string; description: string };
   };
 };
 
@@ -16,6 +16,12 @@ export type Parameter = {
   in: string;
   description: string;
   required: boolean;
+};
+
+type Markdown = {
+  childMdx: {
+    body: string;
+  };
 };
 
 export type DeRefedOpenAPI = {
@@ -88,4 +94,6 @@ export type OpenApiPath = {
 export type OpenAPI = {
   id: string;
   path: OpenApiPath;
+  childOpenApiPathDescription: Markdown;
+  childrenOpenApiPathParameter: (Parameter & Markdown)[];
 };

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
-import { parseBackticks } from "~src/utils";
+import Markdown from "~src/components/markdown.tsx";
 import BasePage from "~src/components/basePage";
 import SmartLink from "~src/components/smartLink";
 import ApiSidebar from "~src/components/apiSidebar";
@@ -27,11 +27,9 @@ const Params = ({ params }) => (
           {!!param.required && <div className="required">REQUIRED</div>}
         </dt>
         {!!param.description && (
-          <dd
-            dangerouslySetInnerHTML={{
-              __html: parseBackticks(param.description),
-            }}
-          ></dd>
+          <dd>
+            <Markdown value={param.childMdx.body} />
+          </dd>
         )}
       </React.Fragment>
     ))}
@@ -58,10 +56,10 @@ export default props => {
   const bodyParameters: RequestBodySchema | null =
     (requestBodyContent?.schema && JSON.parse(requestBodyContent.schema)) ||
     null;
-  const pathParameters = (data.parameters || []).filter(
+  const pathParameters = (openApi.childrenOpenApiPathParameter || []).filter(
     param => param.in === "path"
   );
-  const queryParameters = (data.parameters || []).filter(
+  const queryParameters = (openApi.childrenOpenApiPathParameter || []).filter(
     param => param.in === "query"
   );
   const contentType = requestBodyContent?.content_type;
@@ -113,11 +111,9 @@ export default props => {
 
           {data.description && (
             <div className="pb-3 content-flush-bottom">
-              <p
-                dangerouslySetInnerHTML={{
-                  __html: parseBackticks(data.description),
-                }}
-              ></p>
+              <Markdown
+                value={openApi.childOpenApiPathDescription.childMdx.body}
+              />
             </div>
           )}
 
@@ -261,6 +257,26 @@ export const pageQuery = graphql`
   query OpenApiQuery($id: String) {
     openApi(id: { eq: $id }) {
       id
+      childOpenApiPathDescription {
+        childMdx {
+          body
+        }
+      }
+      childrenOpenApiPathParameter {
+        id
+        childMdx {
+          body
+        }
+        schema {
+          enum
+          format
+          type
+        }
+        name
+        in
+        description
+        required
+      }
       path {
         description
         method

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -113,7 +113,11 @@ export default props => {
 
           {data.description && (
             <div className="pb-3 content-flush-bottom">
-              <p>{parseBackticks(data.description)}</p>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: parseBackticks(data.description),
+                }}
+              ></p>
             </div>
           )}
 

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -4,7 +4,7 @@ import Prism from "prismjs";
 
 import ApiSidebar from "~src/components/apiSidebar";
 import BasePage from "~src/components/basePage";
-import Markdown from "~src/components/markdown.tsx";
+import Content from "~src/components/content"
 import SmartLink from "~src/components/smartLink";
 
 import {
@@ -28,7 +28,7 @@ const Params = ({ params }) => (
         </dt>
         {!!param.description && (
           <dd>
-            <Markdown value={param.childMdx.body} />
+            <Content file={param} />
           </dd>
         )}
       </React.Fragment>
@@ -111,9 +111,7 @@ export default props => {
 
           {data.description && (
             <div className="pb-3 content-flush-bottom">
-              <Markdown
-                value={openApi.childOpenApiPathDescription.childMdx.body}
-              />
+              <Content file={openApi.childOpenApiPathDescription} />
             </div>
           )}
 

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -2,10 +2,10 @@ import React, { useState, useEffect } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
-import Markdown from "~src/components/markdown.tsx";
-import BasePage from "~src/components/basePage";
-import SmartLink from "~src/components/smartLink";
 import ApiSidebar from "~src/components/apiSidebar";
+import BasePage from "~src/components/basePage";
+import Markdown from "~src/components/markdown.tsx";
+import SmartLink from "~src/components/smartLink";
 
 import {
   OpenAPI,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,18 +75,3 @@ export const sortPages = (
     );
   });
 };
-
-// Does not cover the following edge cases:
-// - a code block containing a single backtick
-// But I don't think this case will occur in the OpenAPI schema.
-// We assume that individuals will always close out their code blocks, as they have done in the markdown files.
-export const parseBackticks = (str: string) => {
-  let i = 0;
-  return str
-    .replace(/\`+/g, "`") // Squash backticks for code blocks with multiple backticks
-    .split("")
-    .map(c => {
-      return c === "`" ? (i++ % 2 ? "</code>" : "<code>") : c;
-    })
-    .join("");
-};


### PR DESCRIPTION
## Objective
Original Problem:
On the API docs, the description field no longer formats backticks correctly, instead rendering them as "<code>id</code>" for example.

In this PR, I made the `gatsby-plugin-openapi` create child nodes for each API path's parameters and description. For this child nodes, I tagged as `text/markdown` so that the `gatsby-plugin-mdx` and `gatsby-transformer-remark` automatically parse the strings. Then we can render the result in the `<Markdown>` component. This removes the need to `dangerouslySetInnerHTML` for the params and the description.

I removed `parseBacticks` bc we don't need it anymore.

## UI
**Before**
<img width="521" alt="Screen Shot 2020-10-15 at 11 51 31 AM" src="https://user-images.githubusercontent.com/10491193/96173517-d68b9d00-0edc-11eb-9ae8-ae602e186747.png">

**After**
<img width="521" alt="Screen Shot 2020-10-15 at 11 51 45 AM" src="https://user-images.githubusercontent.com/10491193/96173530-dd1a1480-0edc-11eb-8856-b8bfab13e510.png">
