### PR TITLE
fix: Specify valid content types for attachments

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -63,7 +63,7 @@ In addition, you can set these parameters:
 
 `contentType`
 
-: The type of content stored in this attachment. The default is `application/octet-stream`.
+: The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
 </PlatformSection>
 


### PR DESCRIPTION
Specify the valid content types. Brought up in here https://github.com/getsentry/sentry-docs/pull/2826#issuecomment-755500370 and also fixed in the develop docs: https://github.com/getsentry/develop/pull/238