### PR TITLE
Dart/Flutter now supports SentryOptions.sendDefaultPii

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -115,7 +115,7 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
-<ConfigKey name="send-default-pii" supported={["apple", "dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust"]}>
+<ConfigKey name="send-default-pii" supported={["apple", "dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust", "dart"]}>
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 


### PR DESCRIPTION
See [this PR](https://github.com/getsentry/sentry-dart/pull/360).