### PR TITLE
Revert "Fix: push anchor headers below fixed top bar"

### DIFF
--- a/src/css/_includes/global-header.scss
+++ b/src/css/_includes/global-header.scss
@@ -42,31 +42,3 @@
     }
   }
 }
-
-/*
-
-  Push anchor headers below fixed top bar.
-  Fixes https://github.com/getsentry/sentry-docs/issues/2685.
-
-*/
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-  &::before {
-    display: block;
-    content: " ";
-    margin-top: -($headerHeight + $spacer);
-    height: ($headerHeight + $spacer);
-    visibility: hidden;
-    pointer-events: none;
-  }
-}


### PR DESCRIPTION
Reverts getsentry/sentry-docs#2987

The fix introduced a bug misaligning the anchor link and header text. The link needs to be shifted down as well, will look into it another time.