### PR TITLE
feat(apple): Enable sendDefaultPii

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -113,7 +113,7 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
-<ConfigKey name="send-default-pii" supported={["dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust"]}>
+<ConfigKey name="send-default-pii" supported={["apple", "dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust"]}>
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 


### PR DESCRIPTION
We added this for Apple recently, see
https://github.com/getsentry/sentry-cocoa/pull/923.

Only merge when sentry-cocoa 6.1.5 is released.