### PR TITLE
chore: Reformat JavaScript code with prettier

### DIFF
--- a/src/wizard/javascript/angularjs.md
+++ b/src/wizard/javascript/angularjs.md
@@ -41,4 +41,3 @@ angular.module("yourApplicationModule", ["ngSentry"]);
 ```
 
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/performance/sampling/).
-

--- a/src/wizard/javascript/backbone.md
+++ b/src/wizard/javascript/backbone.md
@@ -23,10 +23,8 @@ import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
-  integrations: [
-    new Integrations.BrowserTracing(),
-  ],
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0,
 });
 ```
@@ -41,4 +39,4 @@ myUndefinedFunction();
 
 If you're new to Sentry, use the email alert to access your account and complete a product tour.
 
-If you're an existing user and have disabled alerts, you won't receive this email.  
+If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/javascript/browser.md
+++ b/src/wizard/javascript/browser.md
@@ -23,10 +23,8 @@ import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
-  integrations: [
-    new Integrations.BrowserTracing(),
-  ],
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0,
 });
 ```
@@ -41,4 +39,4 @@ myUndefinedFunction();
 
 If you're new to Sentry, use the email alert to access your account and complete a product tour.
 
-If you're an existing user and have disabled alerts, you won't receive this email.  
+If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/javascript/ember.md
+++ b/src/wizard/javascript/ember.md
@@ -15,12 +15,12 @@ ember install @sentry/ember
 You should `init` the Sentry SDK as soon as possible during your application load up in `app.js`, before initializing Ember:
 
 ```javascript
-import Application from '@ember/application';
-import Resolver from 'ember-resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import Application from "@ember/application";
+import Resolver from "ember-resolver";
+import loadInitializers from "ember-load-initializers";
+import config from "./config/environment";
 
-import { InitSentryForEmber } from '@sentry/ember';
+import { InitSentryForEmber } from "@sentry/ember";
 
 InitSentryForEmber();
 
@@ -34,11 +34,11 @@ export default class App extends Application {
 Then add the following config to your `config/environment.js`:
 
 ```javascript
-ENV['@sentry/ember'] = {
+ENV["@sentry/ember"] = {
   sentry: {
-    dsn: '___PUBLIC_DSN___',
+    dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
-  }
+  },
 };
 ```
 

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -23,13 +23,12 @@ import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
-  integrations: [
-    new Integrations.BrowserTracing(),
-  ],
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0,
 });
 ```
+
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/performance/sampling/).
 
 This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
@@ -40,4 +39,4 @@ myUndefinedFunction();
 
 If you're new to Sentry, use the email alert to access your account and complete a product tour.
 
-If you're an existing user and have disabled alerts, you won't receive this email.  
+If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/javascript/react.md
+++ b/src/wizard/javascript/react.md
@@ -26,9 +26,7 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Integrations.BrowserTracing(),
-  ],
+  integrations: [new Integrations.BrowserTracing()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -9,8 +9,8 @@ type: framework
 
 To begin collecting error and performance data from your Vue application, you'll need the following packages:
 
-* `@sentry/vue` (Sentry's Vue SDK)
-* `@sentry/tracing` (instruments performance data)
+- `@sentry/vue` (Sentry's Vue SDK)
+- `@sentry/tracing` (instruments performance data)
 
 Below are instructions for using your favorite package manager, or alternatively loaded directly from our CDN.
 
@@ -36,9 +36,7 @@ import { Integrations } from "@sentry/tracing";
 Sentry.init({
   Vue,
   dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Integrations.BrowserTracing(),
-  ],
+  integrations: [new Integrations.BrowserTracing()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/wizard/node/awslambda.md
+++ b/src/wizard/node/awslambda.md
@@ -23,7 +23,7 @@ You can use the AWS Lambda integration for the Node like this:
 const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
 });
 
@@ -36,7 +36,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(async (event, context) => {
 const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
 });
 

--- a/src/wizard/node/gcpfunctions.md
+++ b/src/wizard/node/gcpfunctions.md
@@ -22,7 +22,7 @@ Sentry.GCPFunction.init({
 });
 
 exports.helloHttp = Sentry.GCPFunction.wrapHttpFunction((req, res) => {
-  throw new Error('oh, hello there!');
+  throw new Error("oh, hello there!");
 });
 ```
 
@@ -34,9 +34,11 @@ Sentry.GCPFunction.init({
   tracesSampleRate: 1.0,
 });
 
-exports.helloEvents = Sentry.GCPFunction.wrapEventFunction((data, context, callback) => {
-  throw new Error('oh, hello there!');
-});
+exports.helloEvents = Sentry.GCPFunction.wrapEventFunction(
+  (data, context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
 ```
 
 ```javascript {tabTitle:cloudEvents}
@@ -47,7 +49,9 @@ Sentry.GCPFunction.init({
   tracesSampleRate: 1.0,
 });
 
-exports.helloEvents = Sentry.GCPFunction.wrapCloudEventFunction((context, callback) => {
-  throw new Error('oh, hello there!');
-});
+exports.helloEvents = Sentry.GCPFunction.wrapCloudEventFunction(
+  (context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
 ```


### PR DESCRIPTION
```
yarn prettier:fix src/wizard/javascript/* src/wizard/node/*
```

Inspired by #2982 to apply standard formatting to other JavaScript snippets.