### PR TITLE
fix: Remove repeated sentence

### DIFF
--- a/src/includes/performance/default-sampling-context/node.mdx
+++ b/src/includes/performance/default-sampling-context/node.mdx
@@ -1,4 +1,4 @@
-The information contained in the `samplingContext` object passed to the `tracesSampler` when a transaction is created varies by platform. For node-based SDKs, it includes the following:
+For node-based SDKs, it includes the following:
 
 ```javascript
 {


### PR DESCRIPTION
The same sentence makes up a generic paragraph before the include.

---

https://docs.sentry.io/platforms/node/guides/aws-lambda/performance/sampling/#default-sampling-context-data
![image](https://user-images.githubusercontent.com/88819/96177772-a967da80-0f2e-11eb-888b-29b649e7b02b.png)
