### PR TITLE
fix: remove android-manifest command from upload-proguard docs

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -246,21 +246,19 @@ when you only release some of the builds you are creating).
 
 <Note><markdown>
 
-You need to specify the organization and project you are working with 
-because ProGuard files work on projects. For more information about this refer to 
+You need to specify the organization and project you are working with
+because ProGuard files work on projects. For more information about this refer to
 [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
 </markdown></Note>
 
 The `upload-proguard` command is the one to use for uploading ProGuard files. It
 takes the path to one or more ProGuard mapping files and will upload them to
-Sentry. If you want to associate them with an Android app you should also point
-it to a processed _AndroidManifest.xml_ from a build intermediate folder.
+Sentry.
 Example:
 
 ```bash
 sentry-cli upload-proguard \
-    --android-manifest app/build/intermediates/manifests/full/release/AndroidManifest.xml \
     app/build/outputs/mapping/release/mapping.txt
 ```
 
@@ -270,7 +268,6 @@ to embed it in a `sentry-debug-meta.properties` file. If you supply
 
 ```bash
 sentry-cli upload-proguard \
-    --android-manifest app/build/intermediates/manifests/full/release/AndroidManifest.xml \
     --write-properties app/build/intermediates/assets/release/sentry-debug-meta.properties \
     app/build/outputs/mapping/release/mapping.txt
 ```


### PR DESCRIPTION
because of https://github.com/getsentry/sentry-android-gradle-plugin/pull/28