### PR TITLE
Add default Next.js event environment

### DIFF
--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -29,4 +29,4 @@ const handler = async (req, res) => {
 export default withSentry(handler);
 ```
 
-By default the SDK sets events’ environment to `process.env.NODE_ENV`, although you can [set your own](/platforms/javascript/guides/nextjs/configuration/environments/).
+By default, the SDK sets the environment for events to `process.env.NODE_ENV`, although you can [set your own](/platforms/javascript/guides/nextjs/configuration/environments/).

--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -28,3 +28,5 @@ const handler = async (req, res) => {
 
 export default withSentry(handler);
 ```
+
+By default the SDK sets events’ environment to `process.env.NODE_ENV`, although you can [set your own](/platforms/javascript/guides/nextjs/configuration/environments/).


### PR DESCRIPTION
This PR adds the corresponding docs for https://github.com/getsentry/sentry-javascript/pull/3495, where the `process.env.NODE_ENV` is added as the `environment` by default.