### PR TITLE
fix(copy): updated path to match new copy in the app

### DIFF
--- a/src/docs/product/alerts-notifications/issue-alerts.mdx
+++ b/src/docs/product/alerts-notifications/issue-alerts.mdx
@@ -6,7 +6,7 @@ description: "Learn how to configure and manage Issue Alerts."
 
 Issue alerts apply only to error events, and trigger whenever any issue in the project matches the specified criteria, such as a resolved issue re-appearing or an issue affecting many users.
 
-The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change this to admin in **Settings > General Settings > Grant Members Alerts Write**.
+The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change this to admin in **Settings > General Settings > Let Members Create and Edit Alerts**.
 
 ## Conditions
 
@@ -31,7 +31,7 @@ Triggers specify what type of activity you'd like monitored. The following trigg
 <Note>
 
 If no trigger is selected, the alert will be triggered by every event, subject to rate limits.
-  
+
 </Note>
 
 ### Filters
@@ -47,6 +47,7 @@ Filters help control noise by filtering down the triggered alerts to only those 
 - The event's level is {**match**} {**level**}. **Match**: equal to, less than or equal to, or greater than or equal to. **Level**: fatal, error, warning, info, debug, or sample.
 
 ### Actions
+
 Actions specify what should happen when the alert is triggered and passes the filters. The following actions are available:
 
 - Send an email to either [Issue Owners](/product/error-monitoring/issue-owners/), Team, or [Member](/product/accounts/membership/#member).
@@ -60,9 +61,7 @@ Actions specify what should happen when the alert is triggered and passes the fi
 
   If no legacy integrations or integrations built using the integration platform are enabled, this option is hidden.
 
-- Issue creation for an [integration](/product/integrations/), which includes:
-	- [Jira](/product/integrations/jira/)
-	- [Azure DevOps](/product/integrations/azure-devops)
+- Issue creation for an [integration](/product/integrations/), which includes: - [Jira](/product/integrations/jira/) - [Azure DevOps](/product/integrations/azure-devops)
 
 #### Issue Owners
 

--- a/src/docs/product/alerts-notifications/metric-alerts.mdx
+++ b/src/docs/product/alerts-notifications/metric-alerts.mdx
@@ -10,7 +10,7 @@ description: "Learn how to configure and manage Metric Alerts."
 
 Metric alerts tell you when a metric breaches a threshold, such as a spike in the number of errors in a project, or a change in a performance metric like [latency](/product/performance/metrics/#latency), [Apdex](/product/performance/metrics/#apdex), [failure rate](/product/performance/metrics/#failure-rate), and [throughput](/product/performance/metrics/#throughput-total-tpm-tps).
 
-The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Grant Members Alerts Write**.
+The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Let Members Create and Edit Alerts**.
 
 ## Alert Builder
 

--- a/src/docs/product/sentry-basics/guides/alert-notifications/issue-alerts.mdx
+++ b/src/docs/product/sentry-basics/guides/alert-notifications/issue-alerts.mdx
@@ -6,17 +6,20 @@ description: "Learn more about creating and managing Issue Alerts."
 
 Create and manage Issue Alerts by navigating to Alerts and clicking the "Alert Rules" tab, where you can both view a list of all active rules and add new rules or modify existing ones. Then, select your project and choose Issue Alert.
 
-The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Grant Members Alerts Write**.
+The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Let Members Create and Edit Alerts**.
 
 ## 1: Choose an Environment
+
 Specify which [environment(s)](/platforms/javascript/configuration/environments/) will use this particular alert rule. `Environment` is a Sentry supported tag that you can (and should) add to your SDK. Generally, the [tag](/platforms/javascript/enriching-events/tags/) accepts any value but is targeted to refer to your code deployments' naming convention such as _Development_, _Testing_, _Staging_, or _Production_. The environment drop-down list is populated with the environment tag values available in your [Event Stream](/product/accounts/quotas/manage-event-stream-guide/).
 
 Each environment typically necessitates different levels of urgency and workflow. The urgency and workflows you apply to Production alerts might differ from those you apply to alerts originating from your QA environment, for example.
 
 ## 2: Give the Alert Rule a Name
+
 Manage your alert rule by giving it a descriptive name. A descriptive alert rule name specifies the team affected and the topic of the alert. For example, "Frontend Latency," "Backend Failure Rate," or "Billing Apdex."
 
 ## 3: Set Conditions
+
 Conditions rely on event [tags](#event-tags), [attribute](#event-attributes) values, [event frequency](#event-frequency), and [issue state](/product/alerts-notifications/notifications/#issue-states) changes. Conditions are evaluated for an issue alert **each time** Sentry receives a new event, subject to [rate limits](/product/alerts-notifications/issue-alerts/#rate-limit). Customize your alerts by setting conditions for notifying the most relevant team members. Define who to notify about what error, when, and how, making sure errors are getting the proper audience's attention.
 
 Alert conditions have three parts:
@@ -66,6 +69,7 @@ To handle regressions, set-up two regression alert rules to:
 - Notify your engineering team via a [Slack](/product/integrations/slack/) channel when a regression is identified in any environment.
 
 ## 4: Set a Rate Limit & Finalize
+
 1. The rate limit controls how often the alert rule can be triggered for a particular issue. The rate limit is set to perform the action according to one of these intervals:
 
 - minutes: 5, 10, 30, 60

--- a/src/docs/product/sentry-basics/guides/alert-notifications/metric-alerts.mdx
+++ b/src/docs/product/sentry-basics/guides/alert-notifications/metric-alerts.mdx
@@ -6,7 +6,7 @@ description: "Learn more about creating and managing Metric Alerts."
 
 Create and manage Metric Alerts by navigating to Alerts and clicking the "Alert Rules" tab, where you'll see a list of all active rules and can add new rules or modify existing ones. Then, select your project and choose Metric Alert.
 
-The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Grant Members Alerts Write**.
+The minimum role required to create alerts is member. Sentry users with manager or owner permissions can change the minimum role requirement in **Settings > General Settings > Let Members Create and Edit Alerts**.
 
 ## 1. Choose Errors or Transactions
 
@@ -42,10 +42,10 @@ Choose the time period over which to evaluate your metric. Your choices range be
 
 Sentry evaluates the specified window each minute. For example, if you specify an hour time window, Sentry evaluates:
 
- - 3:00pm: 2:00pm - 3:00pm
- - 3:01pm: 2:01pm - 3:01pm
- - 3:02pm: 2:02pm - 3:02pm
- - ...
+- 3:00pm: 2:00pm - 3:00pm
+- 3:01pm: 2:01pm - 3:01pm
+- 3:02pm: 2:02pm - 3:02pm
+- ...
 
 </Note>
 


### PR DESCRIPTION
Changing every instance of `Grant Members Alerts Write` to `Let Members Create and Edit Alerts` because I renamed it in the app to make it easier to read: https://github.com/getsentry/sentry/pull/23800