### PR TITLE
ref: remove dotnet 4.7 advise

### DIFF
--- a/src/platforms/dotnet/index.mdx
+++ b/src/platforms/dotnet/index.mdx
@@ -6,7 +6,7 @@ This section will describe features, configurations and general functionality wh
 
 The main [Sentry NuGet package](https://www.nuget.org/packages/Sentry) targets .NET Standard 2.0. That means, according to the [compatibility table](https://docs.microsoft.com/en-us/dotnet/standard/net-standard), it is compatible with the following versions or newer:
 
-- .NET Framework 4.6.1 (4.7.2 advised)
+- .NET Framework 4.6.1
 - .NET Core 2.0
 - Mono 5.4
 - Xamarin.Android 8.0


### PR DESCRIPTION
This isn't relevant since we mult-itargeted netstandard2.0 and net461