### PR TITLE
Fix: special case Proguard mapping location

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -272,7 +272,7 @@ sentry-cli upload-proguard \
     app/build/outputs/mapping/release/mapping.txt
 ```
 
-After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify correct operation, ensure that the ProGuard mapping files are listed in Project Settings > ProGuard.
+After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in Project Settings > ProGuard.
 
 ### Upload Options
 

--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -272,7 +272,7 @@ sentry-cli upload-proguard \
     app/build/outputs/mapping/release/mapping.txt
 ```
 
-After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in Project Settings > ProGuard.
+After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in _Project Settings > ProGuard_.
 
 ### Upload Options
 

--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -262,7 +262,7 @@ sentry-cli upload-proguard \
     app/build/outputs/mapping/release/mapping.txt
 ```
 
-Since the sentry-java SDK needs to know the UUID of the mapping file, you need
+Since the Android SDK needs to know the UUID of the mapping file, you need
 to embed it in a `sentry-debug-meta.properties` file. If you supply
 `--write-properties` that is done automatically:
 
@@ -271,6 +271,8 @@ sentry-cli upload-proguard \
     --write-properties app/build/intermediates/assets/release/sentry-debug-meta.properties \
     app/build/outputs/mapping/release/mapping.txt
 ```
+
+After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify correct operation, ensure that the ProGuard mapping files are listed in Project Settings > ProGuard.
 
 ### Upload Options
 

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -50,6 +50,9 @@ Debug information files can be managed on the _Debug Files_ section in _Project
 Settings_. This page lists all uploaded files and allows to configure symbol
 servers for automatic downloads.
 
+ProGuard files can be managed on the _ProGuard_ section in _Project
+Settings_. This page lists all uploaded files.
+
 ## Learn More
 
 <PageGrid />


### PR DESCRIPTION
Fix #3046

We can't completely remove the support of `debug files` for ProGuard because we still need to support debug files for NDK.
Also, the debug files page tell how to use sentry-cli manually, hence this small change is a quick win instead of moving or duplicating the content around.