### PR TITLE
feat(express): Add option of passing router to tracing integration

### DIFF
--- a/src/platforms/node/guides/express/index.mdx
+++ b/src/platforms/node/guides/express/index.mdx
@@ -165,7 +165,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({ app }),
+    new Tracing.Integrations.Express({ app.router }),
   ],
 
   // We recommend adjusting this value in production, or using tracesSampler

--- a/src/platforms/node/guides/express/index.mdx
+++ b/src/platforms/node/guides/express/index.mdx
@@ -165,7 +165,12 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({ app.router }),
+    new Tracing.Integrations.Express({ 
+      // to trace all requests to the default router
+      app, 
+      // alternatively, you can specify the routes you want to trace:
+      // router: someRouter, 
+    }),
   ],
 
   // We recommend adjusting this value in production, or using tracesSampler


### PR DESCRIPTION
As of https://github.com/getsentry/sentry-javascript/pull/3078 the integration can also take a router instead of an app.