### PR TITLE
Remove link to Flutter guide

### DIFF
--- a/src/platforms/flutter/index.mdx
+++ b/src/platforms/flutter/index.mdx
@@ -16,11 +16,6 @@ Capture a test exception:
 
 <PlatformContent includePath="getting-started-verify" />
 
-### Resources
-
-The Flutter website has extensive documentation, including a
-[cookbook on integrating with a Sentry version earlier than 4.0.0](https://flutter.dev/docs/cookbook/maintenance/error-reporting).
-
 ### Source code
 
 The Sentry Dart/Flutter SDK can be found on GitHub [`sentry-dart`](https://github.com/getsentry/sentry-dart/).


### PR DESCRIPTION
We're updating the guide to reflect the latest version so it no longer adds value linking there.