### PR TITLE
Move framework list off common as it's in the RH sidebar

### DIFF
--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -8,8 +8,6 @@ If you don't already have an account and Sentry project established, head over t
 
 </Note>
 
-<PlatformContent includePath="framework-list" notSupported={["react-native"]}/>
-
 ## Install
 
 Sentry captures data by using an SDK within your application’s runtime.


### PR DESCRIPTION
We are adjusting the Getting Started page to ensure users can access related guides more efficiently, thus they don't need to be listed only on the primary platform page.