### PR TITLE
feat(wasm): Add initial docs for WASM

### DIFF
--- a/src/docs/contributing/approach/write-data-management.mdx
+++ b/src/docs/contributing/approach/write-data-management.mdx
@@ -51,7 +51,7 @@ This file is `/sensitive-data/index.mdx`. It explains how to scrub or filter dat
 
 For data scrubbing that the SDK DOES NOT support, add the name of the SDK to the `PlatformSection notSupported` statement, which ensures the content won't display. For example:
 
-`<PlatformSection notSupported={["flutter", "apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.ue4", "go", "ruby", "native", "elixir"]}>`
+`<PlatformSection notSupported={["flutter", "apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4", "go", "ruby", "native", "elixir"]}>`
 
 Add the code sample to these directories:
 

--- a/src/includes/upload-dif/native.mdx
+++ b/src/includes/upload-dif/native.mdx
@@ -1,0 +1,11 @@
+```bash
+sentry-cli upload-dif -o <org> -p <project> /path/to/myfile.debug.wasm
+
+> Found 2 debug information files
+> Prepared debug information files for upload
+> Uploaded 2 missing debug information files
+> File processing complete:
+
+  PENDING 1ddb3423-950a-3646-b17b-d4360e6acfc9 (MyApp; x86_64 executable)
+  PENDING 1ddb3423-950a-3646-b17b-d4360e6acfc9 (MyApp; x86_64 debug companion)
+```

--- a/src/includes/upload-dif/native.wasm.mdx
+++ b/src/includes/upload-dif/native.wasm.mdx
@@ -1,0 +1,11 @@
+```bash
+wasm-split /path/to/myfile.wasm -d /path/to/myfile.debug.wasm --strip
+sentry-cli upload-dif -o <org> -p <project> /path/to/files
+
+> Found 1 debug information files
+> Prepared debug information files for upload
+> Uploaded 1 missing debug information files
+> File processing complete:
+
+  PENDING 1ddb3423-950a-3646-b17b-d4360e6acfc9 (mylib; wasm debug companion)
+```

--- a/src/platforms/common/configuration/index.mdx
+++ b/src/platforms/common/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 notSupported:
-  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps"]
+  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm"]
 description: "Additional configuration options for the SDK."
 sidebar_order: 5
 ---

--- a/src/platforms/common/data-management/debug-files.mdx
+++ b/src/platforms/common/data-management/debug-files.mdx
@@ -54,15 +54,6 @@ servers for automatic downloads.
 
 Sentry differentiates in four kinds of debug information:
 
-- **Unwind Information:** Enables Sentry to extract stack traces from Minidumps
-  and other binary crash formats of optimized builds. This process is referred
-  to as "stack unwinding" or "stack walking". Since this is also required when
-  throwing exceptions in C++, this information is often included in the
-  executable or library. If an uploaded file contains this information, it shows
-  the `unwind` tag.  Note that on some platforms no actual unwinding takes place.
-  For instance, WebAssembly currently does not have the equivalent of minidumps
-  which means we do not require that type of information in such cases.
-
 - **Debug Information:** Provides function names, paths to source files, line
   numbers and inline frames. The process of resolving this information from
   instruction addresses is called "symbolication". This information is
@@ -81,6 +72,15 @@ Sentry differentiates in four kinds of debug information:
   information files. Sentry CLI can bundle source code of your application and
   upload it to display source context in stack traces in Sentry. These bundles
   show up with the `sources` tag.
+
+- **Unwind Information:** Enables Sentry to extract stack traces from Minidumps
+  and other binary crash formats of optimized builds. This process is referred
+  to as "stack unwinding" or "stack walking". Since this is also required when
+  throwing exceptions in C++, this information is often included in the
+  executable or library. If an uploaded file contains this information, it shows
+  the `unwind` tag. Note that on some platforms no actual unwinding takes place.
+  For instance, WebAssembly currently does not have the equivalent of minidumps
+  which means we do not require that type of information in such cases.
 
 Compilers place the above debug information in different files passed on the
 target platform, architecture, build flags or optimization level. Consequently,
@@ -242,7 +242,7 @@ while removing all debug information from the release binary.
 
 <Note>
 
-  The recommended method for [Android users is to use the Gradle plugin](/platforms/android/proguard/).
+The recommended method for [Android users is to use the Gradle plugin](/platforms/android/proguard/).
 
 </Note>
 
