### PR TITLE
Add `assigned_or_suggested` syntax to Search docs

### DIFF
--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -139,7 +139,13 @@ Supported suffixes:
 
 : Filter on the user which the issue is assigned to.
 
-Values can be your user ID (your email address), `me` for yourself, or `#team-name`.
+Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee, or `#team-name`.
+
+`assigned_or_suggested`
+
+: Filter on the user or team which the issue is assigned or suggested to be assigned to. Suggested assignees are based off matching ownership rules and suspect commits.
+
+Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee/suggestions, or `#team-name`.
 
 `bookmarks`
 

--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -143,7 +143,7 @@ Values can be a user ID (your email address), `me` for yourself, `me_or_none` fo
 
 `assigned_or_suggested`
 
-: Filter on the user or team which the issue is assigned or suggested to be assigned to. Suggested assignees are based off matching ownership rules and suspect commits.
+: Filter on the user or team to which the issue is assigned or suggested to be assigned. Suggested assignees are determined by matching [ownership rules](/product/error-monitoring/issue-owners/) and [suspect commits](/product/releases/suspect-commits/).
 
 Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee/suggestions, or `#team-name`.
 


### PR DESCRIPTION
Adding an assigned_or_suggested section as well as me_or_none to the assigned section.

In the future, we may want to elaborate on suggested assignees in another section and link to it from here.