### PR TITLE
Initial refactor

### DIFF
--- a/src/includes/getting-started-install/java.log4j2.mdx
+++ b/src/includes/getting-started-install/java.log4j2.mdx
@@ -1,0 +1,17 @@
+```xml {tabTitle:Maven}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-log4j2</artifactId>
+    <version>{{ packages.version('sentry.java', '3.1.1') }}</version>
+</dependency>
+```
+
+```groovy {tabTitle:Gradle}
+implementation 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '3.1.1') }}'
+```
+
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-log4j2" % "{{ packages.version('sentry.java', '3.1.1') }}"
+```
+
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-log4j2).

--- a/src/includes/getting-started-primer/java.log4j2.mdx
+++ b/src/includes/getting-started-primer/java.log4j2.mdx
@@ -1,0 +1,3 @@
+_The `sentry-log4j2` library provides [Log4j 2.x](https://logging.apache.org/log4j/2.x/) support for Sentry via an [Appender](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/Appender.html) that sends logged exceptions to Sentry._
+
+Once the integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), in order to do things like record breadcrumbs, set the current user, or manually send events. The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-log4j2).

--- a/src/platforms/java/guides/log4j2/config.yml
+++ b/src/platforms/java/guides/log4j2/config.yml
@@ -1,0 +1,6 @@
+title: Log4j 2.x
+caseStyle: canonical
+supportLevel: production
+sdk: sentry.java.log4j2
+redirect_from:
+  - /clients/java/modules/log4j2/

--- a/src/platforms/java/guides/log4j2/configuration/example_configuration.mdx
+++ b/src/platforms/java/guides/log4j2/configuration/example_configuration.mdx
@@ -1,36 +1,16 @@
 ---
-title: log4j 2.x
-redirect_from:
-  - /clients/java/modules/log4j2/
+title: Example Configuration
+sidebar_order: 6
+description: "Review an example of configuring the integration."
 ---
 
-The `sentry-log4j2` library provides [Log4j 2.x](https://logging.apache.org/log4j/2.x/) support for Sentry via an [Appender](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/Appender.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), in order to do things like record breadcrumbs, set the current user, or manually send events.
+The following example configures a `ConsoleAppender` that logs to standard out at the `INFO` level, and a `SentryAppender` that logs to the Sentry server at the `ERROR` level.
 
-The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-log4j2).
+<Note>
 
-### Installation
+The `ConsoleAppender` is  provided only as an example of a non-Sentry appender that is set to a different logging threshold, like one you may already have in your project.
 
-```xml {tabTitle:Maven}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-log4j2</artifactId>
-    <version>{{ packages.version('sentry.java', '3.1.1') }}</version>
-</dependency>
-```
-
-```groovy {tabTitle:Gradle}
-implementation 'io.sentry:sentry-log4j2:{{ packages.version('sentry.java', '3.1.1') }}'
-```
-
-```scala {tabTitle: SBT}
-libraryDependencies += "io.sentry" % "sentry-log4j2" % "{{ packages.version('sentry.java', '3.1.1') }}"
-```
-
-For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-log4j2).
-
-### Usage
-
-The following example configures a `ConsoleAppender` that logs to standard out at the `INFO` level and a `SentryAppender` that logs to the Sentry server at the `ERROR` level. The `ConsoleAppender` is only provided as an example of a non-Sentry appender that is set to a different logging threshold, like one you may already have in your project.
+</Note>
 
 Example configuration using the `log4j2.xml` format:
 


### PR DESCRIPTION
Refactor of Getting Started page. This refactor enables use of the common content. In addition, the content:

- [ ] uses Java fallbacks for the Configuration and Verification step

- [ ] moves usage (which appears to be about configuration) into an example configuration page as a subpage of configuration - feedback particularly welcome on this change.