### PR TITLE
ref(node): Clarify usage of onFatalError option in node

### DIFF
--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -69,6 +69,13 @@ Available options:
 _Import name: `Sentry.Integrations.OnUncaughtException`_
 
 This integration attaches a global uncaught exception handler. It can be modified to provide a custom shutdown function.
+The `onFatalError` option is meant to perform a cleanup before the process exits, not fully prevent it.
+
+<Alert level="warning" title="Note">
+
+Be aware that if you are overwriting this setting, you will lose the default implementation, which handles draining queued events before exiting. If you want to see how it works and recreates in your custom code, see the implementation of [`logAndExitProcess`](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts) function.
+
+</Alert>
 
 Available options:
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -73,7 +73,7 @@ The `onFatalError` option is meant to perform a cleanup before the process exits
 
 <Alert level="warning" title="Note">
 
-Be aware that if you overwrite this setting, you will lose the default implementation, which handles draining queued events before exiting. If you want to see how it works in order to be able to recreate it in your code, see the implementation of the [`logAndExitProcess`](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts) function.
+Be aware that if you overwrite this setting, you will lose the default implementation, which handles draining queued events before exiting. If you want to examine how it works in order to be able to recreate it in your code, see the implementation of the [`logAndExitProcess`](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts) function.
 
 </Alert>
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -69,11 +69,11 @@ Available options:
 _Import name: `Sentry.Integrations.OnUncaughtException`_
 
 This integration attaches a global uncaught exception handler. It can be modified to provide a custom shutdown function.
-The `onFatalError` option is meant to perform a cleanup before the process exits, not fully prevent it.
+The `onFatalError` option is meant to perform a cleanup before the process exits, not fully prevent it from exiting.
 
 <Alert level="warning" title="Note">
 
-Be aware that if you are overwriting this setting, you will lose the default implementation, which handles draining queued events before exiting. If you want to see how it works and recreates in your custom code, see the implementation of [`logAndExitProcess`](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts) function.
+Be aware that if you overwrite this setting, you will lose the default implementation, which handles draining queued events before exiting. If you want to see how it works in order to be able to recreate it in your code, see the implementation of the [`logAndExitProcess`](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts) function.
 
 </Alert>
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1661#issuecomment-718200921
Fixes https://github.com/getsentry/sentry-javascript/issues/2796#issuecomment-718204061