### PR TITLE
Fix NLog DSN Constructor documentation

### DIFF
--- a/src/platforms/dotnet/guides/nlog/index.mdx
+++ b/src/platforms/dotnet/guides/nlog/index.mdx
@@ -75,7 +75,7 @@ LogManager.Configuration
     .AddSentry(o =>
     {
         // The NLog integration will initialize the SDK if DSN is set:
-        o.Dsn = new Dsn("___PUBLIC_DSN___"));
+        o.Dsn = "___PUBLIC_DSN___";
     });
 ```
 


### PR DESCRIPTION
Release 3.x of the .NET SDK changes DSN to take a string instead of object - update NLog docs accordingly