### PR TITLE
Remove EA note

### DIFF
--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -8,14 +8,6 @@ redirect_from:
 description: "Sentry's Dashboards provide a single view of your application's health, including the ability to navigate issues and performance across multiple projects."
 ---
 
-<Note>
-
-Dashboards are available only if you're in the Early Adopter program. Features available to Early Adopters are still in progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 Dashboards provide you with a broad overview of your application’s health by allowing you to navigate through error and performance data across multiple projects. Dashboards are made up of one or more widgets, and each widget visualizes one or more [Discover queries](/product/discover-queries/).
 
 ![Widgets visualizing events, errors by country, affected users, and handled vs unhandled issues.](dashboard_default.png)


### PR DESCRIPTION
Dashboards is now GA; EA note is no longer applicable.