### PR TITLE
fix: Correct a small typo

### DIFF
--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -66,7 +66,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler((event, context, callback) => {
 
 ## Enable Timeout Warning
 
-Sentry reports timeout warning when the function is within 500ms of it's execution time. You can turn off timeout warnings by setting `captureTimeoutWarning` to `false` in the handler options. To change timeout warning limit, assign a numeric value (in ms) to `timeoutWarningLimit`
+Sentry reports timeout warning when the function is within 500ms of its execution time. You can turn off timeout warnings by setting `captureTimeoutWarning` to `false` in the handler options. To change timeout warning limit, assign a numeric value (in ms) to `timeoutWarningLimit`
 
 ```javascript {tabTitle:captureTimeoutWarning}
 exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, {


### PR DESCRIPTION
Hi,

This fixes a small typo to make the use of "its" possessive, instead of a contraction.