### PR TITLE
docs(nextjs): Link to Vercel integration

### DIFF
--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -30,3 +30,5 @@ export default withSentry(handler);
 ```
 
 By default, the SDK sets the environment for events to `process.env.NODE_ENV`, although you can [set your own](/platforms/javascript/guides/nextjs/configuration/environments/).
+
+To learn how to connect your app to Sentry and deploy it on Vercel, see the [Vercel integration](/product/integrations/vercel/).


### PR DESCRIPTION
The Next.js SDK is strongly connected to the Vercel integration, and the docs weren't linking to it.