### PR TITLE
fix(tracing): Fix dangling modifiers

### DIFF
--- a/src/includes/performance/enable-automatic-instrumentation/javascript.mdx
+++ b/src/includes/performance/enable-automatic-instrumentation/javascript.mdx
@@ -1,4 +1,4 @@
-After configuration, you will see both `pageload` and `navigation` when viewing transactions in sentry.io.
+After configuration, you will see both `pageload` and `navigation` transactions in sentry.io.
 
 ```javascript {tabTitle: ESM}
 // If you're using one of our integration packages, like `@sentry/react` or `@sentry/angular`,


### PR DESCRIPTION
They were adjectives in search of a noun. They were lonely. It was sad. Now it's fixed.