### PR TITLE
fix(nextjs): Clarify env variable usage on SDK init

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -52,7 +52,6 @@ export default withSentry(handler);
 
 You can hardcode your DSN and other configuration values directly inside your `Sentry.init` calls, or use use `process.env` placeholders, in these two files; or Next.js' built-in [environment variables](https://nextjs.org/docs/basic-features/environment-variables) support instead.
 
-
 ## Extend Default Webpack Usage for Source Maps
 
 Extend the default Next.js usage of Webpack to generate source maps and upload them to Sentry. Include the following in `next.config.js`:

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -50,7 +50,8 @@ const handler = async (req, res) => {
 export default withSentry(handler);
 ```
 
-You can provide your DSN to `Sentry.init` by hardcoding it directly or using environment variables (such as `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`), in these two files.
+You can hardcode your DSN and other configuration values directly inside your `Sentry.init` calls, or use use `process.env` placeholders, in these two files; or Next.js' built-in [environment variables](https://nextjs.org/docs/basic-features/environment-variables) support instead.
+
 
 ## Extend Default Webpack Usage for Source Maps
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -50,7 +50,7 @@ const handler = async (req, res) => {
 export default withSentry(handler);
 ```
 
-You can include your DSN directly in these two files, or provide it in either of two environment variables, `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`.
+You can provide your DSN to `Sentry.init` by hardcoding it directly or using environment variables (such as `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`), in these two files.
 
 ## Extend Default Webpack Usage for Source Maps
 


### PR DESCRIPTION
Clarify the usage of environment variables to initialize the Next.js SDK. Environment variables have never been an alternative to not providing a DSN, but an alternative to not hardcode it.

Closes https://github.com/getsentry/sentry-javascript/issues/3565.