### PR TITLE
Fix @sentry/cli version inconsistency in hermes.mdx

### DIFF
--- a/src/platforms/react-native/hermes.mdx
+++ b/src/platforms/react-native/hermes.mdx
@@ -6,7 +6,7 @@ Sentry added support for `react-native` builds that use the `hermes` engine, whi
 
 Sentry customers using the SaaS product (sentry.io) will need to update the SDK, and `sentry-cli`.
 The minimum required version for the SDK is `@sentry/react-native` [SDK version `1.3.3`](https://github.com/getsentry/sentry-react-native/releases/tag/1.3.3),
-and `@sentry/cli` [version `1.5.1`](https://github.com/getsentry/sentry-cli/releases/tag/1.51.1).
+and `@sentry/cli` [version `1.51.1`](https://github.com/getsentry/sentry-cli/releases/tag/1.51.1).
 
 For Sentry open source, self-hosted users, the minimum version required is [f07352b](https://hub.docker.com/r/getsentry/sentry/tags?page=1&name=f07352b).
 


### PR DESCRIPTION
Fix inconsistency between incorrect link text version (1.5.1) and link target version (1.51.1)