### PR TITLE
fix(nextjs): Tone down beta note

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -13,8 +13,8 @@ Features:
 
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
 
-<Alert level="warning" title="Experimental Plugin">
+<Alert level="info" title="Early Adopter">
 
-The SDK relies on the experimental plugin system of Next.js. This restricts the SDK to running on the production server (it runs on the client in both dev and production), and means changes to the plugin system may prevent the SDK from working as expected. We recognize the irony.
+The SDK is in the early stages of being released. This means changes are possible and may prevent the SDK from working as expected. We recognize the irony.
 
 </Alert>


### PR DESCRIPTION
[We no longer rely on the nextjs plugin system](https://github.com/getsentry/sentry-javascript/pull/3462). This updates the warning about it to a) remove mention of said system, and b) make it sound a little less dire while still letting people know that things aren't entirely stable yet. H/t to @PeloWriter for the wording.