### PR TITLE
fix: Use correct fastlane command

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -19,7 +19,7 @@ Use the [Fastlane](https://github.com/fastlane/fastlane) action, _download_dsyms
 ```ruby
 lane :upload_symbols do
   download_dsyms # this is the important part
-  upload_symbols_to_sentry(
+  sentry_upload_dsym(
     auth_token: 'YOUR_AUTH_TOKEN',
     org_slug: '___ORG_SLUG___',
     project_slug: '___PROJECT_SLUG___',
@@ -71,7 +71,7 @@ If you are already using Fastlane you can use it in this situation as well:
 ```ruby
 lane :build do
   gym # building your app
-  upload_symbols_to_sentry(
+  sentry_upload_dsym(
     auth_token: 'YOUR_AUTH_TOKEN',
     org_slug: '___ORG_SLUG___',
     project_slug: '___PROJECT_SLUG___',


### PR DESCRIPTION
`upload_symbols_to_sentry` doesn't exist, it's called `sentry_upload_dsym`
ref: https://github.com/getsentry/sentry-fastlane-plugin#uploading-symbolication-files