### PR TITLE
Add: front matter descriptions to /guides in /platforms

### DIFF
--- a/src/platforms/java/guides/logback/index.mdx
+++ b/src/platforms/java/guides/logback/index.mdx
@@ -3,6 +3,7 @@ title: Logback
 redirect_from:
   - /clients/java/modules/logback/
   - /platforms/java/guides/logback/config/
+description: "Learn about Sentry's integration with Logback."
 ---
 
 The `sentry-logback` library provides [Logback](https://logback.qos.ch/) support for Sentry via an [Appender](https://logback.qos.ch/apidocs/ch/qos/logback/core/Appender.html) that sends logged exceptions to Sentry. Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), in order to do things like record breadcrumbs, set the current user, or manually send events.

--- a/src/platforms/java/guides/spring-boot/index.mdx
+++ b/src/platforms/java/guides/spring-boot/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Spring Boot
+description: "Learn about Sentry's integration with Spring Boot."
 ---
 
 The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/java/guides/spring/) support with an auto-configuration for [Spring Boot](https://spring.io/projects/spring-boot) providing following features:

--- a/src/platforms/java/guides/spring/index.mdx
+++ b/src/platforms/java/guides/spring/index.mdx
@@ -2,6 +2,7 @@
 title: Spring
 redirect_from:
   - /platforms/java/guides/spring/config/
+description: "Learn about Sentry's integration with Spring."
 ---
 
 The `sentry-spring` library provides [Spring MVC](https://spring.io/) support for Sentry via:


### PR DESCRIPTION
A few files in /guides needed front matter descriptions.