### PR TITLE
Add Kotlin pointer page

### DIFF
--- a/src/platforms/common/configuration/index.mdx
+++ b/src/platforms/common/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 notSupported:
-  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "perl"]
+  ["native.ue4", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "perl", "kotlin"]
 description: "Additional configuration options for the SDK."
 sidebar_order: 5
 ---

--- a/src/platforms/common/data-management/index.mdx
+++ b/src/platforms/common/data-management/index.mdx
@@ -1,7 +1,8 @@
 ---
 title: Data Management
 notSupported:
-  ["perl", "kotlin"]
+  - perl
+  - kotlin
 sidebar_order: 4000
 description: Manage your events by pre-filtering, scrubbing sensitive information, and forwarding them to other systems.
 ---

--- a/src/platforms/common/data-management/index.mdx
+++ b/src/platforms/common/data-management/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Data Management
+notSupported:
+  ["perl", "kotlin"]
 sidebar_order: 4000
 description: Manage your events by pre-filtering, scrubbing sensitive information, and forwarding them to other systems.
 ---

--- a/src/platforms/common/enriching-events/index.mdx
+++ b/src/platforms/common/enriching-events/index.mdx
@@ -3,6 +3,8 @@ title: Enriching Events
 sidebar_order: 3000
 description: Enrich events with additional context to make debugging simpler.
 notSupported:
+  - kotlin
+  - perl
   - native.breakpad
   - native.crashpad
   - native.minidumps

--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -9,6 +9,8 @@ notSupported:
   - native.minidumps
   - native.wasm
   - native.ue4
+  - kotlin
+  - perl
 ---
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, uncaught exceptions, and unhandled rejections as well as other types of errors depending on the platform.

--- a/src/platforms/kotlin/config.yml
+++ b/src/platforms/kotlin/config.yml
@@ -1,10 +1,10 @@
 title: Kotlin
 caseStyle: camelCase
 supportLevel: production
-sdk: sentry.kotlin
+sdk: sentry.java
 fallbackPlatform: java
 categories:
   - mobile
-keywords:
-  - kotlin
-  - ndk
+  - desktop
+  - server
+keywords: ["kotlin"]

--- a/src/platforms/kotlin/config.yml
+++ b/src/platforms/kotlin/config.yml
@@ -1,0 +1,10 @@
+title: Kotlin
+caseStyle: camelCase
+supportLevel: production
+sdk: sentry.kotlin
+fallbackPlatform: java
+categories:
+  - mobile
+keywords:
+  - kotlin
+  - ndk

