### PR TITLE
fix: Remove sentryclirc and sentry-cli mention from Node options docs

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -14,7 +14,7 @@ initialized.
 
 ## Common Options
 
-The list of common options across SDKs. These work more or less the same in all SDKs, but some subtle differences will exist to better support the platform. Options that can be read from an environment variable or your `~/.sentryclirc` file (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`) are read automatically. See [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects) for more information.
+The list of common options across SDKs. These work more or less the same in all SDKs, but some subtle differences will exist to better support the platform. Options that can be read from an environment variable (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`) are read automatically.
 
 <ConfigKey name="dsn">
 


### PR DESCRIPTION
`.sentryclirc` was never a thing in `@sentry/node` nor any other SDK. It works only in `sentry-cli`.
Mentioning sentry-cli here is also kinda redundant.