### PR TITLE
Add: front matter description to Ruby guides

### DIFF
--- a/src/platforms/ruby/guides/rails/index.mdx
+++ b/src/platforms/ruby/guides/rails/index.mdx
@@ -1,6 +1,8 @@
 ---
+title: Rails
 redirect_from:
   - /clients/ruby/integrations/rails/
+description: "Learn about using Sentry with Rails."
 ---
 
 In Rails, all uncaught exceptions will be automatically reported.


### PR DESCRIPTION
One file in Ruby guides needed front matter description.