### PR TITLE
feat(apple): Remove note on beta for attachments

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -13,8 +13,6 @@ supported:
 
 <PlatformSection supported={["apple"]}>
 
-__Attention: This is a preview API available since 6.1.0-alpha.0. This API is not in stable state yet. It may be renamed, changed or even removed in a future version.__
-
 Be aware that attachments don't work yet with crashes.
 
 </PlatformSection>


### PR DESCRIPTION
The attachments API is going to be stable with sentry-cocoa 6.1.0.
Therefore we can remove the note about the alpha release.

Only merge this PR after sentry-cocoa 6.1.0 is released.