### PR TITLE
feat(apple): Add AutoSessionTrackingIntegration

### DIFF
--- a/src/platforms/apple/common/configuration/integrations/default.mdx
+++ b/src/platforms/apple/common/configuration/integrations/default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Default Integrations
-description: "Learn more about SentryCrashIntegration, SentryAutoBreadcrumbTrackingIntegration, and SentryAutoSessionTrackingIntegration that are enabled by default."
+description: "Learn more about the SentryCrashIntegration, SentryAutoBreadcrumbTrackingIntegration, and SentryAutoSessionTrackingIntegration, which are enabled by default."
 ---
 
 All of Sentry’s SDKs provide integrations, which extend functionality of the SDK.

--- a/src/platforms/apple/common/configuration/integrations/default.mdx
+++ b/src/platforms/apple/common/configuration/integrations/default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Default Integrations
-description: "Learn more about SentryCrashIntegration and SentryAutoBreadcrumbTrackingIntegration that are enabled by default."
+description: "Learn more about SentryCrashIntegration, SentryAutoBreadcrumbTrackingIntegration, and SentryAutoSessionTrackingIntegration that are enabled by default."
 ---
 
 All of Sentry’s SDKs provide integrations, which extend functionality of the SDK.
@@ -14,6 +14,11 @@ This integration is the core part of the SDK. It hooks into all signal and excep
 ### SentryAutoBreadcrumbTrackingIntegration
 
 This integration will swizzle some methods to create breadcrumbs. For example, for `UIApplicationDidReceiveMemoryWarningNotification`, `sendAction:to:from:forEvent:` (UI interactions) or `viewDidAppear:` those breadcrumbs will be attached to your events.
+
+### SentryAutoSessionTrackingIntegration
+
+This integration registers for lifecycle notifications and automatically starts and ends sessions required for [Release Health](/product/releases/health/#session).
+
 
 ## Disable an Integration
 


### PR DESCRIPTION
The SentryAutoSessionTrackingIntegration was missing in the list of
integrations. This is fixed now.

Fixes GH-3276