### PR TITLE
Fix sentry-native capture exception with values list

### DIFF
--- a/src/includes/capture-error/native.mdx
+++ b/src/includes/capture-error/native.mdx
@@ -8,8 +8,15 @@ sentry_value_t exc = sentry_value_new_object();
 sentry_value_set_by_key(exc, "type", sentry_value_new_string("Exception"));
 sentry_value_set_by_key(exc, "value", sentry_value_new_string("Error message."));
 
+sentry_value_t exceptions = sentry_value_new_object();
+sentry_value_t values = sentry_value_new_list();
+
+sentry_value_set_by_key(exceptions, "values", values);
+sentry_value_append(values, exc);
+
 sentry_value_t event = sentry_value_new_event();
-sentry_value_set_by_key(event, "exception", exc);
+sentry_value_set_by_key(event, "exception", exceptions);
+
 sentry_capture_event(event);
 ```
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-dart/issues/386

Android NDK requires the exception to be a `values` list, the protocol is flexible enough but we don't parse it like this on Android (relying on Gson).