### PR TITLE
Add default trigger note

### DIFF
--- a/src/docs/product/alerts-notifications/issue-alerts.mdx
+++ b/src/docs/product/alerts-notifications/issue-alerts.mdx
@@ -26,6 +26,10 @@ Triggers specify what type of activity you'd like monitored. The following trigg
 - The issue is seen more than {**value**} times in {**interval**}. **Value**: a positive integer. **Interval**: one min, one hour, one day, one week, or 30 days.
 - The issue is seen by more than {**value**} users in {**interval**}. **Value**: a positive integer. **Interval**: one min, one hour, one day, one week, or 30 days.
 
+<Alert>
+  If no trigger is selected, the alert will be triggered by every event, subject to rate limits.
+</Alert>
+
 ### Filters
 
 Filters help control noise by filtering down the triggered alerts to only those matching specific criteria. The following filters are available:

--- a/src/docs/product/alerts-notifications/issue-alerts.mdx
+++ b/src/docs/product/alerts-notifications/issue-alerts.mdx
@@ -26,9 +26,11 @@ Triggers specify what type of activity you'd like monitored. The following trigg
 - The issue is seen more than {**value**} times in {**interval**}. **Value**: a positive integer. **Interval**: one min, one hour, one day, one week, or 30 days.
 - The issue is seen by more than {**value**} users in {**interval**}. **Value**: a positive integer. **Interval**: one min, one hour, one day, one week, or 30 days.
 
-<Alert>
-  If no trigger is selected, the alert will be triggered by every event, subject to rate limits.
-</Alert>
+<Note>
+
+If no trigger is selected, the alert will be triggered by every event, subject to rate limits.
+  
+</Note>
 
 ### Filters
 


### PR DESCRIPTION
Adding the default trigger "When an event occurs" note to alert triggers session as this question comes up quite frequently in support.