### PR TITLE
fix(apple): Copy bash code missing character

### DIFF
--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -119,7 +119,9 @@ fi
 
 3.  If you are using Xcode 10 or newer, you also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
 
-```bash
+[//]: # (Don't use bash here. Clicking the copy button on the code sample with bash)
+[//]: # (removes the leading $.)
+```text
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -114,7 +114,9 @@ fi
 
 3.  If you are using Xcode 10 or newer, you also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
 
-```bash
+[//]: # (Don't use bash here. Clicking the copy button on the code sample with bash)
+[//]: # (removes the leading $.)
+```text
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 


### PR DESCRIPTION
Copying the bash code for uploading dSYMs via the copy button
removed the leading $. This is fixed now by using text instead.

Fixes GH-2893