### PR TITLE
feat(apple): Add comment about min on-prem version

### DIFF
--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -52,6 +52,6 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 
 ## Known Limitations
 
-- Since version 6.0.0 of this SDK, Sentry on-premise version >= v20.6.0 is required. If you are using sentry.io, no action is needed.
+- Since version 6.0.0 of this SDK, Sentry on-premises version greater than version 20.6.0 is required. If you are using sentry.io, no action is needed.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
 - Since version 6.0.0, this SDK can't be used on Macs with Apple Silicon when importing it via Carthage because of an [open issue in Carthage](https://github.com/Carthage/Carthage/issues/3019).

--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -52,5 +52,6 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 
 ## Known Limitations
 
+- Since version 6.0.0 of this SDK, Sentry on-premise version >= v20.6.0 is required. If you are using sentry.io, no action is needed.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
 - Since version 6.0.0, this SDK can't be used on Macs with Apple Silicon when importing it via Carthage because of an [open issue in Carthage](https://github.com/Carthage/Carthage/issues/3019).


### PR DESCRIPTION
Add a comment about Sentry on-prem minimum version since sentry-cocoa 6.0.0.