### PR TITLE
fix(apple): Verifying Performance

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -67,7 +67,7 @@ Test out tracing using our <PlatformLink to="/performance/instrumentation/automa
 
 </PlatformSection>
 
-<PlatformSection supported={["dotnet", "go", "java", "android", "ruby"]} notSupported={["javascript", "react-native", "java.spring", "java.spring-boot"]}>
+<PlatformSection supported={["dotnet", "go", "java", "android", "ruby", "apple"]} notSupported={["javascript", "react-native", "java.spring", "java.spring-boot"]}>
 
 Test out tracing by starting and finishing a transaction, which you _must_ do so transactions can be sent to Sentry. Learn how in our <PlatformLink to="/performance/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink> content.
 


### PR DESCRIPTION
The Cocoa SDK doesn't support automatic performance monitoring yet.
Customers think they get transactions out of the box. This is fixed
now by displaying the section on custom instrumentation for
verifying performance.

## Before
<img width="742" alt="Screen Shot 2021-05-21 at 11 27 35" src="https://user-images.githubusercontent.com/2443292/119115528-8bfc7100-ba27-11eb-89b6-4a6c8f34db96.png">

## After
<img width="766" alt="Screen Shot 2021-05-21 at 11 27 47" src="https://user-images.githubusercontent.com/2443292/119115550-93237f00-ba27-11eb-9c9c-f5d54cf8d2c5.png">
