### PR TITLE
docs(lambda): Remove unnecessary colons

### DIFF
--- a/src/docs/product/integrations/aws-lambda/how-it-works.mdx
+++ b/src/docs/product/integrations/aws-lambda/how-it-works.mdx
@@ -3,7 +3,7 @@ title: Lambda Layer Modifications
 description: "Understand how the Sentry AWS Lambda integration works unnder the hood"
 ---
 
-## Node:
+## Node
 
 When Sentry is added to a Lambda function, the following modifications are made to your Lambda functions:
 * The layer for Sentry is added to your Lambdas. Any existing layers are honored and the Sentry layer is appended to the end.
@@ -18,7 +18,7 @@ When Sentry is added to a Lambda function, the following modifications are made 
   ![](env_variables.png)
 
 
-## Python:
+## Python
 
 When Sentry is added to a Lambda function, the following modifications are made to your Lambda functions:
 * The layer for Sentry is added to your Lambdas. Any existing layers are honored and the Sentry layer is appended to the end.


### PR DESCRIPTION
Because it looks strange (kinda broken) now:

![image](https://user-images.githubusercontent.com/1523305/119837048-85c43400-bf02-11eb-8ca0-662d66def0c6.png)
