### PR TITLE
Java: add migration entry about nullability annotations.

### DIFF
--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -14,6 +14,8 @@ You may remove `android:extractNativeLibs="true"` meta-data in the `AndroidManif
 A random generated `installationId` replaces `Settings.Secure.ANDROID_ID`, which has been removed. This may affect the number of unique users displayed on the the Issues page and Alerts.
 If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet:
 
+All SDK methods have been annotated with [JetBrains Annotations](https://github.com/JetBrains/java-annotations): `@Nullable` and `@NotNull`. Kotlin compiler respects these annotations and as a result, in Kotlin code, some fields that were recognized as not-null, are now nullable, and the other way around.
+
 ```java
 User user = new User();
 user.setId(Settings.Secure.ANDROID_ID);

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -8,6 +8,8 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
 
 `Sentry#startTransaction` by default does not bind created transaction to the scope. To start transaction with binding to the scope, use one of the new overloaded `startTransaction` methods taking `bindToScope` parameter and set it to `true`. Bound transaction can be retrieved with `Sentry#getSpan`.
 
+All SDK methods have been annotated with [JetBrains Annotations](https://github.com/JetBrains/java-annotations): `@Nullable` and `@NotNull`. Kotlin compiler respects these annotations and as a result, in Kotlin code, some fields that were recognized as not-null, are now nullable, and the other way around.
+
 ### Spring Boot
 
 The property `sentry.enable-tracing` is deprecated. To enable tracing simply set `sentry.traces-sample-rate` or create a bean implementing `TracesSamplerCallback`.


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry-docs/issues/3567