### PR TITLE
ref(tracing): Improve note about sampling when testing on Python page

### DIFF
--- a/src/platforms/python/common/performance/index.mdx
+++ b/src/platforms/python/common/performance/index.mdx
@@ -8,22 +8,17 @@ Sentry allows you to monitor the performance of your application, showing you ho
 ## Enabling Tracing
 
 To get started automatically sending traces you can:
- - Set a uniform sample rate for all transactions, by setting the `traces_sample_rate` option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set `traces_sample_rate` to `0.2`.)
- - Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the `traces_sampler` config option.
+
+- Set a uniform sample rate for all transactions, by setting the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
+- Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
 
 <PlatformContent includePath="performance/enable-tracing" />
 
-Your application will now start automatically capturing transactions.
+If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
 
-<Note>
+As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Flask integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
 
-When you first enable tracing, the easiest thing to do to test it is to set `traces_sample_rate` to `1.0`, because that guarantees that every transaction will be sent to Sentry for you to see.
-
-Once you're done with testing, however, we recommend that you either **lower your `traces_sample_rate` value, or switch to using `traces_sampler` to dynamically sample and filter your transactions**.
-
-Without sampling, our automatic instrumentation will send a transaction with every server request, celery task, etc (depending on which integrations you're using), which can add up quickly. Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
-
-</Note>
+You can learn more about the <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> options in <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
 
 ## Manual Instrumentation
 


### PR DESCRIPTION
This removes the `<Note>` component (so they text doesn't show up in grey) and pulls in more content from the JS version of the page, to bring them more in line.