### PR TITLE
correct application.yaml for sample-rate config

### DIFF
--- a/src/includes/configuration/sample-rate/java.spring-boot.mdx
+++ b/src/includes/configuration/sample-rate/java.spring-boot.mdx
@@ -3,5 +3,6 @@ sentry.sample-rate=0.25
 ```
 
 ```yaml {tabTitle: application.yml}
-sentry.sample-rate: 0.25
+sentry:
+  sample-rate: 0.25
 ```


### PR DESCRIPTION
The config for sentry.sample-rate was invalid for yaml form.