### PR TITLE
Update broken link in sensitive Data 

### DIFF
--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -84,6 +84,6 @@ As a best practice you should always avoid logging confidential information. If 
 
 - Anonymize the confidential information within the log statements (for example, swap out email addresses -> for internal identifiers)
 - Use `beforeBreadcrumb` to filter it out from breadcrumbs before it is attached
-- Disable logging breadcrumb integration (for example, as described [here] /platforms/javascript/#breadcrumbs-10)
+- Disable logging breadcrumb integration (for example, as described [here](/platforms/javascript/configuration/integrations/default/#breadcrumbs))
 
 </PlatformSection>


### PR DESCRIPTION
In this issue https://github.com/getsentry/sentry-docs/issues/3153, we surfaced a broken link. This PR fixes it.