### PR TITLE
Add missing links

### DIFF
--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -39,9 +39,9 @@ Releases are global per organization; prefix them with something project-specifi
 
 How you make the version available to your code is up to you. For example, you could use an environment variable that is set during the build process.
 
-This tags each event with the release value. We recommend that you tell Sentry about a new release before deploying it, as this will unlock a few more features as discussed in our documentation about . But if you don’t, Sentry will automatically create a release entity in the system the first time it sees an event with that release ID.
+This tags each event with the release value. We recommend that you tell Sentry about a new release before deploying it, as this will unlock a few more features as discussed in our documentation about [releases](/product/releases/). But if you don’t, Sentry will automatically create a release entity in the system the first time it sees an event with that release ID.
 
-After configuring your SDK, you can install a repository integration or manually supply Sentry with your own commit metadata. Read our documentation about [Releases](/product/releases/) for further information about integrations, associating commits, and telling Sentry when deploying releases.
+After configuring your SDK, you can install a repository integration or manually supply Sentry with your own commit metadata. Read our documentation about [setting up releases](/product/releases/setup/) for further information about integrations, associating commits, and telling Sentry when deploying releases.
 
 <PlatformSection supported={["apple", "android", "javascript", "flutter", "native"]}>
 


### PR DESCRIPTION
A link from the SDK content to the releases product content has been missing (though the sentence was sadly still there), and the link to setting up needing refreshing due to the refactor.