### PR TITLE
Unity: Enable performance content

### DIFF
--- a/src/platforms/common/configuration/index.mdx
+++ b/src/platforms/common/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 notSupported:
-  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "perl", "unity"]
+  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "perl"]
 description: "Additional configuration options for the SDK."
 sidebar_order: 5
 ---

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -16,6 +16,7 @@ supported:
   - dotnet
   - apple
   - javascript.cordova
+  - unity
 notSupported:
   - capacitor
 redirect_from:

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -13,6 +13,7 @@ supported:
   - android
   - ruby
   - apple
+  - unity
 notSupported:
   - javascript.cordova
 description: "Learn how to enable performance monitoring in your app if it is not already set up."


### PR DESCRIPTION
Update the performance index page so that Unity content displays. A later PR will address the `init` code sample issue.