### PR TITLE
Add missing word

### DIFF
--- a/src/docs/product/releases/setup/index.mdx
+++ b/src/docs/product/releases/setup/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Set Up
 sidebar_order: 1
-description: "Learn how set up releases."
+description: "Learn how to set up releases."
 ---
 
 Setting up releases fully is a multi-step process, and is adaptable to your organization's needs.


### PR DESCRIPTION
Small change to add missing word to link description. Affects https://docs.sentry.io/product/releases/