### PR TITLE
docs(sentry-cli): fix typo on releases page

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -95,7 +95,7 @@ If you receive an "Unable to Fetch Commits" email, take a look at our [Help Cent
 
 When you are working with JavaScript and other platforms, you can upload release artifacts to Sentry which are then considered during processing. The most common release artifact are [source maps](/clients/javascript/sourcemaps/) for which `sentry-cli` has specific support.
 
-To manage release artfacts the `sentry-cli releases files` command can be used which itself provides various sub commands.
+To manage release artifacts the `sentry-cli releases files` command can be used which itself provides various sub commands.
 
 ### Upload Files
 


### PR DESCRIPTION
Fixes a minor typo where "artifacts" is misspelled.