### PR TITLE
Add: front matter descriptions to Native guides

### DIFF
--- a/src/platforms/native/guides/breakpad/index.mdx
+++ b/src/platforms/native/guides/breakpad/index.mdx
@@ -3,6 +3,7 @@ title: Google Breakpad
 redirect_from:
   - /platforms/breakpad/
   - /platforms/native/breakpad/
+description: "Learn about Sentry's integration with Google Breakpad."
 ---
 
 [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) is an open-source multiplatform crash reporting system written in C++ by Google and the predecessor of Crashpad. It supports macOS, Windows and Linux, and features an uploader to submit minidumps to a configured URL right when the process crashes.

--- a/src/platforms/native/guides/crashpad/index.mdx
+++ b/src/platforms/native/guides/crashpad/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Google Crashpad
+description: "Learn about using Sentry with Google Crashpad."
 ---
 
 [Crashpad](https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md)

--- a/src/platforms/native/guides/minidumps/index.mdx
+++ b/src/platforms/native/guides/minidumps/index.mdx
@@ -4,6 +4,7 @@ redirect_from:
   - /platforms/minidump/
   - /platforms/native/minidump/
   - /clients/minidump/
+description: "Learn about how Sentry processes Minidump crash reports."
 ---
 
 Sentry can process Minidump crash reports, a memory dump used on Windows and by

--- a/src/platforms/native/guides/ue4/advanced-config.mdx
+++ b/src/platforms/native/guides/ue4/advanced-config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Advanced Configuration
+description: "Learn about Sentry's Advanced Configuration for Unreal Engine 4 (UE4)."
 ---
 
 Basic attributes can be reconfigured by providing a special game data to the

--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -3,6 +3,7 @@ title: Unreal Engine 4
 redirect_from:
   - /platforms/unrealengine/
   - /platforms/native/ue4/
+description: "Learn about Sentry's integration with Unreal Engine 4 (UE4)."
 ---
 
 Installation of a Sentry SDK is not required in order to capture the crashes of your


### PR DESCRIPTION
A few files in /guides needed front matter descriptions.