### PR TITLE
docs(js): Add note regarding browser devtools not triggering errors

### DIFF
--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -34,6 +34,7 @@ This snippet includes an intentional error, so you can test that everything is w
 
 <Note>
 
+Keep in mind that errors triggered within Browser DevTools are sandboxed and they will not trigger an error handler. Place the snippet directly in your code instead.
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
 </Note>

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -34,7 +34,7 @@ This snippet includes an intentional error, so you can test that everything is w
 
 <Note>
 
-Keep in mind that errors triggered within Browser DevTools are sandboxed and they will not trigger an error handler. Place the snippet directly in your code instead.
+Errors triggered from within Browser DevTools are sandboxed, so will not trigger an error handler. Place the snippet directly in your code instead.
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
 </Note>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3378