### PR TITLE
fix(ci): Invalidate caches when node version changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,8 @@ jobs:
         with:
           path: ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}-${{ hashfiles('**/yarn.lock') }}
-      - run: yarn install
+      # Added --force as a workaround for https://github.com/yarnpkg/yarn/issues/4867
+      - run: yarn install --force
         if: steps.cache.outputs.cache-hit != 'true'
 
       - uses: actions/cache@v2


### PR DESCRIPTION
Getting the following error in CI:

```
Error: Missing binding /home/runner/work/sentry-docs/sentry-docs/node_modules/node-sass/vendor/linux-x64-83/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 14.x

Found bindings for the following environments:
  - Linux 64-bit with Node.js 12.x

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to download the binding for your current environment.
    at module.exports (/home/runner/work/sentry-docs/sentry-docs/node_modules/node-sass/lib/binding.js:15:13)
    at Object.<anonymous> (/home/runner/work/sentry-docs/sentry-docs/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (/home/runner/work/sentry-docs/sentry-docs/node_modules/gatsby/node_modules/v8-compile-cache/v8-compile-cache.js:178:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (/home/runner/work/sentry-docs/sentry-docs/node_modules/gatsby/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at getDefaultSassImpl (/home/runner/work/sentry-docs/sentry-docs/node_modules/sass-loader/dist/index.js:198:10)
    at Object.loader (/home/runner/work/sentry-docs/sentry-docs/node_modules/sass-loader/dist/index.js:80:29)
error Generating JavaScript bundles failed
```