### PR TITLE
fix(unreal): Do not mention DSN in the context of UE4

### DIFF
--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -12,7 +12,7 @@ To integrate your UE4 game or application with Sentry, the following steps are r
 
 1. Include the _UE4 Crash Reporter_ to your game or application.
 2. Include Debug information in the crash reports.
-3. Add the Sentry DSN to the relevant configuration file.
+3. Add the Unreal Engine Endpoint to the relevant configuration file.
 4. Upload your games symbols so Sentry can display function names and line numbers.
 5. Optionally enable Event Attachments for your Sentry project.
 
@@ -54,10 +54,10 @@ to be uploaded to Sentry](#upload-debug-symbols).
 The option is also located under _Project > Packaging_ menu, then select _show advanced_ followed by
 checking the box for: `Include Debug Files`.
 
-## Add the Sentry DSN
+## Configure the Crash Reporter Endpoint
 
 Now that the _Crash Reporter_ and _Debug Files_ are included, UE4 needs to know where to send the
-crash. For that, we add the Sentry _DSN_ (Data Source Name) to game's configuration file. This will
+crash. For that, we add the Sentry _Unreal Engine Endpoint_ from the _Client Keys_ settings page to game's configuration file. This will
 include which project within Sentry you want to see the crashes arriving in real time.
 That's accomplished by configuring the `CrashReportClient` in the _DefaultEngine.ini_ file.
 


### PR DESCRIPTION
Remove mentioning the DSN since correct configuration on UE4 requires the Unreal Engine Endpoint instead of the DSN.