### PR TITLE
Add `inAppIncludes` and `inAppExcludes` options to Java docs.

### DIFF
--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -197,6 +197,38 @@ sentry.tags.first_tag=first-tag-value
 sentry.tags.second_tag=second-tag-value
 ```
 
+### In App Includes
+
+To set the in-app-includes that will be sent with each event, use the `in-app-includes` option:
+
+```properties {tabTitle:sentry.properties}
+in-app-includes=host1
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_IN_APP_INCLUDES=host1
+```
+
+```properties {tabTitle:system property}
+sentry.in-app-includes=host1
+```
+
+### In App Excludes
+
+To set the in-app-excludes that will be sent with each event, use the `in-app-excludes` option:
+
+```properties {tabTitle:sentry.properties}
+in-app-excludes=host1
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_IN_APP_EXCLUDES=host1
+```
+
+```properties {tabTitle:system property}
+sentry.in-app-excludes=host1
+```
+
 ## Configuring Timeouts
 
 It’s possible to manually set the connection timeouts length with `connectionTimeoutMillis` and `readTimeoutMillis`:


### PR DESCRIPTION
Note - setting `inAppIncludes` and `inAppExcludes` from external configuration has been added in 4.0 which is currently in alpha stage.

This should be merged after https://github.com/getsentry/sentry-java/pull/1145

Fixes #2801 