### PR TITLE
Fix redirect from platform docs to specific guides

### DIFF
--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -1,18 +1,18 @@
 <PlatformContent includePath="getting-started-primer" />
 
-<PlatformSection notSupported={["android", "dart", "elixir", "flutter", "perl", "react-native", "unity"]}>
+On this page, we get you up and running with Sentry's SDK, so that it will automatically report errors and exceptions in your application.
 
-<Alert level="warning" title="Using a framework?">
+<PlatformSection noGuides notSupported={["android", "dart", "elixir", "flutter", "perl", "react-native", "unity"]}>
+
+<Alert level="info" title="Using a framework?">
 
 Get started using a guide listed in the right sidebar.
 
 </Alert>
 
-On this page, we get you up and running with Sentry's SDK, so that it will automatically report errors and exceptions in your application.
+</PlatformSection>
 
 Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
-
-</PlatformSection>
 
 ## Install
 


### PR DESCRIPTION
The note would end up in in guides as well due to the missing
noGuides attribute.

The PlaformSection was also excluding more than the guide redirection,
causing sub-guides to lose content. If we want to do this the change
should probably happen along with a followup to add it back to the
sub-guides unless they explicitly don't want that content.

The redirect is also now a green note, instead of a warning. Warnings
should be reserved for very extraordinary cases.