### PR TITLE
feat(sdk-guide): Make file references consistent

### DIFF
--- a/src/docs/contributing/approach/write-getting-started.mdx
+++ b/src/docs/contributing/approach/write-getting-started.mdx
@@ -4,7 +4,7 @@ noindex: true
 sidebar_order: 4
 ---
 
-In most cases, the platform/SDK will adopt the common index page, which is stored in `/platforms/common/`, as the `index.mdx` file - feel free to peruse that file to answer any questions.
+In most cases, the platform/SDK will adopt the common index page, which is stored in [`src/platforms/common/`](https://github.com/getsentry/sentry-docs/tree/master/src/platforms/common), as the [`index.mdx`](https://github.com/getsentry/sentry-docs/blob/master/src/platforms/common/index.mdx) file - feel free to peruse that file to answer any questions.
 
 <Alert >
 
@@ -60,11 +60,11 @@ Provide an example of the configuration of this SDK, commenting in the code samp
 
 Add the configuration code sample to this directory:
 
-- `/src/includes/getting-started-config/`
+- [`/src/includes/getting-started-config/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-config)
 
 <Note >
 
-If the SDK supports performance monitoring, add it to the list that links back into the SDK content from Product, stored in /src/docs/product/performance/getting-started.mdx.
+If the SDK supports performance monitoring, add it to the list that links back into the SDK content from Product, stored in [`/src/docs/product/performance/getting-started.mdx`](https://github.com/getsentry/sentry-docs/blob/master/src/docs/product/performance/getting-started.mdx).
 
 </Note >
 
@@ -74,7 +74,7 @@ Provide a verification code sample for this SDK. It can be as simple as one line
 
 Add the verification code sample to this directory:
 
-- `/src/includes/getting-started-verify/`
+- [`/src/includes/getting-started-verify/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-verify)
 
 ## But, that's not all
 

--- a/src/docs/contributing/approach/write-getting-started.mdx
+++ b/src/docs/contributing/approach/write-getting-started.mdx
@@ -44,7 +44,7 @@ Explain the SDK at a high level in these two parts:
 
 Add the primer content to this directory:
 
-- `/src/includes/getting-started-primer/`
+- [`/src/includes/getting-started-primer/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-primer)
 
 ## Installation Method
 
@@ -52,7 +52,7 @@ Provide an example of the primary installation method for this SDK. While we doc
 
 Add the installation method to this directory:
 
-- `/src/includes/getting-started-install/`
+- [`/src/includes/getting-started-install/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-install)
 
 ## Configuration Code Sample
 


### PR DESCRIPTION
Makes all code file references in the guide consistent and link to relevant GitHub pages in the getting started guide.