### PR TITLE
ci(stalebot): Add new triage labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           debug-only: false
           ascending: false
 
-          exempt-issue-labels: "Status: Accepted,Status: On Hold"
+          exempt-issue-labels: "Status: Accepted,Status: On Hold,Status: Backlog,Status: In Progress"
           stale-issue-label: "Status: Stale"
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
@@ -32,7 +32,7 @@ jobs:
           close-issue-label: ""
           close-issue-message: ""
 
-          exempt-pr-labels: "Status: Accepted,Status: On Hold"
+          exempt-pr-labels: "Status: Accepted,Status: On Hold,Status: Backlog,Status: In Progress"
           stale-pr-label: "Status: Stale"
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.


### PR DESCRIPTION
This PR adds the 2 new triage labels to replace old ones:

1. `Status: Accepted` -> `Status: In Progress`
2. `Status: On Hold` -> `Status: Backlog`
