### PR TITLE
Migrate Gradle plugin v1 to v2

### DIFF
--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -7,7 +7,7 @@ redirect_from:
 
 ## Migrating from `io.sentry:sentry-android-gradle-plugin 1.x` to `io.sentry:sentry-android-gradle-plugin 2.0.0`
 
-The `io.sentry.android.gradle` >= 2.0.0 publishes the Gradle Plugin Marker to Maven Central as well, so now you don't need to set the `classpath` anymore.
+The `io.sentry.android.gradle` >= `2.0.0` publishes the Gradle Plugin Marker to Maven Central as well, so now you don't need to set the `classpath` anymore.
 
 _Old_:
 
@@ -41,7 +41,7 @@ buildscript {
 
 The Sentry Android Gradle Plugin has been rewritten in Kotlin and because of that, the Groovy or Kotlin DSL syntax has slightly changed.
 
-The `autoProguardConfig` flag has been removed, the Android SDK >= 2.0.0 version already merges the ProGuard rules automatically.
+The `autoProguardConfig` flag has been removed, the Android SDK >= `2.0.0` version already merges the ProGuard rules automatically.
 
 _Old_:
 
@@ -54,7 +54,7 @@ sentry {
 }
 ```
 
-_New__:
+_New_:
 
 ```groovy
 sentry {
@@ -62,6 +62,7 @@ sentry {
     uploadNativeSymbols = false
     includeNativeSources = false
 }
+```
 
 ```kotlin
 sentry {

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -51,7 +51,7 @@ buildscript {
 }
 ```
 
-The Sentry Android Gradle Plugin has been rewritten in Kotlin and because of that, the Groovy or Kotlin DSL syntax has slightly changed.
+The Sentry Android Gradle Plugin has been rewritten in Kotlin. As a result, the Groovy or Kotlin DSL syntax has slightly changed.
 
 The `autoProguardConfig` flag has been removed, the Android SDK >= `2.0.0` version already merges the ProGuard rules automatically.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -39,7 +39,7 @@ buildscript {
 }
 ```
 
-The Sentry Android Gradle Plugin has been rewritten in Kotlin and because of that, the Groovy or Kotlin DSL syntax have slighly changed.
+The Sentry Android Gradle Plugin has been rewritten in Kotlin and because of that, the Groovy or Kotlin DSL syntax has slightly changed.
 
 The `autoProguardConfig` flag has been removed, the Android SDK >= 2.0.0 version already merges the ProGuard rules automatically.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -7,7 +7,7 @@ redirect_from:
 
 ## Migrating from `io.sentry:sentry-android-gradle-plugin 1.x` to `io.sentry:sentry-android-gradle-plugin 2.0.0`
 
-The `io.sentry.android.gradle` >= `2.0.0` publishes the Gradle Plugin Marker to Maven Central as well, so now you don't need to set the `classpath` anymore.
+The `io.sentry.android.gradle` >= `2.0.0` publishes the Gradle Plugin Marker to Maven Central. As a result, you no longer need to set the `classpath`.
 
 _Old_:
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -412,7 +412,7 @@ Sentry.configureScope { it.clear() }
 
 ### Sentry Gradle Plugin
 
-Disable the `autoProguardConfig` flag from the Sentry Gradle Plugin, `io.sentry:sentry-android` >= `2.0.0` already does it automatically.
+Disable the `autoProguardConfig` flag from the Sentry Gradle Plugin since `io.sentry:sentry-android` >= `2.0.0` does this automatically.
 
 ```groovy
 sentry {

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -29,7 +29,19 @@ _New_:
 
 ```groovy
 plugins {
-    id("io.sentry.android.gradle")
+    id "io.sentry.android.gradle" version "{version}"
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+```
+
+```kotlin
+plugins {
+    id("io.sentry.android.gradle") version "{version}"
 }
 
 buildscript {

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -5,7 +5,73 @@ redirect_from:
   - /platforms/android/migrate/
 ---
 
-## Migrating from `io.sentry:sentry` `4.3.0` to `io.sentry:sentry` `5.0.0`
+## Migrating from `io.sentry:sentry-android-gradle-plugin 1.x` to `io.sentry:sentry-android-gradle-plugin 2.0.0`
+
+The `io.sentry.android.gradle` >= 2.0.0 publishes the Gradle Plugin Marker to Maven Central as well, so now you don't need to set the `classpath` anymore.
+
+_Old_:
+
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'io.sentry:sentry-android-gradle-plugin:{version}'
+    }
+}
+
+apply plugin: 'io.sentry.android.gradle'
+```
+
+_New_:
+
+```groovy
+plugins {
+    id("io.sentry.android.gradle")
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+```
+
+The Sentry Android Gradle Plugin has been rewritten in Kotlin and because of that, the Groovy or Kotlin DSL syntax have slighly changed.
+
+The `autoProguardConfig` flag has been removed, the Android SDK >= 2.0.0 version already merges the ProGuard rules automatically.
+
+_Old_:
+
+```groovy
+sentry {
+    autoProguardConfig false
+    autoUpload true
+    uploadNativeSymbols false
+    includeNativeSources false
+}
+```
+
+_New__:
+
+```groovy
+sentry {
+    autoUpload = true
+    uploadNativeSymbols = false
+    includeNativeSources = false
+}
+
+```kotlin
+sentry {
+    autoUpload.set(true)
+    uploadNativeSymbols.set(false)
+    includeNativeSources.set(false)
+}
+```
+
+## Migrating from `io.sentry:sentry-android 4.3.0` to `io.sentry:sentry-android 5.0.0`
 
 You may remove `android:extractNativeLibs="true"` meta-data in the `AndroidManifest` file or `android.bundle.enableUncompressedNativeLibs=false` in the `gradle.properties` file if you're using the [Android Native Development Kit](/platforms/android/using-ndk/). Sentry can now symbolicate events with the default value of [extractNativeLibs](https://developer.android.com/studio/releases/gradle-plugin#extractNativeLibs) and [android.bundle.enableUncompressedNativeLibs](https://developer.android.com/studio/releases/gradle-plugin#behavior-changes).
 
@@ -59,7 +125,7 @@ _New_:
 </application>
 ```
 
-## Migrating from `io.sentry:sentry` `4.1.0` to `io.sentry:sentry` `4.2.0`
+## Migrating from `io.sentry:sentry-android 4.1.0` to `io.sentry:sentry-android 4.2.0`
 
 `operation` is now a required property of the `SentryTransaction` and `SentrySpan`. Whenever a transaction or span is started, the value for `operation` must be provided:
 
@@ -67,7 +133,7 @@ _New_:
 Sentry.startTransaction("transaction-name", "operation-name");
 ```
 
-## Migrating from `sentry-android 2.x` to `sentry-android 3.x`
+## Migrating from `io.sentry:sentry-android 2.x` to `io.sentry:sentry-android 3.x`
 
 ### Package changes
 
@@ -81,9 +147,9 @@ Other than that, the APIs didn't change. Release Heath sets by default. If you p
 </application>
 ```
 
-## Migrating from `sentry-android 1.x` to `sentry-android 2.x`
+## Migrating from `io.sentry:sentry-android 1.x` to `io.sentry:sentry-android 2.x`
 
-With Sentry Android, we've updated the API to resemble the [Unified API](https://develop.sentry.dev/sdk/unified-api/) more closely. And now that the SDK isn't built on top of `sentry-java`, Sentry Android has more Android-specific features.
+With Sentry Android, we've updated the API to resemble the [Unified API](https://develop.sentry.dev/sdk/unified-api/) more closely. And now that the SDK isn't built on top of `io.sentry:sentry-java`, Sentry Android has more Android-specific features.
 
 If you want to upgrade from the previous version of the SDK, please check the following sections of changes that may need updating in your code.
 
@@ -333,7 +399,7 @@ Sentry.configureScope { it.clear() }
 
 ### Sentry Gradle Plugin
 
-Disable the `autoProguardConfig` flag from the Sentry Gradle Plugin, `sentry-android` >= v2.0 already does it automatically.
+Disable the `autoProguardConfig` flag from the Sentry Gradle Plugin, `io.sentry:sentry-android` >= `2.0.0` already does it automatically.
 
 ```groovy
 sentry {

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -10,7 +10,7 @@ The breaking changes are relevant only to Android. There are no breaking changes
 
 ### Android Specific Changes
 
-Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`. Please [refer to the Android migration guide for Android-specific changes](/platforms/android/migration).
+Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`. Please [refer to the Android migration guide for Android-specific changes](/platforms/android/migration/#migrating-from-iosentrysentry-android-430-to-iosentrysentry-android-500).
 
 `Settings.Secure.ANDROID_ID` has been removed and replaced with a randomly-generated `installationId`. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet which makes use of the [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) library.
 
@@ -159,7 +159,7 @@ Other than the one line change noted above, the migration should not cause break
 <Note>
 <markdown>
 
-If you use our Android SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration).
+If you use our Android SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration/#migrating-from-iosentrysentry-android-2x-to-iosentrysentry-android-3x).
 
 </markdown>
 </Note>

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -10,7 +10,7 @@ The breaking changes are relevant only to Android. There are no breaking changes
 
 ### Android Specific Changes
 
-Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`. Please [refer to the Android migration guide for Android-specific changes](/platforms/android/migration/#migrating-from-iosentrysentry-430-to-iosentrysentry-500).
+Sentry React Native version `2.5.0` depends on Sentry Android `5.0.0`. Please [refer to the Android migration guide for Android-specific changes](/platforms/android/migration).
 
 `Settings.Secure.ANDROID_ID` has been removed and replaced with a randomly-generated `installationId`. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using `Sentry.setUser(customUser)`, the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet which makes use of the [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) library.
 
@@ -159,7 +159,7 @@ Other than the one line change noted above, the migration should not cause break
 <Note>
 <markdown>
 
-If you use our Android SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration/#migrating-from-sentry-android-2x-to-sentry-android-3x).
+If you use our Android SDK directly, you should follow its [migration guide for 2.x to 3.x](/platforms/android/migration).
 
 </markdown>
 </Note>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/3591