### PR TITLE
Add: front matter description to Rust guide

### DIFF
--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -2,6 +2,7 @@
 title: actix-web
 redirect_from:
   - /platforms/rust/actix/
+description: "Learn about using Sentry with Actix Web."
 ---
 
 The `sentry-actix` crate adds a middleware for [`actix-web`](https://actix.rs/) that captures errors and report them to `Sentry`.


### PR DESCRIPTION
A file in Rust's guide needed front matter description.