### PR TITLE
Remove self from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,20 +25,8 @@
 /src/platforms/rust/ @getsentry/owners-native
 /src/wizard/rust/ @getsentry/owners-native
 
-/src/platforms/javascript/ @rhcarvalho
-/src/wizard/javascript/ @rhcarvalho
-/src/platforms/php/ @rhcarvalho
-/src/wizard/php/ @rhcarvalho
-/src/platforms/go/ @rhcarvalho
-/src/wizard/go/ @rhcarvalho
-/src/platforms/elixir/ @rhcarvalho
-/src/wizard/elixir/ @rhcarvalho
-/src/platforms/python/ @rhcarvalho
-/src/wizard/python/ @rhcarvalho
-
 /src/docs/product/discover-queries/ @getsentry/visibility
 /src/docs/product/performance/ @getsentry/visibility
 
 /src/docs/product/cli/ @kamilogorek
-/src/docs/product/cli/releases/ @rhcarvalho
 /src/docs/product/cli/dif/ @getsentry/owners-native


### PR DESCRIPTION
I was covering the areas for the Web Platform team to shield the rest of the team from notifications, but now need to reduce the amount of notifications I'm getting.

The expectation is that the triage process will take care of directing attention to the Web team (or any other team) when necessary.