### PR TITLE
fix(query-builder): Update count(id) to count()

### DIFF
--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -37,12 +37,12 @@ import standardFields from "./standard-fields.json";
 
 ### Syntax
 
-The Query Builder syntax is identical to [Sentry's Search syntax](/product/sentry-basics/search/). After you enter a key field from above or a custom tag, you can use any of the referenced syntax. For example, `count(id)` gives you the number of times an event occurs. This can be written in the following ways:
+The Query Builder syntax is identical to [Sentry's Search syntax](/product/sentry-basics/search/). After you enter a key field from above or a custom tag, you can use any of the referenced syntax. For example, `count()` gives you the number of times an event occurs. This can be written in the following ways:
 
-- Exact match (is equal to): `count(id):99`
-- Upper bounds (is less than or equal to): `count(id):<99` or `count(id):<=99`
-- Lower bounds (is more than or equal to): `count(id):>99` or `count(id):>=99`
-- Multiple bounds (is more and less than): `count(id):>10 count(id):<20`
+- Exact match (is equal to): `count():99`
+- Upper bounds (is less than or equal to): `count():<99` or `count():<=99`
+- Lower bounds (is more than or equal to): `count():>99` or `count():>=99`
+- Multiple bounds (is more and less than): `count():>10 count():<20`
 
 Use `OR` and `AND` search conditions between filters. However `OR` cannot be used between aggregate and non-aggregate filters. For more details about these conditions, see [Using `OR` and `AND`](/product/sentry-basics/search/#using-or-and-and).
 


### PR DESCRIPTION
- We still support `count(id)` but everywhere in the UI we now say `count()` instead