### PR TITLE
feat(tracing): Add python includes for transaction sampling

### DIFF
--- a/src/includes/performance/always-inherit-sampling-decision/python.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/python.mdx
@@ -1,0 +1,9 @@
+```python
+def traces_sampler(sampling_context):
+    # always inherit
+    if sampling_context["parent_sampled"] is not None:
+        return sampling_context["parent_sampled"]
+
+    ...
+    # rest of sampling logic here
+```

--- a/src/includes/performance/custom-sampling-context/python.mdx
+++ b/src/includes/performance/custom-sampling-context/python.mdx
@@ -1,0 +1,20 @@
+```python
+sentry_sdk.start_transaction(
+    # kwargs passed to Transaction constructor - will be recorded on transaction
+    name="GET /search",
+    op="search",
+    data={
+      "query_params": {
+        "animal": "dog",
+        "type": "very good"
+      }
+    },
+    # `custom_sampling_context` - won't be recorded
+    custom_sampling_context={
+        # PII
+        "user_id": "12312012",
+        # too big to send
+        "search_results": { ... }
+    }
+);
+```

--- a/src/includes/performance/default-sampling-context/python.mdx
+++ b/src/includes/performance/default-sampling-context/python.mdx
@@ -1,0 +1,12 @@
+For Python-based SDKs, it includes at least the following:
+
+```python
+{
+  "transaction_context": {
+    "name": string  # human-readable identifier, like "GET /users"
+    "op": string  # short description of transaction type, like "pageload"
+  },
+  "parent_sampled": bool  # if this transaction has a parent, its sampling decision
+  ...  # custom context as passed to `start_transaction`
+}
+```

--- a/src/includes/performance/dynamic-sampling-function-intro/python.mdx
+++ b/src/includes/performance/dynamic-sampling-function-intro/python.mdx
@@ -1,0 +1,5 @@
+To sample dynamically, set the <PlatformIdentifier name="traces-sampler" /> option in your `sentry-sdk.init()` to a function that will accept a <PlatformIdentifier name="sampling-context" /> dictionary and return a sample rate between 0 and 1. For example:
+
+<PlatformContent includePath="performance/traces-sampler-as-sampler" />
+
+For convenience, the function can also return a boolean. Returning `True` is equivalent to returning `1`, and will guarantee the transaction will be sent to Sentry. Returning `False` is equivalent to returning `0` and will guarantee the transaction will **not** be sent to Sentry.

--- a/src/includes/performance/force-sampling-decision/python.mdx
+++ b/src/includes/performance/force-sampling-decision/python.mdx
@@ -1,0 +1,6 @@
+```python
+sentry_sdk.start_transaction(
+  name="GET /search",
+  sampled=True
+);
+```

--- a/src/includes/performance/traces-sample-rate/python.mdx
+++ b/src/includes/performance/traces-sample-rate/python.mdx
@@ -1,0 +1,7 @@
+```python
+sentry_sdk.init(
+    # ...
+
+    traces_sample_rate=0.2,
+)
+```

--- a/src/includes/performance/traces-sampler-as-filter/python.mdx
+++ b/src/includes/performance/traces-sampler-as-filter/python.mdx
@@ -1,0 +1,15 @@
+```python
+def traces_sampler(sampling_context):
+    if "...":
+        # Drop this transaction, by setting its sample rate to 0%
+        return 0
+    else:
+        # Default sample rate for all others (replaces traces_sample_rate)
+        return 0.1
+
+sentry_sdk.init(
+    # ...
+
+    traces_sampler=traces_sampler,
+)
+```

--- a/src/includes/performance/traces-sampler-as-sampler/python.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/python.mdx
@@ -1,0 +1,21 @@
+```python
+def traces_sampler(sampling_context):
+    if "...":
+        # These are important - take a big sample
+        0.5
+    elif "...":
+        # These are less important or happen much more frequently - only take 1% of them
+        0.01
+    elif "...":
+        # These aren't something worth tracking - drop all transactions like this
+        0
+    else:
+        # Default sample rate
+        0.1
+
+sentry_sdk.init(
+    # ...
+
+    traces_sampler=traces_sampler,
+)
+```

--- a/src/includes/performance/traces-sampler-as-sampler/python.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/python.mdx
@@ -1,10 +1,14 @@
 ```python
 def traces_sampler(sampling_context):
+    # Examine provided context data (including parent decision, if any)
+    # along with anything in the global namespace to compute the sample rate
+    # or sampling decision for this transaction
+
     if "...":
         # These are important - take a big sample
         0.5
     elif "...":
-        # These are less important or happen much more frequently - only take 1% of them
+        # These are less important or happen much more frequently - only take 1%
         0.01
     elif "...":
         # These aren't something worth tracking - drop all transactions like this

--- a/src/includes/performance/uniform-sample-rate/python.mdx
+++ b/src/includes/performance/uniform-sample-rate/python.mdx
@@ -1,0 +1,3 @@
+To do this, set the <PlatformIdentifier name="traces-sample-rate" /> option in your `sentry_sdk.init()` to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. (So, for example, if you set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`, approximately 20% of your transactions will get recorded and sent.) That looks like this:
+
+<PlatformContent includePath="performance/traces-sample-rate" />

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -93,7 +93,7 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 **Note:** The error sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-<PlatformSection supported={["javascript", "node"]} notSupported={["react-native"]}>
+<PlatformSection supported={["javascript", "node", "python"]} notSupported={["react-native"]}>
 
 ## Filtering Transaction Events
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -217,7 +217,7 @@ A number between 0 and 1, controlling the percentage chance a given transaction 
 
 </ConfigKey>
 
-<ConfigKey name="tracesSampler" supported={["node", "javascript", "php"]}>
+<ConfigKey name="tracesSampler" supported={["node", "javascript", "python", "php"]}>
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
 

--- a/src/platforms/common/performance/sampling.mdx
+++ b/src/platforms/common/performance/sampling.mdx
@@ -6,6 +6,7 @@ description: "Learn how to configure the volume of transactions sent to Sentry."
 supported:
   - javascript
   - node
+  - python
 ---
 
 You can control the volume of transactions sent to Sentry in two ways.


### PR DESCRIPTION
This add includes for both the filtering config page and the performance/sampling page for Python, and adds Python to the list of supported platforms for the latter, so that it will show up in the Python docs.