### PR TITLE
Add note to look for frameworks

### DIFF
--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -1,12 +1,18 @@
 <PlatformContent includePath="getting-started-primer" />
 
+<PlatformSection notSupported={["android", "dart", "elixir", "flutter", "perl", "react-native", "unity"]}>
+
+<Alert level="warning" title="Using a framework?">
+
+Get started using a guide listed in the right sidebar.
+
+</Alert>
+
 On this page, we get you up and running with Sentry's SDK, so that it will automatically report errors and exceptions in your application.
 
-<Note>
+Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
-
-</Note>
+</PlatformSection>
 
 ## Install
 


### PR DESCRIPTION
We moved the frameworks off the primary list into the RH sidebar to make space for the feature overview. User feedback is that we need a more aggressive pointer to the list. This note addition is a compromise to enable surfacing of the guides more aggressively while preserving vertical space on the page.