### PR TITLE
adding performance links for the performance pages

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -24,8 +24,10 @@ Customers on legacy plans must add transaction events to their subscription in o
   - [Vue](/platforms/javascript/guides/vue/#monitor-performance)
 
 - [Node.js](/platforms/node/performance/)
+  - [AWS Lambda](/platforms/node/guides/aws-lambda/)
   - [Express](/platforms/node/guides/express/#monitor-performance)
   - [Koa](/platforms/node/guides/koa/#monitor-performance)
+  - [GCP Cloud Functions](/platforms/node/guides/gcp-functions/)
 
 - [Python](/platforms/python/performance/)
   - [AWS Lambda](/platforms/python/guides/aws-lambda/performance/)
@@ -33,6 +35,7 @@ Customers on legacy plans must add transaction events to their subscription in o
   - [Celery](/platforms/python/guides/celery/performance/)
   - [Django](/platforms/python/guides/django/performance/)
   - [Flask](/platforms/python/guides/flask/performance/)
+  - [GCP Cloud Functions](/platforms/python/guides/gcp-functions/)
   - [Pyramid](/platforms/python/guides/pyramid/performance/)
   - [RQ (Redis Queue)](/platforms/python/guides/rq/performance/)
 


### PR DESCRIPTION
Minor fix: Links to serverless performance getting started