### PR TITLE
ref: Rename sentry_shutdown

### DIFF
--- a/src/includes/configuration/auto-session-tracking/native.mdx
+++ b/src/includes/configuration/auto-session-tracking/native.mdx
@@ -2,7 +2,7 @@ To benefit from the health data, you must use at least version 0.4.0 of the Nati
 
 Release health is captured, by default, unless you specifically disabled collecting it in the initialization options for the SDK.
 
-The SDK automatically starts a new session when it is initialized via `sentry_init`, and will end that session automatically when the SDK is shut down via `sentry_shutdown`, or explicitly by calling `sentry_end_session`.
+The SDK automatically starts a new session when it is initialized via `sentry_init`, and will end that session automatically when the SDK is shut down via `sentry_close`, or explicitly by calling `sentry_end_session`.
 
 The SDK currently tracks only one concurrent session and will end the running session when using `sentry_start_session`. If you prefer to start sessions manually, consider disabling automatic session tracking during initialization:
 

--- a/src/includes/configuration/drain-example/native.mdx
+++ b/src/includes/configuration/drain-example/native.mdx
@@ -1,11 +1,11 @@
 ```c
 #include <sentry.h>
 
-sentry_shutdown();
+sentry_close();
 ```
 
-Calling `sentry_shutdown()` before exiting the application is critical to avoid
+Calling `sentry_close()` (formerly `sentry_shutdown()`) before exiting the application is critical to avoid
 data loss.
 
-After shutdown, the client cannot be used anymore. It's important to only call
-`sentry_shutdown()` immediately before shutting down the application.
+After closing, the client cannot be used anymore. It's important to only call
+`sentry_close()` immediately before shutting down the application.

--- a/src/includes/getting-started-config/native.mdx
+++ b/src/includes/getting-started-config/native.mdx
@@ -10,7 +10,7 @@ int main(void) {
   /* ... */
 
   // make sure everything flushes
-  sentry_shutdown();
+  sentry_close();
 }
 ```
 
@@ -18,7 +18,7 @@ Alternatively, the DSN can be passed as `SENTRY_DSN` environment variable during
 
 <Alert level="warning" title="Warning">
 
-Calling `sentry_shutdown()` before exiting the application is critical. It
+Calling `sentry_close()` before exiting the application is critical. It
 ensures that events can be sent to Sentry before execution stops. Otherwise,
 event data may be lost.
 

--- a/src/includes/getting-started-config/native.qt.mdx
+++ b/src/includes/getting-started-config/native.qt.mdx
@@ -10,7 +10,7 @@ int main(int argc, char *argv[])
     sentry_init(options);
 
     // Make sure everything flushes
-    auto sentryShutdown = qScopeGuard([] { sentry_shutdown(); });
+    auto sentryClose = qScopeGuard([] { sentry_close(); });
 
     QApplication app(argc, argv);
     QWidget widget;
@@ -24,7 +24,7 @@ Alternatively, the DSN can be passed as `SENTRY_DSN` environment variable during
 
 <Alert level="warning" title="Warning">
 
-Calling `sentry_shutdown()` before exiting the application is critical. It
+Calling `sentry_close()` (formerly `sentry_shutdown()`) before exiting the application is critical. It
 ensures that events can be sent to Sentry before execution stops. Otherwise,
 event data may be lost.
 

--- a/src/wizard/native/index.md
+++ b/src/wizard/native/index.md
@@ -22,7 +22,7 @@ int main(void) {
   /* ... */
 
   // make sure everything flushes
-  sentry_shutdown();
+  sentry_close();
 }
 ```
 

--- a/src/wizard/native/qt.md
+++ b/src/wizard/native/qt.md
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
     sentry_init(options);
 
     // Make sure everything flushes
-    auto sentryShutdown = qScopeGuard([] { sentry_shutdown(); });
+    auto sentryClose = qScopeGuard([] { sentry_close(); });
 
     QApplication app(argc, argv);
     /* ... */


### PR DESCRIPTION
A soon-to-be-released version of native renames `sentry_shutdown` to `sentry_close` so make sure the docs reflect that.