### PR TITLE
fix(nextjs): Namespace and verify snippets

### DIFF
--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -12,6 +12,18 @@ You'll be prompted to log in to Sentry. The wizard will then automatically add t
 
 See [manual configuration](/platforms/javascript/guides/nextjs/manual-setup/) for examples of the files created by the wizard. If any of these files already exists, it will be created with a leading underscore and you will need to merge it with the existing file manually.
 
-To complete your configuration, add [options](/platforms/javascript/configuration/) to your two `Sentry.init()` calls (in `sentry.client.config.js` and `sentry.server.config.js`, respectively). In those two files you can also set context data - data about the [user](/platforms/javascript/enriching-events/identify-user/), for example, or [tags](/platforms/javascript/enriching-events/tags/), or even [arbitrary data](/platforms/javascript/enriching-events/context/) - which will be added to every event sent to Sentry.
+To complete your configuration, add [options](/platforms/javascript/configuration/) to your two `Sentry.init()` calls (in `sentry.client.config.js` and `sentry.server.config.js`, respectively).
+In those two files you can also set context data - data about the [user](/platforms/javascript/enriching-events/identify-user/), for example, or [tags](/platforms/javascript/enriching-events/tags/), or even [arbitrary data](/platforms/javascript/enriching-events/context/) - which will be added to every event sent to Sentry.
+For example:
+
+```javascript {filename:sentry.client.config.js}
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.configureScope(scope => {
+  scope.setUser({ id: '4711' });
+  scope.setTag('user_mode', 'admin');
+  scope.setExtra('battery', 0.7);
+});
+```
 
 Once you're set up, the SDK will automatically capture unhandled errors and promise rejections. You can also [manually capture errors](/platforms/javascript/guides/nextjs/usage).

--- a/src/includes/getting-started-verify/javascript.nextjs.mdx
+++ b/src/includes/getting-started-verify/javascript.nextjs.mdx
@@ -1,0 +1,13 @@
+```JSX {filename:pages/index.js}
+<button onClick={methodDoesNotExist}>
+    Break the world
+</button>;
+```
+
+You can also verify the server side:
+
+```javascript {filename:pages/api/server.js}
+export default (req, res) => {
+  throw new Error("Break the server");
+}
+```


### PR DESCRIPTION
Showing how to import the namespace (updated in `getting-started-config/javascript.nextjs.mdx`) and a more meaningful code snippet (added to `getting-started-verify/javascript.nextjs.mdx`) were two pieces of feedback after the Next.js SDK release; addressed in this PR.