### PR TITLE
meta: Tell stalebot to ignore `Status: On Hold`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           debug-only: false
           ascending: false
 
-          exempt-issue-labels: "Status: Accepted"
+          exempt-issue-labels: "Status: Accepted,Status: On Hold"
           stale-issue-label: "Status: Stale"
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
@@ -32,7 +32,7 @@ jobs:
           close-issue-label: ""
           close-issue-message: ""
 
-          exempt-pr-labels: "Status: Accepted"
+          exempt-pr-labels: "Status: Accepted,Status: On Hold"
           stale-pr-label: "Status: Stale"
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.


### PR DESCRIPTION
Heads up, @PeloWriter. We're adding another label for stalebot to ignore, to allow holding open an issue without communicating that we've strongly committed to it.