### PR TITLE
User keys are actually listed _below_ the lines

### DIFF
--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -46,7 +46,7 @@ An override for Sentry’s automatic language detection (e.g. `lang=de`)
 | ---------------- | ------------------------------------------------------------------------------------------------- |
 | `eventId`        | Manually set the id of the event.                                                                 |
 | `dsn`            | Manually set dsn to report to.                                                                    |
-| `user`           | Manually set user data _[an object with keys listed above]_.                                      |
+| `user`           | Manually set user data _[an object with keys listed below]_.                                      |
 | `user.email`     | User's email address.                                                                             |
 | `user.name`      | User's name.                                                                                      |
 | `lang`           | _[automatic]_ – **override for Sentry’s language code**                                           |


### PR DESCRIPTION
Unless I'm mistaking, it seems like the user properties are listed below, not above the line mentioned