### PR TITLE
Performance SDK: Add .NET

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -17,6 +17,9 @@ Customers on legacy plans must add transaction events to their subscription in o
 
 ## Supported SDKs
 
+- [.NET](/platforms/dotnet/performance)
+  - [ASP.NET Core](/platforms/dotnet/guides/aspnetcore/performance)
+
 - [Go](/platforms/go/performance/)
   - [Echo](/platforms/go/guides/echo/performance/)
   - [FastHTTP](/platforms/go/guides/fasthttp/performance/)


### PR DESCRIPTION
Missing .NET on the list

@Tyrrrz we're missing the ASP.NET "included instrumentation" docs. There's no reference to `UseSentryTracing` yet.

Example for Spring Boot: https://docs.sentry.io/platforms/java/guides/spring-boot/performance/included-instrumentation/