### PR TITLE
ref: Rename "GCP Functions" to "Google Cloud Functions"

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -47,7 +47,7 @@ Customers on legacy plans must add transaction events to their subscription in o
   - [AWS Lambda](/platforms/node/guides/aws-lambda/)
   - [Express](/platforms/node/guides/express/#monitor-performance)
   - [Koa](/platforms/node/guides/koa/#monitor-performance)
-  - [GCP Cloud Functions](/platforms/node/guides/gcp-functions/)
+  - [Google Cloud Functions](/platforms/node/guides/gcp-functions/)
 
 - [Python](/platforms/python/performance/)
   - [AWS Lambda](/platforms/python/guides/aws-lambda/performance/)
@@ -55,13 +55,13 @@ Customers on legacy plans must add transaction events to their subscription in o
   - [Celery](/platforms/python/guides/celery/performance/)
   - [Django](/platforms/python/guides/django/performance/)
   - [Flask](/platforms/python/guides/flask/performance/)
-  - [GCP Cloud Functions](/platforms/python/guides/gcp-functions/)
+  - [Google Cloud Functions](/platforms/python/guides/gcp-functions/)
   - [Pyramid](/platforms/python/guides/pyramid/performance/)
   - [RQ (Redis Queue)](/platforms/python/guides/rq/performance/)
 
 - [PHP](/platforms/php/#monitor-performance)
   - [Laravel](/platforms/php/guides/laravel/#monitor-performance)
   - [Symfony](/platforms/php/guides/symfony/performance/)
-  
+
 - [Ruby](/platforms/ruby/performance/)
   - [Rails](/platforms/ruby/guides/rails/)

--- a/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
+++ b/src/includes/performance/default-sampling-context/python.gcp-functions.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The GCP Functions integration adds information about the environment and incoming event:
+The Google Cloud Functions integration adds information about the environment and incoming event:
 
 ```python
 {

--- a/src/platforms/node/guides/gcp-functions/index.mdx
+++ b/src/platforms/node/guides/gcp-functions/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: GCP Functions
+title: Google Cloud Functions
 redirect_from:
   - /platforms/node/gcp_functions/
-description: "Learn about using Sentry with GCP Cloud Functions."
+description: "Learn about using Sentry with Google Cloud Functions."
 ---
 
 _(New in version 5.26.0)_
@@ -13,7 +13,7 @@ Add `@sentry/serverless` as a dependency to `package.json`:
   "@sentry/serverless": "^5.26.0"
 ```
 
-To set up Sentry for a GCP Cloud Function:
+To set up Sentry for a Google Cloud Function:
 
 ```javascript {tabTitle:http functions}
 const Sentry = require("@sentry/serverless");
@@ -58,7 +58,7 @@ Check out Sentry's [GCP sample apps](https://github.com/getsentry/examples/tree
 
 ## Behavior
 
-With the GCP Cloud Functions integration enabled, the Node SDK will:
+With the Google Cloud Functions integration enabled, the Node SDK will:
 
 - Automatically report all events from your Cloud Functions.
 - Allows you to <PlatformLink to="/configuration/sampling/#configuring-the-transaction-sample-rate">modify the transaction sample rate</PlatformLink> using <PlatformIdentifier name="traces-sample-rate" />.

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: GCP Functions
+title: Google Cloud Functions
 redirect_from:
   - /platforms/python/gcp_functions/
-description: "Learn about using Sentry with GCP Functions."
+description: "Learn about using Sentry with Google Cloud Functions."
 ---
 
 _(New in version 0.17.1)_
@@ -17,7 +17,7 @@ Add the Sentry SDK to your `requirements.txt`:
 
 ## Configure
 
-You can use the GCP Functions integration for the Python SDK like this:
+You can use the Google Cloud Functions integration for the Python SDK like this:
 
 ```python
 import sentry_sdk
@@ -38,7 +38,7 @@ Check out Sentry's [GCP sample apps](https://github.com/getsentry/examples/tree/
 
 <Alert level="info" title="Note">
 
-If you are using another web framework inside of GCP, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.
+If you are using a web framework inside of your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.
 
 </Alert>
 
@@ -57,13 +57,13 @@ sentry_sdk.init(
 )
 ```
 
-The timeout warning is sent only if the timeout in the GCP Function configuration is set to a value greater than one second.
+The timeout warning is sent only if the timeout in the Cloud Function configuration is set to a value greater than one second.
 
 ## Behavior
 
-With the GCP Functions integration enabled, the Python SDK will:
+With the GCP integration enabled, the Python SDK will:
 
-- Automatically report all events from your Lambda Functions
+- Automatically report all events from your Cloud Functions
 - You can <PlatformLink to="/configuration/filtering/">modify the transaction sample rate</PlatformLink> using `traces_sample_rate`.
 - Issues reports automatically include:
 

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -61,7 +61,7 @@ The timeout warning is sent only if the timeout in the Cloud Function configurat
 
 ## Behavior
 
-With the GCP integration enabled, the Python SDK will:
+With the Google Cloud Functions integration enabled, the Python SDK will:
 
 - Automatically report all events from your Cloud Functions
 - You can <PlatformLink to="/configuration/filtering/">modify the transaction sample rate</PlatformLink> using `traces_sample_rate`.

--- a/src/platforms/python/guides/serverless/index.mdx
+++ b/src/platforms/python/guides/serverless/index.mdx
@@ -9,7 +9,7 @@ _(New in version 0.7.3)_
 
 It is recommended to use an integration for your particular serverless environment if available, as those are easier to use and capture more useful information:
 
-- <Link to="/platforms/python/guides/gcp-functions">Google Cloud Platform/GCP Functions</Link>
+- <Link to="/platforms/python/guides/gcp-functions">Google Cloud Functions</Link>
 [//]:# (Temporary turning off azure integration - need to fix the integration)
 [//]:# (- <Link to="/platforms/python/guides/azure-functions">Azure Functions</Link>)
 - <Link to="/platforms/python/guides/aws-lambda">AWS Lambda Functions</Link>

--- a/src/wizard/node/gcpfunctions.md
+++ b/src/wizard/node/gcpfunctions.md
@@ -1,5 +1,5 @@
 ---
-name: GCP Cloud Functions (Node)
+name: Google Cloud Functions (Node)
 doc_link: https://docs.sentry.io/platforms/node/guides/gcp-functions/
 support_level: production
 type: framework
@@ -11,7 +11,7 @@ Add `@sentry/serverless` as a dependency to `package.json`:
   "@sentry/serverless": "^5.26.0"
 ```
 
-To set up Sentry for a GCP Cloud Function:
+To set up Sentry for a Google Cloud Function:
 
 ```javascript {tabTitle:http functions}
 const Sentry = require("@sentry/serverless");

--- a/src/wizard/python/gcpfunctions.md
+++ b/src/wizard/python/gcpfunctions.md
@@ -1,5 +1,5 @@
 ---
-name: GCP Cloud Functions (Python)
+name: Google Cloud Functions (Python)
 doc_link: https://docs.sentry.io/platforms/python/guides/gcp-functions/
 support_level: production
 type: framework
@@ -11,7 +11,7 @@ Install our Python SDK using `pip`:
 pip install --upgrade sentry-sdk
 ```
 
-You can use the GCP Functions integration for the Python SDK like this:
+You can use the Google Cloud Functions integration for the Python SDK like this:
 
 ```python
 import sentry_sdk
@@ -43,7 +43,7 @@ sentry_sdk.init(
 )
 ```
 
-The timeout warning is sent only if the timeout in the GCP Function configuration is set to a value greater than one second.
+The timeout warning is sent only if the timeout in the Cloud Function configuration is set to a value greater than one second.
 
-<div class="alert alert-info" role="alert"><h5 class="no_toc">Note</h5><div class="alert-body content-flush-bottom">If you are using another web framework inside of GCP Functions, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*](/platforms/python/#integrations) for more information.</div>
+<div class="alert alert-info" role="alert"><h5 class="no_toc">Note</h5><div class="alert-body content-flush-bottom">If you are using a web framework in your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [*Integrations*](/platforms/python/#integrations) for more information.</div>
 </div>


### PR DESCRIPTION
The official [product name](https://cloud.google.com/functions/) is "Cloud Functions", "GCP Functions" is not really used anywhere.

A small remaining inconsistency is that the Python integration is actually called [`GcpIntegration`](https://github.com/getsentry/sentry-python/blob/a7ef7c05df6669593b168581c9e5d616cb0a1af5/sentry_sdk/integrations/gcp.py#L119), but I'm not changing that here.