### PR TITLE
fix: Update docs to the most recent Rust SDK version

### DIFF
--- a/src/includes/getting-started-install/rust.mdx
+++ b/src/includes/getting-started-install/rust.mdx
@@ -2,5 +2,5 @@ To add Sentry to your Rust project you just need to add a new dependency to your
 
 ```toml
 [dependencies]
-sentry = "*"
+sentry = "{{ packages.version('sentry.rust') }}"
 ```

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -15,62 +15,44 @@ In your `Cargo.toml`:
 
 ```toml {filename:Cargo.toml}
 [dependencies]
-sentry = "0.19.0"
-sentry-actix = "0.19.0"
+sentry = "{{ packages.version('sentry.rust') }}"
+sentry-actix = "{{ packages.version('sentry.rust') }}"
 ```
 
 And your Rust code:
 
 ```rust {filename:main.rs}
-extern crate actix_web;
-extern crate sentry;
-extern crate sentry_actix;
-
-use std::env;
 use std::io;
 
-use actix_web::{server, App, Error, HttpRequest};
-use sentry_actix::SentryMiddleware;
+use actix_web::{get, App, Error, HttpRequest, HttpServer};
 
-fn failing(_req: &HttpRequest) -> Result<String, Error> {
+#[get("/")]
+async fn failing(_req: HttpRequest) -> Result<String, Error> {
     Err(io::Error::new(io::ErrorKind::Other, "An error happens here").into())
 }
 
-fn main() {
-    let _guard = sentry::init("___PUBLIC_DSN___");
-    env::set_var("RUST_BACKTRACE", "1");
+#[actix_web::main]
+async fn main() -> io::Result<()> {
+    let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    }));
+    std::env::set_var("RUST_BACKTRACE", "1");
 
-    server::new(|| {
+    HttpServer::new(|| {
         App::new()
-            .middleware(SentryMiddleware::new())
-            .resource("/", |r| r.f(failing))
-    }).bind("127.0.0.1:3001")
-        .unwrap()
-        .run();
+            .wrap(sentry_actix::Sentry::new())
+            .service(failing)
+    })
+    .bind("127.0.0.1:3001")?
+    .run()
+    .await?;
+
+    Ok(())
 }
 ```
 
 ## Reusing the Hub
 
-If you use this integration the `Hub::current()` returned hub is typically the wrong one.
-To get the request specific one you need to use the `ActixWebHubExt` trait:
-
-```rust
-use sentry::{Hub, Level};
-use sentry_actix::ActixWebHubExt;
-
-let hub = Hub::from_request(req);
-hub.capture_message("Something is not well", Level::Warning);
-```
-
-The hub can also be made current:
-
-```rust
-use sentry::{Hub, Level};
-use sentry_actix::ActixWebHubExt;
-
-let hub = Hub::from_request(req);
-Hub::run(hub, || {
-    sentry::capture_message("Something is not well", Level::Warning);
-});
-```
+When using the actix integration, a new per-request Hub will be created from the main Hub, and will be set automatically as the current Hub (`Hub::current()`).
+No manual intervention in needed.

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -21,7 +21,7 @@ To add Sentry to your Rust project, just add a new dependency to your `Cargo.tom
 
 ```toml {filename:Cargo.toml}
 [dependencies]
-sentry = "*"
+sentry = "{{ packages.version('sentry.rust') }}"
 ```
 
 ## Configure
@@ -31,7 +31,10 @@ The most convenient way to use this library is the `sentry::init` function, whic
 The `sentry::init` function returns a guard that, when dropped, will flush Events that were not yet sent to the Sentry service. It has a two second deadline for this, so shutdown of applications might slightly delay as a result. Keeping the guard around or sending events will not work.
 
 ```rust {filename:main.rs}
-let _guard = sentry::init("___PUBLIC_DSN___");
+let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+    release: sentry::release_name!(),
+    ..Default::default()
+}));
 ```
 
 **Important:** Note your DSN. The DSN (Data Source Name) tells the SDK where to send events. If you forget it, view Settings -> Projects -> Client Keys (DSN) in sentry.io.
@@ -42,10 +45,13 @@ The quickest way to verify Sentry in your Rust application is to cause a panic:
 
 ```rust {filename:main.rs}
 fn main() {
-  let _guard = sentry::init("___PUBLIC_DSN___");
+    let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    }));
 
-  // Sentry will capture this
-  panic!("Everything is on fire!");
+    // Sentry will capture this
+    panic!("Everything is on fire!");
 }
 ```
 

--- a/src/wizard/rust/index.md
+++ b/src/wizard/rust/index.md
@@ -9,20 +9,26 @@ To add Sentry to your Rust project you just need to add a new dependency to your
 
 ```toml
 [dependencies]
-sentry = "0.19.0"
+sentry = "{{ packages.version('sentry.rust') }}"
 ```
 
 `sentry.init()` will return you a guard that when freed, will prevent process exit until all events have been sent (within a timeout):
 
 ```rust
-let _guard = sentry::init("___PUBLIC_DSN___");
+let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+    release: sentry::release_name!(),
+    ..Default::default()
+}));
 ```
 
 The quickest way to verify Sentry in your Rust application is to cause a panic:
 
 ```rust
 fn main() {
-    let _guard = sentry::init("___PUBLIC_DSN___");
+    let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    }));
 
     // Sentry will capture this
     panic!("Everything is on fire!");


### PR DESCRIPTION
This uses the current release-registry version of the Rust SDK.
It also updates some examples to use Releases, and updates the Actix docs to the current version.