### PR TITLE
feat(actions): Create new workflow to bump sentry-api-schema SHA

### DIFF
--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -1,0 +1,31 @@
+name: bump-openapi
+on:
+  workflow_dispatch:
+    inputs:
+      sentry-api-schema-sha:
+        description: 'The "sentry-api-schema" SHA to run against'
+        required: false
+  push:
+    branches:
+      - master
+
+jobs:
+  bump:
+    name: Bump SHA referencing "sentry-api-schema" to ${{ github.event.inputs.sentry-api-schema-sha }}
+    runs-on: ubuntu-16.04
+    if: ${{ github.event.inputs.sentry-api-schema-sha != '' }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Bump latest SHA
+        sed -i "" 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
+
+    - name: Git Commit & Push
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        repository: sentry-docs
+        branch: master
+        commit_message: Latest SHA from getsentry/sentry-api-schema
+        commit_user_email: bot@getsentry.com
+        commit_user_name: openapi-getsentry-bot

--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -1,4 +1,6 @@
 name: bump-openapi
+# Deploys depend on the workflow file name: 'bump-openapi.yml'
+# You should not independently update it without updating the corresponding workflow in getsentry/sentry-api-schema
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -25,6 +25,6 @@ jobs:
         run: |
           git config user.name openapi-getsentry-bot
           git config user.email bot@getsentry.com
-          git add .
+          git add src/gatsby/utils/resolveOpenAPI.ts
           git commit -m "Latest SHA from getsentry/sentry-api-schema"
           git push

--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -22,10 +22,9 @@ jobs:
           sed -i "" 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
 
       - name: Git Commit & Push
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          repository: sentry-docs
-          branch: master
-          commit_message: Latest SHA from getsentry/sentry-api-schema
-          commit_user_email: bot@getsentry.com
-          commit_user_name: openapi-getsentry-bot
+        run: |
+          git config user.name openapi-getsentry-bot
+          git config user.email bot@getsentry.com
+          git add .
+          git commit -m "Latest SHA from getsentry/sentry-api-schema"
+          git push

--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -5,9 +5,6 @@ on:
       sentry-api-schema-sha:
         description: 'The "sentry-api-schema" SHA to run against'
         required: false
-  push:
-    branches:
-      - master
 
 jobs:
   bump:
@@ -16,16 +13,17 @@ jobs:
     if: ${{ github.event.inputs.sentry-api-schema-sha != '' }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Bump latest SHA
-        sed -i "" 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
+      - name: Bump latest SHA
+        run: |
+          sed -i "" 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
 
-    - name: Git Commit & Push
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        repository: sentry-docs
-        branch: master
-        commit_message: Latest SHA from getsentry/sentry-api-schema
-        commit_user_email: bot@getsentry.com
-        commit_user_name: openapi-getsentry-bot
+      - name: Git Commit & Push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          repository: sentry-docs
+          branch: master
+          commit_message: Latest SHA from getsentry/sentry-api-schema
+          commit_user_email: bot@getsentry.com
+          commit_user_name: openapi-getsentry-bot

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 
+<<<<<<< HEAD
 const SENTRY_API_SCHEMA_SHA = "20c924b1bb3ead4c76b540c075f59733590c0c3a";
+=======
+// SENTRY_API_SCHEMA_SHA is used in the bump-openapi GHA workflow.
+// DO NOT change variable name unless you change it in the bump-openapi GHA workflow.
+const SENTRY_API_SCHEMA_SHA = "03ccef5d80c6e636994e0594312778e1186ba41c"
+>>>>>>> comment
 
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 
+// SENTRY_API_SCHEMA_SHA is used in the bump-openapi GHA workflow.
+// DO NOT change variable name unless you change it in the bump-openapi GHA workflow.
 const SENTRY_API_SCHEMA_SHA = "20c924b1bb3ead4c76b540c075f59733590c0c3a";
 
 const activeEnv =

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,13 +1,7 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 
-<<<<<<< HEAD
 const SENTRY_API_SCHEMA_SHA = "20c924b1bb3ead4c76b540c075f59733590c0c3a";
-=======
-// SENTRY_API_SCHEMA_SHA is used in the bump-openapi GHA workflow.
-// DO NOT change variable name unless you change it in the bump-openapi GHA workflow.
-const SENTRY_API_SCHEMA_SHA = "03ccef5d80c6e636994e0594312778e1186ba41c"
->>>>>>> comment
 
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 
+const SENTRY_API_SCHEMA_SHA = "20c924b1bb3ead4c76b540c075f59733590c0c3a";
+
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
 
@@ -18,7 +20,7 @@ export default async () => {
     }
   }
   const response = await axios.get(
-    "https://raw.githubusercontent.com/getsentry/sentry-api-schema/20c924b1bb3ead4c76b540c075f59733590c0c3a/openapi-derefed.json"
+    `https://raw.githubusercontent.com/getsentry/sentry-api-schema/${SENTRY_API_SCHEMA_SHA}/openapi-derefed.json`
   );
   return response.data;
 };


### PR DESCRIPTION
## Objective
Refactor our existing bump SHA action in `sentry-api-docs`, so that we have something similar to `./bin/bump-sentry` in getsentry.

This workflow listens to a workflow dispatch event and takes in a SHA. Then it will search and replace the with this latest SHA.

Concurrent PR: https://github.com/getsentry/sentry-api-schema/pull/32