### PR TITLE
Remove redundant option onUnmount

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -87,10 +87,6 @@ The ErrorBoundary component exposes a variety of props that can be passed in for
 
 : A function that gets called on ErrorBoundary `componentWillUnmount()`.
 
-`onUnmount` (Function)
-
-: A function that gets called on ErrorBoundary `componentWillUnmount()`.
-
 `beforeCapture` (Function)
 
 _(New in version 5.20.0)_


### PR DESCRIPTION
Remove the same option mentioned twice in order to avoid any confusion.