### PR TITLE
Enable some of enriching events for minidumps

### DIFF
--- a/src/platforms/common/enriching-events/index.mdx
+++ b/src/platforms/common/enriching-events/index.mdx
@@ -7,7 +7,6 @@ notSupported:
   - perl
   - native.breakpad
   - native.crashpad
-  - native.minidumps
   - native.wasm
 ---
 


### PR DESCRIPTION
We're missing some of the content for Minidumps. 