### PR TITLE
ref(breadcrumbs): Add to and tweak common SDK breadcrumb content

### DIFF
--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -25,14 +25,16 @@ You can manually add breadcrumbs whenever something interesting happens. For exa
 
 <PlatformContent includePath="breadcrumbs-example" />
 
+The available breadcrumb keys are "type", "category", "message", "level", "timestamp" (which many SDKs will set automatically for you), and "data", which is the place to put any information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
+
 ## Automatic Breadcrumbs
 
-SDKs will automatically start recording breadcrumbs by enabling integrations. For instance, the browser JavaScript SDK will automatically record all location changes.
-
-<PlatformContent includePath="before-breadcrumb" />
+SDKs and their associated integrations will automatically record many types of breadcrumbs. For instance, the browser JavaScript SDK will automatically record all location changes.
 
 ## Customize Breadcrumbs
 
-SDKs customize breadcrumbs through the `before_breadcrumb` hook. This hook passes an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely:
+SDKs allow you to customize breadcrumbs through the `before_breadcrumb` hook. This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
+
+<PlatformContent includePath="before-breadcrumb" />
 
 For information about what can be done with the hint, see <PlatformLink to="/enriching-events/breadcrumbs/">Filtering Events</PlatformLink>.

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -25,7 +25,7 @@ You can manually add breadcrumbs whenever something interesting happens. For exa
 
 <PlatformContent includePath="breadcrumbs-example" />
 
-The available breadcrumb keys are "type", "category", "message", "level", "timestamp" (which many SDKs will set automatically for you), and "data", which is the place to put any information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
+The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
 
 ## Automatic Breadcrumbs
 

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -25,8 +25,6 @@ You can manually add breadcrumbs whenever something interesting happens. For exa
 
 <PlatformContent includePath="breadcrumbs-example" />
 
-<!-- TODO: Native shouldn't really be on this list, since c++ is statically typed. Remove it once types have been added to the native SDK. -->
-
 <PlatformSection supported={["javascript", "node", "python", "php", "ruby", "elixir", "perl", "native"]}><markdown>
 
 The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any additional information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -25,7 +25,13 @@ You can manually add breadcrumbs whenever something interesting happens. For exa
 
 <PlatformContent includePath="breadcrumbs-example" />
 
-The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
+<!-- TODO: Native shouldn't really be on this list, since c++ is statically typed. Remove it once types have been added to the native SDK. -->
+
+<PlatformSection supported={["javascript", "node", "python", "php", "ruby", "elixir", "perl", "native"]}><markdown>
+
+The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any additional information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
+
+</markdown></PlatformSection>
 
 ## Automatic Breadcrumbs
 


### PR DESCRIPTION
This PR does a few things:

- Adds a list of the keys which can be used in a manually-captured breadcrumb, along with a warning that sending keys other than those listed will result in the data being lost.

- Moves the `beforeBreadcrumb` example into the correct section.

- Explains how `beforeBreadcrumb` can be used to drop a breadcrumb.

- Does general wordsmithing.