### PR TITLE
feat(stacktrace-link): Add minimal docs

### DIFF
--- a/src/docs/product/integrations/github/index.mdx
+++ b/src/docs/product/integrations/github/index.mdx
@@ -221,28 +221,34 @@ You can also resolve issues with pull requests by including `fixes <SENTRY-SHORT
 When Sentry sees this, we’ll automatically annotate the matching issue with a reference to the commit or pull request, and, later, when that commit or pull request is part of a release, we’ll mark the issue as resolved.
 
 ### Stack Trace Linking
-Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the `default_branch`).
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
 1. Navigate to **Settings > Integrations > GitHub > Configurations**.
 
-1. Next to your GitHub Instance, click "Configure".
+1. Click the "Configure" button next to your GitHub Instance.
 
-1. Next click on the **Code Mappings** tab.
+1. Click the **Code Mappings** tab.
 
-1. To enable stack trace linking, you'll need to set up a code mapping for each project you want to enable stack trace linking for. To create a new code mapping, click **Add Mapping**.
+1. Set up a code mapping for each project for which you want to enable stack trace linking. To create a new code mapping, click **Add Mapping**.
 
-1. Fill out the form, and click **Save Changes**. For more information on each form field, see below:
-   * `project` (required): This is the Sentry project. 
-   * `repo` (required): This is the GitHub repository that is associated with the Sentry project above. If you have more than one GitHub repository being used per Sentry project, you'll need multiple code mappings.
-   * `default_branch` (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
-   * `stack_root` and `source_root` (optional):
-      1. If the filename in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
-         * ex. My filename is `code.py` and my source code path is `https://github.com/MeredithAnya/testing/blob/main/code.py`. Everything after the branch (`main`) matches my filename so I don't need to set a `stack_root` and `source_root`.
+1. Fill out the form, then click **Save Changes**. Each form field is described below:
+   * **project** (required): This is the Sentry project. 
+   * **repo** (required): This is the GitHub repository associated with the Sentry project above. If you have more than one GitHub repository being used per Sentry project, you'll need multiple code mappings.
+   * **branch** (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
+   * **stack trace root** and **source code root** (optional):
+      1. If the file path in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
+         * ex. For example, everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://github.com/MeredithAnya/testing/blob/main/code.py` so you don't need to set a **stack trace root** and **source code root**.
       
-      1. If the filename in your Sentry stack trace frame doesn't match the path to your source code, your `stack_root` will be the part of the filename you need to replace with your `source_root` in order to make the filename match the source code path.
-         * ex. My filename is `src/code.py` and my source code path is `https://github.com/MeredithAnya/testing/blob/main/code.py`. In order to get `src/code.py` to match `code.py`, I'll need my `stack_root` to be set as `src/`, and my `source_root` can remain empty. 
+      1. If the filename in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the **stack_root** part of the filename with your **source_root** to make the filename match the source code path.
+         * ex. For example, to get `src/code.py` to match `code.py` when the source code path is `https://github.com/MeredithAnya/testing/blob/main/code.py`, change the **stack trace root** to be set as `src/`, and leave **source code root** empty.
          
-         For the filename `src/code.py`, when I replace my `stack_root`, `src/`, with my `source_root`, `''`, I get `code.py`. This now matches my source code path.
 
 ### GitHub Single Sign-On
 

--- a/src/docs/product/integrations/github/index.mdx
+++ b/src/docs/product/integrations/github/index.mdx
@@ -220,6 +220,30 @@ You can also resolve issues with pull requests by including `fixes <SENTRY-SHORT
 
 When Sentry sees this, we’ll automatically annotate the matching issue with a reference to the commit or pull request, and, later, when that commit or pull request is part of a release, we’ll mark the issue as resolved.
 
+### Stack Trace Linking
+Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the `default_branch`).
+
+1. Navigate to **Settings > Integrations > GitHub > Configurations**.
+
+1. Next to your GitHub Instance, click "Configure".
+
+1. Next click on the **Code Mappings** tab.
+
+1. To enable stack trace linking, you'll need to set up a code mapping for each project you want to enable stack trace linking for. To create a new code mapping, click **Add Mapping**.
+
+1. Fill out the form, and click **Save Changes**. For more information on each form field, see below:
+   * `project` (required): This is the Sentry project. 
+   * `repo` (required): This is the GitHub repository that is associated with the Sentry project above. If you have more than one GitHub repository being used per Sentry project, you'll need multiple code mappings.
+   * `default_branch` (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
+   * `stack_root` and `source_root` (optional):
+      1. If the filename in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
+         * ex. My filename is `code.py` and my source code path is `https://github.com/MeredithAnya/testing/blob/main/code.py`. Everything after the branch (`main`) matches my filename so I don't need to set a `stack_root` and `source_root`.
+      
+      1. If the filename in your Sentry stack trace frame doesn't match the path to your source code, your `stack_root` will be the part of the filename you need to replace with your `source_root` in order to make the filename match the source code path.
+         * ex. My filename is `src/code.py` and my source code path is `https://github.com/MeredithAnya/testing/blob/main/code.py`. In order to get `src/code.py` to match `code.py`, I'll need my `stack_root` to be set as `src/`, and my `source_root` can remain empty. 
+         
+         For the filename `src/code.py`, when I replace my `stack_root`, `src/`, with my `source_root`, `''`, I get `code.py`. This now matches my source code path.
+
 ### GitHub Single Sign-On
 
 Single Sign-On (or SSO) allows you to manage your organization’s entire membership via a third-party provider.

--- a/src/docs/product/integrations/gitlab/index.mdx
+++ b/src/docs/product/integrations/gitlab/index.mdx
@@ -123,6 +123,31 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
 ![Issue detail highlighting suspect commits](short-id.png)
 
+### Stack Trace Linking
+Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the `default_branch`).
+
+1. Navigate to **Settings > Integrations > GitLab > Configurations**.
+
+1. Next to your GitLab Instance, click "Configure".
+
+1. Next click on the **Code Mappings** tab.
+
+1. To enable stack trace linking, you'll need to set up a code mapping for each project you want to enable stack trace linking for. To create a new code mapping, click **Add Mapping**.
+
+1. Fill out the form, and click **Save Changes**. For more information on each form field, see below:
+   * `project` (required): This is the Sentry project. 
+   * `repo` (required): This is the GitLab project that is associated with the Sentry project above. If you have more than one GitLab project being used per Sentry project, you'll need multiple code mappings.
+   * `default_branch` (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
+   * `stack_root` and `source_root` (optional):
+      1. If the filename in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
+         * ex. My filename is `code.py` and my source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`. Everything after the branch (`main`) matches my filename so I don't need to set a `stack_root` and `source_root`.
+      
+      1. If the filename in your Sentry stack trace frame doesn't match the path to your source code, your `stack_root` will be the part of the filename you need to replace with your `source_root` in order to make the filename match the source code path.
+         * ex. My filename is `src/code.py` and my source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`. In order to get `src/code.py` to match `code.py`, I'll need my `stack_root` to be set as `src/`, and my `source_root` can remain empty. 
+         
+         For the filename `src/code.py`, when I replace my `stack_root`, `src/`, with my `source_root`, `''`, I get `code.py`. This now matches my source code path.
+
+
 ## Troubleshooting
 
 - I'm using GitLab on-premise. Do I need to allow Sentry's IP addresses?

--- a/src/docs/product/integrations/gitlab/index.mdx
+++ b/src/docs/product/integrations/gitlab/index.mdx
@@ -124,28 +124,33 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 ![Issue detail highlighting suspect commits](short-id.png)
 
 ### Stack Trace Linking
-Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the `default_branch`).
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
 1. Navigate to **Settings > Integrations > GitLab > Configurations**.
 
