### PR TITLE
fix(performance): Remove sample rate advice

### DIFF
--- a/src/docs/product/performance/distributed-tracing.mdx
+++ b/src/docs/product/performance/distributed-tracing.mdx
@@ -248,10 +248,6 @@ On the other hand, when your backend processes the requests from B's browser, it
 
 Put simply: as a result of this head-based approach, where the decision is made once in the originating service and passed to all subsequent services, either all of the transactions for a given trace are collected, or none are, so there shouldn't be any incomplete traces.
 
-### Consistency Between Traces
-
-If you enable tracing in services with multiple entry points, we recommend choosing similar sampling rates, to avoid biasing your data. For example, suppose the backend of our on-going web app example also serves as a public API. In that case, some traces would start with a page-load transaction in the web app, and likely include multiple backend transactions, while other traces (those representing folks hitting the public API) would begin with a single backend request transaction, which would be the only backend transaction in the trace. Choosing a very different sampling rate for your web app from that chosen for your backend would lead to one of those scenarios being oversampled compared to the other, compromising the accuracy of your overall data.
-
 ## Viewing Trace Data
 
 Through [Performance](/product/performance/) and [Discover](/product/discover-queries/), you can view trace data in the event details.


### PR DESCRIPTION
Different sample rates in different interconnected Sentry projects do
not affect sample bias any more than other factors such as uneven load
patterns.

The current advice suggests that "similar sampling rates [...] avoid
biasing [...] data", but that's not a fact.

We could either change the paragraph to discuss sources of data bias and
the effects on summaries like latency percentiles in the product, or
remove the paragraph altogether.

Since our docs are not the best place to discuss statistics, opting for
the latter.

The sample rate can be anything users want and keep them within their
quota. We even document how to have custom sample rates for different
endpoints as users see fit (tracesSampler callback).

Closes #1678.