### PR TITLE
fix(apple): Incomplete withScope code sample

### DIFF
--- a/src/includes/enriching-events/scopes/with-scope/apple.mdx
+++ b/src/includes/enriching-events/scopes/with-scope/apple.mdx
@@ -2,6 +2,7 @@
 import Sentry
 
 SentrySDK.capture(error: error) { scope in
+    scope.setLevel(.warning)
     // will be tagged with my-tag="my value"
     scope.setTag(value: "my-tag", key: "my value")
 }
@@ -14,6 +15,7 @@ SentrySDK.capture(error: error)
 @import Sentry;
 
 [SentrySDK captureError:error withScopeBlock:^(SentryScope * _Nonnull scope) {
+    [scope setLevel:kSentryLevelWarning];
     // will be tagged with my-tag="my value"
     [scope setTagValue:@"my-tag" forKey:@"my value"];
 }];


### PR DESCRIPTION
The code sample for withScope was missing setting the level. This is fixed now.

Fixes GH-3601