@@ -263,7 +263,7 @@ correct files. Sentry distinguishes two kinds of identifiers:
 - **Code Identifier**: The unique identifier of the executable or dynamic
   library -- the code file. The contents of this identifier are
   platform-dependent: MachO files use a UUID, ELF files a SHA hash, PE files use
-  a concatenation of certain header attributes.  For WebAssembly we use an
+  a concatenation of certain header attributes. For WebAssembly we use an
   embedded UUID in the `build_id` section of the file.
 
 - **Debug Identifier**: The unique identifier of the debug companion file. In
@@ -338,12 +338,12 @@ for symbolication.
 
 ### WASM Build IDs
 
-WebAssembly does not yet support build IDs.  The option proposed to
-implement build IDs for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))has not yet found widespread adoption.  Instead, we use a custom
+WebAssembly does not yet support build IDs. The option proposed to
+implement build IDs for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))has not yet found widespread adoption. Instead, we use a custom
 extension to WebAssembly.
 
 Our recommendation is to embed a UUID in the `build_id` custom section as
-raw binary.  Our `wasm-split` tool can do this for you automatically.
+raw binary. Our `wasm-split` tool can do this for you automatically.
 
 <PlatformSection notSupported={["native.wasm"]}>
 
@@ -381,17 +381,7 @@ application:
 Files can be uploaded using the `upload-dif` command. This command will scan a
 given folder recursively for files and upload them to Sentry:
 
-```bash
-sentry-cli upload-dif -o <org> -p <project> /path/to/files
-
-> Found 2 debug information files
-> Prepared debug information files for upload
-> Uploaded 2 missing debug information files
-> File processing complete:
-
-  PENDING 1ddb3423-950a-3646-b17b-d4360e6acfc9 (MyApp; x86_64 executable)
-  PENDING 1ddb3423-950a-3646-b17b-d4360e6acfc9 (MyApp; x86_64 debug companion)
-```
+<PlatformContent includePath="upload-dif" />
 
 For all available options and more information refer to [_Uploading Debug
 Information_](/product/cli/dif/#uploading-files).

--- a/src/platforms/common/data-management/debug-files.mdx
+++ b/src/platforms/common/data-management/debug-files.mdx
@@ -60,7 +60,7 @@ Sentry differentiates in four kinds of debug information:
   throwing exceptions in C++, this information is often included in the
   executable or library. If an uploaded file contains this information, it shows
   the `unwind` tag.  Note that on some platforms no actual unwinding takes place.
-  For instance WebAssembly currently does not have the equivalent of minidumps
+  For instance, WebAssembly currently does not have the equivalent of minidumps
   which means we do not require that type of information in such cases.
 
 - **Debug Information:** Provides function names, paths to source files, line
@@ -224,14 +224,14 @@ traces.
 
 </PlatformSection>
 
-For WebAssembly we support [DWARF in WASM containers](https://yurydelendik.github.io/webassembly-dwarf/).
-Note that we do not support source maps which are also a format used for WASM
-debugging but have shortcommings that make them impractical for a crash reporting
+For WebAssembly, we support [DWARF in WASM containers](https://yurydelendik.github.io/webassembly-dwarf/).
+Note that we do not support source maps, which are also a format used for WASM
+debugging, but have shortcomings that make them impractical for a crash reporting
 tool like Sentry.
 
-Since WASM does not specify debug/build IDs yet we provide a separate tool to
+Since WASM does not specify debug/build IDs yet, we provide a separate tool to
 add build IDs and split files called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
-that can help you create a debug companion file ready for uploading to us
+to help you create a debug companion file ready for uploading to Sentry
 while removing all debug information from the release binary.
 
 <PlatformSection notSupported={["native.wasm"]}>
@@ -338,10 +338,9 @@ for symbolication.
 
 ### WASM Build IDs
 
-WebAssembly does not yet support build IDs.  There is an option proposal to
-implement these for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))
-but that proposal has not yet found widespread adoption.  We do use a custom
-extension to WebAssembly for this however.
+WebAssembly does not yet support build IDs.  The option proposed to
+implement build IDs for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))has not yet found widespread adoption.  Instead, we use a custom
+extension to WebAssembly.
 
 Our recommendation is to embed a UUID in the `build_id` custom section as
 raw binary.  Our `wasm-split` tool can do this for you automatically.

--- a/src/platforms/common/data-management/debug-files.mdx
+++ b/src/platforms/common/data-management/debug-files.mdx
@@ -339,11 +339,13 @@ for symbolication.
 ### WASM Build IDs
 
 WebAssembly does not yet support build IDs. The option proposed to
