### PR TITLE
feat: Docs for GA React Native Performance

### DIFF
--- a/src/includes/performance/enable-tracing/react-native.mdx
+++ b/src/includes/performance/enable-tracing/react-native.mdx
@@ -1,17 +1,20 @@
 To enable automatic tracing, include the `ReactNativeTracing` integration in your SDK configuration options, if you have not already done so.
 
+<Alert level="Info" title="Minimum Version">
+To use ReactNativeTracing along with our included instrumentation, you will need at least version 2.2.0 of the Sentry React Native SDK.
+</Alert>
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-integrations: [
+  integrations: [
     new Sentry.ReactNativeTracing({
       tracingOrigins: ["localhost", "my-site-url.com", /^\//],
       // ... other options
     }),
   ],
-
 });
 ```

--- a/src/includes/performance/tracingOrigins-example/react-native.mdx
+++ b/src/includes/performance/tracingOrigins-example/react-native.mdx
@@ -1,0 +1,22 @@
+For example:
+
+- A frontend application is served from `example.com`
+- A backend service is served from `api.example.com`
+- The frontend application makes API calls to the backend
+- Therefore, the option needs to be configured like this: `new Sentry.ReactNativeTracing({tracingOrigins: ['api.example.com']})`
+- Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.ReactNativeTracing({
+      tracingOrigins: ["localhost", "my-site-url.com"],
+    }),
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+```

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -50,8 +50,7 @@ Learn more about how the options work in <PlatformLink to="/performance/sampling
 ## Verify
 
 <PlatformSection supported={["react-native"]} notSupported={["javascript"]}>
-
-You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/custom-instrumentation/">Custom Instrumentation</PlatformLink>
+You can now test out tracing by adding our <PlatformLink to="/performance/included-instrumentation/">included instrumentation</PlatformLink> or you can learn how to add <PlatformLink to="/performance/custom-instrumentation/">custom instrumentation</PlatformLink>.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -51,13 +51,13 @@ Learn more about how the options work in <PlatformLink to="/performance/sampling
 ## Verify
 
 <PlatformSection supported={["react-native"]} notSupported={["javascript"]}>
-  
+
 You can now test out tracing by adding our <PlatformLink to="/performance/included-instrumentation/">included instrumentation</PlatformLink> or you can learn how to add <PlatformLink to="/performance/custom-instrumentation/">custom instrumentation</PlatformLink>.
-  
+
 </PlatformSection>
 
