### PR TITLE
userfeedback not supported for unity.lite

### DIFF
--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -16,6 +16,7 @@ notSupported:
   - dart
   - flutter
   - ruby
+  - unity
 ---
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. This type of feedback is useful when you may typically render a plain error page (the classic `500.html`).


### PR DESCRIPTION
Until we release Unity on top of .NET, this doc needs to be hiden