### PR TITLE
Polish Java Performance docs.

### DIFF
--- a/src/includes/java/performance/getting-started/java.mdx
+++ b/src/includes/java/performance/getting-started/java.mdx
@@ -4,6 +4,17 @@ Performance Monitoring is available for the Sentry Java SDK version ≥ 4.0.
 
 Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
+<Note>
+
+Sentry Java SDK for Performance comes with dedicated integrations for **Spring** and **Spring Boot** that drastically simplify using the Performance feature.
+
+If you are using any of these, make sure to follow their corresponding guides.
+
+* <PlatformLink to="/spring-boot/performance/">Spring Boot</PlatformLink>
+* <PlatformLink to="/spring/performance/">Spring</PlatformLink>
+
+</Note>
+
 ## Enabling Tracing
 
 <PlatformContent includePath="performance/enable-tracing" />

--- a/src/includes/performance/enable-tracing/java.mdx
+++ b/src/includes/performance/enable-tracing/java.mdx
@@ -1,4 +1,4 @@
-To get started automatically sending traces you can:
+To enable sending traces you must configure sampling. It can be done in two ways:
 
 - Set a uniform sample rate for all transactions, by setting the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 - Control the sample rate dynamically, based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
@@ -36,6 +36,6 @@ Sentry.init {
 }
 ```
 
-If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
+If either of these options is set, tracing will be enabled in your app, and you can start capturing transactions. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
 
 As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Spring Boot integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.

--- a/src/includes/performance/enable-tracing/java.spring-boot.mdx
+++ b/src/includes/performance/enable-tracing/java.spring-boot.mdx
@@ -19,7 +19,7 @@ sentry.traces-sample-rate=0.3
 
 Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:
 
-```java
+```java {tabTitle:Java}
 import io.sentry.SentryOptions.TracesSamplerCallback;
 import io.sentry.SamplingContext;
 import org.springframework.stereotype.Component;
@@ -28,6 +28,21 @@ import org.springframework.stereotype.Component;
 class CustomTracesSamplerCallback implements TracesSamplerCallback {
     @Override
     public Double sample(SamplingContext samplingContext) {
+        HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request")
+        // return a number between 0 and 1
+    }
+}
+```
+
+```kotlin {tabTitle:Kotlin}
+import io.sentry.SentryOptions.TracesSamplerCallback
+import io.sentry.SamplingContext
+import org.springframework.stereotype.Component
+
+@Component
+class CustomTracesSamplerCallback : TracesSamplerCallback {
+    override fun sample(context: SamplingContext): Double {
+        val request = context.customSamplingContext!!["request"] as HttpServletRequest
         // return a number between 0 and 1
     }
 }

--- a/src/includes/performance/enable-tracing/java.spring.mdx
+++ b/src/includes/performance/enable-tracing/java.spring.mdx
@@ -48,6 +48,7 @@ import org.springframework.stereotype.Component;
 class CustomTracesSamplerCallback implements TracesSamplerCallback {
     @Override
     public Double sample(SamplingContext samplingContext) {
+        HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request")
         // return a number between 0 and 1
     }
 }
@@ -61,6 +62,7 @@ import org.springframework.stereotype.Component
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {
     override fun sample(context: SamplingContext): Double {
+        val request = context.customSamplingContext!!["request"] as HttpServletRequest
         // return a number between 0 and 1
     }
 }

--- a/src/platforms/java/guides/spring-boot/performance/index.mdx
+++ b/src/platforms/java/guides/spring-boot/performance/index.mdx
@@ -14,7 +14,7 @@ Sentry allows you to monitor the performance of your application, showing you ho
 
 <PlatformContent includePath="performance/enable-tracing" />
 
-If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
+If either of these options is set, tracing will be enabled in your app, and transactions around incoming HTTP request handled by Spring MVC will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
 
 As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Spring Boot integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
 

--- a/src/platforms/java/guides/spring/performance/index.mdx
+++ b/src/platforms/java/guides/spring/performance/index.mdx
@@ -14,7 +14,7 @@ Sentry allows you to monitor the performance of your application, showing you ho
 
 <PlatformContent includePath="performance/enable-tracing" />
 
-If either of these options is set, tracing will be enabled in your app, and transactions will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
+If either of these options is set, tracing will be enabled in your app, and transactions around incoming HTTP request handled by Spring MVC will start getting captured automatically. (The two options are meant to be mutually exclusive, but if you do set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.)
 
 As you're getting tracing set up, we recommend setting <PlatformIdentifier name="traces-sample-rate" /> to `1`, so all created transactions are sent to Sentry. Once you're done with testing, though, you'll probably want to consider either **lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to <PlatformIdentifier name="traces-sampler" />**, which will allow you to set the sample rate individually for each transaction. Without sampling, automatically-captured transactions can add up quickly. (The Spring integration, for example, will send a transaction for every request made to the server.) Sampling allows you to send representative data without overwhelming either your system or your Sentry transaction quota.
 


### PR DESCRIPTION
The goal of this PR is to make docs less confusing and easier to follow.

- traces are not captured **automatically** with manual integration
- on the top of Java performance I added links to Spring and Spring Boot guides
- updated sampling function example in Spring & Spring Boot to have already a request taken out from the context.

cc @bruno-garcia 