### PR TITLE
Document `serializeAttribute` option of browser breadcrumbs.

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -46,14 +46,33 @@ This integration wraps native APIs to capture breadcrumbs. By default, the Sentr
 
 Available options:
 
-```bash
-{ beacon: boolean; // Log HTTP requests done with the Beacon API
-  console: boolean; // Log calls to `console.log`, `console.debug`, etc
-  dom: boolean; // Log all click and keypress events
-  fetch: boolean; // Log HTTP requests done with the Fetch API
-  history: boolean; // Log calls to `history.pushState` and friends
-  sentry: boolean; // Log whenever we send an event to the server
-  xhr: boolean; // Log HTTP requests done with the XHR API
+```js
+{
+  // Log HTTP requests done with the Beacon API
+  beacon: boolean;
+
+  // Log calls to `console.log`, `console.debug`, etc
+  console: boolean;
+
+  // Log all click and keypress events
+  // - When an object with `serializeAttribute` key is provided,
+  //   Breadcrumbs integration will look for that attribute in DOM elements,
+  //   while generating the breadcrumb trails.
+  //   Matched elements will be followed by their custom attributes,
+  //   instead of their `id`s or `class` names.
+  dom: boolean | { serializeAttribute: string };
+
+  // Log HTTP requests done with the Fetch API
+  fetch: boolean;
+
+  // Log calls to `history.pushState` and friends
+  history: boolean;
+
+  // Log whenever we send an event to the server
+  sentry: boolean;
+
+  // Log HTTP requests done with the XHR API
+  xhr: boolean;
 }
 ```
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/pull/3620