### PR TITLE
fix: Force redirect for Ember

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -327,6 +327,10 @@
     {
       "source": "/platforms/javascript/angular/",
       "destination": "/platforms/javascript/guides/angular/"
+    }, 
+    {
+      "source": "/platforms/javascript/ember/",
+      "destination": "/platforms/javascript/guides/ember/"
     }
   ]
 }


### PR DESCRIPTION
This adds a redirect for Ember to fix search results in google not bringing you to the new guides.