### PR TITLE
Vue Updates

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -37,7 +37,7 @@ Customers on legacy plans must add transaction events to their subscription in o
   - [Angular](/platforms/javascript/guides/angular/performance/)
   - [Ember](/platforms/javascript/guides/ember/performance/)
   - [React](/platforms/javascript/guides/react/#monitor-performance)
-  - [Vue](/platforms/javascript/guides/vue/#monitor-performance)
+  - [Vue](/platforms/javascript/guides/vue/performance)
 
 - Mobile
   - [Android](/platforms/android/performance/)

--- a/src/includes/getting-started-config/javascript.vue.mdx
+++ b/src/includes/getting-started-config/javascript.vue.mdx
@@ -1,8 +1,3 @@
-
-On its own, `@sentry/vue` will report any uncaught exceptions triggered by your application.
-
-Additionally, the SDK will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
-
 To initialize Sentry in your Vue application, add this to your `app.js`:
 
 ```javascript

--- a/src/includes/getting-started-config/javascript.vue.mdx
+++ b/src/includes/getting-started-config/javascript.vue.mdx
@@ -1,33 +1,9 @@
----
-title: Vue
-sdk: sentry.javascript.vue
-fallbackPlatform: javascript
-sidebar_order: 6000
-redirect_from:
-  - /platforms/javascript/vue/
-  - /clients/javascript/integrations/vue/
-description: "Learn how to use Sentry with your Vue application."
----
-
-## Install
-
-To use Sentry with your Vue application, you will need to use Sentry’s Vue SDK: `@sentry/vue`.
-
-```bash {tabTitle:npm}
-npm install --save  @sentry/vue @sentry/tracing
-```
-
-```bash {tabTitle:Yarn}
-yarn add  @sentry/vue @sentry/tracing
-```
-
-## Configure
 
 On its own, `@sentry/vue` will report any uncaught exceptions triggered by your application.
 
 Additionally, the SDK will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
 
-Then add this to your `app.js`:
+To initialize Sentry in your Vue application, add this to your `app.js`:
 
 ```javascript
 import Vue from "vue";
@@ -45,7 +21,7 @@ Sentry.init({
 });
 ```
 
-Additionally the SDK accepts a few different configuration options that let you change its behavior:
+Sentry's Vue SDK accepts a few different configuration options that let you change its behavior:
 
 - Passing in `Vue` is optional, if you do not pass it `window.Vue` must be present.
 - Passing in `attachProps` is optional and is `true` if it is not provided. If you set it to `false`, Sentry will suppress sending all Vue components' props for logging.
@@ -57,23 +33,3 @@ Please note that if you enable the SDK, Vue will not call its `logError` interna
 If you want to preserve this functionality, make sure to pass the `logErrors: true` option.
 
 </Alert>
-
-In case you are using the CDN version or the Loader, we provide a standalone file for every integration, you can use it
-like this:
-
-```html
-<script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/vue.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'vue.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
-
-<script>
-  Sentry.init({
-    Vue,
-    dsn: "___PUBLIC_DSN___",
-  });
-</script>
-```
-
-<PageGrid header="Next Steps" nextSteps />

--- a/src/includes/getting-started-config/javascript.vue.mdx
+++ b/src/includes/getting-started-config/javascript.vue.mdx
@@ -23,13 +23,12 @@ Sentry.init({
 
 Sentry's Vue SDK accepts a few different configuration options that let you change its behavior:
 
-- Passing in `Vue` is optional, if you do not pass it `window.Vue` must be present.
-- Passing in `attachProps` is optional and is `true` if it is not provided. If you set it to `false`, Sentry will suppress sending all Vue components' props for logging.
-- Passing in `logErrors` is optional and is `false` if it is not provided. If you set it to `true`, Sentry will call original Vue's `logError` function as well.
+- Passing in `Vue` is optional. If you do not pass it, `window.Vue` must be present.
+- Passing in `attachProps` is optional and is `true` if it is not provided. If set to `false`, Sentry will suppress sending all Vue components' props for logging.
+- Passing in `logErrors` is optional and is `false` if it is not provided. If set to `true`, Sentry will call original Vue's `logError` function as well.
 
-<Alert level="warning" title="Vue Error Handling">
+<Note>
 
-Please note that if you enable the SDK, Vue will not call its `logError` internally. This means that errors occurring in the Vue renderer will not show up in the developer console.
-If you want to preserve this functionality, make sure to pass the `logErrors: true` option.
+If you enable the SDK, Vue will not call its `logError` internally. As a result, errors occurring in the Vue renderer will not display in the developer console. To preserve this functionality, pass the `logErrors: true` option.
 
-</Alert>
+</Note>

--- a/src/includes/getting-started-install/javascript.vue.mdx
+++ b/src/includes/getting-started-install/javascript.vue.mdx
@@ -1,5 +1,3 @@
-To use Sentry with your Vue application, you will need to use Sentry’s Vue SDK: `@sentry/vue`.
-
 ```bash {tabTitle:npm}
 npm install --save  @sentry/vue @sentry/tracing
 ```

--- a/src/includes/getting-started-install/javascript.vue.mdx
+++ b/src/includes/getting-started-install/javascript.vue.mdx
@@ -1,0 +1,9 @@
+To use Sentry with your Vue application, you will need to use Sentry’s Vue SDK: `@sentry/vue`.
+
+```bash {tabTitle:npm}
+npm install --save  @sentry/vue @sentry/tracing
+```
+
+```bash {tabTitle:Yarn}
+yarn add  @sentry/vue @sentry/tracing
+```

--- a/src/includes/getting-started-primer/javascript.vue.mdx
+++ b/src/includes/getting-started-primer/javascript.vue.mdx
@@ -1,7 +1,7 @@
 <Note>
-<markdown>
 
-_Sentry's Vue SDK enables automatic reporting of errors and exceptions._
+*Sentry's Vue SDK enables automatic reporting of errors and exceptions.*
 
-</markdown>
+*The SDK will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.*
+
 </Note>

--- a/src/includes/getting-started-primer/javascript.vue.mdx
+++ b/src/includes/getting-started-primer/javascript.vue.mdx
@@ -1,0 +1,7 @@
+<Note>
+<markdown>
+
+_Sentry's Vue SDK enables automatic reporting of errors and exceptions._
+
+</markdown>
+</Note>

--- a/src/includes/getting-started-verify/javascript.vue.mdx
+++ b/src/includes/getting-started-verify/javascript.vue.mdx
@@ -1,0 +1,18 @@
+Add a button to your view template that throws an error:
+
+```javascript {filename:App.vue}
+// ...
+<button :onClick="throwError" />
+    Throw error
+</button>
+// ...
+
+export default {
+  // ...
+  methods: {
+    throwError: function() {
+        throw new Error('Sentry Error')
+    }
+  }
+};
+```

--- a/src/includes/getting-started-verify/javascript.vue.mdx
+++ b/src/includes/getting-started-verify/javascript.vue.mdx
@@ -1,4 +1,4 @@
-Add a button to your view template that throws an error:
+Add a button to your page that throws an error:
 
 ```javascript {filename:App.vue}
 // ...

--- a/src/includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -1,0 +1,42 @@
+```javascript {tabTitle: ESM}
+import Vue from "vue";
+import * as Sentry from "@sentry/vue";
+
+// If taking advantage of automatic instrumentation (highly recommended)
+import { Integrations } from "@sentry/tracing";
+// Or, if only manually tracing
+// import * as _ from "@sentry/tracing"
+// Note: You MUST import the package in some way for tracing to work
+
+Sentry.init({
+  // Passing in `Vue` is optional, if you do not pass it `window.Vue` must be present.
+  Vue: Vue,
+  dsn: "___PUBLIC_DSN___",
+
+  // This enables automatic instrumentation (highly recommended), but is not
+  // necessary for purely manual usage
+  integrations: [new Integrations.BrowserTracing()],
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2
+
+  // Alternatively, to control sampling dynamically
+  tracesSampler: samplingContext => { ... }
+});
+```
+
+```javascript {tabTitle: CDN}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // This enables automatic instrumentation (highly recommended), but is not
+  // necessary for purely manual usage
+  integrations: [new Sentry.Integrations.BrowserTracing()],
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2
+
+  // Alternatively, to control sampling dynamically
+  tracesSampler: samplingContext => { ... }
+});
+```

--- a/src/includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -40,3 +40,16 @@ Sentry.init({
   tracesSampler: samplingContext => { ... }
 });
 ```
+
+### Tracking Child Components
+
+If you want to track child components, and see more details about the rendering process, configure the integration to track them all:
+
+```js
+Sentry.init({
+  Vue,
+  tracingOptions: {
+    trackComponents: true,
+  },
+});
+```

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -3,6 +3,7 @@ title: Set Up
 sidebar_order: 4000
 supported:
   - javascript
+  - javascript.vue
   - react-native
   - dotnet
   - python
@@ -38,7 +39,7 @@ Automatic instrumentation for monitoring the performance of your application isn
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
+<PlatformSection supported={["javascript", "javascript.vue", "java.spring-boot", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet"]}>
 
 ## Enable Tracing
 

--- a/src/platforms/javascript/guides/vue/config.yml
+++ b/src/platforms/javascript/guides/vue/config.yml
@@ -1,0 +1,10 @@
+title: Vue
+caseStyle: camelCase
+supportLevel: production
+sdk: sentry.javascript.vue
+fallbackPlatform: javascript
+categories:
+  - browser
+redirect_from:
+  - /platforms/javascript/vue/
+  - /clients/javascript/integrations/vue/

--- a/src/platforms/javascript/guides/vue/index.mdx
+++ b/src/platforms/javascript/guides/vue/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Vue
+sdk: sentry.javascript.vue
+fallbackPlatform: javascript
 sidebar_order: 6000
 redirect_from:
   - /platforms/javascript/vue/
@@ -7,15 +9,19 @@ redirect_from:
 description: "Learn how to use Sentry with your Vue application."
 ---
 
+## Install
+
 To use Sentry with your Vue application, you will need to use Sentry’s Vue SDK: `@sentry/vue`.
 
 ```bash {tabTitle:npm}
-npm install --save  @sentry/vue
+npm install --save  @sentry/vue @sentry/tracing
 ```
 
 ```bash {tabTitle:Yarn}
-yarn add  @sentry/vue
+yarn add  @sentry/vue @sentry/tracing
 ```
+
+## Configure
 
 On its own, `@sentry/vue` will report any uncaught exceptions triggered by your application.
 
@@ -26,10 +32,16 @@ Then add this to your `app.js`:
 ```javascript
 import Vue from "vue";
 import * as Sentry from "@sentry/vue";
+import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
   Vue: Vue,
   dsn: "___PUBLIC_DSN___",
+  integrations: [new Integrations.BrowserTracing()],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
 });
 ```
 
@@ -64,40 +76,4 @@ like this:
 </script>
 ```
 
-## Monitor Performance
-
-```bash {tabTitle:npm}
-npm install --save @sentry/vue @sentry/tracing
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/vue @sentry/tracing
-```
-
-The most basic configuration for tracing your Vue app, which would track only the top-level component, looks like this:
-
-```js
-import Vue from "vue";
-import * as Sentry from "@sentry/vue";
-import { Integrations } from "@sentry/tracing";
-
-Sentry.init({
-  // ...
-  integrations: [new Integrations.BrowserTracing()],
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 1.0,
-});
-```
-
-If you want to track child components, and see more details about the rendering process, configure the integration to track them all:
-
-```js
-Sentry.init({
-  Vue,
-  tracingOptions: {
-    trackComponents: true,
-  },
-});
-```
+<PageGrid header="Next Steps" nextSteps />


### PR DESCRIPTION
Fixes: #3607 

- [x] Merge `Monitor Performance` with standard configuration.
- [x] Move Vue-specific snippets inside `includes/performance/...` and use from there.
- [x] Reference to `@sentry/vue` instead of `@sentry/browser` from Vue guide page.