### PR TITLE
Update Symfony Monolog integration

### DIFF
--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -61,12 +61,24 @@ return [
 
 ### Monolog Integration
 
-If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the normal error listener approach, you also need these additional configuration and services to log the errors correctly:
+If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the typical error listener approach, you need this additional configuration to log the errors correctly:
 
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
 
+monolog:
+    handlers:
+        sentry:
+            type: sentry
+            level: !php/const Monolog\Logger::ERROR
+            hub_id: Sentry\State\HubInterface
+```
+
+If you are using a version of [MonologBundle](https://github.com/symfony/monolog-bundle) prior to `3.7`, you need to
+configure the handler as a service instead:
+
+```yaml {filename:config/packages/sentry.yaml}
 monolog:
     handlers:
         sentry:


### PR DESCRIPTION
Update Symfony Monolog integration to use the [`hub_id` option](https://github.com/symfony/monolog-bundle/pull/393) introduced in MonologBundle v3.7.