### PR TITLE
ref(azure): Change usage of bold, add final step for successful login

### DIFF
--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -26,7 +26,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Navigate back to **Overview**, click on "2. Set up single sign-on" and then select SAML as your single sign-on method.
 
-1. For Section (1) labeled as "Basic SAML Configuration", enter the following data in each line and save your changes.
+1. For Section (1), labeled "Basic SAML Configuration", enter the following data in each line and save your changes.
 
    - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/`
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -48,7 +48,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Paste the App Federation Metadata URL from above and click "Get Metadata".
 
-1. In the following page, enter these to map the attributes from AzureAD to Sentry and save them.
+1. In the next page, enter the following keys in their respective fields to map the attributes from AzureAD to Sentry, and then save them.
 
     - IdP User ID: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -8,7 +8,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Log in to the [Azure portal](https://portal.azure.com/).
 
-1. Under "Manage Azure Active Directory" (the shield picture), click **View**, which takes you to the "Organization Overview" page.
+1. Under "Manage Azure Active Directory" (the picture of the shield), click "View". This takes you to the **Organization Overview** page.
 
 1. If you don't require a permission group for Sentry, skip to Step 5.
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -40,7 +40,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    ![SAML Configuration](azure-basic-saml-configuration.png)
 
-1. In Section (3) labeled as "SAML Signing Certificate", copy the **App Federation Metadata URL**.
+1. In Section (3), labeled "SAML Signing Certificate", copy the "App Federation Metadata URL".
 
    ![SAML Signing Certificate](azure-saml-signing-certificate.png)
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -8,25 +8,25 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Log in to the [Azure portal](https://portal.azure.com/).
 
-1. Under "Manage Azure Active Directory" (the shield picture), click "View", which takes you to the Organization Overview page.
+1. Under "Manage Azure Active Directory" (the shield picture), click **View**, which takes you to the "Organization Overview" page.
 
 1. If you don't require a permission group for Sentry, skip to Step 5.
 
 1. In the search bar, search for "Groups" then navigate to it. From there, create a new group, add an owner and members to the group. Set "Group type" to Office 365. For more details about group creation, see the [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal).
 
-1. Return to the Overview page. In the search bar, search for "Enterprise Applications" and navigate to it. Click `+ New application`. Search for "Sentry" to create the application for Sentry. 
+1. Return to the "Overview" page. In the search bar, search for "Enterprise Applications" and navigate to it. Click **+ New application**. Search for "Sentry" to create the application for Sentry. 
    
    ![Sentry in Azure Gallery](azure-search-sentry.png)
 
-1. Once created, you'll be directed to `Sentry - Overview`.
+1. Once created, you'll be directed to "Sentry - Overview".
 
    ![Sentry Overview](azure-sentry-overview.png)
 
-1. Click on `1. Assign users and groups`, then `+ Add user`. Add yourself and the group you've created to the Sentry app. Click `Assign`.
+1. Click on **1. Assign users and groups**, then **+ Add user**. Add yourself and the group you've created to the Sentry app. Click **Assign**.
 
-1. Navigate back to "Overview," click on `2. Set up single sign-on` and then select SAML as your single sign-on method.
+1. Navigate back to "Overview," click on **2. Set up single sign-on** and then select SAML as your single sign-on method.
 
-1. For Section (1) labeled as `Basic SAML Configuration`, enter the following data in each line and save your changes.
+1. For Section (1) labeled as "Basic SAML Configuration", enter the following data in each line and save your changes.
 
    - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/`
 
@@ -40,15 +40,15 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    ![SAML Configuration](azure-basic-saml-configuration.png)
 
-1. In Section (3) labeled as `SAML Signing Certificate`, copy the `App Federation Metadata URL`.
+1. In Section (3) labeled as "SAML Signing Certificate", copy the **App Federation Metadata URL**.
 
    ![SAML Signing Certificate](azure-saml-signing-certificate.png)
 
-1. Navigate to your **Org Settings > Auth** (or go to `https://sentry.io/settings/YOUR_ORG_SLUG/auth/`) and click on "Configure" for Active Directory.
+1. Navigate to your **Org Settings > Auth** (or go to `https://sentry.io/settings/YOUR_ORG_SLUG/auth/`) and click on **Configure** for Active Directory.
 
-1. Paste the `App Federation Metadata URL` and click `Get Metadata`.
+1. Paste the App Federation Metadata URL from aboveand click **Get Metadata**.
 
-1. In the following page, enter these to map the values from AzureAD to Sentry and save them.
+1. In the following page, enter these to map the attributes from AzureAD to Sentry and save them.
 
     - IdP User ID: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
 
