### PR TITLE
Make React Router more visible

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -96,7 +96,7 @@ Otherwise, backend services with Performance Monitoring connect automatically.
 
 ## React Router
 
-If you are using `react-router`, we provide [instrumentation](configuration/integrations/react-router/) to use with our `@sentry/tracing` package.
+If you are using `react-router`, we provide <PlatformLink to="/configuration/integrations/react-router/">instrumentation</PlatformLink> to use with our `@sentry/tracing` package.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -96,7 +96,7 @@ Otherwise, backend services with Performance Monitoring connect automatically.
 
 ## React Router
 
-If you are using `react-router`, we provide `[react-router` instrumentation](configuration/integrations/react-router/) to use with our `@sentry/tracing` package. 
+If you are using `react-router`, we provide [instrumentation](configuration/integrations/react-router/) to use with our `@sentry/tracing` package.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -22,7 +22,6 @@ redirect_from:
   - /platforms/javascript/performance/apm-to-tracing/
 ---
 
-
 <Alert level="info" title="Do you need to set up?">
 
 The Getting Started page includes code samples that both enable and configure Performance Monitoring, so you don’t need to set up anything further. You can proceed straight to our content about instrumentation.
@@ -79,15 +78,25 @@ Leaving the sample rate at `1.0` means that included instrumentation will send a
 </PlatformSection>
 
 <!-- notSupported here should be the opposite of whats in common/connect-services.mdx -->
+
 <PlatformSection notSupported={["javascript", "javascript.cordova"]}>
 
 ## Connecting Services
 
 If you are also using Performance Monitoring for [JavaScript](/platforms/javascript/performance/), depending on where your request originates, you can connect traces:
+
 1. For requests that start in your backend, by [adding a meta tag](/platforms/javascript/performance/connect-services/#pageload) in your HTML template that contains tracing information.
 2. For requests that start in JavaScript, by the SDK [setting a header](/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests) on requests to your backend.
 
 Otherwise, backend services with Performance Monitoring connect automatically.
+
+</PlatformSection>
+
+<PlatformSection supported={["javascript",]} notSupported={["react-native"]}>
+
+## React Router
+
+If you are using `react-router`, we provide `react-router` instrumentation you can use alongside Performance Monitoring with `@sentry/tracing`. Please see the [React Router Integration documentation](configuration/integrations/react-router/) for more details on setting it up.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -92,7 +92,7 @@ Otherwise, backend services with Performance Monitoring connect automatically.
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript",]} notSupported={["react-native"]}>
+<PlatformSection supported={["javascript.react"]}>
 
 ## React Router
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -96,7 +96,7 @@ Otherwise, backend services with Performance Monitoring connect automatically.
 
 ## React Router
 
-If you are using `react-router`, we provide `react-router` instrumentation you can use alongside Performance Monitoring with `@sentry/tracing`. Please see the [React Router Integration documentation](configuration/integrations/react-router/) for more details on setting it up.
+If you are using `react-router`, we provide `[react-router` instrumentation](configuration/integrations/react-router/) to use with our `@sentry/tracing` package. 
 
 </PlatformSection>
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -33,7 +33,7 @@ const history = createBrowserHistory();
 Sentry.init({
   integrations: [
     new Integrations.BrowserTracing({
-      // Can also use reactRouterV4Instrumentation
+      // Can also use reactRouterV3Instrumentation or reactRouterV4Instrumentation
       routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
     });
   ],

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -186,7 +186,7 @@ const history = createBrowserHistory();
 Sentry.init({
   integrations: [
     new Integrations.BrowserTracing({
-      // Can also use reactRouterV4Instrumentation
+      // Can also use reactRouterV3Instrumentation or reactRouterV4Instrumentation
       routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
     });
   ],

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -168,7 +168,7 @@ Performance data is transmitted using a new event type called “transactions”
 
 Learn more about sampling in [Filtering Events Reported to Sentry](configuration/filtering/).
 
-## React Router
+### React Router
 
 _(New in version 5.21.0)_
 

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -164,11 +164,52 @@ export default Sentry.withProfiler(App);
 
 Learn more about using and customizing the React Profiler in [Profiler](components/profiler/).
 
-If you are using `react-router`, we provide `react-router` instrumentation you can use alongside Performance Monitoring with `@sentry/tracing`. Please see the [React Router Integration documentation](configuration/integrations/react-router/) for more details on setting it up.
-
 Performance data is transmitted using a new event type called “transactions”, which you can learn about in [Distributed Tracing](/product/performance/distributed-tracing/). To capture transactions, you must install the performance package and configure your SDK to set the <PlatformIdentifier name="traces-sample-rate" /> configuration to a nonzero value. The example configuration above will transmit 100% of captured transactions; lower this value in production to avoid consuming your quota too quickly.
 
 Learn more about sampling in [Filtering Events Reported to Sentry](configuration/filtering/).
+
+## React Router
+
+_(New in version 5.21.0)_
+
+React Router support is included in the `@sentry/react` package since version `5.21.0`. We support integrations for React Router 3, 4 and 5.
+
+```JSX
+import { Router } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
+
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+
+const history = createBrowserHistory();
+
+Sentry.init({
+  integrations: [
+    new Integrations.BrowserTracing({
+      // Can also use reactRouterV4Instrumentation
+      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
+    });
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+
+// ...
+
+// In your App render:
+render() {
+  return (
+    // Use custom history with a Router component
+    <Router history={history}>
+      <Components />
+    </Router>
+  );
+}
+```
+
+Please see the [React Router Integration documentation](configuration/integrations/react-router/) for more details on setting it up.
 
 ## Redux
 

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -172,7 +172,7 @@ Learn more about sampling in [Filtering Events Reported to Sentry](configuration
 
 _(New in version 5.21.0)_
 
-Sentry's performance instrumentation includes support for React Router 3, 4 and 5.
+Sentry's performance instrumentation includes support for React Router 3, 4, and 5.
 
 ```JSX
 import { Router } from 'react-router-dom';

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -209,7 +209,7 @@ render() {
 }
 ```
 
-Please see the [React Router Integration documentation](configuration/integrations/react-router/) for more details on setting it up.
+Learn more about set up information for our [React Router Integration](configuration/integrations/react-router/).
 
 ## Redux
 

--- a/src/platforms/javascript/guides/react/index.mdx
+++ b/src/platforms/javascript/guides/react/index.mdx
@@ -172,7 +172,7 @@ Learn more about sampling in [Filtering Events Reported to Sentry](configuration
 
 _(New in version 5.21.0)_
 
-React Router support is included in the `@sentry/react` package since version `5.21.0`. We support integrations for React Router 3, 4 and 5.
+Sentry's performance instrumentation includes support for React Router 3, 4 and 5.
 
 ```JSX
 import { Router } from 'react-router-dom';


### PR DESCRIPTION
A number of customers miss the fact that we have a React Router integration and can do parameterization.
Highlight this integration on `Getting Started` for React and Performance Set Up.