### PR TITLE
add missing this (context) for android getting started config

### DIFF
--- a/src/includes/getting-started-config/android.mdx
+++ b/src/includes/getting-started-config/android.mdx
@@ -11,7 +11,7 @@ Or, if you are manually instrumenting Sentry:
 ```java
 import io.sentry.android.core.SentryAndroid;
 
-SentryAndroid.init(options -> {
+SentryAndroid.init(this, options -> {
   options.setDsn("___PUBLIC_DSN___");
 });
 ```


### PR DESCRIPTION
I guess a few more are missing the `this` or `context`, need to search for it, it's a typo from copying the examples from Java which doesn't require the context.