### PR TITLE
Add guides for new onboarding wizards

### DIFF
--- a/src/docs/contributing/onboarding-wizard.mdx
+++ b/src/docs/contributing/onboarding-wizard.mdx
@@ -23,6 +23,8 @@ To add a guide to a platform:
     - Add the platform to `tests/fixtures/integration-docs/_platforms`. Note that you don’t have to add it to `src/sentry/integration-docs`, since this is automatically generated when the platform assets are built.
     - It may be required to be added to platform-specific places, such as `isEventFromBrowserJavaScriptSDK` in `static/app/components/events/interfaces/spans/utils.tsx`.
 
+If after following these steps the guide isn’t on Sentry, you may need to update the platform assets by running `make build-platform-assets`.
+
 ## Directory Structure
 
 The directory structure directly influences how content is exposed within onboarding. It takes the form of:


### PR DESCRIPTION
At the moment, there're no docs of how to add new guides to the onboarding wizard.