### PR TITLE
fix(native): Document ip_address {{auto}}

### DIFF
--- a/src/includes/set-user/native.mdx
+++ b/src/includes/set-user/native.mdx
@@ -2,6 +2,7 @@
 #include <sentry.h>
 
 sentry_value_t user = sentry_value_new_object();
+sentry_value_set_by_key(user, "ip_address", sentry_value_new_string("{{auto}}"));
 sentry_value_set_by_key(user, "email", sentry_value_new_string("jane.doe@example.com"));
 sentry_set_user(user);
 ```

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -26,7 +26,7 @@ Users consist of a few critical pieces of information that construct a unique id
 
 `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available.
+: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. Set to `"{{auto}}"` to let Sentry infer the IP address from the connection.
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 


### PR DESCRIPTION
Documents the special `{{auto}}` value for `user.ip_address` for all SDKs.
Client-side SDKs set this by default, whereas in server-side SDKs this must be
set manually.

Since the Native SDK is used in both contexts, we document `{{auto}}` explicitly
in the code example.

---

![image](https://user-images.githubusercontent.com/1433023/103513132-440af200-4e6a-11eb-9c28-5bc213439d05.png)

---

Fixes https://github.com/getsentry/sentry-docs/issues/2821
