### PR TITLE
Add: front matter descriptions to /guides in /platforms

### DIFF
--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -1,3 +1,8 @@
+---
+title: Echo
+description: "Learn how to use the Echo framework with Sentry."
+---
+
 This page shows how to use the Echo framework with Sentry.
 
 For a quick reference, there is a [complete

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: FastHTTP
+description: "Learn how to add Sentry instrumentation to programs using the FastHTTP package."
 redirect_from:
   - /platforms/go/fasthttp/
 ---

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Gin
+description: "Learn how to use the Gin framework with Sentry."
 redirect_from:
   - /platforms/go/gin/
 ---

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: net/http
+description: "Learn how to add Sentry instrumentation to programs using the net/http package."
 redirect_from:
   - /clients/go/integrations/http/
   - /platforms/go/http/

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Iris
+description: "Learn how to use the Iris framework with Sentry."
 redirect_from:
   - /platforms/go/iris/
 ---

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Martini
+description: "Learn how to use the Martini framework with Sentry."
 redirect_from:
   - /platforms/go/martini/
 ---

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Negroni
+description: "Learn how to use the Negroni framework with Sentry."
 redirect_from:
   - /platforms/go/negroni/
 ---


### PR DESCRIPTION
A few files in /guides needed front matter descriptions.