### PR TITLE
ref: del auto_enabling, explain non-included

### DIFF
--- a/src/platforms/python/common/performance/included-instrumentation.mdx
+++ b/src/platforms/python/common/performance/included-instrumentation.mdx
@@ -31,13 +31,4 @@ Spans are instrumented for the following operations within a transaction:
 - Spawned subprocesses
 - Redis operations
 
-If you want to automatically enable all relevant transactions, you can use this alternative configuration:
-
-```python
-import sentry_sdk
-
-sentry_sdk.init(
-    "___PUBLIC_DSN___",
-    _experiments={"auto_enabling_integrations": True}
-)
-```
+Spans are only created within an existing transaction. If you're not using any of the supported frameworks, you'll need to <PlatformLink to="/performance/custom-instrumentation/">create transactions manually</PlatformLink>.


### PR DESCRIPTION
auto_enabling_integrations was removed in 0.19.0 according to [0].

@silent1mezzo and I encountered some confusion in this area, since the documentation gave us the impression that the listed operations are always instrumented. In fact, they are only instrumented within existing transactions, and one isn't created automatically.

[0] https://github.com/getsentry/sentry-python/blob/master/CHANGELOG.md#0190