### PR TITLE
Add: front matter descriptions for Python guides

### DIFF
--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -2,7 +2,7 @@
 title: AIOHTTP
 redirect_from:
   - /platforms/python/aiohttp/
-description: "Learn about Sentry's integration with AIOHTTP."
+description: "Learn about using Sentry with AIOHTTP."
 ---
 
 _(New in version : 0.6.1)_

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -2,6 +2,7 @@
 title: AIOHTTP
 redirect_from:
   - /platforms/python/aiohttp/
+description: "Learn about Sentry's integration with AIOHTTP."
 ---
 
 _(New in version : 0.6.1)_

--- a/src/platforms/python/guides/airflow/index.mdx
+++ b/src/platforms/python/guides/airflow/index.mdx
@@ -2,6 +2,7 @@
 title: Apache Airflow
 redirect_from:
   - /platforms/python/airflow/
+description: "Learn about using Sentry with Apache Airflow."
 ---
 
 [Apache Airflow](https://airflow.apache.org/) **1.10.6** and above can be set up to send errors to Sentry.

--- a/src/platforms/python/guides/asgi/index.mdx
+++ b/src/platforms/python/guides/asgi/index.mdx
@@ -2,7 +2,7 @@
 title: ASGI
 redirect_from:
   - /platforms/python/asgi/
-description: "Learn about using Sentry with Asynchronous Server Gateway Interface (ASGI)."
+description: "Learn about using Sentry with ASGI applications."
 ---
 
 _(New in version 0.10.2)_

--- a/src/platforms/python/guides/asgi/index.mdx
+++ b/src/platforms/python/guides/asgi/index.mdx
@@ -2,6 +2,7 @@
 title: ASGI
 redirect_from:
   - /platforms/python/asgi/
+description: "Learn about using Sentry with Asynchronous Server Gateway Interface (ASGI)."
 ---
 
 _(New in version 0.10.2)_

--- a/src/platforms/python/guides/aws-lambda/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/index.mdx
@@ -3,6 +3,7 @@ title: AWS Lambda
 redirect_from:
   - /clients/python/integrations/lambda/
   - /platforms/python/aws_lambda/
+description: "Learn about using Sentry with AWS Lambda."
 ---
 
 _(New in version 0.3.5)_

--- a/src/platforms/python/guides/azure-functions/index.mdx
+++ b/src/platforms/python/guides/azure-functions/index.mdx
@@ -2,6 +2,7 @@
 title: Azure Functions
 redirect_from:
   - /platforms/python/azure_functions/
+description: "Learn about using Sentry with Azure Functions."
 ---
 
 Create a .venv in the local machine on VS Code, create a Python function, and install the sentry SDK:

--- a/src/platforms/python/guides/beam/index.mdx
+++ b/src/platforms/python/guides/beam/index.mdx
@@ -2,6 +2,7 @@
 title: Apache Beam
 redirect_from:
   - /platforms/python/beam/
+description: "Learn about Sentry's integration with Beam."
 ---
 
 _(New in version 0.11.0)_

--- a/src/platforms/python/guides/beam/index.mdx
+++ b/src/platforms/python/guides/beam/index.mdx
@@ -2,7 +2,7 @@
 title: Apache Beam
 redirect_from:
   - /platforms/python/beam/
-description: "Learn about Sentry's integration with Beam."
+description: "Learn about using Sentry with Beam."
 ---
 
 _(New in version 0.11.0)_

--- a/src/platforms/python/guides/bottle/index.mdx
+++ b/src/platforms/python/guides/bottle/index.mdx
@@ -3,6 +3,7 @@ title: Bottle
 redirect_from:
   - /clients/python/integrations/bottle/
   - /platforms/python/bottle/
+description: "Learn about Sentry's integration with Bottle."
 ---
 
 _(New in version 0.7.9)_

--- a/src/platforms/python/guides/bottle/index.mdx
+++ b/src/platforms/python/guides/bottle/index.mdx
@@ -3,7 +3,7 @@ title: Bottle
 redirect_from:
   - /clients/python/integrations/bottle/
   - /platforms/python/bottle/
-description: "Learn about Sentry's integration with Bottle."
+description: "Learn about using Sentry with Bottle."
 ---
 
 _(New in version 0.7.9)_

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -3,9 +3,10 @@ title: Celery
 redirect_from:
   - /clients/python/integrations/celery/
   - /platforms/python/celery/
+description: "Learn about Sentry's integration with Celery."
 ---
 
-The celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).
+The Celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).
 
 Just add `CeleryIntegration()` to your `integrations` list:
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -3,7 +3,7 @@ title: Celery
 redirect_from:
   - /clients/python/integrations/celery/
   - /platforms/python/celery/
