### PR TITLE
Update the set-user scope example in Dart

### DIFF
--- a/src/includes/set-user/dart.mdx
+++ b/src/includes/set-user/dart.mdx
@@ -2,6 +2,6 @@
 import 'package:sentry/sentry.dart';
 
 Sentry.configureScope(
-  (scope) => scope.user = User(email: 'jane.doe@example.com'),
+  (scope) => scope.user = User(id: 1234, email: 'jane.doe@example.com'),
 );
 ```


### PR DESCRIPTION
The documentation currently suggests that creating a user with `User(email: 'jane.doe@example.com')` is enough, but [the implementation refuses](https://github.com/getsentry/sentry-dart/blob/dd380f283576cbf816c19b358aacf9f76bf4c963/dart/lib/src/protocol/user.dart#L35) and [asks explicitly](https://github.com/getsentry/sentry-dart/blob/dd380f283576cbf816c19b358aacf9f76bf4c963/dart/lib/src/protocol/user.dart#L28) for either an ip or an id.

```dart
class User {
...
/// At a minimum you must set an [id] or an [ipAddress].
assert(id != null || ipAddress != null)
...
}
````
So adding an ID in the example makes it easy for the user to copy/paste some code that will work on the first try.
```dart
User(id: 1234, email: 'jane.doe@example.com')
```

Edit: [Direct link](https://sentry-docs-git-fork-c4ptaincrunch-patch-1.sentry.dev/platforms/flutter/enriching-events/identify-user/) to the modified page on the Vercel deployment.