### PR TITLE
Add: front matter descriptions to Guides

### DIFF
--- a/src/docs/product/sentry-basics/guides/integrate-backend/capturing-errors.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-backend/capturing-errors.mdx
@@ -2,6 +2,7 @@
 title: Capturing Errors
 redirect_from:
   - /guides/integrate-backend/capturing-errors/
+description: "Learn more about capturing errors with Sentry."
 ---
 
 Once initialized in your code, the Sentry SDK will capture various types of events and notify you about them in real-time, depending on the alert rules you've configured. With the Django app already running on your [localhost](http://localhost:8000/), let's try them out.

--- a/src/docs/product/sentry-basics/guides/integrate-backend/configuration-options.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-backend/configuration-options.mdx
@@ -2,6 +2,7 @@
 title: Configuration Options
 redirect_from:
   - /guides/integrate-backend/configuration-options/
+description: "Learn about Sentry's various configuration options to help enhance SDK functionality."
 ---
 
 Sentry has various configuration options to help enhance the SDK functionality. The options can help provide additional data needed to debug issues even faster or help control what is sent to Sentry by filtering. For more information, see [Configuration](/platforms/python/guides/django/configuration/).

--- a/src/docs/product/sentry-basics/guides/integrate-backend/getting-started.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-backend/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 redirect_from:
   - /guides/integrate-backend/getting-started/
-description: "Learn more about importing the backend app source code into your local development environment, adding the Sentry SDK, and initializing it"
+description: "Learn more about importing the backend app source code into your local development environment, adding the Sentry SDK, and initializing it."
 ---
 
 In this tutorial, you will import the backend app source code into your local development environment, add the Sentry SDK, and initialize it.

--- a/src/docs/product/sentry-basics/guides/integrate-backend/getting-started.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-backend/getting-started.mdx
@@ -2,6 +2,7 @@
 title: Getting Started
 redirect_from:
   - /guides/integrate-backend/getting-started/
+description: "Learn more about importing the backend app source code into your local development environment, adding the Sentry SDK, and initializing it"
 ---
 
 In this tutorial, you will import the backend app source code into your local development environment, add the Sentry SDK, and initialize it.

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/configure-scms.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/configure-scms.mdx
@@ -2,6 +2,7 @@
 title: Enable Suspect Commits
 redirect_from:
   - /guides/integrate-frontend/configure-scms/
+description: "Learn more about how Sentry uses commit metadata from your source code repositories to help you resolve your issues faster."
 ---
 
 Sentry uses commit metadata from your source code repositories to help you resolve your issues faster. This is done by suggesting **Suspect Commits** that might have introduced an error right in your issue details page. It also allows Sentry to display **Suggested Assignees** - the list of authors of those commits and suggest their assignment to resolve the issue.

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/create-new-project.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/create-new-project.mdx
@@ -2,6 +2,7 @@
 title: Create a Sentry Project
 redirect_from:
   - /guides/integrate-frontend/create-new-project/
+description: "Learn more about creating a Sentry Project and how they allow you to scope events to a distinct application in your organization and assign responsibility and ownership to specific users and teams within your organization."
 ---
 
 In this tutorial, you create a new `Project` in your Sentry account. Projects allow you to scope events to a distinct application in your organization and assign responsibility and ownership to specific users and teams within your organization. You can create a project for a particular language or framework used in your application. For example, you might have separate projects for your API server and frontend client. For more information see [Best Practices for Creating Projects](/product/sentry-basics/guides/getting-started/#4-create-projects)

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/generate-first-error.mdx
@@ -2,6 +2,7 @@
 title: Capture Your First Error
 redirect_from:
   - /guides/integrate-frontend/generate-first-error/
+description: "Learn more about capturing your first error."
 ---
 
 Now that the Demo App is up and running on your local environment integrated with the Sentry SDK, you're ready to generate the first error.

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/initialize-sentry-sdk.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/initialize-sentry-sdk.mdx
@@ -2,6 +2,7 @@
 title: Introduce Sentry SDK to your Frontend Code
 redirect_from:
   - /guides/integrate-frontend/initialize-sentry-sdk/
+description: "Learn more about integrating the Sentry SDK to your frontend codebase."
 ---
 
 In this tutorial, you import the React demo code into your local development environment, add the Sentry SDK, and initialize it.

--- a/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
+++ b/src/docs/product/sentry-basics/guides/integrate-frontend/upload-source-maps.mdx
@@ -2,6 +2,7 @@
 title: Enable Readable Stack Traces in your Errors
 redirect_from:
   - /guides/integrate-frontend/upload-source-maps/
+description: "Learn more about enabling readable stack traces in your errors."
 ---
 
 A `release version` is a dynamic identifier that changes whenever you ship a new version of your code. When you give Sentry information about your releases, you unlock several features, including source mapping of minified JavaScript stack traces upon ingestion. For more information, see [Releases](/product/releases/).


### PR DESCRIPTION
A few docs in the Guides section of Product needed descriptions in the front matter.