### PR TITLE
perf in getting started

### DIFF
--- a/src/includes/getting-started-config/dotnet.mdx
+++ b/src/includes/getting-started-config/dotnet.mdx
@@ -4,15 +4,25 @@ For example, initialize in the `Main` method in `Program.cs`:
 using (SentrySdk.Init(o => {
     // Tells which project in Sentry to send events to:
     o => o.Dsn = "___PUBLIC_DSN___";
-    // Set TracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    options.TracesSampleRate = 1.0; }))
+    // When configuring for the first time, to see what the SDK is doing:
+    o.Debug = true;
+    // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+    // We recommend adjusting this value in production.
+    o.TracesSampleRate = 1.0; }))
 {
     // App code goes here - Disposing will flush events out
 }
 ```
 
 ```fsharp {filename:Program.fs}
-use __ = SentrySdk.Init ("___PUBLIC_DSN___")
+use __ = SentrySdk.Init (fun o ->
+    o.Dsn <- "___PUBLIC_DSN___"
+    // When configuring for the first time, to see what the SDK is doing:
+    o.Debug <- true
+    // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+    // We recommend adjusting this value in production.
+    o.TracesSampleRate <- 1.0
+    )
+
+// App code goes here - Disposing will flush events out
 ```

--- a/src/includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-config/dotnet.xamarin.mdx
@@ -4,8 +4,13 @@ on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate fo
 ```csharp
 SentryXamarin.Init(o =>
 {
-	  o.AddXamarinFormsIntegration();
-    o.Dsn = "___PUBLIC_DSN___";
+    o.AddXamarinFormsIntegration();
+    // Tells which project in Sentry to send events to:
+    o => o.Dsn = "___PUBLIC_DSN___";
+    // Set TracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    options.TracesSampleRate = 1.0; }))
 });
 // App code
 

--- a/src/includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-config/dotnet.xamarin.mdx
@@ -7,6 +7,8 @@ SentryXamarin.Init(o =>
     o.AddXamarinFormsIntegration();
     // Tells which project in Sentry to send events to:
     o => o.Dsn = "___PUBLIC_DSN___";
+    // When configuring for the first time, to see what the SDK is doing:
+    o.Debug = true;
     // Set TracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production

--- a/src/includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-config/dotnet.xamarin.mdx
@@ -6,7 +6,7 @@ SentryXamarin.Init(o =>
 {
     o.AddXamarinFormsIntegration();
     // Tells which project in Sentry to send events to:
-    o => o.Dsn = "___PUBLIC_DSN___";
+    o.Dsn = "___PUBLIC_DSN___";
     // When configuring for the first time, to see what the SDK is doing:
     o.Debug = true;
     // Set TracesSampleRate to 1.0 to capture 100%

--- a/src/includes/getting-started-verify/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-verify/dotnet.xamarin.mdx
@@ -1,6 +1,5 @@
 You can verify Sentry is capturing unhandled exceptions by raising an exception. For example, you can use the following snippet to raise a `NullReferenceException`:
 
 ```csharp
-SentryXamarin.Init("___PUBLIC_DSN___");
 throw null;
 ```

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -25,19 +25,29 @@ as well as your logs as breadcrumbs. The logging integrations also capture event
 You configure the SDK in the `Global.asax.cs`:
 
 ```csharp
-
+using System.Web;
 using Sentry;
+using Sentry.EntityFramework; // if you also installed Sentry.EntityFramework
 
-public class MvcApplication : System.Web.HttpApplication
+public class MvcApplication : HttpApplication
 {
     private IDisposable _sentry;
 
     protected void Application_Start()
     {
+        // Initialize Sentry to capture AppDomain unhandled exceptions and more.
         _sentry = SentrySdk.Init(o =>
         {
             o.AddAspNet();
             o.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+            // Set TracesSampleRate to 1.0 to capture 100%
+            // of transactions for performance monitoring.
+            // We recommend adjusting this value in production
+            options.TracesSampleRate = 1.0;
+            // If you are using EF (and installed the NuGet package):
+            o.AddEntityFramework();
         });
     }
 
@@ -47,8 +57,19 @@ public class MvcApplication : System.Web.HttpApplication
         SentrySdk.CaptureException(exception);
     }
 
+    protected void Application_BeginRequest()
+    {
+        Context.StartSentryTransaction();
+    }
+
+    protected void Application_EndRequest()
+    {
+        Context.FinishSentryTransaction();
+    }
+
     protected void Application_End()
     {
+        // Flushes out events before shutting down.
         _sentry?.Dispose();
     }
 }

--- a/src/platforms/unity/unity-lite.mdx
+++ b/src/platforms/unity/unity-lite.mdx
@@ -14,8 +14,6 @@ This is a stable but lightweight SDK that doesn't support all of Sentry's featur
 
 </Note>
 
-<PlatformContent includePath="framework-list" />
-
 ## Install
 
 Sentry captures data by using an SDK within your application’s runtime.

--- a/src/wizard/dotnet/aspnet.md
+++ b/src/wizard/dotnet/aspnet.md
@@ -13,6 +13,12 @@ Package Manager:
 Install-Package Sentry.AspNet -Version {{ packages.version('sentry.dotnet.aspnet') }}
 ```
 
+Using Entity Framework 6?
+
+```shell
+Install-Package Sentry.EntityFramework -Version {{ packages.version('sentry.dotnet.ef') }}
+```
+
 <div class="alert alert-info" role="alert"><h5 class="no_toc">Using .NET Framework prior to 4.6.1?</h5>
     <div class="alert-body content-flush-bottom">
         <a href="https://docs.sentry.io/clients/csharp/">Our legacy SDK</a> supports .NET Framework as early as 3.5.
@@ -24,6 +30,7 @@ You should `init` the Sentry SDK as soon as possible during your application loa
 ```csharp
 using System.Web;
 using Sentry;
+using Sentry.EntityFramework; // if you installed Sentry.EntityFramework
 
 public class MvcApplication : HttpApplication
 {
@@ -36,14 +43,31 @@ public class MvcApplication : HttpApplication
         {
             o.AddAspNet();
             o.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+            // Set TracesSampleRate to 1.0 to capture 100%
+            // of transactions for performance monitoring.
+            // We recommend adjusting this value in production
+            options.TracesSampleRate = 1.0;
+            // If you are using EF (and installed the NuGet package):
+            o.AddEntityFramework();
         });
     }
 
     protected void Application_Error()
     {
         var exception = Server.GetLastError();
-        // Capture the server errors.
         SentrySdk.CaptureException(exception);
+    }
+
+    protected void Application_BeginRequest()
+    {
+        Context.StartSentryTransaction();
+    }
+
+    protected void Application_EndRequest()
+    {
+        Context.FinishSentryTransaction();
     }
 
     protected void Application_End()


### PR DESCRIPTION
The goal is to add performance monitoring to more _getting started_ and _wizard_s.
Also, to always suggest `Debug=true` to help users troubleshoot their setup.

Blocked by GA of .NET for the nicer API to start/finish transaction for ASP.NET Classic

/cc @Tyrrrz 