### PR TITLE
Change @sentry/serverless to @sentry/node

### DIFF
--- a/src/platforms/node/guides/gcp-functions/index.mdx
+++ b/src/platforms/node/guides/gcp-functions/index.mdx
@@ -7,18 +7,18 @@ description: "Learn about using Sentry with GCP Cloud Functions."
 
 _(New in version 5.26.0)_
 
-Add `@sentry/serverless` as a dependency to `package.json`:
+Add `@sentry/node` as a dependency to `package.json`:
 
 ```bash
-  "@sentry/serverless": "^5.26.0"
+  "@sentry/node": "^5.26.0"
 ```
 
 To set up Sentry for a GCP Cloud Function:
 
 ```javascript {tabTitle:http functions}
-const Sentry = require("@sentry/serverless");
+const Sentry = require("@sentry/node");
 
-Sentry.GCPFunction.init({
+Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
 });
@@ -42,9 +42,9 @@ exports.helloEvents = Sentry.GCPFunction.wrapEventFunction((data, context, callb
 ```
 
 ```javascript {tabTitle:cloudEvents}
-const Sentry = require("@sentry/serverless");
+const Sentry = require("@sentry/node");
 
-Sentry.GCPFunction.init({
+Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
 });


### PR DESCRIPTION
Honestly not sure what the correct documentation should be here. Changing to @sentry/node clears all the compile time errors for me. I couldn't find the  Sentry.GCPFunction.wrapCloudEventFunction(..) so I handle it manually in my project. 

I'm using Firebase Functions.