### PR TITLE
ref: Update sensitive data management

### DIFF
--- a/src/docs/product/data-management-settings/index.mdx
+++ b/src/docs/product/data-management-settings/index.mdx
@@ -4,14 +4,6 @@ sidebar_order: 200
 description: "Learn more about managing data using the Settings for your project and organization."
 ---
 
-As with any third-party service, it’s important to understand what data is being sent to Sentry, and where relevant, ensure sensitive data either never reaches the Sentry servers, or at the very least doesn’t get stored.
-
-There are two great examples for data scrubbing that every company should think about:
-
-1. PII (Personally Identifiable Information) such as a user's name or email address, which post-GDPR should be on every company's mind.
-Authentication credentials, like your AWS password or key.
-2. Confidential IP (Intellectual Property), such as your favorite color, or your upcoming plans for world domination.
-
-Sentry offers three methods to scrub data. The first, which is our recommended method, is to <PlatformLink to="/data-management/sensitive-data/">scrub data in your SDK</PlatformLink>. The second two methods use the Data Scrubber option available for both your Organization and individual Project settings.
+Please refer to <PlatformLink to="/data-management/sensitive-data/">the SDK documentation for a general introduction to managing sensitive data</PlatformLink>. This page only documents the server-side options.
 
 <PageGrid />

--- a/src/docs/product/data-management-settings/index.mdx
+++ b/src/docs/product/data-management-settings/index.mdx
@@ -4,6 +4,6 @@ sidebar_order: 200
 description: "Learn more about managing data using the Settings for your project and organization."
 ---
 
-Please refer to <PlatformLink to="/data-management/sensitive-data/">the SDK documentation for a general introduction to managing sensitive data</PlatformLink>. This page only documents the server-side options.
+Please refer to <PlatformLink to="/data-management/sensitive-data/">the SDK documentation for a general introduction to managing sensitive data</PlatformLink>. This page documents only the server-side options.
 
 <PageGrid />

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -9,7 +9,7 @@ description: "Learn about filtering or scrubbing sensitive data within the SDK, 
 
 As with any third-party service it’s important to understand what data is being sent to Sentry, and where relevant ensure sensitive data either never reaches the Sentry servers, or at the very least it doesn’t get stored.
 
-There are two great examples for data scrubbing that every company should think about:
+These are some great examples for data scrubbing that every company should think about:
 
 - PII (Personally Identifiable Information) such as a user's name or email address, which post-GDPR should be on every company's mind.
 - Authentication credentials, like your AWS password or key.
@@ -17,9 +17,9 @@ There are two great examples for data scrubbing that every company should think 
 
 We offer the following options depending on your legal and operational needs:
 
-- filtering or scrubbing sensitive data within the SDK, so that data is not *sent to* Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
-- [configuring server-side scrubbing](/product/data-management-settings/server-side-scrubbing/) to ensure Sentry does not *store* data. Configuration changes are done in the Sentry UI and apply immediately for new events.
-- [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is not *sent to* Sentry while configuration can still be applied without deploying.
+- filtering or scrubbing sensitive data within the SDK, so that data is *not sent to* Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- [configuring server-side scrubbing](/product/data-management-settings/server-side-scrubbing/) to ensure Sentry does *not store* data. Configuration changes are done in the Sentry UI and apply immediately for new events.
+- [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is *not sent to* Sentry while configuration can still be applied without deploying.
 
 <Note>
 

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -7,13 +7,25 @@ redirect_from:
 description: "Learn about filtering or scrubbing sensitive data within the SDK, so that data is not sent with the event. You can also configure server-side scrubbing to ensure the data is not stored."
 ---
 
-As with any third-party service it’s important to understand what data is being sent to Sentry, and where relevant ensure sensitive data either never reaches the Sentry servers, or at the very least it doesn’t get stored. We recommend filtering or scrubbing sensitive data within the SDK, so that data is not sent with the event, and also [configuring server-side scrubbing](/product/data-management-settings/server-side-scrubbing/) to ensure the data is not stored.
+As with any third-party service it’s important to understand what data is being sent to Sentry, and where relevant ensure sensitive data either never reaches the Sentry servers, or at the very least it doesn’t get stored.
 
 There are two great examples for data scrubbing that every company should think about:
 
 - PII (Personally Identifiable Information) such as a user's name or email address, which post-GDPR should be on every company's mind.
 - Authentication credentials, like your AWS password or key.
 - Confidential IP (Intellectual Property), such as your favorite color, or your upcoming plans for world domination.
+
+We offer the following options depending on your legal and operational needs:
+
+- filtering or scrubbing sensitive data within the SDK, so that data is not *sent to* Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- [configuring server-side scrubbing](/product/data-management-settings/server-side-scrubbing/) to ensure Sentry does not *store* data. Configuration changes are done in the Sentry UI and apply immediately for new events.
+- [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is not *sent to* Sentry while configuration can still be applied without deploying.
+
+<Note>
+
+Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
+
+</Note>
 
 <PlatformSection notSupported={["apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4", "go", "ruby", "native", "elixir", "dart", "flutter"]}>
 
@@ -38,12 +50,6 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 SDKs provide a `before-send` hook, which is invoked before an event is sent and can be used to modify event data to remove sensitive information. Using `before-send` in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, so sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send" />
-
-<Note>
-
-Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
-
-</Note>
 
 There's a few areas you should consider that sensitive data may appear:
 


### PR DESCRIPTION
- Recommend Relay as alternative to either SDK or server-side scrubbing

- Do not give clear recommendation for SDK-scrubbing in product docs --
  this entirely depends on your legal/privacy needs. Simply point out
  advantages and disadvantages

- Remove duplicated intro to sensitive data in product docs and make
  platform page the central starting point, as that's what most things
  link (and redirect) to.