### PR TITLE
Fix syntax error on breadcrumbs common content and add Android Platfo…

### DIFF
--- a/src/includes/before-breadcrumb/android.mdx
+++ b/src/includes/before-breadcrumb/android.mdx
@@ -1,3 +1,9 @@
+The Android SDK automatically collects and converts the following events into breadcrumbs:
+- Android Activity Lifecycle Events
+- Application Lifecycle Events (Lifecycle of the application process)
+- System Events (Low battery, Low storage space, Airplane mode started, Shutdown, Changes of the configuration, and so forth)
+- App. Component callbacks
+
 ```java
 import io.sentry.android.core.SentryAndroid;
 
@@ -10,4 +16,22 @@ SentryAndroid.init(options -> {
         }
     });
 });
+```
+
+If you want to disable the automatic collection of breadcrumbs, please add the following items into your manifest.
+
+```xml
+<application>
+    <!--    To disable the activity lifecycle breadcrumbs integration-->
+    <meta-data android:name="io.sentry.breadcrumbs.activity-lifecycle" android:value="false" />
+
+    <!--     To disable the app lifecycle breadcrumbs integration-->
+    <meta-data android:name="io.sentry.breadcrumbs.app-lifecycle" android:value="false" />
+
+    <!--    To disable the system events breadcrumbs integration-->
+    <meta-data android:name="io.sentry.breadcrumbs.system-events" android:value="false" />
+
+    <!--    To disable the app components breadcrumbs integration-->
+    <meta-data android:name="io.sentry.breadcrumbs.app-components" android:value="false" />
+</application>
 ```

--- a/src/platforms/android/common/enriching-events/context/default-context.mdx
+++ b/src/platforms/android/common/enriching-events/context/default-context.mdx
@@ -64,12 +64,3 @@ Screen info
 Emulator indicator
 
 - Whether the device is an emulator
-
-**Automatically Collected Breadcrumbs**
-
-The Android SDK automatically collects and converts the following events into breadcrumbs:
-
-- Android Activity Lifecycle Events
-- Application Lifecycle Events (Lifecycle of the application process)
-- System Events (Low battery, Low storage space, Airplane mode started, Shutdown, Changes of the configuration, etc. )
-- App. Component callbacks

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -29,7 +29,7 @@ You can manually add breadcrumbs whenever something interesting happens. For exa
 
 SDKs will automatically start recording breadcrumbs by enabling integrations. For instance, the browser JavaScript SDK will automatically record all location changes.
 
-<PlatformContent includePath="before-breadcrumb"><markdown>
+<PlatformContent includePath="before-breadcrumb" />
 
 ## Customize Breadcrumbs
 
@@ -37,8 +37,6 @@ SDKs customize breadcrumbs through the `before_breadcrumb` hook. This hook passe
 hint. The function can modify the breadcrumb or decide to discard it entirely:
 
 For information about what can be done with the hint see [Filtering Events](../../configuration/filtering/#before-breadcrumb).
-
-</markdown></PlatformContent>
 
 ## Next Steps:
 

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -33,12 +33,6 @@ SDKs will automatically start recording breadcrumbs by enabling integrations. Fo
 
 ## Customize Breadcrumbs
 
-SDKs customize breadcrumbs through the `before_breadcrumb` hook. This hook passes an already assembled breadcrumb and, in some SDKs, an optional
-hint. The function can modify the breadcrumb or decide to discard it entirely:
+SDKs customize breadcrumbs through the `before_breadcrumb` hook. This hook passes an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely:
 
-For information about what can be done with the hint see [Filtering Events](../../configuration/filtering/#before-breadcrumb).
-
-## Next Steps:
-
-- [Return to **Getting Started**](../../)
-- [Return to the main enriching event data page](../)
+For information about what can be done with the hint, see <PlatformLink to="/enriching-events/breadcrumbs/">Filtering Events</PlatformLink>.


### PR DESCRIPTION
This PR fixes a syntax issue for breadcrumbs common content, and moves the Android content into the correct location (removing it from default context)