### PR TITLE
fix: PHP request body

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -115,7 +115,7 @@ This option can be overridden using `in-app-include`.
 
 </ConfigKey>
 
-<ConfigKey name="request-bodies" supported={["python", "php"]}>
+<ConfigKey name="request-bodies" supported={["python"]}>
 
 This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
 
@@ -125,6 +125,18 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 - `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
 
 </ConfigKey>
+
+<ConfigKey name="max-request-body-size" supported={["php"]}>
+
+This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
+
+- `never`: request bodies are never sent
+- `small`: only small request bodies will be captured where the cutoff for small depends on the SDK (typically 4KB)
+- `medium`: medium and small requests will be captured (typically 10KB)
+- `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
+
+</ConfigKey>
+
 
 <ConfigKey name="with-locals" supported={["python"]}>
 


### PR DESCRIPTION
Once Python SDK implemented this correctly we can remove the dupe.
https://github.com/getsentry/sentry-python/issues/926