### PR TITLE
fix: Split react native install code blocks

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -16,13 +16,17 @@ If you are using Expo, see [How to Add Sentry to Your Expo Project](https://docs
 
 ### Linking
 
-Link the SDK to your native projects to enable native crash reporting. If you are running a project with `react-native` < 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` >=0.60 does this automatically.
+Link the SDK to your native projects to enable native crash reporting.
 
 ```bash
 react-native link @sentry/react-native
 ```
 
-```NPX
+<Note>
+If you are running a project with `react-native` < 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` >=0.60 does this automatically.
+</Note>
+
+```npx
 npx @sentry/wizard -i reactNative -p ios android
 
 cd ios

--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -23,7 +23,9 @@ react-native link @sentry/react-native
 ```
 
 <Note>
-If you are running a project with `react-native` < 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` >=0.60 does this automatically.
+
+If you are running a project with `react-native` prior to 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` version 0.60 and above does this automatically.
+
 </Note>
 
 ```npx


### PR DESCRIPTION
RN >= does not need to run the link step