### PR TITLE
Java: update configuration docs.

### DIFF
--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -97,17 +97,35 @@ The following options can all be configured as described above: via a `sentry.pr
 
 To set the application version that will be sent with each event, use the `release` option:
 
-```
+```properties {tabTitle:sentry.properties}
 release=1.0.0
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_RELEASE=1.0.0
+```
+
+```properties {tabTitle:system property}
+sentry.release=1.0.0
 ```
 
 ### Distribution
 
 To set the application distribution that will be sent with each event, use the `dist` option:
 
-```
+```properties {tabTitle:sentry.properties}
 release=1.0.0
 dist=x86
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_RELEASE=1.0.0
+SENTRY_DIST=x86
+```
+
+```properties {tabTitle:system property}
+sentry.release=1.0.0
+sentry.dist=x86
 ```
 
 The distribution is only useful (and used) if the `release` is also set.
@@ -116,16 +134,51 @@ The distribution is only useful (and used) if the `release` is also set.
 
 To set the application environment that will be sent with each event, use the `environment` option:
 
-```
+```properties {tabTitle:sentry.properties}
 environment=staging
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_ENVIRONMENT=staging
+```
+
+```properties {tabTitle:system property}
+sentry.environment=staging
 ```
 
 ### Server Name
 
 To set the server name that will be sent with each event, use the `servername` option:
 
-```
+```properties {tabTitle:sentry.properties}
 servername=host1
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_SERVERNAME=host1
+```
+
+```properties {tabTitle:system property}
+sentry.servername=host1
+```
+
+### Tags
+
+To set the common tags that will be sent with each event, use the `tags` options:
+
+```properties {tabTitle:sentry.properties}
+tags.first_tag=first-tag-value
+tags.second_tag=second-tag-value
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_TAGS_FIRST_TAG=first-tag-value
+SENTRY_TAGS_SECOND_TAG=second-tag-value
+```
+
+```properties {tabTitle:system property}
+sentry.tags.first_tag=first-tag-value
+sentry.tags.second_tag=second-tag-value
 ```
 
 ## Configuring Timeouts
@@ -165,10 +218,26 @@ See [Java Networking and Proxies](http://docs.oracle.com/javase/8/docs/technotes
 
 Alternatively, using Sentry options (only affects the Sentry HTTP client, useful inside shared application containers),
 
-```properties
+```properties {tabTitle:sentry.properties}
 proxy.host=proxy.example.com
 # optional
 proxy.port=8080 # default 80
 proxy.user=proxy-user
 proxy.pass=proxy-password
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_PROXY_HOST=proxy.example.com
+# optional
+SENTRY_PROXY_PORT=8080 # default 80
+SENTRY_PROXY_USER=proxy-user
+SENTRY_PROXY_PASS=proxy-password
+```
+
+```properties {tabTitle:system property}
+sentry.proxy.host=proxy.example.com
+# optional
+sentry.proxy.port=8080 # default 80
+sentry.proxy.user=proxy-user
+sentry.proxy.pass=proxy-password
 ```


### PR DESCRIPTION
Adds docs about setting tags from the external configuration (https://github.com/getsentry/sentry-java/issues/981) and for each property that can be set externally adds an example on how to set it from the properties file, system property and environment variable.

Fixes https://github.com/getsentry/sentry-java/issues/992