### PR TITLE
Add a promo banner

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -9,7 +9,7 @@ const SHOW_BANNER = true;
 const BANNER_TEXT =
   "Upcoming Technical Workshop: 3 Ways to Group Similar Issues";
 const BANNER_LINK_URL =
-  "https://zoom.us/webinar/register/6916061722454/WN_l5OpxMmVR5OPsNq6NUxmeQ";
+  "https://zoom.us/webinar/register/2716112804384/WN_l5OpxMmVR5OPsNq6NUxmeQ";
 const BANNER_LINK_TEXT = "Register here.";
 const OPTIONAL_BANNER_IMAGE = null;
 

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+
+//
+// BANNER CONFIGURATION
+// This is a lazy way of doing things but will work until
+// we put a more robust solution in place.
+//
+const SHOW_BANNER = true;
+const BANNER_TEXT =
+  "Upcoming workshop: How to use Sentry`s Performance Monitoring + Web Vitals.";
+const BANNER_LINK_URL =
+  "https://zoom.us/webinar/register/6916061722454/WN_oBi-VGTeQye5qd2Cri-A6g";
+const BANNER_LINK_TEXT = "Register here.";
+const OPTIONAL_BANNER_IMAGE = null;
+
+//
+// BANNER CODE
+// Don't edit unless you need to change how the banner works.
+//
+
+const LOCALSTORAGE_NAMESPACE = "banner-manifest";
+
+const fastHash = input => {
+  let hash = 0;
+  if (input.length == 0) return hash;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return hash;
+};
+
+const readOrResetLocalStorage = () => {
+  const stored = localStorage.getItem(LOCALSTORAGE_NAMESPACE);
+  if (!stored) return;
+
+  try {
+    return JSON.parse(stored);
+  } catch (e) {
+    localStorage.removeItem(LOCALSTORAGE_NAMESPACE);
+    return;
+  }
+};
+
+const Banner = props => {
+  const [isVisible, setIsVisible] = useState(false);
+  const hash = fastHash(`${BANNER_TEXT}:${BANNER_LINK_URL}`).toString();
+
+  const enablebanner = () => {
+    setIsVisible(true);
+    document.body.classList.add("banner-active");
+  };
+
+  useEffect(() => {
+    const manifest = readOrResetLocalStorage();
+    if (!manifest) {
+      enablebanner();
+      return;
+    }
+
+    if (manifest.indexOf(hash) === -1) enablebanner();
+  });
+
+  return SHOW_BANNER
+    ? isVisible && (
+        <div className="promo-banner">
+          <div className="promo-banner-message">
+            {OPTIONAL_BANNER_IMAGE ? <img src={OPTIONAL_BANNER_IMAGE} /> : ""}
+            <span>
+              {BANNER_TEXT}
+              <a href={BANNER_LINK_URL}>{BANNER_LINK_TEXT}</a>
+            </span>
+          </div>
+          <button
+            className="promo-banner-dismiss"
+            role="button"
+            onClick={() => {
+              const manifest = readOrResetLocalStorage() || [];
+              const payload = JSON.stringify([...manifest, hash]);
+              localStorage.setItem(LOCALSTORAGE_NAMESPACE, payload);
+              setIsVisible(false);
+              document.body.classList.remove("banner-active");
+            }}
+          >
+            ×
+          </button>
+        </div>
+      )
+    : null;
+};
+
+export default Banner;

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 
 //
 // BANNER CONFIGURATION
@@ -8,7 +7,7 @@ import PropTypes from "prop-types";
 //
 const SHOW_BANNER = true;
 const BANNER_TEXT =
-  "Upcoming workshop: How to use Sentry`s Performance Monitoring + Web Vitals.";
+  "Upcoming technical workshop: How to use Sentry`s Performance Monitoring + Web Vitals.";
 const BANNER_LINK_URL =
   "https://zoom.us/webinar/register/6916061722454/WN_oBi-VGTeQye5qd2Cri-A6g";
 const BANNER_LINK_TEXT = "Register here.";
@@ -44,7 +43,7 @@ const readOrResetLocalStorage = () => {
   }
 };
 
