### PR TITLE
ref(JS): Rework JS Loader page

### DIFF
--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -97,6 +97,6 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 ## **Limitations**
 
-Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../perforance/) nor the capturing of any [breadcrumb data]('../../enriching-events/breadcrumbs/') will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
+Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../performance/) nor the capturing of any [breadcrumb data]('../../enriching-events/breadcrumbs/') will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).

--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -97,6 +97,6 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 ## **Limitations**
 
-Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../performance/) nor the capturing of any [breadcrumb data]('../../enriching-events/breadcrumbs/') will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
+Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../performance/) nor the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).

--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -1,19 +1,23 @@
 ---
-title: Lazy Loading Sentry
+title: Lazy-Loading Sentry
 sidebar_order: 10
 redirect_from:
   - /platforms/javascript/loader/
-description: "Learn about the Loader wrapper and how it always has the newest recommended stable version of our SDK, captures all global errors and unhandled promise rejections, and lazy injects our SDK into your website."
+description: "Learn about lazy-loading the Javascript SDK."
 ---
 
-The _Loader_ is a small wrapper around our SDK, which does a few things:
+If you're concerned about the performance impact of loading the full SDK before any of the rest of your JavaScript, you have the option of lazy-loading it - either immediately after your other JavaScript or not until it's needed - by using our SDK _Loader_.
 
-- Always has the newest recommended stable version of our SDK
-- Captures all *global errors* and *unhandled promise* rejections
-- Lazy injects our SDK into your website
-- After you’ve loaded the SDK, the Loader will send everything to Sentry
+The loader is a small wrapper around the SDK, which allows you to:
 
-The loader is less than 1kB gzipped and includes the `Sentry.init` call with your DSN.
+- Postpone full SDK loading - either until immediately after the rest of your JavaScript or until the SDK is needed - without losing the ability to begin catching unhandled errors and promise rejections early in your pageload.
+- Automatically use the latest stable version of the SDK.
+
+The loader is less than 1 KB gzipped and includes the `Sentry.init` call with your DSN.
+
+## Using the Loader
+
+To use the loader, go in the Sentry UI to _Settings -> Projects -> Client Keys (DSN)_, and then press the _Configure_ button. Copy the script tag from the _JavaScript Loader_ section, and include it as the first script on your page. (By including it first, you allow it to catch and buffer events from any subsequent scripts, while still ensuring the full SDK doesn't load until after everything else has run.)
 
 ```html
 <script
@@ -22,39 +26,77 @@ The loader is less than 1kB gzipped and includes the `Sentry.init` call with y
 ></script>
 ```
 
-## Additional Configuration
+## Loader Configuration
 
-In case you want to set additional [options](../../configuration/options/), you have to set them like this:
+The loader has two configuration options:
 
-`onLoad` is a function that only the Loader provides; Loader will call it once it injects the SDK into the website. The Loader `init()` works a bit differently as well; instead of just setting the options, we merge the options internally, only for convenience, so you don’t have to set the `DSN` again because the Loader already contains it.
+- What version of the SDK to load
+- When to load the SDK
 
-As explained, the Loader lazy loads and injects our SDK into your website, but you can also tell the loader to fetch it immediately instead of only fetching it when you need it. Setting `data-lazy` to `no` will tell the Loader to inject the SDK as soon as possible:
+### SDK Version
+
+To configure the version, use the dropdown in the _JavaScript Loader_ settings, directly beneath the script tag you copied earlier.
+
+![JavaScript Loader Settings](js-loader-settings.png)
+
+Note that because of caching, it can take a few minutes for version changes made here to take effect.
+
+### Load Timing
+
+By default, the loader won't load the full SDK until triggered by one of the following:
+
+- an unhandled error
+- an unhandled promise rejection
+- a call to `Sentry.captureMessage`
+- a call to `Sentry.captureEvent`
+
+Once one of those occurs, the loader will buffer that event and immediately request the full SDK from our CDN. Any events that occur between that request being made and the completion of SDK initialization will also be buffered, and all buffered events will be sent to Sentry once the SDK is fully initialized.
+
+Alternatively, you can set the loader to request the full SDK earlier: still as part of page load, but _after_ all of the other JavaScript on the page has run. (In other words, in a subsequent event loop.) To do this, include `data-lazy="no"` in your script tag.
+
+```html
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+  data-lazy="no"
+></script>
+```
+
+Finally, if you want to control the timing yourself, you can call `Sentry.forceLoad()`. You can do this as early as immediately after the loader runs (which has the same effect as setting `data-lazy="no"`) and as late as the first unhandled error, unhandled promise rejection, or call to `Sentry.captureMessage` or `Sentry.captureEvent` (which has the same effect as not calling it at all). Note that you can't delay loading past one of the aforementioned triggering events.
+
+## SDK Configuration
+
+The loader script includes a call to `Sentry.init` with one configuration option: your DSN. If you want to [configure your SDK](../../configuration/options/) beyond that, you'll need a second script tag, in which you'll call `Sentry.onLoad`. This script must come _after_ the main loader script.
+
+```html
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script>
+  Sentry.onLoad(function() { ... });
+</script>
+```
+
+`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set.
 
 ```html
 <script>
   Sentry.onLoad(function() {
-    // Use whatever Sentry.* function you want
+    Sentry.init({
+      release: " ... ",
+      environment: " ... "
+    });
+    Sentry.configureScope(scope => {
+      scope.setTag( ... );
+    });
+    // etc.
   });
-  Sentry.forceLoad();
 </script>
 ```
 
-### SDK Version
+## **Limitations**
 
-Go into the Sentry web UI, view _Settings -> Projects -> Client Keys (DSN)_, then press the **Configure** button. From here, you can view the options to configure your DSN and select which SDK version the Loader should load.
-
-<Note>
-
-It can take a few minutes until the change is visible in the code, since it’s cached.
-
-</Note>
-
-![JavaScript Loader Settings](js-loader-settings.png)
-
-## **Current limitations**
-
-Because we inject our SDK asynchronously, we will only monitor *global errors* and *unhandled promise* for you until the SDK is fully loaded. That means that we might miss breadcrumbs during the download.
-
-For example, a user clicking on a button on your website is making an XHR request. We will not miss any errors, only breadcrumbs and only up until the SDK is fully loaded. You can reduce this time by manually calling `forceLoad` or set `data-lazy="no"`.
+Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../perforance/) nor the capturing of any [breadcrumb data]('../../enriching-events/breadcrumbs/') will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).

--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -97,6 +97,6 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 ## **Limitations**
 
-Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](../../performance/) nor the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
+Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](/product/performance/) nor the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).


### PR DESCRIPTION
A substantial rewrite of the JS Loader page, with the aim of clarifying and being more explicit about what each option does.