### PR TITLE
Add How to Write - Index Pages in contributor docs

### DIFF
--- a/src/docs/contributing/approach/product-docs/index.mdx
+++ b/src/docs/contributing/approach/product-docs/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Product Documentation Structure
+noindex: true
+sidebar_order: 20
+---
+
+The topics in this section cover how to create Sentry product documentation.

--- a/src/docs/contributing/approach/product-docs/index.mdx
+++ b/src/docs/contributing/approach/product-docs/index.mdx
@@ -4,4 +4,6 @@ noindex: true
 sidebar_order: 20
 ---
 
-The topics in this section cover how to create Sentry product documentation.
+The topics in this section describe how to create Sentry product documentation.
+
+<PageGrid />

--- a/src/docs/contributing/approach/product-docs/write-index.mdx
+++ b/src/docs/contributing/approach/product-docs/write-index.mdx
@@ -1,0 +1,66 @@
+---
+title: How to Write - Index Pages
+noindex: true
+sidebar_order: 10
+---
+
+This guide to writing index pages is just that—a guide. It won’t answer every question you have about how to write a good index page, but it will help you make a good start.
+
+<Note>
+
+While we use the term “index page” to refer to the top-level page about a feature in Docs, we don’t use this terminology in the actual Docs. Learn more in [Other Guidelines](#other-guidelines).
+
+</Note>
+
+The index page:
+- Explains WHAT the feature is
+- Describes WHY the feature benefits the customer, without veering too far into marketing language
+- Describes HOW the mechanisms of the feature help the customer achieve these benefits
+- Provides easy-to-find LINKS to child pages describing the subpages of the primary feature and/or how to do things with the feature
+
+The index page does not:
+- Describe HOW TO do anything that can’t be described in one or two sentences; that information should be on child pages in Docs.
+
+## What and Why
+
+- The elevator pitch of this feature
+    - What the feature is and what problem it’s solving for the customer
+- Two-to-five sentences
+    - This can be longer if you need to explain the feature as a concept before you can explain what the feature provides (for example, [Releases as a feature/concept vs the Releases page of application](/product/releases/))
+- A pixel perfect overview screenshot showing the feature in action
+
+## How: Contained Features - Page Breakdown
+
+Use this approach for a feature that doesn’t require much explanation and has distinct sections, like [Org Stats]() - it’s good for very contained features.
+- Describe each page section/element focusing on how it helps the customer achieve the WHY of this feature.
+- Add headings describing the page section/element to make each section of text stand out, if needed.
+- Describe how this feature fits in/interacts with other parts of the application, if applicable (e.g., this page has a button that takes you Discover queries).
+
+## How: Wider-Ranging Features - Benefit Breakdown
+
+Use this approach for a page that requires more explanation to break down and/or has a lot of child pages to explain its different benefits, like [Performance Monitoring](https://docs.sentry.io/product/performance/).
+- Describe how each page section/element or child page, helps the customer achieve the WHY of this feature.
+- Include links to relevant child pages in the text.
+- Group page sections/elements or child pages as appropriate like [here]().
+- Add headings that describe the benefit rather than the page section/element like [here]().
+- Describe how this feature fits in/interacts with other parts of the application, if applicable (e.g., this page has a button that takes you Discover queries).
+
+If you use this approach, you may want to include a very high-level, one- or two-sentence description of what the page looks like as part of the WHAT/WHY section.
+
+## Links
+
+- Create a section called “Learn More”
+- Use a `<PageGrid />` element to link to child pages for this feature
+    - This displays a bullet list of page links with their front matter page descriptions
+    - This might require that you edit the front matter descriptions of the pages displayed in the page grid
+
+## Other Quick Guidelines
+
+Following are some quick tips to keep in mind:
+- Refer to the feature’s main page in the application as a page, home page, or even main page. Do not call it an index page or use homepage (all one word).
+- Refer to the organization as Sentry; refer to the UI of the application as [sentry.io](https://sentry.io) (with lower case “s” and embedded link), not the Sentry UI.
+- Avoid beginning sentences with [sentry.io](https://sentry.io).
+- Do not skip heading levels. Don’t use an H3 as your first sub-heading/page-level heading. The page title is considered the H1 and the next heading level that should be used after that is an H2. If you skip heading levels, the right hand sidebar menu won’t render.
+- Do not add more H1 headings to the page. The title is the H1. All other headings on the page should be H2 or lower in hierarchy (that is, higher in number).
+
+Internal writers, refer to the [Tips for Contributors](https://www.notion.so/sentry/Tips-for-Contributors-b1997ea7f5e84eb9a02e0770b6dcc453) and [Writing Style Guide](https://www.notion.so/sentry/Writing-Style-Guide-5b54fc27656c4003bcec4802effcf1eb) pages for further guidance.

--- a/src/docs/contributing/approach/product-docs/write-index.mdx
+++ b/src/docs/contributing/approach/product-docs/write-index.mdx
@@ -31,7 +31,7 @@ The index page does not:
 
 ## How: Contained Features - Page Breakdown
 
-Use this approach for a feature that doesn’t require much explanation and has distinct sections, like [Org Stats]() - it’s good for very contained features.
+Use this approach for a feature that doesn’t require much explanation and has distinct sections, like [Org Stats](/product/accounts/quotas/org-stats/) - it’s good for very contained features.
 - Describe each page section/element focusing on how it helps the customer achieve the WHY of this feature.
 - Add headings describing the page section/element to make each section of text stand out, if needed.
 - Describe how this feature fits in/interacts with other parts of the application, if applicable (e.g., this page has a button that takes you Discover queries).
@@ -41,8 +41,8 @@ Use this approach for a feature that doesn’t require much explanation and has 
 Use this approach for a page that requires more explanation to break down and/or has a lot of child pages to explain its different benefits, like [Performance Monitoring](https://docs.sentry.io/product/performance/).
 - Describe how each page section/element or child page, helps the customer achieve the WHY of this feature.
 - Include links to relevant child pages in the text.
-- Group page sections/elements or child pages as appropriate like [here]().
-- Add headings that describe the benefit rather than the page section/element like [here]().
+- Group page sections/elements or child pages as appropriate like [here](). [link coming soon]
+- Add headings that describe the benefit rather than the page section/element like [here](). [link coming soon]
 - Describe how this feature fits in/interacts with other parts of the application, if applicable (e.g., this page has a button that takes you Discover queries).
 
 If you use this approach, you may want to include a very high-level, one- or two-sentence description of what the page looks like as part of the WHAT/WHY section.
@@ -54,11 +54,11 @@ If you use this approach, you may want to include a very high-level, one- or two
     - This displays a bullet list of page links with their front matter page descriptions
     - This might require that you edit the front matter descriptions of the pages displayed in the page grid
 
-## Other Quick Guidelines
+## Other Guidelines
 
 Following are some quick tips to keep in mind:
-- Refer to the feature’s main page in the application as a page, home page, or even main page. Do not call it an index page or use homepage (all one word).
-- Refer to the organization as Sentry; refer to the UI of the application as [sentry.io](https://sentry.io) (with lower case “s” and embedded link), not the Sentry UI.
+- Refer to the feature’s main page in the application as a *page*, *home page*, or even *main page*. Do not call it an *index page* or use *homepage* (all one word).
+- Refer to the organization as *Sentry*; refer to the UI of the application as [sentry.io](https://sentry.io) (with lower case “s” and embedded link), not *the Sentry UI*.
 - Avoid beginning sentences with [sentry.io](https://sentry.io).
 - Do not skip heading levels. Don’t use an H3 as your first sub-heading/page-level heading. The page title is considered the H1 and the next heading level that should be used after that is an H2. If you skip heading levels, the right hand sidebar menu won’t render.
 - Do not add more H1 headings to the page. The title is the H1. All other headings on the page should be H2 or lower in hierarchy (that is, higher in number).

--- a/src/docs/contributing/approach/sdk-docs/common_content.mdx
+++ b/src/docs/contributing/approach/sdk-docs/common_content.mdx
@@ -1,7 +1,9 @@
 ---
 title: Common Content
 noindex: true
-sidebar_order: 2
+sidebar_order: 20
+redirect_from:
+ - /contributing/approach/common_content/
 ---
 
 We provide common content to prevent duplication in our repository. It is provided for all platforms as well as frameworks that rely on a primary platform. In some circumstances, the common content is not valid, or the content varies enough that it must be written specifically to a particular platform or framework. However, if the content is technically correct for a new SDK or framework, there is no need to develop separate content that duplicates the information.

--- a/src/docs/contributing/approach/sdk-docs/index.mdx
+++ b/src/docs/contributing/approach/sdk-docs/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: SDK Documentation Structure
 noindex: true
-sidebar_order: 3
+sidebar_order: 10
+redirect_from:
+ - /contributing/approach/write-sdk-docs/
 ---
 
 Our structure for SDK content focuses on getting a user up and running quickly, then learning about all the features that can be configured or enabled in subpages. These subpages provide reference material, with code examples specific to the SDK.

--- a/src/docs/contributing/approach/sdk-docs/write-configuration.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-configuration.mdx
@@ -1,7 +1,9 @@
 ---
 title: How to Write - Configuration
 noindex: true
-sidebar_order: 5
+sidebar_order: 40
+redirect_from:
+ - /contributing/approach/write-configuration/
 ---
 
 The Configuration section of the content covers, unsurprisingly, how customers can configure an SDK. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/configuration/` - feel free to peruse the files in that directory to help answer any questions.

--- a/src/docs/contributing/approach/sdk-docs/write-data-management.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-data-management.mdx
@@ -1,7 +1,9 @@
 ---
 title: How to Write - Data Management
 noindex: true
-sidebar_order: 6
+sidebar_order: 60
+redirect_from:
+ - /contributing/approach/write-data-management/
 ---
 
 The Data Management section of the content covers how customers can manage the data sent to Sentry using the SDK. We provide a parallel section in product, which focuses on the settings in [sentry.io](http://sentry.io) a user can user to control data. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/data-management/` - feel free to peruse the files in that directory to answer any questions.

--- a/src/docs/contributing/approach/sdk-docs/write-enriching-events.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-enriching-events.mdx
@@ -1,7 +1,9 @@
 ---
 title: How to Write - Enriching Events
 noindex: true
-sidebar_order: 5
+sidebar_order: 50
+redirect_from:
+ - /contributing/approach/write-enriching-events/
 ---
 
 The Enriching Events section of the content covers how customers can add context to the data sent to Sentry. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/enriching-events/` - feel free to peruse the files in that directory to answer any questions.

--- a/src/docs/contributing/approach/sdk-docs/write-getting-started.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-getting-started.mdx
@@ -1,7 +1,9 @@
 ---
 title: How to Write - Getting Started
 noindex: true
-sidebar_order: 4
+sidebar_order: 30
+redirect_from:
+ - /contributing/approach/write-getting-started/
 ---
 
 In most cases, the platform/SDK will adopt the common index page, which is stored in [`src/platforms/common/`](https://github.com/getsentry/sentry-docs/tree/master/src/platforms/common), as the [`index.mdx`](https://github.com/getsentry/sentry-docs/blob/master/src/platforms/common/index.mdx) file - feel free to peruse that file to answer any questions.

--- a/src/docs/contributing/approach/sdk-docs/write-performance.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-performance.mdx
@@ -1,7 +1,9 @@
 ---
-title: How to Write - SDK Performance Docs
+title: How to Write - Performance
 noindex: true
-sidebar_order: 6
+sidebar_order: 70
+redirect_from:
+ - /contributing/approach/write-performance/
 ---
 
 The Performance section of the content covers performance instrumentation for our SDKs. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/performance/` - feel free to peruse the files in that directory to help answer any questions. **However,** each SDK will have its _own_ page devoted to what instrumentation is included. We do not develop common content for this page, just its structure.

--- a/src/docs/contributing/approach/sdk-docs/write-usage.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-usage.mdx
@@ -1,7 +1,9 @@
 ---
 title: How to Write - Usage
 noindex: true
-sidebar_order: 7
+sidebar_order: 80
+redirect_from:
+ - /contributing/approach/write-usage/
 ---
 
 The Usage section of the content covers how to manually capture events and message. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/usage/` - feel free to peruse the files in that directory to help answer questions.


### PR DESCRIPTION
Add How to Write - Index Pages for product in contributor docs
Restructure Approach section to fit new Product Docs section