### PR TITLE
fix(workflow): Fix sed command for linux

### DIFF
--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Bump latest SHA
         run: |
-        sed -i -e 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
+          sed -i -e 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
 
       - name: Git Commit & Push
         run: |

--- a/.github/workflows/bump-openapi.yml
+++ b/.github/workflows/bump-openapi.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Bump latest SHA
         run: |
-          sed -i "" 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' sentry-docs/src/gatsby/utils/resolveOpenAPI.ts
+        sed -i -e 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "${{ github.event.inputs.sentry-api-schema-sha }}"|g' src/gatsby/utils/resolveOpenAPI.ts
 
       - name: Git Commit & Push
         run: |


### PR DESCRIPTION
## Objective
sed on macos and linux are slightly different. 
There is an issue of sed on linux not being able to read the file path https://github.com/getsentry/sentry-docs/runs/1300790572?check_suite_focus=true

But I am not able to replicate this on MacOs. I think this should fix the issue.