### PR TITLE
fix: Remove draining section for PHP

### DIFF
--- a/src/platforms/common/configuration/draining.mdx
+++ b/src/platforms/common/configuration/draining.mdx
@@ -7,6 +7,7 @@ notSupported:
   - dart
   - ruby
   - unity
+  - php
 ---
 
 The default behavior of most SDKs is to send out events over the network


### PR DESCRIPTION
The PHP transport is synchronous, that means all requests to Sentry always go out before the PHP process ends.

In short, it's never necessary to "drain" the SDK transport by calling "flush" like in other SDKs.

This pull request removes this auto-generated page from common content: https://docs.sentry.io/platforms/php/configuration/draining/

![image](https://user-images.githubusercontent.com/88819/116696878-bfb51f80-a9c2-11eb-820c-9e9791a0e8c3.png)
