### PR TITLE
Align notes about using standalone crash reporting backends

### DIFF
--- a/src/platforms/native/guides/breakpad/index.mdx
+++ b/src/platforms/native/guides/breakpad/index.mdx
@@ -8,11 +8,9 @@ description: "Learn about Sentry's integration with Google Breakpad."
 
 [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) is an open-source multiplatform crash reporting system written in C++ by Google and the predecessor of Crashpad. It supports macOS, Windows and Linux, and features an uploader to submit minidumps to a configured URL right when the process crashes.
 
-As opposed to Crashpad, Breakpad uses in-process crash reporting. This is less robust and has several disadvantages over out-of-process crash reporting. Unless you have integrated Breakpad already, we strongly recommend you to consider using Crashpad instead.
-
 <Note>
 
-We strongly encourage you to use our higher-level [Native SDK](/platforms/native/) if possible, as native Breakpad events are very limited in functionality.
+This page describes **standalone** usage of Breakpad with Sentry. Unless you have integrated Breakpad already, we strongly encourage you to use our [Native SDK](/platforms/native/) instead. Native Breakpad events are very limited in functionality, and Breakpad uses in-process crash reporting, which is less robust and has several disadvantages over out-of-process crash reporting.
 
 </Note>
 

--- a/src/platforms/native/guides/minidumps/index.mdx
+++ b/src/platforms/native/guides/minidumps/index.mdx
@@ -10,13 +10,10 @@ description: "Learn about how Sentry processes Minidump crash reports."
 Sentry can process Minidump crash reports, a memory dump used on Windows and by
 open-source libraries like [_Breakpad_](/platforms/native/guides/breakpad/) or [_Crashpad_](/platforms/native/guides/crashpad/).
 
+
 <Note>
 
-We strongly encourage you to use a higher-level SDK if possible, as Minidumps uploads are very limited in functionality:
-
-- [_Native (C/C++)_](/platforms/native/)
-- [_Apple (Cocoa)_](/platforms/apple/)
-- [_Electron_](/platforms/electron/)
+This page describes **standalone** usage of Minidumps with Sentry. We strongly encourage you to use our [Native SDK](/platforms/native/), as Minidumps uploads are very limited in functionality.
 
 </Note>
 


### PR DESCRIPTION
Use same formatting and similar language.

The references to the Apple and Electron SDKs in the minidump docs
have been removed, as the link points to the root of the native
platform docs, which in turn links to all the guides, and alternate
SDKs. This gives a more consistent flow than duplicating the content
at multiple levels (resulting in slight differences over time due to
bitrot).