### PR TITLE
fix typos spring

### DIFF
--- a/src/platforms/java/guides/spring/index.mdx
+++ b/src/platforms/java/guides/spring/index.mdx
@@ -41,7 +41,7 @@ For other dependency managers see the [central Maven repository](https://search.
 
 ### Usage
 
-The `sentry-spring` library provides `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be places on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
+The `sentry-spring` library provides `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
 
 ```java {tabTitle:Java}
 import io.sentry.spring.EnableSentry;
@@ -62,7 +62,7 @@ import io.sentry.spring.EnableSentry
 class SentryConfiguration
 ```
 
-The DSN can be also proided through the system property `sentry.dsn`, environment variable `SENTRY_DSN` or the `dsn` property in `sentry.properties` file. [See the configuration page](/platforms/java/configuration/) for more details on external configuration.
+The DSN can be also provided through the system property `sentry.dsn`, environment variable `SENTRY_DSN` or the `dsn` property in `sentry.properties` file. [See the configuration page](/platforms/java/configuration/) for more details on external configuration.
 
 #### Recording User Information From HTTP Request
 
@@ -87,7 +87,7 @@ class SentryConfiguration
 
 #### Recording Custom User Information
 
-In order to record custom user information, you care register a bean that implements `SentryUserProvider` interface.
+In order to record custom user information, you can register a bean that implements `SentryUserProvider` interface.
 
 ```java {tabTitle:Java}
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
Correcting some minor typos on Sentry Spring (https://docs.sentry.io/platforms/java/guides/spring/) page.