### PR TITLE
ref(ui): use prism-sentry theme for code snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
     "platformicons": "^4.1.2",
+    "prism-sentry": "^1.0.2",
     "prismjs": "^1.20.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MDXProvider } from "@mdx-js/react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 
-import "prismjs/themes/prism-tomorrow.css";
+import "prism-sentry/index.css";
 
 import Alert from "./alert";
 import Break from "./break";

--- a/src/css/_includes/code-blocks.scss
+++ b/src/css/_includes/code-blocks.scss
@@ -3,8 +3,8 @@
   margin-bottom: 1rem;
 
   .tab-bar {
-    background: #2d2d2d;
-    border-bottom: 1px solid #444;
+    background: #251f3d;
+    border-bottom: 1px solid #40364a;
     height: 36px;
     display: flex;
     align-items: center;
@@ -44,7 +44,7 @@
       position: absolute;
       margin: 0 0.25rem;
       right: 0;
-      top: -33px;
+      top: -35px;
     }
 
     .filename {
@@ -84,7 +84,7 @@
     }
 
     .keyword-selector {
-      background: $desatPurple4;
+      background: #382f5c; // highlightBackground
       border-radius: 2px;
       margin: 0 -2px;
       padding: 0 2px;

--- a/src/css/screen.scss
+++ b/src/css/screen.scss
@@ -60,7 +60,7 @@ code[class*="language-"], pre[class*="language-"] {
 }
 
 pre[class*="language-"] {
-  font-size: 0.85em;
+  font-size: 1em;
   border: 0;
   border-radius: 4px;
   margin: 0 0 1rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14326,6 +14326,11 @@ pretty-format@^26.4.2:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+prism-sentry@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/prism-sentry/-/prism-sentry-1.0.2.tgz#33ef5e6be5f25212b82316c654026b4215da6572"
+  integrity sha512-3W6a1SC+IOjG3e1BIj/IXLccUnLls06ij4A6yq3/DhEbZcQmhxwvNGxVmUR2kNOctn2phXbaAnk18urTtVpc6w==
+
 prismjs@^1.20.0:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"


### PR DESCRIPTION
This replaces the `prism-tomorrow` theme with a custom Sentry-branded theme.

### Before:

<img width="1462" alt="Screen Shot 2020-11-17 at 2 45 24 PM" src="https://user-images.githubusercontent.com/30713/99460191-475f1400-28e4-11eb-855f-eea27b4603db.png">

### After:

<img width="1462" alt="Screen Shot 2020-11-17 at 3 03 25 PM" src="https://user-images.githubusercontent.com/30713/99461389-9b6af800-28e6-11eb-894b-6aa302972a85.png">
