### PR TITLE
Fix typo on JavaScript source maps page

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -46,7 +46,7 @@ The Releases -> Admin permission is also known as 'project:releases' in other AP
 
 </Note>
 
-You may configure [sentry-cli](/product/cli/configuration/) through it's documented mechanisms, or instead simply bind required parameters when initializing the plugin:
+You may configure [sentry-cli](/product/cli/configuration/) through its documented mechanisms, or instead simply bind required parameters when initializing the plugin:
 
 ```javascript {filename:webpack.config.js}
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");


### PR DESCRIPTION
Tiny typo fix 😄 