### PR TITLE
fix(ticket rules): Indicate feature availability by plan

### DIFF
--- a/src/docs/product/integrations/azure-devops/index.mdx
+++ b/src/docs/product/integrations/azure-devops/index.mdx
@@ -55,9 +55,8 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 Issue tracking allows you to create Azure DevOps issues from within Sentry, and link Sentry issues to existing Azure DevOps Issues.
 
 <Alert title="Note" level="info">
-  <p>Manual issue management is available for organizations on the Team, Business, and
-  Enterprise plans.</p>
-  <p>Automatic issue management is available for organizations on the Business plans with Performance Monitoring.</p>
+  <p>Management of issues manually is available to Team, Business, and Enterprise plans.</p>
+  <p>Automatic issue management is available to organizations that include transactions in their Business and Enterprise plans.</p>
 </Alert>
 
 Issue management can be configured in two ways - automatically or manually.

--- a/src/docs/product/integrations/azure-devops/index.mdx
+++ b/src/docs/product/integrations/azure-devops/index.mdx
@@ -55,8 +55,9 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 Issue tracking allows you to create Azure DevOps issues from within Sentry, and link Sentry issues to existing Azure DevOps Issues.
 
 <Alert title="Note" level="info">
-  Issue management is available for organizations on the Team, Business, and
-  Enterprise plans.
+  <p>Manual issue management is available for organizations on the Team, Business, and
+  Enterprise plans.</p>
+  <p>Automatic issue management is available for organizations on the Business plans with Performance Monitoring.</p>
 </Alert>
 
 Issue management can be configured in two ways - automatically or manually.

--- a/src/docs/product/integrations/azure-devops/index.mdx
+++ b/src/docs/product/integrations/azure-devops/index.mdx
@@ -55,7 +55,7 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 Issue tracking allows you to create Azure DevOps issues from within Sentry, and link Sentry issues to existing Azure DevOps Issues.
 
 <Alert title="Note" level="info">
-  <p>Management of issues manually is available to Team, Business, and Enterprise plans.</p>
+  <p>Manual issue management is available to organizations on Team, Business, and Enterprise plans.</p>
   <p>Automatic issue management is available to organizations that include transactions in their Business and Enterprise plans.</p>
 </Alert>
 

--- a/src/docs/product/integrations/jira/index.mdx
+++ b/src/docs/product/integrations/jira/index.mdx
@@ -104,7 +104,8 @@ Use Jira to leverage [issue management](#issue-management), [issue syncing](#iss
 Issue tracking allows you to create Jira issues from within Sentry, and link Sentry issues to existing Jira Issues.
 
 <Alert title="Note" level="info">
-Issue management is available for organizations on the Team, Business, and Enterprise plans.
+<p>Manual issue management is available for organizations on the Team, Business, and Enterprise plans.</p>
+<p>Automatic issue management is available for organizations on the Business plans with Performance Monitoring.</p>
 </Alert>
 
 Issue management can be configured in two ways - automatically or manually.

--- a/src/docs/product/integrations/jira/index.mdx
+++ b/src/docs/product/integrations/jira/index.mdx
@@ -104,8 +104,8 @@ Use Jira to leverage [issue management](#issue-management), [issue syncing](#iss
 Issue tracking allows you to create Jira issues from within Sentry, and link Sentry issues to existing Jira Issues.
 
 <Alert title="Note" level="info">
-<p>Manual issue management is available for organizations on the Team, Business, and Enterprise plans.</p>
-<p>Automatic issue management is available for organizations on the Business plans with Performance Monitoring.</p>
+  <p>Management of issues manually is available to Team, Business, and Enterprise plans.</p>
+  <p>Automatic issue management is available to organizations that include transactions in their Business and Enterprise plans.</p>
 </Alert>
 
 Issue management can be configured in two ways - automatically or manually.

--- a/src/docs/product/integrations/jira/index.mdx
+++ b/src/docs/product/integrations/jira/index.mdx
@@ -104,7 +104,7 @@ Use Jira to leverage [issue management](#issue-management), [issue syncing](#iss
 Issue tracking allows you to create Jira issues from within Sentry, and link Sentry issues to existing Jira Issues.
 
 <Alert title="Note" level="info">
-  <p>Management of issues manually is available to Team, Business, and Enterprise plans.</p>
+  <p>Manual issue management is available to organizations on Team, Business, and Enterprise plans.</p>
   <p>Automatic issue management is available to organizations that include transactions in their Business and Enterprise plans.</p>
 </Alert>
 


### PR DESCRIPTION
Automatic issue creation is only available on the new Business plans, so we want to make that very clear in the documentation.

![Screen Shot 2021-01-22 at 3 48 44 PM](https://user-images.githubusercontent.com/29959063/105560663-52aa3380-5cc9-11eb-8993-f0b17f66a248.png)
