### PR TITLE
feat(python): Add link to `environ` object docs to `wsgi` transaction sampling includes

### DIFF
--- a/src/includes/performance/default-sampling-context/python.bottle.mdx
+++ b/src/includes/performance/default-sampling-context/python.bottle.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Bottle integration adds the WSGI request environ:
+The Bottle integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {

--- a/src/includes/performance/default-sampling-context/python.django.mdx
+++ b/src/includes/performance/default-sampling-context/python.django.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Django integration adds the WSGI request environ:
+The Django integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {

--- a/src/includes/performance/default-sampling-context/python.falcon.mdx
+++ b/src/includes/performance/default-sampling-context/python.falcon.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Falcon integration adds the WSGI request environ:
+The Falcon integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {

--- a/src/includes/performance/default-sampling-context/python.flask.mdx
+++ b/src/includes/performance/default-sampling-context/python.flask.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Flask integration adds the WSGI request environ:
+The Flask integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {

--- a/src/includes/performance/default-sampling-context/python.pyramid.mdx
+++ b/src/includes/performance/default-sampling-context/python.pyramid.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Pyramid integration adds the WSGI request environ:
+The Pyramid integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {

--- a/src/includes/performance/default-sampling-context/python.tryton.mdx
+++ b/src/includes/performance/default-sampling-context/python.tryton.mdx
@@ -1,6 +1,6 @@
 <PlatformContent includePath="performance/default-sampling-context-platform" />
 
-The Tryton integration adds the WSGI request environ:
+The Tryton integration adds the WSGI request [`environ` object](https://www.python.org/dev/peps/pep-3333/#environ-variables):
 
 ```python
 {


### PR DESCRIPTION
This links to the spec for the `wsgi` `environ` object, so people know exactly what's in the data they're being passed when running a `traces_sampler` in the Python SDK.