### PR TITLE
Bundle name change

### DIFF
--- a/src/platforms/react-native/sourcemaps.mdx
+++ b/src/platforms/react-native/sourcemaps.mdx
@@ -13,8 +13,8 @@ react-native bundle \
   --dev false \
   --platform android \
   --entry-file index.android.js \
-  --bundle-output android.main.bundle \
-  --sourcemap-output android.main.bundle.map
+  --bundle-output index.android.bundle \
+  --sourcemap-output index.android.bundle.map
 ```
 
 To then upload you should use this:


### PR DESCRIPTION
Latest react-native cli names the bundles as index.android.bundle when building a release. 
I recently faced with a source map issue about this.
I was following the docs but it was inaccurate.