### PR TITLE
Update breadcrumbs docs to include types link

### DIFF
--- a/src/docs/product/error-monitoring/breadcrumbs/index.mdx
+++ b/src/docs/product/error-monitoring/breadcrumbs/index.mdx
@@ -18,7 +18,7 @@ Each part of the breadcrumb displays in a separate row in one of five columns: `
 
 Type
 
-: A semi-internal attribute `type` can control the type of the breadcrumb. By default all breadcrumbs are recorded as `default`, which makes them appear as a `Debug` entry, but Sentry provides other types that influence how the breadcrumbs are rendered.
+: A semi-internal attribute `type` can control the type of the breadcrumb. By default all breadcrumbs are recorded as `default`, which makes them appear as a `Debug` entry, but Sentry provides other [types](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types) that influence how the breadcrumbs are rendered.
 
 Category
 


### PR DESCRIPTION
It was inconvenient to read about types and not being able to actually look what kind of types are available. This fix it.