### PR TITLE
fix(integrations): Update Splunk self-service HEC url

### DIFF
--- a/src/docs/product/integrations/splunk/index.mdx
+++ b/src/docs/product/integrations/splunk/index.mdx
@@ -94,10 +94,10 @@ After navigating to **Data Forwarding**, enable the Splunk integration:
 
 ![](splunk-data-forwarding-setting.png)
 
-Your instance URL is going to vary based on the type of Splunk service you’re using. If you’re using self-service Splunk Cloud, the instance URL will use the `input` prefix:
+Your instance URL is going to vary based on the type of Splunk service you’re using. If you’re using self-service Splunk Cloud, the instance URL will be <host> the url of the Splunk instance that runs HEC:
 
 ```
-https://input-<host>:8088
+https://<host>:8088
 ```
 
 For all other Splunk Cloud plans, you’ll use the `http-inputs` prefix:

--- a/src/docs/product/integrations/splunk/index.mdx
+++ b/src/docs/product/integrations/splunk/index.mdx
@@ -94,7 +94,7 @@ After navigating to **Data Forwarding**, enable the Splunk integration:
 
 ![](splunk-data-forwarding-setting.png)
 
-Your instance URL is going to vary based on the type of Splunk service you’re using. If you’re using self-service Splunk Cloud, the instance URL will be <host> the url of the Splunk instance that runs HEC:
+Your instance URL is going to vary based on the type of Splunk service you’re using. If you’re using self-service Splunk Cloud, the instance URL will be the URL of the Splunk instance running the HTTP Event Collector (HEC):
 
 ```
 https://<host>:8088


### PR DESCRIPTION
## Objective
Our Splunk integration docs are out of date. When we try to setup an HEC with the self-service Splunk plan and our current docs, we fail to connect with a valid url. 

![Screen Shot 2020-11-16 at 3 22 01 PM](https://user-images.githubusercontent.com/10491193/99856338-9eabf100-2b3d-11eb-9f44-c347a8d5b8c3.png)

Our current docs provide the same instructions as the Splunk docs:
https://docs.splunk.com/Documentation/Splunk/8.1.0/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector_on_Splunk_Cloud_instances

However, when we remove the `input` prefix from the url, we are able to connect to the Splunk instance and forward events. This has only been confirmed with the self-service Splunk Cloud plan.

Apparently for other plans, Splunk need to use `https-input` prefix, but we need to confirm whether this is still true.