### PR TITLE
ref(tags): Mention the maximum tag limits

### DIFF
--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -12,6 +12,8 @@ description: "Tags power UI features such as filters and tag-distribution maps. 
 
 We’ll automatically index all tags for an event, as well as the frequency and the last time that Sentry has seen a tag. We also keep track of the number of distinct tags and can assist you in determining hotspots for various issues.
 
+Tag keys have a maximum length of 32 characters, while tag values have a maximum length of 200 characters.
+
 <PlatformSection notSupported={["native.minidumps", "native.wasm", "php", "php.laravel", "php.symfony", "flutter"]}>
 
 Defining tags is easy, and will bind them to the [current scope](../scopes/) ensuring all future events within scope contain the same tags:


### PR DESCRIPTION
- As far as i can tell we don't mention these limits anywhere publicly, so the only way to notice this is to accidentally hit these limits
- Source of limits: https://github.com/getsentry/relay/blob/10f2c93efb8b5a200168a8fb961c3b136c1e5f18/relay-general/src/processor/attrs.rs#L122-L123