### PR TITLE
Add test for usePlatform() when specifying an explicit platform

### DIFF
--- a/src/components/hooks/__tests__/usePlatform.test.js
+++ b/src/components/hooks/__tests__/usePlatform.test.js
@@ -45,6 +45,25 @@ describe("usePlatform", () => {
     expect(result.current[0].key).toBe("javascript");
   });
 
+  it("allows explicitly requesting a platform", () => {
+    const wrapper = ({ children }) => (
+      <PageContext.Provider value={{}}>{children}</PageContext.Provider>
+    );
+
+    useLocalStorage.mockReturnValue([null, jest.fn()]);
+    useLocation.mockReturnValue({
+      pathname: "/",
+    });
+    useStaticQuery.mockImplementation(() => ({
+      allPlatform: {
+        nodes: PLATFORMS,
+      },
+    }));
+
+    const { result } = renderHook(() => usePlatform("ruby"), { wrapper });
+    expect(result.current[0].key).toBe("ruby");
+  });
+
   it("identifies platform from route", () => {
     const wrapper = ({ children }) => (
       <PageContext.Provider value={{ platform: { name: "ruby" } }}>


### PR DESCRIPTION
The bug was fixed by ca52c4269f5, this just adds a test.