### PR TITLE
feat(apple): Update for better release health data

### DIFF
--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -52,8 +52,7 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 
 ## Known Limitations
 
-- With 5.0.0, we added <PlatformLink to="/configuration/releases/">Release Health</PlatformLink>, which allows you to monitor your releases' health
-by observing user adoption, usage of the application, percentage of crashes, and session data. If you are using this feature, we recommend updating
-to the latest versions of 6.x.x because it contains many improvements to make the stats for Release Health more reliable.
+- We recommend upgrading to 6.x.x to get reliable <PlatformLink to="/configuration/releases/">Release Health</PlatformLink> data,
+as we added many improvements over 5.x.x, in which we introduced Release Health.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
 - Since version 6.0.0, this SDK can't be used on Macs with Apple Silicon when importing it via Carthage because of an [open issue in Carthage](https://github.com/Carthage/Carthage/issues/3019).

--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -52,5 +52,8 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 
 ## Known Limitations
 
+- With 5.x.x, we added <PlatformLink to="/configuration/releases/">Release Health</PlatformLink>, which allows you to monitor your releases' health
+by observing user adoption, usage of the application, percentage of crashes, and session data. If you are using this feature, we recommend updating
+to the latest versions of 6.x.x because it contains many improvements to make the stats for Release Health more reliable.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
 - Since version 6.0.0, this SDK can't be used on Macs with Apple Silicon when importing it via Carthage because of an [open issue in Carthage](https://github.com/Carthage/Carthage/issues/3019).

--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -52,7 +52,7 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 
 ## Known Limitations
 
-- With 5.x.x, we added <PlatformLink to="/configuration/releases/">Release Health</PlatformLink>, which allows you to monitor your releases' health
+- With 5.0.0, we added <PlatformLink to="/configuration/releases/">Release Health</PlatformLink>, which allows you to monitor your releases' health
 by observing user adoption, usage of the application, percentage of crashes, and session data. If you are using this feature, we recommend updating
 to the latest versions of 6.x.x because it contains many improvements to make the stats for Release Health more reliable.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.


### PR DESCRIPTION
Add a point to known limitations to update to 6.x.x for better release
health data for Apple.