### PR TITLE
fix(JS): Hide install link everywhere but browser

### DIFF
--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -2,6 +2,16 @@
 title: Installation Methods
 sidebar_order: 1
 description: "Review our alternate installation methods."
+notSupported:
+  - javascript.angular
+  - javascript.cordova
+  - javascript.electron
+  - javascript.ember
+  - javascript.gatsby
+  - javascript.nextjs
+  - javascript.react
+  - javascript.vue
+  - javascript.wasm
 ---
 
 <PageGrid />


### PR DESCRIPTION
The "Installation Methods" page only applies to the browser SDK (not any of the framework SDKs), because it's the only one we serve from a CDN and the only one we have a loader for. This PR hides it from all of the JS guides which inherit from browser, since it doesn't apply to them.