-1. Next to your GitLab Instance, click "Configure".
+1. Click the "Configure" button next to your GitLab Instance.
 
-1. Next click on the **Code Mappings** tab.
+1. Click the **Code Mappings** tab.
 
-1. To enable stack trace linking, you'll need to set up a code mapping for each project you want to enable stack trace linking for. To create a new code mapping, click **Add Mapping**.
-
-1. Fill out the form, and click **Save Changes**. For more information on each form field, see below:
-   * `project` (required): This is the Sentry project. 
-   * `repo` (required): This is the GitLab project that is associated with the Sentry project above. If you have more than one GitLab project being used per Sentry project, you'll need multiple code mappings.
-   * `default_branch` (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
-   * `stack_root` and `source_root` (optional):
-      1. If the filename in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
-         * ex. My filename is `code.py` and my source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`. Everything after the branch (`main`) matches my filename so I don't need to set a `stack_root` and `source_root`.
-      
-      1. If the filename in your Sentry stack trace frame doesn't match the path to your source code, your `stack_root` will be the part of the filename you need to replace with your `source_root` in order to make the filename match the source code path.
-         * ex. My filename is `src/code.py` and my source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`. In order to get `src/code.py` to match `code.py`, I'll need my `stack_root` to be set as `src/`, and my `source_root` can remain empty. 
+1. Set up a code mapping for each project for which you want to enable stack trace linking. To create a new code mapping, click **Add Mapping**.
          
-         For the filename `src/code.py`, when I replace my `stack_root`, `src/`, with my `source_root`, `''`, I get `code.py`. This now matches my source code path.
+1. Fill out the form, then click **Save Changes**. Each form field is described below:
+   * **project** (required): This is the Sentry project. 
+   * **repo** (required): This is the GitLab project associated with the Sentry project above. If you have more than one GitLab project being used per Sentry project, you'll need multiple code mappings.
+   * **branch** (required): This is the default branch of your code we fall back to if you do not have commit tracking set up. 
+   * **stack trace root** and **source code root** (optional):
+      1. If the file path in your Sentry stack trace frame matches the path to your source code, you do not need to set these values. 
+         * ex. For example, everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py` so you don't need to set a **stack trace root** and **source code root**.
+      
+      1. If the file path in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the **stack_root** part of the file path with your **source_root** to make the file path match the source code path.
+         * ex. For example, to get `src/code.py` to match `code.py` when the source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, change the **stack trace root** to be set as `src/`, and leave **source code root** empty. 
 
 
 ## Troubleshooting


### PR DESCRIPTION
**Stack Trace Linking:**
This feature is an addition to our already existing GH and GitLab integrations, but will only be available for EA. This feature is a little bit of a test in terms of how intuitive it will be for users to set up. We actually have two ways for users to set it up, which I have named **Quick Setup** and **Manual Setup**. This [PR](https://github.com/getsentry/sentry/pull/22329) has a bit more information on that.

The documentation I've added here is for the **Manual Setup**, which users will be directed to if they click an integration in the Setup Modal added in https://github.com/getsentry/sentry/pull/22329, **OR** potentially if they are setting up GH/GitLab for the first time and end up on the configuration settings page. This page will now have both a 'Repositories' tab and a 'Code Mappings' tab (for EA users). For visuals on what that looks like see [this PR](https://github.com/getsentry/sentry/pull/21523).

The main purpose of the docs is to give some further explanations of the fields needed when manually creating the code mappings. The **Quick Setup** makes it so we automatically create this code mappings for the user, and they shouldn't really have to add/edit those code mappings unless they have a more advanced Sentry set up.

**This PR:**
This screenshot is for GitLab, slight wording changes for GitHub include:
* project -> repository 
* `https://gitlab.com...` -> `https://github.com...`

![Screen Shot 2020-12-10 at 10 31 27 AM](https://user-images.githubusercontent.com/15368179/101814358-e2f23780-3ad2-11eb-842c-187b82768675.png)


**No screenshots...?**
I've chosen not to add any screenshots currently because this is still in Beta and I'm expecting user feedback to ultimately shape the set up process for this feature. We'll need them going forward but main focus here is to have a place where we explain what each of the fields (`project`, `repo`, `branch`, `stack trace root`, `source code root`) mean. 