### PR TITLE
feat(apple/java): max attachment size

### DIFF
--- a/src/includes/attachment-max-size/apple.mdx
+++ b/src/includes/attachment-max-size/apple.mdx
@@ -1,0 +1,15 @@
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.maxAttachmentSize = 5
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.maxAttachmentSize = 5;
+}];
+```

--- a/src/includes/attachment-max-size/apple.mdx
+++ b/src/includes/attachment-max-size/apple.mdx
@@ -2,7 +2,7 @@
 import Sentry
 
 SentrySDK.start { options in
-    options.maxAttachmentSize = 5
+    options.maxAttachmentSize = 5 * 1024 * 1024 // 5 MiB
 }
 ```
 
@@ -10,6 +10,6 @@ SentrySDK.start { options in
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.maxAttachmentSize = 5;
+    options.maxAttachmentSize = 5 * 1024 * 1024; // 5 MiB
 }];
 ```

--- a/src/includes/attachment-max-size/java.mdx
+++ b/src/includes/attachment-max-size/java.mdx
@@ -1,0 +1,14 @@
+```java
+import io.sentry.Sentry;
+
+Sentry.init(options -> {
+    options.setMaxAttachmentSize(5 * 1024 * 1024); // 5 MiB
+});
+```
+```kotlin
+import io.sentry.Sentry
+
+Sentry.init {
+    it.maxAttachmentSize = 5 * 1024 * 1024 // 5 MiB
+}
+```

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -124,7 +124,7 @@ If you chose to limit the number of crash reports per issue, you can show _Only 
 ## Maximum Attachment Size
 
 You can set the maximum size for each attachment with `maxAttachmentSize` on the `SentryOptions`.
-The scale is MiB and the default is 20 MiB. Please also check the
+The scale is bytes and the default is 20 MiB / 20 * 1024 * 1024 bytes. Please also check the
 [maxium attachment size of Relay](https://docs.sentry.io/product/relay/options/)
 to make sure your attachments don't get discarded there.
 

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -119,12 +119,12 @@ If you chose to limit the number of crash reports per issue, you can show _Only 
 
 </PlatformSection>
 
-<PlatformSection supported={["apple"]}>
+<PlatformSection supported={["android", "apple", "java"]}>
 
 ## Maximum Attachment Size
 
-You can set the maximum size for each attachment with `maxAttachmentSize` on the `SentryOptions`.
-The scale is bytes and the default is 20 MiB / 20 * 1024 * 1024 bytes. Please also check the
+The maximum size for each attachment is set on `SentryOptions.maxAttachmentSize`.
+The scale is bytes and the default is `20 MiB`. Please also check the
 [maxium attachment size of Relay](https://docs.sentry.io/product/relay/options/)
 to make sure your attachments don't get discarded there.
 

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -125,7 +125,7 @@ If you chose to limit the number of crash reports per issue, you can show _Only 
 
 The maximum size for each attachment is set on `SentryOptions.maxAttachmentSize`.
 The scale is bytes and the default is `20 MiB`. Please also check the
-[maxium attachment size of Relay](https://docs.sentry.io/product/relay/options/)
+[maximum attachment size of Relay](https://docs.sentry.io/product/relay/options/)
 to make sure your attachments don't get discarded there.
 
 <PlatformContent includePath="attachment-max-size" />

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -118,3 +118,16 @@ Alternately, attachments also appear in the _Attachments_ tab on the **Issue Det
 If you chose to limit the number of crash reports per issue, you can show _Only Crash Reports_. This removes all other attachments from the list, which can be useful if the issue has accumulated a large number of events.
 
 </PlatformSection>
+
+<PlatformSection supported={["apple"]}>
+
+## Maximum Attachment Size
+
+You can set the maximum size for each attachment with `maxAttachmentSize` on the `SentryOptions`.
+The scale is MiB and the default is 20 MiB. Please also check the
+[maxium attachment size of Relay](https://docs.sentry.io/product/relay/options/)
+to make sure your attachments don't get discarded there.
+
+<PlatformContent includePath="attachment-max-size" />
+
+</PlatformSection>


### PR DESCRIPTION
Add docs for max attachment size on Apple. This feature is currently
only supported on Apple, but more platforms are going to follow.
Therefore, we hide the feature for other platforms, but already use
PlatformContent.