### PR TITLE
Add Java & Spring Boot performance docs.

### DIFF
--- a/src/includes/performance/always-inherit-sampling-decision/java.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/java.mdx
@@ -1,0 +1,9 @@
+```java
+TracesSamplerCallback tracesSampler = (TracesSamplerCallback) samplingContext -> {
+  Boolean parentSampled = samplingContext.getTransactionContexts().getParentSampled();
+  if (parentSampled != null) {
+    return parentSampled ? 1 : 0;
+  }
+  // the rest of sampling logic
+}
+```

--- a/src/includes/performance/custom-sampling-context/java.mdx
+++ b/src/includes/performance/custom-sampling-context/java.mdx
@@ -1,0 +1,10 @@
+```java
+// sampling context - won't be recorded
+CustomSamplingContext context = new CustomSamplingContext();
+context.put("user_id", 12312012);
+context.put("search_results", searchResults);
+SentryTransaction transaction = Sentry.startTransaction("GET /search", context);
+// transaction context - will be recorded on transaction
+transaction.setOperation("http");
+transaction.setDescription("search results");
+```

--- a/src/includes/performance/default-sampling-context-platform/java.mdx
+++ b/src/includes/performance/default-sampling-context-platform/java.mdx
@@ -1,16 +1,1 @@
-For Java-based SDKs, it includes at least the following:
-
-```javascript
-// contents of `samplingContext`
-{
-  transactionContext: {
-    name: string; // human-readable identifier, like "GET /users"
-    parentSampled: boolean; // if this transaction has a parent, its sampling decision
-  }
-  customSamplingContext: {
-    data: {
-        ... // custom context as passed to `startTransaction`
-    }
-  }
-}
-```
+For Java-based SDKs, it includes a [Transaction Context](https://getsentry.github.io/sentry-java/io/sentry/TransactionContext.html) and a [Custom Sampling Context](https://getsentry.github.io/sentry-java/io/sentry/CustomSamplingContext.html).

--- a/src/includes/performance/default-sampling-context-platform/java.mdx
+++ b/src/includes/performance/default-sampling-context-platform/java.mdx
@@ -1,0 +1,16 @@
+For Java-based SDKs, it includes at least the following:
+
+```javascript
+// contents of `samplingContext`
+{
+  transactionContext: {
+    name: string; // human-readable identifier, like "GET /users"
+    parentSampled: boolean; // if this transaction has a parent, its sampling decision
+  }
+  customSamplingContext: {
+    data: {
+        ... // custom context as passed to `startTransaction`
+    }
+  }
+}
+```

--- a/src/includes/performance/default-sampling-context/java.mdx
+++ b/src/includes/performance/default-sampling-context/java.mdx
@@ -1,0 +1,1 @@
+<PlatformContent includePath="performance/default-sampling-context-platform" />

--- a/src/includes/performance/dynamic-sampling-function-intro/java.mdx
+++ b/src/includes/performance/dynamic-sampling-function-intro/java.mdx
@@ -1,0 +1,3 @@
+To sample dynamically, set the <PlatformIdentifier name="traces-sampler" /> option in your `Sentry.init()` to a function that will accept a <PlatformIdentifier name="sampling-context" /> dictionary and return a sample rate between 0 and 1. For example:
+
+<PlatformContent includePath="performance/traces-sampler-as-sampler" />

--- a/src/includes/performance/enable-tracing/java.mdx
+++ b/src/includes/performance/enable-tracing/java.mdx
@@ -1,0 +1,15 @@
+```java
+import io.sentry.Sentry;
+
+Sentry.init(
+  options -> {
+    options.setDsn("___PUBLIC_DSN___");
+    // To set a uniform sample rate
+    options.setTracesSampleRate(1.0);
+    // Determine traces sample rate based on the sampling context
+    options.setTracesSampler(
+        context -> {
+          // return a number between 0 and 1
+        });
+  });
+```

--- a/src/includes/performance/enable-tracing/java.mdx
+++ b/src/includes/performance/enable-tracing/java.mdx
@@ -6,7 +6,7 @@ Sentry.init(
     options.setDsn("___PUBLIC_DSN___");
     // To set a uniform sample rate
     options.setTracesSampleRate(1.0);
-    // Determine traces sample rate based on the sampling context
+    // OR if you prefer, determine traces sample rate based on the sampling context
     options.setTracesSampler(
         context -> {
           // return a number between 0 and 1

--- a/src/includes/performance/enable-tracing/java.spring-boot.mdx
+++ b/src/includes/performance/enable-tracing/java.spring-boot.mdx
@@ -1,0 +1,30 @@
+To get started automatically sending traces you must enable tracing in `application.properties`:
+
+```properties
+sentry.enable-tracing=true
+```
+
+Next, you must choose one of two options to configure sampling:
+
+- Set a uniform sample rate for all transactions, by setting the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
+- Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
+
+Or alternatively:
+
+Configure sample rate in `application.properties` or `application.yml` file:
+
+```properties
+sentry.traces-sample-rate=0.3
+```
+
+Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:
+
+```java
+@Component
+class CustomTracesSamplerCallback {
+  @Override
+  public @NotNull Double sample(@NotNull SamplingContext samplingContext) {
+    // return a number between 0 and 1
+  }
+}
+```

--- a/src/includes/performance/force-sampling-decision/java.mdx
+++ b/src/includes/performance/force-sampling-decision/java.mdx
@@ -1,0 +1,5 @@
+```java
+TransactionContext transactionContext = new TransactionContext("GET /search");
+transactionContext.setSampled(true);
+SentryTransaction transaction = Sentry.startTransaction(transactionContext);
+```

--- a/src/includes/performance/traces-sample-rate/java.mdx
+++ b/src/includes/performance/traces-sample-rate/java.mdx
@@ -1,0 +1,7 @@
+```java
+Sentry.init(
+  options -> {
+    ...
+    options.setTracesSampleRate(0.2);
+  });
+```

--- a/src/includes/performance/traces-sample-rate/java.spring-boot.mdx
+++ b/src/includes/performance/traces-sample-rate/java.spring-boot.mdx
@@ -1,0 +1,3 @@
+```properties
+sentry.traces-sample-rate=0.2
+```

--- a/src/includes/performance/traces-sampler-as-sampler/java.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/java.mdx
@@ -6,7 +6,7 @@ Sentry.init(
     options.setDsn("___PUBLIC_DSN___");
     // To set a uniform sample rate
     options.setTracesSampleRate(1.0);
-    // Determine traces sample rate based on the sampling context
+    // OR: Determine traces sample rate based on the sampling context
     options.setTracesSampler(
       context -> {
         if (...) {

--- a/src/includes/performance/traces-sampler-as-sampler/java.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/java.mdx
@@ -9,14 +9,14 @@ Sentry.init(
     // OR: Determine traces sample rate based on the sampling context
     options.setTracesSampler(
       context -> {
-        if (...) {
+        if ("/payment".equals(context.get("url"))) {
           // These are important - take a big sample
           return 0.5;
-        } else if (...) {
-          // These are less important or happen much more frequently - only take 1%
+        } else if ("/search".equals(context.get("url"))) {
+          // Search is less important and happen much more frequently - only take 1%
           return 0.01;
-        } else if (...) {
-          // These aren't something worth tracking - drop all transactions like this
+        } else if ("/health".equals(context.get("url"))) {
+          // The health check endpoint is just noise - drop all transactions
           return 0;
         } else {
           // Default sample rate

--- a/src/includes/performance/traces-sampler-as-sampler/java.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/java.mdx
@@ -1,0 +1,27 @@
+```java
+import io.sentry.Sentry;
+
+Sentry.init(
+  options -> {
+    options.setDsn("___PUBLIC_DSN___");
+    // To set a uniform sample rate
+    options.setTracesSampleRate(1.0);
+    // Determine traces sample rate based on the sampling context
+    options.setTracesSampler(
+      context -> {
+        if (...) {
+          // These are important - take a big sample
+          return 0.5;
+        } else if (...) {
+          // These are less important or happen much more frequently - only take 1%
+          return 0.01;
+        } else if (...) {
+          // These aren't something worth tracking - drop all transactions like this
+          return 0;
+        } else {
+          // Default sample rate
+          return 0.1;
+        }
+      });
+  });
+```

--- a/src/includes/performance/traces-sampler-as-sampler/java.spring-boot.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/java.spring-boot.mdx
@@ -1,0 +1,21 @@
+```java
+@Component
+class CustomTracesSamplerCallback {
+  @Override
+  public @NotNull Double sample(@NotNull SamplingContext context) {
+    if ("/payment".equals(context.get("url"))) {
+      // These are important - take a big sample
+      return 0.5;
+    } else if ("/search".equals(context.get("url"))) {
+      // Search is less important and happen much more frequently - only take 1%
+      return 0.01;
+    } else if ("/health".equals(context.get("url"))) {
+      // The health check endpoint is just noise - drop all transactions
+      return 0;
+    } else {
+      // Default sample rate
+      return 0.1;
+    }
+  }
+}
+```

--- a/src/includes/performance/uniform-sample-rate/java.mdx
+++ b/src/includes/performance/uniform-sample-rate/java.mdx
@@ -1,0 +1,3 @@
+To do this, set the <PlatformIdentifier name="traces-sample-rate" /> option in your `sentry_sdk.init()` to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. (So, for example, if you set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`, approximately 20% of your transactions will get recorded and sent.) That looks like this:
+
+<PlatformContent includePath="performance/traces-sample-rate" />

--- a/src/includes/performance/uniform-sample-rate/java.mdx
+++ b/src/includes/performance/uniform-sample-rate/java.mdx
@@ -1,3 +1,3 @@
-To do this, set the <PlatformIdentifier name="traces-sample-rate" /> option in your `sentry_sdk.init()` to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. (So, for example, if you set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`, approximately 20% of your transactions will get recorded and sent.) That looks like this:
+To do this, set the <PlatformIdentifier name="traces-sample-rate" /> option in your `Sentry.init()` to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. (So, for example, if you set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`, approximately 20% of your transactions will get recorded and sent.) That looks like this:
 
 <PlatformContent includePath="performance/traces-sample-rate" />

--- a/src/platforms/common/performance/sampling.mdx
+++ b/src/platforms/common/performance/sampling.mdx
@@ -7,6 +7,7 @@ supported:
   - javascript
   - node
   - python
+  - java
 ---
 
 You can control the volume of transactions sent to Sentry in two ways.
@@ -49,7 +50,7 @@ Whatever a transaction's sampling decision, that decision will be passed to its 
 
 If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, so that you don't end up with partial traces.)
 
-For convenience, the <PlatformIdentifier name="traces-sampler" /> function can return a boolean, so that a parent's decision can be returned directly if that's the desired behavior.
+In some SDKs, for convenience, the <PlatformIdentifier name="traces-sampler" /> function can return a boolean, so that a parent's decision can be returned directly if that's the desired behavior.
 
 <PlatformContent includePath="performance/always-inherit-sampling-decision" />
 

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -1,0 +1,103 @@
+---
+title: Performance Monitoring
+description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
+---
+
+<Alert level="warning" title="Note">
+Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
+</Alert>
+
+Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs. Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
+
+## Enabling Tracing
+
+To get started automatically sending traces you can:
+
+- Set a uniform sample rate for all transactions, by setting the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
+- Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
+
+<PlatformContent includePath="performance/enable-tracing" />
+
+If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
+
+As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Spring Boot integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
+
+You can learn more about the <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> options in <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.
+
+## Manual Instrumentation
+
+To manually instrument certain regions of your code, you can create a transaction to capture them.
+
+The following example creates a transaction for a scope that contains an expensive operation (for example, `processItem`), and sends the result to Sentry:
+
+```java
+import io.sentry.Sentry;
+import io.sentry.SentryTransaction;
+import io.sentry.SpanStatus;
+
+SentryTransaction transaction = Sentry.startTransaction("transaction name");
+transaction.setOperation("task");
+try {
+    processItem();
+} catch (Exception e) {
+    transaction.setThrowable(e);
+    transaction.setSpanStatus(SpanStatus.INTERNAL_ERROR)
+} finally {
+    transaction.finish();
+}
+```
+
+### Adding More Spans to the Transaction
+
+The next example contains the implementation of the hypothetical `processItem` function called from the code snippet in the previous section. Our SDK can determine if there is currently an open transaction and add all newly created spans as child operations to that transaction. Keep in mind that each individual span also needs to be manually finished; otherwise, spans will not show up in the transaction.
+
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#getSpan`. This method will return a `SentryTransaction` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `null`.
+
+You can choose the value of `operation` and `description`.
+
+```java
+import io.sentry.ISpan;
+import io.sentry.Span;
+import io.sentry.SpanStatus;
+
+void processItem(Item item):
+    ISpan span = Sentry.getSpan();
+    Span innerSpan = span.startChild();
+    innerSpan.setOperation("task");
+    innerSpan.setDescription(item.getName());
+    try {
+        // omitted code
+    } catch (NotFoundException e) {
+        innerSpan.setThrowable(e);
+        innerSpan.setSpanStatus(SpanStatus.NOT_FOUND)
+    } finally {
+        innerSpan.finish();
+    }
+}
+```
+
+### Retrieving a Transaction
+
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#getSpan`. This method will return a `SentryTransaction` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `null`.
+
+```java
+import io.sentry.ISpan;
+import io.sentry.Span;
+import io.sentry.SpanStatus;
+
+ISpan span = Sentry.getSpan();
+if (span == null) {
+    span = Sentry.startTransaction("task");
+} else {
+    span = span.startChild();
+}
+
+try {
+    // omitted code
+} catch (Exception e) {
+    span.setThrowable(e);
+    span.setSpanStatus(SpanStatus.INTERNAL_ERROR)
+} finally {
+    span.finish();
+}
+```

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -30,17 +30,18 @@ You can learn more about the <PlatformIdentifier name="traces-sample-rate" /> an
 
 To manually instrument certain regions of your code, you can create a transaction to capture them.
 
-The following example creates a transaction for a scope that contains an expensive operation (for example, `processItem`), and sends the result to Sentry:
+The following example creates a transaction for a scope that contains an expensive operation (for example, `processOrderBatch`), and sends the result to Sentry:
 
 ```java
 import io.sentry.Sentry;
 import io.sentry.SentryTransaction;
 import io.sentry.SpanStatus;
 
-SentryTransaction transaction = Sentry.startTransaction("transaction name");
+// A good name for the transaction is key, to help identify what this is about
+SentryTransaction transaction = Sentry.startTransaction("processOrderBatch()");
 transaction.setOperation("task");
 try {
-    processItem();
+    procesOrderBatch();
 } catch (Exception e) {
     transaction.setThrowable(e);
     transaction.setSpanStatus(SpanStatus.INTERNAL_ERROR)

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -65,9 +65,7 @@ import io.sentry.SpanStatus;
 
 void processItem(Item item):
     ISpan span = Sentry.getSpan();
-    Span innerSpan = span.startChild();
-    innerSpan.setOperation("task");
-    innerSpan.setDescription(item.getName());
+    Span innerSpan = span.startChild("task", item.getName());
     try {
         // omitted code
     } catch (NotFoundException e) {

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -77,6 +77,8 @@ void processItem(Item item):
 }
 ```
 
+Spans are sent together with their parent transaction when the transaction is finished. Make sure to call `finish()` on transaction once all the child spans have finished.
+
 ### Retrieving a Transaction
 
 In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#getSpan`. This method will return a `SentryTransaction` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `null`.

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -16,6 +16,8 @@ To get started automatically sending traces you can:
 - Set a uniform sample rate for all transactions, by setting the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 - Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
 
+Or alternatively:
+
 <PlatformContent includePath="performance/enable-tracing" />
 
 If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)

--- a/src/platforms/java/common/performance/index.mdx
+++ b/src/platforms/java/common/performance/index.mdx
@@ -7,7 +7,7 @@ description: "Learn more about how to configure our Performance integrations to 
 Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
 </Alert>
 
-Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs. Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
+Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
 ## Enabling Tracing
 

--- a/src/platforms/java/guides/spring-boot/performance/capturing/index.mdx
+++ b/src/platforms/java/guides/spring-boot/performance/capturing/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Capturing Transactions
+sidebar_order: 20
+description: "Learn how to capture transactions both automatically and manually."
+---
+
+## Spring MVC Integration
+
+Sentry Spring Boot integration, once enabled, captures each incoming Spring MVC HTTP request and turns it into a transaction with `SentryTracingFilter`. Transaction names follow pattern `<HTTP method> <Spring MVC route>`, for example for a request to a following controller:
+
+```java
+@RestController
+class HelloController {
+
+    @GetMapping("/person/{id}")
+    Person person(@PathVariable Long id) {
+        ...
+    }
+}
+```
+
+Each sampled request executed by this controller method will be turned into a transaction `GET /person/{id}`.
+
+## RestTemplate Instrumentation
+
+Sentry Spring Boot integration provides `SentrySpanRestTemplateCustomizer` that creates a span for each outgoing HTTP request executed with a `RestTemplate`. To use instrumented `RestTemplate` make sure to create `RestTemplate` beans using `RestTemplateBuilder`:
+
+```java
+@Configuration
+class AppConfig {
+    @Bean
+    RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}
+```
+
+## Capturing Bean Method Execution
+
+### Capturing Transaction
+
+Every Spring bean method execution can be turned into a transaction or a span. To enable this feature, you must include `spring-boot-starter-aop` in your application:
+
+```xml {tabTitle:Maven}
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-aop</artifactId>
+</dependency>
+```
+
+Methods executed outside of Spring MVC request processing can be turned into transactions by annotating them with `@SentryTransaction` annotation:
+
+```java
+@Component
+class ScheduledJob {
+
+    @Scheduled(...)
+    @SentryTransaction
+    void execute() {
+        ...
+    }
+}
+```
+`@SentryTransaction` can be configured with custom `name` and `op` properties. If not defined, `name` will be resolved from the class, and the method name.
+
+Advanced Spring AOP users can redefine transaction pointcut by providing a custom `org.springframework.aop.Pointcut` bean with name `sentryTransactionPointcut`.
+
+### Capturing Span
+
+To create a span around a method execution, annotate method with `@SentrySpan` annotation:
+
+```java
+@Component
+class PersonService {
+
+    @SentrySpan
+    Person findById(Long id) {
+        ...
+    }
+}
+```
+
+`@SentrySpan` can be configured with custom `description` and `op` properties. If not defined, `description` will be resolved from the class, and the method name.
+
+Advanced Spring AOP users can redefine span pointcut by providing a custom `org.springframework.aop.Pointcut` bean with name `sentrySpanPointcut`.

--- a/src/platforms/java/guides/spring-boot/performance/index.mdx
+++ b/src/platforms/java/guides/spring-boot/performance/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Performance Monitoring
+description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
+---
+
+<Alert level="warning" title="Note">
+Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
+</Alert>
+
+Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
+
+## Enabling Tracing
+
+
+<PlatformContent includePath="performance/enable-tracing" />
+
+If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
+
+As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Spring Boot integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
+
+You can learn more about the <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> options in <PlatformLink to="/performance/sampling/">Sampling Transactions</PlatformLink>.


### PR DESCRIPTION
First batch of Java performance docs. Spring integration will come next.

Python Performance reference was used as the starting point.

Note: these docs use `Sentry#getSpan` method, which is currently under review: https://github.com/getsentry/sentry-java/pull/1070