### PR TITLE
Clarify DSN explainer

### DIFF
--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -8,11 +8,11 @@ Sentry automatically assigns you a Data Source Name (DSN) when you create a proj
 
 ### What the DSN Does
 
-A DSN tells a Sentry SDK where to send events, such that they are associated with the right project.
+A DSN tells a Sentry SDK where to send events so the events are associated with the correct project.
 
-If this value is not provided, SDKs will try to read it from the `SENTRY_DSN` environment variable, where applicable. This fallback does not apply in cases like a web browser, as the concept of environment variables does not exist.
+If this value is not provided, SDKs will try to read it from the `SENTRY_DSN` environment variable, where applicable. This fallback does not apply in cases like a web browser, where the concept of environment variables does not exist.
 
-If an SDK is not initialized or if it is initialized with an empty DSN, it will not send any data over the network, such as captured exceptions.
+If an SDK is not initialized or if it is initialized with an empty DSN, the SDK will not send any data over the network, such as captured exceptions.
 
 ### Where to Find Your DSN
 

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -8,13 +8,11 @@ Sentry automatically assigns you a Data Source Name (DSN) when you create a proj
 
 ### What the DSN Does
 
-The DSN tells the SDK where to send the events. If this value is not provided, the SDK will try to read it from the `SENTRY_DSN` environment variable. If that variable also does not exist, the SDK will just not send any events.
+A DSN tells a Sentry SDK where to send events, such that they are associated with the right project.
 
-<Note>
+If this value is not provided, SDKs will try to read it from the `SENTRY_DSN` environment variable, where applicable. This fallback does not apply in cases like a web browser, as the concept of environment variables does not exist.
 
-In runtimes without a process environment (such as the browser) that fallback does not apply.
-
-</Note>
+If an SDK is not initialized or if it is initialized with an empty DSN, it will not send any data over the network, such as captured exceptions.
 
 ### Where to Find Your DSN
 
@@ -36,10 +34,7 @@ Has the following settings:
 
 - URI = https://sentry.example.com
 - Public Key = public
-- Secret Key = secret
 - Project ID = 1
-
-The resulting POST request for a plain JSON payload would then transmit to `https://sentry.example.com/api/1/store/`.
 
 <Note>
 


### PR DESCRIPTION
- "the SDK will just not send any events" => "will not send data"
  The important part here is removing "just". The SDK may do/ not do other things as well, such as skipping initialization of certain internal state, on the discretion of the SDK implementation.
- Remove `Secret Key = secret`: is has been removed from the example and stayed here probably by accident
- Remove reference to `/store/` endpoint. This is not necessarily useful for users and can be confusing since SDKs talk to different endpoints, `/store/` being just one of them.


Closes #1635