-description: "Learn about Sentry's integration with Celery."
+description: "Learn about using Sentry with Celery."
 ---
 
 The Celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).

--- a/src/platforms/python/guides/chalice/index.mdx
+++ b/src/platforms/python/guides/chalice/index.mdx
@@ -2,6 +2,7 @@
 title: Chalice
 redirect_from:
   - /platforms/python/chalice/
+description: "Learn about using Sentry with Chalice."
 ---
 
 _(New in version 0.17.4)_

--- a/src/platforms/python/guides/django/http_errors.mdx
+++ b/src/platforms/python/guides/django/http_errors.mdx
@@ -1,6 +1,7 @@
 ---
 title: Reporting HTTP Errors
 sidebar_order: 100
+description: "Learn about reporting HTTP errors with Django."
 ---
 
 If you want to report `404 Not Found` and other errors besides uncaught exceptions (`500 Internal Server Error`) to Sentry, you can write your own Django view for those status codes. For example:

--- a/src/platforms/python/guides/falcon/index.mdx
+++ b/src/platforms/python/guides/falcon/index.mdx
@@ -2,7 +2,7 @@
 title: Falcon
 redirect_from:
   - /platforms/python/falcon/
-description: "Learn about Sentry's integrations with Falcon."
+description: "Learn about using Sentry with Falcon."
 ---
 
 _(New in version 0.7.11)_

--- a/src/platforms/python/guides/falcon/index.mdx
+++ b/src/platforms/python/guides/falcon/index.mdx
@@ -2,6 +2,7 @@
 title: Falcon
 redirect_from:
   - /platforms/python/falcon/
+description: "Learn about Sentry's integrations with Falcon."
 ---
 
 _(New in version 0.7.11)_

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -2,6 +2,7 @@
 title: GCP Functions
 redirect_from:
   - /platforms/python/gcp_functions/
+description: "Learn about using Sentry with Google Cloud Platform (GCP) Functions."
 ---
 
 _(New in version 0.17.1)_

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -2,7 +2,7 @@
 title: GCP Functions
 redirect_from:
   - /platforms/python/gcp_functions/
-description: "Learn about using Sentry with Google Cloud Platform (GCP) Functions."
+description: "Learn about using Sentry with GCP Functions."
 ---
 
 _(New in version 0.17.1)_

--- a/src/platforms/python/guides/logging/index.mdx
+++ b/src/platforms/python/guides/logging/index.mdx
@@ -3,6 +3,7 @@ title: Logging
 redirect_from:
   - /clients/python/integrations/logging/
   - /platforms/python/logging/
+description: "Learn about logging with Python."
 ---
 
 Calling `sentry_sdk.init()` already integrates with the logging module. It is

--- a/src/platforms/python/guides/pyramid/index.mdx
+++ b/src/platforms/python/guides/pyramid/index.mdx
@@ -3,7 +3,7 @@ title: Pyramid
 redirect_from:
   - /clients/python/integrations/pyramid/
   - /platforms/python/pyramid/
-description: "Learn about Sentry's integration with Pyramid."
+description: "Learn about using Sentry with Pyramid."
 ---
 
 _(New in version 0.5.0)_

--- a/src/platforms/python/guides/pyramid/index.mdx
+++ b/src/platforms/python/guides/pyramid/index.mdx
@@ -3,6 +3,7 @@ title: Pyramid
 redirect_from:
   - /clients/python/integrations/pyramid/
   - /platforms/python/pyramid/
+description: "Learn about Sentry's integration with Pyramid."
 ---
 
 _(New in version 0.5.0)_

--- a/src/platforms/python/guides/pyspark/index.mdx
+++ b/src/platforms/python/guides/pyspark/index.mdx
@@ -2,7 +2,7 @@
 title: Apache Spark
 redirect_from:
   - /platforms/python/pyspark/
-description: "Learn about Sentry's integration with Apache Spark."
+description: "Learn about using Sentry with Apache Spark."
 ---
 
 _(New in version 0.13.0)_

