### PR TITLE
.NET: migration from SharpRaven

### DIFF
--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -110,7 +110,9 @@ Please refer to [GitHub for the complete release notes](https://github.com/getse
 
 Below are the main differences between SharpRaven and Sentry SDK.
 
-### List of Differences Between SharpRaven and SentrySdk
+### List of Differences Between SharpRaven and Sentry SDK
+
+Here is a list of features available in Sentry SDK that are not available in SharpRaven
 
 #### Sentry Package
 
@@ -196,6 +198,8 @@ It's also very configurable, for example:
 - Attach stack trace for captured messages (opt-in)
 
 ### Breaking Changes
+
+Upgrading from SharpRaven to Sentry SDK includes the following breaking changes.
 
 #### .NET Framework Support Reduced
 

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -251,6 +251,12 @@ await ravenClient.CaptureAsync(...);
 SentrySdk.CaptureEvent(...);
 ```
 
+If you need to stop the execution until events captured are sent to Sentry, you can also flush the queue:
+
+```csharp
+SentrySdk.CaptureException(...);
+// Only proceed once exception is captured. Waiting up to 2 seconds for it.
+await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
 You can close the SDK, which will also flush the event queue, by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
 
 ```csharp

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -251,7 +251,7 @@ await ravenClient.CaptureAsync(...);
 SentrySdk.CaptureEvent(...);
 ```
 
-You can flush the event queue by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
+You can close the SDK, which will also flush the event queue, by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
 
 ```csharp
 var sentryInitialization = SentrySdk.Init("___PUBLIC_DSN___");

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -112,7 +112,7 @@ Below are the main differences between SharpRaven and Sentry SDK.
 
 ### List of Differences Between SharpRaven and Sentry SDK
 
-Here is a list of features available in Sentry SDK that are not available in SharpRaven
+Here is a list of features available in Sentry SDK that are not available in SharpRaven.
 
 #### Sentry Package
 

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -293,3 +293,20 @@ SentrySdk.Init(o =>
 }
 });
 ```
+
+#### Providing User Information
+
+SharpRaven used `IUserFactory` interface for extracting user information. In Sentry SDK you can instead provide user information directly:
+
+```csharp
+SentrySdk.ConfigureScope(scope =>
+{
+    scope.User = new User
+    {
+        Id = "42",
+        Email = "john.doe@example.com"
+    };
+})
+```
+
+For ASP.NET Core applications, this is done automatically. User information is extracted from the context of the currently executing request.

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -108,3 +108,183 @@ A new package was added ASP.NET Core gPRC support. With the ability to log the r
 # Release notes
 
 Please refer to [GitHub for the complete release notes](https://github.com/getsentry/sentry-dotnet/releases/tag/3.0.0).
+
+<Note>
+
+Migrating from SharpRaven to Sentry SDK
+
+</Note>
+
+# Breaking changes
+
+## .NET Framework support reduced
+
+If your project is targeting .NET Framework, it will need to be using at least v4.6.1 to use Sentry (SharpRaven supported .NET Framework v3.5 and higher).
+
+## Initialization
+
+Changed how to initialize Sentry:
+
+```csharp
+using Sentry;
+
+// Initialize with DSN
+SentrySdk.Init("___PUBLIC_DSN___");
+
+// Initialize with options
+SentrySdk.Init(o =>
+{
+    o.Dsn = "___PUBLIC_DSN___";
+});
+```
+
+For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `o.AddAspNet()`:
+
+```csharp
+using Sentry;
+using Sentry.AspNet;
+
+SentrySdk.Init(o =>
+{
+    o.Dsn = "___PUBLIC_DSN___";
+
+    o.AddAspNet();
+});
+```
+
+## Event queue
+
+Contrary to SharpRaven, events in Sentry SDK are sent in background without blocking the currently executing code. Calling `SentrySdk.CaptureException(...)` does not immediately send an event, but instead queues it up on a background thread.
+
+Usage changes:
+
+```csharp
+// Before
+ravenClient.Capture(...);
+await ravenClient.CaptureAsync(...);
+
+// After
+SentrySdk.CaptureEvent(...);
+```
+
+You can flush the event queue by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
+
+```csharp
+var sentryInitialization = SentrySdk.Init("___PUBLIC_DSN___");
+
+// Capture a non-error message
+SentrySdk.CaptureMessage("hello world");
+
+// Tear down Sentry and flush queued up events
+sentryInitialization.Dispose();
+```
+
+## Event processors
+
+Usage changes:
+
+```csharp
+// Before
+ravenClient.BeforeSend = requester =>
+{
+    // Here you can log data from the requester
+    // or replace it entirely if you want.
+    return requester;
+};
+
+// After
+SentrySdk.Init(o =>
+{
+    o.BeforeSend = e =>
+    {
+        // Mutate the event or return null to drop it altogether
+        return e;
+    };
+}
+});
+```
+
+## List of differences between SharpRaven and SentrySdk
+
+### Sentry package
+
+- Automatic Captures global unhandled exceptions (AppDomain)
+- Scope management
+- Duplicate events automatically dropped
+- Events from the same exception automatically dropped
+- Web proxy support
+- HttpClient/HttpClientHandler configuration callback
+- Compress request body
+- Event sampling opt-in
+- Event flooding protection (429 retry-after and internal bound queue)
+- Release automatically set (AssemblyInformationalVersionAttribute, AssemblyVersion or env var)
+- DSN discovered via environment variable
+- Release (version) reported automatically
+- CLS Compliant
+- Strong named
+- BeforeSend and BeforeBreadcrumb callbacks
+- Event and Exception processors
+- SourceLink (including PDB in nuget package)
+- Device OS info sent
+- Device Runtime info sent
+- Enable SDK debug mode (opt-in)
+- Attach stack trace for captured messages (opt-in)
+
+### Sentry.Extensions.Logging
+
+- Includes all features from the Sentry package.
+- BeginScope data added to Sentry scope, sent with events
+- LogInformation or higher added as breadcrumb, sent with next events.
+- LogError or higher automatically captures an event
+- Minimal levels are configurable.
+
+### Sentry.AspNetCore
+
+- Includes all features from the Sentry package.
+- Includes all features from the Sentry.Extensions.Logging package.
+- Easy ASP.NET Core integration, single line: UseSentry.
+- Captures unhandled exceptions in the middleware pipeline
+- Captures exceptions handled by the framework UseExceptionHandler and Error page display.
+- Any event sent will include relevant application log messages
+- RequestId as tag
+- URL as tag
+- Environment is automatically set (IHostingEnvironment)
+- Request payload can be captured if opt-in
+- Support for EventProcessors registered with DI
+- Support for ExceptionProcessors registered with DI
+- Captures logs from the request (using Microsoft.Extensions.Logging)
+- Supports configuration system (e.g: appsettings.json)
+- Server OS info sent
+- Server Runtime info sent
+- Request headers sent
+- Request body compressed
+
+All packages are:
+
+- Strong named
+- Tested on Windows, Linux and macOS
+- Tested on .NET Core, .NET Framework and Mono
+
+It's also very configurable, for example:
+
+- HTTP Proxy
+- Event sampling
+- Enable request body extraction
+- Send PII data (Personal Identifiable Information, requires opt-in)
+- Read diagnostics activity data
+- BeforeSend: Callback to modify/reject event before sending
+- BeforeBreadcrumb: Callback to modify/reject a breadcrumb
+- LogEventFilter: Filter events by inspecting log data
+- Maximum number of breadcrumbs to store
+- Event queue depth
+- Shutdown timeout: If there are events to send, how long to wait until shutdown
+- Accept compressed response
+- Compress request body
+- Breadcrumb level: Minimum log level to store as a breadcrumb
+- Event level: Minimum log level to send an event to Sentry
+- Disable duplicate event detection
+- Disable capture of global unhandled exceptions
+- Add event processor
+- Add exception processor
+- Enable SDK debug mode
+- Attach stack trace for captured messages (opt-in)

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -53,7 +53,7 @@ To match Sentry's default environment naming convention, unless explicitly set o
 The option `IncludeRequestPayload` that was deprecated in the Sentry SDK 2.0 has been removed.
 The replacement is the option `MaxRequestBodySize`.
 
-#### `IHub` and `ISentryClient` received new methods
+#### `IHub` and `ISentryClient` Received New Methods
 
 Sentry's Performance product requires additive API changes to interfaces such as `IHub` and `ISentryClient`.
 If you implement your own `IHub`, you'll need to implement two new methods:
@@ -61,19 +61,19 @@ If you implement your own `IHub`, you'll need to implement two new methods:
 `ISentryClient` received: `CaptureTransaction`.
 `IHub` received: `StartTransaction` and `GetTraceHeader`.
 
-#### `DiagnosticsLogger` renamed to `DiagnosticLogger`
+#### `DiagnosticsLogger` Renamed to `DiagnosticLogger`
 
 To align with other SDKs, the option is now named: `DiagnosticLogger`
 [Docs PR](https://github.com/getsentry/sentry-docs/pull/2945).
 
-#### `Dsn` is just a string
+#### `Dsn` Is Just a String
 
 `SentryOptions` now take a string for `Dsn`:
 
 Before: `o.Dsn = new Dsn("..");`
 After: `o.Dsn = "..";`
 
-#### `LogEntry` became `Message`
+#### `LogEntry` Became `Message`
 
 The property of `SentryEvent` that supports a structured log entry was renamed to `Message` to align with the protocol and other SDKs.
 
@@ -81,7 +81,7 @@ The property of `SentryEvent` that supports a structured log entry was renamed t
 
 This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are using an on-premise installation it requires Sentry version >= v20.6.0 to work. If you are using sentry.io nothing will change and no action is needed.
 
-### New features and improvements
+### New Features and Improvements
 
 #### Offline Caching
 
@@ -110,9 +110,9 @@ Please refer to [GitHub for the complete release notes](https://github.com/getse
 
 Below are the main differences between SharpRaven and Sentry SDK.
 
-### List of differences between SharpRaven and SentrySdk
+### List of Differences Between SharpRaven and SentrySdk
 
-#### Sentry package
+#### Sentry Package
 
 - Automatic Captures global unhandled exceptions (AppDomain)
 - Scope management
@@ -195,9 +195,9 @@ It's also very configurable, for example:
 - Enable SDK debug mode
 - Attach stack trace for captured messages (opt-in)
 
-### Breaking changes
+### Breaking Changes
 
-#### .NET Framework support reduced
+#### .NET Framework Support Reduced
 
 If your project is targeting .NET Framework, it will need to be using at least v4.6.1 to use Sentry (SharpRaven supported .NET Framework v3.5 and higher).
 
@@ -232,7 +232,7 @@ SentrySdk.Init(o =>
 });
 ```
 
-#### Event queue
+#### Event Queue
 
 Contrary to SharpRaven, events in Sentry SDK are sent in background without blocking the currently executing code. Calling `SentrySdk.CaptureException(...)` does not immediately send an event, but instead queues it up on a background thread.
 
@@ -259,7 +259,7 @@ SentrySdk.CaptureMessage("hello world");
 sentryInitialization.Dispose();
 ```
 
-#### Event processors
+#### Event Processors
 
 Usage changes:
 

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -4,17 +4,15 @@ description: "Migrating between versions of Sentry SDK for .NET."
 sidebar_order: 10
 ---
 
-<Note>
+# Migrating from Sentry SDK v2.x to Sentry SDK v3.x
 
-Migrating to `Sentry` version 3.0.5
+Upgrading to Sentry SDK v3.x includes the following breaking changes and new features.
 
-</Note>
-
-# Breaking changes
+## Breaking Changes
 
 Please read through **all** breaking changes relevant to you before upgrading.
 
-## !Important: Grouping Changes
+### !Important: Grouping Changes
 
 The format of the stack traces were greatly improved with the help of Ben Adam's iconic library `Ben.Demystifier`. Frames now include details such as `async`, `static`, the actual return type, method parameters, tuples and their names, and more.
 
@@ -24,11 +22,11 @@ One big caveat is that this will **affect grouping!**. If you prefer to stay wit
 options.StackTraceMode = StackTraceMode.Original;
 ```
 
-## Namespace change
+### Namespace Change
 
 Classes under `Sentry.Protocol` were moved to the root namespace `Sentry`. All except `Context` classes like `App`, `Device`, etc.
 
-## ASP.NET
+### ASP.NET
 
 ASP.NET (**not Core**) users need to install an additional package:
 
@@ -46,16 +44,16 @@ SentrySdk.Init(o =>
 
 The motivation was to remove the reference to `System.Web` to decouple the core of the package with any specific namespaces of the .NET Framework, which improves the experience from other environments such as game engines like Unity and [Godot](https://gatomalo.dev/blog/2020/03/21/error-monitoring-godot-sentry/#android).
 
-## ASP.NET Core Environment Casing
+### ASP.NET Core Environment Casing
 
 To match Sentry's default environment naming convention, unless explicitly set otherwise, the Sentry environment will be reported lowercase. That means if `ASPNET_ENVIRONMENT` is equal to `Production`, the Sentry SDK will report it as `production`.
 
-## ASP.NET Core `IncludeRequestPayload`
+### ASP.NET Core `IncludeRequestPayload`
 
 The option `IncludeRequestPayload` that was deprecated in the Sentry SDK 2.0 has been removed.
 The replacement is the option `MaxRequestBodySize`.
 
-## `IHub` and `ISentryClient` received new methods
+### `IHub` and `ISentryClient` received new methods
 
 Sentry's Performance product requires additive API changes to interfaces such as `IHub` and `ISentryClient`.
 If you implement your own `IHub`, you'll need to implement two new methods:
@@ -63,146 +61,54 @@ If you implement your own `IHub`, you'll need to implement two new methods:
 `ISentryClient` received: `CaptureTransaction`.
 `IHub` received: `StartTransaction` and `GetTraceHeader`.
 
-## `DiagnosticsLogger` renamed to `DiagnosticLogger`
+### `DiagnosticsLogger` renamed to `DiagnosticLogger`
 
 To align with other SDKs, the option is now named: `DiagnosticLogger`
 [Docs PR](https://github.com/getsentry/sentry-docs/pull/2945).
 
-## `Dsn` is just a string
+### `Dsn` is just a string
 
 `SentryOptions` now take a string for `Dsn`:
 
 Before: `o.Dsn = new Dsn("..");`
 After: `o.Dsn = "..";`
 
-## `LogEntry` became `Message`
+### `LogEntry` became `Message`
 
 The property of `SentryEvent` that supports a structured log entry was renamed to `Message` to align with the protocol and other SDKs.
 
-## Sentry On Premise Support
+### Sentry On Premise Support
 
 This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are using an on-premise installation it requires Sentry version >= v20.6.0 to work. If you are using sentry.io nothing will change and no action is needed.
 
-# New features and improvements
+## New features and improvements
 
-## Offline Caching
+### Offline Caching
 
 You can optionally have events cached to disk.
 To do that, you must specify which directory the SDK can use to write the crash files:
 
 `options.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData))`
 
-## Attachments
+### Attachments
 
 You can add attachments to events now. Please refer to the [Attachments documentation](../enriching-events/attachments/).
 
-## User Feedback
+### User Feedback
 
 You can add user feedback to events via a .NET API. Please refer to the [User Feedback documentation](../enriching-events/user-feedback/).
 
-
-## ASP.NET Core gRPC support
+### ASP.NET Core gRPC support
 
 A new package was added ASP.NET Core gPRC support. With the ability to log the request payload in case of errors.
 
-# Release notes
+## Release Notes
 
 Please refer to [GitHub for the complete release notes](https://github.com/getsentry/sentry-dotnet/releases/tag/3.0.0).
 
-<Note>
+# Migrating from SharpRaven to Sentry SDK
 
-Migrating from SharpRaven to Sentry SDK
-
-</Note>
-
-# Breaking changes
-
-## .NET Framework support reduced
-
-If your project is targeting .NET Framework, it will need to be using at least v4.6.1 to use Sentry (SharpRaven supported .NET Framework v3.5 and higher).
-
-## Initialization
-
-Changed how to initialize Sentry:
-
-```csharp
-using Sentry;
-
-// Initialize with DSN
-SentrySdk.Init("___PUBLIC_DSN___");
-
-// Initialize with options
-SentrySdk.Init(o =>
-{
-    o.Dsn = "___PUBLIC_DSN___";
-});
-```
-
-For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `o.AddAspNet()`:
-
-```csharp
-using Sentry;
-using Sentry.AspNet;
-
-SentrySdk.Init(o =>
-{
-    o.Dsn = "___PUBLIC_DSN___";
-
-    o.AddAspNet();
-});
-```
-
-## Event queue
-
-Contrary to SharpRaven, events in Sentry SDK are sent in background without blocking the currently executing code. Calling `SentrySdk.CaptureException(...)` does not immediately send an event, but instead queues it up on a background thread.
-
-Usage changes:
-
-```csharp
-// Before
-ravenClient.Capture(...);
-await ravenClient.CaptureAsync(...);
-
-// After
-SentrySdk.CaptureEvent(...);
-```
-
-You can flush the event queue by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
-
-```csharp
-var sentryInitialization = SentrySdk.Init("___PUBLIC_DSN___");
-
-// Capture a non-error message
-SentrySdk.CaptureMessage("hello world");
-
-// Tear down Sentry and flush queued up events
-sentryInitialization.Dispose();
-```
-
-## Event processors
-
-Usage changes:
-
-```csharp
-// Before
-ravenClient.BeforeSend = requester =>
-{
-    // Here you can log data from the requester
-    // or replace it entirely if you want.
-    return requester;
-};
-
-// After
-SentrySdk.Init(o =>
-{
-    o.BeforeSend = e =>
-    {
-        // Mutate the event or return null to drop it altogether
-        return e;
-    };
-}
-});
-```
+Below are the main differences between SharpRaven and Sentry SDK.
 
 ## List of differences between SharpRaven and SentrySdk
 
@@ -288,3 +194,92 @@ It's also very configurable, for example:
 - Add exception processor
 - Enable SDK debug mode
 - Attach stack trace for captured messages (opt-in)
+
+## Breaking changes
+
+### .NET Framework support reduced
+
+If your project is targeting .NET Framework, it will need to be using at least v4.6.1 to use Sentry (SharpRaven supported .NET Framework v3.5 and higher).
+
+### Initialization
+
+Changed how to initialize Sentry:
+
+```csharp
+using Sentry;
+
+// Initialize with DSN
+SentrySdk.Init("___PUBLIC_DSN___");
+
+// Initialize with options
+SentrySdk.Init(o =>
+{
+    o.Dsn = "___PUBLIC_DSN___";
+});
+```
+
+For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `o.AddAspNet()`:
+
+```csharp
+using Sentry;
+using Sentry.AspNet;
+
+SentrySdk.Init(o =>
+{
+    o.Dsn = "___PUBLIC_DSN___";
+
+    o.AddAspNet();
+});
+```
+
+### Event queue
+
+Contrary to SharpRaven, events in Sentry SDK are sent in background without blocking the currently executing code. Calling `SentrySdk.CaptureException(...)` does not immediately send an event, but instead queues it up on a background thread.
+
+Usage changes:
+
+```csharp
+// Before
+ravenClient.Capture(...);
+await ravenClient.CaptureAsync(...);
+
+// After
+SentrySdk.CaptureEvent(...);
+```
+
+You can flush the event queue by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
+
+```csharp
+var sentryInitialization = SentrySdk.Init("___PUBLIC_DSN___");
+
+// Capture a non-error message
+SentrySdk.CaptureMessage("hello world");
+
+// Tear down Sentry and flush queued up events
+sentryInitialization.Dispose();
+```
+
+### Event processors
+
+Usage changes:
+
+```csharp
+// Before
+ravenClient.BeforeSend = requester =>
+{
+    // Here you can log data from the requester
+    // or replace it entirely if you want.
+    return requester;
+};
+
+// After
+SentrySdk.Init(o =>
+{
+    o.BeforeSend = e =>
+    {
+        // Mutate the event or return null to drop it altogether
+        return e;
+    };
+}
+});
+```

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -66,7 +66,7 @@ If you implement your own `IHub`, you'll need to implement two new methods:
 To align with other SDKs, the option is now named: `DiagnosticLogger`
 [Docs PR](https://github.com/getsentry/sentry-docs/pull/2945).
 
-#### `Dsn` Is Just a String
+#### `Dsn` as a String
 
 `SentryOptions` now take a string for `Dsn`:
 
@@ -77,7 +77,7 @@ After: `o.Dsn = "..";`
 
 The property of `SentryEvent` that supports a structured log entry was renamed to `Message` to align with the protocol and other SDKs.
 
-#### Sentry On Premise Support
+#### Sentry Self-Hosted Support
 
 This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are using an on-premise installation it requires Sentry version >= v20.6.0 to work. If you are using sentry.io nothing will change and no action is needed.
 

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -4,15 +4,15 @@ description: "Migrating between versions of Sentry SDK for .NET."
 sidebar_order: 10
 ---
 
-# Migrating from Sentry SDK v2.x to Sentry SDK v3.x
+## Migrating from Sentry SDK v2.x to Sentry SDK v3.x
 
 Upgrading to Sentry SDK v3.x includes the following breaking changes and new features.
 
-## Breaking Changes
+### Breaking Changes
 
 Please read through **all** breaking changes relevant to you before upgrading.
 
-### !Important: Grouping Changes
+#### !Important: Grouping Changes
 
 The format of the stack traces were greatly improved with the help of Ben Adam's iconic library `Ben.Demystifier`. Frames now include details such as `async`, `static`, the actual return type, method parameters, tuples and their names, and more.
 
@@ -22,11 +22,11 @@ One big caveat is that this will **affect grouping!**. If you prefer to stay wit
 options.StackTraceMode = StackTraceMode.Original;
 ```
 
