### PR TITLE
fix: Add RN to "Shutdown and Draining" not supported list

### DIFF
--- a/src/platforms/common/configuration/draining.mdx
+++ b/src/platforms/common/configuration/draining.mdx
@@ -7,6 +7,7 @@ notSupported:
   - dart
   - ruby
   - unity
+  - react-native
 ---
 
 The default behavior of most SDKs is to send out events over the network


### PR DESCRIPTION
`Sentry.close()` is not supported on React Native so this PR sets it as not supported.

One person has tried using it: https://github.com/getsentry/sentry-react-native/issues/1279