### PR TITLE
fix(native): Switch caseStyle to snake_case

### DIFF
--- a/src/platforms/native/config.yml
+++ b/src/platforms/native/config.yml
@@ -1,6 +1,6 @@
 title: Native
 sdk: sentry.native
-caseStyle: canonical
+caseStyle: snake_case
 supportLevel: production
 categories:
   - mobile


### PR DESCRIPTION
The Native SDK uses snake_case for its function names, but was incorrectly
tagged as "canonical".

