### PR TITLE
revise figure: slack-overview-details-page.png

### DIFF
--- a/src/docs/product/integrations/slack/index.mdx
+++ b/src/docs/product/integrations/slack/index.mdx
@@ -32,7 +32,7 @@ Slack defaults to let any workspace member authorize apps, but they may have to 
 
 1.  Click "Add workspace".
 
-    ![](slack-overview-details-page.png)
+    ![suggested-slack-overview-details-page](https://user-images.githubusercontent.com/76002357/118428554-b2c04d80-b69d-11eb-9798-a68b23135f0b.png)
 
 1.  Toggle to the Slack workspace to which you want to connect using the dropdown menu in the upper right corner of the authentication window, then select **Allow**. Repeat this process if you are connecting to multiple workspaces.
 


### PR DESCRIPTION
The figure 'slack-overview-details-page' indicates that Slack integrations are available for 'All billing plans.' As of my writing the app currently restricts Slack integrations to Team billing plans and above. I have included a new image in the forked .md however I do not believe it to be the same resolution as the original