### PR TITLE
Use plain alerts instead of notes or warnings for crashpad/breakpad/m…

### DIFF
--- a/src/platforms/native/guides/breakpad/index.mdx
+++ b/src/platforms/native/guides/breakpad/index.mdx
@@ -8,11 +8,11 @@ description: "Learn about Sentry's integration with Google Breakpad."
 
 [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) is an open-source multiplatform crash reporting system written in C++ by Google and the predecessor of Crashpad. It supports macOS, Windows and Linux, and features an uploader to submit minidumps to a configured URL right when the process crashes.
 
-<Note>
+<Alert>
 
 This page describes **standalone** usage of Breakpad with Sentry. Unless you have integrated Breakpad already, we strongly encourage you to use our [Native SDK](/platforms/native/) instead. Native Breakpad events are very limited in functionality, and Breakpad uses in-process crash reporting, which is less robust and has several disadvantages over out-of-process crash reporting.
 
-</Note>
+</Alert>
 
 ## Integration
 

--- a/src/platforms/native/guides/crashpad/index.mdx
+++ b/src/platforms/native/guides/crashpad/index.mdx
@@ -8,7 +8,7 @@ is an open-source multiplatform crash reporting system written in C++ by Google.
 It supports macOS, Windows and Linux (limited), and features an uploader to
 submit minidumps to a configured URL right when the process crashes.
 
-<Alert level="warning">
+<Alert>
 
 This page describes **standalone** usage of Crashpad with Sentry. We strongly encourage you to use our [Native SDK](/platforms/native/). For detailed information about using Crashpad with the Native SDK, see the [Crashpad backend documentation](/platforms/native/configuration/backends/crashpad/).
 

--- a/src/platforms/native/guides/minidumps/index.mdx
+++ b/src/platforms/native/guides/minidumps/index.mdx
@@ -11,11 +11,11 @@ Sentry can process Minidump crash reports, a memory dump used on Windows and by
 open-source libraries like [_Breakpad_](/platforms/native/guides/breakpad/) or [_Crashpad_](/platforms/native/guides/crashpad/).
 
 
-<Note>
+<Alert>
 
 This page describes **standalone** usage of Minidumps with Sentry. We strongly encourage you to use our [Native SDK](/platforms/native/), as Minidumps uploads are very limited in functionality.
 
-</Note>
+</Alert>
 
 In order to receive symbolicated stack traces, you have to upload debug
 information to Sentry. For more information, see [Debug Information Files](/workflow/debug-files/).


### PR DESCRIPTION
…inidump docs