### PR TITLE
RqIntegration documentation: add tip to call sentry_sdk.init once in (Flask) app

### DIFF
--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -31,6 +31,24 @@ The integration will automatically report errors from all RQ jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
+In addition, make sure that **`init` is called once** in your app and imported from there in the different places it is needed. In a Flask app, for example, Sentry and `RqIntegration` can be initalised as 
+
+```python {filename:app.py}
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.rq import RqIntegration
+
+sentry = sentry_sdk.init(
+    dsn=PUBLIC_DSN,
+    integrations=[FlaskIntegration(), RqIntegration()])
+```
+
+`mysettings.py` then becomes
+
+```python {filename:mysettings.py}
+from app import sentry
+```
+
 ## The `--sentry-dsn` CLI option
 
 Passing `--sentry-dsn=""` to RQ forcibly disables [RQ's shortcut for using Sentry](https://python-rq.org/patterns/sentry/). For RQ versions before 1.0 this is necessary to avoid conflicts, because back then RQ would attempt to use the `raven` package instead of this SDK. Since RQ 1.0 it's possible to use this CLI option and the associated RQ settings for initializing the SDK.

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -31,7 +31,7 @@ The integration will automatically report errors from all RQ jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-In addition, make sure that **`init` is called once** in your app and imported from there in the different places it is needed. In a Flask app, for example, Sentry and `RqIntegration` can be initalized as 
+In addition, make sure that **`init` is called only once** in your app. For example, if you have a Flask app and a worker that depends on the app, we recommend initializing Sentry with a single configuration that is suitable for Flask and RQ, as in:
 
 ```python {filename:app.py}
 import sentry_sdk
@@ -43,10 +43,10 @@ sentry_sdk.init(
     integrations=[FlaskIntegration(), RqIntegration()])
 ```
 
-`mysettings.py` then becomes
+The worker configuration `mysettings.py` then becomes:
 
 ```python {filename:mysettings.py}
-# import initialised Sentry SDK from app.py
+# This import causes the Sentry SDK to be initialized
 import app
 ```
 

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -31,7 +31,7 @@ The integration will automatically report errors from all RQ jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-In addition, make sure that **`init` is called once** in your app and imported from there in the different places it is needed. In a Flask app, for example, Sentry and `RqIntegration` can be initalised as 
+In addition, make sure that **`init` is called once** in your app and imported from there in the different places it is needed. In a Flask app, for example, Sentry and `RqIntegration` can be initalized as 
 
 ```python {filename:app.py}
 import sentry_sdk
@@ -39,7 +39,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
 sentry = sentry_sdk.init(
-    dsn=PUBLIC_DSN,
+    dsn=___PUBLIC_DSN___,
     integrations=[FlaskIntegration(), RqIntegration()])
 ```
 

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -38,7 +38,7 @@ import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
-sentry = sentry_sdk.init(
+sentry_sdk.init(
     dsn=___PUBLIC_DSN___,
     integrations=[FlaskIntegration(), RqIntegration()])
 ```
@@ -46,7 +46,8 @@ sentry = sentry_sdk.init(
 `mysettings.py` then becomes
 
 ```python {filename:mysettings.py}
-from app import sentry
+# import initialised Sentry SDK from app.py
+import app
 ```
 
 ## The `--sentry-dsn` CLI option


### PR DESCRIPTION
Extend docs with tips from https://github.com/getsentry/sentry-python/issues/935 and https://github.com/getsentry/sentry-python/issues/907 to initialise Sentry once per (Flask) app and import it in `rq worker`'s settings file. 

Calling `sentry_sdk.init` in the worker's configuration per the  current docs (https://docs.sentry.io/platforms/python/guides/rq/) results in undelivered messages and exceptions.