### PR TITLE
docs(node): Add caCerts option to node configuration page

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -221,7 +221,7 @@ When enabled, local variables are sent along with stackframes. This can have a p
 
 </ConfigKey>
 
-<ConfigKey name="ca-certs" supported={["python"]}>
+<ConfigKey name="ca-certs" supported={["python", "node"]}>
 
 A path to an alternative CA bundle file in PEM-format.
 


### PR DESCRIPTION
Missing in action.