### PR TITLE
fix(performance): Add note about unused `@sentry/tracing` import

### DIFF
--- a/src/platforms/node/common/performance/index.mdx
+++ b/src/platforms/node/common/performance/index.mdx
@@ -8,6 +8,7 @@ By default, Sentry error events will not get trace context unless you configure 
 ```javascript
 const Sentry = require("@sentry/node");
 const Tracing = require("@sentry/tracing");
+// Note: You MUST import the package for tracing to work
 
 const http = require("http");
 


### PR DESCRIPTION
Initializing tracing is a side effect of the import, so we need it, even if we don't use it directly.