### PR TITLE
Update incomplete Next.js manual-setup code samples

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -15,8 +15,10 @@ For the client configuration:
 ```javascript {filename:sentry.client.config.js}
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  dsn: SENTRY_DSN || "___PUBLIC_DSN___",
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
@@ -29,8 +31,10 @@ And the server configuration:
 ```javascript {filename:sentry.server.config.js}
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  dsn: SENTRY_DSN || "___PUBLIC_DSN___",
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
Both the [`sentry.client.config.js`](https://github.com/getsentry/sentry-wizard/blob/f42afd7ad600bfdbc5692b3f3acbb957281cbfce/scripts/NextJs/configs/sentry.client.config.js#L7) and [`sentry.server.config.js`](https://github.com/getsentry/sentry-wizard/blob/f42afd7ad600bfdbc5692b3f3acbb957281cbfce/scripts/NextJs/configs/sentry.server.config.js#L7) generated by the Wizard have a variable to get the DSN from the environment, which the code samples in the manual-setup/ don't. This PR adds these, to be more consistent and reduce any confusion that may exist.