### PR TITLE
Use safe navigation operator in ruby example config

### DIFF
--- a/src/includes/configuration/before-send/ruby.mdx
+++ b/src/includes/configuration/before-send/ruby.mdx
@@ -4,7 +4,12 @@ Sentry.init do |config|
   config.before_send = lambda do |event, hint|
     # note1: if you have config.async configured, the event here will be a Hash instead of an Event object
     # note2: the code below is just an example, you should adjust the logic based on your needs
-    event&.request&.data = filter.filter(event.request.data)
+    request = event.request
+
+    if request
+      request.data = filter.filter(request.data)
+    end
+
     event
   end
 end

--- a/src/includes/configuration/before-send/ruby.mdx
+++ b/src/includes/configuration/before-send/ruby.mdx
@@ -4,7 +4,7 @@ Sentry.init do |config|
   config.before_send = lambda do |event, hint|
     # note1: if you have config.async configured, the event here will be a Hash instead of an Event object
     # note2: the code below is just an example, you should adjust the logic based on your needs
-    event.request.data = filter.filter(event.request.data)
+    event&.request&.data = filter.filter(event.request.data)
     event
   end
 end


### PR DESCRIPTION
NOTE: if you don't do this, it will bomb when trying to filter sensitive data in contexts where this is not set (e.g. cron scripts running in your app env, active job processing)