### PR TITLE
Fix typo in performance monitoring page

### DIFF
--- a/src/platforms/ruby/common/performance/index.mdx
+++ b/src/platforms/ruby/common/performance/index.mdx
@@ -28,7 +28,7 @@ The following example creates a transaction for a scope that contains an expensi
 
 ```ruby
 # start a transaction
-transacton = Sentry.start_transaction(op: "process_item")
+transaction = Sentry.start_transaction(op: "process_item")
 
 # perform the operation
 process_item(args)


### PR DESCRIPTION
Just fixing a minor typo in a code example where "transaction" is misspelled.