### PR TITLE
fix(ui): added styles for active tab in code blocks

### DIFF
--- a/src/css/_includes/code-blocks.scss
+++ b/src/css/_includes/code-blocks.scss
@@ -5,7 +5,7 @@
   .tab-bar {
     background: #2d2d2d;
     border-bottom: 1px solid #444;
-    height: 32px;
+    height: 36px;
     display: flex;
     align-items: center;
     padding: 0 0.5rem;
@@ -13,19 +13,21 @@
 
     button {
       color: $desatPurple8;
-      padding: 3px 6px;
+      padding: 7px 6px 4px;
       display: inline-block;
       cursor: pointer;
       border: none;
       font-size: 0.75rem;
       background: none;
       outline: none;
+      border-bottom: 3px solid transparent;
 
       &.active,
       &:focus,
       &.only-choice {
         color: $white;
         font-weight: 500;
+        border-bottom: 3px solid #6c5fc7;
       }
     }
   }


### PR DESCRIPTION
### Before

<img width="765" alt="Screen Shot 2021-01-13 at 4 03 02 PM" src="https://user-images.githubusercontent.com/1900676/104527260-23a10d00-55b9-11eb-9127-c06e765f4442.png">

### After

<img width="764" alt="Screen Shot 2021-01-13 at 4 02 16 PM" src="https://user-images.githubusercontent.com/1900676/104527271-2b60b180-55b9-11eb-9edc-30226d97df0b.png">
