### PR TITLE
fix: Remove references to auto instrumentation in RN and make clear that it is manual

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -29,10 +29,15 @@ With performance monitoring, Sentry tracks your software performance, measuring 
 
 Once tracing is enabled, certain types of operations are measured automatically in suported SDKs. To learn more, see <PlatformLink to="/performance/capturing/automatic/">Automatic Instrumentation</PlatformLink>.
 
-</PlatformSection>
-
 You can choose to manually measure any operation. To learn more, see <PlatformLink to="/performance/capturing/manual/">Manual Instrumentation</PlatformLink>.
 
+</PlatformSection>
+
+<PlatformSection supported={["react-native"]} notSupported={["javascript"]}>
+
+At this moment, the `@sentry/react-native` SDK does not come with automatic instrumentation. To learn how to measure an operation, see <PlatformLink to="/performance/capturing/manual/">Manual Instrumentation</PlatformLink>.
+
+</PlatformSection>
 
 By monitoring the performance of your application, you can see how latency in one service may affect another service to pinpoint exactly which parts of a given operation may be responsible. To do this, Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
@@ -55,8 +60,18 @@ If either of these options is set, tracing will be enabled in your app. While th
 
 ## Verify
 
+<PlatformSection supported={["react-native"]} notSupported={"javascript"}>
+
+You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/capturing/manual/">Manual Instrumentation</PlatformLink>
+
+</PlatformSection>
+
 When you first enable tracing, verify it is working correctly by setting <PlatformIdentifier name="traces-sample-rate" /> to `1.0` as that ensures that every transaction will be sent to Sentry.
 
 Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to dynamically sample and filter your transactions.
 
+<PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
+
 Without sampling, our automatic instrumentation will send a transaction any time any user loads any page or navigates anywhere in your app. That's a lot of transactions! Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
+
+</PlatformSection>

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -60,7 +60,7 @@ If either of these options is set, tracing will be enabled in your app. While th
 
 ## Verify
 
-<PlatformSection supported={["react-native"]} notSupported={"javascript"}>
+<PlatformSection supported={["react-native"]} notSupported={["javascript"]}>
 
 You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/capturing/manual/">Manual Instrumentation</PlatformLink>
 


### PR DESCRIPTION
Quick fix to make it clear that RN instrumentation is manual only and not automatic yet. This is because the current documentation with references to automatic tracing has confused users such as: https://stackoverflow.com/questions/65750585/sentry-react-native-performance-not-recording-anything