### PR TITLE
Fix typo in django docs.

### DIFF
--- a/src/includes/getting-started-primer/python.django.mdx
+++ b/src/includes/getting-started-primer/python.django.mdx
@@ -3,7 +3,7 @@
 
 _Sentry's Django integration enables automatic reporting of errors and exceptions._
 
-Sentry's Django integration reports all exceptions leading to an Internal Server Error and creates a separate scope for each request. The integration supports [Django Web Framework from Version 1.6 and above](https://www.djangoproject.com/). Django applications using Channnels 2.0 will be correctly instrumented using Python 3.7. Older versions of Python require installation of `aiocontextvars`.
+Sentry's Django integration reports all exceptions leading to an Internal Server Error and creates a separate scope for each request. The integration supports [Django Web Framework from Version 1.6 and above](https://www.djangoproject.com/). Django applications using Channels 2.0 will be correctly instrumented using Python 3.7. Older versions of Python require installation of `aiocontextvars`.
 
 </markdown>
 </Note>


### PR DESCRIPTION
s/channnels/channels/