### PR TITLE
add missing dotnet options

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -75,7 +75,7 @@ When enabled, stack traces are automatically attached to all messages logged. St
 This option is `on` by default.
 
 </PlatformSection>
-<PlatformSection notSupported={["android", "apple", "java"]}>
+<PlatformSection notSupported={["android", "apple", "java", "dotnet"]}>
 
 This option is `off` by default.
 
@@ -93,7 +93,7 @@ If possible, we recommended turning on this feature to send all such data by def
 
 </ConfigKey>
 
-<ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java", "dart"]}>
+<ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java", "dart", "dotnet"]}>
 
 This option can be used to supply a "server name." When provided, the name of the server is sent along and persisted in the event. For many integrations the server name actually corresponds to the device hostname, even in situations where the machine is not actually a server. Most SDKs
 will attempt to auto-discover this value.
@@ -144,7 +144,7 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 
 </ConfigKey>
 
-<ConfigKey name="max-request-body-size" supported={["php"]}>
+<ConfigKey name="max-request-body-size" supported={["php", "dotnet.aspnet", "dotnet.aspnetcore"]}>
 
 This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
 
@@ -206,19 +206,19 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 </ConfigKey>
 
-<PlatformSection supported={["javascript", "java", "python", "node", "php"]}>
+<PlatformSection supported={["javascript", "java", "python", "node", "php", "dotnet"]}>
 
 ## Transport Options
 
 Transports are used to send events to Sentry. Transports can be customized to some degree to better support highly specific deployments.
 
-<ConfigKey name="transport" supported={["javascript", "php", "python", "java"]}>
+<ConfigKey name="transport" supported={["javascript", "php", "python", "java", "dotnet"]}>
 
 Switches out the transport used to send events. How this works depends on the SDK. It can, for instance, be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
 
 </ConfigKey>
 
-<ConfigKey name="http-proxy" supported={["node", "php", "python", "java"]}>
+<ConfigKey name="http-proxy" supported={["node", "php", "python", "java", "dotnet"]}>
 
 When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https-proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.
 
@@ -230,7 +230,7 @@ Configures a separate proxy for outgoing HTTPS requests. This value might not be
 
 </ConfigKey>
 
-<ConfigKey name="shutdown-timeout" supported={["python", "node", "java"]}>
+<ConfigKey name="shutdown-timeout" supported={["python", "node", "java", "dotnet"]}>
 
 Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 


### PR DESCRIPTION
During the docs migration it seems like dotnet's options went missing