### PR TITLE
fix(native): Describe correct casing of the SymStore layout

### DIFF
--- a/src/platforms/common/data-management/debug-files/symbol-servers.mdx
+++ b/src/platforms/common/data-management/debug-files/symbol-servers.mdx
@@ -96,13 +96,13 @@ selected layout and the file type, we try to download files at specific paths.
 The following table contains a mapping from the supported layouts to file path
 schemas applied for specific files:
 
-| Layout                          | MachO   |   ELF   |    PE    |   PDB    | Breakpad | WASM    |
+| Layout                          |  MachO  |   ELF   |    PE    |   PDB    | Breakpad |  WASM   |
 | ------------------------------- | :-----: | :-----: | :------: | :------: | :------: | :-----: |
-| Platform-Specific               | LLDB    | BuildID | SymStore | SymStore | Breakpad | BuildID |
-| Microsoft SymStore              |   -     |    -    | SymStore | SymStore |    -     | -       |
-| Microsoft SymStore (index2.txt) |   -     |    -    |  Index2  |  Index2  |    -     | -       |
-| Microsoft SSQP                  | SSQP    |  SSQP   |   SSQP   |   SSQP   |    -     | -       |
-| Unified Symbol Server Layout    | Unified | Unified | Unified  | Unified  | Unified  | Unified |
+| Platform-Specific               |  LLDB   | BuildID | SymStore | SymStore | Breakpad | BuildID |
+| Microsoft SymStore              |    -    |    -    | SymStore | SymStore |    -     |    -    |
+| Microsoft SymStore (index2.txt) |    -    |    -    |  Index2  |  Index2  |    -     |    -    |
+| Microsoft SSQP                  |  SSQP   |  SSQP   |   SSQP   |   SSQP   |    -     |    -    |
+| Unified Layout                  | Unified | Unified | Unified  | Unified  | Unified  | Unified |
 
 The path schemas in the table above are defined as follows:
 
@@ -178,14 +178,13 @@ Examples:
 
 : Path: `nn/nnnnnnnnnnnnnnnn.../type`
 
-The unified path layout is specific to Sentry and enables a consistent
-structure for all debug files independent of platform.  It can store breakpad files,
-PDBs, PEs, and everything else.  The [symsorter tool](https://github.com/getsentry/symbolicator/tree/master/symsorter)
-can automatically sort debug symbols into this format and also automatically
-create source bundles.
+The unified path layout is specific to Sentry and enables a consistent structure
+for all debug files independent of platform. It can store breakpad files, PDBs,
+PEs, and everything else. The [symsorter tool] can automatically sort debug
+symbols into this format and also automatically create source bundles.
 
 The path is based on a `build_id` formatted to a hexadecimal using
-lower case.  The first two bytes of that ID are taken as a root folder.
+lower case. The first two bytes of that ID are taken as a root folder.
 
 The `build_id` construction differs among file formats:
 
@@ -276,6 +275,7 @@ Examples:
 - `wk/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B5A/wkernel32.pdb`
 - `KE/KERNEL32.dll/590285E9e0000/KERNEL32.dll`
 
+[symsorter tool]: https://github.com/getsentry/symbolicator/tree/master/symsorter
 [ssqp key conventions]: https://github.com/dotnet/symstore/blob/master/docs/specs/SSQP_Key_Conventions.md
 [file mapped uuid directories]: https://lldb.llvm.org/use/symbols.html#file-mapped-uuid-directories
 [build id method]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html

--- a/src/platforms/common/data-management/debug-files/symbol-servers.mdx
+++ b/src/platforms/common/data-management/debug-files/symbol-servers.mdx
@@ -248,8 +248,9 @@ Windows platform. These use a _signature-age_ debug identifier in addition to
 the file name to locate symbols. File paths are identical to SSQP, except for
 the default casing rules:
 
-- Filenames are **as given**
-- The signature and age of a PDB identifier are **uppercase**.
+- Filenames are **as given**.
+- The signature of a PDB identifier is **uppercase**, but the age is
+  **lowercase**.
 - The timestamp of a PE identifier is **uppercase**, but the size is
   **lowercase**.
 


### PR DESCRIPTION
The casing rules for symstore were not correct. This mistake has been here from
the beginning, and symbolicator has always applied the now described mixed
casing rules.

