### PR TITLE
fix: Clarify payload size limits and link to develop

### DIFF
--- a/src/docs/clients/javascript/usage.mdx
+++ b/src/docs/clients/javascript/usage.mdx
@@ -138,7 +138,7 @@ Raven.setTagsContext(tags); // Add back the tags you want to keep.
 ```
 
 **Be aware of maximum payload size** - There are times, when you may want to send the whole application state as extra data.
-This can be quite a large object, which can easily weigh more than 200kB. This 200kB is currently the maximum payload size of a single event you can send to Sentry.
+This can be quite a large object, which can easily exceed the maximum payload size of a single event you can send to Sentry.
 When this happens, you'll get an `HTTP Error 413 Payload Too Large` message as the server response or (when `keepalive: true` is set as `fetch` parameter), the request will stay in the `pending` state forever (eg. in Chrome).
 
 `extra`

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -218,11 +218,18 @@ What this means is that if you experience a spike, we will temporarily protect y
 
 Because Sentry bills on monthly event volume, spikes can consume your Sentry capacity for the rest of the month. If it really is a spike, spike protection drops error events during the spike to try and conserve your capacity. We also send teammates with the "owner" organization permission level a [notification](/product/alerts-notifications/notifications/#quota) email.
 
-## Attribute Limits
+## Size Limits
 
-Sentry imposes hard limits on various components within an event. While the limits may change over time and vary among attributes, most individual attributes are capped at 512 characters. Additionally, certain attributes also limit the maximum number of items. Commonly-trimmed values might include, for example:
+Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 
-- Stack frame details. Stack traces with large frame counts will be trimmed (the middle frames are dropped). We limit to a maximum of 250 frames. Only 50 are retained unaltered, with the remaining 200 removing `vars`, `pre_context` and `post_context`.
-- `extra` data is limited to approximately 256k characters, and each item is capped at approximately 16k characters.
-- Breadcrumbs and their values
-- Error messages and message parameters are limited to 1024 characters.
+- Events, attachments and requests exceeding payload size limits are immediately dropped with a `413 Payload Too Large` error. Sentry allows compressed content encoding, and applies separate limits before and after decompression.
+- Fields exceeding the individual size limits are afterwards trimmed and truncated at a best effort.
+
+To avoid unintentional data loss, consider limiting the size of values passed into Sentry's APIs. For example, if your application attaches application state or request bodies to Sentry events, truncate them first.
+
+The precise limits may change over time. For more information, please refer to the following resources:
+
+- [Envelope Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
+- [Store Endpoint Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
+- [Minidump Size Limits](/platforms/native/guides/minidumps/#size-limits)
+- [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -222,7 +222,7 @@ Because Sentry bills on monthly event volume, spikes can consume your Sentry cap
 
 Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 
-- Events, attachments and requests exceeding payload size limits are immediately dropped with a `413 Payload Too Large` error. Sentry allows compressed content encoding, and applies separate limits before and after decompression.
+- Events, attachments, and requests exceeding payload size limits are immediately dropped with a `413 Payload Too Large` error. Sentry allows compressed content encoding, and applies separate limits before and after decompression.
 - Fields exceeding the individual size limits are afterwards trimmed and truncated at a best effort.
 
 To avoid unintentional data loss, consider limiting the size of values passed into Sentry's APIs. For example, if your application attaches application state or request bodies to Sentry events, truncate them first.


### PR DESCRIPTION
Size limits are an implementation detail at this point, and we're describing them at multiple places. The best place to list the actual size limits is in the develop docs. Quota and platform docs (especially the legacy RavenJS documentation) should be unspecific and link to those places, instead.

Requires https://github.com/getsentry/develop/pull/276
Fixes #3094
