### PR TITLE
fix(copy): Issue Alerts Actions List

### DIFF
--- a/src/docs/product/alerts-notifications/issue-alerts.mdx
+++ b/src/docs/product/alerts-notifications/issue-alerts.mdx
@@ -61,7 +61,10 @@ Actions specify what should happen when the alert is triggered and passes the fi
 
   If no legacy integrations or integrations built using the integration platform are enabled, this option is hidden.
 
-- Issue creation for an [integration](/product/integrations/), which includes: - [Jira](/product/integrations/jira/) - [Azure DevOps](/product/integrations/azure-devops)
+- Issue creation for an [integration](/product/integrations/), which includes:
+
+  - [Jira](/product/integrations/jira/)
+  - [Azure DevOps](/product/integrations/azure-devops)
 
 #### Issue Owners
 


### PR DESCRIPTION
Reading through the docs I saw this:
![Screen Shot 2021-04-30 at 12 37 06 PM](https://user-images.githubusercontent.com/31750075/116746008-c76bc880-a9b0-11eb-84aa-5fb486f94e51.png)
This PR fixes the markdown for the list of issue creating integrations