### PR TITLE
docs(sentry-javascript): Use replace instead of replaceAll

### DIFF
--- a/src/includes/performance/beforeNavigate-example/javascript.mdx
+++ b/src/includes/performance/beforeNavigate-example/javascript.mdx
@@ -13,8 +13,8 @@ Sentry.init({
           // route template here. We don't have one right now, so do some basic
           // parameter replacements.
           name: location.pathname
-            .replaceAll(/\/[a-f0-9]{32}/g, "/<hash>")
-            .replaceAll(/\/\d+/g, "/<digits>"),
+            .replace(/\/[a-f0-9]{32}/g, "/<hash>")
+            .replace(/\/\d+/g, "/<digits>"),
         };
       },
     }),

--- a/src/includes/performance/group-transaction-example/javascript.mdx
+++ b/src/includes/performance/group-transaction-example/javascript.mdx
@@ -29,8 +29,8 @@ Sentry.init({
           // route template here. We don't have one right now, so do some basic
           // parameter replacements.
           name: location.pathname
-            .replaceAll(/\/[a-f0-9]{32}/g, "/<hash>")
-            .replaceAll(/\/\d+/g, "/<digits>"),
+            .replace(/\/[a-f0-9]{32}/g, "/<hash>")
+            .replace(/\/\d+/g, "/<digits>"),
         };
       },
     }),


### PR DESCRIPTION
As `replaceAll` generally isn't supported on older browsers. A good alternative is to just use the `replace` function.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll