### PR TITLE
fix(tls): Bump TLSv1/1.1 sunset to March.

### DIFF
--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -15,7 +15,7 @@ apply to Self-hosted or Single Tenant.
 
 Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.0 to communicate securely.
 
-By the end of January, 2021, Sentry's API and Dashboard will require a minimum TLS version of 1.2.
+By the end of February, 2021, Sentry's API and Dashboard will require a minimum TLS version of 1.2.
 
 Sentry provides a suite of protocols and ciphers that focus on giving our users a balance of security and compatibility. Our servers will negotiate a cipher to the most secure combination the client can support in the following preferential order:
 


### PR DESCRIPTION
It is what it is. Giving some users more of a sunset period than initially required.