-### Namespace Change
+#### Namespace Change
 
 Classes under `Sentry.Protocol` were moved to the root namespace `Sentry`. All except `Context` classes like `App`, `Device`, etc.
 
-### ASP.NET
+#### ASP.NET
 
 ASP.NET (**not Core**) users need to install an additional package:
 
@@ -44,16 +44,16 @@ SentrySdk.Init(o =>
 
 The motivation was to remove the reference to `System.Web` to decouple the core of the package with any specific namespaces of the .NET Framework, which improves the experience from other environments such as game engines like Unity and [Godot](https://gatomalo.dev/blog/2020/03/21/error-monitoring-godot-sentry/#android).
 
-### ASP.NET Core Environment Casing
+#### ASP.NET Core Environment Casing
 
 To match Sentry's default environment naming convention, unless explicitly set otherwise, the Sentry environment will be reported lowercase. That means if `ASPNET_ENVIRONMENT` is equal to `Production`, the Sentry SDK will report it as `production`.
 
-### ASP.NET Core `IncludeRequestPayload`
+#### ASP.NET Core `IncludeRequestPayload`
 
 The option `IncludeRequestPayload` that was deprecated in the Sentry SDK 2.0 has been removed.
 The replacement is the option `MaxRequestBodySize`.
 
-### `IHub` and `ISentryClient` received new methods
+#### `IHub` and `ISentryClient` received new methods
 
 Sentry's Performance product requires additive API changes to interfaces such as `IHub` and `ISentryClient`.
 If you implement your own `IHub`, you'll need to implement two new methods:
@@ -61,58 +61,58 @@ If you implement your own `IHub`, you'll need to implement two new methods:
 `ISentryClient` received: `CaptureTransaction`.
 `IHub` received: `StartTransaction` and `GetTraceHeader`.
 
-### `DiagnosticsLogger` renamed to `DiagnosticLogger`
+#### `DiagnosticsLogger` renamed to `DiagnosticLogger`
 
 To align with other SDKs, the option is now named: `DiagnosticLogger`
 [Docs PR](https://github.com/getsentry/sentry-docs/pull/2945).
 
-### `Dsn` is just a string
+#### `Dsn` is just a string
 
 `SentryOptions` now take a string for `Dsn`:
 
 Before: `o.Dsn = new Dsn("..");`
 After: `o.Dsn = "..";`
 
-### `LogEntry` became `Message`
+#### `LogEntry` became `Message`
 
 The property of `SentryEvent` that supports a structured log entry was renamed to `Message` to align with the protocol and other SDKs.
 
-### Sentry On Premise Support
+#### Sentry On Premise Support
 
 This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are using an on-premise installation it requires Sentry version >= v20.6.0 to work. If you are using sentry.io nothing will change and no action is needed.
 
-## New features and improvements
+### New features and improvements
 
-### Offline Caching
+#### Offline Caching
 
 You can optionally have events cached to disk.
 To do that, you must specify which directory the SDK can use to write the crash files:
 
 `options.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData))`
 
-### Attachments
+#### Attachments
 
 You can add attachments to events now. Please refer to the [Attachments documentation](../enriching-events/attachments/).
 
-### User Feedback
+#### User Feedback
 
 You can add user feedback to events via a .NET API. Please refer to the [User Feedback documentation](../enriching-events/user-feedback/).
 
-### ASP.NET Core gRPC support
+#### ASP.NET Core gRPC support
 
 A new package was added ASP.NET Core gPRC support. With the ability to log the request payload in case of errors.
 
-## Release Notes
+### Release Notes
 
 Please refer to [GitHub for the complete release notes](https://github.com/getsentry/sentry-dotnet/releases/tag/3.0.0).
 
-# Migrating from SharpRaven to Sentry SDK
+## Migrating from SharpRaven to Sentry SDK
 
 Below are the main differences between SharpRaven and Sentry SDK.
 
-## List of differences between SharpRaven and SentrySdk
+### List of differences between SharpRaven and SentrySdk
 
-### Sentry package
+#### Sentry package
 
 - Automatic Captures global unhandled exceptions (AppDomain)
 - Scope management
@@ -136,7 +136,7 @@ Below are the main differences between SharpRaven and Sentry SDK.
 - Enable SDK debug mode (opt-in)
 - Attach stack trace for captured messages (opt-in)
 
-### Sentry.Extensions.Logging
+#### Sentry.Extensions.Logging
 
 - Includes all features from the Sentry package.
 - BeginScope data added to Sentry scope, sent with events
@@ -144,7 +144,7 @@ Below are the main differences between SharpRaven and Sentry SDK.
 - LogError or higher automatically captures an event
 - Minimal levels are configurable.
 
-### Sentry.AspNetCore
+#### Sentry.AspNetCore
 
 - Includes all features from the Sentry package.
 - Includes all features from the Sentry.Extensions.Logging package.
@@ -195,13 +195,13 @@ It's also very configurable, for example:
 - Enable SDK debug mode
 - Attach stack trace for captured messages (opt-in)
 
-## Breaking changes
+### Breaking changes
 
-### .NET Framework support reduced
+#### .NET Framework support reduced
 
 If your project is targeting .NET Framework, it will need to be using at least v4.6.1 to use Sentry (SharpRaven supported .NET Framework v3.5 and higher).
 
-### Initialization
+#### Initialization
 
 Changed how to initialize Sentry:
 
@@ -232,7 +232,7 @@ SentrySdk.Init(o =>
 });
 ```
 
-### Event queue
+#### Event queue
 
 Contrary to SharpRaven, events in Sentry SDK are sent in background without blocking the currently executing code. Calling `SentrySdk.CaptureException(...)` does not immediately send an event, but instead queues it up on a background thread.
 
@@ -259,7 +259,7 @@ SentrySdk.CaptureMessage("hello world");
 sentryInitialization.Dispose();
 ```
 
-### Event processors
+#### Event processors
 
 Usage changes:
 

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -257,6 +257,8 @@ If you need to stop the execution until events captured are sent to Sentry, you 
 SentrySdk.CaptureException(...);
 // Only proceed once exception is captured. Waiting up to 2 seconds for it.
 await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
+```
+
 You can close the SDK, which will also flush the event queue, by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
 
 ```csharp


### PR DESCRIPTION
@PeloWriter do you think it would be possible to create a Migration section and add articles there? For example:

```
-- .NET
  +-- Migration
        +-- From SharpRaven to SentrySdk
        +-- From SentrySdk v2.x to v3.0
```

cc @bruno-garcia 