### PR TITLE
Add: note about `stack.package` for Native 

### DIFF
--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -293,7 +293,7 @@ The following comparative operators are available:
 `stack.stack_level`<br />
 `stack.lineno`<br />
 
-: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. `stack.module` isn't typically used in Native code situations.
+: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. `stack.module` isn't typically used in Native.
 
 `error.type`<br />
 `error.value`<br />

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -293,7 +293,7 @@ The following comparative operators are available:
 `stack.stack_level`<br />
 `stack.lineno`<br />
 
-: Restrict results to events with a matching stack property.
+: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. `stack.module` isn't typically used in Native code situations.
 
 `error.type`<br />
 `error.value`<br />

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -293,7 +293,7 @@ The following comparative operators are available:
 `stack.stack_level`<br />
 `stack.lineno`<br />
 
-: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. `stack.module` isn't typically used in Native.
+: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. For more details about customizing search, see the full documentation on <PlatformLink to="/enriching-events/">Enriching Events</PlatformLink>.
 
 `error.type`<br />
 `error.value`<br />

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -293,7 +293,7 @@ The following comparative operators are available:
 `stack.stack_level`<br />
 `stack.lineno`<br />
 
-: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. For more details about customizing search, see the full documentation on <PlatformLink to="/enriching-events/">Enriching Events</PlatformLink>.
+: Restrict results to events with a matching stack property. Note: For Native SDK users, `stack.package` is the Native equivalent for `stack.module`. For more details about enhancing search, see the full documentation on [adding context and customizing tags](/platforms/native/enriching-events/).
 
 `error.type`<br />
 `error.value`<br />


### PR DESCRIPTION
Customer wrote in about confusion between `stack.package` and `stack.module`. Added a note to clarify the difference.