### PR TITLE
Remove border and drop shadow from platform icons in guide

### DIFF
--- a/src/components/guideGrid.tsx
+++ b/src/components/guideGrid.tsx
@@ -23,7 +23,7 @@ export default ({ platform }: Props): JSX.Element => {
             <PlatformIcon
               size={16}
               platform={guide.key}
-              style={{ marginRight: "0.5rem" }}
+              style={{ marginRight: "0.5rem", border: 0, boxShadow: "none" }}
               format="lg"
             />
             <h4 style={{ display: "inline-block" }}>{guide.title}</h4>


### PR DESCRIPTION
The platform icons from the 'platformicons' package do not have any
border or drop shadow, but type.scss adds them for any image inside
the 'prose' class, which the guide icons are automatically part of,
since they art part of the main content block.

A similar workaround is already added in platformGrid.tsx, while the
icons in the platform navigation dropdown do not need it as they are
not part of the main content (prose section).