### PR TITLE
fix(tracing): Fix wording about sample rate

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -70,7 +70,7 @@ Once testing is complete, **we recommend lowering this value in production** by 
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
-Without setting a sample rate, included instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
+Leaving the sample rate at `1.0` means that included instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
 
 </PlatformSection>
 


### PR DESCRIPTION
If you don't set a sample rate (or use the `tracesSampler`, then in fact _no_ transactions will be sent, because tracing will be off entirely. That's clearly not what we mean.