### PR TITLE
fix(react): Fix docs for ErrorBoundary fallback prop

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -45,7 +45,7 @@ function FallbackComponent() {
 class App extends React.Component {
   render() {
     return (
-      <Sentry.ErrorBoundary fallback={FallbackComponent} showDialog>
+      <Sentry.ErrorBoundary fallback={<FallbackComponent />} showDialog>
         <Example />
       </Sentry.ErrorBoundary>
     );
@@ -69,7 +69,21 @@ The ErrorBoundary component exposes a variety of props that can be passed in for
 
 `fallback` (React.ReactNode or Function)
 
-: A fallback component that gets rendered when the error boundary encounters an error. You can can either provide a React Component, or a function that returns a React Component as a valid fallback prop. If you provide a function, Sentry will call the function with the error and the component stack at the time of the error.
+: A React element to render when the error boundary catches an error. Can be an actual React element (i.e. `<Fallback />`), or a function that returns a React element. If you provide a function, Sentry will call the function with the following object:
+
+```ts
+{
+  // The error that was caught by the error boundary
+  error: Error;
+  // The component stack at the time the error was thrown
+  componentStack: string | null;
+  // A globally unique id for the event that was just sent to Sentry.
+  eventId: string | null;
+  // A function to call to reset the error boundary.
+  // Once reset, the error boundary's childreen will be rendered again.
+  resetError(): void;
+}
+```
 
 `onError` (Function)
 

--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -80,7 +80,7 @@ The ErrorBoundary component exposes a variety of props that can be passed in for
   // A globally unique id for the event that was just sent to Sentry.
   eventId: string | null;
   // A function to call to reset the error boundary.
-  // Once reset, the error boundary's childreen will be rendered again.
+  // Once reset, the error boundary's children will be rendered again.
   resetError(): void;
 }
 ```

--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -42,10 +42,14 @@ function FallbackComponent() {
   return <div>An error has occurred</div>;
 }
 
+const myFallback = <FallbackComponent />;
+// Alternatively:
+// const myFallback = () => <FallbackComponent />;
+
 class App extends React.Component {
   render() {
     return (
-      <Sentry.ErrorBoundary fallback={<FallbackComponent />} showDialog>
+      <Sentry.ErrorBoundary fallback={myFallback} showDialog>
         <Example />
       </Sentry.ErrorBoundary>
     );

--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -69,21 +69,7 @@ The ErrorBoundary component exposes a variety of props that can be passed in for
 
 `fallback` (React.ReactNode or Function)
 
-: A React element to render when the error boundary catches an error. Can be an actual React element (i.e. `<Fallback />`), or a function that returns a React element. If you provide a function, Sentry will call the function with the following object:
-
-```ts
-{
-  // The error that was caught by the error boundary
-  error: Error;
-  // The component stack at the time the error was thrown
-  componentStack: string | null;
-  // A globally unique id for the event that was just sent to Sentry.
-  eventId: string | null;
-  // A function to call to reset the error boundary.
-  // Once reset, the error boundary's children will be rendered again.
-  resetError(): void;
-}
-```
+: A React element to render when the error boundary catches an error. Can be an actual React element (i.e. `<Fallback />`), or a function that returns a React element. If you provide a function, Sentry will call it with additional info and helpers (see example below).
 
 `onError` (Function)
 


### PR DESCRIPTION
The docs previously showed passing a component to the fallback prop. However the fallback prop takes a React _element_ not a React _component_:
https://github.com/getsentry/sentry-javascript/blob/a833f0ec0a186f0672a536ea8f7d3b129a71a4fe/packages/react/src/errorboundary.tsx#L111-L121

You can additionally verify that by checking the TypeScript types:
https://github.com/getsentry/sentry-javascript/blob/a833f0ec0a186f0672a536ea8f7d3b129a71a4fe/packages/react/src/errorboundary.tsx#L30

Since the difference between React elements and React components can be confusing, here's [a link to the React glossary for more information](https://reactjs.org/docs/glossary.html#elements).