### PR TITLE
Documents update for Ruby SDK 4.1.0

### DIFF
--- a/src/includes/getting-started-config/ruby.rack.mdx
+++ b/src/includes/getting-started-config/ruby.rack.mdx
@@ -1,4 +1,4 @@
-Add `use Sentry::Rack::CaptureException` and `use Sentry::Rack::Tracing` to your `config.ru` or other rackup file:
+Add `use Sentry::Rack::CaptureExceptions` to your `config.ru` or other rackup file:
 
 ```ruby {filename:config.ru}
 require 'sentry-ruby'
@@ -15,6 +15,5 @@ Sentry.init do |config|
   end
 end
 
-use Sentry::Rack::Tracing # this needs to be placed first
-use Sentry::Rack::CaptureException
+use Sentry::Rack::CaptureExceptions
 ```

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -42,6 +42,20 @@ end
 
 If the async callback raises an exception, Sentry will attempt to send synchronously.
 
+`background_worker_threads`
+
+: If `config.async` isn't provided, Sentry will send events in a non-blocking way with its own background worker. By default, the worker holds a thread pool that has [the number of processors] threads. But you can configure it with this configuration option:
+
+```ruby
+config.background_worker_threads = 5
+```
+
+Or if you want to send events synchronously, set the value to 0:
+
+```ruby
+config.background_worker_threads = 0
+```
+
 `backtrace_cleanup_callback`
 
 : If you want to clean up exceptions' backtrace before it's sent to Sentry, you can specify a callback with `backtrace_cleanup_callback` to do that. For example:

--- a/src/wizard/ruby/rack.md
+++ b/src/wizard/ruby/rack.md
@@ -15,7 +15,7 @@ gem "sentry-ruby"
 
 ### Configuration
 
-Add `use Sentry::Rack::CaptureException` and `use Sentry::Rack::Tracing` to your `config.ru` or other rackup file (this is automatically inserted in Rails):
+Add `use Sentry::Rack::CaptureExceptions` to your `config.ru` or other rackup file (this is automatically inserted in Rails):
 
 ```ruby
 require 'sentry-ruby'
@@ -32,6 +32,5 @@ Sentry.init do |config|
   end
 end
 
-use Sentry::Rack::Tracing
-use Sentry::Rack::CaptureException
+use Sentry::Rack::CaptureExceptions
 ```


### PR DESCRIPTION
There will be some breaking changes/new config options coming with Ruby SDK's `4.1.0` version. This PR is to keep the documents up-to-date.