### PR TITLE
feat: Add MaxCacheItems to basic options

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -96,6 +96,12 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </ConfigKey>
 
+<ConfigKey name="max-cache-items" supported={[ "dotnet", "android"]} >
+
+The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, as events, attachments, user feedback, session, etc. to Sentry. An envelope can contain multiple items - for example, an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. When the number of envelopes in the local cache exceeds max-cache-items, the SDK deletes the oldest envelope. When deleting an envelope, we migrate sessions to the next envelope to not mess up your release health stats. The default is `30`.
+
+</ConfigKey>
+
 <ConfigKey name="attach-stacktrace">
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -96,7 +96,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </ConfigKey>
 
-<ConfigKey name="max-cache-items" supported={[ "dotnet", "android"]} >
+<ConfigKey name="max-cache-items" supported={[ "dotnet" ]} >
 
 The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, as events, attachments, user feedback, session, etc. to Sentry. An envelope can contain multiple items - for example, an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. When the number of envelopes in the local cache exceeds max-cache-items, the SDK deletes the oldest envelope. When deleting an envelope, we migrate sessions to the next envelope to not mess up your release health stats. The default is `30`.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -98,7 +98,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 <ConfigKey name="max-cache-items" supported={[ "dotnet" ]} >
 
-The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, as events, attachments, user feedback, session, etc. to Sentry. An envelope can contain multiple items - for example, an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. When the number of envelopes in the local cache exceeds max-cache-items, the SDK deletes the oldest envelope. When deleting an envelope, we migrate sessions to the next envelope to not mess up your release health stats. The default is `30`.
+The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, such as events, attachments, user feedback, and sessions to sentry.io. An envelope can contain multiple items, such as an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. If the number of envelopes in the local cache exceeds `max-cache-items`, the SDK deletes the oldest envelope and migrates the sessions to the next envelope to maintain the integrity of your release health stats. The default is `30`.
 
 </ConfigKey>
 


### PR DESCRIPTION
We are going to enable Apple once 7.0.0 GA is released. I added this to https://github.com/getsentry/sentry-docs/issues/3307 to not forget about it.

Fixes GH-2879