### PR TITLE
java wizard with performance

### DIFF
--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -100,4 +100,4 @@ try {
 }
 ```
 
-For more information about the API and automatic instrumentations included in the SDK, [visit the docs](https://docs.sentry.io/platforms/java/performance/instrumentation/custom-instrumentation/).
+For more information about the API and automatic instrumentations included in the SDK, [visit the docs](https://docs.sentry.io/platforms/java/performance/).


### PR DESCRIPTION
Assumes #3646 will get merged.

* Added `debug=true` which help customers troubleshoot installation issues
* Removed Kotlin snippets (too verbose without proper tooling support, aka: tabs). Kotlin gets its own wizard (#3646)
* Performance monitoring opt-in with a code snippet on how to get started for validation.

@maciejwalkowiak 