### PR TITLE
meta(gha): Deploy action issue-status-helper.yml

### DIFF
--- a/.github/workflows/issue-status-helper.yml
+++ b/.github/workflows/issue-status-helper.yml
@@ -1,0 +1,16 @@
+name: Issue Status Helper
+on:
+  issues:
+    types: [labeled]
+jobs:
+  routed:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.event.label.name, 'Status: ')"
+    steps:
+      - name: "Ensure a single 'Status: *' label"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          labels_to_remove=$(gh api "/repos/$GH_REPO/labels" -q '[.[].name | select(startswith("Status: ") and . != "${{ github.event.label.name }}")] | join(",")')
+          gh issue edit ${{ github.event.issue.number }} --remove-label "$labels_to_remove" --add-label "${{ github.event.label.name }}"


### PR DESCRIPTION
I are a bot, here to deploy [issue-status-helper.yml](https://github.com/getsentry/.github/blob/c47baae9fa40046424bda5ff741a8216b2f6f623/.github/workflows/issue-status-helper.yml). 🤖