### PR TITLE
Node: Review Options List

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -120,7 +120,7 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
-<ConfigKey name="send-default-pii" supported={["apple", "dotnet", "javascript", "node", "react-native", "python", "java", "php", "rust", "dart"]}>
+<ConfigKey name="send-default-pii" supported={["apple", "dotnet", "react-native", "python", "java", "php", "rust", "dart"]}>
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -227,6 +227,24 @@ A path to an alternative CA bundle file in PEM-format.
 
 </ConfigKey>
 
+<ConfigKey name="frame-context-lines" supported={["node"]}>
+
+The number of context lines for each frame when loading a file.
+
+</ConfigKey>
+
+<ConfigKey name="initial-scope" supported={["javascript","node"]}>
+
+Data to be set to the initial scope.
+
+</ConfigKey>
+
+<ConfigKey name="max-value-length" supported={["node"]}>
+
+Maxium number of characters a single value can have before it will be truncated.
+
+</ConfigKey>
+
 <ConfigKey name="normalize-depth" supported={["javascript", "node"]}>
 
 Sentry SDKs normalize any contextual data to a given depth. Any keys containing data with a structure deeper than this will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed `3` levels deep.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -239,9 +239,9 @@ Data to be set to the initial scope.
 
 </ConfigKey>
 
-<ConfigKey name="max-value-length" supported={["node"]}>
+<ConfigKey name="max-value-length" supported={["javascript", "node"]}>
 
-Maxium number of characters a single value can have before it will be truncated.
+Maximum number of characters a single value can have before it will be truncated (defaults to `250`).
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -141,13 +141,13 @@ will attempt to auto-discover this value.
 
 </ConfigKey>
 
-<ConfigKey name="deny-urls" supported={["javascript"]}>
+<ConfigKey name="deny-urls" supported={["javascript"]} notSupported={["node"]}>
 
 A list of strings or regex patterns that match error URLs that should not be sent to Sentry. By default, all errors will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
 
 </ConfigKey>
 
-<ConfigKey name="allow-urls" supported={["javascript"]}>
+<ConfigKey name="allow-urls" supported={["javascript"]} notSupported={["node"]}>
 
 A legacy alias for a list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
 will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -29,7 +29,7 @@ If you are using Sentry in your mobile app, read our [frequently asked questions
 
 </Note>
 
-<PlatformSection notSupported={["apple", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4", "go", "ruby", "native", "elixir", "dart", "flutter", "unity"]}>
+<PlatformSection notSupported={["apple", "javascript", "node", "perl", "native.breakpad", "native.crashpad", "native.minidumps", "native.wasm", "native.ue4", "go", "ruby", "native", "elixir", "dart", "flutter", "unity"]}>
 
 ## Personally Identifiable Information (PII)
 


### PR DESCRIPTION
Part of: #3605

- [x] Removed `sendDefaultPii` from options list as it's not supported on JavaScript SDKs 
- [x] Removed `allowUrls` and `denyUrls` from Node options list.
(Might need to also update [inbound filters](https://docs.sentry.io/platforms/node/configuration/integrations/default-integrations/#inboundfilters) on Node, if this gets approved.) 
- [x] Added `frameContextLines` to `node`
- [x] Added `initialScope` to `node` and `javascript`
- [x] Added `maxValueLength` to `node` and `javascript`
