### PR TITLE
ref(css): Give global-header a larger z-index

### DIFF
--- a/src/css/_includes/global-header.scss
+++ b/src/css/_includes/global-header.scss
@@ -1,7 +1,7 @@
 .navbar-right-half {
   position: fixed;
   background: $white;
-  z-index: 1;
+  z-index: 10;
   width: calc(100% - 18rem);
 }
 


### PR DESCRIPTION
The new prism theme was setting z-index 1 on code blocks for whatever
reason