### PR TITLE
Update common to include manual event generation

### DIFF
--- a/src/includes/capture-error/_default.mdx
+++ b/src/includes/capture-error/_default.mdx
@@ -1,0 +1,13 @@
+<Note>
+
+The platform or SDK you've selected either does not support this functionality, or it is missing from our documentation. Please use this code sample from JavaScript as a basis:
+
+</Note>
+
+```javascript
+try {
+  aFunctionThatMightFail();
+} catch (err) {
+  Sentry.captureException(err);
+}
+```

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -28,6 +28,16 @@ This snippet includes an intentional error, so you can test that everything is w
 
 <PlatformContent includePath="getting-started-verify" />
 
+Or, by manually generating an event:
+
+<PlatformContent includePath="capture-error" />
+
+<Note>
+
+Learn more about manually capturing an error or message, in our <PlatformLink to="/enriching-events/breadcrumbs/">Usage documentation</PlatformLink>.
+
+</Note>
+
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 <PageGrid header="Next Steps" nextSteps />

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -28,9 +28,11 @@ This snippet includes an intentional error, so you can test that everything is w
 
 <PlatformContent includePath="getting-started-verify" />
 
+<PlatformContent includePath="capture-error" >
+
 Or, by manually generating an event:
 
-<PlatformContent includePath="capture-error" />
+</PlatformContent>
 
 <Note>
 


### PR DESCRIPTION
This PR adds to the option to manually generate an event to the verification step in Getting Started. 