### PR TITLE
ref(unreal): remove unnecessary note

### DIFF
--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -90,9 +90,7 @@ uploading debug information during your build or release process.
 
 For all libraries where you'd like to receive symbolication, **you need
 to provide debug information**. This includes dependencies and operating system
-libraries. If you are not sure which files are required, go to _Project
-Settings > Processing Issues_, which shows a list of all the necessary files and
-instructions to retrieve them.
+libraries.
 
 In addition to Debug Information Files, Sentry needs _Call Frame Information_
 (CFI) to extract accurate stack traces from minidumps of optimized release


### PR DESCRIPTION
Since symbol status is now visible in the event page, I believe we can remove this.

If this needs to stay, it should be reworded as it's unclear if we're talking about Sentry project or Unreal project here. And what one would find there that would help clarify what needs to be uploaded.