### PR TITLE
Fix incorrect sampling configuration method.

### DIFF
--- a/src/includes/configuration/sample-rate/ruby.mdx
+++ b/src/includes/configuration/sample-rate/ruby.mdx
@@ -1,6 +1,6 @@
 ```ruby
 Sentry.init do |config|
   # ...
-  config.traces_sample_rate = 0.25
+  config.sample_rate = 0.25
 end
 ```


### PR DESCRIPTION
This cost us a few hours of stress as we thought it was a legit thing to be configured -- however, this mistake caused us to turn on performance sampling, quickly exceed the quota and cause all kinds of alarms to go off. :/