### PR TITLE
fix(nextjs): Post-release cleanup

### DIFF
--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -1,16 +1,16 @@
-Though it's possible to [configure everything manually](/platforms/javascript/guides/nextjs/manual-setup/), we have a wizard which will automate the initial steps. To use it, run the following from the root level of your project:
+Though it's possible to [configure everything manually](/platforms/javascript/guides/nextjs/manual-setup/), we have a wizard that will automate the initial steps. To use the wizard, run the following command from the root level of your project:
 
 ```bash
 npx @sentry/wizard -i nextjs
 ```
 
-The wizard will prompt you to log into Sentry, and then will automatically add the necessary configuration files to your project. It will perform the following changes:
+You'll be prompted to log in to Sentry. The wizard will then automatically add these configuration files to your project:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`
 - create `next.config.js` with the default configuration
 - create `sentry.properties` with configuration for `sentry-cli` (which is used when automatically uploading source maps)
 
-See the docs on [manual configuration](/platforms/javascript/guides/nextjs/manual-setup/) for examples of the files created by the wizard. If any of these files already exists, it will be created with a leading underscore and you will need to merge it with the existing file manually.
+See [manual configuration](/platforms/javascript/guides/nextjs/manual-setup/) for examples of the files created by the wizard. If any of these files already exists, it will be created with a leading underscore and you will need to merge it with the existing file manually.
 
 To complete your configuration, add [options](/platforms/javascript/configuration/) to your two `Sentry.init()` calls (in `sentry.client.config.js` and `sentry.server.config.js`, respectively). In those two files you can also set context data - data about the [user](/platforms/javascript/enriching-events/identify-user/), for example, or [tags](/platforms/javascript/enriching-events/tags/), or even [arbitrary data](/platforms/javascript/enriching-events/context/) - which will be added to every event sent to Sentry.
 

--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -1,14 +1,17 @@
-```Npx
+Though it's possible to [configure everything manually](/platforms/javascript/guides/nextjs/manual-setup/), we have a wizard which will automate the initial steps. To use it, run the following from the root level of your project:
+
+```bash
 npx @sentry/wizard -i nextjs
 ```
 
-<Note>
+The wizard will prompt you to log into Sentry, and then will automatically add the necessary configuration files to your project. It will perform the following changes:
 
-The call to the [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will automatically patch your project with the necessary configuration, though you can [setup manually](/platforms/javascript/guides/nextjs/manual-setup/) if you prefer.
-It will perform the following changes:
+- create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`
+- create `next.config.js` with the default configuration
+- create `sentry.properties` with configuration for `sentry-cli` (which is used when automatically uploading source maps)
 
-- create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init` (if those files already exist, it will create `_sentry.client.config.js` and `_sentry.server.config.js` instead).
-- create `next.config.js` with the default configuration (if it already exists it will create `_next.config.js` instead, which will need to be merged with the existing file manually).
-- create `sentry.properties` with Sentry’s project-specific data (used when uploading source maps).
+See the docs on [manual configuration](/platforms/javascript/guides/nextjs/manual-setup/) for examples of the files created by the wizard. If any of these files already exists, it will be created with a leading underscore and you will need to merge it with the existing file manually.
 
-</Note>
+To complete your configuration, add [options](/platforms/javascript/configuration/) to your two `Sentry.init()` calls (in `sentry.client.config.js` and `sentry.server.config.js`, respectively). In those two files you can also set context data - data about the [user](/platforms/javascript/enriching-events/identify-user/), for example, or [tags](/platforms/javascript/enriching-events/tags/), or even [arbitrary data](/platforms/javascript/enriching-events/context/) - which will be added to every event sent to Sentry.
+
+Once you're set up, the SDK will automatically capture unhandled errors and promise rejections. You can also [manually capture errors](/platforms/javascript/guides/nextjs/usage).

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -57,7 +57,7 @@ module.exports = {
 
 <PlatformSection supported={["javascript.nextjs"]}>
 
-You may configure [sentry-cli](/product/cli/configuration/) through its documented mechanisms, or [extend the default usage of webpack](/platforms/javascript/guides/nextjs/manual-setup/manual-config/) of Next.js.
+You may configure [sentry-cli](/product/cli/configuration/) through its documented mechanisms, or [extend the default usage of webpack](/platforms/javascript/guides/nextjs/manual-setup/) of Next.js.
 
 </PlatformSection>
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -8,17 +8,15 @@ If you can’t (or prefer not to) run the [configuration step](/platforms/javasc
 
 ## Set Initialization Config Files
 
-Create two files in the root directory of your project, `sentry.client.config.js` and `sentry.server.config.js`, and include in them your initialization code for the client-side SDK and server-side SDK, respectively.
+Create two files in the root directory of your project, `sentry.client.config.js` and `sentry.server.config.js`. In these files, add your initialization code for the client-side SDK and server-side SDK, respectively. We've included some examples below.
 
 For the client configuration:
 
 ```javascript {filename:sentry.client.config.js}
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-
 Sentry.init({
-  dsn: SENTRY_DSN || "___PUBLIC_DSN___",
+  dsn: "___PUBLIC_DSN___",
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
@@ -31,10 +29,8 @@ And the server configuration:
 ```javascript {filename:sentry.server.config.js}
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-
 Sentry.init({
-  dsn: SENTRY_DSN || "___PUBLIC_DSN___",
+  dsn: "___PUBLIC_DSN___",
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -1,7 +1,7 @@
 ---
-title: Manual Configuration
+title: Manual Setup
 sidebar_order: 1
-description: "Learn about manual configuration of the SDK."
+description: "Learn how to set up the SDK manually."
 ---
 
 If you can’t (or prefer not to) run the [configuration step](/platforms/javascript/guides/nextjs/#configure), you can follow the instructions below to configure your application.

--- a/src/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -1,6 +1,0 @@
----
-title: Manual Setup
-description: "Learn more about manual configuration including webpack usage and managing your app's property file."
----
-
-<PageGrid />


### PR DESCRIPTION
Now that the nextjs SDK has been released, we've gotten some good feedback from folks trying to set it up using the docs. This addresses a few of the points raised, as do https://github.com/getsentry/sentry-docs/pull/3433 and https://github.com/getsentry/sentry-docs/pull/3434.

Changes in this PR:

- Remove unnecessary intermediate page between Getting Started and Manual Setup pages
- Simplify code snippets on Manual Setup page, as option of using the env variables is mentioned below
- Rework the Configuration section of Getting Started, to link to:
  - examples of the wizard's created files
  -  docs on `Sentry.init()` options and setting global context (as those are both things they'll need to do in the created files)
  - manual usage instructions