### PR TITLE
fix(nextjs): Clarify wording re: CLI config

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -90,8 +90,7 @@ Also keep in mind, by default we disable source map upload in `dev` mode when ru
 
 The `SentryWebpackPlugin` uses `sentry-cli`, which can be configured in one of two ways - using a properties file, or with environment variables - both of which are discussed below. For full details, see [the CLI configuration docs](https://docs.sentry.io/product/cli/configuration/).
 
-If you choose to combine the two approaches, the environment variables will take precedence over values set in the properties file.
-You can add the properties file to your VCS, excluding any sensitive data (like tokens), and add it to the environment variables.
+If you choose to combine the two approaches, the environment variables will take precedence over values set in the properties file. One common approach is to set sensitive data (like tokens) in the environment and include everything else in a properties file, which can then be added to your VCS.
 
 ### Properties File
 


### PR DESCRIPTION
> You can add the properties file to your VCS, excluding any sensitive data (like tokens), and add it to the environment variables.

It was unclear to what the final "it" referred. This reorganizes the sentence to make it clearer.