### PR TITLE
feat: Update RN included instrumentation performance docs

### DIFF
--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -4,6 +4,78 @@ sidebar_order: 100
 description: "Learn about migrating from 1.x to 2.x to enable release health tracking and native stack traces by default."
 ---
 
+## React Navigation Instrumentation from <2.3.0
+
+We changed the initialization method for the React Navigation V5 routing instrumentation to avoid a potential issue when using linking. You now register the navigation container inside the `onReady` prop passed to the `NavigationContainer`.
+
+From:
+
+```javascript
+// Old Functional Component Example
+const App = () => {
+  const navigation = React.useRef();
+
+  React.useEffect(() => {
+    routingInstrumentation.registerNavigationContainer(navigation);
+  }, []);
+
+  return <NavigationContainer ref={navigation}>...</NavigationContainer>;
+};
+
+// Old Class Component Example
+class App extends React.Component {
+  navigation = React.createRef();
+
+  componentDidMount() {
+    routingInstrumentation.registerNavigationContainer(navigation);
+  }
+
+  render() {
+    return <NavigationContainer ref={this.navigation}>...</NavigationContainer>;
+  }
+}
+```
+
+To:
+
+```javascript
+// Functional Component Example
+const App = () => {
+  const navigation = React.useRef();
+
+  return (
+    <NavigationContainer
+      ref={navigation}
+      onReady={() => {
+        // Register the navigation container with the instrumentation inside onReady
+        routingInstrumentation.registerNavigationContainer(navigation);
+      }}
+    >
+      ...
+    </NavigationContainer>
+  );
+};
+
+// Class Component Example
+class App extends React.Component {
+  navigation = React.createRef();
+
+  render() {
+    return (
+      <NavigationContainer
+        ref={this.navigation}
+        onReady={() => {
+          // Register the navigation container with the instrumentation inside onReady
+          routingInstrumentation.registerNavigationContainer(navigation);
+        }}
+      >
+        ...
+      </NavigationContainer>
+    );
+  }
+}
+```
+
 ## From 1.x to 2.x
 
 Sentry's most recent version of our React Native SDK enables release health tracking and native stack traces by default.

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -300,12 +300,35 @@ We export the React Profiler from our React Native SDK as well, you can read mor
 
 After you instrument your app's routing, if you wrap a component that renders on one of the routes with `withProfiler`, you will be able to track the component's lifecycle as a child span of the route transaction.
 
-```javascript
+```javascript {tabTitle: Higher Order Component}
 import * as Sentry from "@sentry/react-native";
 
+// withProfiler HOC
 const SomeComponent = () => {
   // ...
 };
 
 export default Sentry.withProfiler(SomeComponent);
+```
+
+```javascript {tabTitle: Parent Component}
+// Profiler parent
+const SomeComponent = () => {
+  return (
+    <Sentry.Profiler name="SomeChild">
+      <SomeChild />
+    </Sentry.Profiler>
+  );
+};
+```
+
+```javascript {tabTitle: Hook}
+// useProfiler hook
+const SomeComponent = () => {
+  Sentry.useProfiler("SomeComponent");
+
+  return (
+    //...
+  )
+}
 ```

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -114,16 +114,16 @@ Sentry.init({
 // Functional Component Example
 const App = () => {
   // Create a ref for the navigation container
-  const navigation = React.createRef();
-
-  // Register the navigation container with the instrumentation
-  React.useEffect(() => {
-    routingInstrumentation.registerNavigationContainer(navigation);
-  }, []);
+  const navigation = React.useRef();
 
   return (
     // Connect the ref to the navigation container
-    <NavigationContainer ref={navigation}>
+    <NavigationContainer
+      ref={navigation}
+      onReady={() => {
+        // Register the navigation container with the instrumentation
+        routingInstrumentation.registerNavigationContainer(navigation);
+      }}>
       ...
     </NavigationContainer>
   );
@@ -134,15 +134,15 @@ class App extends React.Component {
   // Create a ref for the navigation container
   navigation = React.createRef();
 
-  componentDidMount() {
-    // Register the navigation container with the instrumentation
-    routingInstrumentation.registerNavigationContainer(navigation);
-  }
-
   render() {
     return (
       // Connect the ref to the navigation container
-      <NavigationContainer ref={this.navigation}>
+      <NavigationContainer
+        ref={this.navigation}
+        onReady={() => {
+          // Register the navigation container with the instrumentation
+          routingInstrumentation.registerNavigationContainer(navigation);
+        }}>
         ...
       </NavigationContainer>
     )
@@ -172,7 +172,7 @@ Sentry.init({
 // Functional Component Example
 const App = () => {
   // Create a ref for the navigation container
-  const appContainer = React.createRef();
+  const appContainer = React.useRef();
 
   // Register the navigation container with the instrumentation
   React.useEffect(() => {
@@ -192,13 +192,13 @@ class App extends React.Component {
 
   componentDidMount() {
     // Register the navigation container with the instrumentation
-    routingInstrumentation.registerAppContainer(appContainer);
+    routingInstrumentation.registerAppContainer(this.appContainer);
   }
 
   render() {
     return (
       // Connect the ref to the navigation container
-      <AppContainer ref={appContainer} />
+      <AppContainer ref={this.appContainer} />
     )
   }
 }

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -92,6 +92,12 @@ We currently provide two routing instrumentations out of the box to instrument r
 
 ### React Navigation V5
 
+<Note>
+
+If you are coming from a version prior to 2.3.0, make sure you update where `registerNavigationContainer` is called. You can find the instructions on [our migration guide](/platforms/react-native/migration/#react-navigation-instrumentation-from-230).
+
+</Note>
+
 Note that this routing instrumentation will create a transaction on every route change including `goBack` navigations.
 
 ```javascript

--- a/src/platforms/react-native/performance/included-instrumentation.mdx
+++ b/src/platforms/react-native/performance/included-instrumentation.mdx
@@ -150,6 +150,18 @@ class App extends React.Component {
 }
 ```
 
+#### Configuration
+
+You can configure the instrumentation by passing an options object to the constructor:
+
+```javascript
+new Sentry.ReactNavigationV5Instrumentation({ ... });
+```
+
+##### routeChangeTimeoutMs
+
+How long the instrumentation will wait for the route to mount after a change has been initiated before the transaction is discarded. Default: 1000ms
+
 ### React Navigation V4
 
 Note that this routing instrumentation will create a transaction on every route change including `goBack` navigations.
@@ -203,6 +215,18 @@ class App extends React.Component {
   }
 }
 ```
+
+#### Configuration
+
+You can configure the instrumentation by passing an options object to the constructor:
+
+```javascript
+new Sentry.ReactNavigationV4Instrumentation({ ... });
+```
+
+##### routeChangeTimeoutMs
+
+How long the instrumentation will wait for the **initial** route to mount after a change has been initiated before the transaction is discarded. Default: 1000ms
 
 ### Other Routing Libraries or Custom Routing Implementations
 


### PR DESCRIPTION


1. Fixes the routing instrumentation initialization method. Previous method of initialization caused issues: https://github.com/getsentry/sentry-react-native/issues/1361
2. Documentation on the new configuration option: https://github.com/getsentry/sentry-react-native/pull/1370
3. Examples of `Profiler` and `useProfiler`. https://github.com/getsentry/sentry-react-native/pull/1372
<img width="770" alt="Screen Shot 2021-03-10 at 8 39 29 PM" src="https://user-images.githubusercontent.com/30991498/110638119-bc7e8e00-81e0-11eb-9e8d-0239ac5a8394.png">
 Maybe we should document this over in the React package too? Only `withProfiler` is documented.