### PR TITLE
fix: Make checksum check optional

### DIFF
--- a/src/gatsby/sourceNodes/packageRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/packageRegistryNodes.ts
@@ -20,7 +20,8 @@ export const sourcePackageRegistryNodes = async ({
       repoUrl: sdkData.repo_url,
       files: sdkData.files
         ? Object.entries(sdkData.files).map(
-            ([fileName, fileData]: [string, any]) => ({
+          ([fileName, fileData]: [string, any]) => (
+            fileData.checksums ? {
               name: fileName,
               checksums: Object.entries(fileData.checksums).map(
                 ([key, value]) => ({
@@ -28,7 +29,7 @@ export const sourcePackageRegistryNodes = async ({
                   value: value,
                 })
               ),
-            })
+            } : {} )
           )
         : [],
     };


### PR DESCRIPTION
This fixes `master`

There is a bug in the registry / craft
![image](https://user-images.githubusercontent.com/363802/106882702-597c7180-66df-11eb-822e-30c518b01e41.png)
that now added empty files entries without a checksum.

This makes the checksum check optional.
