### PR TITLE
Fix WordPress casing

### DIFF
--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -31,7 +31,7 @@ These SDKs are maintained and supported by [the Sentry community](https://forum.
 - [_OCaml_](https://github.com/brendanlong/sentry-ocaml)
 - [_Scrapy_](https://github.com/llonchj/scrapy-sentry)
 - [_Terraform_](https://github.com/jianyuan/terraform-provider-sentry)
-- [_Wordpress_](https://github.com/stayallive/wp-sentry)
+- [_WordPress_](https://github.com/stayallive/wp-sentry)
 
 ## Other platforms
 


### PR DESCRIPTION
It's WordPress not Wordpress (sorry for the nitpicky fix).