### PR TITLE
fix(tracing): Add link to Enabling Tracing page from Manual Capture page

### DIFF
--- a/src/platforms/javascript/common/performance/capturing/manual.mdx
+++ b/src/platforms/javascript/common/performance/capturing/manual.mdx
@@ -6,6 +6,8 @@ description: "Learn how to capture performance data on any action in your app."
 
 ### Manual Instrumentation
 
+**Note**: To manually capture transactions, you must first <PlatformLink to="/performance/">enable tracing in your app.</PlatformLink>
+
 To manually instrument certain regions of your code, you can create transactions to capture them. This is valid for all JavaScript SDKs (both backend and frontend) and works independently of the `Express`, `Http`, and `BrowserTracing` integrations.
 
 ```javascript


### PR DESCRIPTION
In case someone lands on the latter before the former.