### PR TITLE
Remove 'using Sentry.Protocol' from .NET docs

### DIFF
--- a/src/includes/attachment-init-with-bytes/dotnet.mdx
+++ b/src/includes/attachment-init-with-bytes/dotnet.mdx
@@ -1,6 +1,5 @@
 ```csharp
 using Sentry;
-using Sentry.Protocol;
 
 SentrySdk.ConfigureScope(scope =>
 {

--- a/src/includes/attachment-init-with-path/dotnet.mdx
+++ b/src/includes/attachment-init-with-path/dotnet.mdx
@@ -1,6 +1,5 @@
 ```csharp
 using Sentry;
-using Sentry.Protocol;
 
 SentrySdk.ConfigureScope(scope =>
 {

--- a/src/includes/attachment-upload/dotnet.mdx
+++ b/src/includes/attachment-upload/dotnet.mdx
@@ -1,6 +1,5 @@
 ```csharp
 using Sentry;
-using Sentry.Protocol;
 
 // Global Scope
 SentrySdk.ConfigureScope(scope =>

--- a/src/includes/performance/custom-sampling-context/dotnet.mdx
+++ b/src/includes/performance/custom-sampling-context/dotnet.mdx
@@ -1,6 +1,5 @@
 ```csharp
 using Sentry;
-using Sentry.Protocol;
 
 // The following data will take part in the sampling decision
 var samplingContext = new Dictionary<string, object?>

--- a/src/includes/with-scope/dotnet.mdx
+++ b/src/includes/with-scope/dotnet.mdx
@@ -1,6 +1,5 @@
 ```csharp
 using Sentry;
-using Sentry.Protocol;
 
 SentrySdk.WithScope(scope =>
 {

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -27,7 +27,7 @@ If you're adding tracing, enable and configure it as documented here. If you’r
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/performance/distributed-tracing/).
 
-<PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native", "dotnet"]} notSupported={["java", "go", "android", "ruby", "python"]}>
+<PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python"]}>
 
 ## Enable Tracing
 
@@ -57,7 +57,7 @@ You can now test out tracing by adding our <PlatformLink to="/performance/includ
 </PlatformSection>
 
 <PlatformSection supported={["dotnet"]} notSupported={["javascript", "react-native"]}>
-  
+
 You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/custom-instrumentation/">Custom Instrumentation</PlatformLink>
 
 </PlatformSection>

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -27,7 +27,7 @@ If you're adding tracing, enable and configure it as documented here. If you’r
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/performance/distributed-tracing/).
 
-<PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python"]}>
+<PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
 
 ## Enable Tracing
 


### PR DESCRIPTION
These are no longer needed in latest version.