### PR TITLE
Update Xamarin docs.

### DIFF
--- a/src/platforms/dotnet/guides/xamarin/index.mdx
+++ b/src/platforms/dotnet/guides/xamarin/index.mdx
@@ -27,6 +27,10 @@ Great! Now that you’ve completed setting up the SDK, maybe you want to quickly
 
 <PlatformContent includePath="getting-started-verify" />
 
+<<<<<<< HEAD
+=======
+All you need to do is to [initialize the SDK with `SentryXamarin.Init`](../../), you will not need any additional changes to get the SDK ready to go.
+>>>>>>> e8e9a2ff... Add relative path to SDK Init.
 
 The SDK automatically handles `AppDomain.UnhandledException` and `Application.UnhandledException`, so you'll not need to worry about trying to Catch Unhandled Exceptions.
 
@@ -38,7 +42,7 @@ The following options are only going to be valid during the SDK initialization.
 
 Disable the native event processor for Android,iOS,UWP
 
-#### DisableXamarinFormsCache
+#### DisableOfflineCaching
 
 By calling it, the SDK will not automatically Cache your events and they might be lost if a hard crash happens or no connectivity is available during the transport of the event.
 
@@ -50,4 +54,4 @@ Disables the automatic Logging of internal Warnings that comes from Xamarin Form
 
 ## Samples
 
-- An [example](https://github.com/getsentry/sentry-dotnet-xamarin/tree/main/Samples) using Xamarin Forms and most of the SDK features. (**Android,iOS,UWP**)
+- An [example](https://github.com/getsentry/sentry-xamarin/tree/main/Samples) using Xamarin Forms and most of the SDK features. (**Android,iOS,UWP**)

--- a/src/platforms/dotnet/guides/xamarin/index.mdx
+++ b/src/platforms/dotnet/guides/xamarin/index.mdx
@@ -27,10 +27,7 @@ Great! Now that you’ve completed setting up the SDK, maybe you want to quickly
 
 <PlatformContent includePath="getting-started-verify" />
 
-<<<<<<< HEAD
-=======
 All you need to do is to [initialize the SDK with `SentryXamarin.Init`](../../), you will not need any additional changes to get the SDK ready to go.
->>>>>>> e8e9a2ff... Add relative path to SDK Init.
 
 The SDK automatically handles `AppDomain.UnhandledException` and `Application.UnhandledException`, so you'll not need to worry about trying to Catch Unhandled Exceptions.
 

--- a/src/platforms/dotnet/guides/xamarin/index.mdx
+++ b/src/platforms/dotnet/guides/xamarin/index.mdx
@@ -51,4 +51,4 @@ Disables the automatic Logging of internal Warnings that comes from Xamarin Form
 
 ## Samples
 
-- An [example](https://github.com/getsentry/sentry-xamarin/tree/main/Samples) using Xamarin Forms and most of the SDK features. (**Android,iOS,UWP**)
+- An [example](https://github.com/getsentry/sentry-xamarin/tree/main/Samples) using Xamarin Forms and most of the SDK features. (**Android, iOS, UWP**)

--- a/src/wizard/dotnet/xamarin.md
+++ b/src/wizard/dotnet/xamarin.md
@@ -1,7 +1,7 @@
 ---
 name: Xamarin
 doc_link: https://docs.sentry.io/platforms/dotnet/guides/xamarin/
-support_level: alpha
+support_level: production
 type: library
 ---
 
@@ -9,10 +9,10 @@ type: library
 
 ```shell
 # For Xamarin.Forms
-Install-Package Sentry.Xamarin.Forms -Version 1.0.0
+Install-Package Sentry.Xamarin.Forms -Version {{ packages.version('sentry.dotnet.xamarin') }}
 
 # If you are not using Xamarin.Forms, but only Xamarin:
-Install-Package Sentry.Xamarin -Version 1.0.0
+Install-Package Sentry.Xamarin -Version {{ packages.version('sentry.dotnet.xamarin-forms') }}
 
 ```
 
@@ -89,4 +89,4 @@ There are no line numbers on stack traces for UWP and in release builds for Andr
 
 ### Samples
 
-You can find an example of a Xamarin Forms app with Sentry integrated [on this GitHub repository.](https://github.com/getsentry/sentry-dotnet-xamarin/tree/main/Samples)
+You can find an example of a Xamarin Forms app with Sentry integrated [on this GitHub repository.](https://github.com/getsentry/sentry-xamarin/tree/main/Samples)


### PR DESCRIPTION
This PR aims to include the naming change of DisableXamarinFormsCache to DisableOfflineCaching, additionally, the version is no longer hardcoded.