### PR TITLE
fix issues consuming quota section of Manage Your Event Stream

### DIFF
--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -149,7 +149,7 @@ Our billing system provides a report on usage that you can export as a .csv file
 
 ### > **What issues are consuming my quota?**
 
-The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolve your busiest issues, you can set up a query in **Discover**. When you're building the query, set the columns as seen below:
+The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolve your busiest issues, you can set up a query in **Discover**. When you're building the query, set the columns as shown below:
 
 ![Busiest Projects](manage-event-stream-02.png)
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -149,11 +149,11 @@ Our billing system provides a report on usage that you can export as a .csv file
 
 ### > **What issues are consuming my quota?**
 
-The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolve your busiest errors, follow steps 1 - 6 from above. For step 4 select the columns as seen below:
+The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolve your busiest issues, you can set up a query in **Discover**. When you're building the query, set the columns as seen below:
 
 ![Busiest Projects](manage-event-stream-02.png)
 
-Once applying the changes the Results table will display your busiest issues:
+Once the changes are applied, the "Results" table displays your busiest issues:
 
 ![Busiest Issues](manage-event-stream-10.png)
 


### PR DESCRIPTION
Fixes the section on which issues are consuming quota. Currently includes a confusing reference to content that no longer exists. From issue 3580:

Issue
This an issue with:
https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#-what-issues-are-consuming-my-quota

Description
The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolve your busiest errors, follow steps 1 - 6 from above. For step 4 select the columns as seen below:

I don't see any steps "above" in this guide which relate to this?

