### PR TITLE
Fix "exmaple" typo's in 2 locations

### DIFF
--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -52,7 +52,7 @@ const DEFAULTS: CodeKeywords = {
       PROJECT_ID: 0,
       PROJECT_SLUG: "example-project",
       ORG_ID: 0,
-      ORG_SLUG: "exmaple-org",
+      ORG_SLUG: "example-org",
       ORG_INGEST_DOMAIN: "o0.ingest.sentry.io",
       MINIDUMP_URL:
         "https://o0.ingest.sentry.io/api/0/minidump/?sentry_key=examplePublicKey",

--- a/src/includes/configure-scope/rust.mdx
+++ b/src/includes/configure-scope/rust.mdx
@@ -5,7 +5,7 @@ configure_scope(|scope| {
     scope.set_tag("my-tag", "my value");
     scope.set_user(Some(User {
         id: Some(42.to_string()),
-        email: Some("john.doe@exmaple.com".into()),
+        email: Some("john.doe@example.com".into()),
         ..Default::default()
     }));
 });


### PR DESCRIPTION
The initial typo was found on [this page](https://docs.sentry.io/platforms/javascript/sourcemaps/) of the documentation.
After searching through the repository I found another typo, also "exmaple".

This PR fixes both typo's.