### PR TITLE
Fix migration guides to make the behaviors of two codes same

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -87,7 +87,7 @@ end
 
 # After
 Sentry.with_scope do |scope|
-  scope.set_user(id: 1)
+  scope.set_tags(foo: "bar")
 
   Sentry.capture_message("test")
 end


### PR DESCRIPTION
This PR fixes an example code in the migration guide for Ruby to make the behaviors of the before code and the after code same.