### PR TITLE
Fix the set-user scope example in Dart

### DIFF
--- a/src/includes/set-user/dart.mdx
+++ b/src/includes/set-user/dart.mdx
@@ -2,6 +2,6 @@
 import 'package:sentry/sentry.dart';
 
 Sentry.configureScope(
-  (scope) => scope.user = User(id: "1234", email: 'jane.doe@example.com'),
+  (scope) => scope.user = User(id: '1234', email: 'jane.doe@example.com'),
 );
 ```

--- a/src/includes/set-user/dart.mdx
+++ b/src/includes/set-user/dart.mdx
@@ -2,6 +2,6 @@
 import 'package:sentry/sentry.dart';
 
 Sentry.configureScope(
-  (scope) => scope.user = User(id: 1234, email: 'jane.doe@example.com'),
+  (scope) => scope.user = User(id: "1234", email: 'jane.doe@example.com'),
 );
 ```


### PR DESCRIPTION
This is how the set-user scope example looks right now:

```dart
import 'package:sentry/sentry.dart';

Sentry.configureScope(
  (scope) => scope.user = User(id: 1234, email: 'jane.doe@example.com'),
);
```

But `User.id` is a String, so there are missing quotation marks around `1234`.
How it should look:
```dart
import 'package:sentry/sentry.dart';

Sentry.configureScope(
  (scope) => scope.user = User(id: "1234", email: 'jane.doe@example.com'),
);
```

 #3244 may be related.