### PR TITLE
fix: Scrollable right sidebar should be responsive friendly

### DIFF
--- a/src/css/_includes/grid.scss
+++ b/src/css/_includes/grid.scss
@@ -60,13 +60,28 @@ body {
 .page-nav {
   position: fixed;
   width: 27vw;
-  overflow-y: auto;
-  top: 100px;
-  bottom: 0;
+  
+  @media only screen and (min-width: 576px) {
+    overflow-y: auto;
+    top: 100px;
+    bottom: 0;
+  }
 
+  @media only screen and (min-width: 768px) {
+    top: auto;
+    bottom: auto;
+  }
+  
   @media only screen and (min-width: 900px) {
     width: 20vw;
   }
+  
+  @media only screen and (min-width: 992px) {
+    overflow-y: auto;
+    top: 100px;
+    bottom: 0;
+  }
+  
   @media only screen and (min-width: 1200px) {
     width: 16vw;
   }


### PR DESCRIPTION
Enable scrollable right sidebar introduced in https://github.com/getsentry/sentry-docs/pull/3539 on certain screen widths