### PR TITLE
[JS / Tracing] Reverse the order of pathname replacements

### DIFF
--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -217,8 +217,8 @@ Sentry.init({
           // route template here. We don't have one right now, so do some basic
           // parameter replacements.
           name: location.pathname
-            .replace(/\d+/g, "<digits>")
-            .replace(/[a-f0-9]{32}/g, "<hash>"),
+            .replace(/[a-f0-9]{32}/g, "<hash>")
+            .replace(/\d+/g, "<digits>"),
         };
       },
     }),

--- a/src/platforms/javascript/common/performance/index.mdx
+++ b/src/platforms/javascript/common/performance/index.mdx
@@ -217,8 +217,8 @@ Sentry.init({
           // route template here. We don't have one right now, so do some basic
           // parameter replacements.
           name: location.pathname
-            .replace(/[a-f0-9]{32}/g, "<hash>")
-            .replace(/\d+/g, "<digits>"),
+            .replaceAll(/\/[a-f0-9]{32}/g, "/<hash>")
+            .replaceAll(/\/\d+/g, "/<digits>"),
         };
       },
     }),


### PR DESCRIPTION
Otherwise the digits replacement happens inside hashes (since they also contain digits). 

Also using `replaceAll` otherwise only the first match will be replaced.

I've also added a `/` prefix to make sure you get full path segments and not random numbers in slugs for example.