### PR TITLE
feat(tracing): Document integration-specific default sampling context for Python

### DIFF
--- a/src/includes/performance/default-sampling-context-platform/javascript.mdx
+++ b/src/includes/performance/default-sampling-context-platform/javascript.mdx
@@ -1,0 +1,14 @@
+For browser-based SDKs, it includes at least the following:
+
+```javascript
+// contents of `samplingContext`
+{
+  transactionContext: {
+    name: string; // human-readable identifier, like "GET /users"
+    op: string; // short description of transaction type, like "pageload"
+  }
+  parentSampled: boolean; // if this transaction has a parent, its sampling decision
+  location: Location | WorkerLocation; // the window.location or self.location object
+  ... // custom context as passed to `startTransaction`
+}
+```

--- a/src/includes/performance/default-sampling-context-platform/node.mdx
+++ b/src/includes/performance/default-sampling-context-platform/node.mdx
@@ -1,0 +1,13 @@
+For node-based SDKs, it includes at least the following:
+
+```javascript
+{
+  transactionContext: {
+    name: string; // human-readable identifier, like "GET /users"
+    op: string; // short description of transaction type, like "pageload"
+  }
+  parentSampled: boolean; // if this transaction has a parent, its sampling decision
+  request: object // in server contexts, information about the incoming request
+  ... // custom context as passed to `startTransaction`
+}
+```

--- a/src/includes/performance/default-sampling-context-platform/python.mdx
+++ b/src/includes/performance/default-sampling-context-platform/python.mdx
@@ -1,0 +1,12 @@
+For Python-based SDKs, it includes at least the following:
+
+```python
+{
+  "transaction_context": {
+    "name": string  # human-readable identifier, like "GET /users"
+    "op": string  # short description of transaction type, like "pageload"
+  },
+  "parent_sampled": bool  # if this transaction has a parent, its sampling decision
+  ...  # custom context as passed to `start_transaction`
+}
+```

--- a/src/includes/performance/default-sampling-context-platform/python.mdx
+++ b/src/includes/performance/default-sampling-context-platform/python.mdx
@@ -3,10 +3,10 @@ For Python-based SDKs, it includes at least the following:
 ```python
 {
   "transaction_context": {
-    "name": string  # human-readable identifier, like "GET /users"
-    "op": string  # short description of transaction type, like "pageload"
+    "name": <string>  # human-readable identifier, like "GET /users"
+    "op": <string>  # short description of transaction type, like "http.request"
   },
-  "parent_sampled": bool  # if this transaction has a parent, its sampling decision
+  "parent_sampled": <bool>  # if this transaction has a parent, its sampling decision
   ...  # custom context as passed to `start_transaction`
 }
 ```

--- a/src/includes/performance/default-sampling-context/javascript.mdx
+++ b/src/includes/performance/default-sampling-context/javascript.mdx
@@ -1,14 +1,1 @@
-For browser-based SDKs, it includes at least the following:
-
-```javascript
-// contents of `samplingContext`
-{
-  transactionContext: {
-    name: string; // human-readable identifier, like "GET /users"
-    op: string; // short description of transaction type, like "pageload"
-  }
-  parentSampled: boolean; // if this transaction has a parent, its sampling decision
-  location: Location | WorkerLocation; // the window.location or self.location object
-  ... // custom context as passed to `startTransaction`
-}
-```
+<PlatformContent includePath="performance/default-sampling-context-platform" />

--- a/src/includes/performance/default-sampling-context/node.mdx
+++ b/src/includes/performance/default-sampling-context/node.mdx
@@ -1,13 +1,1 @@
-For node-based SDKs, it includes at least the following:
-
-```javascript
-{
-  transactionContext: {
-    name: string; // human-readable identifier, like "GET /users"
-    op: string; // short description of transaction type, like "pageload"
-  }
-  parentSampled: boolean; // if this transaction has a parent, its sampling decision
-  request: object // in server contexts, information about the incoming request
-  ... // custom context as passed to `startTransaction`
-}
-```
+<PlatformContent includePath="performance/default-sampling-context-platform" />

--- a/src/includes/performance/default-sampling-context/python.aiohttp.mdx
+++ b/src/includes/performance/default-sampling-context/python.aiohttp.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The AIOHTTP integration adds the incoming request object:
+
+```python
+{
+  "aiohttp_request": aiohttp.web_request.Request
+}
+```

