### PR TITLE
Remove deprecated `IncludeRequestPayload` option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -189,12 +189,12 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 
 <ConfigKey name="max-request-body-size" supported={["php"]}>
 
-This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
+This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
-- `none`: request bodies are never sent
-- `small`: only small request bodies will be captured where the cutoff for small depends on the SDK (typically 4KB)
-- `medium`: medium and small requests will be captured (typically 10KB)
-- `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
+- `never`: Request bodies are never sent.
+- `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
+- `medium`: Medium and small requests will be captured (typically 10KB).
+- `always`: The SDK will always capture the request body as long as Sentry can make sense of it.
 
 </ConfigKey>
 

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -71,7 +71,7 @@ For example:
 ```json {filename:appsettings.json}
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",
-    "IncludeRequestPayload": true,
+    "MaxRequestBodySize": "Always",
     "SendDefaultPii": true,
     "MinimumBreadcrumbLevel": "Debug",
     "MinimumEventLevel": "Warning",
@@ -232,9 +232,16 @@ Methods that take precedence over `IHostingEnvironment` are:
 - Environment variable _SENTRY_ENVIRONMENT_
 - Configuration system like `appsettings.json`
 
-### IncludeRequestPayload
+### MaxRequestBodySize
 
-Opt-in to send the request body to Sentry. By enabling this flag, all requests will have the `EnableRewind` method invoked. This is done so that the request data can be read at a later point in case an error happens while processing the request.
+This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
+
+- `never`: request bodies are never sent
+- `small`: only small request bodies will be captured where the cutoff for small depends on the SDK (typically 4KB)
+- `medium`: medium and small requests will be captured (typically 10KB)
+- `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
+
+If the request bodies should be captured, all requests will have the `EnableRewind` method invoked. This is done so that the request data can be read at a later point in case an error happens while processing the request.
 
 ### IncludeActivityData
 

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -234,14 +234,14 @@ Methods that take precedence over `IHostingEnvironment` are:
 
 ### MaxRequestBodySize
 
-This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
+This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
-- `never`: request bodies are never sent
-- `small`: only small request bodies will be captured where the cutoff for small depends on the SDK (typically 4KB)
-- `medium`: medium and small requests will be captured (typically 10KB)
-- `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
+- `never`: Request bodies are never sent.
+- `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
+- `medium`: Medium and small requests will be captured (typically 10KB).
+- `always`: The SDK will always capture the request body as long as Sentry can make sense of it.
 
-If the request bodies should be captured, all requests will have the `EnableRewind` method invoked. This is done so that the request data can be read at a later point in case an error happens while processing the request.
+If the request bodies should be captured, all requests will have the `EnableRewind` method invoked. This is done so that the request data can be read later, in case an error happens while processing the request.
 
 ### IncludeActivityData
 


### PR DESCRIPTION
Remove deprecated `IncludeRequestPayload` option from example and documentation, use `MaxRequestBodySize` instead.