### PR TITLE
Add: front matter descriptions to JS /guides

### DIFF
--- a/src/platforms/javascript/guides/cordova/index.mdx
+++ b/src/platforms/javascript/guides/cordova/index.mdx
@@ -6,6 +6,7 @@ categories:
 redirect_from:
   - /clients/cordova/
   - /platforms/javascript/cordova/
+description: "Learn how to use Sentry's Cordova SDK."
 ---
 
 This is the documentation for our Cordova SDK. The SDK uses a native extension for iOS and Android but will fall back to a pure JavaScript version (`@sentry/browser`) if needed. The SDK is able to catch native crashes that happen on iOS or uncaught exceptions on Android as well.

--- a/src/platforms/javascript/guides/cordova/ionic.mdx
+++ b/src/platforms/javascript/guides/cordova/ionic.mdx
@@ -3,6 +3,7 @@ title: Ionic
 sidebar_order: 201
 redirect_from:
   - /clients/cordova/ionic/
+description: "Learn how to use Sentry with Ionic."
 ---
 
 To use Sentry with [Ionic](https://ionicframework.com/) you have to add _sentry-cordova_ as a dependency to you package.json.

--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -7,6 +7,7 @@ redirect_from:
   - /clients/electron/
   - /platforms/javascript/electron/
   - /platforms/electron/
+description: "Learn how to use Sentry with Electron."
 ---
 
 `@sentry/electron` is the official Sentry SDK for Electron applications. It can capture JavaScript exceptions in the main process and renderers, as well as collect native crash reports (Minidumps).

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -3,6 +3,7 @@ title: Gatsby
 sdk: "sentry.javascript.gatsby"
 redirect_from:
   - /platforms/javascript/gatsby/
+description: "Learn how to use Sentry with Gatsby."
 ---
 
 To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK):

--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -1,6 +1,7 @@
 ---
 title: React Error Boundary
 excerpt: ""
+description: "Learn how Sentry's React SDK exports an error boundary component that leverages React component APIs."
 ---
 
 The React SDK exports an error boundary component that leverages [React component APIs](https://reactjs.org/docs/error-boundaries.html) to automatically catch and send JavaScript errors from inside a React component tree to Sentry.

--- a/src/platforms/javascript/guides/react/components/index.mdx
+++ b/src/platforms/javascript/guides/react/components/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Components
 excerpt: ""
+description: "Learn how Sentry's React SDK exposes custom components for first class integration with the React framework."
 ---
 
 The Sentry React SDK exposes custom components for first class integration with the React framework.

--- a/src/platforms/javascript/guides/react/components/profiler.mdx
+++ b/src/platforms/javascript/guides/react/components/profiler.mdx
@@ -1,6 +1,7 @@
 ---
 title: React Profiler
 excerpt: ""
+description: "Learn how Sentry's React SDK exports a `withProfiler` higher-order component that attaches React related spans to the current active transaction on the scope."
 ---
 
 `@sentry/react` exports a `withProfiler` higher-order component that attaches React related spans to the current active transaction on the scope.

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -2,6 +2,7 @@
 title: React Router Integration
 redirect_from:
   - /platforms/javascript/guides/react/integrations/react-router/
+description: "Learn about Sentry's React Router integration."
 ---
 
 _(New in version 5.21.0)_

--- a/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
@@ -1,5 +1,6 @@
 ---
 title: Redux Integration
+description: "Learn about Sentry's Redux integration."
 ---
 
 _(New in version 5.20.0)_

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -5,6 +5,7 @@ redirect_from:
   - /platforms/javascript/react/
   - /clients/javascript/integrations/react/
   - /sdks/react/
+description: "Learn about Sentry's React SDK and how it automatically reports errors and exceptions in your application."
 ---
 
 On this page, we provide concise information to get you up and running with Sentry's React SDK, automatically reporting errors and exceptions in your application.

--- a/src/platforms/javascript/guides/vue/index.mdx
+++ b/src/platforms/javascript/guides/vue/index.mdx
@@ -4,6 +4,7 @@ sidebar_order: 6000
 redirect_from:
   - /platforms/javascript/vue/
   - /clients/javascript/integrations/vue/
+description: "Learn how to use Sentry with your Vue application."
 ---
 
 To use Sentry with your Vue application, you will need to use Sentry’s browser JavaScript SDK: `@sentry/browser`.

--- a/src/platforms/javascript/guides/vue/integrations/components.mdx
+++ b/src/platforms/javascript/guides/vue/integrations/components.mdx
@@ -1,5 +1,6 @@
 ---
 title: Performance Integration
+description: "Learn how Sentry's Vue Tracing Integration allows you to track rendering performance during an initial application load."
 ---
 
 The Vue Tracing Integration allows you to track rendering performance during an initial application load.


### PR DESCRIPTION
A few files in /guides needed front matter descriptions.