--- a/src/includes/performance/default-sampling-context/python.aiohttp.mdx
+++ b/src/includes/performance/default-sampling-context/python.aiohttp.mdx
@@ -4,6 +4,6 @@ The AIOHTTP integration adds the incoming request object:
 
 ```python
 {
-  "aiohttp_request": aiohttp.web_request.Request
+  "aiohttp_request": <aiohttp.web_request.Request>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.asgi.mdx
+++ b/src/includes/performance/default-sampling-context/python.asgi.mdx
@@ -4,6 +4,6 @@ The ASGI integration adds the request scope:
 
 ```python
 {
-  "asgi_scope": dict
+  "asgi_scope": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.asgi.mdx
+++ b/src/includes/performance/default-sampling-context/python.asgi.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The ASGI integration adds the request scope:
+
+```python
+{
+  "asgi_scope": dict
+}
+```

--- a/src/includes/performance/default-sampling-context/python.aws-lambda.mdx
+++ b/src/includes/performance/default-sampling-context/python.aws-lambda.mdx
@@ -1,0 +1,10 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The AWS Lambda integration adds the `event` and `context` passed to the function handler:
+
+```python
+{
+  "aws_event": any,
+  "aws_context": LambdaContext,
+}
+```

--- a/src/includes/performance/default-sampling-context/python.aws-lambda.mdx
+++ b/src/includes/performance/default-sampling-context/python.aws-lambda.mdx
@@ -4,7 +4,7 @@ The AWS Lambda integration adds the `event` and `context` passed to the function
 
 ```python
 {
-  "aws_event": any,
-  "aws_context": LambdaContext,
+  "aws_event": <any>,
+  "aws_context": <LambdaContext>,
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.bottle.mdx
+++ b/src/includes/performance/default-sampling-context/python.bottle.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Bottle integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.celery.mdx
+++ b/src/includes/performance/default-sampling-context/python.celery.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Celery integration adds information about the current job:
+
+```python
+{
+  "celery_job": dict
+}
+```

--- a/src/includes/performance/default-sampling-context/python.celery.mdx
+++ b/src/includes/performance/default-sampling-context/python.celery.mdx
@@ -4,6 +4,6 @@ The Celery integration adds information about the current job:
 
 ```python
 {
-  "celery_job": dict
+  "celery_job": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.django.mdx
+++ b/src/includes/performance/default-sampling-context/python.django.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Django integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.falcon.mdx
+++ b/src/includes/performance/default-sampling-context/python.falcon.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Falcon integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.flask.mdx
+++ b/src/includes/performance/default-sampling-context/python.flask.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Flask integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
+++ b/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
@@ -4,7 +4,7 @@ The GCP Functions integration adds information about the environment and incomin
 
 ```python
 {
-  "gcp_env": dict,
-  "gcp_event": dict,
+  "gcp_env": <dict>,
+  "gcp_event": <dict>,
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
+++ b/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
@@ -1,0 +1,10 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The GCP Functions integration adds information about the environment and incoming event:
+
+```python
+{
+  "gcp_env": dict,
+  "gcp_event": dict,
+}
+```

--- a/src/includes/performance/default-sampling-context/python.mdx
+++ b/src/includes/performance/default-sampling-context/python.mdx
@@ -1,12 +1,1 @@
-For Python-based SDKs, it includes at least the following:
-
-```python
-{
-  "transaction_context": {
-    "name": string  # human-readable identifier, like "GET /users"
-    "op": string  # short description of transaction type, like "pageload"
-  },
-  "parent_sampled": bool  # if this transaction has a parent, its sampling decision
-  ...  # custom context as passed to `start_transaction`
-}
-```
+<PlatformContent includePath="performance/default-sampling-context-platform" />

--- a/src/includes/performance/default-sampling-context/python.pyramid.mdx
+++ b/src/includes/performance/default-sampling-context/python.pyramid.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Pyramid integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.rq.mdx
+++ b/src/includes/performance/default-sampling-context/python.rq.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The RQ integration adds information about the current job:
+
+```python
+{
+  "rq_job": rq.job.Job
+}
+```

--- a/src/includes/performance/default-sampling-context/python.rq.mdx
+++ b/src/includes/performance/default-sampling-context/python.rq.mdx
@@ -4,6 +4,6 @@ The RQ integration adds information about the current job:
 
 ```python
 {
-  "rq_job": rq.job.Job
+  "rq_job": <rq.job.Job>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.tryton.mdx
+++ b/src/includes/performance/default-sampling-context/python.tryton.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The Tryton integration adds the WSGI request environ:
+
+```python
+{
+  "wsgi_environ": <dict>
+}
+```

--- a/src/includes/performance/default-sampling-context/python.wsgi.mdx
+++ b/src/includes/performance/default-sampling-context/python.wsgi.mdx
@@ -4,6 +4,6 @@ The WSGI integration adds the request environ:
 
 ```python
 {
-  "wsgi_environ": dict
+  "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.wsgi.mdx
+++ b/src/includes/performance/default-sampling-context/python.wsgi.mdx
@@ -1,0 +1,9 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />
+
+The WSGI integration adds the request environ:
+
+```python
+{
+  "wsgi_environ": dict
+}
+```


### PR DESCRIPTION
This documents the changes made in https://github.com/getsentry/sentry-python/pull/888, https://github.com/getsentry/sentry-python/pull/906, and https://github.com/getsentry/sentry-python/pull/916 - adding information to the default sampling context passed to `traces_sampler` for the `aiohttp`, `asgi`, `aws`, `bottle`, `celery`, `django`, `falcon`, `flask`, `gcp`, `pyramid`, `rq`, `tryton`, and `wsgi` integrations to the Python SDK. (Some of those didn't directly have it added but rely on the `wsgi` integration and therefore get it for free.)