-<PlatformSection supported={["dotnet"]} notSupported={["javascript", "react-native]}>
-                                                                      
+<PlatformSection supported={["dotnet"]} notSupported={["javascript", "react-native"]}>
+  
 You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/custom-instrumentation/">Custom Instrumentation</PlatformLink>
 
 </PlatformSection>

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -115,9 +115,10 @@ Sentry.init({
   ],
 })
 
+// Functional Component Example
 const App = () => {
   // Create a ref for the navigation container
-  const navigation = React.createRef<NavigationContainerRef>();
+  const navigation = React.createRef();
 
   // Register the navigation container with the instrumentation
   React.useEffect(() => {
@@ -131,6 +132,26 @@ const App = () => {
     </NavigationContainer>
   );
 };
+
+// Class Component Example
+class App extends React.Component {
+  // Create a ref for the navigation container
+  navigation = React.createRef();
+
+  componentDidMount() {
+    // Register the navigation container with the instrumentation
+    routingInstrumentation.registerNavigationContainer(navigation);
+  }
+
+  render() {
+    return (
+      // Connect the ref to the navigation container
+      <NavigationContainer ref={this.navigation}>
+        ...
+      </NavigationContainer>
+    )
+  }
+}
 ```
 
 ### React Navigation V4
@@ -152,6 +173,7 @@ Sentry.init({
   ],
 })
 
+// Functional Component Example
 const App = () => {
   // Create a ref for the navigation container
   const appContainer = React.createRef();
@@ -166,6 +188,24 @@ const App = () => {
     <AppContainer ref={appContainer} />
   );
 };
+
+// Class Component Example
+class App extends React.Component {
+  // Create a ref for the navigation container
+  appContainer = React.createRef();
+
+  componentDidMount() {
+    // Register the navigation container with the instrumentation
+    routingInstrumentation.registerAppContainer(appContainer);
+  }
+
+  render() {
+    return (
+      // Connect the ref to the navigation container
+      <AppContainer ref={appContainer} />
+    )
+  }
+}
 ```
 
 ### Other Routing Libraries or Custom Routing Implementations

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -5,7 +5,7 @@ description: "Learn what transactions are captured after tracing is enabled."
 ---
 
 <Alert level="Info" title="Minimum Version">
-To use Automatic instrumentation, you will need at least version 2.2.0 of the Sentry React Native SDK.
+To use our included instrumentation, you will need at least version 2.2.0 of the Sentry React Native SDK.
 </Alert>
 
 `@sentry/react-native` provides a `ReactNativeTracing` integration to add instrumentation for monitoring the performance of React Native applications.
@@ -16,11 +16,11 @@ The `ReactNativeTracing` integration creates a child span for every `XMLHttpRequ
 
 ## Configuration Options
 
-You can pass many different options to the `ReactNativeTracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box. For all possible options, see [ReactNativeTracingOptions](https://github.com/getsentry/sentry-react-native/blob/211ec081b6bf8d7d29541afe9d800040f61e3c4e/src/js/tracing/reactnativetracing.ts#L23).
+You can pass many different options to the `ReactNativeTracing` integration (as an object of the form `{optionName: value}`), but it comes with sensible defaults out of the box. For all possible options, see [ReactNativeTracingOptions](https://github.com/getsentry/sentry-react-native/blob/211ec081b6bf8d7d29541afe9d800040f61e3c4e/src/js/tracing/reactnativetracing.ts#L23).
 
 ### beforeNavigate
 
-You can use `beforeNavigate` to modify the transaction from routing instrumentation before the transaction is created. If you chose to not send the transaction, you can set `sampled = false`.
+You can use `beforeNavigate` to modify the transaction from routing instrumentation before the transaction is created. If you prefer not sending the transaction, set `sampled = false`.
 
 ```javascript
 Sentry.init({
@@ -250,7 +250,7 @@ const App = () => {
 
 #### Custom Instrumentation
 
-To create a custom routing instrumentation, you should look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, you should look at the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/reactnavigationv4.ts)
+To create a custom routing instrumentation, look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, review the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/reactnavigationv4.ts)
 
 ```javascript
 class CustomInstrumentation extends RoutingInstrumentation {

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -4,8 +4,8 @@ sidebar_order: 10
 description: "Learn what transactions are captured after tracing is enabled."
 ---
 
-<Alert level="Info" title="Beta Support">
-Automatic instrumentation is currently in beta, available on the Sentry React Native SDK version ≥ 2.2.0-beta.0. As a result, the API may change without warning.
+<Alert level="Info" title="Minimum Version">
+To use Automatic instrumentation, you will need at least version 2.2.0 of the Sentry React Native SDK.
 </Alert>
 
 `@sentry/react-native` provides a `ReactNativeTracing` integration to add instrumentation for monitoring the performance of React Native applications.
@@ -16,7 +16,65 @@ The `ReactNativeTracing` integration creates a child span for every `XMLHttpRequ
 
 ## Configuration Options
 
-You can pass many different options to the `ReactNativeTracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box. For all possible options, see [TypeDocs](https://getsentry.github.io/sentry-javascript/interfaces/tracing.browsertracingoptions.html).
+You can pass many different options to the `ReactNativeTracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box. For all possible options, see [ReactNativeTracingOptions](https://github.com/getsentry/sentry-react-native/blob/211ec081b6bf8d7d29541afe9d800040f61e3c4e/src/js/tracing/reactnativetracing.ts#L23).
+
+### beforeNavigate
+
+You can use `beforeNavigate` to modify the transaction from routing instrumentation before the transaction is created. If you chose to not send the transaction, you can set `sampled = false`.
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.ReactNativeTracing({
+      routingInstrumentation,
+      beforeNavigate: context => {
+        // Decide to not send a transaction by setting sampled = false
+        if (context.data.route.name === "Do Not Send") {
+          context.sampled = false;
+        }
+
+        // Modify the transaction context
+        context.name = context.name.toUpperCase();
+        context.tags = {
+          ...context.tags,
+          customTag: "value",
+        };
+
+        return context;
+      },
+    }),
+  ],
+});
+```
+
+If you use our routing instrumentation for **React Navigation**, the route data is set on the transaction context passed to `beforeNavigate`. This has the type:
+
+```typescript
+type ReactNavigationTransactionContext = {
+  // ...
+  data: {
+    route: {
+      name: string;
+      key: string;
+      params: {
+        [key: string]: any;
+      };
+      /** Will be true if this is not the first time this screen with this key has been seen before. */
+      hasBeenSeen: boolean;
+    };
+    previousRoute: {
+      name: string;
+      key: string;
+      params: {
+        [key: string]: any;
+      };
+    } | null;
+  };
+};
+```
+
+If you use **Typescript**, you can type your `beforeNavigate` function with `Sentry.ReactNavigationTransactionContext`.
 
 ### tracingOrigins
 

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -98,7 +98,7 @@ We currently provide two routing instrumentations out of the box to instrument r
 
 Note that this routing instrumentation will create a transaction on every route change including `goBack` navigations.
 
-```js
+```javascript
 import * as Sentry from "@sentry/react-native";
 
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
@@ -158,7 +158,7 @@ class App extends React.Component {
 
 Note that this routing instrumentation will create a transaction on every route change including `goBack` navigations.
 
-```js
+```javascript
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
 const routingInstrumentation = new Sentry.ReactNavigationV4Instrumentation();
 
@@ -220,7 +220,7 @@ You need to ensure that this method is called **before** the route change occurs
 
 #### Bare Bones
 
-```js
+```javascript
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
 const routingInstrumentation = new Sentry.RoutingInstrumentation();
 
@@ -252,7 +252,7 @@ const App = () => {
 
 To create a custom routing instrumentation, you should look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, you should look at the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/reactnavigationv4.ts)
 
-```js
+```javascript
 class CustomInstrumentation extends RoutingInstrumentation {
   constructor(navigator) {
     super();
@@ -280,7 +280,7 @@ We export the React Profiler from our React Native SDK as well, you can read mor
 
 After you instrument your app's routing, if you wrap a component that renders on one of the routes with `withProfiler`, you will be able to track the component's lifecycle as a child span of the route transaction.
 
-```js
+```javascript
 import * as Sentry from "@sentry/react-native";
 
 const SomeComponent = () => {

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -250,6 +250,8 @@ const App = () => {
 
 #### Custom Instrumentation
 
+To create a custom routing instrumentation, you should look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, you should look at the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/reactnavigationv4.ts)
+
 ```js
 class CustomInstrumentation extends RoutingInstrumentation {
   constructor(navigator) {

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -246,7 +246,7 @@ const App = () => {
 
 #### Custom Instrumentation
 
-To create a custom routing instrumentation, look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, review the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/master/src/js/tracing/reactnavigationv4.ts)
+To create a custom routing instrumentation, look at how the `RoutingInstrumentation` class [is implemented](https://github.com/getsentry/sentry-react-native/blob/211ec081b6bf8d7d29541afe9d800040f61e3c4e/src/js/tracing/routingInstrumentation.ts). If you need an example of how to implement routing instrumentation, review the code of the existing official instrumentation such as [the one for React Navigation V4](https://github.com/getsentry/sentry-react-native/blob/211ec081b6bf8d7d29541afe9d800040f61e3c4e/src/js/tracing/reactnavigationv4.ts)
 
 ```javascript
 class CustomInstrumentation extends RoutingInstrumentation {

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -4,10 +4,6 @@ sidebar_order: 10
 description: "Learn what transactions are captured after tracing is enabled."
 ---
 
-<Alert level="Info" title="Minimum Version">
-To use our included instrumentation, you will need at least version 2.2.0 of the Sentry React Native SDK.
-</Alert>
-
 `@sentry/react-native` provides a `ReactNativeTracing` integration to add instrumentation for monitoring the performance of React Native applications.
 
 ## What Instrumentation Provides


### PR DESCRIPTION
This PR includes:

- Documentation on the new `beforeNavigate` option and the typing if they use the React Navigation instrumentation.
- Note that at least 2.2.0 is required for auto performance.
- Fixes the `tracesOrigins` example not being RN-specific.
- Expands a little on custom routing instrumentation.

closes #2995 