### PR TITLE
ref: Remove markdown tags

### DIFF
--- a/src/api/auth.mdx
+++ b/src/api/auth.mdx
@@ -13,13 +13,21 @@ curl -H 'Authorization: Bearer {TOKEN}' https://sentry.io/api/0/projects/
 
 You can [find or create authentication tokens within Sentry](https://sentry.io/api/).
 
+## DSN Authentication
+
+Some API endpoints may allow DSN-based authentication. This is generally very limited and an endpoint will describe if its supported. This works similar to Bearer token authentication, but uses your DSN (Client Key).
+
+```bash
+curl -H 'Authorization: DSN {DSN}' https://sentry.io/api/0/projects/
+```
+
 ## API Keys
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 API keys are a legacy means of authenticating. They will still be supported but are disabled for new accounts. You should use **authentication tokens** wherever possible.
 
-</markdown></Alert>
+</Alert>
 
 API keys are passed using HTTP Basic auth where the username is your api key, and the password is an empty value.
 
@@ -29,16 +37,8 @@ As an example, to get information about the project which your key is bound to, 
 curl -u {API_KEY}: https://sentry.io/api/0/projects/
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Note>
 
 You **must** pass a value for the password, which is the reason the `:` is present in our example.
 
-</markdown></Alert>
-
-## DSN Authentication
-
-Some API endpoints may allow DSN-based authentication. This is generally very limited and an endpoint will describe if its supported. This works similar to Bearer token authentication, but uses your DSN (Client Key).
-
-```bash
-curl -H 'Authorization: DSN {DSN}' https://sentry.io/api/0/projects/
-```
+</Note>

--- a/src/api/permissions.mdx
+++ b/src/api/permissions.mdx
@@ -25,13 +25,13 @@ If you're looking for information on membership roles please visit the
 | **PUT/POST** | `project:write` |
 |  **DELETE**  | `project:admin` |
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 The `project:releases` scope will give you access to both **project**
 and **organization** release endpoints. The available endpoints are listed in the
 [Releases](/api/releases/) section of the API Documentation.
 
-</markdown></Alert>
+</Alert>
 
 ### Teams
 
@@ -57,12 +57,12 @@ and **organization** release endpoints. The available endpoints are listed in th
 |  **PUT**   | `event:write` |
 | **DELETE** | `event:admin` |
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 **PUT/DELETE** methods only apply to updating/deleting issues.
 Events in sentry are immutable and can only be deleted by deleting the whole issue.
 
-</markdown></Alert>
+</Alert>
 
 ### Releases
 
@@ -70,8 +70,8 @@ Events in sentry are immutable and can only be deleted by deleting the whole iss
 | :---------------------: | :----------------: |
 | **GET/PUT/POST/DELETE** | `project:releases` |
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Be aware that if you're using `sentry-cli` to [manage your releases](/product/cli/releases/), you'll need a token which also has `org:read` scope.
 
-</markdown></Alert>
+</Alert>

--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -30,7 +30,7 @@ end
 
 If you have a legacy API key instead you can supply it with _api_key_ instead of _auth_token_.
 
-<Alert level="" title="On Prem"><markdown>
+<Note>
 
 By default fastlane will connect to sentry.io. For on-prem you need to provide the _api_host_ parameter to instruct the tool to connect to your server:
 
@@ -38,7 +38,7 @@ By default fastlane will connect to sentry.io. For on-prem you need to provide t
 api_host: 'https://mysentry.invalid/'
 ```
 
-</markdown></Alert>
+</Note>
 
 ### Use `sentry-cli`
 
@@ -53,7 +53,7 @@ Afterwards manually upload the symbols with _sentry-cli_:
 sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Note>
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
 
@@ -61,7 +61,7 @@ By default sentry-cli will connect to sentry.io. For on-prem you need to export 
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-</markdown></Alert>
+</Note>
 
 ## Without Bitcode {#dsym-without-bitcode}
 
@@ -84,7 +84,7 @@ end
 
 If you have a legacy API key instead you can supply it with _api_key_ instead of _auth_token_.
 
-<Alert level="" title="On Prem"><markdown>
+<Note>
 
 By default fastlane will connect to sentry.io. For on-prem you need to provide the _api_host_ parameter to instruct the tool to connect to your server:
 
@@ -92,7 +92,7 @@ By default fastlane will connect to sentry.io. For on-prem you need to provide t
 api_host: 'https://mysentry.invalid/'
 ```
 
-</markdown></Alert>
+</Note>
 
 ### Upload Symbols with _sentry-cli_
 
@@ -123,7 +123,7 @@ fi
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Note>
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
 
@@ -131,7 +131,7 @@ By default sentry-cli will connect to sentry.io. For on-prem you need to export 
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-</markdown></Alert>
+</Note>
 
 ### Manually with _sentry-cli_
 
@@ -150,7 +150,7 @@ Then run this (note that `--auth-token` needs to go before `upload-dif`):
 sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org YOUR_ORG_SLUG --project YOUR_PROJECT_SLUG PATH_TO_DSYMS
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Note>
 
 By default, sentry-cli will connect to sentry.io. For on-prem you need to export the `SENTRY_URL` environment variable to instruct the tool to connect to your server:
 
@@ -158,4 +158,4 @@ By default, sentry-cli will connect to sentry.io. For on-prem you need to export
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-</markdown></Alert>
+</Note>

--- a/src/docs/clients/cocoa/index.mdx
+++ b/src/docs/clients/cocoa/index.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new Cocoa SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Cocoa SDK](/platforms/apple/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 This is the documentation for our official clients for Cocoa (Swift and Objective-C). Starting with version `3.0.0` we’ve switched our internal code from Swift to Objective-C to maximize compatibility. Also we trimmed the public API of our SDK to a minimum. Check out [Migration Guide](/clients/cocoa/migration/) or [Advanced Usage](/clients/cocoa/advanced/) for details.
 

--- a/src/docs/clients/csharp/index.mdx
+++ b/src/docs/clients/csharp/index.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 For .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4, or higher we recommend using the new [.NET SDK](/platforms/dotnet/). Raven is still recommended for .NET Framework 3.5 to 4.6.0.
 
-</markdown></Alert>
+</Alert>
 
 Raven is the C# client for Sentry. Raven relies on the most popular logging libraries to capture and convert logs before sending details to a Sentry instance.
 

--- a/src/docs/clients/go/index.mdx
+++ b/src/docs/clients/go/index.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Support"><markdown>
+<Alert level="warning" title="Support">
 
 The `raven-go` SDK is no longer maintained and was superseded by the `sentry-go` SDK. Learn more about the project on [GitHub](https://github.com/getsentry/sentry-go) and check out the [migration guide](/platforms/go/migration/).
 
-</markdown></Alert>
+</Alert>
 
 Raven-Go provides a Sentry client implementation for the Go programming language.
 

--- a/src/docs/clients/javascript/index.mdx
+++ b/src/docs/clients/javascript/index.mdx
@@ -8,19 +8,19 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new JavaScript SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated JavaScript SDK](/platforms/javascript/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 Raven.js is the official browser JavaScript client for Sentry. It automatically reports uncaught JavaScript exceptions triggered from a browser environment, and provides a rich API for reporting your own errors.
 
-<Alert level="warning" title="Node.js"><markdown>
+<Alert level="warning" title="Node.js">
 
 If you’re using Node.js on the server, you’ll need [raven-node](/clients/node/).
 
-</markdown></Alert>
+</Alert>
 
 ## Installation
 

--- a/src/docs/clients/javascript/install.mdx
+++ b/src/docs/clients/javascript/install.mdx
@@ -66,11 +66,11 @@ npm install raven-js --save
 <script src="/node_modules/raven-js/dist/raven.js"></script>
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 If you intend to use Raven with Node, [raven-node](https://github.com/getsentry/raven-node) is the client to use.
 
-</markdown></Alert>
+</Alert>
 
 ## CommonJS
 
@@ -151,11 +151,11 @@ Or you can place those two things in a separate script tags. This will queue all
 
 Be aware however, that there are some trade-offs to this solution, as errors might provide less information due to them being “retriggered” instead of being caught from the original source.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This won’t work when opening `index.html` or any other html file from the file system, as it doesn’t support anonymous cross-origin scripts. The same thing can happen for any cross-origin scripts as well. To read more about it, see [What the heck is Script error?](https://blog.sentry.io/2016/05/17/what-is-script-error).
 
-</markdown></Alert>
+</Alert>
 
 To read un-minified source code for this loader, see [loader.js](https://github.com/getsentry/raven-js/blob/master/packages/raven-js/src/loader.js)
 

--- a/src/docs/clients/javascript/integrations.mdx
+++ b/src/docs/clients/javascript/integrations.mdx
@@ -33,11 +33,11 @@ On its own, Raven.js will report any uncaught exceptions triggered from your app
 
 Additionally, the Raven.js AngularJS plugin will catch any AngularJS-specific exceptions reported through AngularJS’s `$exceptionHandler` interface.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 This documentation is for Angular 1.x. See also: [_Angular 2.x_](#angular).
 
-</markdown></Alert>
+</Alert>
 
 <!-- WIZARD angularjs -->
 
@@ -468,11 +468,11 @@ You may specify an error handler that captures saga exceptions by passing an `on
 
 ## Vue.js (2.0) {#vue}
 
-<Alert level="warning" title="Support"><markdown>
+<Alert level="warning" title="Support">
 
 This plugin only works with Vue 2.0 or greater.
 
-</markdown></Alert>
+</Alert>
 
 To use Sentry with your Vue application, you will need to use both Raven.js (Sentry’s browser JavaScript SDK) and the Raven.js Vue plugin.
 
@@ -569,11 +569,11 @@ The deprecated plugin “React Native for Raven.js” is a pure JavaScript error
 
 **Do not use this plugin for new code but instead use the new :ref:`react-native` client integration instead**.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Unless you have specific reasons not to, it’s recommended to instead the new [React Native](/clients/react-native/) client instead which supports native and JavaScript crashes as well as an improved integration into the Xcode build process.
 
-</markdown></Alert>
+</Alert>
 
 ### Installation
 

--- a/src/docs/clients/javascript/tips.mdx
+++ b/src/docs/clients/javascript/tips.mdx
@@ -107,13 +107,13 @@ $(document).ajaxError(function(event, jqXHR, ajaxSettings, thrownError) {
 });
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 - This handler is not called for cross-domain script and cross-domain JSONP requests.
 - If `$.ajax()` or `$.ajaxSetup()` is called with the `global` option set to `false`, the `.ajaxError()` method will not fire.
 - As of jQuery 1.8, the `.ajaxError()` method should only be attached to document.
 
-</markdown></Alert>
+</Alert>
 
 ## Cross Origin
 

--- a/src/docs/clients/javascript/usage.mdx
+++ b/src/docs/clients/javascript/usage.mdx
@@ -283,11 +283,11 @@ And set an `Access-Control-Allow-Origin` HTTP header on that file.
 Access-Control-Allow-Origin: *
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Both of these steps need to be done or your scripts might not even get executed
 
-</markdown></Alert>
+</Alert>
 
 ## Promises {#raven-js-promises}
 

--- a/src/docs/clients/node/index.mdx
+++ b/src/docs/clients/node/index.mdx
@@ -8,19 +8,19 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new Node SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Node SDK](/platforms/node/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 raven-node is the official Node.js client for Sentry.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 If you’re using JavaScript in the browser, you’ll need [raven-js](/clients/javascript).
 
-</markdown></Alert>
+</Alert>
 
 <!-- WIZARD installation -->
 

--- a/src/docs/clients/php/index.mdx
+++ b/src/docs/clients/php/index.mdx
@@ -8,11 +8,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new PHP SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. If you are using PHP 7.1 or later, we recommend using the [updated PHP SDK](/platforms/php/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 The PHP SDK for Sentry supports PHP 5.3 and higher. It’s available as a BSD licensed Open Source library.
 

--- a/src/docs/clients/php/integrations.mdx
+++ b/src/docs/clients/php/integrations.mdx
@@ -378,13 +378,13 @@ Install the `sentry/sentry-symfony` package:
 composer require sentry/sentry-symfony:^2
 ```
 
-<Alert level="warning" title="Newer version"><markdown>
+<Alert level="warning" title="Newer version">
 
 This documentation refers to the v2.x of the bundle. This version does not support the newest [Unified API client](/platforms/php/).
 
 You can upgrade to [the newer version](/platforms/php/guides/symfony/) if you're on PHP 7.1+ and Symfony 3.4+.
 
-</markdown></Alert>
+</Alert>
 
 Enable the bundle in `app/AppKernel.php`:
 

--- a/src/docs/clients/php/usage.mdx
+++ b/src/docs/clients/php/usage.mdx
@@ -29,11 +29,11 @@ $error_handler->registerErrorHandler();
 $error_handler->registerShutdownFunction();
 ```
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 Calling `install()` on a Raven_Client instance will automatically register these handlers.
 
-</markdown></Alert>
+</Alert>
 
 ## Reporting Exceptions
 

--- a/src/docs/clients/python/index.mdx
+++ b/src/docs/clients/python/index.mdx
@@ -8,11 +8,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new Python SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Python SDK](/platforms/python/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 For pairing Sentry up with Python you can use the Raven for Python (raven-python) library. It is the official standalone Python client for Sentry. It can be used with any modern Python interpreter be it CPython 2.x or 3.x, PyPy or Jython. It’s an Open Source project and available under a very liberal BSD license.
 

--- a/src/docs/clients/python/integrations.mdx
+++ b/src/docs/clients/python/integrations.mdx
@@ -34,11 +34,11 @@ app = bottle.app()
 app.catchall = False
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Bottle will not propagate exceptions to the underlying WSGI middleware by default. Setting catchall to False disables that.
 
-</markdown></Alert>
+</Alert>
 
 Sentry will then act as Middleware:
 
@@ -443,11 +443,11 @@ class MyMiddleware(object):
         return HttpResponse('foo')
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This technique may break unit tests using the Django test client (`django.test.client.Client`) if a view under test generates a `Http404` or `PermissionDenied` exception, because the exceptions won’t be translated into the expected 404 or 403 response codes.
 
-</markdown></Alert>
+</Alert>
 
 Or, alternatively, you can just enable Sentry responses:
 
@@ -868,11 +868,11 @@ logger.error('There was an error, with a stack trace!', extra={
 })
 ```
 
-<Alert level="" title="Note on Python version"><markdown>
+<Alert level="" title="Note on Python version">
 
 Depending on the version of Python you’re using, `extra` might not be an acceptable keyword argument for a logger’s `.exception()` method (`.debug()`, `.info()`, `.warning()`, `.error()` and `.critical()` should work fine regardless of Python version). This should be fixed as of Python 2.7.4 and 3.2. Official issue here: [bugs.python.org/issue15541](https://bugs.python.org/issue15541).
 
-</markdown></Alert>
+</Alert>
 
 While we don’t recommend this, you can also enable implicit stack capturing for all messages:
 
@@ -1193,7 +1193,7 @@ class AsyncExceptionHandler(SentryMixin, tornado.web.RequestHandler):
         self.finish()
 ```
 
-<Alert level="" title="Tip"><markdown>
+<Alert level="" title="Tip">
 
 The value returned by the yield is a `HTTPResponse` object.
 
@@ -1205,7 +1205,7 @@ To dynamically use Python if configuration DSN available, change your base handl
 > BaseHandler.__bases__ = (SentryMixin, ) + BaseHandler.__bases__
 > ```
 
-</markdown></Alert>
+</Alert>
 
 #### Synchronous
 

--- a/src/docs/clients/react-native/cocoapods.mdx
+++ b/src/docs/clients/react-native/cocoapods.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 In order to use Sentry with CocoaPods you have to install the packages with `npm` or `yarn` and link them locally in your `Podfile`.
 

--- a/src/docs/clients/react-native/codepush.mdx
+++ b/src/docs/clients/react-native/codepush.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 If you want to use sentry together with CodePush you have to send us the CodePush version:
 

--- a/src/docs/clients/react-native/config.mdx
+++ b/src/docs/clients/react-native/config.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 These are functions you can call in your JavaScript code:
 

--- a/src/docs/clients/react-native/expo.mdx
+++ b/src/docs/clients/react-native/expo.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 [Expo](https://expo.io/) is an excellent way to quickly create and play around with your React Native app. Now you can also use Sentry together with Expo:
 

--- a/src/docs/clients/react-native/index.mdx
+++ b/src/docs/clients/react-native/index.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 This is the documentation for our React Native SDK. The React Native SDK uses a native extension for iOS and Android but will fall back to a pure JavaScript version if necessary.
 

--- a/src/docs/clients/react-native/manual-setup.mdx
+++ b/src/docs/clients/react-native/manual-setup.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 If you can’t (or don’t want) to run the linking step you can see here what is happening on each platform.
 

--- a/src/docs/clients/react-native/ram-bundles.mdx
+++ b/src/docs/clients/react-native/ram-bundles.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 The [RAM bundle](https://facebook.github.io/react-native/docs/performance#ram-bundles-inline-requires) format is a new approach to packaging React Native apps that optimizes your app's startup time. With RAM bundles, it is possible to load to memory only those modules that are needed for specific functionality, and only when needed.
 

--- a/src/docs/clients/react-native/sourcemaps.mdx
+++ b/src/docs/clients/react-native/sourcemaps.mdx
@@ -7,11 +7,11 @@ noindex: true
 tags: []
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 This SDK has been superseded by the new React Native SDK. Sentry preserves this documentation for customers using the old client. We recommend using the [updated React Native SDK](/platforms/react-native/) for new projects.
 
-</markdown></Alert>
+</Alert>
 
 Currently automatic source map handling is only implemented for iOS with Xcode and Android with gradle. If you manually invoke the [react-native packager](https://github.com/facebook/metro) you can however get source maps anyways by passing _–sourcemap-output_ to it.
 

--- a/src/docs/contributing/onboarding-wizard.mdx
+++ b/src/docs/contributing/onboarding-wizard.mdx
@@ -39,8 +39,8 @@ support_level: production
 This is my content.
 ```
 
-<Note><markdown>
+<Note>
 
 Wizard content is only supported with native markdown (not MDX), thus only with a `.md` extension.
 
-</markdown></Note>
+</Note>

--- a/src/docs/contributing/pages/components.mdx
+++ b/src/docs/contributing/pages/components.mdx
@@ -7,19 +7,17 @@ noindex: true
 
 Render an alert callout.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 This is an alert
 
-</markdown></Alert>
+</Alert>
 
 ```markdown {tabTitle:Example}
 <Alert level="info" title="Note">
-<markdown>
 
 This is an alert
 
-</markdown>
 </Alert>
 ```
 
@@ -35,19 +33,17 @@ See also the Note component.
 
 Render a heading with a configuration key in the correctly cased format for a given platform.
 
-<Note><markdown>
+<Note>
 
 If content is specified, it will automatically hide the content when the given `platform` is not selected in context.
 
-</markdown></Note>
+</Note>
 
 ```markdown {tabTitle:Example}
 <ConfigKey name="send-default-pii" notSupported={["javascript", "node"]}>
-<markdown>
 
 Description of send-default-pii
 
-</markdown>
 </ConfigKey>
 ```
 
@@ -90,20 +86,16 @@ var foo = "bar";
 Render a note.
 
 <Note>
-<markdown>
 
 Something important, but maybe not _that_ important.
 
-</markdown>
 </Note>
 
 ```markdown {tabTitle:Example}
 <Note>
-<markdown>
 
 Something important, but maybe not _that_ important.
 
-</markdown>
 </Note>
 ```
 
@@ -153,11 +145,9 @@ Render a section based on the currently selected `platform` in context. When the
 
 ```markdown {tabTitle:Example}
 <PlatformSection notSupported={["javascript", "node"]}>
-<markdown>
 
 Something that applies to all platforms, but not javascript or node.
 
-</markdown>
 </PlatformSection>
 ```
 

--- a/src/docs/contributing/pages/index.mdx
+++ b/src/docs/contributing/pages/index.mdx
@@ -12,16 +12,16 @@ Documentation is written in Markdown (via Remark) and MDX.
 
 :pray: that MDX v2 fixes this.
 
-MDX has its flaws. When rendering components, any text inside of them is treated as raw text (_not_ markdown). To work around this you can use the `<markdown>` tag, but it also has its issues. Generally speaking, put an empty line after the opening tag, and before the closing tag.
+MDX has its flaws. When rendering components, any text inside of them is treated as raw text (_not_ markdown). To work around this you can use the `` tag, but it also has its issues. Generally speaking, put an empty line after the opening tag, and before the closing tag.
 
 ```jsx
 // don't do this as parsing will hit weird breakages
-<markdown>foo bar</markdown>
+foo bar
 ```
 
 ```jsx
 // do this
-<markdown>foo bar</markdown>
+foo bar
 ```
 
 ## Additional Topics

--- a/src/docs/contributing/platforms/common_content.mdx
+++ b/src/docs/contributing/platforms/common_content.mdx
@@ -57,7 +57,6 @@ Let's look at the [`src/platforms/common/configuration/environments.mdx`](https:
 
 The common Getting Started content exemplifies further how we avoid duplication in our content with extensive tuning. This file is [`src/platforms/common/index.mdx`](https://github.com/getsentry/sentry-docs/blob/master/src/platforms/common/index.mdx):
 
-
     On this page, we get you up and running with Sentry's SDK, so that
     it will automatically report errors and exceptions in your
     application.
@@ -65,12 +64,12 @@ The common Getting Started content exemplifies further how we avoid duplication 
     // Succinct introduction to what's going to happen
 
     <Note>
-    <markdown>
+
 
     If you don't already have an account and Sentry project established, head
     over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-    </markdown>
+
     </Note>
 
     // An offramp for a user who may have begun reading the content without
@@ -101,14 +100,14 @@ The common Getting Started content exemplifies further how we avoid duplication 
 
     // An include explains what the configuration code sample provides
 
-    <Note><markdown>
+    <Note>
 
     We'll automatically assign you a Data Source Name (DSN), which looks like
     a standard URL. It's required by Sentry and configures the protocol, public
     key, server address, and project identifier. If you forget it, view
     _Settings -> Projects -> Client Keys (DSN)_ in sentry.io.
 
-    </markdown></Note>
+    </Note>
 
     // Succinct explanation of a key implementation detail
 

--- a/src/docs/contributing/platforms/index.mdx
+++ b/src/docs/contributing/platforms/index.mdx
@@ -91,11 +91,11 @@ All of this content will be automatically duplicated within every guide, as well
 
 Sometimes a page may not make sense within the context of a given platform. To control this, you can use the `supported` and `notSupported` frontmatter on all common pages in platforms.
 
-<Note><markdown>
+<Note>
 
 Page visiblity works similar to the supported/notSupported attributes in other platform components (such as `PlatformSection`).
 
-</markdown></Note>
+</Note>
 
 For example, to make attachments only available on native platforms, you'd open up the document file (e.g. `attachments/index.mdx`) and add the following to frontmatter:
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -325,8 +325,8 @@ Your plan will continue until the end of the current billing cycle. After this, 
 
 Users with the role of [Billing or Owner](/product/accounts/membership/) can find all previous invoices by going to **Organization > Usage & Billing > Usage & Payments > Receipts**.
 
-<Note><markdown>
+<Note>
 
 You must have either `Billing` or `Owner` permissions to access and/or make changes to information on this page. If you don't have those permissions, or you are not a member of the organization in Sentry, please reach out to a Billing member or an Owner to obtain invoices.
 
-</markdown></Note>
+</Note>

--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -93,11 +93,9 @@ In this example, the `SingleLogoutService` isn’t provided by the IdP, and is t
 ## Map IdP Attributes
 
 <Alert title="Note on field names">
-<markdown>
 
 Metadata field names can vary from one provider to another. For example, Microsoft Azure AD refers to these very metadata fields as **Claims**, while Okta refers to them as **Attributes**. Similarly, one platform might use **user.email**, while another vendor uses **emailaddress**.
 
-</markdown>
 </Alert>
 
 Here, the field values of Sentry members need to be matched up with the corresponding values for members in the IdP. The basic required fields are the IdP's User ID and email address, but Sentry can also optionally pull first and last name values from there as well.

--- a/src/docs/product/accounts/user-settings/index.mdx
+++ b/src/docs/product/accounts/user-settings/index.mdx
@@ -17,9 +17,9 @@ Security Settings include options to reset a password, sign out of all devices, 
 After setting up your two-factor authentication codes, click "View Codes" to download, print, or copy your codes to a secure location. If you cannot receive two-factor authentication codes in the future, such as if you lose your device, use your recovery codes to access your account.
 
 <Note>
-<markdown>
+
 Clicking "Sign out of all devices" will end your sessions with any device logged in to Sentry using your account.
-</markdown>
+
 </Note>
 
 ## Notifications

--- a/src/docs/product/cli/configuration.mdx
+++ b/src/docs/product/cli/configuration.mdx
@@ -62,11 +62,11 @@ Alternatively you can add it to your `~/.sentryclirc` config. This is also what 
 url = https://mysentry.invalid/
 ```
 
-<Note><markdown>
+<Note>
 
 By default sentry-cli loads .env files. On versions of sentry-cli 1.24 and newer you can disable this by exporting an environment variable `SENTRY_LOAD_DOTENV=0`.
 
-</markdown></Note>
+</Note>
 
 ## Configuration Values
 

--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -8,11 +8,11 @@ information about crash reports for most compiled platforms. `sentry-cli` can be
 used to validate and upload debug information files. For more general
 information, refer to [_Debug Information Files_](/workflow/debug-files/).
 
-<Note><markdown>
+<Note>
 
 Source maps, while also being debug information files, are handled differently
 
-</markdown></Note>
+</Note>
 
 in Sentry. For more information see [Source Maps in sentry-cli](/product/cli/releases/#sentry-cli-sourcemaps).
 
@@ -93,13 +93,13 @@ application. Alternatively, files can be uploaded during the build process. See
 [_Debug Information Files_](/workflow/debug-files/)
 for more information.
 
-<Note><markdown>
+<Note>
 
 You need to specify the organization and project you are working with because
 debug information files work on projects. For more information about this refer
 to [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
-</markdown></Note>
+</Note>
 
 A basic debug file upload can be started with:
 
@@ -244,13 +244,13 @@ plugin](https://github.com/getsentry/sentry-android-gradle-plugin) to do that. T
 situations, however, where you would upload ProGuard files manually (for instance
 when you only release some of the builds you are creating).
 
-<Note><markdown>
+<Note>
 
 You need to specify the organization and project you are working with
 because ProGuard files work on projects. For more information about this refer to
 [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
-</markdown></Note>
+</Note>
 
 The `upload-proguard` command is the one to use for uploading ProGuard files. It
 takes the path to one or more ProGuard mapping files and will upload them to

--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -45,11 +45,11 @@ In case you want to install this with npm system wide with sudo you will need to
 sudo npm install -g @sentry/cli --unsafe-perm
 ```
 
-<Note><markdown>
+<Note>
 
 This installation is not recommended however.
 
-</markdown></Note>
+</Note>
 
 ### Downloading From a Custom Source
 

--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -5,11 +5,11 @@ sidebar_order: 2
 
 The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization. If you want the releases in different projects to be treated as separate entities, make the version name unique across the organization. For example, if you have projectA and projectB that share version numbers, you can name the releases `projectA-1.0` and `projectB-1.0` respectively.
 
-<Note><markdown>
+<Note>
 
 Because releases work on projects you will need to specify the organization and project you are working with. For more information about this refer to [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
 
-</markdown></Note>
+</Note>
 
 ## Creating Releases
 

--- a/src/docs/product/integrations/amazon-sqs/index.mdx
+++ b/src/docs/product/integrations/amazon-sqs/index.mdx
@@ -13,11 +13,11 @@ This integration needs to be set up in each project for which you wish to use it
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 Navigate to **Settings > Integrations > Amazon SQS**
 

--- a/src/docs/product/integrations/amixr/index.mdx
+++ b/src/docs/product/integrations/amixr/index.mdx
@@ -13,13 +13,13 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
 Amixr **won't** work with self-hosted Sentry.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Amixr**
 

--- a/src/docs/product/integrations/asana/index.mdx
+++ b/src/docs/product/integrations/asana/index.mdx
@@ -14,11 +14,11 @@ This integration needs to be set up in each project for which you wish to use it
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Asana**
 

--- a/src/docs/product/integrations/azure-devops/index.mdx
+++ b/src/docs/product/integrations/azure-devops/index.mdx
@@ -14,11 +14,11 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install
 
-<Note><markdown>
+<Note>
 
 Sentry organization owner or manager permissions and Azure organization owner permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
 

--- a/src/docs/product/integrations/bitbucket/index.mdx
+++ b/src/docs/product/integrations/bitbucket/index.mdx
@@ -14,11 +14,11 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions, and Bitbucket admin permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Bitbucket**.
 

--- a/src/docs/product/integrations/clickup/index.mdx
+++ b/src/docs/product/integrations/clickup/index.mdx
@@ -13,13 +13,13 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
 ClickUp **won't** work with self-hosted Sentry.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > ClickUp**
 

--- a/src/docs/product/integrations/clubhouse/index.mdx
+++ b/src/docs/product/integrations/clubhouse/index.mdx
@@ -14,13 +14,13 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
 Clubhouse **won't** work with self-hosted Sentry.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Clubhouse**
 

--- a/src/docs/product/integrations/github/index.mdx
+++ b/src/docs/product/integrations/github/index.mdx
@@ -14,11 +14,11 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions, and GitHub owner permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > GitHub**.
 

--- a/src/docs/product/integrations/gitlab/index.mdx
+++ b/src/docs/product/integrations/gitlab/index.mdx
@@ -13,11 +13,11 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions and GitLab owner or maintainer permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > GitLab**.
 
@@ -126,21 +126,26 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 ## Troubleshooting
 
 - I'm using GitLab on-premise. Do I need to allow Sentry's IP addresses?
+
   - Yes. You can find our IP ranges [ here ](/product/security/ip-ranges/).
   - Verify the provided installation URL is a fully qualified domain name (FQDN), which is resolvable on the internet.
   - Make sure that Sentry's access to your installation URL is not path restricted.
   - To add the GitLab repo, navigate to ** GitLab > Admim area > Settings > Network > Outbound requests > Allow requests to the local network from hooks and services ** and enable the option.
 
 - I'm using both GitLab on-premise and Sentry on-premise, and I get an error `Error Communicating with GitLab (HTTP 422): unknown error` when I try to use the integration. How can I fix this?
+
   - By default, GitLab does not allow Hooks to communicate with the local private network, which prevents the integration with Sentry from working. To enable local network communication in GitLab, enable "Allow requests to the local network from hooks and services" on the **Admin > Settings > Network** page.
 
 - Do you support subgroups?
+
   - Currently, we only support subgroups for users using GitLab 11.6 or higher.
 
 - My repositories are hosted under my user account, not a group account. Can I still use this integration?
+
   - Unfortunately, not. The GitLab integration only works for repositories that are hosted under group accounts.
 
 - Are there pricing restrictions?
+
   - This integration is available for organizations on the [Team, Business, or Enterprise plan](https://sentry.io/pricing/).
 
 - Who has permission to install this?

--- a/src/docs/product/integrations/heroku/index.mdx
+++ b/src/docs/product/integrations/heroku/index.mdx
@@ -13,11 +13,11 @@ This integration needs to be set up in each project for which you wish to use it
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 Navigate to **Settings > Integrations > Heroku**
 
@@ -33,11 +33,11 @@ Once done, you’ll be able to confirm that Sentry’s credentials are available
 heroku config:get SENTRY_DSN
 ```
 
-<Note><markdown>
+<Note>
 
 If you’re not using the add-on, you can still bind the `SENTRY_DSN` environment variable which the SDK will automatically pick up.
 
-</markdown></Note>
+</Note>
 
 ### Install the SDK
 

--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -320,11 +320,11 @@ It is possible to use Auth Tokens from the browser if you allow the origins of t
 
 Plugins (aka Legacy Integrations) are extensions of Sentry packaged as Python libraries. Plugins have been contributed both internally (for example, sentry-plugins) and externally by outside developers (for example, sentry-trello). Plugins are configured separately for each project.
 
-<Note><markdown>
+<Note>
 
 Going forward, writing a Sentry Integration is the preferred method of integrating with Sentry."
 
-</markdown></Note>
+</Note>
 
 #### How is the Sentry Integration different from OAuth Apps?
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -118,29 +118,29 @@ All webhook requests have some common elements.
 
 ```json
 {
-    "action": "created",
-    "actor": {
-        "id": 1,
-        "name": "Meredith Heller",
-        "type": "user",
-    },
-    "data": {
-        "installation": {
-            "status": "pending",
-            "organization": {
-                "slug": "test-org"
-            },
-            "app": {
-                "uuid": "2ebf071f-28df-4989-aca9-c37c763b278f",
-                "slug": "webhooks-galore"
-            },
-            "code": "f3c71b491e3949b6b033ae45312a4fcb",
-            "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"
-        }
-    },
+  "action": "created",
+  "actor": {
+    "id": 1,
+    "name": "Meredith Heller",
+    "type": "user"
+  },
+  "data": {
     "installation": {
-        "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"
+      "status": "pending",
+      "organization": {
+        "slug": "test-org"
+      },
+      "app": {
+        "uuid": "2ebf071f-28df-4989-aca9-c37c763b278f",
+        "slug": "webhooks-galore"
+      },
+      "code": "f3c71b491e3949b6b033ae45312a4fcb",
+      "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"
     }
+  },
+  "installation": {
+    "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"
+  }
 }
 ```
 
@@ -428,10 +428,11 @@ All webhook requests have some common elements.
 - description: the api url for the incident
 
 #### Payload
+
 <Note>
-  <markdown>
+
     Note: The webhook payload stack frame order lists the oldest frame to the most recent (where the exception happened).
-  </markdown>
+
 </Note>
 
 ```json
@@ -457,9 +458,7 @@ All webhook requests have some common elements.
         "include_all_projects": false,
         "name": "Too many errors",
         "organization_id": "5",
-        "projects": [
-          "bar"
-        ],
+        "projects": ["bar"],
         "query": "level:error",
         "resolution": 1,
         "resolve_threshold": null,
@@ -476,15 +475,13 @@ All webhook requests have some common elements.
       "id": "4",
       "identifier": "1",
       "organization_id": "5",
-      "projects": [
-        "bar"
-      ],
+      "projects": ["bar"],
       "status": 2,
       "status_method": 3,
       "title": "Sacred Marmot",
       "type": 2
     },
-    "web_url": "https://sentry.io/organizations/baz/alerts/1/",
+    "web_url": "https://sentry.io/organizations/baz/alerts/1/"
   },
   "installation": {
     "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"

--- a/src/docs/product/integrations/jira/index.mdx
+++ b/src/docs/product/integrations/jira/index.mdx
@@ -81,11 +81,11 @@ openssl x509 -pubkey -noout -in jira_publickey.cer  > jira_publickey.pem
 
 #### Connect your Jira Server application with Sentry
 
-<Note><markdown>
+<Note>
 
 Confirm [Sentry's IP ranges](/product/security/ip-ranges/) are allowed.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Organization Settings > Integrations**.
 2. Next to Jira Server, click "Install".

--- a/src/docs/product/integrations/rookout/index.mdx
+++ b/src/docs/product/integrations/rookout/index.mdx
@@ -13,13 +13,13 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
 Rookout **won't** work with self-hosted Sentry.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Rookout**
 

--- a/src/docs/product/integrations/slack/index.mdx
+++ b/src/docs/product/integrations/slack/index.mdx
@@ -14,11 +14,11 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 Slack defaults to let any workspace member authorize apps, but they may have to request access. See this [Slack help article](https://get.slack.help/hc/en-us/articles/202035138-Add-an-app-to-your-workspace) for more details.
 

--- a/src/docs/product/integrations/split/index.mdx
+++ b/src/docs/product/integrations/split/index.mdx
@@ -13,13 +13,13 @@ This integration needs to set up only once per organization, then it is availabl
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration. The Split integration is available only for organizations on the Business and Enterprise plans.
 
 Split **won't** work with self-hosted Sentry.
 
-</markdown></Note>
+</Note>
 
 1. Navigate to **Settings > Integrations > Split**
 

--- a/src/docs/product/integrations/splunk/index.mdx
+++ b/src/docs/product/integrations/splunk/index.mdx
@@ -9,21 +9,21 @@ description: "Learn more about Sentry's Splunk integration and how you can conne
 
 Connect Splunk to Sentry with the [Data Forwarding](/platform-redirect/?next=/data-management/data-forwarding/) feature.
 
-<Note><markdown>
+<Note>
 
 We only support Splunk Cloud plans. We do not support Splunk Enterprise plans. See the [Splunk documentation](https://dev.splunk.com/view/event-collector/SP-CAAAE7F) for specific details on your Splunk installation.
 
-</markdown></Note>
+</Note>
 
 This integration needs to be set up in each project for which you wish to use it. It is maintained and supported by the [Sentry community](https://forum.sentry.io/).
 
 ## Install and Configure
 
-<Note><markdown>
+<Note>
 
 Sentry owner or manager permissions permissions are required to install this integration.
 
-</markdown></Note>
+</Note>
 
 Navigate to **Settings > Integrations > Splunk**
 
@@ -49,11 +49,11 @@ Change **All Tokens** to **Enabled**, and note the HTTP Port Number (`8088` by d
 
 ![](splunk-hec-global-settings.png)
 
-<Note><markdown>
+<Note>
 
 If you’re running Splunk in a privileged environment, you may need to expose the HEC port.
 
-</markdown></Note>
+</Note>
 
 ### Creating a Sentry Input
 
@@ -114,10 +114,10 @@ Once you’ve filled in the required fields, hit **Save Changes**:
 
 We’ll now begin forwarding all new events into your Splunk instance.
 
-<Note><markdown>
+<Note>
 
 Sentry will internally limit the maximum number of events sent to your Splunk instance to 50 per second.
 
-</markdown></Note>
+</Note>
 
 ![](splunk-search-sentry.png)

--- a/src/docs/product/performance/event-detail.mdx
+++ b/src/docs/product/performance/event-detail.mdx
@@ -45,11 +45,9 @@ The waterfall view is a split view where the left reflects the transaction's spa
 Clicking on a span row expands the details of that span. From here, you can see all attached properties, such as tags and other field data. With the Trace ID, you'll be able to view all transactions within that given trace. Click "Search by Trace" to view that Discover list. Learn more about [distributed tracing](/product/performance/distributed-tracing/) in our docs.
 
 <Alert>
-<markdown>
 
 The trace view may be limited to one project at a time if you're on the [Team plan](https://sentry.io/pricing/). Further, project permissions may affect access to some of these transactions.
 
-</markdown>
 </Alert>
 
 **Traversing Transactions**

--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -10,11 +10,9 @@ description: "Get started with Sentry's Performance Monitoring. This quick setup
 After this quick setup, you'll have access to [Performance](/product/performance/). This tool will empower you to see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), but you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.
 
 <Alert>
-<markdown>
 
 Sentry's Performance features are now generally available. Customers on any of our legacy plans will need to add transaction events to their subscription to access Performance. For more details about access to these features, feel free to reach out at [performance-feedback@sentry.io](mailto:performance-feedback@sentry.io).
 
-</markdown>
 </Alert>
 
 ## Supported SDKs

--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -9,12 +9,10 @@ redirect_from:
 Getting started with Relay is as simple as using the default settings. You can also configure Relay to suit your organization's needs. Check the [Configuration Options](../options/) page for a detailed discussion of operating scenarios.
 
 <Note>
-<markdown>
 
 The Relay server is called `relay`. Download binaries from [GitHub
 Releases](https://github.com/getsentry/relay/releases). A Docker image is provided on [DockerHub](https://hub.docker.com/r/getsentry/relay/).
 
-</markdown>
 </Note>
 
 ## Initializing Configuration

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -40,11 +40,11 @@ This step is optional - you can manually supply Sentry with your own commit meta
 
 Using one of Sentry's repository integrations (such as GitHub, GitLab, Bitbucket, and so forth) is the easiest way to connect your commit metadata to Sentry. For a list of available integrations, go to Organization Settings > Integrations.
 
-<Note><markdown>
+<Note>
 
 You need to be an Owner or Manager of your Sentry organization to set up or configure an integration. Read more about [roles in Sentry](/product/accounts/membership/).
 
-</markdown></Note>
+</Note>
 
 ![](releases-repo-integrations.png)
 
@@ -86,11 +86,11 @@ sentry-cli releases new -p project1 -p project2 $VERSION
 sentry-cli releases set-commits --auto $VERSION
 ```
 
-<Note><markdown>
+<Note>
 
 You need to make sure you’re using [Auth Tokens](/api/auth/#auth-tokens), **not** [API Keys](/api/auth/#api-keys), which are deprecated.
 
-</markdown></Note>
+</Note>
 
 In the above example, first, we're using environment variables to configure the CLI (see [_Working with Projects_](/product/cli/configuration/#sentry-cli-working-with-projects) for other possible ways), and then the `propose-version` sub-command to determine a release ID automatically. Next, we’re creating a release tagged `VERSION` for the organization `my-org` for projects `project1` and `project2`. Finally, we’re using the `--auto` flag to determine the repository name automatically, and associate commits between the previous release’s commit and the current head commit with the release. If the previous release doesn't have any commits associated with it, we’ll use the latest 20 commits.
 
@@ -177,11 +177,11 @@ res = requests.post(
 
 For more information, see the [API reference](/api/releases/create-a-new-release-for-an-organization/).
 
-<Note><markdown>
+<Note>
 
 If you receive an "Unable to Fetch Commits" email, take a look at our [Help Center Article](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-).
 
-</markdown></Note>
+</Note>
 
 #### After Associating Commits
 
@@ -199,11 +199,11 @@ Fixes SENTRY-317
 
 When Sentry sees this commit, we’ll reference the commit in the issue, and when you create a release in Sentry we’ll mark the issue as resolved in that release.
 
-<Note><markdown>
+<Note>
 
 If you’re using GitHub, you may have a privacy setting enabled which prevents Sentry from identifying the user’s real email address. If you wish to use the suggested owners feature, you’ll need to ensure “Keep my email address private” is unchecked in GitHub’s [account settings](https://github.com/settings/emails).
 
-</markdown></Note>
+</Note>
 
 #### Alternatively: Without a Repository Integration
 

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -6,12 +6,10 @@ redirect_from:
 ---
 
 <Alert title="Note" level="warning">
-<markdown>
 
 The contents of this page apply only to Sentry's SaaS product. It **does not**
 apply to Self-hosted or Single Tenant.
 
-</markdown>
 </Alert>
 
 ## Dashboard and API
@@ -25,6 +23,7 @@ Sentry's dashboard and API are both served from a single IP address for all web 
 ## Event Ingestion
 
 Sentry's Event Ingestion respects two domains within a Data Source Name (DSN):
+
 1. The [organization subdomain](https://forum.sentry.io/t/organization-subdomains-in-dsns/9360)
 2. Sentry's apex domain
 

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -6,12 +6,10 @@ redirect_from:
 ---
 
 <Alert title="Note" level="warning">
-<markdown>
 
 The contents of this page apply only to Sentry's SaaS product. It **does not**
 apply to Self-hosted or Single Tenant.
 
-</markdown>
 </Alert>
 
 Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.0 to communicate securely.

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -11,11 +11,9 @@ Sentry automatically assigns you a Data Source Name (DSN) when you create a proj
 The DSN tells the SDK where to send the events. If this value is not provided, the SDK will try to read it from the `SENTRY_DSN` environment variable. If that variable also does not exist, the SDK will just not send any events.
 
 <Note>
-<markdown>
 
 In runtimes without a process environment (such as the browser) that fallback does not apply.
 
-</markdown>
 </Note>
 
 ### Where to Find Your DSN
@@ -31,7 +29,7 @@ The DSN configures the protocol, public key, server address, and project identif
 For example:
 
 ```javascript
-Sentry.init({dsn: 'https://public@sentry.example.com/1'})
+Sentry.init({ dsn: "https://public@sentry.example.com/1" });
 ```
 
 Has the following settings:
@@ -44,9 +42,7 @@ Has the following settings:
 The resulting POST request for a plain JSON payload would then transmit to `https://sentry.example.com/api/1/store/`.
 
 <Note>
-<markdown>
 
 The secret part of the DSN is optional and effectively deprecated. While clients will still honor it, if supplied, future versions of Sentry will entirely ignore it.
 
-</markdown>
 </Note>

--- a/src/docs/product/sentry-basics/guides/alert-notifications/metric-alerts.mdx
+++ b/src/docs/product/sentry-basics/guides/alert-notifications/metric-alerts.mdx
@@ -15,10 +15,12 @@ In the Alert Conditions section, choose between [Errors](/platforms/javascript/u
 Errors and Transactions each have different metrics for alerting.
 
 ### Error Metrics for Alerting
+
 - `count()`
 - `count_unique(...)`
 
 ### Transaction Metrics for Alerting
+
 - `avg(...)`
 - `percentile(...)`
 - `failure_rate()`
@@ -35,9 +37,9 @@ Errors and Transactions each have different metrics for alerting.
 Decide how often you want your metric evaluated. Your choices range between one minute and four hours.
 
 <Note>
-<markdown>
+
 Triggers are evaluated every minute, regardless of this value.
-</markdown>
+
 </Note>
 
 ## 4: Choose an Environment

--- a/src/docs/product/sentry-basics/guides/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/guides/grouping-and-fingerprints/index.mdx
@@ -28,11 +28,11 @@ Notice the only difference is one had function testTypeIssue15 and the other had
 
 Sometimes two stack traces are the same function execution path but differ by one frame. This can be due to several things like middleware you've configured, node_modules, the framework itself, or library imports. To have greater control over which stack frames are included or excluded, see [Custom Grouping Enhancements](/platform-redirect/?next=/data-management/event-grouping/grouping-enhancements/).
 
-<Note><markdown>
+<Note>
 
 Fortunately you can change the default grouping behavior to make certain issue types match on something other than stack trace. You can do this from both the **Server side** and the **SDK side**
 
-</markdown></Note>
+</Note>
 
 # Solutions
 

--- a/src/docs/product/sentry-basics/guides/integrate-backend/index.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-backend/index.mdx
@@ -12,11 +12,11 @@ This step-by-step tutorial walks you through the flow of setting up and configur
 - Monitor various types of events and errors to Sentry
 - Implement error tracing between your frontend and backend applications
 
-<Note><markdown>
+<Note>
 
 We provided the source code for a sample `Django` application to use along with this guide. This allows us to streamline the steps required to getting the maximum value out of integrating Sentry into your development workflow.
 
-</markdown></Note>
+</Note>
 
 Alternatively, you can follow this guide as a reference and apply the relevant changes directly to your source code.
 

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
@@ -6,11 +6,11 @@ redirect_from:
 
 Now that the Demo App is up and running on your local environment integrated with the Sentry SDK, you're ready to generate the first error.
 
-<Note><markdown>
+<Note>
 
 If you're not using the provided React demo code, follow [the Verification step](/platforms/javascript/) to introduce an error to your source code and continue with [Step 2](#step-2-handle-the-error)
 
-</markdown></Note>
+</Note>
 
 ## Step 1: Capture your first event
 

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/index.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/index.mdx
@@ -12,11 +12,11 @@ This step-by-step tutorial walks you through the flow of setting up and configur
 - Receive a readable stack trace with source code context
 - View suspect commits and suggested assignees based on commit information and stack trace.
 
-<Note><markdown>
+<Note>
 
 We provided the source code for a sample React application to use along with this guide. This allows us to streamline the steps required to getting the maximum value out of integrating Sentry into your development workflow.
 
-</markdown></Note>
+</Note>
 
 Alternatively, you can follow this tutorial as a reference and apply the relevant changes directly to your source code.
 

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/initialize-sentry-sdk.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/initialize-sentry-sdk.mdx
@@ -6,11 +6,11 @@ redirect_from:
 
 In this tutorial, you import the React demo code into your local development environment, add the Sentry SDK, and initialize it.
 
-<Note><markdown>
+<Note>
 
 If you're using your own source code you can skip this section and instead
 
-</markdown></Note>
+</Note>
 
 - Follow the instructions on [Getting Started](/platforms/) for your platform. Notice that you can select the desired platform.
 - Continue with the [Next section](/guides/integrate-frontend/generate-first-error/).

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
@@ -14,11 +14,11 @@ In this section, we will:
 
 2. Add the release version to the Sentry SDK configuration --- this will associate any error captured by the SDK in our app to this specific release. Sentry will use the release's uploaded source maps to unminify the error's stack trace.
 
-<Note><markdown>
+<Note>
 
 As part of the **CI/CD workflow** for this app demo, we're using a `Makefile` to handle the `sentry-cli` related tasks through `make` targets. If you're using a different code base, you can still apply the settings and commands described below to your specific setup or run them directly in a command-line shell as part of your build process. For more information, see [Command Line Interface](/product/cli/).
 
-</markdown></Note>
+</Note>
 
 ## Step 1: Prepare the build environment
 

--- a/src/docs/product/sentry-basics/guides/migration/index.mdx
+++ b/src/docs/product/sentry-basics/guides/migration/index.mdx
@@ -33,11 +33,11 @@ Once you complete the onboarding steps, grab your **org slug** from the browser 
 
 ![Org Slug](02.png)
 
-<Note><markdown>
+<Note>
 
 You can modify your org slug in the org settings.
 
-</markdown></Note>
+</Note>
 
 ### 2. Choose a plan
 

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -10,11 +10,11 @@ description: "Learn more about Search, which is available on several major Sentr
 
 Search is available on several major Sentry views: Issues, Events, and Releases.
 
-<Alert title="Looking for information on Discover?" level="info"><markdown>
+<Alert title="Looking for information on Discover?" level="info">
 
 Discover is Sentry's powerful query builder for aggregating raw event data and has its own unique syntax not covered here. For more information, see [full Discover documentation](/product/discover-queries/).
 
-</markdown></Alert>
+</Alert>
 
 ## Syntax
 

--- a/src/includes/configuration/config-intro/php.mdx
+++ b/src/includes/configuration/config-intro/php.mdx
@@ -7,8 +7,8 @@ Sentry\init([
 ]);
 ```
 
-<Note><markdown>
+<Note>
 
 Some of the options listed below that are marked as _not available_ may be available in another form; see [PHP specific documentation](/product/releases/).
 
-</markdown></Note>
+</Note>

--- a/src/includes/configuration/decluttering/javascript.mdx
+++ b/src/includes/configuration/decluttering/javascript.mdx
@@ -4,11 +4,11 @@ You can construct an allowed list of domains which might raise acceptable except
 
 You can also use `denyUrls` if you want to block specific URLs forever.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Prior to version 5.17.0, `allowUrls` and `denyUrls` were called `whitelistUrls` and `blacklistUrls` respectively. These options are still supported for backwards compatibility reasons, but they will be removed in version 6.0. For more information, please see our [Inclusive Language Policy](https://develop.sentry.dev/inclusion/).
 
-</markdown></Alert>
+</Alert>
 
 Additionally, our community has compiled a list of common ignore rules for everyday things, like Facebook, Chrome extensions, and so forth. It's useful and recommended to check these out and see if they apply to you. [Here is the original gist](https://gist.github.com/impressiver/5092952). This is not the default value of our SDK; it's just a highlight of an extensive example.
 

--- a/src/includes/framework-list/java.mdx
+++ b/src/includes/framework-list/java.mdx
@@ -1,7 +1,7 @@
-<PlatformSection noGuides><markdown>
+<PlatformSection noGuides>
 
 Using a framework or logging library? Take a look at our specific guides to get started.
 
 <GuideGrid />
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/includes/framework-list/javascript.mdx
+++ b/src/includes/framework-list/javascript.mdx
@@ -1,7 +1,7 @@
-<PlatformSection noGuides><markdown>
+<PlatformSection noGuides>
 
 Using a framework? Take a look at our specific guides to get started.
 
 <GuideGrid />
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/includes/framework-list/python.mdx
+++ b/src/includes/framework-list/python.mdx
@@ -1,7 +1,7 @@
-<PlatformSection noGuides><markdown>
+<PlatformSection noGuides>
 
 Using a framework? Take a look at our specific guides to get started.
 
 <GuideGrid />
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/includes/getting-started-config/javascript.ember.mdx
+++ b/src/includes/getting-started-config/javascript.ember.mdx
@@ -1,13 +1,12 @@
-
 This snippet includes automatic instrumentation to monitor the performance of your application, which registers and configures the Tracing integration, including custom [Ember instrumentation](./configuration/ember-options/).
 
 ```javascript
-import Application from '@ember/application';
-import Resolver from 'ember-resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import Application from "@ember/application";
+import Resolver from "ember-resolver";
+import loadInitializers from "ember-load-initializers";
+import config from "./config/environment";
 
-import { InitSentryForEmber } from '@sentry/ember';
+import { InitSentryForEmber } from "@sentry/ember";
 
 InitSentryForEmber();
 
@@ -21,20 +20,20 @@ export default class App extends Application {
 Then add the following config to your `config/environment.js`:
 
 ```javascript
-ENV['@sentry/ember'] = {
+ENV["@sentry/ember"] = {
   sentry: {
-    dsn: '___PUBLIC_DSN___',
+    dsn: "___PUBLIC_DSN___",
 
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production,
     tracesSampleRate: 1.0,
-  }
+  },
 };
 ```
 
-<Note><markdown>
+<Note>
 
 This SDK uses Ember configuration conventions to manage its automatic instrumentation and other Sentry options, this additional configuration can be found under <PlatformLink to="/configuration/ember-options/">Ember options</PlatformLink>.
 
-</markdown></Note>
+</Note>

--- a/src/includes/getting-started-config/python.django.mdx
+++ b/src/includes/getting-started-config/python.django.mdx
@@ -19,8 +19,8 @@ sentry_sdk.init(
 )
 ```
 
-<Note><markdown>
+<Note>
 
 Additional configuration for `DjangoIntegration` can be found under <PlatformLink to="/configuration/integrations/django/">integration configuration</PlatformLink>.
 
-</markdown></Note>
+</Note>

--- a/src/includes/getting-started-config/python.flask.mdx
+++ b/src/includes/getting-started-config/python.flask.mdx
@@ -6,7 +6,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     integrations=[FlaskIntegration()],
-    
+
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production,
@@ -16,8 +16,8 @@ sentry_sdk.init(
 app = Flask(__name__)
 ```
 
-<Note><markdown>
+<Note>
 
 Additional configuration for `FlaskIntegration` can be found under <PlatformLink to="/configuration/integrations/flask/">integration configuration</PlatformLink>.
 
-</markdown></Note>
+</Note>

--- a/src/includes/getting-started-install/javascript.mdx
+++ b/src/includes/getting-started-install/javascript.mdx
@@ -6,9 +6,7 @@ npm install --save @sentry/browser @sentry/tracing
 ```
 
 <Note>
-<markdown>
 
 We also support alternate [installation methods](/platforms/javascript/install/).
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/_default.mdx
+++ b/src/includes/getting-started-primer/_default.mdx
@@ -1,7 +1,5 @@
 <Note>
-<markdown>
 
 **Sentry's SDKs enable automatic reporting of errors and exceptions.**
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/go.mdx
+++ b/src/includes/getting-started-primer/go.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 _Sentry's Go SDK enables reporting messages, errors, and panics._
 
 Our Go SDK supports all recent versions of the language, and integrates well with a variety of popular frameworks and packages in the Go ecosystem. It gives developers helpful hints for where and why an error or panic might have occurred.
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/java.mdx
+++ b/src/includes/getting-started-primer/java.mdx
@@ -1,11 +1,9 @@
 <Note>
-<markdown>
 
 _Sentry's Java SDK enables capturing sessions for Release Health as well as reporting messages and errors._
 
 Sentry for Java is a collection of modules provided by Sentry; it supports Java 1.8 and above. At its core, Sentry for Java provides a raw client for sending events to Sentry. To begin, we **highly recommend** you use one of the logging libraries or framework integrations.
 
-</markdown>
 </Note>
 
 <!-- TODO: add version and value information, similar to what we have for Go:

--- a/src/includes/getting-started-primer/javascript.ember.mdx
+++ b/src/includes/getting-started-primer/javascript.ember.mdx
@@ -1,7 +1,5 @@
 <Note>
-<markdown>
 
 _Sentry's Ember addon enables automatic reporting of errors, exceptions, and transactions._
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/python.django.mdx
+++ b/src/includes/getting-started-primer/python.django.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 _Sentry's Django integration enables automatic reporting of errors and exceptions._
 
 Sentry's Django integration reports all exceptions leading to an Internal Server Error and creates a separate scope for each request. The integration supports [Django Web Framework from Version 1.6 and above](https://www.djangoproject.com/). Django applications using Channels 2.0 will be correctly instrumented using Python 3.7. Older versions of Python require installation of `aiocontextvars`.
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/python.flask.mdx
+++ b/src/includes/getting-started-primer/python.flask.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 _Sentry's Flask integration enables automatic reporting of errors and exceptions._
 
 Our Python SDK will install the Flask integration for all of your apps. It hooks into Flask’s signals, not anything on the app object. Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.
 
-</markdown>
 </Note>

--- a/src/includes/getting-started-primer/python.mdx
+++ b/src/includes/getting-started-primer/python.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 _Sentry's Python SDK enables automatic reporting of errors and exceptions as well as identifies perfomance issues in your application._
 
 Sentry's Python SDK includes powerful hooks that let you get more out of Sentry, and helps you bind data like tags, users, or contexts. Our SDK supports Python 2.7, then 3.4 and above; specific versions for each framework are documented on the respective framework page. Migrating from older versions is documented [here](./migration/).
 
-</markdown>
 </Note>

--- a/src/includes/sensitive-data/set-tag/_default.mdx
+++ b/src/includes/sensitive-data/set-tag/_default.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 The platform or SDK you've selected either does not support this functionality, or it is missing from our documentation. Please use this code sample from JavaScript as a basis:
 
-</markdown>
 </Note>
 
 ```javascript

--- a/src/includes/sensitive-data/set-user/_default.mdx
+++ b/src/includes/sensitive-data/set-user/_default.mdx
@@ -1,9 +1,7 @@
 <Note>
-<markdown>
 
 The platform or SDK you've selected either does not support this functionality, or the code sample is missing from our documentation. Please use this code sample from JavaScript as a basis:
 
-</markdown>
 </Note>
 
 ```javascript

--- a/src/includes/set-release/dotnet.mdx
+++ b/src/includes/set-release/dotnet.mdx
@@ -6,11 +6,11 @@ SentrySdk.Init(o => o.Release = "my-project-name@2.3.12");
 
 The SDK attempts to locate the release to add to events sent to Sentry.
 
-<Note><markdown>
+<Note>
 
 [Default values like 1.0 or 1.0.0.0 are ignored](https://github.com/getsentry/sentry-dotnet/blob/dbb5a3af054d0ca6f801de37fb7db3632ca2c65a/src/Sentry/Internal/ApplicationVersionLocator.cs#L14-L21).
 
-</markdown></Note>
+</Note>
 
 The SDK will first look at the [entry assembly's](<https://msdn.microsoft.com/en-us/library/system.reflection.assembly.getentryassembly(v=vs.110).aspx>) `AssemblyInformationalVersionAttribute`, which accepts a string as
 value and is often used to set a GIT commit hash.

--- a/src/includes/set-release/ruby.mdx
+++ b/src/includes/set-release/ruby.mdx
@@ -4,8 +4,8 @@ Raven.configure do |config|
 end
 ```
 
-<Note><markdown>
+<Note>
 
 We'll automatically attempt to detect the release in certain environments, such as Heroku and Capistrano.
 
-</markdown></Note>
+</Note>

--- a/src/includes/set-user/android.mdx
+++ b/src/includes/set-user/android.mdx
@@ -9,8 +9,8 @@ Sentry.configureScope(scope -> {
 });
 ```
 
-<Note><markdown>
+<Note>
 
 Sentry will by fallback to `Settings.Secure.ANDROID_ID` if you do not provide a user identity.
 
-</markdown></Note>
+</Note>

--- a/src/platforms/android/index.mdx
+++ b/src/platforms/android/index.mdx
@@ -17,11 +17,11 @@ The NDK is not only catching the unhandled exceptions but is also set as a signa
 
 <PlatformContent includePath="getting-started-install" />
 
-<Note><markdown>
+<Note>
 
 For the minimal required API level, see [Advanced usage](usage/advanced-usage/).
 
-</markdown></Note>
+</Note>
 
 ## Configure
 

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -27,7 +27,7 @@ lane :upload_symbols do
 end
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Alert level="" title="On Prem">
 
 By default fastlane will connect to sentry.io. For on-prem you need to provide the _api_host_ parameter to instruct the tool to connect to your server:
 
@@ -35,7 +35,7 @@ By default fastlane will connect to sentry.io. For on-prem you need to provide t
 api_host: 'https://mysentry.invalid/'
 ```
 
-</markdown></Alert>
+</Alert>
 
 ### Using `sentry-cli` {#bitcode-sentrycli}
 
@@ -50,7 +50,7 @@ Afterwards manually upload the symbols with _sentry-cli_:
 sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_DSYMS
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Alert level="" title="On Prem">
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
 
@@ -58,7 +58,7 @@ By default sentry-cli will connect to sentry.io. For on-prem you need to export 
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-</markdown></Alert>
+</Alert>
 
 ## Without Bitcode {#dsym-without-bitcode}
 
@@ -79,7 +79,7 @@ lane :build do
 end
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Alert level="" title="On Prem">
 
 By default fastlane will connect to sentry.io. For on-prem you need to provide the _api_host_ parameter to instruct the tool to connect to your server:
 
@@ -87,7 +87,7 @@ By default fastlane will connect to sentry.io. For on-prem you need to provide t
 api_host: 'https://mysentry.invalid/'
 ```
 
-</markdown></Alert>
+</Alert>
 
 ### Uploading Symbols with _sentry-cli_
 
@@ -118,7 +118,7 @@ fi
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 
-<Alert level="" title="On Prem"><markdown>
+<Alert level="" title="On Prem">
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
 
@@ -126,4 +126,4 @@ By default sentry-cli will connect to sentry.io. For on-prem you need to export 
 export SENTRY_URL=https://mysentry.invalid/
 ```
 
-</markdown></Alert>
+</Alert>

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -93,7 +93,7 @@ To send a representative sample of your errors to Sentry, set the `sampleRate` o
 
 **Note:** The error sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-<PlatformSection supported={["javascript", "node"]} notSupported={["react-native"]}><markdown>
+<PlatformSection supported={["javascript", "node"]} notSupported={["react-native"]}>
 
 ## Filtering Transaction Events
 
@@ -115,9 +115,9 @@ tracesSampler: samplingContext => {
 
 To learn more about the `tracesSampler` option, please see <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
 
-</markdown></PlatformSection>
+</PlatformSection>
 
-<PlatformSection supported={["javascript", "node", "python", "PHP"]} notSupported={["react-native"]}><markdown>
+<PlatformSection supported={["javascript", "node", "python", "PHP"]} notSupported={["react-native"]}>
 
 ## Sampling Transaction Events
 
@@ -127,4 +127,4 @@ When choosing a sampling rate, the goal is not to collect *too* much data, but
 
 To set a sample rate for your transactions, provide a number between `0` (0% of transactions sent) and `1` (100% of transactions sent) to the `tracesSampleRate` configuration option. For example, including `tracesSampleRate: 0.2` in your SDK config will cause the SDK to only send 20% of possible transaction events.
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -13,57 +13,57 @@ initialized.
 
 The list of common options across SDKs. These work more or less the same in all SDKs, but some subtle differences will exist to better support the platform. Options that can be read from an environment variable or your `~/.sentryclirc` file (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`) are read automatically. See [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects) for more information.
 
-<ConfigKey name="dsn"><markdown>
+<ConfigKey name="dsn">
 
 The _DSN_ tells the SDK where to send the events. If this value is not provided, the SDK will try to read it from the `SENTRY_DSN` environment variable. If that variable also does not exist, the SDK will just not send any events.
 
 In runtimes without a process environment (such as the browser) that fallback does not apply.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="debug" notSupported={["php"]}><markdown>
+<ConfigKey name="debug" notSupported={["php"]}>
 
 Turns debug mode on or off. If debug is enabled SDK will attempt to print out useful debugging information if something goes wrong with sending the event. The default is always `false`. It's generally not recommended to turn it on in production, though turning `debug` mode on will not cause any safety concerns.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="release"><markdown>
+<ConfigKey name="release">
 
 Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/).
 
 By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="environment"><markdown>
+<ConfigKey name="environment">
 
 Sets the environment. This string is freeform and not set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 
 By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` environment variable (except for the browser SDK where this is not applicable).
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="error-types" supported={["php"]}><markdown>
+<ConfigKey name="error-types" supported={["php"]}>
 
 Sets which errors are reported. It takes the same values as PHP's [`error_reporting`](https://www.php.net/manual/errorfunc.configuration.php#ini.error-reporting) configuration parameter.
 
 By default all types of errors are be reported (equivalent to `E_ALL`).
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="sample-rate"><markdown>
+<ConfigKey name="sample-rate">
 
 Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="max-breadcrumbs"><markdown>
+<ConfigKey name="max-breadcrumbs">
 
 This variable controls the total amount of breadcrumbs that should be captured. This defaults to `100`.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="attach-stacktrace"><markdown>
+<ConfigKey name="attach-stacktrace">
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.
 
@@ -71,51 +71,51 @@ This option is `off` by default.
 
 Grouping in Sentry is different for events with stack traces and without. As a result, you will get new groups as you enable or disable this flag for certain events.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="send-default-pii" supported={["dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust"]}><markdown>
+<ConfigKey name="send-default-pii" supported={["dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust"]}>
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 
 If possible, we recommended turning on this feature to send all such data by default, and manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java"]}><markdown>
+<ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java"]}>
 
 This option can be used to supply a "server name." When provided, the name of the server is sent along and persisted in the event. For many integrations the server name actually corresponds to the device hostname, even in situations where the machine is not actually a server. Most SDKs
 will attempt to auto-discover this value.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="deny-urls" supported={["javascript"]}><markdown>
+<ConfigKey name="deny-urls" supported={["javascript"]}>
 
 A list of strings or regex patterns that match error URLs that should not be sent to Sentry. By default, all errors will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="allow-urls" supported={["javascript"]}><markdown>
+<ConfigKey name="allow-urls" supported={["javascript"]}>
 
 A legacy alias for a list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
 will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `[https://bar.com/myfile/foo.com](https://bar.com/myfile/foo.com)` By default, all errors will be sent.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="in-app-include" supported={["python", "rust", "csharp", "php", "java"]}><markdown>
+<ConfigKey name="in-app-include" supported={["python", "rust", "csharp", "php", "java"]}>
 
 A list of string prefixes of module names that belong to the app. This option takes precedence over `in-app-exclude`.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="in-app-exclude" supported={["python", "rust", "csharp", "php", "java"]}><markdown>
+<ConfigKey name="in-app-exclude" supported={["python", "rust", "csharp", "php", "java"]}>
 
 A list of string prefixes of module names that do not belong to the app, but rather to third-party packages. Modules considered not part of the app will be hidden from stack traces by default.
 
 This option can be overridden using `in-app-include`.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="request-bodies" supported={["python", "php"]}><markdown>
+<ConfigKey name="request-bodies" supported={["python", "php"]}>
 
 This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
 
@@ -124,27 +124,27 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 - `medium`: medium and small requests will be captured (typically 10KB)
 - `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="with-locals" supported={["python"]}><markdown>
+<ConfigKey name="with-locals" supported={["python"]}>
 
 When enabled, local variables are sent along with stackframes. This can have a performance and PII impact. Enabled by default on platforms where this is available.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="ca-certs" supported={["python"]}><markdown>
+<ConfigKey name="ca-certs" supported={["python"]}>
 
 A path to an alternative CA bundle file in PEM-format.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="normalize-depth" supported={["javascript", "node"]}><markdown>
+<ConfigKey name="normalize-depth" supported={["javascript", "node"]}>
 
 Sentry SDKs normalize any contextual data to a given depth. Any keys containing data with a structure deeper than this will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed `3` levels deep.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<PlatformSection supported={["javascript", "python", "node"]}><markdown>
+<PlatformSection supported={["javascript", "python", "node"]}>
 
 ## Integration Configuration
 
@@ -158,65 +158,65 @@ In some SDKs, the integrations are configured through this parameter on library 
 
 This can be used to disable integrations that are added by default. When set to `false`, no default integrations are added.
 
-</markdown></PlatformSection>
+</PlatformSection>
 
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
 
-<ConfigKey name="before-send"><markdown>
+<ConfigKey name="before-send">
 
 This function is called with an SDK-specific event object, and can return a modified event object or nothing to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="before-breadcrumb"><markdown>
+<ConfigKey name="before-breadcrumb">
 
 This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<PlatformSection supported={["javascript", "java", "python", "node", "php"]}><markdown>
+<PlatformSection supported={["javascript", "java", "python", "node", "php"]}>
 
 ## Transport Options
 
 Transports are used to send events to Sentry. Transports can be customized to some degree to better support highly specific deployments.
 
-<ConfigKey name="transport" supported={["javascript", "php", "python", "java"]}><markdown>
+<ConfigKey name="transport" supported={["javascript", "php", "python", "java"]}>
 
 Switches out the transport used to send events. How this works depends on the SDK. It can, for instance, be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="http-proxy" supported={["node", "php", "python", "java"]}><markdown>
+<ConfigKey name="http-proxy" supported={["node", "php", "python", "java"]}>
 
 When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https-proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="https-proxy" supported={["python", "node"]}><markdown>
+<ConfigKey name="https-proxy" supported={["python", "node"]}>
 
 Configures a separate proxy for outgoing HTTPS requests. This value might not be supported by all SDKs. When not supported the `http-proxy` value is also used for HTTPS requests at all times.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="shutdown-timeout" supported={["python", "node", "java"]}><markdown>
+<ConfigKey name="shutdown-timeout" supported={["python", "node", "java"]}>
 
 Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 
-</markdown></ConfigKey>
+</ConfigKey>
 
-</markdown></PlatformSection>
+</PlatformSection>
 
 ## Tracing Options
 
-<ConfigKey name="tracesSampleRate" supported={["node", "javascript", "python", "php"]}><markdown>
+<ConfigKey name="tracesSampleRate" supported={["node", "javascript", "python", "php"]}>
 
 A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or `tracesSampler` must be defined to enable tracing.
-</markdown></ConfigKey>
+</ConfigKey>
 
-<ConfigKey name="tracesSampler" supported={["node", "javascript", "php"]}><markdown>
+<ConfigKey name="tracesSampler" supported={["node", "javascript", "php"]}>
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between 0 (0% chance of being sent) and 1 (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or `tracesSampleRate` must be defined to enable tracing.
-</markdown></ConfigKey>
+</ConfigKey>

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -13,11 +13,11 @@ A release is a version of your code that is deployed to an environment. When you
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-<PlatformSection supported={["javascript", "node", "java"]}><markdown>
+<PlatformSection supported={["javascript", "node", "java"]}>
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-</markdown></PlatformSection>
+</PlatformSection>
 
 ### Bind the Version
 
@@ -29,11 +29,11 @@ The release name cannot:
 - use a forward slash ("/"), back slash ("\\"), period ("."), or double period ("..")
 - exceed 200 characters
 
-<Note><markdown>
+<Note>
 
 Releases are global per organization; prefix them with something project-specific for easy differentiation.
 
-</markdown></Note>
+</Note>
 
 <PlatformContent includePath="set-release" notateUnsupported />
 
@@ -43,7 +43,7 @@ This tags each event with the release value. We recommend that you tell Sentry a
 
 After configuring your SDK, you can install a repository integration or manually supply Sentry with your own commit metadata. Read our documentation about [Releases](/product/releases/) for further information about integrations, associating commits, and telling Sentry when deploying releases.
 
-<PlatformSection supported={["apple"]}><markdown>
+<PlatformSection supported={["apple"]}>
 
 ## Release Health
 
@@ -57,9 +57,8 @@ By default, the session is terminated once the application is in the background 
 
 <PlatformContent includePath="configuration/session-tracking-interval" />
 
-
 If you'd like to opt-out of this feature, you can do it via options.
 
 <PlatformContent includePath="configuration/auto-session-tracking" />
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/platforms/common/data-management/debug-files.mdx
+++ b/src/platforms/common/data-management/debug-files.mdx
@@ -28,14 +28,14 @@ the following formats:
 - [_ProGuard mappings_](#proguard-mappings) for
   Java and Android
 
-<Note><markdown>
+<Note>
 
 Source maps, while also being debug information files, are handled
 in Sentry. For more information see [Source Maps in sentry-cli](/product/cli/releases/#sentry-cli-sourcemaps).
 
 differently
 
-</markdown></Note>
+</Note>
 
 Sentry requires access to debug information files of your application as well as
 system libraries to provide fully symbolicated crash reports. You can either
@@ -190,11 +190,11 @@ Database_ files, commonly referred to as _PDB_.
   contain unwind information. In rare cases, they might have different file
   names than their corresponding executable.
 
-<Note><markdown>
+<Note>
 
 At the moment, Sentry supports Native PDBs only. PDBs for the .NET platform are not supported.
 
-</markdown></Note>
+</Note>
 
 ### Breakpad Symbols
 
@@ -239,11 +239,11 @@ compute a _Debug Identifier_ for each uploaded file. This identifier is
 associated with executables and libraries as well as debug companions to ensure
 that they can be uniquely located via one common mechanism.
 
-<Note><markdown>
+<Note>
 
 Debug information does not have to be associated with releases. The unique debug
 
-</markdown></Note>
+</Note>
 identifier ensures that Sentry can choose the right files for every crash
 report. However, it is still recommended to configure releases in the client to
 benefit from other features.
@@ -424,12 +424,12 @@ Beware that these cause notifications to your team members.
 
 ### Custom Repositories
 
-<Alert title="Note" level="info"><markdown>
+<Alert title="Note" level="info">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.
 
-</markdown></Alert>
+</Alert>
 
 Independent of the internal format, Sentry supports three kinds of custom
 repositories:

--- a/src/platforms/common/data-management/sensitive-data/advanced-datascrubbing.mdx
+++ b/src/platforms/common/data-management/sensitive-data/advanced-datascrubbing.mdx
@@ -58,11 +58,9 @@ Rules generally consist of three parts:
 - _Anything_: Matches any value. This is useful if you want to remove a certain JSON key by path using [_Sources_](#sources) regardless of the value.
 
 <Alert title="Sentry does not know what your code does" level="warning">
-<markdown>
 
 Sentry does not know if a local variable that looks like a credit card number actually is one. As such, you need to expect not only false-positives but also false-negatives. [_Sources_](#sources) can help you in limiting the scope in which your rule runs.
 
-</markdown>
 </Alert>
 
 ## Sources

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -14,7 +14,6 @@ There are two great examples for data scrubbing that every company should think 
 - Authentication credentials, like your AWS password or key.
 - Confidential IP (Intellectual Property), such as your favorite color, or your upcoming plans for world domination.
 
-
 ## Personally Identifiable Information (PII)
 
 <PlatformSection notSupported={["flutter", "apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.ue4", "go", "ruby", "native", "elixir"]}>
@@ -45,11 +44,11 @@ SDKs provide a `before-send` hook, which is invoked before an event is sent and 
 
 <PlatformContent includePath="configuration/before-send" />
 
-<Note><markdown>
+<Note>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
-</markdown></Note>
+</Note>
 
 There's a few areas you should consider that sensitive data may appear:
 
@@ -121,11 +120,11 @@ credentials = {
 
 Using the default options would not cause the _object_ `credentials` to be redacted in its entirety; rather, all of its entries would be subject to scrubbing. So `password` would be redacted by default, and adding `cats`, `username`, and/or `lastLogin` to the list of additional fields would cause those values to be redacted as well.
 
-<Note><markdown>
+<Note>
 
 You can choose to expand the keys which are scrubbed by the server, as well as prevent IP addresses from being stored. The latter is particularly important if you’re concerned about PII and using our Browser JavaScript SDK.
 
-</markdown></Note>
+</Note>
 
 In addition, we provide an [_Advanced Data Scrubbing_](advanced-datascrubbing/) feature which allows more control over how filters are applied..
 

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -41,7 +41,7 @@ Attachments persist for 30 days; if your total storage included in your quota is
 
 Learn more about how attachments impact your [quota](/product/accounts/quotas/).
 
-<PlatformSection supported={["native", "javascript.electron"]}><markdown>
+<PlatformSection supported={["native", "javascript.electron"]}>
 
 ## Crash Reports and Privacy
 
@@ -57,7 +57,7 @@ You can enable _Store Native Crash Reports_ in your organization's **Security an
 
 If you set a limit per issue, as in the example above, a limit of 10, Sentry will store the first 10 attachments associated with this issue, but drop any that follow. To make room for additional attachments, delete them. Sentry will then accept attachments until the limit is reached again.
 
-</markdown></PlatformSection>
+</PlatformSection>
 
 ### Access to Attachments
 
@@ -77,8 +77,8 @@ Alternately, attachments also appear in the _Attachments_ tab on the **Issue Det
 
 ![Attachments List Example](attachments-list-example.png)
 
-<PlatformSection supported={["native", "javascript.electron"]}><markdown>
+<PlatformSection supported={["native", "javascript.electron"]}>
 
 If you chose to limit the number of crash reports per issue, you can show _Only Crash Reports_. This removes all other attachments from the list, which can be useful if the issue has accumulated a large number of events.
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -13,11 +13,11 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage"><markdown>
+<Alert level="" title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can read about this in detail using the developer documentation devoted to the [Breadcrumbs Interface](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/).
 
-</markdown></Alert>
+</Alert>
 
 ## Manual Breadcrumbs
 

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -12,11 +12,11 @@ Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries
 
 ![Custom contexts as viewed on the Additional Data section of an event](additional_data.png)
 
-<Note><markdown>
+<Note>
 
 If you need to be able to search on custom data, you will want to [use tags](../tags).
 
-</markdown></Note>
+</Note>
 
 To configure additional context:
 
@@ -32,7 +32,7 @@ For more details, see the [developer documentation on SDK data handling](https:
 
 If you come across any usages of "extra" (<PlatformIdentifier name="set-extra" /> in code) or "Additional Data" (in the UI), just mentally substitute it for context. Extra is deprecated in favor of context within most SDKs.
 
-<PlatformSection supported={["javascript", "node"]}><markdown>
+<PlatformSection supported={["javascript", "node"]}>
 
 ### Passing Context Directly
 
@@ -114,4 +114,4 @@ Sentry.configureScope(scope => scope.clear());
 
 To learn more about setting the Scope, see our documentation on [Scopes and Hubs](../scopes/).
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -33,9 +33,7 @@ To identify the user:
 Additional key/value pairs can be specified as metadata and the Sentry SDK will store those with the user.
 
 <PlatformContent includePath="unset-user">
-<markdown>
 
 You can also clear the currently set user:
 
-</markdown>
 </PlatformContent>

--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -19,11 +19,11 @@ Defining tags is easy, and will bind them to the [current scope](../scopes/) ens
 
 <PlatformContent includePath="set-tag" />
 
-<Note><markdown>
+<Note>
 
 Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags, and instead using your own nomenclature for names.
 
-</markdown></Note>
+</Note>
 
 Once you've started sending tagged data, you'll see it in the Sentry web UI: the filters within the sidebar on the Project page, summarized within an event, and on the tags page for an aggregated event.
 

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -3,11 +3,9 @@
 On this page, we get you up and running with Sentry's SDK, so that it will automatically report errors and exceptions in your application.
 
 <Note>
-<markdown>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown>
 </Note>
 
 <PlatformContent includePath="framework-list" />
@@ -24,11 +22,11 @@ Configure Sentry as early as possible in your app.
 
 <PlatformContent includePath="getting-started-config" />
 
-<Note><markdown>
+<Note>
 
 We'll automatically assign you a [Data Source Name (DSN)](/product/sentry-basics/dsn-explainer/).
 
-</markdown></Note>
+</Note>
 
 ## Verify
 

--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -13,7 +13,6 @@ notSupported:
 Sentry's SDK hooks into your runtime environment and automatically reports errors, exceptions, and rejections.
 
 <Note>
-<markdown>
 
 Key terms:
 
@@ -22,7 +21,6 @@ Key terms:
 - The reporting of an event is called _capturing_.
   When an event is captured, it’s sent to Sentry.
 
-</markdown>
 </Note>
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception it can be captured. For some SDKs you can also omit the argument to `capture_exception` and Sentry will attempt to capture the current exception. It can also be useful to manually report errors or messages to Sentry.

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -19,11 +19,11 @@ dotnet add package Sentry.Extensions.Logging -v {{ packages.version('sentry.dotn
 
 This package extends `Sentry` main SDK. That means that besides the logging related features, through this package you'll also get access to all API and features available in the main `Sentry` SDK.
 
-<Note><markdown>
+<Note>
 
 Messages logged from assemblies with the name starting with `Sentry` will not generate events.
 
-</markdown></Note>
+</Note>
 
 ## Features
 
@@ -116,11 +116,11 @@ More settings can be passed via the callback configuring the `SentryOptions`.
 
 In cases where `AddSentry` is called without arguments, it's worth noting that an overload exists where `SentryOptions` can be configured just like if `SentrySdk.Init` had been called.
 
-<Note><markdown>
+<Note>
 
 The SDK needs to be initialized only once. If the `DSN` is made available to this integration, by default it **will** initialize the SDK. If you do not wish to initialize the SDK via this configuration, set the `InitializeSdk` flag to **false**. Not providing a DSN or leaving it as an _empty string_ will disable the SDK.
 
-</markdown></Note>
+</Note>
 
 For example:
 

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -35,11 +35,11 @@ This can be done, for example, via the `app.config` for console and desktop apps
   </appender>
 ```
 
-<Note><markdown>
+<Note>
 
 Only a subset of the options are exposed via the log4net appender configuration. If you wish to access an [SDK option](/platforms/dotnet/configuration/options/) which is not listed below, you'll need to initialize the SDK via [SentrySdk.Init](https://docs.sentry.io/platforms/dotnet/) instead of doing it via this integration as described below.
 
-</markdown></Note>
+</Note>
 
 ### SendIdentity
 

--- a/src/platforms/dotnet/guides/nlog/index.mdx
+++ b/src/platforms/dotnet/guides/nlog/index.mdx
@@ -19,11 +19,11 @@ dotnet add package Sentry.NLog -v {{ packages.version('sentry.dotnet.nlog') }}
 
 This package extends `Sentry` main SDK. That means that besides the logging related features, through this package you'll also get access to all API and features available in the main `Sentry` SDK.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Messages logged from assemblies with the name starting with `Sentry` will not generate events.
 
-</markdown></Alert>
+</Alert>
 
 ## Features
 
@@ -77,11 +77,11 @@ LogManager.Configuration
     });
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 The SDK needs to be initialized only once. If a `DSN` is made available to this integration, by default it **will** initialize the SDK. If you do not wish to initialize the SDK via this integration, set the `InitializeSdk` flag to **false**. Not providing a DSN or leaving it as `null` instructs the integration not to initialize the SDK and unless another integration initializes it or you call `SentrySdk.Init`, the SDK will stay disabled.
 
-</markdown></Alert>
+</Alert>
 
 ### Minimum log level
 

--- a/src/platforms/dotnet/guides/serilog/index.mdx
+++ b/src/platforms/dotnet/guides/serilog/index.mdx
@@ -19,11 +19,11 @@ dotnet add package Sentry.Serilog -v {{ packages.version('sentry.dotnet.serilog'
 
 This package extends `Sentry` main SDK. That means that besides the logging related features, through this package you'll also get access to all API and features available in the main `Sentry` SDK.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 Messages logged from assemblies with the name starting with `Sentry` will not generate events.
 
-</markdown></Alert>
+</Alert>
 
 ## Features
 
@@ -62,11 +62,11 @@ Log.Logger = new LoggerConfiguration()
   .CreateLogger();
 ```
 
-<Note><markdown>
+<Note>
 
 The SDK only needs to be initialized once. If a `DSN` is made available to this integration, by default it **will** initialize the SDK. If you do not wish to initialize the SDK via this integration, set the `InitializeSdk` flag to **false**. Not providing a DSN or leaving it as `null` instructs the integration not to initialize the SDK and unless another integration initializes it or you call `SentrySdk.Init`, the SDK will stay disabled.
 
-</markdown></Note>
+</Note>
 
 ### Options
 

--- a/src/platforms/dotnet/guides/wpf/index.mdx
+++ b/src/platforms/dotnet/guides/wpf/index.mdx
@@ -9,11 +9,11 @@ Sentry's .NET SDK works with Windows Presentation Foundation applications throug
 
 In addition to [initializing the SDK with `SentrySdk.Init`](/platforms/dotnet/), you must configure the WPF specific error handler.
 
-<Note><markdown>
+<Note>
 
 The SDK should be initialized in the constructor of your application class (usually `App.xaml.cs`). Do not initialize the SDK in the `OnStartup()` event of the application or the `Hub` will not be initialized correctly.
 
-</markdown></Note>
+</Note>
 
 The SDK automatically handles `AppDomain.UnhandledException`. On WPF, for production apps (when no debugger is attached), WPF catches exception to show the dialog to the user. You can also configure your app to capture those exceptions before the dialog shows up:
 

--- a/src/platforms/dotnet/index.mdx
+++ b/src/platforms/dotnet/index.mdx
@@ -21,11 +21,11 @@ Of those, we run our unit/integration tests against:
 - .NET Core 2.1 Windows, macOS and Linux
 - .NET Core 3.1 Windows, macOS and Linux
 
-<Alert level="info" title="Using an older version of .NET Framework or Mono?"><markdown>
+<Alert level="info" title="Using an older version of .NET Framework or Mono?">
 
 [Our legacy SDK](/clients/csharp/) supports .NET Framework as early as 3.5.
 
-</markdown></Alert>
+</Alert>
 
 ## Install
 

--- a/src/platforms/java/common/legacy/configuration/index.mdx
+++ b/src/platforms/java/common/legacy/configuration/index.mdx
@@ -4,10 +4,10 @@ sidebar_order: 10
 description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new Java SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Java SDK](/platforms/java/) for new projects.
-</markdown></Alert>
+</Alert>
 
 ## Setting the DSN (Data Source Name) {#setting-the-dsn}
 
@@ -252,11 +252,11 @@ If a buffer directory is provided, a background thread will periodically attempt
 buffer.flushtime=10000
 ```
 
-<Alert level="warning" title="Security Warning"><markdown>
+<Alert level="warning" title="Security Warning">
 
     The Java SDK currently uses the native Java serialization system to write out events to the filesystem when buffering is enabled. Due to weaknesses in the Java serialization system it is possible for users that have write access to the `buffer.dir` directory to cause the Java SDK to deserialize arbitrary Java classes. In extreme cases this might lead to the ability to execute code.
 
-</markdown></Alert>
+</Alert>
 
 #### Graceful Shutdown of Buffering (Advanced)
 

--- a/src/platforms/java/common/legacy/google-app-engine/index.mdx
+++ b/src/platforms/java/common/legacy/google-app-engine/index.mdx
@@ -3,10 +3,10 @@ title: Google App Engine
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 An [updated Java SDK](/platforms/java/) Java SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the updated Java SDK for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry-appengine` library provides [Google App Engine](https://cloud.google.com/appengine/) support for Sentry via the [Task Queue API](https://cloud.google.com/appengine/docs/java/taskqueue/).
 

--- a/src/platforms/java/common/legacy/log4j/index.mdx
+++ b/src/platforms/java/common/legacy/log4j/index.mdx
@@ -3,10 +3,10 @@ title: log4j 1.x
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 An [updated Java SDK](/platforms/java/) supersedes this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the updated Java SDK for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry-log4j` library provides [Log4j 1.x](https://logging.apache.org/log4j/1.2/) support for Sentry via an [Appender](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](/platforms/java/legacy/usage/), in order to do things like record breadcrumbs, set the current user, or manually send events.
 

--- a/src/platforms/java/common/legacy/log4j2/index.mdx
+++ b/src/platforms/java/common/legacy/log4j2/index.mdx
@@ -3,10 +3,10 @@ title: log4j 2.x
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 An [updated Java SDK](/platforms/java/) SDK supersedes this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the updated Java SDK for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry-log4j2` library provides [Log4j 2.x](https://logging.apache.org/log4j/2.x/) support for Sentry via an [Appender](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/Appender.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](/platforms/java/legacy/usage), in order to do things like record breadcrumbs, set the current user, or manually send events.
 

--- a/src/platforms/java/common/legacy/logback/index.mdx
+++ b/src/platforms/java/common/legacy/logback/index.mdx
@@ -3,10 +3,10 @@ title: Logback
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 A new Java SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Java SDK](/platforms/java/) for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry-logback` library provides [Logback](http://logback.qos.ch/) support for Sentry via an [Appender](http://logback.qos.ch/apidocs/ch/qos/logback/core/Appender.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](/platforms/java/legacy/usage), in order to do things like record breadcrumbs, set the current user, or manually send events.
 

--- a/src/platforms/java/common/legacy/logging/index.mdx
+++ b/src/platforms/java/common/legacy/logging/index.mdx
@@ -3,10 +3,10 @@ title: java.util.logging
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 An [updated Java SDK](/platforms/java/) supersedes this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the updated Java SDK for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry` library provides a [java.util.logging Handler](http://docs.oracle.com/javase/8/docs/api/java/util/logging/Handler.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](/platforms/java/legacy/usage), in order to do things like record breadcrumbs, set the current user, or manually send events.
 

--- a/src/platforms/java/common/legacy/spring/index.mdx
+++ b/src/platforms/java/common/legacy/spring/index.mdx
@@ -3,10 +3,10 @@ title: Spring
 sidebar_order: 30
 ---
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 An [updated Java SDK](/platforms/java/) supersedes this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the updated Java SDK for new projects.
-</markdown></Alert>
+</Alert>
 
 The `sentry-spring` library provides [Spring](https://spring.io/) support for Sentry via a [HandlerExceptionResolver](https://docs.spring.io/spring/docs/4.3.9.RELEASE/javadoc-api/org/springframework/web/servlet/HandlerExceptionResolver.html) that sends exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](/platforms/java/legacy/usage), in order to do things like record breadcrumbs, set the current user, or manually send events.
 

--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -8,11 +8,11 @@ The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/jav
 - automatically includes the release when [Spring Boot Git integration is configured](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-git-info)
 - automatically registering `BeforeSendCallback`, `BeforeBreadcrumbCallback`, `EventProcessor`, `Integration` beans
 
-<Note><markdown>
+<Note>
 
 We support Spring Boot 2.1.0 and above. Still on an older version? You can use [our legacy SDK](/platforms/java/legacy/spring/).
 
-</markdown></Note>
+</Note>
 
 For the best experience we recommend using Sentry Spring Boot integration with one of the logging framework integrations as they seamlessly work together:
 
@@ -207,9 +207,11 @@ Minimum logging levels for `SentryAppender` can be configured in `application.pr
 sentry.logging.minimum-event-level=info
 sentry.logging.minimum-breadcrumb-level=debug
 ```
+
 The default values are:
-* `info` or higher to include a log message as breadcrumb.
-* `error` or higher will send an event to Sentry.
+
+- `info` or higher to include a log message as breadcrumb.
+- `error` or higher will send an event to Sentry.
 
 When `SentryAppender` auto-configuration does not suit your needs, it can be turned off by setting:
 
@@ -234,13 +236,13 @@ If you decide to opt-out from `application.properties` based Spring Boot logging
 </configuration>
 ```
 
-<Note><markdown>
+<Note>
 
 There is no need to configure _DSN_ in Logback configuration file as Sentry gets configured via Spring Boot integration.
 
 However, if potential errors that appear during the startup are meant to be sent to Sentry, the _DSN_ must be provided to both Logback and Spring Boot configuration.
 
-</markdown></Note>
+</Note>
 
 ### Log4j2
 
@@ -264,10 +266,10 @@ To use Sentry Log4j2 integration in Spring Boot application, [follow the guide o
 </Configuration>
 ```
 
-<Note><markdown>
+<Note>
 
 There is no need to configure _DSN_ in Log4j2 configuration file as Sentry gets configured via Spring Boot integration.
 
 However, if potential errors that appear during the startup are meant to be sent to Sentry, the _DSN_ must be provided to both Log4j2 and Spring Boot configuration.
 
-</markdown></Note>
+</Note>

--- a/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
@@ -8,13 +8,13 @@ redirect_from:
 
 Sentry provides a proof-of-concept integration with [rrweb](https://www.rrweb.io/) - a toolkit for recording and replaying user sessions. This can be extremely helpful when diagnosing complex user behavior in a rich Single Page Application.
 
-<Note><markdown>
+<Note>
 
 For information about which hints are available see <PlatformLink to="/configuration/filtering/#using-hints">hints in JavaScript</PlatformLink>
 
 Replays utilize <PlatformLink to="/enriching-events/attachments/">Attachments</PlatformLink>.
 
-</markdown></Note>
+</Note>
 
 ![](rrweb.gif)
 
@@ -43,11 +43,11 @@ Sentry.init({
 });
 ```
 
-<Note><markdown>
+<Note>
 
 For more information on configuration, see the [@sentry/rrweb project on GitHub](https://github.com/getsentry/sentry-rrweb).
 
-</markdown></Note>
+</Note>
 
 Once a replay is captured with an event, you'll find it visible within Issue Details under the Replay section of the event.
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -27,11 +27,11 @@ To use Sentry's performance tracing an alternative bundle is needed. This allows
 ></script>
 ```
 
-<Note><markdown>
+<Note>
 
 You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring.
 
-</markdown></Note>
+</Note>
 
 The most important thing to note here is that `Sentry.Integrations` has been made available, and can be referenced in your call to `Sentry.init`:
 

--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -40,11 +40,11 @@ As explained, the Loader lazy loads and injects our SDK into your website, but
 
 Go into the Sentry web UI, view _Settings -> Projects -> Client Keys (DSN)_, then press the **Configure** button. From here, you can view the options to configure your DSN and select which SDK version the Loader should load.
 
-<Note><markdown>
+<Note>
 
 It can take a few minutes until the change is visible in the code, since it’s cached.
 
-</markdown></Note>
+</Note>
 
 ![JavaScript Loader Settings](js-loader-settings.png)
 

--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -84,7 +84,7 @@ Sentry.init({
 
 If either of these options is set, tracing will be enabled in your app. (They are meant to be mutually exclusive, but if you do set both, `tracesSampler` will take precedence.) You can learn more about how they work in <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 When you first enable tracing, the easiest thing to do to test it is to set `tracesSampleRate` to `1.0`, because that guarantees that every transaction will be sent to Sentry for you to see.
 
@@ -92,7 +92,7 @@ Once you're done with testing, however, we recommend that you either **lower you
 
 Without sampling, our atomatic instrumenation will send a transaction any time any user loads any page or navigates anywhere in your app. That's a lot of transactions! Sampling allows you to get representative data without overwhelming either your system or your Sentry transaction quota.
 
-</markdown></Alert>
+</Alert>
 
 ## Connecting Backend and Frontend Transactions
 

--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -11,11 +11,11 @@ description: "Learn more about the Sentry SDK's automatic fetching of source cod
 
 Sentry supports un-minifying JavaScript via source maps, which lets you view source code context obtained from stack traces in their original untransformed form. This is particularly useful for debugging minified code (for example, UglifyJS), or transpiled code from a higher-level language (such as TypeScript and ES6).
 
-<Note><markdown>
+<Note>
 
 Sentry will automatically fetch the source code and source maps by scraping the URLs within the stack trace. However, you may have legitimate reasons for [disabling the JavaScript source fetching in Sentry](https://blog.sentry.io/2018/07/17/source-code-fetching).
 
-</markdown></Note>
+</Note>
 
 ## Capturing Source Maps
 
@@ -26,7 +26,7 @@ Most modern JavaScript transpilers support source maps. Below you'll find our re
 - [UglifyJS](tools/uglifyjs/)
 - [SystemJS](tools/systemjs/)
 
-<PlatformSection notSupported={["javascript.angular"]}><markdown>
+<PlatformSection notSupported={["javascript.angular"]}>
 
 We recommend using [Sentry's Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) to configure source maps and upload them automatically during the build:
 
@@ -40,11 +40,11 @@ yarn add --dev @sentry/webpack-plugin
 
 Next you need to generate an access token for our API. Within your organization's settings, navigate to Developer Settings, [create a new internal integration](/product/integrations/integration-platform/#internal-integrations), and provide a name appropriate to your organization. **Important:** Select **Releases -> Admin** for Permissions.
 
-<Note><markdown>
+<Note>
 
 The Releases -> Admin permission is also known as 'project:releases' in other API documentation.
 
-</markdown></Note>
+</Note>
 
 You may configure [sentry-cli](/product/cli/configuration/) through it's documented mechanisms, or instead simply bind required parameters when initializing the plugin:
 
@@ -78,9 +78,9 @@ In Vue 2.x, you should use `vue.config.js` instead of `webpack.config.js`, and u
 
 Additional information can be found in our [Webpack documentation](tools/webpack/).
 
-</markdown></PlatformSection>
+</PlatformSection>
 
-<PlatformSection supported={["javascript.angular"]}><markdown>
+<PlatformSection supported={["javascript.angular"]}>
 
 SystemJS is the default module loader for Angular projects. The [SystemJS build tool](https://github.com/systemjs/builder) can be used to bundle, transpile, and minify source code for use in production environments, and can be configured to output source maps.
 
@@ -96,7 +96,7 @@ Additional information can be found in our [SystemJS documentation](tools/system
 
 From here, you can [upload your source maps](uploading/) to Sentry.
 
-</markdown></PlatformSection>
+</PlatformSection>
 
 ## Additional Resources
 

--- a/src/platforms/javascript/common/sourcemaps/multiple-origins.mdx
+++ b/src/platforms/javascript/common/sourcemaps/multiple-origins.mdx
@@ -20,8 +20,8 @@ You can upload using the URL of `~/js/app.js`. This will tell Sentry to ignore t
 
 Additionally you can also upload the same file under multiple names. Under the hood Sentry will deduplicate these.
 
-<Note><markdown>
+<Note>
 
 The ~ prefix tells Sentry that for a given URL, **any** combination of protocol and hostname whose path is `/js/app.js` should use this artifact. Use this method **only** if your source/source map files are identical at all possible protocol/hostname combinations. **Sentry will prioritize full URLs over tilde prefixed paths**, if found.
 
-</markdown></Note>
+</Note>

--- a/src/platforms/javascript/common/sourcemaps/tools/systemjs.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/systemjs.mdx
@@ -13,11 +13,11 @@ builder.bundle("src/app.js", "dist/app.min.js", {
 });
 ```
 
-<Note><markdown>
+<Note>
 
 The example configuration above will inline your original, un-transformed source code into the generated source map file. Sentry requires both source map(s) **and** your original source files to perform reverse transformations. If you choose NOT to inline your source files, you must make those source files available to Sentry in _addition_ to your source maps (see below).
 
-</markdown></Note>
+</Note>
 
 ## Next Steps
 

--- a/src/platforms/javascript/common/sourcemaps/tools/uglifyjs.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/uglifyjs.mdx
@@ -5,11 +5,11 @@ description: "UglifyJS is a popular tool for minifying your source code for prod
 
 UglifyJS is a popular tool for minifying your source code for production. It can dramatically reduce the size of your files by eliminating whitespace, rewriting variable names, removing dead code branches, and more.
 
-<Note><markdown>
+<Note>
 
 We strongly encourage you to use a higher level bundler (or transpiler) as UglifyJS configuration can get quite complicated to achieve the desired results.
 
-</markdown></Note>
+</Note>
 
 If you are using UglifyJS to minify your source code, the following command will additionally generate a source map that maps the minified code back to the original source:
 

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -45,11 +45,11 @@ In Vue 2.x, you should use `vue.config.js` instead of `webpack.config.js`, and u
 
 </PlatformSection>
 
-<Note><markdown>
+<Note>
 
 Set up the `SentryWebpackPlugin` as the last running plugin, otherwise, the resulting source maps the plugin receives may not be the final one.
 
-</markdown></Note>
+</Note>
 
 ## Advanced Usage
 

--- a/src/platforms/javascript/common/sourcemaps/uploading.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading.mdx
@@ -4,11 +4,11 @@ title: Uploading Source Maps
 
 We recommend uploading source maps as part of your build process, but you can also [serve them publicly alongside your source files](../hosting-publicly/).
 
-<Note><markdown>
+<Note>
 
 The recommended way to upload source maps is using [sentry-cli](/product/cli/). If you have used [_Sentry Wizard_](https://github.com/getsentry/sentry-wizard) to set up your project, it has already created all necessary configuration to upload source maps. Otherwise, follow the [CLI configuration docs](/product/cli/configuration/) to set up your project.
 
-</markdown></Note>
+</Note>
 
 You need to set up your build system to create a release and attach the various source files. For Sentry to de-minify your stack traces, you must provide both the minified files (for example, `app.min.js`) and the corresponding source maps. If the source map files do not contain your original source code (`sourcesContent`), you must also provide the original source files. (Alternatively, sentry-cli will automatically embed the sources (if missing) into your source maps if you pass the `--rewrite` flag.
 
@@ -18,21 +18,21 @@ Sentry uses [**Releases**](/product/releases/) to match the correct source maps 
 sentry-cli releases new <release_name>
 ```
 
-<Note><markdown>
+<Note>
 
 The release name must be **unique within your organization** and match the `release` option in your SDK initialization code. Then, use the `upload-sourcemaps` command to scan a folder for source maps, process them and upload them to Sentry.
 
-</markdown></Note>
+</Note>
 
 ```bash
 sentry-cli releases files <release_name> upload-sourcemaps /path/to/files
 ```
 
-<Note><markdown>
+<Note>
 
 You can find the artifacts uploaded to Sentry by navigating to **[Project] » Project Settings » Source Maps**.
 
-</markdown></Note>
+</Note>
 
 This command will upload all files ending in _.js_ and _.map_ to the specified release. If you wish to change these extensions – for example, to upload typescript sources – use the `--ext` option:
 

--- a/src/platforms/javascript/guides/cordova/ionic.mdx
+++ b/src/platforms/javascript/guides/cordova/ionic.mdx
@@ -11,11 +11,11 @@ First run `npm i --save sentry-cordova` and make sure you already added the plat
 
 After that it’s important to run `cordova plugin add sentry-cordova` without the ionic wrapper.
 
-<Alert level="warning" title="Warning"><markdown>
+<Alert level="warning" title="Warning">
 
 Do not run `ionic cordova plugin add sentry-cordova`. The ionic cli wrapper sucks up all the input and sentry-wizard will not be able to setup your project.
 
-</markdown></Alert>
+</Alert>
 
 When building your app with ionic for production make sure you have source maps enabled. You have to add this to your `package.json`:
 
@@ -33,11 +33,11 @@ ionic build --prod --source-map
 
 Otherwise we are not able to upload source maps to Sentry.
 
-<Alert level="warning" title="Warning"><markdown>
+<Alert level="warning" title="Warning">
 
 If you want to skip the automatic release version and set the release completely for yourself. You have to add this env var to disable it e.g.: `SENTRY_SKIP_AUTO_RELEASE=true ionic cordova emulate ios --prod`
 
-</markdown></Alert>
+</Alert>
 
 To setup Sentry in your codebase, add this to your `app.module.ts`:
 

--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -146,11 +146,11 @@ node sentry-symbols.js
 
 If your app uses a custom Electron fork, contains modules with native extensions or spawns subprocesses, you have to upload those symbols manually using Sentry CLI. For more information, see [_Native Usage_](/platforms/electron/).
 
-<Alert level="warning" title="Known Issue"><markdown>
+<Alert level="warning" title="Known Issue">
 
 It is currently not possible to send events from native code (such as a C++ extension). However, crashes will still be reported to Sentry if they happen in a process where the SDK has been configured. Also, crash reports from sub processes will not be reported automatically on all platforms. This feature will be added in a future SDK update.
 
-</markdown></Alert>
+</Alert>
 
 ## Dealing with Minified Source Code
 
@@ -162,11 +162,11 @@ Sentry can process Minidumps created when the Electron process or one of its ren
 
 Due to restrictions of macOS app sandboxing, native crashes cannot be collected in Mac App Store builds. In this case, native crash handling will be disabled, regardless of the `enableNative` setting.
 
-<Alert level="warning" title="A Word on Data Privacy"><markdown>
+<Alert level="warning" title="A Word on Data Privacy">
 
 Minidumps are memory dumps of the process at the moment it crashes. As such, they might contain sensitive information on the target system, such as environment variables, local path names or maybe even in-memory representations of input fields including passwords. **Sentry does not store these memory dumps**. Once processed, they are removed immediately and all sensitive information is stripped from the resulting issues.
 
-</markdown></Alert>
+</Alert>
 
 ### Providing Debug Information
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -15,11 +15,11 @@ npm install --save @sentry/gatsby
 yarn add @sentry/gatsby
 ```
 
-<Note><markdown>
+<Note>
 
 `@sentry/gatsby` is a wrapper around the `@sentry/react` package, with added functionality related to Gatsby. All methods available in the `@sentry/react` package can also be imported from `@sentry/gatsby`.
 
-</markdown></Note>
+</Note>
 
 ## Connecting the SDK to Sentry
 

--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -23,11 +23,11 @@ import * as Sentry from "@sentry/react";
 Sentry.withErrorBoundary(Example, { fallback: "an error has occured" });
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 In development mode, React will rethrow errors caught within an error boundary. This will result in errors being reported twice to Sentry with the above setup, but this won’t occur in your production build.
 
-</markdown></Alert>
+</Alert>
 
 In the example below, when the `<Example />` component hits an error, the `<Sentry.ErrorBoundary>` component will send data about that error and the component tree to Sentry, open a user feedback dialog, and render a fallback UI.
 

--- a/src/platforms/javascript/guides/react/components/profiler.mdx
+++ b/src/platforms/javascript/guides/react/components/profiler.mdx
@@ -40,11 +40,10 @@ The React Profiler currently generates spans with three different kinds of op-co
 : The span that represents when the profiled component updated. This span is only generated if the profiled component has mounted.
 
 <Alert>
-  <markdown>
+
 
     In [React Strict Mode](https://reactjs.org/docs/strict-mode.html), certain component methods will be [invoked twice](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects). This may lead to duplicate `react.mount` spans appearing in a transaction. React Strict Mode only runs in development mode, so this will have no impact on your production traces.
 
-  </markdown>
 </Alert>
 
 ## Profiler Options

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -8,11 +8,11 @@ _(New in version 5.21.0)_
 
 React Router support is included in the `@sentry/react` package since version `5.21.0`.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 The React Router integration is designed to work with our Tracing SDK, `@sentry/tracing`. Please see [Getting Started with React Performance](/product/performance/getting-started/?platform=react) for more details on how to set up and install the SDK.
 
-</markdown></Alert>
+</Alert>
 
 We support integrations for React Router 3, 4 and 5.
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
@@ -30,11 +30,11 @@ const store = createStore(
 );
 ```
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 Sentry uses a redux **enhancer**. Pass the enhancer, as indicated above. Don't pass it to `applyMiddleware` and don't call the method when you pass it to the `createStore` method.
 
-</markdown></Alert>
+</Alert>
 
 ## Normalization Depth
 
@@ -51,11 +51,11 @@ Sentry.init({
 
 Pass an options object as the first parameter to `Sentry.createReduxEnhancer` to configure it.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 We advise against sending sensitive information to Sentry, but if you do, we will try our best to filter out things such as user passwords.
 
-</markdown></Alert>
+</Alert>
 
 `actionTransformer` (Function)
 

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -9,11 +9,11 @@ redirect_from:
 
 On this page, we provide concise information to get you up and running with Sentry's React SDK, automatically reporting errors and exceptions in your application.
 
-<Note><markdown>
+<Note>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown></Note>
+</Note>
 
 ## Install
 

--- a/src/platforms/javascript/guides/vue/index.mdx
+++ b/src/platforms/javascript/guides/vue/index.mdx
@@ -39,12 +39,12 @@ Additionally, `Integrations.Vue` accepts a few different configuration options t
 - Passing in `attachProps` is optional and is `true` if it is not provided. If you set it to `false`, Sentry will suppress sending all Vue components' props for logging.
 - Passing in `logErrors` is optional and is `false` if it is not provided. If you set it to `true`, Sentry will call original Vue's `logError` function as well.
 
-<Alert level="warning" title="Vue Error Handling"><markdown>
+<Alert level="warning" title="Vue Error Handling">
 
 Please note that if you enable this integration, Vue will not call its `logError` internally. This means that errors occurring in the Vue renderer will not show up in the developer console.
 If you want to preserve this functionality, make sure to pass the `logErrors: true` option.
 
-</markdown></Alert>
+</Alert>
 
 In case you are using the CDN version or the Loader, we provide a standalone file for every integration, you can use it
 like this:

--- a/src/platforms/native/advanced-config.mdx
+++ b/src/platforms/native/advanced-config.mdx
@@ -101,7 +101,7 @@ into a readable crash report.
 For more information on Minidumps and the limits that apply, see
 [What is a Minidump](/platforms/native/guides/minidumps/#what-is-a-minidump).
 
-<Alert level="warning" title="Size Limits"><markdown>
+<Alert level="warning" title="Size Limits">
 
 The size of Minidumps can vary between a few kilobytes and many megabytes.
 Contributing factors are the number of threads, size of stack space, and the
@@ -110,4 +110,4 @@ contain large regions of empty memory, the SDK compresses Minidumps before
 uploading. Sentry drops requests with a body larger than _20MB_, or if they
 contain files larger than _100MB_.
 
-</markdown></Alert>
+</Alert>

--- a/src/platforms/native/context.mdx
+++ b/src/platforms/native/context.mdx
@@ -30,13 +30,13 @@ components:
 
 : Arbitrary unstructured data which the Sentry SDK stores with an event sample.
 
-<Alert level="warning" title="Context Size Limits"><markdown>
+<Alert level="warning" title="Context Size Limits">
 
 Sentry will try its best to accommodate the data you send it, but large context
 payloads will be trimmed or may be truncated entirely. For more details see the
 [data handling SDK documentation](https://develop.sentry.dev/sdk/data-handling/)
 
-</markdown></Alert>
+</Alert>
 
 Context information is attached to every event until explicitly removed or
 overwritten.

--- a/src/platforms/native/filter-events.mdx
+++ b/src/platforms/native/filter-events.mdx
@@ -34,10 +34,10 @@ For more information, see:
 - [Manage Your Flow of Errors Using Inbound
   Filters](https://blog.sentry.io/2017/11/27/setting-up-inbound-filters).
 
-<Alert level="warning" title="Crashpad Notice"><markdown>
+<Alert level="warning" title="Crashpad Notice">
 
 The Crashpad Backend sends Minidumps with an additional event payload
 out-of-process. `before_send` hooks are not invoked when capturing crashes
 using Crashpad.
 
-</markdown></Alert>
+</Alert>

--- a/src/platforms/native/guides/minidumps/index.mdx
+++ b/src/platforms/native/guides/minidumps/index.mdx
@@ -41,7 +41,7 @@ and can later be uploaded to Sentry. A minidump typically includes:
   assertion message is also included in the dump.
 - Meta data about the CPU architecture and the user’s operating system.
 
-<Alert level="" title="A Word on Data Privacy"><markdown>
+<Alert level="" title="A Word on Data Privacy">
 
 Minidumps are memory dumps of the process at the moment it crashes. As such,
 they might contain sensitive information on the target system, such as
@@ -50,7 +50,7 @@ of input fields, including passwords. **Sentry does not store these memory
 dumps**. Once processed, they are removed immediately, and all sensitive
 information is stripped from the resulting issues.
 
-</markdown></Alert>
+</Alert>
 
 In addition to this information, you can add further metadata specific to
 Sentry, which can help in organizing and analyzing issues. For more information,

--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -73,12 +73,12 @@ CrashReportClientVersion=1.0
 DataRouterUrl="___UNREAL_URL___"
 ```
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 If a `[CrashReportClient]` section already exists, simply changing the value of `DataRouterUrl`
 is enough.
 
-</markdown></Alert>
+</Alert>
 
 ## Upload Debug Symbols {#upload-debug-symbols}
 

--- a/src/platforms/native/index.mdx
+++ b/src/platforms/native/index.mdx
@@ -69,13 +69,13 @@ int main(void) {
 }
 ```
 
-<Alert level="warning" title="Warning"><markdown>
+<Alert level="warning" title="Warning">
 
 Calling `sentry_shutdown()` before exiting the application is critical. It
 ensures that events can be sent to Sentry before execution stops. Otherwise,
 event data may be lost.
 
-</markdown></Alert>
+</Alert>
 
 Alternatively, the DSN can be passed as `SENTRY_DSN` environment variable during
 runtime. This can be especially useful for server applications.

--- a/src/platforms/node/common/sourcemaps.mdx
+++ b/src/platforms/node/common/sourcemaps.mdx
@@ -37,11 +37,11 @@ module.exports = {
 };
 ```
 
-<Alert level="warning" title="source-map-support"><markdown>
+<Alert level="warning" title="source-map-support">
 
 If you want to rely on Sentry's source map resolution, make sure that your code is not using the [source-map-support](https://www.npmjs.com/package/source-map-support) package, as it overwrites the captured stack trace in a way that makes it impossible for our processors to correctly parse it.
 
-</markdown></Alert>
+</Alert>
 
 ## Making Source Maps Available to Sentry
 
@@ -84,11 +84,11 @@ Sentry.init({
 });
 ```
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 You don't _have_ to use _RELEASE_ environment variables. You can provide them in any way you want, just make sure that `release` from your upload **matches** `release` from your `init` call.
 
-</markdown></Alert>
+</Alert>
 
 Additional information can be found in the [Releases API documentation](/api/releases/).
 

--- a/src/platforms/node/index.mdx
+++ b/src/platforms/node/index.mdx
@@ -4,11 +4,11 @@ title: Node.js
 
 On this page, we provide concise information to get you up and running with Sentry's Node SDK, automatically reporting errors and exceptions in your application.
 
-<Note><markdown>
+<Note>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown></Note>
+</Note>
 
 Take a look at our specific guides to get started.
 

--- a/src/platforms/perl/index.mdx
+++ b/src/platforms/perl/index.mdx
@@ -3,11 +3,11 @@ redirect_from:
   - /clients/perl/
 ---
 
-<Alert level="warning" title="Support"><markdown>
+<Alert level="warning" title="Support">
 
 The Perl SDK is maintained and supported by the Sentry community. Learn more about the project on [GitHub](https://github.com/rentrak/perl-raven).
 
-</markdown></Alert>
+</Alert>
 
 ## Installation
 

--- a/src/platforms/php/common/configuration/transports.mdx
+++ b/src/platforms/php/common/configuration/transports.mdx
@@ -73,11 +73,11 @@ $builder->setTransportFactory($transportFactory);
 Hub::getCurrent()->bindClient($builder->getClient());
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 `Hub::getCurrent()->bindClient($builder->getClient());` is required to make the global function calls to use your new `Client` instead.
 
-</markdown></Alert>
+</Alert>
 
 ##### HttpTransport
 
@@ -132,11 +132,11 @@ $builder->setTransportFactory($transportFactory);
 Hub::getCurrent()->bindClient($builder->getClient());
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 `Hub::getCurrent()->bindClient($builder->getClient());` is required to make the global function calls to use your new `Client` instead.
 
-</markdown></Alert>
+</Alert>
 
 ##### SpoolTransport
 
@@ -176,8 +176,8 @@ Hub::getCurrent()->bindClient($builder->getClient());
 $spool->flushQueue($httpTransport);
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 `Hub::getCurrent()->bindClient($builder->getClient());` is required to make the global function calls to use your new `Client` instead.
 
-</markdown></Alert>
+</Alert>

--- a/src/platforms/php/guides/laravel/configuration/other-versions/laravel4.mdx
+++ b/src/platforms/php/guides/laravel/configuration/other-versions/laravel4.mdx
@@ -4,11 +4,11 @@ title: Laravel 4.x
 
 Install the `sentry/sentry-laravel` package:
 
-<Note><markdown>
+<Note>
 
 Laravel 4.x is supported until version 0.8.x of the `sentry/sentry-laravel` package.
 
-</markdown></Note>
+</Note>
 
 ```shell
 composer require sentry/sentry-laravel

--- a/src/platforms/php/guides/laravel/usage/index.mdx
+++ b/src/platforms/php/guides/laravel/usage/index.mdx
@@ -88,11 +88,11 @@ class SentryContext
 
 ### Log Channels
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 If you're using log channels to log your exceptions and are also logging exceptions to Sentry in your exception handler (as you would have configured above) exceptions might end up twice in Sentry.
 
-</markdown></Alert>
+</Alert>
 
 Starting with Laravel & Lumen 5.6 we can setup Sentry using log channels.
 
@@ -239,11 +239,11 @@ If you followed the regular installation instructions above (you should), make s
 
 The namespace `\App\Support` can be anything you want in the examples above.
 
-<Alert level="warning" title="Note"><markdown>
+<Alert level="warning" title="Note">
 
 If you're on Laravel 5.5+ the Sentry package is probably auto-discovered by Laravel. To solve this, add or append to the `extra` section in your `composer.json` file and run composer update/install afterward.
 
-</markdown></Alert>
+</Alert>
 
 ```json
 "extra": {

--- a/src/platforms/php/index.mdx
+++ b/src/platforms/php/index.mdx
@@ -6,11 +6,11 @@ redirect_from:
 
 On this page, we get you up and running with Sentry's PHP SDK, automatically reporting errors and exceptions in your application.
 
-<Note><markdown>
+<Note>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown></Note>
+</Note>
 
 Using a framework? Take a look at our specific guides to get started.
 

--- a/src/platforms/python/common/troubleshooting.mdx
+++ b/src/platforms/python/common/troubleshooting.mdx
@@ -115,7 +115,7 @@ be fixed from within the SDK.
 This [issue has been fixed with gevent 20.5](https://github.com/gevent/gevent/issues/1407) but continues to be one for
 eventlet.
 
-<PlatformSection supported={["python.django"]}><markdown>
+<PlatformSection supported={["python.django"]}>
 
 ## Django Channels
 
@@ -123,4 +123,4 @@ A Django application using Channels 2.0 will be correctly instrumented under Pyt
 
 If you experience memory leaks in your channels' consumers while using the SDK, you need to wrap your entire application in [Sentry's ASGI middleware](/platforms/python/guides/asgi/). Unfortunately the SDK is not able to do so by itself, as [Channels is missing some hooks for instrumentation](https://github.com/django/channels/issues/1348).
 
-</markdown></PlatformSection>
+</PlatformSection>

--- a/src/platforms/python/guides/aws-lambda/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/index.mdx
@@ -34,11 +34,11 @@ def my_function(event, context):
 
 Check out Sentry's [AWS sample apps](https://github.com/getsentry/examples/tree/master/aws-lambda/python) for detailed examples.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.
 
-</markdown></Alert>
+</Alert>
 
 ## Timeout Warning
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -25,11 +25,10 @@ The integration will automatically report errors from all celery jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-
-<Alert level="info" title="Note on distributed tracing"><markdown>
+<Alert level="info" title="Note on distributed tracing">
 
 Sentry uses custom message headers for distributed tracing. Since Celery version 4.0, for [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken and Celery fails to propagate custom headers to the worker. Protocol version 2, which is default since Celery version 4.0, is not affected.
 
 Fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) and hopefully will be included in the upcoming release.
 
-</markdown></Alert>
+</Alert>

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -35,11 +35,11 @@ def http_function_entrypoint(request):
 
 Check out Sentry's [GCP sample apps](https://github.com/getsentry/examples/tree/master/gcp-cloud-functions) for detailed examples.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.
 
-</markdown></Alert>
+</Alert>
 
 ### Timeout Warning
 

--- a/src/platforms/python/guides/logging/index.mdx
+++ b/src/platforms/python/guides/logging/index.mdx
@@ -69,11 +69,11 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
 
 - `event_level` (default `ERROR`): The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events. If a value of `None` occurs, the SDK won't send log records as events.
 
-<Alert level="info" title="Note"><markdown>
+<Alert level="info" title="Note">
 
 The Sentry Python SDK will honor the configured level of each logger. That means that you will not see any `INFO` events from a logger with the level set to `WARNING`, regardless of how you configure the integration.
 
-</markdown></Alert>
+</Alert>
 
 ## Handler classes
 

--- a/src/platforms/react-native/codepush.mdx
+++ b/src/platforms/react-native/codepush.mdx
@@ -17,11 +17,12 @@ Sentry.init({
 ```
 
 If you need to use `codePush.getUpdateMetadata`, you will have to wait to initialize the Sentry SDK until the Promise is resolved.
-<Alert level="warning" title="Warning"><markdown>
+
+<Note>
 
 This method is not recommended as any errors or crashes that happen before the initialization of the Sentry SDK will not be caught.
 
-</markdown></Alert>
+</Note>
 
 ```javascript
 import codePush from "react-native-code-push";

--- a/src/platforms/react-native/index.mdx
+++ b/src/platforms/react-native/index.mdx
@@ -5,22 +5,22 @@ redirect_from:
 
 On this page, we get you up and running with Sentry's React Native SDK, automatically reporting errors and exceptions in your application.
 
-<Note><markdown>
+<Note>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown></Note>
+</Note>
 
 ## Install
 
 Sentry captures data by using an SDK within your application’s runtime. These are platform-specific and allow Sentry to have a deep understanding of how your application works.
 
-<Alert level="warning" title="Note"><markdown>
+<Note>
 
 If you are using `expo-cli` you need to use another SDK see: [https://docs.expo.io/versions/latest/guides/using-sentry/](https://docs.expo.io/versions/latest/guides/using-sentry/)
 This SDK only works for ejected projects or projects that directly use React Native.
 
-</markdown></Alert>
+</Note>
 
 Add the `@sentry/react-native` dependency:
 

--- a/src/platforms/react-native/touchevents.mdx
+++ b/src/platforms/react-native/touchevents.mdx
@@ -40,11 +40,11 @@ export default AppRegistry.registerComponent("Your Amazing App", () =>
 );
 ```
 
-<Alert level="warning" title="Multiple Boundaries"><markdown>
+<Alert level="warning" title="Multiple Boundaries">
 
 While you can track specific sections of your app by wrapping each section with the boundary, do not nest them or the touches could be tracked multiple times along with possible undefined behavior.
 
-</markdown></Alert>
+</Alert>
 
 ## How Touches are Tracked Automatically
 
@@ -132,8 +132,8 @@ module.exports = {
 };
 ```
 
-<Alert level="warning" title="Note"><markdown>
+<Note>
 
 As this applies to **all** class and function names — not just React components — this could increase your JS bundle size.
 
-</markdown></Alert>
+</Note>

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -5,11 +5,11 @@ redirect_from:
 
 On this page, we get you up and running with Sentry's Rust SDK.
 
-<Note><markdown>
+<Note>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</markdown></Note>
+</Note>
 
 Using a framework? Take a look at our specific guides to get started.
 


### PR DESCRIPTION
Unclear where we received the idea that this was required, but it seems to no-op and pass through the tag.