### PR TITLE
docs(usage): Format capture exception for platform

### DIFF
--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -25,7 +25,7 @@ Key terms:
 
 </Note>
 
-The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to `capture_exception` and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
+The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to <PlatformIdentifier name="capture-exception" /> and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
 
 While capturing an event, you can also record the breadcrumbs that lead up to that event. Breadcrumbs are different from events: they will not create an event in Sentry, but will be buffered until the next event is sent. Learn more about breadcrumbs in our <PlatformLink to="/enriching-events/breadcrumbs/">Breadcrumbs documentation</PlatformLink>.
 


### PR DESCRIPTION
The capture exception function should be formatted appropriately for the
corresponding platform.