### PR TITLE
Note about Unity UPM installation gotcha

### DIFF
--- a/src/wizard/unity/index.md
+++ b/src/wizard/unity/index.md
@@ -9,7 +9,7 @@ type: framework
 
 Get the SDK via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
 
-> Make sure not empty space is appended to the end of the URL, otherwise Unity fails to find the package.
+> Confirm there's no empty space at the end of the line. The Unity Package Manager will fail to find the package if an empty space is appended to the end of the URL.
 
 ```
 https://github.com/getsentry/sentry-unity-lite.git#1.0.2

--- a/src/wizard/unity/index.md
+++ b/src/wizard/unity/index.md
@@ -9,6 +9,8 @@ type: framework
 
 Get the SDK via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
 
+> Make sure not empty space is appended to the end of the URL, otherwise Unity fails to find the package.
+
 ```
 https://github.com/getsentry/sentry-unity-lite.git#1.0.2
 ```


### PR DESCRIPTION
In the Unity wizard, I click 3 times to get the line selected (note **no spaces at the end**):

![image](https://user-images.githubusercontent.com/1633368/107459506-568ce100-6b24-11eb-8035-8ab3a1da1a0e.png)

Paste it in Unity:

![image](https://user-images.githubusercontent.com/1633368/107459538-6c9aa180-6b24-11eb-82da-7c3fba8af049.png)

I just get an error on the console:

![image](https://user-images.githubusercontent.com/1633368/107459406-21808e80-6b24-11eb-8184-d0c05fc66c9f.png)

Basically no indication of what went wrong.

In reality, there's a space at the end of the line, and Unity can't handle it (nor it says that's what's wrong in the error message):

![image](https://user-images.githubusercontent.com/1633368/107459593-863be900-6b24-11eb-83ae-eb3fe87ea1f7.png)

Hit backspace and:

![image](https://user-images.githubusercontent.com/1633368/107459603-8d62f700-6b24-11eb-8b1a-370b40435423.png)

Adding now works as expected.