### PR TITLE
fix(tracing): Add missing `return`s to snippet

### DIFF
--- a/src/includes/performance/traces-sampler-as-sampler/python.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/python.mdx
@@ -6,16 +6,16 @@ def traces_sampler(sampling_context):
 
     if "...":
         # These are important - take a big sample
-        0.5
+        return 0.5
     elif "...":
         # These are less important or happen much more frequently - only take 1%
-        0.01
+        return 0.01
     elif "...":
         # These aren't something worth tracking - drop all transactions like this
-        0
+        return 0
     else:
         # Default sample rate
-        0.1
+        return 0.1
 
 sentry_sdk.init(
     # ...


### PR DESCRIPTION
Somehow all the `return`s in the return statements went missing.

Fixes #2660.