### PR TITLE
ref(stacktrace-link): Remove EA note

### DIFF
--- a/src/docs/product/integrations/github/index.mdx
+++ b/src/docs/product/integrations/github/index.mdx
@@ -222,13 +222,6 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 ### Stack Trace Linking
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
 1. Navigate to **Settings > Integrations > GitHub > Configurations**.

--- a/src/docs/product/integrations/gitlab/index.mdx
+++ b/src/docs/product/integrations/gitlab/index.mdx
@@ -124,12 +124,6 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 ![Issue detail highlighting suspect commits](short-id.png)
 
 ### Stack Trace Linking
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 


### PR DESCRIPTION
Stack trace linking is no longer in EA, so we should have removed the note