### PR TITLE
error-tracing: use the defined log_format

### DIFF
--- a/src/docs/product/sentry-basics/guides/error-tracing/index.mdx
+++ b/src/docs/product/sentry-basics/guides/error-tracing/index.mdx
@@ -96,7 +96,7 @@ log_format access_json escape=json
     '"upstream_response_time":"$upstream_response_time"'
     '}';
 
-access_log /var/log/nginx/access.log access_log;
+access_log /var/log/nginx/access_log.json access_json;
 ```
 
 Now that your access logs are spitting out your request ID, you can set an `X-Request-Id` header on all requests to pass it along to your application:


### PR DESCRIPTION
access_json was defined but not actually used.