### PR TITLE
Update errorboundary.mdx

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -83,10 +83,6 @@ The ErrorBoundary component exposes a variety of props that can be passed in for
 
 : A function that gets called on ErrorBoundary `componentWillUnmount()`.
 
-`onUnmount` (Function)
-
-: A function that gets called on ErrorBoundary `componentWillUnmount()`.
-
 `beforeCapture` (Function)
 
 _(New in version 5.20.0)_


### PR DESCRIPTION
`onUnmount` was included twice -- we now only include it once.