### PR TITLE
fix(apple): Hide hints in configuration / filtering

### DIFF
--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -25,6 +25,8 @@ All Sentry SDKs support the `beforeSend` callback method. `beforeSend` is called
 
 Note also that breadcrumbs can be filtered, as discussed in [our Breadcrumbs documentation](/product/error-monitoring/breadcrumbs/).
 
+<PlatformSection notSupported={["apple"]}>
+
 #### Event Hints
 
 The `before-send` callback is passed both the `event` and a second argument, `hint`, that holds one or more hints.
@@ -35,7 +37,9 @@ Typically a `hint` holds the original exception so that additional data can be e
 
 When the SDK creates an event or breadcrumb for transmission, that transmission is typically created from some sort of source object. For instance, an error event is typically created from a log record or exception instance. For better customization, SDKs send these objects to certain callbacks (`beforeSend`, `beforeBreadcrumb` or the event processor system in the SDK).
 
-<PlatformSection notSupported={["native"]}>
+</PlatformSection>
+
+<PlatformSection notSupported={["native", "apple" ]}>
 
 ### Using Hints
 


### PR DESCRIPTION
Hide hins in the filtering section because the Apple SDK doesn't support them.