### PR TITLE
fix: Update default release for Vercel

### DIFF
--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -72,8 +72,8 @@ The Gatsby SDK will set certain options automatically based on environmental var
 
 `release` (string)
 
-: Defaults to certain environmental variables based on the platform
+: Defaults to certain environment variables based on the platform
 
 - GitHub Actions: `process.env.GITHUB_SHA`
 - Netlify: `process.env.COMMIT_REF`
-- Vercel: `process.env.VERCEL_GITHUB_COMMIT_SHA` or `process.env.VERCEL_GITLAB_COMMIT_SHA` or `process.env.VERCEL_BITBUCKET_COMMIT_SHA`
+- Vercel: `process.env.VERCEL_GIT_COMMIT_SHA`


### PR DESCRIPTION
The defaulting rules changed in https://github.com/getsentry/sentry-javascript/commit/cb66fa46dccc6fc7d7edd906284f3bf10eff5c39.

Fixes #3360.