### PR TITLE
Add `assigned_or_suggested` syntax to Search Documentation

### DIFF
--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -112,9 +112,15 @@ Below is a list of Issue-level tokens reserved and known to Sentry:
 
 `assigned`
 
-: Filter on the user which the issue is assigned to.
+: Filter on the user or team which the issue is assigned to.
 
-  Values can be your user ID (your email address), `me` for yourself, or `#team-name`.
+  Values can be your user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee, or `#team-name`.
+
+`assigned_or_suggested`
+
+: Filter on the user or team which the issue is assigned or suggested to be assigned to. Suggested assignees are based off matching ownership rules and suspect commits.
+
+  Values can be your user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee/suggestions, or `#team-name`.
 
 `bookmarks`
 

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -72,7 +72,7 @@ In the example above, the search query will match on `browser` values like `"Saf
 
 #### Tag Syntax
 
-Search supports an implicit and explicit tag search. We can automatically recognize most tags implicitly, but if you wish to use an explicit tag syntax, you can wrap the tag in `tags[]` such as: 
+Search supports an implicit and explicit tag search. We can automatically recognize most tags implicitly, but if you wish to use an explicit tag syntax, you can wrap the tag using our `tags[]` syntax like so: 
 
 ```
 tags[tag_name]:tag_value

--- a/src/collections/_documentation/workflow/search.md
+++ b/src/collections/_documentation/workflow/search.md
@@ -72,12 +72,13 @@ In the example above, the search query will match on `browser` values like `"Saf
 
 #### Tag Syntax
 
-Search supports an implicit and explicit tag search. If you wish to use a reserved keyword as a tag (such as `product_id`), you will need to wrap the search parameter in `tags[]` such as: 
+Search supports an implicit and explicit tag search. We can automatically recognize most tags implicitly, but if you wish to use an explicit tag syntax, you can wrap the tag in `tags[]` such as: 
+
 ```
-tags[product_id]:123
+tags[tag_name]:tag_value
 ```
 
-This is optional, and only really required to be explicit and use special keywords as tags. If you run into issues with your search using custom tags, it may be a good idea to try explicitly wrapping them.
+Wrapping your tags is optional, and is usually only needed if you wish to use reserved keywords as tags (such as `project_id`). However, if you run into issues with your search while using custom tags, it could be a good idea to try explicitly wrapping them.
 
 ## Search Properties
 


### PR DESCRIPTION
Adding an `assigned_or_suggested` section as well as `me_or_none` to the assigned section.

In the future, we may want to elaborate on suggested assignees in another section and link to it from here.