### PR TITLE
fix: Remove /product/releases/health/ redirect

### DIFF
--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -3,7 +3,6 @@ title: Health
 sidebar_order: 40
 redirect_from:
   - /workflow/releases/health/
-  - /product/releases/health/
 description: "Monitor the health of releases by observing user adoption, usage of the application, percentage of crashes, and session data."
 ---
 


### PR DESCRIPTION
`/product/releases/health/` is already the generated URL. Adding it to `redirect_from` creates an infinite redirect loop when visiting the page using a direct link.


https://user-images.githubusercontent.com/1523305/105028007-c097f600-5a50-11eb-9050-b91fdf12d69a.mp4
