### PR TITLE
Fix: push anchor headers below fixed top bar

### DIFF
--- a/src/css/_includes/global-header.scss
+++ b/src/css/_includes/global-header.scss
@@ -42,3 +42,31 @@
     }
   }
 }
+
+/*
+
+  Push anchor headers below fixed top bar.
+  Fixes https://github.com/getsentry/sentry-docs/issues/2685.
+
+*/
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  &::before {
+    display: block;
+    content: " ";
+    margin-top: -($headerHeight + $spacer);
+    height: ($headerHeight + $spacer);
+    visibility: hidden;
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
Based on https://css-tricks.com/hash-tag-links-padding/

Fixes https://github.com/getsentry/sentry-docs/issues/2685