### PR TITLE
Add: front matter descriptions to PHP guides

### DIFF
--- a/src/platforms/php/guides/laravel/configuration/laravel-options.mdx
+++ b/src/platforms/php/guides/laravel/configuration/laravel-options.mdx
@@ -1,6 +1,7 @@
 ---
 title: Laravel Options
 sidebar_order: 1
+description: "Learn about Sentry's integration with Laravel and its options for breadcrumbs, and performance."
 ---
 
 All configuration for Laravel is done in `config/sentry.php`.

--- a/src/platforms/php/guides/laravel/configuration/other-versions/laravel4.mdx
+++ b/src/platforms/php/guides/laravel/configuration/other-versions/laravel4.mdx
@@ -1,5 +1,6 @@
 ---
 title: Laravel 4.x
+description: "Learn about using Sentry with Laravel 4.x."
 ---
 
 Install the `sentry/sentry-laravel` package:

--- a/src/platforms/php/guides/laravel/configuration/other-versions/laravel5-6.mdx
+++ b/src/platforms/php/guides/laravel/configuration/other-versions/laravel5-6.mdx
@@ -1,5 +1,6 @@
 ---
 title: Laravel 5.x and 6.x
+description: "Learn about using Sentry with Laravel 5.x and 6.x."
 ---
 
 ## Install

--- a/src/platforms/php/guides/laravel/configuration/other-versions/lumen.mdx
+++ b/src/platforms/php/guides/laravel/configuration/other-versions/lumen.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lumen
+description: "Learn about using Sentry with Lumen."
 ---
 
 Lumen is supported via a native package, [sentry-laravel](https://github.com/getsentry/sentry-laravel).

--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -5,6 +5,7 @@ sidebar_order: 0
 redirect_from:
   - /clients/php/integrations/laravel/
   - /platforms/php/laravel/
+description: "Learn about using Sentry with Laravel."
 ---
 
 Laravel is supported via a native package, [sentry-laravel](https://github.com/getsentry/sentry-laravel).

--- a/src/platforms/php/guides/symfony/config.mdx
+++ b/src/platforms/php/guides/symfony/config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Config
+description: "Learn about Symfony-specific configuration options."
 ---
 
 In addition to the [configuration available in the PHP SDK](../configuration/options/), there are some Symfony-specific options.

--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -4,6 +4,7 @@ sdk: sentry.php.symfony
 redirect_from:
   - /clients/php/integrations/symfony2/
   - /platforms/php/symfony/
+description: "Learn about using Sentry with Symfony."
 ---
 
 Symfony is supported via the [sentry-symfony](https://github.com/getsentry/sentry-symfony) package as a native bundle.


### PR DESCRIPTION
A few files in /guides needed front matter descriptions.