### PR TITLE
Update Android Native Bundle group

### DIFF
--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -61,7 +61,7 @@ buildscript {
     dependencies {
         // Add the line below, the plugin that copies the binaries
         // https://github.com/howardpang/androidNativeBundle/releases
-        classpath 'com.ydq.android.gradle.build.tool:nativeBundle:{version}'
+        classpath 'io.github.howardpang:androidNativeBundle:{version}'
     }
 }
 ```


### PR DESCRIPTION
Plugin https://github.com/howardpang/androidNativeBundle migrated from JCenter to MavenCentral, but the group and artifact id needed to change, hence updating our docs