### PR TITLE
Java: Migration for deprecating `sentry.enable-tracing`

### DIFF
--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -4,6 +4,12 @@ sidebar_order: 1000
 description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentry 3.x."
 ---
 
+## Migrating from `io.sentry:sentry` `4.3.0` to `io.sentry:sentry` `5.0.0`
+
+### Spring Boot
+
+- the property `sentry.enable-tracing` is deprecated. To enable tracing simply set `sentry.traces-sample-rate` or create a bean implementing `TracesSamplerCallback`
+
 ## Migrating from `io.sentry:sentry` `4.1.0` to `io.sentry:sentry` `4.2.0`
 
 `operation` is now a required property of the `SentryTransaction` and `SentrySpan`. Whenever a transaction or span is started, the value for `operation` must be provided:

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -6,11 +6,11 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
 
 ## Migrating from `io.sentry:sentry` `4.3.0` to `io.sentry:sentry` `5.0.0`
 
+`Sentry#startTransaction` by default does not bind created transaction to the scope. To start transaction with binding to the scope, use one of the new overloaded `startTransaction` methods taking `bindToScope` parameter and set it to `true`. Bound transaction can be retrieved with `Sentry#getSpan`.
+
 ### Spring Boot
 
 The property `sentry.enable-tracing` is deprecated. To enable tracing simply set `sentry.traces-sample-rate` or create a bean implementing `TracesSamplerCallback`.
-
-`Sentry#startTransaction` by default does not bind created transaction to the scope. To start transaction with binding to the scope, use one of the new overloaded `startTransaction` methods taking `bindToScope` parameter and set it to `true`. Bound transaction can be retrieved with `Sentry#getSpan`.
 
 ## Migrating from `io.sentry:sentry` `4.1.0` to `io.sentry:sentry` `4.2.0`
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -8,7 +8,7 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
 
 ### Spring Boot
 
-- the property `sentry.enable-tracing` is deprecated. To enable tracing simply set `sentry.traces-sample-rate` or create a bean implementing `TracesSamplerCallback`
+- the property `sentry.enable-tracing` is deprecated. To enable tracing simply set `sentry.traces-sample-rate` or create a bean implementing `TracesSamplerCallback`.
 
 ## Migrating from `io.sentry:sentry` `4.1.0` to `io.sentry:sentry` `4.2.0`
 


### PR DESCRIPTION
Migration docs related to: https://github.com/getsentry/sentry-docs/pull/3293