### PR TITLE
Adding organisation slug to relay state URL

### DIFF
--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -28,7 +28,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    - Sign on URL: `https://sentry.io/auth/login/YOUR-ORG-SLUG/`
 
-   - Relay State: `https://sentry.io/`
+   - Relay State: `https://sentry.io/YOUR-ORG-SLUG/`
 
    - Logout URL: `https://sentry.io/saml/sls/YOUR-ORG-SLUG/`
 


### PR DESCRIPTION
Correcting the relay state URL. The screenshot still needs to be updated, unfortunately, I do not have access to an Azure account to get an updated one. 