### PR TITLE
fix(membership): Remove gratuitous asterisks

### DIFF
--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -21,10 +21,10 @@ including notification and security settings.
 | Can view and act on issues, such as assigning/resolving/etc. |         | X      | X     | X       | X     |
 | Can join and leave teams.                                    |         | X      | X     | X       | X     |
 | Can change Project Settings                                  |         |        | X     | X       | X     |
-| Can add/remove projects\*                                    |         |        | X     | X       | X     |
+| Can add/remove projects.                                     |         |        | X     | X       | X     |
 | Can edit Global Integrations                                 |         |        | X     | X       | X     |
 | Can add/remove/change members                                |         |        |       | X       | X     |
-| Can add/remove teams\*                                       |         |        | X     | X       | X     |
+| Can add/remove teams.                                        |         |        | X     | X       | X     |
 | Can add Repositories                                         |         |        | X     | X       | X     |
 | Can delete Repositories                                      |         |        |       |         | X     |
 | Can change Organization Settings                             |         |        |       | X       | X     |

--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -19,12 +19,12 @@ including notification and security settings.
 | ------------------------------------------------------------ | ------- | ------ | ----- | ------- | ----- |
 | Can see/edit billing information and subscription details    | X       |        |       |         | X     |
 | Can view and act on issues, such as assigning/resolving/etc. |         | X      | X     | X       | X     |
-| Can join and leave teams.                                    |         | X      | X     | X       | X     |
+| Can join and leave teams                                     |         | X      | X     | X       | X     |
 | Can change Project Settings                                  |         |        | X     | X       | X     |
-| Can add/remove projects.                                     |         |        | X     | X       | X     |
+| Can add/remove projects                                      |         |        | X     | X       | X     |
 | Can edit Global Integrations                                 |         |        | X     | X       | X     |
 | Can add/remove/change members                                |         |        |       | X       | X     |
-| Can add/remove teams.                                        |         |        | X     | X       | X     |
+| Can add/remove teams                                         |         |        | X     | X       | X     |
 | Can add Repositories                                         |         |        | X     | X       | X     |
 | Can delete Repositories                                      |         |        |       |         | X     |
 | Can change Organization Settings                             |         |        |       | X       | X     |


### PR DESCRIPTION
These asterisks are either a formatting issue or linked to some long lost footnotes that are no longer on the page. This PR removes them