### PR TITLE
Fix: remove extra "crashed"

### DIFF
--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -93,7 +93,7 @@ plug Sentry.PlugContext
 
 `Sentry.PlugContext` gathers the contextual information for errors, and `Sentry.PlugCapture` captures and sends any errors that occur in the Plug stack. `Sentry.PlugContext` should be below `Plug.Parsers` if you are using it.
 
-To capture crashed crashed process exceptions, add `Sentry.LoggerBackend` to your Logger backends:
+To capture crashed process exceptions, add `Sentry.LoggerBackend` to your Logger backends:
 
 ```
 config :logger,


### PR DESCRIPTION
Just noticed a typo while reading the docs.