### PR TITLE
Fix: push anchor headers below fixed top bar

### DIFF
--- a/src/css/_includes/global-header.scss
+++ b/src/css/_includes/global-header.scss
@@ -42,3 +42,31 @@
     }
   }
 }
+
+/*
+
+  Push anchor headers below fixed top bar.
+  Fixes https://github.com/getsentry/sentry-docs/issues/2685.
+
+*/
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  &::before {
+    display: block;
+    content: " ";
+    margin-top: -($headerHeight + $spacer);
+    height: ($headerHeight + $spacer);
+    visibility: hidden;
+    pointer-events: none;
+  }
+}

--- a/src/css/_includes/type.scss
+++ b/src/css/_includes/type.scss
@@ -47,7 +47,7 @@
     $icon-width: 12px;
     $icon-margin: 5px;
     display: none;
-    position: absolute;
+    position: relative;
     margin-left: -($icon-width + $icon-margin);
     padding-right: $icon-margin;
     top: 0px;


### PR DESCRIPTION
Based on https://css-tricks.com/hash-tag-links-padding/

Change also anchor link to be positioned relative to the associated
header, so that both anchor and header are pushed down equally, visible
right below the top bar.

See also #2987 & #2990.

Fixes #2685.