### PR TITLE
Upgrade platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "^3.1.0",
+    "platformicons": "^3.2.0",
     "prismjs": "^1.20.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14046,10 +14046,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.1.1.tgz#ca50a544230b5656e012ed775957ffe88b6f938e"
-  integrity sha512-EdC6ig6jnOgx8Zx8Uw5LgALzX7EXCNGXzDO/eT2O1AXeJs+MTIpK3ULT3PT8HXDbPQ/1j3Fwh4CPctof9N0CvA==
+platformicons@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.2.0.tgz#18c551ad6588b15eb8e12706e129c647d91be3c5"
+  integrity sha512-E7N0YnqAFVKMsM/NQ5YxaIjW56Jj2LmdpuRxGR5c3o8R2+hqmNO1dPCpcvUbFQitQmrPqSH8SP56RNv8kb8blw==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Upgrade platformicons in order to display Spring and Spring Boot logos.