### PR TITLE
add type caveat for contexts

### DIFF
--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -26,7 +26,9 @@ The best practice to attach custom data is via structured contexts. A context mu
 
 <PlatformContent includePath="set-context" />
 
-There are no restrictions for naming contexts or their fields. However, there is a set of conventions for common contexts. For more information, refer to the [contexts interface developer documentation](https://develop.sentry.dev/sdk/event-payloads/contexts/).
+You cannot use `type` as a key in contexts that you add.
+
+Learn more about conventions for common contexts in the [contexts interface developer documentation](https://develop.sentry.dev/sdk/event-payloads/contexts/).
 
 ## Size Limitations
 

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -26,7 +26,7 @@ The best practice to attach custom data is via structured contexts. A context mu
 
 <PlatformContent includePath="set-context" />
 
-You cannot use `type` as a key in contexts that you add.
+There are no restrictions on context name. In the context object, all keys are allowed except for `type`, which is used internally. 
 
 Learn more about conventions for common contexts in the [contexts interface developer documentation](https://develop.sentry.dev/sdk/event-payloads/contexts/).
 


### PR DESCRIPTION
From [linked issue 3543](https://github.com/getsentry/sentry-docs/issues/3543):

This an issue with: Platform documentation

I didn't check all of the platforms, but it's present in at least the Python and JS docs.

https://docs.sentry.io/platforms/python/enriching-events/context/#structured-context
https://docs.sentry.io/platforms/javascript/enriching-events/context/#structured-context
(Perhaps worth your checking all of them, though.)

## Description
The docs on adding structured contexts say that "There are no restrictions for naming contexts or their fields" but it seems to me like the key "type" has a special meaning inside of a context.

That feels like a restriction worth documenting to me.

FWIW, the linked contexts interface developer documentation gives me more of an impression that "type" is reserved, but even there it's never explicitly spelled out that I cannot use "type" for my own purposes.

This is really not a difficult rule to overcome except for the fact that I have to discover it by trial and error.

## Suggested Solution
I think the "Structured Context" section of the "Add Context" docs should not tell people there are no restrictions.

I think it should be plainly spelled out in that section that "type" has a special meaning.

If there are any other nuances like that about contexts that are lurking, I think they should also be included in those platform docs.