### PR TITLE
feat: Remove autoSession from Wizard

### DIFF
--- a/src/includes/configuration/auto-session-tracking/javascript.mdx
+++ b/src/includes/configuration/auto-session-tracking/javascript.mdx
@@ -1,5 +1,7 @@
+By default, the JavaScript SDKs are sending sessions, to disable this toggle the flag `autoSessionTracking` to `false`:
+
 ```javascript
 Sentry.init({
-  autoSessionTracking: true
+  autoSessionTracking: false // default: true
 });
 ```

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -115,7 +115,7 @@ will be sent. This is a "contains" match to the entire file URL. As a result, if
 
 <ConfigKey name="auto-session-tracking" supported={["javascript"]}>
 
-When set to `true`, the SDK will send session events to Sentry. This is supported in all browser SDKs, emitting one session per pageload to Sentry.
+When set to `true`, the SDK will send session events to Sentry. This is supported in all browser SDKs, emitting one session per pageload and page navigation to Sentry.
 
 </ConfigKey>
 

--- a/src/wizard/javascript/angular.md
+++ b/src/wizard/javascript/angular.md
@@ -29,7 +29,6 @@ import { AppModule } from "./app/app.module";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing({
       tracingOrigins: ["localhost", "https://yourserver.io/api"],

--- a/src/wizard/javascript/angularjs.md
+++ b/src/wizard/javascript/angularjs.md
@@ -27,7 +27,6 @@ import { Angular as AngularIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  autoSessionTracking: true,
   integrations: [
     new AngularIntegration(),
     new Integrations.BrowserTracing({

--- a/src/wizard/javascript/backbone.md
+++ b/src/wizard/javascript/backbone.md
@@ -24,7 +24,6 @@ import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],

--- a/src/wizard/javascript/browser.md
+++ b/src/wizard/javascript/browser.md
@@ -24,7 +24,6 @@ import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],

--- a/src/wizard/javascript/ember.md
+++ b/src/wizard/javascript/ember.md
@@ -37,7 +37,6 @@ Then add the following config to your `config/environment.js`:
 ENV['@sentry/ember'] = {
   sentry: {
     dsn: '___PUBLIC_DSN___',
-    autoSessionTracking: true,
     tracesSampleRate: 1.0,
   }
 };

--- a/src/wizard/javascript/gatsby.md
+++ b/src/wizard/javascript/gatsby.md
@@ -27,7 +27,6 @@ Register the plugin in your Gatsby configuration file (typically `gatsby-config.
       resolve: "@sentry/gatsby",
       options: {
         dsn: "___PUBLIC_DSN___",
-        autoSessionTracking: true,
         sampleRate: 0.7,
       },
     },

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -27,7 +27,6 @@ Sentry.init({
   integrations: [
     new Integrations.BrowserTracing(),
   ],
-
   tracesSampleRate: 1.0,
 });
 ```

--- a/src/wizard/javascript/react.md
+++ b/src/wizard/javascript/react.md
@@ -26,7 +26,6 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],

--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -36,7 +36,6 @@ import { Integrations } from "@sentry/tracing";
 Sentry.init({
   Vue,
   dsn: "___PUBLIC_DSN___",
-  autoSessionTracking: true,
   integrations: [
     new Integrations.BrowserTracing(),
   ],


### PR DESCRIPTION
Since version `6`, we have it enabled by default and therefore we don't need this anymore.