### PR TITLE
fix: setContext examples in multiple platforms

### DIFF
--- a/src/includes/set-context/dart.mdx
+++ b/src/includes/set-context/dart.mdx
@@ -1,10 +1,10 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-final person = {
+final character = {
   'name': 'Mighty Fighter',
   'age': '19',
   'attack_type': 'melee',
 };
-Sentry.configureScope((scope) => scope.setContexts('person', person));
+Sentry.configureScope((scope) => scope.setContexts('character', character));
 ```

--- a/src/includes/set-context/dart.mdx
+++ b/src/includes/set-context/dart.mdx
@@ -3,7 +3,7 @@ import 'package:sentry/sentry.dart';
 
 final character = {
   'name': 'Mighty Fighter',
-  'age': '19',
+  'age': 19,
   'attack_type': 'melee',
 };
 Sentry.configureScope((scope) => scope.setContexts('character', character));

--- a/src/includes/set-context/dart.mdx
+++ b/src/includes/set-context/dart.mdx
@@ -4,6 +4,7 @@ import 'package:sentry/sentry.dart';
 final person = {
   'name': 'Mighty Fighter',
   'age': '19',
+  'attack_type': 'melee',
 };
 Sentry.configureScope((scope) => scope.setContexts('person', person));
 ```

--- a/src/includes/set-context/dotnet.mdx
+++ b/src/includes/set-context/dotnet.mdx
@@ -6,8 +6,8 @@ SentrySdk.ConfigureScope(scope =>
     scope.Contexts["character"] = new
     {
         Name = "Mighty Fighter",
-        Strength = 14,
-        Agility = 21
+        Age = 19,
+        AttackType = "melee"
     };
 });
 ```
@@ -18,8 +18,8 @@ open Sentry
 SentrySdk.ConfigureScope(fun scope ->
     scope.Contexts["character"] <- {|
         Name = "Mighty Fighter"
-        Strength = 14
-        Agility = 21
+        Age = 19
+        AttackType = "melee"
     |}
     )
 ```

--- a/src/includes/set-context/go.mdx
+++ b/src/includes/set-context/go.mdx
@@ -1,5 +1,9 @@
 ```go
 sentry.ConfigureScope(func(scope *sentry.Scope) {
-	scope.SetExtra("character.name", "Mighty Fighter")
+	scope.SetContext("character", map[string]interface{}{
+		"name":        "Mighty Fighter",
+		"age":         19,
+		"attack_type": "melee",
+	})
 })
 ```

--- a/src/includes/set-context/php.mdx
+++ b/src/includes/set-context/php.mdx
@@ -1,5 +1,9 @@
 ```php
 \Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
-  $scope->setExtra('character.name', 'Mighty Fighter');
+  $scope->setContext('character', [
+    'name' => 'Mighty Fighter',
+    'age' => 19,
+    'attack_type' => 'melee'
+  ]);
 });
 ```

--- a/src/includes/set-context/ruby.mdx
+++ b/src/includes/set-context/ruby.mdx
@@ -2,7 +2,11 @@
 Sentry.configure_scope do |scope|
   scope.set_context(
     'character',
-    { name: 'Mighty Fighter', age: 19 }
+    {
+      name: 'Mighty Fighter',
+      age: 19,
+      attack_type: 'melee'
+    }
   )
 end
 ```

--- a/src/includes/set-context/rust.mdx
+++ b/src/includes/set-context/rust.mdx
@@ -1,5 +1,10 @@
 ```rust
 sentry::configure_scope(|scope| {
-    scope.set_extra("character.name", "Mighty Fighter".to_owned().into());
-});
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(String::from("name"), "Mighty Fighter".into());
+    map.insert(String::from("age"), 19.into());
+    map.insert(String::from("attack_type"), "melee".into());
+
+    scope.set_context("character", sentry::protocol::Context::Other(map));
+})
 ```


### PR DESCRIPTION
Fixes #3448 (fixes the Go example, and additionally other platforms not listed in the issue).

Note: the Java/Kotlin example is left for another pass.