### PR TITLE
fix: Attachments intro

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -25,7 +25,7 @@ Be aware that attachments don't work yet with crashes.
 
 </PlatformSection>
 
-Sentry can augment your crash reports by storing additional files alongside the event, such as log files, as attachments. Attachments allow the files within a crash to not only upload to Sentry, but also persist for further investigation.
+Sentry can enrich your events for further investigation by storing additional files, such as config or log files, as attachments.
 
 <PlatformSection supported={["native"]}>
 


### PR DESCRIPTION
The current attachment intro mostly mentions crash reports, but you can attach
them to all types of events.