### PR TITLE
Simplify Ruby's before_send example

### DIFF
--- a/src/includes/configuration/before-send/ruby.mdx
+++ b/src/includes/configuration/before-send/ruby.mdx
@@ -2,13 +2,8 @@
 Sentry.init do |config|
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda do |event, hint|
-    request = event.request
-
-    if request
-      request.data = filter.filter(request.data)
-    end
-
-    event
+    # use Rails' parameter filter to senitize the event
+    filter.filter(event.to_hash)
   end
 end
 ```

--- a/src/includes/configuration/before-send/ruby.mdx
+++ b/src/includes/configuration/before-send/ruby.mdx
@@ -2,7 +2,7 @@
 Sentry.init do |config|
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda do |event, hint|
-    # use Rails' parameter filter to senitize the event
+    # use Rails' parameter filter to sanitize the event
     filter.filter(event.to_hash)
   end
 end


### PR DESCRIPTION
Users can filter the entire event payload with Rails' parameter filter, which would make things a lot simpler.