### PR TITLE
Add documentation for Offline integration

### DIFF
--- a/src/includes/configuration/offline/javascript.mdx
+++ b/src/includes/configuration/offline/javascript.mdx
@@ -1,0 +1,38 @@
+```javascript {tabTitle: JavaScript}
+import * as Sentry from "@sentry/browser";
+import { Offline as OfflineIntegration } from "@sentry/integrations";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new OfflineIntegration(
+    {
+      // limit how many events will be localled saved. Defaults to 30.
+      maxStoredEvents: number;
+    }
+  )],
+});
+```
+
+```jsx {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/offline.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'offline.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Offline(
+    {
+      // limit how many events will be localled saved. Defaults to 30.
+      maxStoredEvents: number;
+    }
+  )],
+});
+```

--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -58,7 +58,7 @@ _Import name: `Sentry.Integrations.Offline`_
 
 This integration uses the web browser's [online and offline events](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events) to detect when no network connectivity is available. If offline, it saves events to the web browser's client-side storage (typically IndexedDB) then automatically uploads events when network connectivity is restored.
 
-This plugin does not attempt to provide local storage or retries for other scenarios; for example, if the browser has a local area connection but no Internet connection, then it may report that it's online, and Sentry's `Offline` plugin will not attempt to save or retry any send failures in this case.
+This plugin does not attempt to provide local storage or retries for other scenarios. For example, if the browser has a local area connection but no internet connection, then it may report that it's online, and Sentry's `Offline` plugin will not attempt to save or retry any send failures in this case.
 
 <PlatformContent includePath="configuration/offline" />
 

--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pluggable Integrations
-description: "Learn more about pluggable integrations `ExtraErrorData`, `CaptureConsole`, `Dedupe`, `Debug`, `RewriteFrames`, `ReportingObserver`, which are snippets of code that augment functionality for specific applications and/or frameworks."
+description: "Learn more about pluggable integrations ExtraErrorData, CaptureConsole, Dedupe, Debug, Offline, RewriteFrames, and ReportingObserver, which are snippets of code that augment functionality for specific applications and/or frameworks."
 redirect_from:
   - /platforms/javascript/integrations/plugin/
   - /platforms/javascript/pluggable-integrations/
@@ -25,7 +25,6 @@ This integration extracts all non-native attributes from the Error object and at
 Available options:
 
 <PlatformContent includePath="configuration/extra-error-data" />
-
 
 ### CaptureConsole
 
@@ -52,6 +51,16 @@ This integration allows you to inspect the content of the processed event, that 
 Available options:
 
 <PlatformContent includePath="configuration/debug" />
+
+### Offline
+
+_Import name: `Sentry.Integrations.Offline`_
+
+This integration uses the web browser's [online and offline events](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events) to detect when no network connectivity is available. If offline, it saves events to the web browser's client-side storage (typically IndexedDB) then automatically uploads events when network connectivity is restored.
+
+This plugin does not attempt to provide local storage or retries for other scenarios; for example, if the browser has a local area connection but no Internet connection, then it may report that it's online, and Sentry's `Offline` plugin will not attempt to save or retry any send failures in this case.
+
+<PlatformContent includePath="configuration/offline" />
 
 ### RewriteFrames
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry-javascript/pull/2778

Remove backticks from plugin.mdx's description; PageGrid doesn't render them as monospace, so they appear as literals in the [index page](https://docs.sentry.io/platforms/javascript/configuration/integrations/), and the default.mdx description doesn't use them for its class names.