### PR TITLE
fix(python): Make default sampling context comments more helpful

### DIFF
--- a/src/includes/performance/default-sampling-context-platform/python.mdx
+++ b/src/includes/performance/default-sampling-context-platform/python.mdx
@@ -3,7 +3,7 @@ For Python-based SDKs, it includes at least the following:
 ```python
 {
   "transaction_context": {
-    "name": <string>  # human-readable identifier, like "GET /users"
+    "name": <string>  # transaction title at creation time
     "op": <string>  # short description of transaction type, like "http.request"
   },
   "parent_sampled": <bool>  # if this transaction has a parent, its sampling decision

--- a/src/includes/performance/default-sampling-context/python.bottle.mdx
+++ b/src/includes/performance/default-sampling-context/python.bottle.mdx
@@ -4,6 +4,9 @@ The Bottle integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.django.mdx
+++ b/src/includes/performance/default-sampling-context/python.django.mdx
@@ -4,6 +4,9 @@ The Django integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.falcon.mdx
+++ b/src/includes/performance/default-sampling-context/python.falcon.mdx
@@ -4,6 +4,9 @@ The Falcon integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.flask.mdx
+++ b/src/includes/performance/default-sampling-context/python.flask.mdx
@@ -4,6 +4,9 @@ The Flask integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.pyramid.mdx
+++ b/src/includes/performance/default-sampling-context/python.pyramid.mdx
@@ -4,6 +4,9 @@ The Pyramid integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.tryton.mdx
+++ b/src/includes/performance/default-sampling-context/python.tryton.mdx
@@ -4,6 +4,9 @@ The Tryton integration adds the WSGI request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```

--- a/src/includes/performance/default-sampling-context/python.wsgi.mdx
+++ b/src/includes/performance/default-sampling-context/python.wsgi.mdx
@@ -4,6 +4,9 @@ The WSGI integration adds the request environ:
 
 ```python
 {
+  # This can be useful for cases in which the transaction starts before the URL
+  # is resolved into a route (meaning the transaction's name won't help much),
+  # as it contains parsed URL data
   "wsgi_environ": <dict>
 }
 ```


### PR DESCRIPTION
In particular, this points people to look in `wsgi_environ` for (all the parts of) the request URL.

Fixes https://github.com/getsentry/sentry-python/issues/969.