### PR TITLE
fix: Update attach-stacktrace default

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -67,7 +67,16 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.
 
+<PlatformSection supported={["android", "apple", "java"]}>
+
+This option is `on` by default.
+
+</PlatformSection>
+<PlatformSection notSupported={["android", "apple", "java"]}>
+
 This option is `off` by default.
+
+</PlatformSection>
 
 Grouping in Sentry is different for events with stack traces and without. As a result, you will get new groups as you enable or disable this flag for certain events.
 


### PR DESCRIPTION
The attach-stacktrace on the options is default on for Android, Apple, and Java. This is now updated for the docs.

@bruno-garcia did we also set the default to `true` for .NET? If so ping me, so I update the PR.