### PR TITLE
Fix truncation statement

### DIFF
--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -32,7 +32,7 @@ There are no restrictions for naming contexts or their fields. However, there is
 
 When sending context, _consider payload size limits_. Sentry does not recommend sending the entire application state and large data blobs in contexts. If you exceed the maximum payload size, Sentry will respond with HTTP error `413 Payload Too Large` and reject the event. <PlatformSection supported={["javascript", "node"]}>When `keepalive: true` is used, the request may additionally stay pending forever.</PlatformSection>
 
-The Sentry SDK will try its best to accommodate the data you send and trim large context payloads or truncate them entirely. For more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/data-handling/).
+The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKS can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/data-handling/).
 
 <PlatformSection supported={["javascript", "node"]}>
 


### PR DESCRIPTION
Not all SDKs truncate; this update makes that more clear.