-implement build IDs for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))has not yet found widespread adoption. Instead, we use a custom
+implement build IDs for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))
+has not yet found widespread adoption. Instead, we use a custom
 extension to WebAssembly.
 
 Our recommendation is to embed a UUID in the `build_id` custom section as
-raw binary. Our `wasm-split` tool can do this for you automatically.
+raw binary. Our [`wasm-split`](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+tool can do this for you automatically.
 
 <PlatformSection notSupported={["native.wasm"]}>
 

--- a/src/platforms/common/data-management/debug-files.mdx
+++ b/src/platforms/common/data-management/debug-files.mdx
@@ -16,6 +16,8 @@ in debug files includes original function names, paths to source files and line
 numbers, source code context, or the placement of variables in memory. Sentry
 can use some of this information and display it on the issue details page.
 
+<PlatformSection notSupported={["native.wasm"]}>
+
 Each major platform uses different debug information files. We currently support
 the following formats:
 
@@ -26,8 +28,11 @@ the following formats:
 - [_PDB files_](#pe-and-pdb) for Windows
 - [_Breakpad symbols_](#breakpad-symbols) for all
   platforms
+- [_WASM files_](#wasm) for WebAssembly
 - [_ProGuard mappings_](#proguard-mappings) for
   Java and Android
+
+</PlatformSection>
 
 <Note>
 
@@ -54,7 +59,9 @@ Sentry differentiates in four kinds of debug information:
   to as "stack unwinding" or "stack walking". Since this is also required when
   throwing exceptions in C++, this information is often included in the
   executable or library. If an uploaded file contains this information, it shows
-  the `unwind` tag.
+  the `unwind` tag.  Note that on some platforms no actual unwinding takes place.
+  For instance WebAssembly currently does not have the equivalent of minidumps
+  which means we do not require that type of information in such cases.
 
 - **Debug Information:** Provides function names, paths to source files, line
   numbers and inline frames. The process of resolving this information from
@@ -82,6 +89,8 @@ Still, it is always a good idea to provide all available debug information.
 
 `sentry-cli` can be used to list properties of supported debug files and
 validate their contents. See [_Debug Information Files in sentry-cli_](/product/cli/dif/) for more information.
+
+<PlatformSection notSupported={["native.wasm"]}>
 
 The remainder of this section describes the file formats in detail.
 
@@ -211,6 +220,22 @@ that is not required to process minidumps. Most notably, inline functions are
 not declared, such that Sentry is not able to display inline frames in stack
 traces.
 
+### WASM
+
+</PlatformSection>
+
+For WebAssembly we support [DWARF in WASM containers](https://yurydelendik.github.io/webassembly-dwarf/).
+Note that we do not support source maps which are also a format used for WASM
+debugging but have shortcommings that make them impractical for a crash reporting
+tool like Sentry.
+
+Since WASM does not specify debug/build IDs yet we provide a separate tool to
+add build IDs and split files called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+that can help you create a debug companion file ready for uploading to us
+while removing all debug information from the release binary.
+
+<PlatformSection notSupported={["native.wasm"]}>
+
 ### ProGuard Mappings
 
 <PlatformSection supported={["android", "flutter", "react-native"]}>
@@ -227,6 +252,8 @@ ProGuard mapping files allow Sentry to resolve obfuscated Java classpaths and
 method names into their original form. In that sense, they act as debug
 information files for Java and Android applications.
 
+</PlatformSection>
+
 ## Debug Identifiers
 
 Each debug information file specifies a unique identifier. Crash reports declare
@@ -236,7 +263,8 @@ correct files. Sentry distinguishes two kinds of identifiers:
 - **Code Identifier**: The unique identifier of the executable or dynamic
   library -- the code file. The contents of this identifier are
   platform-dependent: MachO files use a UUID, ELF files a SHA hash, PE files use
-  a concatenation of certain header attributes.
+  a concatenation of certain header attributes.  For WebAssembly we use an
+  embedded UUID in the `build_id` section of the file.
 
 - **Debug Identifier**: The unique identifier of the debug companion file. In
   contrast to the code identifier, Sentry enforces the same structure on all
@@ -264,6 +292,8 @@ files that match it in the _Debug Files_ settings screen.
 
 `sentry-cli` can help to print properties of debug information files like their
 debug identifier. See [_Checking Debug Information Files_](/product/cli/dif/#checking-files) for more information.
+
+<PlatformSection notSupported={["native.wasm"]}>
 
 ### GNU Build Identifiers
 
@@ -304,6 +334,20 @@ files are uploaded in the same invocation of the upload command. Otherwise, the
 identifiers diverge and Sentry might not be able to resolve the correct file
 for symbolication.
 
+</PlatformSection>
+
+### WASM Build IDs
+
+WebAssembly does not yet support build IDs.  There is an option proposal to
+implement these for WebAssembly ([Build ID Section for WASM](https://github.com/WebAssembly/tool-conventions/issues/133))
+but that proposal has not yet found widespread adoption.  We do use a custom
+extension to WebAssembly for this however.
+
+Our recommendation is to embed a UUID in the `build_id` custom section as
+raw binary.  Our `wasm-split` tool can do this for you automatically.
+
+<PlatformSection notSupported={["native.wasm"]}>
+
 ### ProGuard UUIDs
 
 Unlike other debug information files, ProGuard files do not have an intrinsic
@@ -323,6 +367,8 @@ def get_proguard_uuid(filename):
     with open(filename, 'rb') as f:
         return uuid.uuid5(NAMESPACE, f.read())
 ```
+
+</PlatformSection>
 
 ## Uploading Files
 

--- a/src/platforms/common/data-management/event-grouping/index.mdx
+++ b/src/platforms/common/data-management/event-grouping/index.mdx
@@ -11,7 +11,7 @@ All events have a fingerprint. Events with the same fingerprint are grouped toge
 
 By default, Sentry will run one of our built-in grouping algorithms to generate a fingerprint based on information available within the event such as `stacktrace`, `exception`, and `message`. To extend the default grouping behavior or change it completely, you can use a combination of the following options:
 
-1. In your SDK, using [SDK Fingerprinting](./sdk-fingerprinting/)
+1. In your SDK<PlatformSection notSupported={["native.wasm", "native.minidumps"]}>, using [SDK Fingerprinting](./sdk-fingerprinting/)</PlatformSection>
 2. In your project, using [Fingerprint Rules](./fingerprint-rules/)
 3. In your project, using [Stack Trace Rules](./stack-trace-rules/)
 

--- a/src/platforms/common/data-management/event-grouping/sdk-fingerprinting.mdx
+++ b/src/platforms/common/data-management/event-grouping/sdk-fingerprinting.mdx
@@ -4,6 +4,8 @@ sidebar_order: 0
 redirect_from:
   - ../../../enriching-events/context/fingerprint-override/
 description: "Learn about overriding default fingerprinting in your SDK."
+notSupported:
+  ["native.wasm", "native.minidump"]
 ---
 
 In supported SDKs, you can override Sentry's default grouping that passes the fingerprint attribute as an array of strings. The length of a fingerprint's array is not restricted. This works similarly to the [fingerprint rules functionality](../fingerprint-rules/), which is always available and can achieve similar results.

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -15,9 +15,9 @@ There are two great examples for data scrubbing that every company should think 
 - Authentication credentials, like your AWS password or key.
 - Confidential IP (Intellectual Property), such as your favorite color, or your upcoming plans for world domination.
 
-## Personally Identifiable Information (PII)
+<PlatformSection notSupported={["apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4", "go", "ruby", "native", "elixir", "dart", "flutter"]}>
 
-<PlatformSection notSupported={["apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.ue4", "go", "ruby", "native", "elixir", "dart", "flutter"]}>
+## Personally Identifiable Information (PII)
 
 Our newer SDKs do not purposefully send PII to stay on the safe side. This behavior is controlled by an option called [`send-default-pii`](../../configuration/options/#send-default-pii).
 
@@ -25,13 +25,13 @@ Turning this option on is required for certain features in Sentry to work, but a
 
 </PlatformSection>
 
-<PlatformSection notSupported={["native.breakpad", "native.crashpad", "native.minidumps", "native.ue4"]}>
+<PlatformSection notSupported={["native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4"]}>
 
 If you _do not_ wish to use the default PII behavior, you can also choose to identify users in a more controlled manner, using our [user identity context](../../enriching-events/identify-user/).
 
 </PlatformSection>
 
-<PlatformSection notSupported={["perl", "native.ue4", "native.breakpad", "native.crashpad", "native.minidumps"]}>
+<PlatformSection notSupported={["perl", "native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm"]}>
 
 ## Scrubbing Data
 

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -6,6 +6,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
   - native.ue4
 ---
 

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -5,6 +5,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
   - native.ue4
 description: "Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries) to an event."
 ---

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -5,6 +5,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
   - native.ue4
 description: "Learn how to configure the SDK to capture the user and gain critical pieces of information that construct a unique identity in Sentry."
 ---

--- a/src/platforms/common/enriching-events/index.mdx
+++ b/src/platforms/common/enriching-events/index.mdx
@@ -6,6 +6,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
 ---
 
 <PageGrid />

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -8,7 +8,9 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.minidumps
   - native.ue4
+  - native.wasm
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -8,7 +8,6 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
-  - native.minidumps
   - native.ue4
   - native.wasm
 ---

--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -12,7 +12,7 @@ description: "Tags power UI features such as filters and tag-distribution maps. 
 
 We’ll automatically index all tags for an event, as well as the frequency and the last time that Sentry has seen a tag. We also keep track of the number of distinct tags and can assist you in determining hotspots for various issues.
 
-<PlatformSection notSupported={["native.minidumps"]}>
+<PlatformSection notSupported={["native.minidumps", "native.wasm"]}>
 
 Defining tags is easy, and will bind them to the [current scope](../scopes/) ensuring all future events within scope contain the same tags:
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -17,6 +17,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
   - native.ue4
   - dart
   - flutter

--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -7,6 +7,7 @@ notSupported:
   - native.breakpad
   - native.crashpad
   - native.minidumps
+  - native.wasm
   - native.ue4
 ---
 

--- a/src/platforms/native/common/debug-information.mdx
+++ b/src/platforms/native/common/debug-information.mdx
@@ -14,11 +14,30 @@ libraries. If you are not sure which files are required, go to _Project
 Settings > Processing Issues_, which shows a list of all the necessary files and
 instructions to retrieve them.
 
+<PlatformSection notSupported={["native.wasm"]}>
 In addition to Debug Information Files, Sentry needs _Call Frame Information_
 (CFI) to extract accurate stack traces from minidumps of optimized release
 builds. CFI is usually part of the executables and not copied to debug symbols.
 Unless you are uploading Breakpad symbols, be sure to also include the binaries
 when uploading files to Sentry.
+</PlatformSection>
+
+<PlatformSection supported={["native.wasm"]}>
+
+For WASM you need to provide both the debug information and the original code
+in the same debug information file.  For this purpose we provide a custom
+tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+which can do the splitting for you:
+
+```shell
+wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
+```
+
+This modifies the `file.wasm` in place to add the `build_id` and then removes all
+debug information, but puts that into a `file.debug.wasm` instead.  That latter file
+then needs to be uploaded to Sentry.
+
+</PlatformSection>
 
 For more information on uploading debug information and their supported formats,
 see [Debug Information Files](/workflow/debug-files/).

--- a/src/platforms/native/common/debug-information.mdx
+++ b/src/platforms/native/common/debug-information.mdx
@@ -25,7 +25,7 @@ when uploading files to Sentry.
 <PlatformSection supported={["native.wasm"]}>
 
 For WASM, you need to provide both the debug information and the original code
-in the same debug information file.  To do this, we provide a custom
+in the same debug information file. To do this, we provide a custom
 tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
 that can do the splitting for you:
 
@@ -34,10 +34,10 @@ wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
 ```
 
 This command modifies the `file.wasm` in place to add the `build_id`, then removes all
-debug information. The debug information is put in a `file.debug.wasm` which 
+debug information. The debug information is put in a `file.debug.wasm` which
 then needs to be uploaded to Sentry.
 
 </PlatformSection>
 
 For more information on uploading debug information and their supported formats,
-see [Debug Information Files](/workflow/debug-files/).
+see [Debug Information Files](../data-management/debug-files/).

--- a/src/platforms/native/common/debug-information.mdx
+++ b/src/platforms/native/common/debug-information.mdx
@@ -24,17 +24,17 @@ when uploading files to Sentry.
 
 <PlatformSection supported={["native.wasm"]}>
 
-For WASM you need to provide both the debug information and the original code
-in the same debug information file.  For this purpose we provide a custom
+For WASM, you need to provide both the debug information and the original code
+in the same debug information file.  To do this, we provide a custom
 tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
-which can do the splitting for you:
+that can do the splitting for you:
 
 ```shell
 wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
 ```
 
-This modifies the `file.wasm` in place to add the `build_id` and then removes all
-debug information, but puts that into a `file.debug.wasm` instead.  That latter file
+This command modifies the `file.wasm` in place to add the `build_id`, then removes all
+debug information. The debug information is put in a `file.debug.wasm` which 
 then needs to be uploaded to Sentry.
 
 </PlatformSection>

--- a/src/platforms/native/common/debug-information.mdx
+++ b/src/platforms/native/common/debug-information.mdx
@@ -15,6 +15,7 @@ Settings > Processing Issues_, which shows a list of all the necessary files and
 instructions to retrieve them.
 
 <PlatformSection notSupported={["native.wasm"]}>
+
 In addition to Debug Information Files, Sentry needs _Call Frame Information_
 (CFI) to extract accurate stack traces from minidumps of optimized release
 builds. CFI is usually part of the executables and not copied to debug symbols.

--- a/src/platforms/native/guides/wasm/index.mdx
+++ b/src/platforms/native/guides/wasm/index.mdx
@@ -33,7 +33,7 @@ the debug information so it isn't sent to customers.
 ## Using wasm-split
 
 Once your compiler has produced a `.wasm` file, you can use our [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
-tool that adds a `build_id` (if missing) and splits the file into a debug information
+tool to add a `build_id` (if missing) and split the file into a debug information
 file and a final stripped `.wasm` file without debug information:
 
 ```shell

--- a/src/platforms/native/guides/wasm/index.mdx
+++ b/src/platforms/native/guides/wasm/index.mdx
@@ -3,19 +3,17 @@ title: WebAssembly
 description: "Learn about how Sentry processes WASM crash reports."
 ---
 
-WebAssembly is a technology that allows you to compile native code into a platform
-independent bytecode format.  This for instance permits you to run native C, C++ or
-Rust code in a web browser.
+WebAssembly allows you to compile native code into a platform-independent bytecode format, which, for example, permits you to run native C, C++, or Rust code in a web browser.
 
-**This feature is still rough around the edges for a range of different reasons.**
+**This feature is still developing, so may be rough around the edges.**
 
-Debugging support for WebAssembly is an ongoing effort by the WebAssembly community
-and support for it in Sentry is limited by what's possible in that ecosystem.
+Debugging support for WebAssembly is an ongoing effort by the WebAssembly community.
+Support for it in Sentry is limited by what's possible in that ecosystem.
 
 <Note>
 
-Want to be an early adopter but you're running into issues?  Please reach out to
-Support or the Forums, we would love to talk.
+Want to be an early adopter, but running into issues? Please reach out to
+us using our [GitHub Forum](https://forum.sentry.io/), we would love to talk.
 
 </Note>
 
@@ -23,37 +21,35 @@ Support or the Forums, we would love to talk.
 
 As of now it's possible to get crash reports uploaded to Sentry if your compiler can
 output [WASM DWARF debug information](https://yurydelendik.github.io/webassembly-dwarf/)
-alongside the binary code.  In addition we require you to upload your WebAssembly
-debug information files to Sentry or use a symbol server the same way you
-would do that for our other platforms.
+alongside the binary code.  In addition, you need to upload your WebAssembly
+debug information files to Sentry or use a symbol server as you
+would for our other platforms.
 
-For this process to work we require debug information files to be augmented by a
-`build_id` custom section.  We provide a tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
-which can be used to automatically add this section if missing and to split off
-the debug information so you don't need to ship this to customers.
+For this process to work, we require debug information files to be augmented by a
+`build_id` custom section. We provide a tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+that can automatically add this section if missing and splits off
+the debug information so it isn't sent to customers.
 
 ## Using wasm-split
 
-Once your compiler has produced a `.wasm` file you can use our [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
-tool to add a `build_id` (if missing) and to split the file into a debug information
+Once your compiler has produced a `.wasm` file, you can use our [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+tool that adds a `build_id` (if missing) and splits the file into a debug information
 file and a final stripped `.wasm` file without debug information:
 
 ```shell
 wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
 ```
 
-This modifies the `file.wasm` in place to add the `build_id` and then removes all
-debug information, but puts that into a `file.debug.wasm` instead.  That latter file
-then needs to be uploaded to Sentry.  For more information, see [Debug Information Files](/workflow/debug-files/).
+This command modifies the `file.wasm` in place to add the `build_id`, then removes all
+debug information. The debug information is put in a `file.debug.wasm` which 
+then needs to be uploaded to Sentry. For more information, see [Debug Information Files](/workflow/debug-files/).
 
 ## Crash Reporting
 
-WebAssembly currently does not have a runtime that can produce stack traces.  We
-do not yet provide a ready-to-use SDK but we have a small integration for the
-Sentry JavaScript SDK that can enhance error reports in the browser environment
-which include WASM frames.  [wasm-support.js](https://gist.github.com/mitsuhiko/c27fee8445d2a18a8c134e0169119058)
-It needs to be loaded _after_ the JavaScript SDK and before you start loading
-your WASM modules:
+WebAssembly does not currently have a runtime that can produce stack traces.  We
+do not yet provide a ready-to-use SDK, though we have a small integration for the
+Sentry JavaScript SDK to enhance error reports in the browser environment
+which include WASM frames, called [wasm-support.js](https://gist.github.com/mitsuhiko/c27fee8445d2a18a8c134e0169119058), which needs to be loaded _after_ the JavaScript SDK and before you start loading your WASM modules:
 
 ```html {tabTitle: CDN}
 <script
@@ -89,9 +85,9 @@ async function loadWasm(url) {
 
 ## Custom Crash Reports
 
-Chances are that when you're working with WebAssembly you might want to send up custom
-crash reports.  For instance because you execute WebAssembly not in a browser but your
-own runtime.  In that case you can follow the general protocol documentation which
+It's likely that if you're working with WebAssembly, you want to send custom
+crash reports; for example, if you don't execute WebAssembly in a browser, but in your
+own runtime. In that case, you can follow the general protocol documentation which
 also covers how to describe WebAssembly frames: [stack trace interface](https://develop.sentry.dev/sdk/event-payloads/stacktrace/).
 
 Here is an example event for WebAssembly:

--- a/src/platforms/native/guides/wasm/index.mdx
+++ b/src/platforms/native/guides/wasm/index.mdx
@@ -13,7 +13,7 @@ Support for it in Sentry is limited by what's possible in that ecosystem.
 <Note>
 
 Want to be an early adopter, but running into issues? Please reach out to
-us using our [GitHub Forum](https://forum.sentry.io/), we would love to talk.
+us using our [Forum](https://forum.sentry.io/), we would love to talk.
 
 </Note>
 
@@ -21,7 +21,7 @@ us using our [GitHub Forum](https://forum.sentry.io/), we would love to talk.
 
 As of now it's possible to get crash reports uploaded to Sentry if your compiler can
 output [WASM DWARF debug information](https://yurydelendik.github.io/webassembly-dwarf/)
-alongside the binary code.  In addition, you need to upload your WebAssembly
+alongside the binary code. In addition, you need to upload your WebAssembly
 debug information files to Sentry or use a symbol server as you
 would for our other platforms.
 
@@ -41,12 +41,12 @@ wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
 ```
 
 This command modifies the `file.wasm` in place to add the `build_id`, then removes all
-debug information. The debug information is put in a `file.debug.wasm` which 
+debug information. The debug information is put in a `file.debug.wasm` which
 then needs to be uploaded to Sentry. For more information, see [Debug Information Files](/workflow/debug-files/).
 
 ## Crash Reporting
 
-WebAssembly does not currently have a runtime that can produce stack traces.  We
+WebAssembly does not currently have a runtime that can produce stack traces. We
 do not yet provide a ready-to-use SDK, though we have a small integration for the
 Sentry JavaScript SDK to enhance error reports in the browser environment
 which include WASM frames, called [wasm-support.js](https://gist.github.com/mitsuhiko/c27fee8445d2a18a8c134e0169119058), which needs to be loaded _after_ the JavaScript SDK and before you start loading your WASM modules:
@@ -60,7 +60,7 @@ which include WASM frames, called [wasm-support.js](https://gist.github.com/mits
 <script src="wasm-support.js"></script>
 ```
 
-If you then throw a JavaScript exception you can get the stack trace.  If you want
+If you then throw a JavaScript exception you can get the stack trace. If you want
 to capture an error from within your WebAssembly application you can export a
 utility function like this:
 
@@ -77,7 +77,7 @@ async function loadWasm(url) {
   const importObj = {
     env: {
       capture_error: captureError,
-    }
+    },
   };
   return await WebAssembly.instantiateStreaming(fetch(url), importObj);
 }

--- a/src/platforms/native/guides/wasm/index.mdx
+++ b/src/platforms/native/guides/wasm/index.mdx
@@ -1,0 +1,144 @@
+---
+title: WebAssembly
+description: "Learn about how Sentry processes WASM crash reports."
+---
+
+WebAssembly is a technology that allows you to compile native code into a platform
+independent bytecode format.  This for instance permits you to run native C, C++ or
+Rust code in a web browser.
+
+**This feature is still rough around the edges for a range of different reasons.**
+
+Debugging support for WebAssembly is an ongoing effort by the WebAssembly community
+and support for it in Sentry is limited by what's possible in that ecosystem.
+
+<Note>
+
+Want to be an early adopter but you're running into issues?  Please reach out to
+Support or the Forums, we would love to talk.
+
+</Note>
+
+## Requirements
+
+As of now it's possible to get crash reports uploaded to Sentry if your compiler can
+output [WASM DWARF debug information](https://yurydelendik.github.io/webassembly-dwarf/)
+alongside the binary code.  In addition we require you to upload your WebAssembly
+debug information files to Sentry or use a symbol server the same way you
+would do that for our other platforms.
+
+For this process to work we require debug information files to be augmented by a
+`build_id` custom section.  We provide a tool called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+which can be used to automatically add this section if missing and to split off
+the debug information so you don't need to ship this to customers.
+
+## Using wasm-split
+
+Once your compiler has produced a `.wasm` file you can use our [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+tool to add a `build_id` (if missing) and to split the file into a debug information
+file and a final stripped `.wasm` file without debug information:
+
+```shell
+wasm-split /path/to/file.wasm -d /path/to/file.debug.wasm --strip
+```
+
+This modifies the `file.wasm` in place to add the `build_id` and then removes all
+debug information, but puts that into a `file.debug.wasm` instead.  That latter file
+then needs to be uploaded to Sentry.  For more information, see [Debug Information Files](/workflow/debug-files/).
+
+## Crash Reporting
+
+WebAssembly currently does not have a runtime that can produce stack traces.  We
+do not yet provide a ready-to-use SDK but we have a small integration for the
+Sentry JavaScript SDK that can enhance error reports in the browser environment
+which include WASM frames.  [wasm-support.js](https://gist.github.com/mitsuhiko/c27fee8445d2a18a8c134e0169119058)
+It needs to be loaded _after_ the JavaScript SDK and before you start loading
+your WASM modules:
+
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+<script src="wasm-support.js"></script>
+```
+
+If you then throw a JavaScript exception you can get the stack trace.  If you want
+to capture an error from within your WebAssembly application you can export a
+utility function like this:
+
+```javascript
+function captureError() {
+  try {
+    throw new Error();
+  } catch (e) {
+    Sentry.captureException(e);
+  }
+}
+
+async function loadWasm(url) {
+  const importObj = {
+    env: {
+      capture_error: captureError,
+    }
+  };
+  return await WebAssembly.instantiateStreaming(fetch(url), importObj);
+}
+```
+
+## Custom Crash Reports
+
+Chances are that when you're working with WebAssembly you might want to send up custom
+crash reports.  For instance because you execute WebAssembly not in a browser but your
+own runtime.  In that case you can follow the general protocol documentation which
+also covers how to describe WebAssembly frames: [stack trace interface](https://develop.sentry.dev/sdk/event-payloads/stacktrace/).
+
+Here is an example event for WebAssembly:
+
+```javascript
+{
+  "platform": "native",
+  "debug_meta": {
+    "images": [
+      {
+        // the URL where the wasm file lives
+        "code_file": "http://localhost:8002/demo.wasm",
+        // indicates a web assembly module
+        "type": "wasm",
+        // the contents of the build_id section in hex,
+        // truncated to 32 characters with a 0 appended
+        "debug_id": "9e5cbc5553b44e8b9c69d18cdd7bfd2e0"
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            // wasm frame
+            {
+              "function": "wasm_func",
+              "abs_path": "http://localhost:8002/demo.wasm",
+              // the absolute offset in the wasm file for the instruction
+              "instruction_addr": "0x8c",
+              // indicates that the instruction_addr is relative to the 1st
+              // module in the debug_info images list.
+              "addr_mode": "rel:0"
+            },
+            // javascript frame
+            {
+              "function": "crash",
+              "abs_path": "http://localhost:8002/index.html",
+              "lineno": 24,
+              "platform": "javascript"
+            }
+          ]
+        },
+        "type": "Error"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
Initial documentation to use wasm with Sentry.