### PR TITLE
feat: Migration docs for RN 2.5.x regarding the ANDROID_ID

### DIFF
--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -4,6 +4,42 @@ sidebar_order: 100
 description: "Learn about migrating from 1.x to 2.x to enable release health tracking and native stack traces by default."
 ---
 
+## From 2.4.x to 2.5.x
+
+The breaking changes are only relevant to Android. You do not need to do anything for other platforms.
+
+### Android Specific Changes
+
+As Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`, you can [read the migration docs over on its page](/platforms/android/migration/#migrating-from-iosentrysentry-430-to-iosentrysentry-500).
+
+A random generated `installationId` replaces `Settings.Secure.ANDROID_ID`, which has been removed. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet. It makes use of the [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) library.
+
+```javascript
+import { Platform } from "react-native";
+import DeviceInfo from "react-native-device-info";
+
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  // ...
+});
+
+// Only add the event processor on Android
+if (Platform.OS === "android") {
+  Sentry.addGlobalEventProcessor(event => {
+    // Get the ANDROID_ID
+    const id = DeviceInfo.getUniqueId();
+
+    // If the user does not exist, set the id to be the unique id.
+    if (!event.user) {
+      event.user = { id };
+    }
+
+    return event;
+  });
+}
+```
+
 ## React Navigation Instrumentation from <2.3.0
 
 We changed the initialization method for the React Navigation V5 routing instrumentation to avoid a potential issue when using linking. You now register the navigation container inside the `onReady` prop passed to the `NavigationContainer`.

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -6,13 +6,13 @@ description: "Learn about migrating from 1.x to 2.x to enable release health tra
 
 ## From 2.4.x to 2.5.x
 
-The breaking changes are only relevant to Android. You do not need to do anything for other platforms.
+The breaking changes are relevant only to Android. There are no breaking changes for other platforms.
 
 ### Android Specific Changes
 
-As Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`, you can [read the migration docs over on its page](/platforms/android/migration/#migrating-from-iosentrysentry-430-to-iosentrysentry-500).
+Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`. Please [refer to the Android migration guide for Android-specific changes](/platforms/android/migration/#migrating-from-iosentrysentry-430-to-iosentrysentry-500).
 
-A random generated `installationId` replaces `Settings.Secure.ANDROID_ID`, which has been removed. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet. It makes use of the [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) library.
+`Settings.Secure.ANDROID_ID` has been removed and replaced with a randomly-generated `installationId`. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet which makes use of the [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) library.
 
 ```javascript
 import { Platform } from "react-native";


### PR DESCRIPTION
Migration docs for RN 2.5.x using a code snippet from https://github.com/getsentry/sentry-react-native/pull/1511 to handle the breaking ANDROID_ID change.

Fixes https://github.com/getsentry/sentry-react-native/issues/1489

Related from Flutter: #3564