### PR TITLE
upgrade(trim): Force trim>=1.0.1 to get security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   "resolutions": {
     "**/axios": ">=0.21.1",
     "**/is-svg": ">=4.2.2",
-    "**/xmlhttprequest-ssl": ">=1.6.2"
+    "**/xmlhttprequest-ssl": ">=1.6.2",
+    "**/trim": ">=1.0.1"
   },
   "scripts": {
     "clean": "gatsby clean",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17256,10 +17256,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
   integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@>=1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
+  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
[CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq)
