### PR TITLE
Wrong argument format for breadcrumbs_logger

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -89,8 +89,8 @@ end
 And you can enable them with the `breadcrumbs_logger` option:
 
 ```ruby
-config.breadcrumbs_logger = :sentry_logger
-config.breadcrumbs_logger = :active_support_logger
+config.breadcrumbs_logger = [:sentry_logger]
+config.breadcrumbs_logger = [:active_support_logger]
 config.breadcrumbs_logger = [:sentry_logger, :active_support_logger]
 ```
 


### PR DESCRIPTION
Without wrapping with array it gives the exception:
```
.rvm/gems/ruby-2.6.6/gems/sentry-rails-4.3.2/lib/sentry/rails/railtie.rb:66:in `inject_breadcrumbs_logger': undefined method `include?' for :sentry_logger:Symbol (NoMethodError)
```