### PR TITLE
add dsn to unity getting started

### DIFF
--- a/src/includes/getting-started-config/unity.mdx
+++ b/src/includes/getting-started-config/unity.mdx
@@ -1,11 +1,12 @@
 Currently, you can only configure Sentry using the Unity tools window.
 
-Open `Tools` -> `Sentry`.
+The minimum required configuration, is to set your DSN in the window. The DSN is available in your Sentry project settings, or if you're logged in, you can copy from below:
 
-The first time you open the window, Unity Sentry SDK related files are created:
+```
+___PUBLIC_DSN___
+```
 
-* `Assets/Resources/Sentry/SentryOptions.json` - Sentry settings
-* `Assets/Resources/Sentry/link.xml` - [a special file](https://docs.unity3d.com/Manual/ManagedCodeStripping.html) for [ILL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds
+To configure it, open `Tools` -> `Sentry`.
 
 ![Sentry tools](tools_sentry.png)
 
@@ -13,7 +14,4 @@ And the Sentry configuration window will open:
 
 ![Sentry window](sentry_window.png)
 
-* Check `Enable` to enable Sentry event capturing
-* `DSN` displays the Sentry DSN value
-
-After you close the window, all settings are saved into `Assets/Resources/Sentry/SentryOptions.json`.
+After you close the window, all settings are saved into `Assets/Resources/Sentry/SentryOptions.json`. This file should be saved in your version control system.

--- a/src/includes/getting-started-config/unity.mdx
+++ b/src/includes/getting-started-config/unity.mdx
@@ -1,12 +1,12 @@
 Currently, you can only configure Sentry using the Unity tools window.
 
-The minimum required configuration, is to set your DSN in the window. The DSN is available in your Sentry project settings, or if you're logged in, you can copy from below:
+The minimum required configuration is to set your [DSN](/product/sentry-basics/dsn-explainer/) in the window. The DSN is available either in your Sentry project settings or, if you're logged in, by copying:
 
 ```
 ___PUBLIC_DSN___
 ```
 
-To configure it, open `Tools` -> `Sentry`.
+To configure the DSN, open `Tools` -> `Sentry`.
 
 ![Sentry tools](tools_sentry.png)
 
@@ -14,4 +14,4 @@ And the Sentry configuration window will open:
 
 ![Sentry window](sentry_window.png)
 
-After you close the window, all settings are saved into `Assets/Resources/Sentry/SentryOptions.json`. This file should be saved in your version control system.
+After you close the window, all settings are saved to `Assets/Resources/Sentry/SentryOptions.json`, which should be maintained in your version control system.


### PR DESCRIPTION
This is relevant but not on the getting started:

* `Assets/Resources/Sentry/SentryOptions.json` - Sentry settings
* `Assets/Resources/Sentry/link.xml` - [a special file](https://docs.unity3d.com/Manual/ManagedCodeStripping.html) for [ILL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds