### PR TITLE
feat(apple): Note on Carthage for Apple Silicon

### DIFF
--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -56,4 +56,4 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 - We recommend upgrading to 6.x.x to get reliable <PlatformLink to="/configuration/releases/">Release Health</PlatformLink> data,
 as we added many improvements over 5.x.x, in which we introduced Release Health.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
-- For using Sentry via Carthage on Macs with Apple Silicon, please use Carthage >= 0.37.0, which introduced support for XCFramework needed for Apple Silicons. Please read the [release notes of Carthage 0.37.0](https://github.com/Carthage/Carthage/releases/tag/0.37.0) for more details.
+- To use Sentry via Carthage on Macs with Apple Silicon, please use Carthage >= 0.37.0, which introduced support for XCFramework needed for Apple Silicons. Learn more in the [release notes for Carthage 0.37.0](https://github.com/Carthage/Carthage/releases/tag/0.37.0).

--- a/src/platforms/apple/common/usage.mdx
+++ b/src/platforms/apple/common/usage.mdx
@@ -56,4 +56,4 @@ This integration will swizzle some methods to create breadcrumbs e.g.: for `UIAp
 - We recommend upgrading to 6.x.x to get reliable <PlatformLink to="/configuration/releases/">Release Health</PlatformLink> data,
 as we added many improvements over 5.x.x, in which we introduced Release Health.
 - If you're currently using a version between 6.0.2 and 6.0.8, we **highly recommend** you upgrade to the latest version to avoid [a regression](https://github.com/getsentry/sentry-cocoa/pull/786) that affected the quality of the stacktraces and error messages, which was fixed in 6.0.9.
-- Since version 6.0.0, this SDK can't be used on Macs with Apple Silicon when importing it via Carthage because of an [open issue in Carthage](https://github.com/Carthage/Carthage/issues/3019).
+- For using Sentry via Carthage on Macs with Apple Silicon, please use Carthage >= 0.37.0, which introduced support for XCFramework needed for Apple Silicons. Please read the [release notes of Carthage 0.37.0](https://github.com/Carthage/Carthage/releases/tag/0.37.0) for more details.


### PR DESCRIPTION
Add a note to known limitations on how to use Carthage for Apple Silicon. There was an open issue for that. See https://github.com/getsentry/sentry-cocoa/issues/866.