### PR TITLE
fix a typo in minidump doc

### DIFF
--- a/src/platforms/native/guides/minidumps/index.mdx
+++ b/src/platforms/native/guides/minidumps/index.mdx
@@ -30,7 +30,7 @@ process. When the process crashes, the minidump is written to the user’s disk
 and can later be uploaded to Sentry. A minidump typically includes:
 
 - The runtime stack of each thread that was active during the time of the crash.
-  This allows yout to reconstruct stack traces for all stacks and even infer
+  This allows you to reconstruct stack traces for all stacks and even infer
   variable values in some cases.
 - Thread contexts -- that is, register values -- at the time of the crash. This
   is especially relevant for stack walking.


### PR DESCRIPTION
I founded a typo `yout`, it need to be corrected to `you` 😊 