### PR TITLE
fix(apple): Typo in UserFeedback

### DIFF
--- a/src/platforms/apple/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/apple/common/enriching-events/user-feedback.mdx
@@ -13,7 +13,7 @@ import Sentry
 
 let eventId = SentrySDK.capture(message: "My message.")
 
-let userFeedback = UserFeedack(eventId: eventId)
+let userFeedback = UserFeedback(eventId: eventId)
 userFeedback.comments = "It broke."
 userFeedback.email = "john.doe@example.com"
 userFeedback.name = "John Doe"


### PR DESCRIPTION
In the code sample for Swift user feedback was written UserFeedback.
This is fixed now.