### PR TITLE
docs(nextjs): Add `silent` option in default webpack config

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -74,6 +74,8 @@ const SentryWebpackPluginOptions = {
   // recommended:
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
+
+  silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 };


### PR DESCRIPTION
The [Sentry Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) outputs logs that may be annoying for some users, especially when running in `dryRun` mode. Adding `silent` suppresses all logs, decreasing noise to users.