### PR TITLE
ref(integration-platform): Update permissions language

### DIFF
--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -20,7 +20,7 @@ Permissions specify what level of access your service requires of Sentry resourc
 
 ![Form that allows developer to set what permissions they'll need from their user.](permissions.png)
 
-You cannot create an integration or change an existing integration to have permissions greater than your own user settings.
+You cannot create an integration or change an existing integration to have permissions greater than your own user settings. Permissions are scoped to the organization, so adding scopes for issues and events, projects, or teams will enable access to issues and events, projects, or teams across the organization. 
 
 ### Using Auth Tokens
 
@@ -366,4 +366,4 @@ Sentry Integration apps will be able to augment Sentry’s UI in meaningful and 
 
 #### How can I build an Integration with Sentry?
 
-You can visit Organization Settings > Developer Settings.
+If you are a Manager or Owner for your organization you can visit Organization Settings > Developer Settings.


### PR DESCRIPTION
Docs PR to reflect the changes made in https://github.com/getsentry/sentry/pull/25458. The two changes are:
* Make it explicit that permissions are scoped to the organization, you can't limit the integration to only have access to certain projects/teams within an integration (at least for now). 
* Mention that Managers and Owners are the ones that can create the internal or public integrations. 

![Screen Shot 2021-04-21 at 12 26 42 PM](https://user-images.githubusercontent.com/15368179/115609832-e2498900-a29c-11eb-8a1a-574a40805ee6.png)
![Screen Shot 2021-04-21 at 12 26 31 PM](https://user-images.githubusercontent.com/15368179/115609830-e1b0f280-a29c-11eb-8e4d-2aef50e130f2.png)
