### PR TITLE
Correct 'occurred' typo in code example

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -9,7 +9,7 @@ The React SDK exports an error boundary component that leverages [React componen
 import React from "react";
 import * as Sentry from "@sentry/react";
 
-<Sentry.ErrorBoundary fallback={"An error has occured"}>
+<Sentry.ErrorBoundary fallback={"An error has occurred"}>
   <Example />
 </Sentry.ErrorBoundary>;
 ```
@@ -20,7 +20,7 @@ The Sentry Error Boundary is also available as a higher order component.
 import React from "react";
 import * as Sentry from "@sentry/react";
 
-Sentry.withErrorBoundary(Example, { fallback: "an error has occured" });
+Sentry.withErrorBoundary(Example, { fallback: "an error has occurred" });
 ```
 
 <Alert level="warning" title="Note">


### PR DESCRIPTION
Believe 'occured' should be: 'occurred'