--- a/src/platforms/kotlin/index.mdx
+++ b/src/platforms/kotlin/index.mdx
@@ -1,0 +1,8 @@
+Sentry supports JVM related use of Kotlin with our [Java](/java) SDK, and, for Android applications, with our [Android](/android) platform.
+
+Select your platform to get started:
+
+- [Java](/java/)
+- [Android](/android)
+
+We also offer an [experimental SDK for Kotlin Multiplatform](https://github.com/getsentry/sentry-kotlin-multiplatform)

--- a/src/platforms/kotlin/index.mdx
+++ b/src/platforms/kotlin/index.mdx
@@ -1,8 +1,8 @@
-Sentry supports JVM related use of Kotlin with our [Java](/java) SDK, and, for Android applications, with our [Android](/android) platform.
+Sentry supports JVM related use of Kotlin with our [Java](/platforms/java) SDK, and, for Android applications, with our [Android](/platforms/android) platform.
 
 Select your platform to get started:
 
-- [Java](/java/)
-- [Android](/android)
+- [Java](/platforms/java)
+- [Android](/platforms/android)
 
-We also offer an [experimental SDK for Kotlin Multiplatform](https://github.com/getsentry/sentry-kotlin-multiplatform)
+We are also working on an [experimental SDK for Kotlin Multiplatform](https://github.com/getsentry/sentry-kotlin-multiplatform). Feedback welcome.

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -48,6 +48,7 @@ Add your DSN to the manifest file.
 Great! Now that you’ve completed setting up the SDK, maybe you want to quickly test out how Sentry works. Start by capturing an exception:
 
 In **Java**:
+
 ```java
 public class MyActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -58,6 +58,7 @@ public class MyActivity extends AppCompatActivity {
 ```
 
 In **Kotlin**:
+
 ```kotlin
 class MyActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -47,6 +47,7 @@ Add your DSN to the manifest file.
 
 Great! Now that you’ve completed setting up the SDK, maybe you want to quickly test out how Sentry works. Start by capturing an exception:
 
+In **Java**:
 ```java
 public class MyActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
@@ -56,6 +57,7 @@ public class MyActivity extends AppCompatActivity {
 }
 ```
 
+In **Kotlin**:
 ```kotlin
 class MyActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,7 +67,7 @@ class MyActivity : AppCompatActivity() {
 }
 ```
 
-### Next steps
+### Next Steps
 
 Using ProGuard or R8 to obfuscate your app? Check out [our docs on how to set it up](https://docs.sentry.io/platforms/android/proguard/).
 

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -71,7 +71,8 @@ Sentry.init { options ->
 Trigger your first event from your development environment by intentionally creating an error with the `Sentry#captureException` method, to test that everything is working, using either Java or Kotlin.
 
 In **Java**:
-```java {tabTitle: Java}
+
+```java
 import java.lang.Exception;
 import io.sentry.Sentry;
 

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -14,6 +14,7 @@ type: language
 Install the SDK via Gradle, Maven, or SBT:
 
 For **Gradle**, add to your `build.gradle` file:
+
 ```groovy
 // Make sure mavenCentral is there.
 repositories {

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -13,7 +13,8 @@ type: language
 
 Install the SDK via Gradle, Maven, or SBT:
 
-```groovy {filename:build.gradle}
+For **Gradle**, add to your `build.gradle` file:
+```groovy
 // Make sure mavenCentral is there.
 repositories {
     mavenCentral()
@@ -25,7 +26,9 @@ dependencies {
 }
 ```
 
-```xml {tabTitle:Maven}{filename:pom.xml}
+For **Maven**, add to your `pom.xml` file:
+
+```xml
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry</artifactId>
@@ -33,14 +36,16 @@ dependencies {
 </dependency>
 ```
 
-```scala {tabTitle:SBT}
+For **SBT**:
+
+```scala
 libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.java', '4.0.0') }}"
 ```
-
 ## Configure
 
-Configure Sentry as soon as possible in your application's lifecycle:
+Configure Sentry as soon as possible in your application's lifecycle, using either Java or Kotlin.
 
+In **Java**:
 ```java {tabTitle: Java}
 import io.sentry.Sentry;
 
@@ -49,7 +54,8 @@ Sentry.init(options -> {
 });
 ```
 
-```kotlin {tabTitle: Kotlin}
+In **Kotlin**:
+```kotlin
 import io.sentry.Sentry
 
 Sentry.init { options ->
@@ -59,9 +65,9 @@ Sentry.init { options ->
 
 ### Send First Event
 
-Trigger your first event from your development environment by intentionally creating an error with the `Sentry#captureException` method, to test that everything is working:
+Trigger your first event from your development environment by intentionally creating an error with the `Sentry#captureException` method, to test that everything is working, using either Java or Kotlin.
 
-
+In **Java**:
 ```java {tabTitle: Java}
 import java.lang.Exception;
 import io.sentry.Sentry;
@@ -73,6 +79,7 @@ try {
 }
 ```
 
+In **Kotlin**:
 ```kotlin {tabTitle: Kotlin}
 import java.lang.Exception
 import io.sentry.Sentry
@@ -84,4 +91,6 @@ try {
 }
 ```
 
-To view and resolve the error, log in to <a href="https://sentry.io/">sentry.io</a> then open your project. Click the error's title to open a page with detailed information and mark it as resolved.
+If you're new to Sentry, use the email alert to access your account and complete a product tour.
+
+If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -84,7 +84,8 @@ try {
 ```
 
 In **Kotlin**:
-```kotlin {tabTitle: Kotlin}
+
+```kotlin
 import java.lang.Exception
 import io.sentry.Sentry
 

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -47,7 +47,8 @@ libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.jav
 Configure Sentry as soon as possible in your application's lifecycle, using either Java or Kotlin.
 
 In **Java**:
-```java {tabTitle: Java}
+
+```java
 import io.sentry.Sentry;
 
 Sentry.init(options -> {

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -57,6 +57,7 @@ Sentry.init(options -> {
 ```
 
 In **Kotlin**:
+
 ```kotlin
 import io.sentry.Sentry
 


### PR DESCRIPTION
Kotlin is an increasingly popular search item, and users aren't able to find that it's supported by our Java and Android SDKs. This PR adds a page that directs users to the supported SDKs. The PR also update the wizards for Android and Java to more clearly identify the different code snippets.