### PR TITLE
fix(apple): Remove typo dot in OOM

### DIFF
--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -9,7 +9,7 @@ description: "Learn how to turn off Out Of Memory"
 This is a preview API, available in 7.0.0-alpha.3. Features available in a preview API are still in-progress and may have bugs. We recognize the irony. The API may be renamed, changed, or removed in a future version.
 We welcome your [feedback](https://github.com/getsentry/sentry-cocoa/discussions/1016).
 
-</Note>.
+</Note>
 
 This integration tracks out-of-memory (OOM) crashes based on heuristics. This feature is available for iOS, tvOS, and Mac Catalyst and works only if the application was in the foreground.
 


### PR DESCRIPTION
Before

<img width="750" alt="Screenshot 2021-03-24 at 10 26 41" src="https://user-images.githubusercontent.com/2443292/112286270-6e12ca00-8c8b-11eb-858b-9b372cc4ce14.png">

After

<img width="749" alt="Screenshot 2021-03-24 at 10 26 53" src="https://user-images.githubusercontent.com/2443292/112286301-7539d800-8c8b-11eb-9ad1-de2f2f958ead.png">