--- a/src/platforms/python/guides/pyspark/index.mdx
+++ b/src/platforms/python/guides/pyspark/index.mdx
@@ -2,6 +2,7 @@
 title: Apache Spark
 redirect_from:
   - /platforms/python/pyspark/
+description: "Learn about Sentry's integration with Apache Spark."
 ---
 
 _(New in version 0.13.0)_

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -3,7 +3,7 @@ title: RQ (Redis Queue)
 redirect_from:
   - /clients/python/integrations/rq/
   - /platforms/python/rq/
-description: "Learn about Sentry's integration with Redis Queue (RQ)."
+description: "Learn about using Sentry with RQ."
 ---
 
 _(New in version 0.5.1)_

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -3,6 +3,7 @@ title: RQ (Redis Queue)
 redirect_from:
   - /clients/python/integrations/rq/
   - /platforms/python/rq/
+description: "Learn about Sentry's integration with Redis Queue (RQ)."
 ---
 
 _(New in version 0.5.1)_

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -2,7 +2,7 @@
 title: Sanic
 redirect_from:
   - /platforms/python/sanic/
-description: "Learn about Sentry's integration with Sanic."
+description: "Learn about using Sentry with Sanic."
 ---
 
 _(New in version 0.3.6)_

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -2,6 +2,7 @@
 title: Sanic
 redirect_from:
   - /platforms/python/sanic/
+description: "Learn about Sentry's integration with Sanic."
 ---
 
 _(New in version 0.3.6)_

--- a/src/platforms/python/guides/serverless/index.mdx
+++ b/src/platforms/python/guides/serverless/index.mdx
@@ -2,6 +2,7 @@
 title: Serverless
 redirect_from:
   - /platforms/python/serverless/
+description: "Learn about using Sentry's Python SDK for a serverless environment."
 ---
 
 _(New in version 0.7.3)_

--- a/src/platforms/python/guides/tornado/index.mdx
+++ b/src/platforms/python/guides/tornado/index.mdx
@@ -3,7 +3,7 @@ title: Tornado
 redirect_from:
   - /clients/python/integrations/tornado/
   - /platforms/python/tornado/
-description: "Learn about Sentry's integration with Tornado."
+description: "Learn about using Sentry with Tornado."
 ---
 
 _(New in version : 0.6.3)_

--- a/src/platforms/python/guides/tornado/index.mdx
+++ b/src/platforms/python/guides/tornado/index.mdx
@@ -3,6 +3,7 @@ title: Tornado
 redirect_from:
   - /clients/python/integrations/tornado/
   - /platforms/python/tornado/
+description: "Learn about Sentry's integration with Tornado."
 ---
 
 _(New in version : 0.6.3)_

--- a/src/platforms/python/guides/tryton/index.mdx
+++ b/src/platforms/python/guides/tryton/index.mdx
@@ -2,6 +2,7 @@
 title: Tryton
 redirect_from:
   - /platforms/python/tryton/
+description: "Learn about Sentry's integration with Tryton."
 ---
 
 _(New in version 0.14.0)_

--- a/src/platforms/python/guides/tryton/index.mdx
+++ b/src/platforms/python/guides/tryton/index.mdx
@@ -2,7 +2,7 @@
 title: Tryton
 redirect_from:
   - /platforms/python/tryton/
-description: "Learn about Sentry's integration with Tryton."
+description: "Learn aboutn using Sentry with Tryton."
 ---
 
 _(New in version 0.14.0)_

--- a/src/platforms/python/guides/wsgi/index.mdx
+++ b/src/platforms/python/guides/wsgi/index.mdx
@@ -3,6 +3,7 @@ title: WSGI
 redirect_from:
   - /clients/python/integrations/wsgi/
   - /platforms/python/wsgi/
+description: "Learn about using Sentry's Python SDK with a Web Server Gateway Interface (WSGI) framework."
 ---
 
 _(New in version 0.6.0)_

--- a/src/platforms/python/guides/wsgi/index.mdx
+++ b/src/platforms/python/guides/wsgi/index.mdx
@@ -3,7 +3,7 @@ title: WSGI
 redirect_from:
   - /clients/python/integrations/wsgi/
   - /platforms/python/wsgi/
-description: "Learn about using Sentry's Python SDK with a Web Server Gateway Interface (WSGI) framework."
+description: "Learn about using Sentry's Python SDK with a WSGI application."
 ---
 
 _(New in version 0.6.0)_


### PR DESCRIPTION
A few files in Python guides needed front matter descriptions.