### PR TITLE
Add navigation information

### DIFF
--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -37,10 +37,11 @@ Each release links to one project. If a release has multiple projects, Sentry wi
 
 ![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
 
-
 ## Track Release Health
 
 _Release health_ provides insight into the impact of crashes and bugs as it relates to your user's experience and reveals trends with each new issue. Monitor [Release Health](/product/releases/health/) by observing user adoption, usage of the application, percentage of crashes, and session data.
+
+You can view Release Health data either from the Issue Details page by selecting the commit ID listed under **Last Seen** or from the Releases homepage by selecting the **Project Name**.
 
 ## Apply Source Maps
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -41,7 +41,7 @@ Each release links to one project. If a release has multiple projects, Sentry wi
 
 _Release health_ provides insight into the impact of crashes and bugs as it relates to your user's experience and reveals trends with each new issue. Monitor [Release Health](/product/releases/health/) by observing user adoption, usage of the application, percentage of crashes, and session data.
 
-You can view Release Health data either from the Issue Details page by selecting the commit ID listed under **Last Seen** or from the Releases homepage by selecting the **Project Name**.
+You can view Release Health data either from the Issue Details page by selecting the commit ID listed under **Last Seen** or from the Releases homepage.
 
 ## Apply Source Maps
 


### PR DESCRIPTION
To help users find their release health info, added a brief explainer to find Release Health via Issue Details or from the Releases home page.