### PR TITLE
ref(apple): Use tabTitle for code snippets

### DIFF
--- a/src/docs/clients/cocoa/advanced.mdx
+++ b/src/docs/clients/cocoa/advanced.mdx
@@ -15,7 +15,7 @@ By default macOS application do not crash whenever an uncaught exception occurs.
 
 Sending a basic event can be done with _send_.
 
-```swift
+```swift {tabTitle:Swift}
 let event = Event(level: .debug)
 event.message = "Test Message"
 Client.shared?.send(event: event) { (error) in
@@ -25,7 +25,7 @@ Client.shared?.send(event: event) { (error) in
 
 If more detailed information is required, _Event_ has many more properties to be filled.
 
-```swift
+```swift {tabTitle:Swift}
 let event = Event(level: .debug)
 event.message = "Test Message"
 event.environment = "staging"
@@ -37,7 +37,7 @@ Client.shared?.send(event: event)
 
 A user, tags, and extra information can be stored on a _Client_. This information will be sent with every event. They can be used like...
 
-```swift
+```swift {tabTitle:Swift}
 let user = User(userId: "1234")
 user.email = "hello@sentry.io"
 user.extra = ["is_admin": true]
@@ -59,7 +59,7 @@ All of the above (_user_, _tags_, _extra_, _releaseName_, _dist_ and _environmen
 
 You can disable the client to prevent events from being sent. The events will still be stored to disk. This functionality is helpful in case you want to ask the user for consent if they want to send the crash reports for example.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.enabled = false
 ```
 
@@ -67,7 +67,7 @@ Client.shared?.enabled = false
 
 You can also `init` the client with options:
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared = try Client(options: [
     "dsn": "___PUBLIC_DSN___",
     "enabled": false, // In Objective-C this is @YES/@NO
@@ -87,19 +87,19 @@ The _User Feedback_ feature has been removed as of version `3.0.0`. But if you w
 
 Breadcrumbs are used as a way to trace how an error occurred. They will queue up in a`Client` and will be sent with every event.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.breadcrumbs.add(Breadcrumb(level: .info, category: "test"))
 ```
 
 The client will queue up a maximum of 50 breadcrumbs by default. To change the maximum amount of breadcrumbs call:
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.breadcrumbs.maxBreadcrumbs = 100
 ```
 
 With version _1.1.0_ we added another iOS only feature which tracks breadcrumbs automatically by calling:
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.enableAutomaticBreadcrumbTracking()
 ```
 
@@ -110,7 +110,7 @@ If called this will track every action sent from a Storyboard and every _viewDid
 If you call this function after setting up the Client, we will store an event to disk in case your application receives Memory Pressure Notification. This function installs a listener so you only need to call it once.
 On the next app start or successful sent of an event, we will send this event to the server.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.trackMemoryPressureAsEvent()
 ```
 
@@ -118,7 +118,7 @@ Client.shared?.trackMemoryPressureAsEvent()
 
 With version _1.3.0_ we added the possibility to change an event before it will be sent to the server. You have to set the block somewhere in your code.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.beforeSerializeEvent = { event in
     event.extra = ["b": "c"]
 }
@@ -130,7 +130,7 @@ This block is meant to be used for stripping sensitive data or add additional da
 
 You can change the _NSURLRequest_ before it will be send. This is helpful e.g.: for adding additional headers to the request.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.beforeSendRequest = { request in
     request.addValue("my-token", forHTTPHeaderField: "Authorization")
 }
@@ -143,7 +143,7 @@ callback and calling _appendStacktrace_ and pass the event.
 
 _snapshotStacktrace_ captures the stack trace at the location where it’s called. After that you have to append the stack trace to the event you want to send with _appendStacktrace_. So for example if you want to send a simple message to the server and add the stack trace to it you have to do this.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.snapshotStacktrace {
     let event = Event(level: .debug)
     event.message = "Test Message"
@@ -156,7 +156,7 @@ Client.shared?.snapshotStacktrace {
 
 If you want to filter certain events, you can use `shouldSendEvent` which takes the event, returns a boolean, and decides whether or not to send the event.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.shouldSendEvent = { (event) in
             if (event.environment == "staging") {
                 return false
@@ -167,7 +167,7 @@ Client.shared?.shouldSendEvent = { (event) in
 
 Here's an example in Objective C too:
 
-```objc
+```objc {tabTitle:Objective-C}
 client.shouldSendEvent = ^BOOL(SentryEvent *_Nonnull event) {
     return (sampleRate >= ((double)arc4random() / 0x100000000));
 };
@@ -177,6 +177,6 @@ client.shouldSendEvent = ^BOOL(SentryEvent *_Nonnull event) {
 
 If you are sending too many events and want to not send all events you can set the `sampleRate` parameter. It’s a number between 0 and 1 where when you set it to 1, all events will be sent. Notice that `shouldSendEvent` will set for this.
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.sampleRate = 0.75 // 75% of all events will be sent
 ```

--- a/src/docs/clients/cocoa/index.mdx
+++ b/src/docs/clients/cocoa/index.mdx
@@ -69,7 +69,7 @@ NOTE: Version tags or branches need to have the Package.swift file in it or Xcod
 
 To use the client, change your AppDelegate’s _application_ method to instantiate the Sentry client:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 func application(_ application: UIApplication,
@@ -89,7 +89,7 @@ func application(_ application: UIApplication,
 
 If you prefer to use Objective-C you can do so like this:
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 NSError *error = nil;
@@ -118,13 +118,13 @@ You can use the following methods to cause a crash:
 
 - Swift:
 
-  ```swift
+  ```swift {tabTitle:Swift}
   Client.shared?.crash()
   ```
 
 - Objective-C:
 
-  ```objc
+  ```objc {tabTitle:Objective-C}
   [SentryClient.sharedClient crash];
   ```
 

--- a/src/docs/clients/react-native/manual-setup.mdx
+++ b/src/docs/clients/react-native/manual-setup.mdx
@@ -31,7 +31,7 @@ The library you need to link is `node_modules/react-native-sentry/ios/RNSentry.x
 
 Update your `AppDelegate.m` file to pull in the proper native library and initialize it.
 
-```objc
+```objc {tabTitle:Objective-C}
 #if __has_include(<React/RNSentry.h>)
 #import <React/RNSentry.h> // This is used for versions of react-native >= 0.40
 #else

--- a/src/includes/before-breadcrumb/apple.mdx
+++ b/src/includes/before-breadcrumb/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -8,7 +8,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/breadcrumbs-example/apple.mdx
+++ b/src/includes/breadcrumbs-example/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let crumb = Breadcrumb()
@@ -8,7 +8,7 @@ crumb.message = "Authenticated user \(user.email)"
 SentrySDK.addBreadcrumb(crumb: crumb)
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] init];

--- a/src/includes/capture-error/apple.mdx
+++ b/src/includes/capture-error/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.capture(error: error)
@@ -9,7 +9,7 @@ SentrySDK.capture(exception: exception)
 
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK captureError:error];

--- a/src/includes/capture-message/apple.mdx
+++ b/src/includes/capture-message/apple.mdx
@@ -1,10 +1,10 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.capture(message: "My first test message")
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK captureMessage:@"My first test message"];

--- a/src/includes/cocoa/integrations/apple.mdx
+++ b/src/includes/cocoa/integrations/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start(options: [
@@ -10,7 +10,7 @@ SentrySDK.start(options: [
 ])
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 NSMutableArray *integrations = [SentryOptions defaultIntegrations].mutableCopy;

--- a/src/includes/cocoa/pass-scope/apple.mdx
+++ b/src/includes/cocoa/pass-scope/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: nil)
@@ -11,7 +11,7 @@ scope.setLevel(.fatal)
 SentrySDK.capture(exception: exception, scope: scope)
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 NSException *exception = [[NSException alloc] initWithName:@"My Custom exception" reason:@"User clicked the button" userInfo:nil];

--- a/src/includes/cocoa/scope-callback/apple.mdx
+++ b/src/includes/cocoa/scope-callback/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let userInfo = [NSLocalizedDescriptionKey : "Object does not exist"]
@@ -11,7 +11,7 @@ SentrySDK.capture(error: error) { (scope) in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 NSDictionary *userInfo = @ { NSLocalizedDescriptionKey : @"Object does not exist" };

--- a/src/includes/configuration/auto-session-tracking/apple.mdx
+++ b/src/includes/configuration/auto-session-tracking/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -8,7 +8,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithOptions:@{

--- a/src/includes/configuration/before-send-fingerprint/apple.mdx
+++ b/src/includes/configuration/before-send-fingerprint/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -12,7 +12,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/configuration/before-send/apple.mdx
+++ b/src/includes/configuration/before-send/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -10,7 +10,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/configuration/config-intro/apple.mdx
+++ b/src/includes/configuration/config-intro/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
 // ....
@@ -15,7 +15,7 @@ func application(_ application: UIApplication,
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {

--- a/src/includes/configuration/sample-rate/apple.mdx
+++ b/src/includes/configuration/sample-rate/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -6,7 +6,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/configuration/session-tracking-interval/apple.mdx
+++ b/src/includes/configuration/session-tracking-interval/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -7,7 +7,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithOptions:@{

--- a/src/includes/configure-scope/apple.mdx
+++ b/src/includes/configure-scope/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.configureScope { scope in
@@ -9,7 +9,7 @@ SentrySDK.configureScope { scope in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 import Sentry
 
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {

--- a/src/includes/getting-started-config/apple.mdx
+++ b/src/includes/getting-started-config/apple.mdx
@@ -1,6 +1,6 @@
 Initialize the SDK as soon as possible in your application lifecycle, such as in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
 // ....
@@ -17,7 +17,7 @@ func application(_ application: UIApplication,
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {

--- a/src/includes/getting-started-verify/apple.mdx
+++ b/src/includes/getting-started-verify/apple.mdx
@@ -1,12 +1,12 @@
 One way to verify your setup is by intentionally causing an error that breaks your application.
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.crash()
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK crash];

--- a/src/includes/set-context/apple.mdx
+++ b/src/includes/set-context/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.configureScope { scope in
@@ -10,7 +10,7 @@ SentrySDK.configureScope { scope in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {

--- a/src/includes/set-environment/apple.mdx
+++ b/src/includes/set-environment/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -7,7 +7,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/set-extra/apple.mdx
+++ b/src/includes/set-extra/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.configureScope { scope in
@@ -6,7 +6,7 @@ SentrySDK.configureScope { scope in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {

--- a/src/includes/set-fingerprint/basic/apple.mdx
+++ b/src/includes/set-fingerprint/basic/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -9,7 +9,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/set-level/apple.mdx
+++ b/src/includes/set-level/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in

--- a/src/includes/set-release/apple.mdx
+++ b/src/includes/set-release/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -6,7 +6,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {

--- a/src/includes/set-tag/apple.mdx
+++ b/src/includes/set-tag/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.configureScope { scope in
@@ -6,7 +6,7 @@ SentrySDK.configureScope { scope in
 }
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {

--- a/src/includes/set-user/apple.mdx
+++ b/src/includes/set-user/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let user = User()
@@ -6,7 +6,7 @@ user.email = "john.doe@example.com"
 SentrySDK.setUser(user)
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryUser *user = [[SentryUser alloc] init];

--- a/src/includes/trigger-crash/apple.mdx
+++ b/src/includes/trigger-crash/apple.mdx
@@ -1,10 +1,10 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.crash()
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK crash];

--- a/src/includes/unset-user/apple.mdx
+++ b/src/includes/unset-user/apple.mdx
@@ -1,10 +1,10 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.setUser(nil)
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK setUser:nil];

--- a/src/includes/with-scope/apple.mdx
+++ b/src/includes/with-scope/apple.mdx
@@ -1,4 +1,4 @@
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.capture(error: error) { scope in
@@ -10,7 +10,7 @@ SentrySDK.capture(error: error) { scope in
 SentrySDK.capture(error: error)
 ```
 
-```objc
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK captureError:error withScopeBlock:^(SentryScope * _Nonnull scope) {

--- a/src/platforms/apple/common/install/swift-package-manager.mdx
+++ b/src/platforms/apple/common/install/swift-package-manager.mdx
@@ -6,7 +6,7 @@ To integrate Sentry into your Xcode project using Swift Package Manager (SPM), o
 
 When using SPM version 5.2 or later, you must specify the the target name too:
 
-```swift
+```swift {tabTitle:Swift}
 .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "version"),
 ```
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -42,7 +42,7 @@ events of your users when upgrading.
 
 We removed the [deprecated SDK inits](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentrySDK.h#L35-L47). The recommended way to initialize Sentry is now:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
@@ -74,7 +74,7 @@ Instead of returning `nil` when an event couldn't be queued for submission we re
 
 `5.x`
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let eventId = SentrySDK.capture(message: "A message")
@@ -98,7 +98,7 @@ if (nil != eventId) {
 
 `6.x`
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let eventId = SentrySDK.capture(message: "A message")
@@ -128,7 +128,7 @@ to Sentry, which can help to group similar messages into the same issue.
 
 `5.x`
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let event = Event()
@@ -144,7 +144,7 @@ event.message = "Hello World";
 
 `6.x`
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry
 
 let event = Event()
@@ -174,7 +174,7 @@ Here are some examples of how the new SDK works.
 
 `4.x`
 
-```swift
+```swift {tabTitle:Swift}
 do {
     Client.shared = try Client(dsn: "___PUBLIC_DSN___")
     try Client.shared?.startCrashHandler()
@@ -196,7 +196,7 @@ if (nil != error) {
 `5.x`
 
 
-```swift
+```swift {tabTitle:Swift}
 SentrySDK.start(options: [
     "dsn": "___PUBLIC_DSN___",
     "debug": true
@@ -214,7 +214,7 @@ SentrySDK.start(options: [
 
 `4.x`
 
-```swift
+```swift {tabTitle:Swift}
 Client.shared?.breadcrumbs.add(Breadcrumb(level: .info, category: "test"))
 ```
 
@@ -224,7 +224,7 @@ Client.shared?.breadcrumbs.add(Breadcrumb(level: .info, category: "test"))
 
 `5.x`
 
-```swift
+```swift {tabTitle:Swift}
 SentrySDK.addBreadcrumb(Breadcrumb(level: .info, category: "test"))
 ```
 
@@ -236,7 +236,7 @@ SentrySDK.addBreadcrumb(Breadcrumb(level: .info, category: "test"))
 
 `4.x`
 
-```swift
+```swift {tabTitle:Swift}
 let event = Event(level: .debug)
 event.message = "Test Message"
 event.environment = "staging"
@@ -254,7 +254,7 @@ event.extra = @{@"ios": @(YES)};
 
 `5.x`
 
-```swift
+```swift {tabTitle:Swift}
 SentrySDK.capture(message: "Test Message") { (scope) in
     scope.setEnvironment("staging")
     scope.setExtras(["ios": true])
@@ -278,7 +278,7 @@ SentrySDK.capture(message: "Test Message") { (scope) in
 
 `4.x`
 
-```swift
+```swift {tabTitle:Swift}
 let u = User(userId: "1")
 u.email = "tony@example.com"
 Client.shared?.user = user
@@ -292,7 +292,7 @@ SentryClient.sharedClient.user = user;
 
 `5.x`
 
-```swift
+```swift {tabTitle:Swift}
 let u = Sentry.User(userId: "1")
 u.email = "tony@example.com"
 SentrySDK.setUser(u)

--- a/src/wizard/apple/index.md
+++ b/src/wizard/apple/index.md
@@ -24,7 +24,7 @@ For other installation methods, please see our [documentation](/platforms/apple/
 
 Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
 // ....

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -24,7 +24,7 @@ For other installation methods, please see our [documentation](/platforms/apple/
 
 Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
 // ....

--- a/src/wizard/apple/macos.md
+++ b/src/wizard/apple/macos.md
@@ -24,7 +24,7 @@ For other installation methods, please see our [documentation](/platforms/apple/
 
 Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
-```swift
+```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
 // ....


### PR DESCRIPTION
Use tabTitle for both Swift and Objective-C so code snippets display
Swift and Objective-C instead of Swift and Objc.