### PR TITLE
fix(nextjs): Update minimum supported version to 10.0.8

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -4,7 +4,7 @@ _Sentry's Next.js SDK enables automatic reporting of errors and exceptions._
 
 </Note>
 
-Currently, the minimum Next.js supported version is `10.0.0`.
+Currently, the minimum Next.js supported version is `10.0.8`.
 
 Features:
 


### PR DESCRIPTION
Currently, the SDK needs the `next.config.js` to be loaded async: vercel/next.js#22578
This change was introduced in v10.0.8: https://github.com/vercel/next.js/releases/tag/v10.0.8