### PR TITLE
Add tracesSampleRate comment for prod deploys

### DIFF
--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -35,6 +35,9 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: "___PUBLIC_DSN___",
+  
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
   tracesSampleRate: 1.0,
 });
 
@@ -48,6 +51,9 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: "___PUBLIC_DSN___",
+  
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
   tracesSampleRate: 1.0,
 });
 


### PR DESCRIPTION
Adding the comment telling users to adjust traces sample rate in production. This comment was present only in the performance pages, not on the getting started page. 