### PR TITLE
fix(apple): Typo in fingerprint for database

### DIFF
--- a/src/includes/set-fingerprint/database-connection/apple.mdx
+++ b/src/includes/set-fingerprint/database-connection/apple.mdx
@@ -25,5 +25,5 @@ SentrySDK.start { options in
         }
         return event;
     };
-}
+}];
 ```


### PR DESCRIPTION
The code sample was missing a few characters to compile. This is fixed now.