### PR TITLE
update performance pages descriptions

### DIFF
--- a/src/docs/product/performance/event-detail.mdx
+++ b/src/docs/product/performance/event-detail.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Event Detail"
 sidebar_order: 70
-description: "Learn more about how you can drill down into a span for a single transaction and traverse multiple directions to debug slow HTTP requests, database queries, identify associated errors, and root out other bottlenecks."
+description: "Learn more about how to drill down into a span of a single transaction to debug slow HTTP requests and database queries, identify associated errors, and root out other bottlenecks."
 ---
 
 From [Performance](/product/performance/) and [Discover](/product/discover-queries/), you can drill all the way down into a span for a single transaction and traverse multiple directions. This will accelerate your ability to debug slow HTTP requests, database queries, identify associated errors, and root out other bottlenecks.
-
 
 ![Event detail showing critical event information, breakdowns, minimaps and waterfall view](./perf-transaction-detail.png)
 

--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -4,7 +4,7 @@ sidebar_order: 1
 redirect_from:
   - /performance-monitoring/setup/
   - /performance-monitoring/getting-started/
-description: "Get started with Sentry's Performance Monitoring. This quick setup will empower you to see everything from macro-level metrics to micro-level spans, and you'll be able to cross-reference transactions with related issues and customize queries."
+description: "Get started with Sentry's Performance Monitoring, which allows you to see macro-level metrics to micro-level spans, cross-reference transactions with related issues, and customize queries."
 ---
 
 If you don't already have performance monitoring enabled, use the link below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -3,7 +3,7 @@ title: "Metrics"
 sidebar_order: 90
 redirect_from:
   - /performance-monitoring/performance/metrics/
-description: "Learn more about Sentry's Performance Metrics and how they provide insight into what users are experiencing your application. Gauge application performance with Apdex, failure rate, throughput, and latency."
+description: "Learn more about Sentry's Performance metrics such as, Apdex, failure rate, throughput, and latency, and the user experience insights about your application that they provide."
 ---
 
 Metrics provide insight about how users are experiencing your application. In [Performance](/product/performance/), we'll set you up with a few of the basic metrics to get you started. For further customizations on target thresholds, feel free to build out a query using the Discover [Query Builder](/product/discover-queries/query-builder/). By identifying useful thresholds to measure your application, you have a quantifiable measurement of your application's health. This means you can more easily identify when errors occur or if performance issues are emerging.

--- a/src/docs/product/performance/trace-view.mdx
+++ b/src/docs/product/performance/trace-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Trace View"
 sidebar_order: 80
-description: "Learn more about the trace view and the high level information you can view for a Trace."
+description: "Learn more about trace view, where you can drill down into the details of a single trace, allowing you to debug slow services, identify related errors, and find other bottlenecks."
 ---
 
 With the [trace](/product/performance/distributed-tracing) view, you can drill down into the details of a single trace and traverse every transaction in that trace. This will accelerate your ability to debug slow services, identify related errors, and root out other bottlenecks. There are multiple entry points to get to the trace view.

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transaction Summary"
 sidebar_order: 40
-description: "Learn more about Sentry's Transaction Summary and how every transaction has a summary view that gives you a better understanding of its overall health. With this view, you'll find graphs, instances of these events, stats, facet maps, and related errors."
+description: "Learn more about the transaction summary, which helps you evaluate the transaction's overall health. This view includes graphs, instances of these events, stats, facet maps, and related errors."
 ---
 
 Every transaction has a summary view that gives you a better understanding of its overall health. With this view, you'll find graphs, instances of these events, stats, facet maps, related errors, and more.

--- a/src/docs/product/performance/trends.mdx
+++ b/src/docs/product/performance/trends.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Trends"
 sidebar_order: 30
-description: "View performance trends over time"
+description: "Learn more about the Trends view, which allows you to see signficant changes in performance over time."
 ---
 
 From the Performance homepage, you can find the Trends View by toggling the tab in the Performance homepage's upper right corner. This page surfaces transactions that have had significant changes in their performance over time.
@@ -11,7 +11,7 @@ From the Performance homepage, you can find the Trends View by toggling the tab 
 Trending transactions are calculated first by filtering out transactions with large [throughput](/product/performance/metrics/#throughput-total-tpm-tps) fluctuations, determining the baselines of the two halves of the duration, and calculating their percentage change. Regressions are any percentage changes greater than zero, while improvements are percentage changes less than zero.
 Sentry uses a [t-test](https://academic.oup.com/beheco/article/17/4/688/215960) to compare the before and after periods of the transaction and assign a confidence score.
 
-This confidence score is unbounded, and by default Sentry shows trends with a high confidence score. To view trends regardless of the confidence score, add `confidence():>0` to the search bar.
+This confidence score is unbounded, and by default [sentry.io](https://sentry.io) shows trends with a high confidence score. To view trends regardless of the confidence score, add `confidence():>0` to the search bar.
 
 For example, looking at a transaction over two weeks with the default [P50](/product/performance/metrics/#average-transaction-duration) baseline, if the first week had a `p(50)=100s`, and the second a `p(50)=110s`, the percentage is `(110/100)-1 = 0.1`. The example transaction had a performance regression of `10%`.
 

--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Vitals"
 sidebar_order: 50
-description: "Learn more about Web Vitals in Sentry and how they give you a better understanding of your application's health."
+description: "Learn more about Web Vitals in Sentry, and how they give you a better understanding of your application's health."
 ---
 
 [Web Vitals](https://web.dev/vitals/) are a set of metrics defined by Google to measure render time, response time, and layout shift. Each data point provides insights about the overall performance of your application.


### PR DESCRIPTION
Update the front matter descriptions of several Performance pages for concision
Getting these descriptions down to 25-30 words improves the user experience when these are listed in a "related articles" type section on a higher-level page