@@ -57,7 +57,17 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
     - First Name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`
 
     - Last Name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
+    
+    - For more details about mappings for custom configs, see [The Role of Claims](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims).
 
    ![Map Identity with provider attributes](azure-map-identity-provider-attributes.png)
+   
+1. Sentry will attempt to authenticate and link your account with Azure. After successful authentication, you'll be redirected to Sentry's SSO configuration page.
 
-   For more details about mappings for custom configs, see [The Role of Claims](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims).
+   - The `Login URL` will be used for SP-initiated SSO. You can share it with the users in your organization.
+   
+   - Scroll down to the bottom. Ensure that `Require SSO` is checked if you want to enforce logging in with Okta.
+   
+   - Set a `Default Role` for new SSO users. Selecting `Member` should cover most use-cases.
+   
+   - If you made changes, click **Save Settings** and that's all for the setup!

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -62,7 +62,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    ![Map Identity with provider attributes](azure-map-identity-provider-attributes.png)
    
-1. Sentry will attempt to authenticate and link your account with Azure. After successful authentication, you'll be redirected to Sentry's SSO configuration page.
+1. Sentry will attempt to authenticate and link your account with Azure. After successful authentication, you'll be redirected to Sentry's SSO configuration page, where you can take the following actions:
 
    - The `Login URL` will be used for SP-initiated SSO. You can share it with the users in your organization.
    

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -14,7 +14,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. In the search bar, search for "Groups" then navigate to it. From there, create a new group, add an owner and members to the group. Set "Group type" to Office 365. For more details about group creation, see the [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal).
 
-1. Return to the "Overview" page. In the search bar, search for "Enterprise Applications" and navigate to it. Click **+ New application**. Search for "Sentry" to create the application for Sentry. 
+1. Return to the **Overview** page. In the search bar, enter `Enterprise Applications` and navigate to it. Click "+ New application". Search for `Sentry` to create the application for Sentry. 
    
    ![Sentry in Azure Gallery](azure-search-sentry.png)
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -46,7 +46,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Navigate to your **Org Settings > Auth** (or go to `https://sentry.io/settings/YOUR_ORG_SLUG/auth/`) and click on **Configure** for Active Directory.
 
-1. Paste the App Federation Metadata URL from aboveand click **Get Metadata**.
+1. Paste the App Federation Metadata URL from above and click "Get Metadata".
 
 1. In the following page, enter these to map the attributes from AzureAD to Sentry and save them.
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -58,7 +58,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
     - Last Name: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`
     
-    - For more details about mappings for custom configs, see [The Role of Claims](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims).
+      For more details about mappings for custom configs, see [The Role of Claims](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims).
 
    ![Map Identity with provider attributes](azure-map-identity-provider-attributes.png)
    

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -22,7 +22,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    ![Sentry Overview](azure-sentry-overview.png)
 
-1. Click on **1. Assign users and groups**, then **+ Add user**. Add yourself and the group you've created to the Sentry app. Click **Assign**.
+1. Click on "1. Assign users and groups", then "+ Add user". Add yourself and the group you've created to the Sentry app. Click "Assign".
 
 1. Navigate back to "Overview," click on **2. Set up single sign-on** and then select SAML as your single sign-on method.
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -64,10 +64,10 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
    
 1. Sentry will attempt to authenticate and link your account with Azure. After successful authentication, you'll be redirected to Sentry's SSO configuration page, where you can take the following actions:
 
-   - The `Login URL` will be used for SP-initiated SSO. You can share it with the users in your organization.
+   - You can share the "Login URL" value, which will be used for SP-initiated SSO, with the users in your organization.
    
-   - Scroll down to the bottom. Ensure that `Require SSO` is checked if you want to enforce logging in with Okta.
+   - Scroll down to the bottom and ensure that "Require SSO" is checked if you want to enforce logging in with Okta.
    
-   - Set a `Default Role` for new SSO users. Selecting `Member` should cover most use-cases.
+   - Set a "Default Role" for new SSO users. Selecting "Member" should cover most use-cases.
    
-   - If you made changes, click **Save Settings** and that's all for the setup!
+   - If you made changes, click "Save Settings" to complete your setup.

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -24,7 +24,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
 1. Click on "1. Assign users and groups", then "+ Add user". Add yourself and the group you've created to the Sentry app. Click "Assign".
 
-1. Navigate back to "Overview," click on **2. Set up single sign-on** and then select SAML as your single sign-on method.
+1. Navigate back to **Overview**, click on "2. Set up single sign-on" and then select SAML as your single sign-on method.
 
 1. For Section (1) labeled as "Basic SAML Configuration", enter the following data in each line and save your changes.
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -18,7 +18,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
    
    ![Sentry in Azure Gallery](azure-search-sentry.png)
 
-1. Once created, you'll be directed to "Sentry - Overview".
+1. Once the application is created, you'll be directed to **Sentry - Overview**.
 
    ![Sentry Overview](azure-sentry-overview.png)
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -44,7 +44,7 @@ description: "Learn about the Azure Active Directory Single Sign-On (SSO)."
 
    ![SAML Signing Certificate](azure-saml-signing-certificate.png)
 
-1. Navigate to your **Org Settings > Auth** (or go to `https://sentry.io/settings/YOUR_ORG_SLUG/auth/`) and click on **Configure** for Active Directory.
+1. Navigate to your **Org Settings > Auth** (or go to `https://sentry.io/settings/YOUR_ORG_SLUG/auth/`) and click on "Configure" for Active Directory.
 
 1. Paste the App Federation Metadata URL from above and click "Get Metadata".
 


### PR DESCRIPTION
Using **bold** instead of `code` is better to indicate action. Example:

<img width="781" alt="Screen Shot 2021-03-23 at 10 08 09 PM" src="https://user-images.githubusercontent.com/1748388/112258765-463c4b80-8c24-11eb-8e25-28fe63d94025.png">

**Org Settings > Auth** is so much clearer/obvious than `Get metadata`.