### PR TITLE
fix(nextjs): Add import to manual usage snippet

### DIFF
--- a/src/includes/capture-error/javascript ember.mdx
+++ b/src/includes/capture-error/javascript ember.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/ember";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.angular.mdx
+++ b/src/includes/capture-error/javascript.angular.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/angular";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.cordova.mdx
+++ b/src/includes/capture-error/javascript.cordova.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "sentry-cordova";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.gatsby.mdx
+++ b/src/includes/capture-error/javascript.gatsby.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/gatsby";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.nextjs.mdx
+++ b/src/includes/capture-error/javascript.nextjs.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/nextjs";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.react.mdx
+++ b/src/includes/capture-error/javascript.react.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/react";
 
 try {
   aFunctionThatMightFail();

--- a/src/includes/capture-error/javascript.vue.mdx
+++ b/src/includes/capture-error/javascript.vue.mdx
@@ -1,7 +1,7 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stacktrace.
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/vue";
 
 try {
   aFunctionThatMightFail();


### PR DESCRIPTION
In the nextjs SDK, the happy path uses `sentry-wizard` to create config files and pre-fill them with `Sentry.init()` calls. For this reason, we don't show those calls on the Getting Started page (they can be found on the Manual Setup page, to which we link multiple times). We also don't show any `Sentry.captureException()` calls, as those appear on the Manual Usage page, to which we also link multiple times.

As a result of all this, there's no opportunity/reason to include the import line (`import * as Sentry from @sentry/nextjs`) anywhere on that page. It's included on the Manual Setup page, but up until how hasn't been included on the Manual Usage page. As Manual Usage is a logical next stop after Getting Started, it's important to include the import there, since that may be the first `Sentry.*` call the user sees.

Because each framework corresponds to a package with a different name, and because you can't embed an include in a code snippet (I tried), this necessitated making framework-specific copies of the entire manual usage include. `@sentry/wasm` is not included because it's really just an integration, and therefore you still import from browser (meaning it can use the default JS snippet).