### PR TITLE
feat: Reword RN shutdown-drain + mention flush

### DIFF
--- a/src/includes/configuration/drain-example/react-native.mdx
+++ b/src/includes/configuration/drain-example/react-native.mdx
@@ -1,3 +1,3 @@
-The React Native SDK ensures all Sentry events are accounted for in the event of a hard crash by prolonging the process until all events are successfully stored on the device's disk. The events will then be sent the next time the application is open.
+The React Native SDK ensures all Sentry events are accounted for in the event of a hard crash. This is done by prolonging the process until all events are successfully stored on the device's disk. The events will then be sent the next time the application is open.
 
 You can manually flush all events to disk by calling `Sentry.flush()`.

--- a/src/includes/configuration/drain-example/react-native.mdx
+++ b/src/includes/configuration/drain-example/react-native.mdx
@@ -1,1 +1,3 @@
-The React Native SDK automatically stores the Sentry events on the device's disk before shutdown.
+The React Native SDK ensures all Sentry events are accounted for in the event of a hard crash by prolonging the process until all events are successfully stored on the device's disk. The events will then be sent the next time the application is open.
+
+You can manually flush all events to disk by calling `Sentry.flush()`.


### PR DESCRIPTION
Reword the shutdown/draining page, and mention new flush method, awaiting https://github.com/getsentry/sentry-react-native/pull/1547