### PR TITLE
fixing broken links to help center

### DIFF
--- a/src/docs/support/index.mdx
+++ b/src/docs/support/index.mdx
@@ -6,7 +6,7 @@ description: "As a paying customer of Sentry, you have access to various forms o
 
 As a paying customer of Sentry, you have access to various forms of support; and if you are using the Open Source version, you can get in contact with the Sentry community for questions. All Sentry repositories can be found on [GitHub](https://github.com/getsentry).
 
-If you're unable to find the answer in our documentation, you can also check out our [Help Center](https://help.sentry.io/hc/en-us) for commonly asked questions.
+If you're unable to find the answer in our documentation, you can also check out our [Help Center](https://help.sentry.io/) for commonly asked questions.
 
 ## System Status
 
@@ -16,10 +16,10 @@ The availability of the Sentry cloud hosted installation is independently monito
 
 We offer community support through [forum.sentry.io](https://forum.sentry.io/). This is a great place to provide product feedback, get help and advice with various issues, as well as to take part in the larger Sentry community.
 
-You can also find answers to commonly asked questions in our [Help Center](https://help.sentry.io/hc/en-us).
+You can also find answers to commonly asked questions in our [Help Center](https://help.sentry.io/).
 
 If you’re looking for support on a specific SDK, check the documentation specific to that SDK. Several SDKs are maintained by the Sentry team, whereas others are not. Nearly every SDK also has its own bug tracker, which is generally where the code lives (i.e. on GitHub).
 
 ## Paid Support
 
-If you're a paid customer, you can contact support from within your Sentry organization. This can be found by clicking on the "Help" button on the bottom left. We suggest reserving that for actual problems with the service, and when possible referring to our documentation, [Help Center](https://help.sentry.io/hc/en-us), and community support.
+If you're a paid customer, you can contact support from within your Sentry organization. This can be found by clicking on the "Help" button on the bottom left. We suggest reserving that for actual problems with the service, and when possible referring to our documentation, [Help Center](https://help.sentry.io/), and community support.


### PR DESCRIPTION
Fixed broken links to Help Center from docs Support page.