### PR TITLE
Link Next.js SDK from Vercel integration

### DIFF
--- a/src/docs/product/integrations/vercel/index.mdx
+++ b/src/docs/product/integrations/vercel/index.mdx
@@ -7,7 +7,7 @@ redirect_from:
 description: "Learn more about Sentry's Vercel integration and how you can connect your Sentry and Vercel projects to automatically upload source maps and notify Sentry of release deployment."
 ---
 
-Vercel is an all-in-one platform with Global CDN supporting static and JAMstack deployment and Serverless Functions. Connect your Sentry and Vercel projects to automatically upload source maps and notify Sentry of release deployment.
+Vercel is an all-in-one platform with Global CDN supporting static and JAMstack deployment and Serverless Functions. Connect your Sentry and Vercel projects to automatically upload source maps and notify Sentry of release deployment. To learn more about using Sentry in your Next.js app, check out the [Next.js SDK](/platforms/javascript/guides/nextjs/).
 
 This integration needs to set up only once per organization, then it is available for _all_ projects.
 


### PR DESCRIPTION
The Next.js SDK now references the Vercel integration (change in https://github.com/getsentry/sentry-docs/pull/3586). This PR does the opposite: reference the Next.js SDK from the Vercel integration, to cross-link them.