### PR TITLE
feat(trace-view): For !javascript add a common connect services

### DIFF
--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -8,7 +8,18 @@ description: "Learn how to connect backend and frontend transactions."
 redirect_from:
 ---
 
-To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value which is propagated between frontend and backend. Depending on the circumstance, this id is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible for you to navigate between them in the Sentry UI, so you can better understand how the different parts of your system are affecting each other. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
+To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value which is propagated between frontend and backend services. Depending on the circumstance, this id is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible for you to navigate between them in the Sentry UI, so you can better understand how the different parts of your system are affecting each other. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
+
+### Navigation and Other XHR Requests
+
+Once a page is loaded, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
+
+All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate the trace header automatically as appropriate, for all transactions and spans which they generate.
+
+The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination contains a string in or matches a regex in the <PlatformLink to="/performance/included-instrumentation/#tracingorigins">tracingOrigin</PlatformLink> list.
+
+You can also attach and read the header yourself, in any case in which you've manually created either a transaction or a span and it makes sense to do so. The header's name is `sentry-trace` and its value is obtained by calling `span.toTraceparent()` (or the equivalent), where `span` is either the relevant transaction or any of its children.
+
 
 ### Pageload
 
@@ -28,11 +39,3 @@ The `name` attribute must be the string `"sentry-trace"` and the `content` attri
 The `span` reference is either the transaction that serves the HTML, or any of its child spans. It defines the parent of the `pageload` transaction.
 
 Once the data is included in the `<meta>` tag, our `BrowserTracing` integration will pick it up automatically and link it to the transaction generated on pageload. (Note that it will not get linked to automatically-generated `navigation` transactions, that is, those which don't require a full page reload. Each of those will be the result of a different request transaction on the backend, and therefore should have a unique `trace_id`.)
-
-### Navigation and Other XHR Requests
-
-Once a page is loaded, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
-
-As is the case with the `<meta>` tag discussed above, the header's name is `sentry-trace` and its value is obtained by calling `span.toTraceparent()` (or the equivalent), where `span` is either the relevant transaction or any of its children.
-
-All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate this header automatically as appropriate, for all transactions and spans which they generate. You can also attach and read the header yourself, in any case in which you've manually created either a transaction or a span and it makes sense to do so.

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -20,7 +20,7 @@ The JavaScript SDK will only attach the trace header to outgoing HTTP requests w
 
 ### Pageload
 
-For traces that backend in your backend, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.
+For traces that begin in your backend, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.
 
 ```html
 <html>

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -12,18 +12,15 @@ To connect backend and frontend transactions into a single coherent trace, Sentr
 
 ### Navigation and Other XHR Requests
 
-Once a page is loaded, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
+For traces that begin in JavaScript, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
 
 All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate the trace header automatically as appropriate for all transactions and spans that they generate.
 
 The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination contains a string in or matches a regex in the <PlatformLink to="/performance/included-instrumentation/#tracingorigins">tracingOrigin</PlatformLink> list.
 
-You can also attach and read the header yourself whenever you've manually created either a transaction or a span and it makes sense to do so. The header's name is `sentry-trace` and its value is obtained by calling `span.toTraceparent()` (or the equivalent), where `span` is either the relevant transaction or any of its children.
-
-
 ### Pageload
 
-When enabling tracing in both frontend and backend as well as taking advantage of automatic frontend instrumentation, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.
+For traces that backend in your backend, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.
 
 ```html
 <html>

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -18,6 +18,9 @@ All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Exp
 
 The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination contains a string in or matches a regex in the <PlatformLink to="/performance/included-instrumentation/#tracingorigins">tracingOrigin</PlatformLink> list.
 
+<!-- copied from included-instrumentation to emphasize this point -->
+You will need to configure your web server [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) to allow the sentry-trace header. The configuration might look like "Access-Control-Allow-Headers: sentry-trace", but the configuration depends on your set up. If you do not allow the sentry-trace header, the request might be blocked.
+
 ### Pageload
 
 For traces that begin in your backend, you can connect the automatically-generated `pageload` transaction on the frontend with the request transaction that serves the page on the backend. Because JavaScript code running in a browser cannot read the response headers of the current page, the `trace_id` must be transmitted in the response itself, specifically in a `<meta>` tag in the `<head>` of the HTML sent from your backend.

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -8,7 +8,7 @@ description: "Learn how to connect backend and frontend transactions."
 redirect_from:
 ---
 
-To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value that is propagated between frontend and backend services. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible to navigate between them in sentry.io to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
+To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value that is propagated between frontend and backend services. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible to navigate between them in [sentry.io](https://sentry.io) to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
 ### Navigation and Other XHR Requests
 

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -8,17 +8,17 @@ description: "Learn how to connect backend and frontend transactions."
 redirect_from:
 ---
 
-To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value which is propagated between frontend and backend services. Depending on the circumstance, this id is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible for you to navigate between them in the Sentry UI, so you can better understand how the different parts of your system are affecting each other. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
+To connect backend and frontend transactions into a single coherent trace, Sentry uses a `trace_id` value that is propagated between frontend and backend services. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. Linking transactions in this way makes it possible to navigate between them in sentry.io to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/performance/distributed-tracing/) docs.
 
 ### Navigation and Other XHR Requests
 
 Once a page is loaded, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
 
-All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate the trace header automatically as appropriate, for all transactions and spans which they generate.
+All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate the trace header automatically as appropriate for all transactions and spans that they generate.
 
 The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination contains a string in or matches a regex in the <PlatformLink to="/performance/included-instrumentation/#tracingorigins">tracingOrigin</PlatformLink> list.
 
-You can also attach and read the header yourself, in any case in which you've manually created either a transaction or a span and it makes sense to do so. The header's name is `sentry-trace` and its value is obtained by calling `span.toTraceparent()` (or the equivalent), where `span` is either the relevant transaction or any of its children.
+You can also attach and read the header yourself whenever you've manually created either a transaction or a span and it makes sense to do so. The header's name is `sentry-trace` and its value is obtained by calling `span.toTraceparent()` (or the equivalent), where `span` is either the relevant transaction or any of its children.
 
 
 ### Pageload

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -84,6 +84,15 @@ Leaving the sample rate at `1.0` means that included instrumentation will send a
 
 </PlatformSection>
 
+<!-- notSupported here should be the opposite of whats in common/connect-services.mdx -->
+<PlatformSection notSupported={["javascript", "javascript.cordova"]}>
+
+## Connecting Services
+
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
+
+</PlatformSection>
+
 **Next Steps:**
 
 <PageGrid />

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -89,7 +89,11 @@ Leaving the sample rate at `1.0` means that included instrumentation will send a
 
 ## Connecting Services
 
-If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) depending on where your request originates there are two methods to connect your traces:
+1. For requests that start in your backend, this is done by [adding a meta tag](/platforms/javascript/performance/connect-services/#pageload) in your HTML template that contains tracing information.
+2. For requests that start in JavaScript, this is done by [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
+
+Otherwise backend services with Performance Monitoring will connect automatically.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -91,7 +91,7 @@ Leaving the sample rate at `1.0` means that included instrumentation will send a
 
 If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) depending on where your request originates there are two methods to connect your traces:
 1. For requests that start in your backend, this is done by [adding a meta tag](/platforms/javascript/performance/connect-services/#pageload) in your HTML template that contains tracing information.
-2. For requests that start in JavaScript, this is done by [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
+2. For requests that start in JavaScript, this is done by the SDK [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
 
 Otherwise backend services with Performance Monitoring will connect automatically.
 

--- a/src/platforms/javascript/common/performance/included-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/included-instrumentation.mdx
@@ -34,7 +34,7 @@ The default value of `tracingOrigins` is `['localhost', /^\//]`. The JavaScript 
 
 <PlatformContent includePath="performance/tracingOrigins-example" />
 
-You will need to configure your web server CORS to allow the `sentry-trace` header. The configuration might look like `"Access-Control-Allow-Headers: sentry-trace"`, but the configuration depends on your set up. If you do not allow the `sentry-trace` header, the request might be blocked.
+You will need to configure your web server [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) to allow the `sentry-trace` header. The configuration might look like `"Access-Control-Allow-Headers: sentry-trace"`, but the configuration depends on your set up. If you do not allow the `sentry-trace` header, the request might be blocked.
 
 ### beforeNavigate
 

--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -112,21 +112,19 @@ Currently, we recommend using Relay in `managed` mode (which is the default). Th
 Don't forget to update your `DSN` to point to your running Relay instance.
 After you set up Relay, you should see a dramatic improvement to the impact on your server.
 
-<PlatformSection notSupported={["php.laravel"]}>
-
 ## Connecting Services
+
+<PlatformSection notSupported={["php.laravel"]}>
 
 If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) depending on where your request originates there are two methods to connect your traces:
 1. For requests that start in your backend, this is done by [adding a meta tag](/platforms/javascript/performance/connect-services/#pageload) in your HTML template that contains tracing information.
-2. For requests that start in JavaScript, this is done by [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
+2. For requests that start in JavaScript, this is done by the SDK [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
 
 Otherwise backend services with Performance Monitoring will connect automatically.
 
 </PlatformSection>
 
 <PlatformSection supported={["php.laravel"]}>
-
-## Connecting Services
 
 If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can use a helper function to continue the trace started from your backend in order to [connect services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests).
 Add the following line to your blade template rendering the `<head/>` of your page.

--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -116,7 +116,11 @@ After you set up Relay, you should see a dramatic improvement to the impact on y
 
 ## Connecting Services
 
-If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) depending on where your request originates there are two methods to connect your traces:
+1. For requests that start in your backend, this is done by [adding a meta tag](/platforms/javascript/performance/connect-services/#pageload) in your HTML template that contains tracing information.
+2. For requests that start in JavaScript, this is done by [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
+
+Otherwise backend services with Performance Monitoring will connect automatically.
 
 </PlatformSection>
 
@@ -136,5 +140,7 @@ Add the following line to your blade template rendering the `<head/>` of your pa
 ```
 
 This helper function will render a meta tag similar to this `<meta name="sentry-trace" content="49879feb76c84743ba5034bd2d3f1ca3-7cb5535c930d4666-1"/>` which our JS SDK will pick up and continue the trace. Therefore your frontend and your backend are connected via the same trace.
+
+Otherwise other backend services with Performance Monitoring will connect automatically.
 
 </PlatformSection>

--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -112,11 +112,19 @@ Currently, we recommend using Relay in `managed` mode (which is the default). Th
 Don't forget to update your `DSN` to point to your running Relay instance.
 After you set up Relay, you should see a dramatic improvement to the impact on your server.
 
+<PlatformSection notSupported={["php.laravel"]}>
+
+## Connecting Services
+
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
+
+</PlatformSection>
+
 <PlatformSection supported={["php.laravel"]}>
 
 ## Connecting Services
 
-If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can use a helper function to continue the trace started from your backend in order to [connect services](/javascript/performance/connect-services/#navigation-and-other-xhr-requests).
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can use a helper function to continue the trace started from your backend in order to [connect services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests).
 Add the following line to your blade template rendering the `<head/>` of your page.
 
 ```php {filename:app.blade.php}
@@ -128,13 +136,5 @@ Add the following line to your blade template rendering the `<head/>` of your pa
 ```
 
 This helper function will render a meta tag similar to this `<meta name="sentry-trace" content="49879feb76c84743ba5034bd2d3f1ca3-7cb5535c930d4666-1"/>` which our JS SDK will pick up and continue the trace. Therefore your frontend and your backend are connected via the same trace.
-
-</PlatformSection>
-
-<PlatformSection notSupported={["php.laravel"]}>
-
-## Connecting Services
-
-If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
 
 </PlatformSection>

--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -114,9 +114,9 @@ After you set up Relay, you should see a dramatic improvement to the impact on y
 
 <PlatformSection supported={["php.laravel"]}>
 
-### Connect Your Frontend
+## Connecting Services
 
-If you are using Performance Monitoring also for [JavaScript](/platforms/javascript/performance/) you can use a helper function to continue the trace started from your backend.
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can use a helper function to continue the trace started from your backend in order to [connect services](/javascript/performance/connect-services/#navigation-and-other-xhr-requests).
 Add the following line to your blade template rendering the `<head/>` of your page.
 
 ```php {filename:app.blade.php}
@@ -128,5 +128,13 @@ Add the following line to your blade template rendering the `<head/>` of your pa
 ```
 
 This helper function will render a meta tag similar to this `<meta name="sentry-trace" content="49879feb76c84743ba5034bd2d3f1ca3-7cb5535c930d4666-1"/>` which our JS SDK will pick up and continue the trace. Therefore your frontend and your backend are connected via the same trace.
+
+</PlatformSection>
+
+<PlatformSection notSupported={["php.laravel"]}>
+
+## Connecting Services
+
+If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/) you can have a trace header set on requests to your backend service to [connect the two services](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests), which will allow you to connect requests and errors back to the frontend request that started the trace.
 
 </PlatformSection>


### PR DESCRIPTION
- This is so that the app can consistently link to the platform specific performance setup page, and so we have a location for platform specific docs, like what laravel already has.
  - specifically the plan is to link to:
    1. For backend platforms that are specific enough go to: docs.sentry.io/platforms/{platform}/guides/{guide}/performance/#connecting-services
    2. otherwise for backend platforms just go to: docs.sentry.io/platforms/{platform}/performance/#connecting-services 
    3. then for everything else: docs.sentry.io/platforms/javascript/performance/connect-services/
- So far the only other platform with specific content is php/laravel, changed the content there slightly so it is more consistent with the common content
- Also reordered and reworded the connect service docs a bit to emphasize how to get included instrumentation setup over doing it manually