### PR TITLE
fix: Correct wording of basic options intro

### DIFF
--- a/src/includes/configuration/config-intro/javascript.mdx
+++ b/src/includes/configuration/config-intro/javascript.mdx
@@ -1,4 +1,4 @@
-Options are passed to the `init()` as object:
+Options are passed to the `init()` function as object:
 
 ```javascript
 Sentry.init({

--- a/src/includes/configuration/config-intro/rust.mdx
+++ b/src/includes/configuration/config-intro/rust.mdx
@@ -1,4 +1,4 @@
-Options are passed to the `init()` as tuple where the first argument is the DSN and the second the options:
+Options are passed to the `init()` function as tuple where the first argument is the DSN and the second the options:
 
 ```rust
 sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic Options
 sidebar_order: 1
-description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init function as an object."
 ---
 
 SDKs are configurable using a variety of options. The options are largely standardized among SDKs, but there are some differences to better accommodate platform peculiarities. Options are set when the SDK is first
@@ -142,7 +142,6 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 - `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
 
 </ConfigKey>
-
 
 <ConfigKey name="with-locals" supported={["python"]}>
 

--- a/src/platforms/elixir/configuration/options.mdx
+++ b/src/platforms/elixir/configuration/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic Options
 sidebar_order: 0
-description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init function as an object."
 redirect_from:
   - /clients/elixir/config/
 ---

--- a/src/platforms/go/common/configuration/options.mdx
+++ b/src/platforms/go/common/configuration/options.mdx
@@ -3,7 +3,7 @@ title: Basic Options
 sidebar_order: 0
 redirect_from:
   - /platforms/go/config/
-description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init method as an object."
 ---
 
 SDKs are configurable using a variety of options. The options are largely standardized among SDKs, but there are some differences to better accommodate platform peculiarities. Options are set when the SDK is first

--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_order: 10
-description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init method as an object."
 ---
 
 ## Setting the DSN (Data Source Name) {#setting-the-dsn}

--- a/src/platforms/java/common/legacy/configuration/index.mdx
+++ b/src/platforms/java/common/legacy/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_order: 10
-description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the `init()` as an object."
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init method as an object."
 ---
 
 <Alert level="warning" title="Note">


### PR DESCRIPTION
Adds a missing noun to the description of passing basic options to the init function or method. Whether it is a function or method depends on the platform.

Note that I had to remove the code backticks from descriptions as they are not being rendered by our page grid component:

![image](https://user-images.githubusercontent.com/1433023/101939297-16bd8200-3be5-11eb-8f8e-2e01aa2fd836.png)
