### PR TITLE
fix(nextjs): Import Next.js SDK on enriching-content

### DIFF
--- a/src/includes/enriching-events/import/javascript.nextjs.mdx
+++ b/src/includes/enriching-events/import/javascript.nextjs.mdx
@@ -1,0 +1,3 @@
+```javascript
+import * as Sentry from "@sentry/nextjs";
+```


### PR DESCRIPTION
On enriching events page, even if the platform Next.js is selected, the imported SDK is `@sentry/browser`. The import must be from `@sentry/nextjs`.