### PR TITLE
Update CTA for GitHub

### DIFF
--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -18,14 +18,32 @@ const GitHubCTA = ({
   relativePath,
 }: GitHubCTAProps): JSX.Element => (
   <div className="github-cta">
+    <medium>
+    Help improve this content
+    </medium>
+    <br></br>
     <small>
-      You can{" "}
-      <SmartLink
+    Our documentation is open source and available on GitHub. Your contributions are welcome, whether fixing a typo (drat!) to suggesting an update ("yeah, this would be better").
+    </small>
+    <small>
+    <br></br>
+     <SmartLink
         to={`https://github.com/getsentry/sentry-docs/edit/master/src/${sourceInstanceName}/${relativePath}`}
       >
-        edit this page
+         Suggest an edit to this page
       </SmartLink>{" "}
-      on GitHub.
+      &nbsp;&nbsp;|&nbsp;&nbsp;
+      <SmartLink
+        to={`https://docs.sentry.io/contributing/`}
+      >
+        Read our contributor guidelines
+      </SmartLink>{" "}
+      &nbsp;&nbsp;|&nbsp;&nbsp;
+      <SmartLink
+        to={`https://github.com/getsentry/sentry-docs/issues/new/choose`}
+      >
+        Report a problem
+      </SmartLink>{" "}
     </small>
   </div>
 );

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -18,9 +18,9 @@ const GitHubCTA = ({
   relativePath,
 }: GitHubCTAProps): JSX.Element => (
   <div className="github-cta">
-    <medium>
+    <small>
     Help improve this content
-    </medium>
+    </small>
     <br></br>
     <small>
     Our documentation is open source and available on GitHub. Your contributions are welcome, whether fixing a typo (drat!) to suggesting an update ("yeah, this would be better").

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -24,9 +24,7 @@ const GitHubCTA = ({
     <br></br>
     <small>
     Our documentation is open source and available on GitHub. Your contributions are welcome, whether fixing a typo (drat!) to suggesting an update ("yeah, this would be better").
-    </small>
-    <small>
-    <br></br>
+    <div className={"muted"}>
      <SmartLink
         to={`https://github.com/getsentry/sentry-docs/edit/master/src/${sourceInstanceName}/${relativePath}`}
       >
@@ -44,6 +42,7 @@ const GitHubCTA = ({
       >
         Report a problem
       </SmartLink>{" "}
+      </div>
     </small>
   </div>
 );


### PR DESCRIPTION
We've updated our guidelines and want our users to feel more welcomed to contribute to Docs. This change updates our base page footer to incorporate our Contributor Guidelines and our new Issues Template:

![Screen Shot 2021-05-14 at 3 15 43 PM](https://user-images.githubusercontent.com/61481573/118336936-8a7ef600-b4c7-11eb-9794-6bdf44ca0edc.png)
