### PR TITLE
ref: Set javascript release value

### DIFF
--- a/src/includes/getting-started-config/javascript.mdx
+++ b/src/includes/getting-started-config/javascript.mdx
@@ -7,8 +7,9 @@ import { Integrations } from "@sentry/tracing";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To set your release version
-  release: "my-project-name@" + process.env.npm_package_version,
+  // Alternatively, use `process.env.npm_package_version` for a dynamic release version
+  // if your build tool supports it.
+  release: "my-project-name@2.3.12",
   integrations: [new Integrations.BrowserTracing()],
 
   // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Change getting started step to include a static release name, as without some JS build tool, it wouldn't work.