### PR TITLE
Add: front matter description to /guides in /platforms

### DIFF
--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ASP.NET
-description: "Learn about Sentry's .NET integration ASP.NET."
+description: "Learn about Sentry's .NET integration with ASP.NET."
 ---
 
 Sentry provides an integration with _ASP.NET_ through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry).

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: ASP.NET
+description: "Learn about Sentry's .NET integration ASP.NET."
 ---
 
 Sentry provides an integration with _ASP.NET_ through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry).

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ASP.NET Core
-description: "Learn about Sentry's .NET integration ASP.NET Core."
+description: "Learn about Sentry's .NET integration with ASP.NET Core."
 redirect_from:
   - /platforms/dotnet/aspnetcore/
 ---

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: ASP.NET Core
+description: "Learn about Sentry's .NET integration ASP.NET Core."
 redirect_from:
   - /platforms/dotnet/aspnetcore/
 ---

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Entity Framework
-description: "Learn about Sentry's .NET integration Entity Framework."
+description: "Learn about Sentry's .NET integration with Entity Framework."
 redirect_from:
   - /platforms/dotnet/entityframework/
 ---

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Entity Framework
+description: "Learn about Sentry's .NET integration Entity Framework."
 redirect_from:
   - /platforms/dotnet/entityframework/
 ---

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Microsoft.Extensions.Logging
+description: "Learn about Sentry's .NET integration Microsoft.Extensions.Logging."
 redirect_from:
   - /platforms/dotnet/microsoft-extensions-logging/
 ---

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Microsoft.Extensions.Logging
-description: "Learn about Sentry's .NET integration Microsoft.Extensions.Logging."
+description: "Learn about Sentry's .NET integration with Microsoft.Extensions.Logging."
 redirect_from:
   - /platforms/dotnet/microsoft-extensions-logging/
 ---

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: log4net
-description: "Learn about Sentry's .NET integration log4net."
+description: "Learn about Sentry's .NET integration with log4net."
 redirect_from:
   - /platforms/dotnet/log4net/
 ---

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: log4net
+description: "Learn about Sentry's .NET integration log4net."
 redirect_from:
   - /platforms/dotnet/log4net/
 ---

--- a/src/platforms/dotnet/guides/nlog/index.mdx
+++ b/src/platforms/dotnet/guides/nlog/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: NLog
+description: "Learn about Sentry's .NET integration NLog."
 redirect_from:
   - /platforms/dotnet/nlog/
 ---

--- a/src/platforms/dotnet/guides/nlog/index.mdx
+++ b/src/platforms/dotnet/guides/nlog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: NLog
-description: "Learn about Sentry's .NET integration NLog."
+description: "Learn about Sentry's .NET integration with NLog."
 redirect_from:
   - /platforms/dotnet/nlog/
 ---

--- a/src/platforms/dotnet/guides/serilog/index.mdx
+++ b/src/platforms/dotnet/guides/serilog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Serilog
-description: "Learn about Sentry's .NET integration Serilog."
+description: "Learn about Sentry's .NET integration with Serilog."
 redirect_from:
   - /platforms/dotnet/serilog/
 ---

--- a/src/platforms/dotnet/guides/serilog/index.mdx
+++ b/src/platforms/dotnet/guides/serilog/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Serilog
+description: "Learn about Sentry's .NET integration Serilog."
 redirect_from:
   - /platforms/dotnet/serilog/
 ---

--- a/src/platforms/dotnet/guides/winforms/index.mdx
+++ b/src/platforms/dotnet/guides/winforms/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Windows Forms
+description: "Learn how Sentry's .NET SDK works with WinForms applications."
 redirect_from:
   - /platforms/dotnet/winforms/
 ---

--- a/src/platforms/dotnet/guides/wpf/index.mdx
+++ b/src/platforms/dotnet/guides/wpf/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Windows Presentation Foundation
-description: "Learn how Sentry's .NET SDK works with Windows Presentation Foundation applications."
+description: "Learn how Sentry's .NET SDK works with Windows Presentation Foundation (WPF) applications."
 redirect_from:
   - /platforms/dotnet/wpf/
 ---

--- a/src/platforms/dotnet/guides/wpf/index.mdx
+++ b/src/platforms/dotnet/guides/wpf/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Windows Presentation Foundation
+description: "Learn how Sentry's .NET SDK works with Windows Presentation Foundation applications."
 redirect_from:
   - /platforms/dotnet/wpf/
 ---


### PR DESCRIPTION
A few files in /guides needed descriptions in the front matter.