### PR TITLE
Clarify spike protection applies to error events

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -202,12 +202,12 @@ When you are unable to take immediate action on an issue, but it continues to oc
 
 ## Spike Protection
 
-A spike is both a **large** and **temporary** increase in event volume. Sentry's spike protection prevents huge overages from consuming your event capacity. We use your historical event volume to implement a dynamic rate limit which discards events when you hit its threshold. This dynamic rate limit is designed to protect you from short-term spikes. The threshold will increase if your increased volume persists for many hours.
+A spike is both a **large** and **temporary** increase in error event volume; ; spike protection is not currently available for transactions. Sentry's spike protection prevents huge overages from consuming your error event capacity. We use your historical error event volume to implement a dynamic rate limit which discards error events when you hit its threshold. This dynamic rate limit is designed to protect you from short-term spikes. The threshold will increase if your increased volume persists for many hours.
 
-When spike protection is activated, we limit the number of events accepted in any minute to:
+When spike protection is activated, we limit the number of error events accepted in any minute to:
 
 ```
-maximum(20, 6 x average events per minute over the last 24 hours)
+maximum(20, 6 x average error events per minute over the last 24 hours)
 ```
 
 _The 24 hour window ends at the beginning of the current hour, not at the current minute._
@@ -216,7 +216,7 @@ What this means is that if you experience a spike, we will temporarily protect y
 
 ### How Does Spike Protection Help?
 
-Because Sentry bills on monthly event volume, spikes can consume your Sentry capacity for the rest of the month. If it really is a spike, spike protection drops events during the spike to try and conserve your capacity. We also send teammates with the "owner" organization permission level a [notification](/product/alerts-notifications/notifications/#quota) email.
+Because Sentry bills on monthly event volume, spikes can consume your Sentry capacity for the rest of the month. If it really is a spike, spike protection drops error events during the spike to try and conserve your capacity. We also send teammates with the "owner" organization permission level a [notification](/product/alerts-notifications/notifications/#quota) email.
 
 ## Attribute Limits
 


### PR DESCRIPTION
Further clarifying that spike protection currently applies only to error events.