### PR TITLE
Update performance monitoring verification step

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -52,25 +52,25 @@ Learn more about how the options work in <PlatformLink to="/configuration/sampli
 
 ## Verify
 
-<PlatformSection supported={["react-native"]} notSupported={["javascript"]}>
+<PlatformSection supported={["react-native", "java.spring", "java.spring-boot"]} notSupported={["javascript"]}>
 
-You can now test out tracing by adding our <PlatformLink to="/performance/included-instrumentation/">included instrumentation</PlatformLink> or you can learn how to add <PlatformLink to="/performance/custom-instrumentation/">custom instrumentation</PlatformLink>.
-
-</PlatformSection>
-
-<PlatformSection supported={["dotnet"]} notSupported={["javascript", "react-native"]}>
-
-You can now test out tracing by starting and finishing a transaction. You can learn how to do so with <PlatformLink to="/performance/custom-instrumentation/">Custom Instrumentation</PlatformLink>
+Test out tracing by adding our <PlatformLink to="/performance/included-instrumentation/">included instrumentation</PlatformLink> or by starting and finishing a transaction using <PlatformLink to="/performance/custom-instrumentation/">custom instrumentation</PlatformLink>.
 
 </PlatformSection>
 
-When you first enable tracing, verify it is working correctly by setting <PlatformIdentifier name="traces-sample-rate" /> to `1.0` as that ensures that every transaction will be sent to Sentry.
+<PlatformSection supported={["dotnet", "go", "java", "android", "ruby"]} notSupported={["javascript", "react-native", "java.spring", "java.spring-boot"]}>
+
+Test out tracing by starting and finishing a transaction, which you *must* do so transactions can be sent to Sentry. Learn how in our <PlatformLink to="/performance/custom-instrumentation/">Custom Instrumentation</PlatformLink> content.
+
+</PlatformSection>
+
+Verify that performance monitoring is working correctly by setting <PlatformIdentifier name="traces-sample-rate" /> to `1.0` as that ensures that every transaction will be sent to Sentry.
 
 Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to dynamically sample and filter your transactions.
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
-Without sampling, our included instrumentation will send a transaction any time any user loads any page or navigates anywhere in your app, which is a lot of transactions! Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
+Without setting a sample rate, included instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
 
 </PlatformSection>
 


### PR DESCRIPTION
The verification step for performance was causing confusion. It made it seem as if transactions would be simply sent, when in fact for some SDKs, you need to first use custom instrumentation to start and stop a transaction to test. This fix modifies the verification step appropriate to the instrumentation supported in each SDK.