### PR TITLE
Adding trace rate comment for prod deploy

### DIFF
--- a/src/wizard/node/awslambda.md
+++ b/src/wizard/node/awslambda.md
@@ -24,6 +24,9 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: "___PUBLIC_DSN___",
+  
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
   tracesSampleRate: 1.0,
 });
 
@@ -37,6 +40,9 @@ const Sentry = require("@sentry/serverless");
 
 Sentry.AWSLambda.init({
   dsn: "___PUBLIC_DSN___",
+  
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
   tracesSampleRate: 1.0,
 });
 


### PR DESCRIPTION
Adding the comment telling users to adjust traces sample rate in production. This comment was present only in the performance pages, not on the instrumentation guide in the Sentry web ui.