### PR TITLE
Add deprecation note to cocoa client pages

### DIFF
--- a/src/docs/clients/cocoa/advanced.mdx
+++ b/src/docs/clients/cocoa/advanced.mdx
@@ -7,6 +7,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note">
+
+A new Cocoa SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Cocoa SDK](/platforms/apple/) for new projects.
+
+</Alert>
+
 ## Capturing uncaught exceptions on macOS
 
 By default macOS application do not crash whenever an uncaught exception occurs. There are some additional steps you have to take to make this work with Sentry. You have to open the applications `Info.plist` file and look for `Principal class`. The content of it which should be `NSApplication` should be replaced with `SentryCrashExceptionApplication`.

--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -7,6 +7,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note">
+
+A new Cocoa SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Cocoa SDK](/platforms/apple/) for new projects.
+
+</Alert>
+
 A dSYM upload is required for Sentry to symbolicate your crash logs for viewing. The symbolication process unscrambles Apple’s crash logs to reveal the function, variables, file names, and line numbers of the crash. The dSYM file can be uploaded through the [sentry-cli](https://github.com/getsentry/sentry-cli) tool or through a [Fastlane](https://fastlane.tools/) action.
 
 ## With Bitcode {#dsym-with-bitcode}

--- a/src/docs/clients/cocoa/migration.mdx
+++ b/src/docs/clients/cocoa/migration.mdx
@@ -7,6 +7,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note">
+
+A new Cocoa SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated Cocoa SDK](/platforms/apple/) for new projects.
+
+</Alert>
+
 ## Upgrade from 2.x.x to 3.x.x {#upgrade-from-2-x-x-to-3-0-x}
 
 ### CocoaPods


### PR DESCRIPTION
We've had an issue related to updates of our old content. This update highlights the new SDK at the top of each Cocoa page.