### PR TITLE
fix: Hide sidebar entries without CSS

### DIFF
--- a/src/components/sidebarLink.tsx
+++ b/src/components/sidebarLink.tsx
@@ -22,10 +22,8 @@ export default ({
   const location = useLocation();
   const isActive = location && location.pathname.indexOf(withPrefix(to)) === 0;
 
-  className += " toc-item";
-  if (isActive || collapsed === false) {
-    className += " toc-visible";
-  }
+  const showSubtree = isActive || collapsed === false;
+  className += "toc-item";
 
   return (
     <li className={className} data-sidebar-branch>
@@ -34,7 +32,7 @@ export default ({
       </SmartLink>
       {title && children && (
         <ul className="list-unstyled" data-sidebar-tree>
-          {children}
+          {showSubtree && children}
         </ul>
       )}
     </li>

--- a/src/css/_includes/sidebar.scss
+++ b/src/css/_includes/sidebar.scss
@@ -68,12 +68,7 @@
 }
 
 [data-sidebar-branch] [data-sidebar-branch] > [data-sidebar-tree] {
-  display: none;
   margin-bottom: 0;
-}
-
-[data-sidebar-branch].toc-visible > [data-sidebar-tree] {
-  display: block;
 }
 
 [data-sidebar-link] {


### PR DESCRIPTION
This is *not* logically equivalent but I can't find a case in the sidebar where it makes a difference.

This is continuation from #2776 and removes another 300MB from `public/`, bringing down the total to 284MB.