### PR TITLE
feat: add "other" wizard

### DIFF
--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -80,7 +80,7 @@ const writeJson = async (
     // eslint-disable-next-line no-unused-vars
     const [, main, sub] = pathMatch;
     if (!indexJson[main]) indexJson[main] = {};
-    if (!node.frontmatter.doc_link) {
+    if (!node.frontmatter.doc_link && main !== "other") {
       throw new Error(
         `Invalid wizard frontmatter found in ${node.fields.slug}`
       );

--- a/src/wizard/README.md
+++ b/src/wizard/README.md
@@ -1,1 +1,3 @@
 This directory is used by the wizard, and contains content automatically generated via Jekyll.
+
+Note that the "other" wizard is not rendered here but is used for Sentry onboarding.

--- a/src/wizard/other/index.md
+++ b/src/wizard/other/index.md
@@ -1,0 +1,9 @@
+---
+name: Other
+---
+
+To set up a community client, follow the instructions for your SDK. Use the following DSN:
+
+```
+___PUBLIC_DSN___
+```


### PR DESCRIPTION
Improve the "other" onboarding process in Sentry:

<img src="https://user-images.githubusercontent.com/78757344/112730009-724a1c00-8f05-11eb-8a40-3e30ca061c17.png" width="45%"> <img src="https://user-images.githubusercontent.com/78757344/112730093-fac8bc80-8f05-11eb-9c1e-478d509c5248.png" width="45%">


Requires https://github.com/getsentry/sentry/pull/24772 to be useful.

This could of course be special-cased in sentry, but I think it makes more sense to put it here in part because it's the easiest way to get the DSN filled in properly.