-const Banner = props => {
+const Banner = ({ isModule = false }) => {
   const [isVisible, setIsVisible] = useState(false);
   const hash = fastHash(`${BANNER_TEXT}:${BANNER_LINK_URL}`).toString();
 
@@ -65,7 +64,11 @@ const Banner = props => {
 
   return SHOW_BANNER
     ? isVisible && (
-        <div className="promo-banner">
+        <div
+          className={["promo-banner", isModule && "banner-module"]
+            .filter(Boolean)
+            .join(" ")}
+        >
           <div className="promo-banner-message">
             {OPTIONAL_BANNER_IMAGE ? <img src={OPTIONAL_BANNER_IMAGE} /> : ""}
             <span>

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -7,9 +7,9 @@ import React, { useState, useEffect } from "react";
 //
 const SHOW_BANNER = true;
 const BANNER_TEXT =
-  "Upcoming technical workshop: How to use Sentry`s Performance Monitoring + Web Vitals.";
+  "Upcoming Technical Workshop: 3 Ways to Group Similar Issues";
 const BANNER_LINK_URL =
-  "https://zoom.us/webinar/register/6916061722454/WN_oBi-VGTeQye5qd2Cri-A6g";
+  "https://zoom.us/webinar/register/6916061722454/WN_l5OpxMmVR5OPsNq6NUxmeQ";
 const BANNER_LINK_TEXT = "Register here.";
 const OPTIONAL_BANNER_IMAGE = null;
 

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -6,6 +6,7 @@ import Layout from "./layout";
 import SmartLink from "./smartLink";
 import TableOfContents from "./tableOfContents";
 import * as Sentry from "@sentry/gatsby";
+import Banner from "./banner";
 
 type GitHubCTAProps = {
   sourceInstanceName: string;
@@ -109,6 +110,7 @@ export default ({
         {(hasToc || prependToc) && (
           <div className="col-sm-4 col-md-12 col-lg-4 col-xl-3">
             <div className="page-nav">
+              <Banner isModule={true} />
               <React.Fragment>
                 {prependToc}
                 {hasToc && <WrappedTOC ref={contentRef} />}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -4,7 +4,6 @@ import Breadcrumbs from "./breadcrumbs";
 import Header from "./header";
 import Sidebar from "./sidebar";
 import Navbar from "./navbar";
-import Banner from "./banner";
 
 import "~src/css/screen.scss";
 
@@ -39,7 +38,6 @@ export default ({
             </div>
           </div>
         </div>
-        <Banner />
       </div>
 
       <main role="main" className="px-0">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -4,6 +4,7 @@ import Breadcrumbs from "./breadcrumbs";
 import Header from "./header";
 import Sidebar from "./sidebar";
 import Navbar from "./navbar";
+import Banner from "./banner";
 
 import "~src/css/screen.scss";
 
@@ -38,6 +39,7 @@ export default ({
             </div>
           </div>
         </div>
+        <Banner />
       </div>
 
       <main role="main" className="px-0">
@@ -54,6 +56,7 @@ export default ({
             <div className="pb-3">
               <Breadcrumbs />
             </div>
+
             {children}
           </section>
         </div>

--- a/src/css/_includes/banner.scss
+++ b/src/css/_includes/banner.scss
@@ -8,18 +8,18 @@
   z-index: 2;
   color: $desatPurple3;
 
-  @include media-breakpoint-up(sm) {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-  }
-
   a {
     color: inherit
+  }
+
+  &.banner-module {
+    border-radius: 5px;
+    margin-bottom: 1rem;
   }
 }
 
 .promo-banner-message{
-  margin: 0.75rem 4.5rem 0.75rem 2rem;
+  margin: 1rem 3rem 1rem 1rem;
   line-height: 1.5;
   display: inline-flex;
   align-items: center;

--- a/src/css/_includes/banner.scss
+++ b/src/css/_includes/banner.scss
@@ -1,0 +1,65 @@
+.promo-banner{
+  background: $flame6;
+  min-height: 4.5rem;
+  display: flex;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+  color: $desatPurple3;
+
+  @include media-breakpoint-up(sm) {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  a {
+    color: inherit
+  }
+}
+
+.promo-banner-message{
+  margin: 0.75rem 4.5rem 0.75rem 2rem;
+  line-height: 1.5;
+  display: inline-flex;
+  align-items: center;
+  text-align: left;
+
+  > img {
+    max-height: 3rem;
+    margin-right: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  > span a {
+    text-decoration: underline;
+    margin-left: 0.5rem;
+  }
+}
+
+.promo-banner-dismiss {
+  background: $flame4;
+  height: 3rem;
+  width: 3rem;
+  line-height: 3rem;
+  font-size: 2.5rem;
+  border-radius: 3rem;
+  text-align: center;
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: 0;
+  color: $desatPurple3;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  @include media-breakpoint-up(sm) {
+    height: 1.5rem;
+    width: 1.5rem;
+    line-height: 1.5rem;
+    font-size: 1rem;
+    top: 0.75rem;
+  }
+}

--- a/src/css/_includes/index.scss
+++ b/src/css/_includes/index.scss
@@ -16,8 +16,12 @@
 
 .index-container {
   max-width: 1032px;
-  margin: 3rem auto 0;
+  margin: 0 auto;
   padding: 0 1rem;
+
+  &.pad-top {
+   padding-top: 3rem;
+  }
 
   h2 {
     margin: 0 auto 1rem;

--- a/src/css/_includes/index.scss
+++ b/src/css/_includes/index.scss
@@ -16,7 +16,7 @@
 
 .index-container {
   max-width: 1032px;
-  margin: 0 auto;
+  margin: 3rem auto 0;
   padding: 0 1rem;
 
   h2 {
@@ -73,7 +73,7 @@ a.hover-card-link {
   background-image: url("../pages/geo-back.svg");
   background-size: cover;
   background-position: center;
-  margin: -3px 0 3rem;
+  margin: -3px 0 0;
   padding-bottom: 2rem;
 }
 

--- a/src/css/_includes/sidebar.scss
+++ b/src/css/_includes/sidebar.scss
@@ -1,11 +1,11 @@
 .sidebar {
-
   top: 0;
   bottom:0;
   flex-direction: column;
   display: flex;
   width: 100%;
   z-index: 1;
+
   @media only screen and (min-width: 768px) {
     position: fixed;
     width: 18rem;

--- a/src/css/screen.scss
+++ b/src/css/screen.scss
@@ -52,6 +52,7 @@
 @import "_includes/user-content-ui";
 @import "_includes/code-blocks";
 @import "_includes/large-definition-list";
+@import "_includes/banner";
 
 code[class*="language-"], pre[class*="language-"] {
   font-family: 'IBM Plex', SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,8 @@ import NavbarPlatformDropdown from "../components/navbarPlatformDropdown";
 
 import SentryWordmarkSVG from "../logos/sentry-wordmark-dark.svg";
 
+import Banner from "../components/banner";
+
 const HIGHLIGHTED_PLATFORMS = [
   "javascript",
   "node",
@@ -120,6 +122,7 @@ const IndexPage = () => {
             </a>
           </div>
         </div>
+        <Banner />
       </div>
       <div className="index-container">
         <div className="flex-row card-row">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -122,8 +122,8 @@ const IndexPage = () => {
             </a>
           </div>
         </div>
-        <Banner />
       </div>
+      <Banner />
       <div className="index-container">
         <div className="flex-row card-row">
           <a className="hover-card-link" href="/product/">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -124,7 +124,7 @@ const IndexPage = () => {
         </div>
       </div>
       <Banner />
-      <div className="index-container">
+      <div className="index-container pad-top">
         <div className="flex-row card-row">
           <a className="hover-card-link" href="/product/">
             Product Guides


### PR DESCRIPTION
This adds a dismissible banner that allows for promoting things, in this case, an upcoming work shop. 

Right now it looks like this:

<img width="655" alt="Screen Shot 2021-01-21 at 4 09 46 PM" src="https://user-images.githubusercontent.com/72919/105427926-1b714f00-5c03-11eb-8737-3bbc8b2c75b3.png">

I don't love this, but due to the css layout and the way jest is configured, this is about the only way to get something in the app by the deadline. With some refactoring of things, we could do more of a traditional banner, but that will require a surprising amount of effort.