### PR TITLE
feat: Clearer instructions for Hermes sourcemaps

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -14,7 +14,7 @@ and `@sentry/cli` [version `1.51.1`](https://github.com/getsentry/sentry-cli/rel
 
 For Sentry open source, self-hosted users, the minimum version required is [f07352b](https://hub.docker.com/r/getsentry/sentry/tags?page=1&name=f07352b).
 
-Other than making sure you have the minimum version of the SDK, Sentry itself is all you need besides the standard integration described in the [React Native Sentry documentation](/clients/react-native/).
+Other than making sure you have the minimum version of the SDK, Sentry itself is all you need besides the standard integration described in the [React Native Sentry documentation](/platforms/react-native/).
 
 ## Source Maps
 

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -45,7 +45,7 @@ $ node react-native/scripts/compose-source-maps.js index.android.bundle.packager
 
 You will then upload the output from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via `sentry-cli`, you can read more about custom sourcemaps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step you just did replaces the regular bundle step.
 
-```bash{tabTitle:iOS}
+```bash {tabTitle:iOS}
 node_modules/@sentry/cli/bin/sentry-cli releases \
     files RELEASE_NAME \
     upload-sourcemaps \

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -31,13 +31,13 @@ source map.
 2. Compiling to bytecode using `hermes`: `.compiler.map`
 3. Merging SourceMaps using `compose-source-maps`: `.packager.map + .compiler.map => .map`
 
-```bash{tabTitle:iOS}
+```bash {tabTitle:iOS}
 $ react-native bundle --platform ios --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
 $ hermes -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle.packager.map
 $ node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
 ```
 
-```bash{tabTitle:Android}
+```bash {tabTitle:Android}
 $ react-native bundle --platform android --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
 $ hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle.packager.map
 $ node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
@@ -54,7 +54,7 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
     --rewrite main.jsbundle main.jsbundle.map
 ```
 
-```bash{tabTitle:Android}
+```bash {tabTitle:Android}
 node_modules/@sentry/cli/bin/sentry-cli releases \
     files RELEASE_NAME \
     upload-sourcemaps \

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -24,27 +24,39 @@ If you do not need custom sourcemaps, the `sentry.gradle` build step fully suppo
 
 When manually bundling and building React Native apps, building Hermes bundles is a three-step process, each of which creates a different source map.
 
-1. Bundling / minifying using `metro` (`react-native`): `.packager.map`
-2. Compiling to bytecode using `hermes`: `.compiler.map`
-3. Merging SourceMaps using `compose-source-maps`: `.packager.map + .compiler.map => .map`
+1. Bundling / minifying using `metro` (`react-native`) to get the packager source map => `.packager.map`:
 
 ```bash {tabTitle:iOS}
-react-native bundle --platform ios --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
+npx react-native bundle --platform ios --dev false --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
+```
 
-hermes -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle.packager.map
+```bash {tabTitle:Android}
+npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
+```
 
+2. Compiling to bytecode using `hermes` to get the compiler source map => `.compiler.map`:
+
+- `{OS-BIN}` is either `osx-bin`, `win64-bin`, or `linux-bin` depending on which operating system you are using.
+
+```bash {tabTitle:iOS}
+node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle
+```
+
+```bash {tabTitle:Android}
+node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle
+```
+
+3. Merging the two source maps using `compose-source-maps` to get the final source map => `.map`:
+
+```bash {tabTitle:iOS}
 node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
 ```
 
 ```bash {tabTitle:Android}
-react-native bundle --platform android --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
-
-hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle.packager.map
-
 node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
 ```
 
-Then upload the output from either `main.jsbundle.map` or `index.android.bundle.map` to Sentry via Sentry CLI. 
+Then upload the bundle from the first command (`main.jsbundle` or `index.android.bundle`), and the source map from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via Sentry CLI.
 
 You can read more about custom source maps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step replaces the regular bundle step.
 

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -34,29 +34,29 @@ npx react-native bundle --platform ios --dev false --entry-file index.js --bundl
 npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
 ```
 
-2. Compiling to bytecode using `hermes` to get the compiler source map => `.compiler.map`:
+2. Compiling to bytecode using `hermes` to get the compiler source map => `.hbc.map`:
 
 - `{OS-BIN}` is either `osx-bin`, `win64-bin`, or `linux-bin` depending on which operating system you are using.
 
 ```bash {tabTitle:iOS}
-node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle
+node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.hbc main.jsbundle
 ```
 
 ```bash {tabTitle:Android}
-node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle
+node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.hbc index.android.bundle
 ```
 
 3. Merging the two source maps using `compose-source-maps` to get the final source map => `.map`:
 
 ```bash {tabTitle:iOS}
-node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
+node node_modules/react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
 ```
 
 ```bash {tabTitle:Android}
-node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
+node node_modules/react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.hbc.map -o index.android.bundle.map
 ```
 
-Then upload the bundle from the first command (`main.jsbundle` or `index.android.bundle`), and the source map from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via Sentry CLI.
+Then upload the bundle from the first command, either `main.jsbundle` or `index.android.bundle`, and the source map from the third command, either `main.jsbundle.map` or `index.android.bundle.map`, to Sentry via Sentry CLI.
 
 You can read more about custom source maps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step replaces the regular bundle step.
 

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -18,14 +18,11 @@ Other than making sure you have the minimum version of the SDK, Sentry itself is
 
 ## Source Maps
 
-If you do not need custom sourcemaps, the `sentry.gradle` build step fully supports hermes sourcemaps and should handle everything for you.
+If you do not need custom sourcemaps, the `sentry.gradle` build step fully supports Hermes source maps.
 
 ## Custom Source Maps
 
-However, care must be taken to upload the correct source map when manually bundling and building React Native apps.
-
-Building Hermes bundles is a three-step process, each of which creates a different
-source map.
+When manually bundling and building React Native apps, building Hermes bundles is a three-step process, each of which creates a different source map.
 
 1. Bundling / minifying using `metro` (`react-native`): `.packager.map`
 2. Compiling to bytecode using `hermes`: `.compiler.map`
@@ -47,7 +44,9 @@ hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map
 node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
 ```
 
-You will then upload the output from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via `sentry-cli`, you can read more about custom sourcemaps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step you just did replaces the regular bundle step.
+Then upload the output from either `main.jsbundle.map` or `index.android.bundle.map` to Sentry via Sentry CLI. 
+
+You can read more about custom source maps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step replaces the regular bundle step.
 
 ```bash {tabTitle:iOS}
 node_modules/@sentry/cli/bin/sentry-cli releases \

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -16,19 +16,49 @@ For Sentry open source, self-hosted users, the minimum version required is [f073
 
 Other than making sure you have the minimum version of the SDK, Sentry itself is all you need besides the standard integration described in the [React Native Sentry documentation](/clients/react-native/).
 
-## Custom SourceMaps
+## Source Maps
 
-The combination of `@sentry/react-native` and `@sentry/cli` should integrate
-correctly into the `react-native` build pipeline to find and upload the correct source map.
+If you do not need custom sourcemaps, the `sentry.gradle` build step fully supports hermes sourcemaps and should handle everything for you.
+
+## Custom Source Maps
 
 However, care must be taken to upload the correct source map when manually bundling and building React Native apps.
 
 Building Hermes bundles is a three-step process, each of which creates a different
 source map.
 
-1. Bundling / minifying using `metro`: `index.android.bundle.packager.map`
-2. Compiling to bytecode using `hermes`: `index.android.bundle.compiler.map`
-3. Merging SourceMaps using `compose-source-maps`: `index.android.bundle.packager.map + index.android.bundle.compiler.map => index.android.bundle.map`
+1. Bundling / minifying using `metro` (`react-native`): `.packager.map`
+2. Compiling to bytecode using `hermes`: `.compiler.map`
+3. Merging SourceMaps using `compose-source-maps`: `.packager.map + .compiler.map => .map`
 
-It is important to upload the third SourceMap (`index.android.bundle.map`)
-via `sentry-cli`.
+```bash{tabTitle:iOS}
+$ react-native bundle --platform ios --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
+$ hermes -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle.packager.map
+$ node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
+```
+
+```bash{tabTitle:Android}
+$ react-native bundle --platform android --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
+$ hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle.packager.map
+$ node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
+```
+
+You will then upload the output from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via `sentry-cli`, you can read more about custom sourcemaps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step you just did replaces the regular bundle step.
+
+```bash{tabTitle:iOS}
+node_modules/@sentry/cli/bin/sentry-cli releases \
+    files RELEASE_NAME \
+    upload-sourcemaps \
+    --dist DISTRIBUTION_NAME \
+    --strip-prefix /path/to/project/root \
+    --rewrite main.jsbundle main.jsbundle.map
+```
+
+```bash{tabTitle:Android}
+node_modules/@sentry/cli/bin/sentry-cli releases \
+    files RELEASE_NAME \
+    upload-sourcemaps \
+    --dist DISTRIBUTION_NAME \
+    --strip-prefix /path/to/project/root \
+    --rewrite index.android.bundle index.android.bundle.map
+```

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -32,15 +32,19 @@ source map.
 3. Merging SourceMaps using `compose-source-maps`: `.packager.map + .compiler.map => .map`
 
 ```bash {tabTitle:iOS}
-$ react-native bundle --platform ios --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
-$ hermes -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle.packager.map
-$ node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
+react-native bundle --platform ios --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
+
+hermes -O -emit-binary -output-source-map -out=main.jsbundle.compiler.map main.jsbundle.packager.map
+
+node react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
 ```
 
 ```bash {tabTitle:Android}
-$ react-native bundle --platform android --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
-$ hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle.packager.map
-$ node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
+react-native bundle --platform android --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
+
+hermes -O -emit-binary -output-source-map -out=index.android.bundle.compiler.map index.android.bundle.packager.map
+
+node react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.compiler.map -o index.android.bundle.map
 ```
 
 You will then upload the output from the third command (`main.jsbundle.map` or `index.android.bundle.map`) to Sentry via `sentry-cli`, you can read more about custom sourcemaps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step you just did replaces the regular bundle step.

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -22,13 +22,11 @@ If you do not need custom sourcemaps, the `sentry.gradle` build step fully suppo
 
 ## Custom Source Maps
 
-When manually bundling and building React Native apps, building Hermes bundles is a three-step process, each of which creates a different source map.
+When manually bundling and building React Native apps, a three-step process is only needed for Hermes source maps on Android. For Hermes on iOS you will only need to follow the [normal source maps guide](/platforms/react-native/sourcemaps/).
+
+### Compile for Android
 
 1. Bundling / minifying using `metro` (`react-native`) to get the packager source map => `.packager.map`:
-
-```bash {tabTitle:iOS}
-npx react-native bundle --platform ios --dev false --entry-file index.js --bundle-output main.jsbundle --sourcemap-output main.jsbundle.packager.map
-```
 
 ```bash {tabTitle:Android}
 npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
@@ -36,11 +34,9 @@ npx react-native bundle --platform android --dev false --entry-file index.js --b
 
 2. Compiling to bytecode using `hermes` to get the compiler source map => `.hbc.map`:
 
-- `{OS-BIN}` is either `osx-bin`, `win64-bin`, or `linux-bin` depending on which operating system you are using.
-
-```bash {tabTitle:iOS}
-node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.hbc main.jsbundle
-```
+  <Note>
+    `OS-BIN` is either `osx-bin`, `win64-bin`, or `linux-bin` depending on which operating system you are using.
+  </Note>
 
 ```bash {tabTitle:Android}
 node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.hbc index.android.bundle
@@ -48,32 +44,10 @@ node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -
 
 3. Merging the two source maps using `compose-source-maps` to get the final source map => `.map`:
 
-```bash {tabTitle:iOS}
-node node_modules/react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.compiler.map -o main.jsbundle.map
-```
-
 ```bash {tabTitle:Android}
 node node_modules/react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.hbc.map -o index.android.bundle.map
 ```
 
-Then upload the bundle from the first command, either `main.jsbundle` or `index.android.bundle`, and the source map from the third command, either `main.jsbundle.map` or `index.android.bundle.map`, to Sentry via Sentry CLI.
+### Upload the bundle and source maps
 
-You can read more about custom source maps [over at the Source Maps page](/platforms/react-native/manual-setup/sourcemaps/#configure-cli). Note that this three-stage bundle step replaces the regular bundle step.
-
-```bash {tabTitle:iOS}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files RELEASE_NAME \
-    upload-sourcemaps \
-    --dist DISTRIBUTION_NAME \
-    --strip-prefix /path/to/project/root \
-    --rewrite main.jsbundle main.jsbundle.map
-```
-
-```bash {tabTitle:Android}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files RELEASE_NAME \
-    upload-sourcemaps \
-    --dist DISTRIBUTION_NAME \
-    --strip-prefix /path/to/project/root \
-    --rewrite index.android.bundle index.android.bundle.map
-```
+You can then return to [Step 3 on the default source maps guide](/platforms/react-native/sourcemaps/#3-upload-the-bundle-and-source-maps) to upload your source maps.

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -14,7 +14,7 @@ and `@sentry/cli` [version `1.51.1`](https://github.com/getsentry/sentry-cli/rel
 
 For Sentry open source, self-hosted users, the minimum version required is [f07352b](https://hub.docker.com/r/getsentry/sentry/tags?page=1&name=f07352b).
 
-Other than making sure you have the minimum version of the SDK, Sentry itself is all you need besides the standard integration described in the [React Native Sentry documentation](/platforms/react-native/).
+Once you have the minimum version of the SDK, Sentry provides the standard integration as described in the [React Native Sentry documentation](/platforms/react-native/).
 
 ## Source Maps
 
@@ -22,32 +22,34 @@ If you do not need custom sourcemaps, the `sentry.gradle` build step fully suppo
 
 ## Custom Source Maps
 
-When manually bundling and building React Native apps, a three-step process is only needed for Hermes source maps on Android. For Hermes on iOS you will only need to follow the [normal source maps guide](/platforms/react-native/sourcemaps/).
+If you are manually bundling and building React Native apps for Android, follow this three-step process. For Hermes on iOS, follow the [normal source maps guide](/platforms/react-native/sourcemaps/).
 
 ### Compile for Android
 
-1. Bundling / minifying using `metro` (`react-native`) to get the packager source map => `.packager.map`:
+1. Bundle/minify with `metro` (`react-native`) to get the packager source map (`.packager.map`):
 
 ```bash {tabTitle:Android}
 npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
 ```
 
-2. Compiling to bytecode using `hermes` to get the compiler source map => `.hbc.map`:
+2. Compile to bytecode using `hermes` to get the compiler source map (`.hbc.map`):
 
-  <Note>
-    `OS-BIN` is either `osx-bin`, `win64-bin`, or `linux-bin` depending on which operating system you are using.
-  </Note>
+ <Note>
+ 
+ `OS-BIN` is `osx-bin`, `win64-bin`, or `linux-bin`, depending on which operating system you are using.
+ 
+ </Note>
 
 ```bash {tabTitle:Android}
 node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.hbc index.android.bundle
 ```
 
-3. Merging the two source maps using `compose-source-maps` to get the final source map => `.map`:
+3. Merge the two source maps using `compose-source-maps` to get the final source map (`.map`):
 
 ```bash {tabTitle:Android}
 node node_modules/react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.hbc.map -o index.android.bundle.map
 ```
 
-### Upload the bundle and source maps
+### Upload the Bundle and Source Maps
 
-You can then return to [Step 3 on the default source maps guide](/platforms/react-native/sourcemaps/#3-upload-the-bundle-and-source-maps) to upload your source maps.
+Upload your source maps following [Step 3 on the normal source maps guide](/platforms/react-native/sourcemaps/#3-upload-the-bundle-and-source-maps).

--- a/src/platforms/react-native/sourcemaps.mdx
+++ b/src/platforms/react-native/sourcemaps.mdx
@@ -34,6 +34,12 @@ Configure the CLI by reviewing the [configuration guide](https://docs.sentry.io/
 
 ### 2. Generate the bundle and source maps
 
+<Alert level="warning" title="Hermes on Android">
+
+If you use the **Hermes engine** on Android, you will need to [follow this guide to compile source maps for Hermes on Android](/platforms/react-native/manual-setup/hermes/#custom-source-maps). This alternative step is not required for Hermes on iOS and you can continue following the steps below.
+
+</Alert>
+
 You can use the React Native CLI to generate the JavaScript bundle and source maps for your app:
 
 ```bash {tabTitle:Android}

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -19,6 +19,10 @@ Common fixes to this issue include:
 
 [For more details, please read the guide on React Native source maps.](/platforms/react-native/sourcemaps)
 
+### Source Maps with Hermes on Android
+
+You will need to perform some extra steps when using the source maps with the Hermes engine on Android. [You can follow the guide here.](http://localhost:3000/platforms/react-native/manual-setup/hermes/#custom-source-maps)
+
 ## iOS Build Script Failed
 
 Try passing `--force_foreground` to the Sentry CLI command in the build script. This is possibly a bug with our CLI that [we are investigating](https://github.com/getsentry/sentry-react-native/issues/1424).

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -21,7 +21,7 @@ Common fixes to this issue include:
 
 ### Source Maps with Hermes on Android
 
-You will need to perform some extra steps when using the source maps with the Hermes engine on Android. [You can follow the guide here.](http://localhost:3000/platforms/react-native/manual-setup/hermes/#custom-source-maps)
+You will need to perform some extra steps when using the source maps with the Hermes engine on Android. [You can follow the guide here.](/platforms/react-native/manual-setup/hermes/#custom-source-maps)
 
 ## iOS Build Script Failed
 


### PR DESCRIPTION
Make Hermes source maps less confusing by providing clear code examples instead of just instructions. This PR took a while due to needing lots of testing, turns out the whole three-step process isn't even needed for Hermes on iOS.

- Adds detailed guide on Hermes source maps for Android.
- Adds a warning on the source maps page about Hermes on Android and links to this guide.
- Adds a section in the troubleshooting page about Hermes on Android.

Addresses https://github.com/getsentry/sentry-react-native/issues/1270