### PR TITLE
Add video components

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -22,6 +22,7 @@ import PlatformLink from "./platformLink";
 import PlatformSection from "./platformSection";
 import PlatformIdentifier from "./platformIdentifier";
 import RelayMetrics from "./relayMetrics";
+import { VimeoEmbed, YouTubeEmbed } from "./video";
 
 const mdxComponents = {
   Alert,
@@ -43,6 +44,8 @@ const mdxComponents = {
   PlatformIdentifier,
   RelayMetrics,
   LambdaLayerDetail,
+  VimeoEmbed,
+  YouTubeEmbed,
 };
 
 export default ({ value }) => {

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+type Video = {
+  id: string;
+  className?: string;
+};
+
+const ResponsiveEmbed = styled.div`
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  margin-bottom: 1rem;
+
+  &:before {
+    content: "";
+    display: block;
+    padding-top: 56.25%;
+  }
+`;
+
+export const VimeoEmbed = ({ id, className }: Video) => (
+  <ResponsiveEmbed className={className}>
+    <StyledVimeoIframe
+      src={`https://player.vimeo.com/video/${id}`}
+      frameBorder="0"
+      allowFullScreen
+    />
+  </ResponsiveEmbed>
+);
+
+const StyledVimeoIframe = styled.iframe`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+`;
+
+export const YouTubeEmbed = ({ id, className }: Video) => (
+  <ResponsiveEmbed className={className}>
+    <StyledYouTubeIframe
+      src={`https://www.youtube-nocookie.com/embed/${id}?rel=0`}
+      frameBorder="0"
+      allowFullScreen
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+    />
+  </ResponsiveEmbed>
+);
+
+const StyledYouTubeIframe = styled.iframe`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+`;


### PR DESCRIPTION
At @PeloWriter's behest, this adds video components to MDX docs. There are currently no instances of them in use.

```html
<VimeoEmbed id="375329202" />
<YouTubeEmbed id="cp2U0E3dpO4" />
```