### PR TITLE
Clean up URL in JS docs - allowUrls

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -144,7 +144,7 @@ A list of strings or regex patterns that match error URLs that should not be sen
 <ConfigKey name="allow-urls" supported={["javascript"]}>
 
 A legacy alias for a list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
-will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `[https://bar.com/myfile/foo.com](https://bar.com/myfile/foo.com)` By default, all errors will be sent.
+will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
 
 </ConfigKey>
 


### PR DESCRIPTION
Currently leaking markdown in [`allowUrls`](https://docs.sentry.io/platforms/javascript/configuration/options/#allow-urls):

<img width="779" alt="Screen Shot 2021-04-23 at 10 04 43 AM" src="https://user-images.githubusercontent.com/134455/115883025-5611a000-a41b-11eb-8501-6f9187fa2dbc.png">
