### PR TITLE
fix(integrations): Separate out metric alerts v issue alerts

### DIFF
--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -21,17 +21,17 @@ For more details, see the [full Integration Platform documentation](/product/int
 
 ## Notification & Incidents
 
-| Integration                                       | Alerts | Link Unfurling |
-| ------------------------------------------------- | ------ | -------------- |
-| [Amixr](/product/integrations/amixr/)             | X      |                |
-| Datadog                                           | X      |                |
-| OpsGenie                                          | X      |                |
-| [PagerDuty](/product/integrations/pagerduty/)     | X      |                |
-| Pushover                                          | X      |                |
-| [Slack](/product/integrations/slack/)             | X      | X              |
-| [Microsoft Teams](/product/integrations/msteams/) | X      |                |
-| Twilio                                            | X      |                |
-| VictorOps                                         | X      |                |
+| Integration                                       | Issue alerts | Metric alerts | Link Unfurling |
+| ------------------------------------------------- | ------------ | ------------- | -------------- |
+| [Amixr](/product/integrations/amixr/)             | X            |               |                |
+| Datadog                                           | X            |               |                |
+| OpsGenie                                          | X            |               |                |
+| [PagerDuty](/product/integrations/pagerduty/)     | X            | X             |                |
+| Pushover                                          | X            |               |                |
+| [Slack](/product/integrations/slack/)             | X            | X             | X              |
+| [Microsoft Teams](/product/integrations/msteams/) | X            | X             |                |
+| Twilio                                            | X            |               |                |
+| VictorOps                                         | X            |               |                |
 
 ## Source Code Management
 


### PR DESCRIPTION
To make it clearer on what we support v not support on each integration.

<img width="792" alt="Screen Shot 2021-04-15 at 4 26 50 PM" src="https://user-images.githubusercontent.com/1417849/114950200-6caa6c80-9e07-11eb-95b9-3433b6dda30b.png">
