### PR TITLE
Feat: move other guides to sidebar

### DIFF
--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -113,7 +113,9 @@ export default ({
               <Banner isModule={true} />
               <React.Fragment>
                 {prependToc}
-                {hasToc && <WrappedTOC ref={contentRef} />}
+                {hasToc && (
+                  <WrappedTOC ref={contentRef} pageContext={pageContext} />
+                )}
               </React.Fragment>
             </div>
           </div>

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -30,8 +30,23 @@ const GitHubCTA = ({
   </div>
 );
 
+export type PageContext = {
+  title?: string;
+  description?: string;
+  excerpt?: string;
+  noindex?: boolean;
+  notoc?: boolean;
+  platform?: {
+    name: string;
+  };
+};
+
+type WrappedTOCProps = {
+  pageContext: PageContext;
+};
+
 const WrappedTOC = React.forwardRef(
-  (props, ref: React.RefObject<HTMLDivElement>) => {
+  (props: WrappedTOCProps, ref: React.RefObject<HTMLDivElement>) => {
     return <TableOfContents {...props} contentRef={ref} />;
   }
 );

--- a/src/components/guideGrid.tsx
+++ b/src/components/guideGrid.tsx
@@ -6,9 +6,10 @@ import usePlatform, { Platform } from "./hooks/usePlatform";
 
 type Props = {
   platform?: string;
+  className?: string;
 };
 
-export default ({ platform }: Props): JSX.Element => {
+export default ({ platform, className }: Props): JSX.Element => {
   const [currentPlatform] = usePlatform(platform);
   // platform might actually not be a platform, so lets handle that case gracefully
   if (!(currentPlatform as Platform).guides) {
@@ -16,7 +17,7 @@ export default ({ platform }: Props): JSX.Element => {
   }
 
   return (
-    <ul>
+    <ul className={className}>
       {(currentPlatform as Platform).guides.map(guide => (
         <li key={guide.key}>
           <SmartLink to={guide.url}>

--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -253,7 +253,7 @@ export default (
     location
   );
   let currentValue: string | null =
-    value || valueFromLocation ? valueFromLocation.join(".") : null;
+    value || (valueFromLocation ? valueFromLocation.join(".") : null);
 
   if (!currentValue && !isFixed && useStoredValue) {
     currentValue = storedValue;

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -100,18 +100,6 @@ export const PlatformSidebar = ({
         tree={tree}
       />
       <DynamicNav
-        root={`/platforms/${platformName}/guides`}
-        title="Other Guides"
-        prependLinks={
-          guideName ? [[`/platforms/${platformName}/`, platform.title]] : null
-        }
-        exclude={
-          guideName ? [`/platforms/${platformName}/guides/${guideName}/`] : []
-        }
-        suppressMissing
-        tree={tree}
-      />
-      <DynamicNav
         root="platforms"
         title="Other Platforms"
         tree={tree}

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import * as Sentry from "@sentry/gatsby";
 import GuideGrid from "./guideGrid";
+import { PageContext } from "./basePage";
 
 type Item = {
   title?: string;
@@ -57,11 +58,7 @@ const getHeadings = (element: HTMLElement): Item[] => {
 
 type Props = {
   contentRef: React.RefObject<HTMLElement>;
-  pageContext?: {
-    platform?: {
-      name: string;
-    };
-  };
+  pageContext?: PageContext;
 };
 
 export default ({ contentRef, pageContext }: Props) => {

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -98,7 +98,7 @@ export default ({ contentRef, pageContext }: Props) => {
       </div>
       <ul className="section-nav">{recurse(items)}</ul>
       <div className="doc-toc-title">
-        <h6>Other Guides</h6>
+        <h6>Related Guides</h6>
       </div>
       <GuideGrid platform={platform.name} className="section-nav" />
     </div>

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import * as Sentry from "@sentry/gatsby";
+import GuideGrid from "./guideGrid";
 
 type Item = {
   title?: string;
@@ -56,10 +57,16 @@ const getHeadings = (element: HTMLElement): Item[] => {
 
 type Props = {
   contentRef: React.RefObject<HTMLElement>;
+  pageContext?: {
+    platform?: {
+      name: string;
+    };
+  };
 };
 
-export default ({ contentRef }: Props) => {
+export default ({ contentRef, pageContext }: Props) => {
   const [items, setItems] = useState<Item[]>(null);
+  const { platform } = pageContext;
 
   useEffect(() => {
     if (!items && contentRef.current) {
@@ -90,6 +97,10 @@ export default ({ contentRef }: Props) => {
         <h6>On this page</h6>
       </div>
       <ul className="section-nav">{recurse(items)}</ul>
+      <div className="doc-toc-title">
+        <h6>Other Guides</h6>
+      </div>
+      <GuideGrid platform={platform.name} className="section-nav" />
     </div>
   );
 };


### PR DESCRIPTION
At @PeloWriter's behest, I've moved "Other guides" from the left sidebar, to the right.

We had discussed also removing the list from the body of the guides, but that is a potentially dogmatic change that is easy enough for the content team to handle themselves if they would like to do it.

This PR is dependent on #3249 where I had to fix a bug to make `usePlatform` work.

<img width="1494" alt="JavaScript | Sentry Documentation 2021-03-15 16-27-42" src="https://user-images.githubusercontent.com/72919/111234331-8c056e00-85ab-11eb-95cc-42f1d28038be.png">
