### PR TITLE
chore: Use volta for main build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       JEKYLL_ENABLE_PLATFORM_API: false
     steps:
       - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
       - uses: actions/cache@v2
         id: cache
         with:


### PR DESCRIPTION
We will likely have to change the cache key to include package.json.

Follows up on #2666 