### PR TITLE
Fix a typo in .NET docs

### DIFF
--- a/src/includes/performance/traces-sampler-as-sampler/dotnet.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/dotnet.mdx
@@ -13,7 +13,7 @@ SentrySdk.Init(options =>
     {
         var ctx = context.CustomSamplingContext;
 
-        return ctx["url"] switch
+        return ctx.GetValueOrDefault("url") switch
         {
             // These are important - take a big sample
             "/payment" => 0.5,

--- a/src/includes/performance/traces-sampler-as-sampler/dotnet.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/dotnet.mdx
@@ -13,7 +13,7 @@ SentrySdk.Init(options =>
     {
         var ctx = context.CustomSamplingContext;
 
-        return ctx switch
+        return ctx["url"] switch
         {
             // These are important - take a big sample
             "/payment" => 0.5,


### PR DESCRIPTION
Related: https://github.com/getsentry/sentry-dotnet/issues/799