### PR TITLE
feat: Add Release Health to wizard

### DIFF
--- a/src/wizard/javascript/angular.md
+++ b/src/wizard/javascript/angular.md
@@ -29,6 +29,7 @@ import { AppModule } from "./app/app.module";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
+  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing({
       tracingOrigins: ["localhost", "https://yourserver.io/api"],

--- a/src/wizard/javascript/angularjs.md
+++ b/src/wizard/javascript/angularjs.md
@@ -1,121 +1,45 @@
 ---
 name: AngularJS
-doc_link: https://docs.sentry.io/clients/javascript/integrations/angularjs/
+doc_link: https://docs.sentry.io/platforms/javascript/guides/angular/angular1/
 support_level: production
 type: framework
 ---
 
-### Installation
+To use Sentry with your Angular application, you will need to use `@sentry/angular` (Sentry’s Browser Angular SDK).
 
-Raven.js and the Raven.js Angular plugin are distributed using a few different methods.
+Add the Sentry SDK as a dependency using `yarn` or `npm`:
 
-#### Using our CDN
+```bash
+# Using yarn
+yarn add @sentry/browser @sentry/integrations
 
-For convenience, our CDN serves a single, minified JavaScript file containing both Raven.js and the Raven.js AngularJS plugin. It should be included **after** Angular, but **before** your application code.
-
-Example:
-
-```html
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
-<script
-  src="https://cdn.ravenjs.com/3.26.4/angular/raven.min.js"
-  crossorigin="anonymous"
-></script>
-<script>
-  Raven.config("___PUBLIC_DSN___").install();
-</script>
+# Using npm
+npm install --save @sentry/browser @sentry/integrations
 ```
 
-Note that this CDN build auto-initializes the Angular plugin.
-
-#### Using package managers
-
-Pre-built distributions of Raven.js and the Raven.js AngularJS plugin are available via both Bower and npm.
-
-##### Bower
-
-```shell
-bower install raven-js --save
-```
-
-```html
-<script src="/bower_components/angular/angular.js"></script>
-<script src="/bower_components/raven-js/dist/raven.js"></script>
-<script src="/bower_components/raven-js/dist/plugins/angular.js"></script>
-<script>
-  Raven.config("___PUBLIC_DSN___")
-    .addPlugin(Raven.Plugins.Angular)
-    .install();
-</script>
-```
-
-##### npm
-
-```shell
-npm install raven-js --save
-```
-
-```html
-<script src="/node_modules/angular/angular.js"></script>
-<script src="/node_modules/raven-js/dist/raven.js"></script>
-<script src="/node_modules/raven-js/dist/plugins/angular.js"></script>
-<script>
-  Raven.config("___PUBLIC_DSN___")
-    .addPlugin(Raven.Plugins.Angular)
-    .install();
-</script>
-```
-
-These examples assume that AngularJS is exported globally as _window.angular_. You can alternatively pass a reference to the _angular_ object directly as the second argument to _addPlugin_:
+You should `init` the Sentry browser SDK as soon as possible during your application load up, before initializing Angular:
 
 ```javascript
-Raven.addPlugin(Raven.Plugins.Angular, angular);
+import angular from "angular";
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/tracing";
+import { Angular as AngularIntegration } from "@sentry/integrations";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  autoSessionTracking: true,
+  integrations: [
+    new AngularIntegration(),
+    new Integrations.BrowserTracing({
+      tracingOrigins: ["localhost", "https://yourserver.io/api"],
+    }),
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+
+// Finally require ngSentry as a dependency in your application module.
+angular.module("yourApplicationModule", ["ngSentry"]);
 ```
-
-#### Module loaders (CommonJS)
-
-Raven and the Raven AngularJS plugin can be loaded using a module loader like Browserify or Webpack.
-
-```javascript
-var angular = require("angular");
-var Raven = require("raven-js");
-
-Raven.config("___PUBLIC_DSN___")
-  .addPlugin(require("raven-js/plugins/angular"), angular)
-  .install();
-```
-
-Note that when using CommonJS-style imports, you must pass a reference to _angular_ as the second argument to _addPlugin_.
-
-### AngularJS Configuration
-
-Inside your main AngularJS application module, you need to declare _ngRaven_ as a module dependency:
-
-```javascript
-var myApp = angular.module("myApp", [
-  "ngRaven",
-  "ngRoute",
-  "myAppControllers",
-  "myAppFilters",
-]);
-```
-
-#### Module loaders (CommonJS) {#id1}
-
-The raven angular module can be loaded using a module loader like Browserify or Webpack.
-
-```javascript
-var angular = require("angular");
-var ngRaven = require("raven-js/plugins/angular").moduleName;
-var ngRoute = require("angular-route");
-
-var myAppFilters = require("./myAppFilters");
-var myAppControllers = require("./myAppControllers");
-var moduleName = "myApp";
-
-angular.module(moduleName, [ngRaven, ngRoute, myAppControllers, myAppFilters]);
-
-module.exports = moduleName;
-```
-
-<!-- TODO-ADD-VERIFICATION-EXAMPLE -->

--- a/src/wizard/javascript/angularjs.md
+++ b/src/wizard/javascript/angularjs.md
@@ -5,7 +5,7 @@ support_level: production
 type: framework
 ---
 
-To use Sentry with your Angular application, you will need to use `@sentry/angular` (Sentry’s Browser Angular SDK).
+Install our Browser Angular SDK using either `yarn` or `npm`:
 
 Add the Sentry SDK as a dependency using `yarn` or `npm`:
 
@@ -17,7 +17,7 @@ yarn add @sentry/browser @sentry/integrations
 npm install --save @sentry/browser @sentry/integrations
 ```
 
-You should `init` the Sentry browser SDK as soon as possible during your application load up, before initializing Angular:
+`init` the Sentry Browser SDK as soon as possible during your page load, before initializing Angular:
 
 ```javascript
 import angular from "angular";
@@ -35,8 +35,6 @@ Sentry.init({
     }),
   ],
 
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
   tracesSampleRate: 1.0,
 });
 

--- a/src/wizard/javascript/backbone.md
+++ b/src/wizard/javascript/backbone.md
@@ -1,29 +1,45 @@
 ---
 name: Backbone
-doc_link: https://docs.sentry.io/clients/javascript/integrations/#backbone
+doc_link: https://docs.sentry.io/platforms/javascript/
 support_level: production
 type: framework
 ---
 
-### Installation
+Install our JavaScript browser SDK using either `yarn` or `npm`:
 
-Start by adding the `raven.js` script tag to your page. It should be loaded as early as possible.
-
-```html
-<script
-  src="https://cdn.ravenjs.com/3.26.4/raven.min.js"
-  crossorigin="anonymous"
-></script>
+```bash {tabTitle: ESM}
+# Using yarn
+yarn add @sentry/browser @sentry/tracing
+# Using npm
+npm install --save @sentry/browser @sentry/tracing
 ```
 
-### Configuring the Client
+We also support alternate [installation methods](/platforms/javascript/install/).
 
-Next configure Raven.js to use your Sentry DSN:
+`init` the Sentry Browser SDK as soon as possible during your page load:
 
 ```javascript
-Raven.config("___PUBLIC_DSN___").install();
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/tracing";
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  autoSessionTracking: true,
+  integrations: [
+    new Integrations.BrowserTracing(),
+  ],
+  tracesSampleRate: 1.0,
+});
 ```
 
-At this point, Raven is ready to capture any uncaught exception.
+We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/performance/sampling/).
 
-<!-- TODO-ADD-VERIFICATION-EXAMPLE -->
+Then create an intentional error, so you can test that everything is working:
+
+```js
+myUndefinedFunction();
+```
+
+If you're new to Sentry, use the email alert to access your account and complete a product tour.
+
+If you're an existing user and have disabled alerts, you won't receive this email.  

--- a/src/wizard/javascript/browser.md
+++ b/src/wizard/javascript/browser.md
@@ -24,6 +24,7 @@ import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
+  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],

--- a/src/wizard/javascript/ember.md
+++ b/src/wizard/javascript/ember.md
@@ -37,7 +37,7 @@ Then add the following config to your `config/environment.js`:
 ENV['@sentry/ember'] = {
   sentry: {
     dsn: '___PUBLIC_DSN___',
-
+    autoSessionTracking: true,
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production, or using tracesSampler

--- a/src/wizard/javascript/gatsby.md
+++ b/src/wizard/javascript/gatsby.md
@@ -27,6 +27,7 @@ Register the plugin in your Gatsby configuration file (typically `gatsby-config.
       resolve: "@sentry/gatsby",
       options: {
         dsn: "___PUBLIC_DSN___",
+        autoSessionTracking: true,
         sampleRate: 0.7,
       },
     },

--- a/src/wizard/javascript/react.md
+++ b/src/wizard/javascript/react.md
@@ -26,6 +26,7 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
+  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],

--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -36,6 +36,7 @@ import { Integrations } from "@sentry/tracing";
 Sentry.init({
   Vue,
   dsn: "___PUBLIC_DSN___",
+  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],


### PR DESCRIPTION
This tells users to by default enable session health in the JS onboarding wizard.
Eventually, we want to make this the default behaviour but we decided to do this with a major release because it might upset some people if we sneak this into a minor bump.

This will give us some graceful way to get more customers using Release Health for JS.

_Also fixed backbone and angular1 docs._