### PR TITLE
fix(nextjs): Clear up the extended webpack goal of Next.js

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -54,7 +54,12 @@ You can include your DSN directly in these two files, or provide it in either of
 
 ## Extend Default Webpack Usage
 
-Extend the default Next.js usage of Webpack to initialize the SDK, capture errors, and generate and upload source maps to Sentry. Include the following in your `next.config.js`:
+Use `withSentryConfig` to extend the default Next.js usage of Webpack. This will do two things:
+
+- Automatically call the code in `sentry.server.config.js` and `sentry.client.config.js`, at server start up and client page load, respectively. Using `withSentryConfig` is the only way to guarantee that the SDK is initialized early enough to catch all errors.
+- Generate and upload source maps to Sentry, so that your stacktraces contain original, demangled code.
+
+Include the following in your `next.config.js`:
 
 ```javascript {filename:next.config.js}
 // This file sets a custom webpack configuration to use your Next.js app

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -54,7 +54,7 @@ You can include your DSN directly in these two files, or provide it in either of
 
 ## Extend Default Webpack Usage for Source Maps
 
-Extend the default Next.js usage of Webpack to generate source maps and upload them to Sentry. Include the following in `next.config.js`:
+Extend the default Next.js usage of Webpack to initialize the SDK, capture errors, and generate and upload source maps to Sentry. Include the following in your `next.config.js`:
 
 ```javascript {filename:next.config.js}
 // This file sets a custom webpack configuration to use your Next.js app

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -52,7 +52,7 @@ export default withSentry(handler);
 
 You can include your DSN directly in these two files, or provide it in either of two environment variables, `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`.
 
-## Extend Default Webpack Usage for Source Maps
+## Extend Default Webpack Usage
 
 Extend the default Next.js usage of Webpack to initialize the SDK, capture errors, and generate and upload source maps to Sentry. Include the following in your `next.config.js`:
 


### PR DESCRIPTION
Extending the Webpack usage on Next.js is not an option with the only purpose of generating and uploading source maps; it's required to initialize the SDK.