### PR TITLE
ref(nextjs): Add minimum Next.js supported version

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -4,7 +4,7 @@ _Sentry's Next.js SDK enables automatic reporting of errors and exceptions._
 
 </Note>
 
-Currently, the minimum Next.js supported version is 10.0.0.
+Currently, the minimum Next.js supported version is `10.0.0`.
 
 Features:
 

--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -4,6 +4,8 @@ _Sentry's Next.js SDK enables automatic reporting of errors and exceptions._
 
 </Note>
 
+Currently, the minimum Next.js supported version is 10.0.0.
+
 Features:
 
 - Automatic [Error Tracking](/product/issues/) with source maps for both JavaScript and TypeScript


### PR DESCRIPTION
Currently, the minimum Next.js supported version for the Next.js SDK is `10.0.0`; but this was missing in the docs. This PR adds it.