### PR TITLE
fix(native): Show a stronger warning on crashpad vs native SDK

### DIFF
--- a/src/platforms/native/guides/crashpad/index.mdx
+++ b/src/platforms/native/guides/crashpad/index.mdx
@@ -8,11 +8,11 @@ is an open-source multiplatform crash reporting system written in C++ by Google.
 It supports macOS, Windows and Linux (limited), and features an uploader to
 submit minidumps to a configured URL right when the process crashes.
 
-<Note>
+<Alert level="warning">
 
-We strongly encourage you to use our higher-level [Native SDK](/platforms/native/) if possible, as native Crashpad events are very limited in functionality.
+This page describes **standalone** usage of Crashpad with Sentry. We strongly encourage you to use our [Native SDK](/platforms/native/). For detailed information about using Crashpad with the Native SDK, see the [Crashpad backend documentation](/platforms/native/configuration/backends/crashpad/).
 
-</Note>
+</Alert>
 
 Follow the [Crashpad developer docs](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/developing.md) for instructions on how to build Crashpad from source. Make sure that crashpad’s header files are in your include path, then add a call to [StartHandler()](https://crashpad.chromium.org/doxygen/classcrashpad_1_1CrashpadClient.html#a810ad9941bedba543bf60507c31c55da) during your program startup:
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1433023/102191954-65f00500-3eba-11eb-90c1-860f932d5307.png)
