### PR TITLE
feat(apple): Add example for default release name

### DIFF
--- a/src/includes/set-release/apple.mdx
+++ b/src/includes/set-release/apple.mdx
@@ -14,4 +14,4 @@ SentrySDK.start { options in
 }
 ```
 
-If no release name is set the SDK creates a default combined of `CFBundleIdentifier, CFBundleShortVersionString and CFBundleVersion`.
+If no release name is set the SDK creates a default combined of `CFBundleIdentifier, CFBundleShortVersionString and CFBundleVersion`, for example `my.project.name@2.3.12+1234`.


### PR DESCRIPTION
@jan-auer asked for an example in a DM and other SDKs have it too. Therefore I added it.