### PR TITLE
feat(apple): Update migration guide on enabled

### DIFF
--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -24,11 +24,11 @@ application.
 
 - Use a BOOL in SentryOptions instead of NSNumber to store booleans.
 
-- We removed [enabled](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentryOptions.h#L63) on the SentryOptions,
-but we brought them back in 6.0.7 with slightly changed functionality. Previously setting
-an empty or wrong DSN also set `enabled` to `false`. This side effect is removed now. Setting
+- We removed the [enabled](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentryOptions.h#L63) option from SentryOptions,
+but we brought it back in 6.0.7 with a slightly changed functionality. Previously setting
+an empty or incorrect DSN also set `enabled` to `false`. This side effect is removed now. Setting
 the DSN has no impact on `enabled`. If the DSN is nil or empty or `enabled` is set
-to `false`, the client doesn't send anything to Sentry.
+to `false`, the client won't send anything to Sentry.
 
 ### Breaking Changes
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -28,7 +28,7 @@ application.
 but we brought it back in 6.0.7 with a slightly changed functionality. Previously setting
 an empty or incorrect DSN also set `enabled` to `false`. This side effect is removed now. Setting
 the DSN has no impact on `enabled`. If the DSN is nil or empty or `enabled` is set
-to `false`, the client won't send anything to Sentry.
+to `false`, the client won't send any data to Sentry.
 
 ### Breaking Changes
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -24,7 +24,11 @@ application.
 
 - Use a BOOL in SentryOptions instead of NSNumber to store booleans.
 
-- We removed [enabled](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentryOptions.h#L63) on the SentryOptions.
+- We removed [enabled](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentryOptions.h#L63) on the SentryOptions,
+but we brought them back in 6.0.7 with slightly changed functionality. Previously setting
+an empty or wrong DSN also set `enabled` to `false`. This side effect is removed now. Setting
+the DSN has no impact on `enabled`. If the DSN is nil or empty or `enabled` is set
+to `false`, the client doesn't send anything to Sentry.
 
 ### Breaking Changes
 


### PR DESCRIPTION
Merge only after https://github.com/getsentry/sentry-cocoa/pull/819 is merged and Cocoa 6.0.7 is released.