### PR TITLE
Make Java docs less confusing and easier to follow.

### DIFF
--- a/src/includes/performance/configure-sample-rate/java.spring-boot.mdx
+++ b/src/includes/performance/configure-sample-rate/java.spring-boot.mdx
@@ -17,8 +17,14 @@ import org.springframework.stereotype.Component;
 class CustomTracesSamplerCallback implements TracesSamplerCallback {
   @Override
   public Double sample(SamplingContext samplingContext) {
-    HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request")
-    // return a number between 0 and 1
+    CustomSamplingContext customSamplingContext = context.getCustomSamplingContext();
+    if (customSamplingContext != null) {
+      HttpServletRequest request = (HttpServletRequest) customSamplingContext.get("request");
+      // return a number between 0 and 1
+    } else {
+      // return a number between 0 and 1
+    }
+
   }
 }
 ```

--- a/src/includes/performance/configure-sample-rate/java.spring-boot.mdx
+++ b/src/includes/performance/configure-sample-rate/java.spring-boot.mdx
@@ -8,7 +8,7 @@ sentry.traces-sample-rate=0.3
 
 Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:
 
-```java {tabTitle:Java}
+```java
 import io.sentry.SentryOptions.TracesSamplerCallback;
 import io.sentry.SamplingContext;
 import org.springframework.stereotype.Component;
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 class CustomTracesSamplerCallback implements TracesSamplerCallback {
   @Override
   public Double sample(SamplingContext samplingContext) {
+    HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request")
     // return a number between 0 and 1
   }
 }
@@ -30,7 +31,13 @@ import org.springframework.stereotype.Component
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {
   override fun sample(samplingContext: SamplingContext): Double? {
-    // return a number between 0 and 1
+    val customSamplingContext = samplingContext.customSamplingContext
+    if (customSamplingContext != null) {
+      val request = customSamplingContext["request"] as HttpServletRequest
+      // return a number between 0 and 1
+    } else {
+      // return a number between 0 and 1
+    }
   }
 }
 ```

--- a/src/includes/performance/configure-sample-rate/java.spring.mdx
+++ b/src/includes/performance/configure-sample-rate/java.spring.mdx
@@ -8,7 +8,7 @@ traces-sample-rate=0.3
 
 Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:
 
-```java {tabTitle:Java}
+```java
 import io.sentry.SentryOptions.TracesSamplerCallback;
 import io.sentry.SamplingContext;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ class CustomTracesSamplerCallback implements TracesSamplerCallback {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```kotlin
 import io.sentry.SentryOptions.TracesSamplerCallback
 import io.sentry.SamplingContext
 import org.springframework.stereotype.Component
@@ -30,7 +30,13 @@ import org.springframework.stereotype.Component
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {
   override fun sample(context: SamplingContext): Double? {
-    // return a number between 0 and 1
+    val customSamplingContext = samplingContext.customSamplingContext
+    if (customSamplingContext != null) {
+      val request = customSamplingContext["request"] as HttpServletRequest
+      // return a number between 0 and 1
+    } else {
+      // return a number between 0 and 1
+    }
   }
 }
 ```

--- a/src/includes/performance/connect-errors-spans/java.mdx
+++ b/src/includes/performance/connect-errors-spans/java.mdx
@@ -2,6 +2,16 @@
 
 Sentry errors can be linked with transactions and spans.
 
+<PlatformSection supported={["java"]} notSupported={["android", "java.spring", "java.spring-boot"]}>
+
+<Note>
+
+If you are using either our [Spring](/platforms/java/guides/spring/) or [Spring Boot](/platforms/java/guides/spring-boot/) integrations, errors are linked with spans automatically.
+
+</Note>
+
+</PlatformSection>
+
 Errors reported to Sentry while transaction or span is running are linked automatically:
 
 ```java {tabTitle:Java}

--- a/src/includes/performance/connect-errors-spans/java.mdx
+++ b/src/includes/performance/connect-errors-spans/java.mdx
@@ -6,7 +6,7 @@ Sentry errors can be linked with transactions and spans.
 
 <Note>
 
-If you are using either our [Spring](/platforms/java/guides/spring/) or [Spring Boot](/platforms/java/guides/spring-boot/) integrations, errors are linked with spans automatically.
+We have dedicated performance features for our [Spring](/platforms/java/guides/spring/) and [Spring Boot](/platforms/java/guides/spring-boot/) integrations. In addition, errors are linked with spans automatically using either of these integrations.
 
 </Note>
 

--- a/src/includes/performance/traces-sampler-as-sampler/java.spring.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/java.spring.mdx
@@ -27,7 +27,7 @@ class CustomTracesSamplerCallback implements TracesSamplerCallback {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```kotlin
 import io.sentry.SamplingContext
 import io.sentry.SentryOptions.TracesSamplerCallback
 import org.springframework.stereotype.Component
@@ -36,24 +36,29 @@ import javax.servlet.http.HttpServletRequest
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {
   override fun sample(context: SamplingContext): Double {
-    val request = context.customSamplingContext!!["request"] as HttpServletRequest
-    return when (request.requestURI) {
-      "/payment" -> {
-        // These are important - take a big sample
-        0.5
+    val customSamplingContext = samplingContext.customSamplingContext
+    if (customSamplingContext != null) {
+      val request = customSamplingContext["request"] as HttpServletRequest
+      return when (request.requestURI) {
+        "/payment" -> {
+          // These are important - take a big sample
+          0.5
+        }
+        "/search" -> {
+          // Search is less important and happen much more frequently - only take 1%
+          0.01
+        }
+        "/health" -> {
+          // The health check endpoint is just noise - drop all transactions
+          0.0
+        }
+        else -> {
+          // Default sample rate
+          0.1
+        }
       }
-      "/search" -> {
-        // Search is less important and happen much more frequently - only take 1%
-        0.01
-      }
-      "/health" -> {
-        // The health check endpoint is just noise - drop all transactions
-        0.0
-      }
-      else -> {
-        // Default sample rate
-        0.1
-      }
+    } else {
+      return 0.1
     }
   }
 }

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -27,16 +27,6 @@ If you're adding tracing, enable and configure it as documented here. If you’r
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/performance/distributed-tracing/).
 
-<PlatformSection supported={["java"]} notSupported={["android", "java.spring", "java.spring-boot"]}>
-
-<Note>
-
-Sentry Java SDK for Performance comes with dedicated integrations for [Spring](/platforms/java/guides/spring/) or [Spring Boot](/platforms/java/guides/spring-boot/) that drastically simplify using the Performance feature.
-
-</Note>
-
-</PlatformSection>
-
 <PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
 
 ## Enable Tracing

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -27,6 +27,16 @@ If you're adding tracing, enable and configure it as documented here. If you’r
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/performance/distributed-tracing/).
 
+<PlatformSection supported={["java"]} notSupported={["android", "java.spring", "java.spring-boot"]}>
+
+<Note>
+
+Sentry Java SDK for Performance comes with dedicated integrations for [Spring](/platforms/java/guides/spring/) or [Spring Boot](/platforms/java/guides/spring-boot/) that drastically simplify using the Performance feature.
+
+</Note>
+
+</PlatformSection>
+
 <PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
 
 ## Enable Tracing


### PR DESCRIPTION
- on the top of Java performance added links to Spring and Spring Boot guides
- updated sampling function example in Spring & Spring Boot to have already a request taken out from the context.

Replaces https://github.com/getsentry/sentry-docs/pull/2974 as it was easier to start from scratch than resolve conflicts.