### PR TITLE
docs: update react-native.mdx

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -59,7 +59,7 @@ When you use Xcode, you can hook directly into the build process to upload debug
 
 ### Android Specifics
 
-For Android, we hook into Gradle for the source map build process. When you run `react-native link`, the Gradle files are automatically updated. When you run `./gradlew assembleRelease`, source maps are automatically built and uploaded to Sentry.
+For Android, we hook into Gradle for the source map build process. When you run `react-native link`, the Gradle files are automatically updated. When you run `./gradlew assembleRelease` or `./gradlew bundleRelease`, source maps are automatically built and uploaded to Sentry.
 
 If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build.
 


### PR DESCRIPTION
`bundleRelease` are famous for android build nowadays.