### PR TITLE
fix(apple): Clarification for manual transactions

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -33,6 +33,12 @@ If you're adding tracing, enable and configure it as documented here. If you’r
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/performance/distributed-tracing/).
 
+<PlatformSection supported={["apple"]}>
+
+The `sentry-cocoa` SDK doesn't yet support automatic instrumentation for monitoring the performance of your application. Instead, you have to manually capture transactions.
+
+</PlatformSection>
+
 <PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
 
 ## Enable Tracing

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -35,7 +35,7 @@ With [performance monitoring](/product/performance/), Sentry tracks your softwar
 
 <PlatformSection supported={["apple"]}>
 
-The `sentry-cocoa` SDK doesn't yet support automatic instrumentation for monitoring the performance of your application. Instead, you have to manually capture transactions.
+Automatic instrumentation for monitoring the performance of your application isn't yet supported. Instead, you can <PlatformLink to="/performance/custom-instrumentation/">use custom instrumentation to capture transactions</PlatformLink>.
 
 </PlatformSection>
 


### PR DESCRIPTION
A user assumed that the sentry-cocoa SDK already supports automatic
instrumentation. This is fixed now by clarifying this.