### PR TITLE
Fix: Add missing Apple draining example

### DIFF
--- a/src/includes/configuration/drain-example/apple.mdx
+++ b/src/includes/configuration/drain-example/apple.mdx
@@ -1,0 +1,1 @@
+The Apple SDK automatically stores the Sentry events on the device's disk before shutdown.


### PR DESCRIPTION
See Android https://docs.sentry.io/platforms/android/configuration/draining/