### PR TITLE
fix: include path of gatsby integration

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -62,7 +62,7 @@ module.exports = {
         project: "___PROJECT_SLUG___",
 
         // webpack specific configuration
-        include: ".",
+        include: "public",
         ignore: ["node_modules", "webpack.config.js"],
       }),
     ],


### PR DESCRIPTION
Gatsby's dist path is "public". When `include` is `'.'`, source maps of http://example.com/blah-blah-blah.js are uploaded as "~/public/blah-blah-blah.js.map". This is misconfigured.

![image](https://user-images.githubusercontent.com/623449/101246323-e776c300-3755-11eb-96ad-f882f017d87d.png)

When `"include"` is `"public"`, they will be "~/blah-blah-blah.js.map" and source mapping would work.

![image](https://user-images.githubusercontent.com/623449/101246367-44727900-3756-11eb-8d4c-8b606b7c5a89.png)
