### PR TITLE
document diagnostic logger

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -30,6 +30,20 @@ Turns debug mode on or off. If debug is enabled SDK will attempt to print out us
 
 </ConfigKey>
 
+<ConfigKey name="diagnostic-level" supported={["dotnet", "java", "android", "dart", "flutter"]}>
+
+Simply enabling `debug` mode makes the SDK generate as much diagnostic data as possible.
+Sometimes you want to lower the verbosity of the Sentry SDK diagnostics logs.
+With this setting you can control that.
+
+- `debug`: **default** The most verbose mode.
+- `info`: Informational messages
+- `warning`: Warning that something might not be right
+- `error`: Only SDK internal errors are printed
+- `fatal`: Only critical errors are printed
+
+</ConfigKey>
+
 <ConfigKey name="release">
 
 Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/).

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -32,11 +32,9 @@ Turns debug mode on or off. If debug is enabled SDK will attempt to print out us
 
 <ConfigKey name="diagnostic-level" supported={["dotnet", "java", "android", "dart", "flutter"]}>
 
-Simply enabling `debug` mode makes the SDK generate as much diagnostic data as possible.
-Sometimes you want to lower the verbosity of the Sentry SDK diagnostics logs.
-With this setting you can control that.
+Enabling `debug` mode makes the SDK generate as much diagnostic data as possible. However, if you'd prefer to lower the verbosity of the Sentry SDK diagnostics logs, configure this option to set the appropriate level:
 
-- `debug`: **default** The most verbose mode.
+- `debug`: **default** The most verbose mode
 - `info`: Informational messages
 - `warning`: Warning that something might not be right
 - `error`: Only SDK internal errors are printed


### PR DESCRIPTION
I have Sentry SDK logging enabled in Prod, with `info`. Helps me see what the SDK does in logs.

Dart, .NET and Java have it.