### PR TITLE
ref(tracing): Update traces_sampler support

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -216,7 +216,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or `tracesSampler` must be defined to enable tracing.
 </ConfigKey>
 
-<ConfigKey name="tracesSampler" supported={["node", "javascript", "php"]}>
+<ConfigKey name="tracesSampler" supported={["node", "javascript", "python", "php"]}>
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between 0 (0% chance of being sent) and 1 (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or `tracesSampleRate` must be defined to enable tracing.
 </ConfigKey>


### PR DESCRIPTION
Reverts getsentry/sentry-docs#2543, as `traces_sampler` is now supported in Python.