### PR TITLE
Unity lite bump

### DIFF
--- a/src/includes/getting-started-install/unity.mdx
+++ b/src/includes/getting-started-install/unity.mdx
@@ -1,5 +1,5 @@
 Get the SDK via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
 
 ```
-https://github.com/getsentry/sentry-unity-lite.git#1.0.2
+https://github.com/getsentry/sentry-unity-lite.git#1.0.3
 ```


### PR DESCRIPTION
Bump to latest unity lite.

Note: The include and common content needs to be moved to the new Unity SDK, which uses release registry for bumping:

Tracked on: https://github.com/getsentry/sentry-docs/issues/3407
