### PR TITLE
fix(nextjs): Update code sample in Advanced Usage of Webpack

### DIFF
--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
@@ -1,0 +1,10 @@
+```javascript
+module.exports = {
+  output: {
+    path: path.join(__dirname, "dist"),
+    filename: "[name].js",
+    sourceMapFilename: "[name].js.map",
+  },
+  // other configuration
+};
+```

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
@@ -1,10 +1,11 @@
 ```javascript
 module.exports = {
   output: {
-    path: path.join(__dirname, "dist"),
+    // Make maps auto-detectable by sentry-cli
     filename: "[name].js",
     sourceMapFilename: "[name].js.map",
+    // Other `output` configuration
   },
-  // other configuration
+  // Other configuration
 };
 ```

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -1,0 +1,24 @@
+```javascript {filename:next.config.js}
+const { withSentryConfig } = require("@sentry/nextjs");
+
+const moduleExports = {
+  webpack: (config, options) => {
+    config.output = {
+      ...config.output,
+      path: path.join(__dirname, "dist"),
+      filename: "[name].js",
+      sourceMapFilename: "[name].js.map",
+    };
+    return config;
+  },
+  // Other nextjs configuration
+};
+
+const SentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin.
+};
+
+module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
+```
+
+Learn more about the Webpack usage for the Next.js SDK in [Extend Default Webpack Usage](/platforms/javascript/guides/nextjs/manual-setup/#extend-default-webpack-usage).

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -3,14 +3,16 @@ const { withSentryConfig } = require("@sentry/nextjs");
 
 const moduleExports = {
   webpack: (config, options) => {
+    devtool = 'source-map',
     config.output = {
       ...config.output,
-      path: path.join(__dirname, "dist"),
+      // Make maps auto-detectable by sentry-cli
       filename: "[name].js",
       sourceMapFilename: "[name].js.map",
     };
     return config;
   },
+  productionBrowserSourceMaps: true,
   // Other nextjs configuration
 };
 

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -77,49 +77,7 @@ Set up the `SentryWebpackPlugin` as the last running plugin, otherwise, the resu
 
 If you prefer to upload source maps manually, configure Webpack to output source maps:
 
-<PlatformSection notSupported={["javascript.nextjs"]}>
-
-```javascript
-module.exports = {
-  output: {
-    path: path.join(__dirname, "dist"),
-    filename: "[name].js",
-    sourceMapFilename: "[name].js.map",
-  },
-  // other configuration
-};
-```
-
-</PlatformSection>
-
-<PlatformSection supported={["javascript.nextjs"]}>
-
-```javascript {filename:next.config.js}
-const { withSentryConfig } = require("@sentry/nextjs");
-
-const moduleExports = {
-  webpack: (config, options) => {
-    config.output = {
-      ...config.output,
-      path: path.join(__dirname, "dist"),
-      filename: "[name].js",
-      sourceMapFilename: "[name].js.map",
-    };
-    return config;
-  },
-  // Other nextjs configuration
-};
-
-const SentryWebpackPluginOptions = {
-  // Additional config options for the Sentry Webpack plugin.
-};
-
-module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
-```
-
-Learn more about the Webpack usage for the Next.js SDK in [Extend Default Webpack Usage](/platforms/javascript/guides/nextjs/manual-setup/#extend-default-webpack-usage).
-
-</PlatformSection>
+<PlatformContent includePath="configuration/sourcemaps/tools/webpack/advanced-usage" />
 
 If you use [SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin) for more fine-grained control of source map generation, turn off `noSources` so Sentry can display proper source code context in event stack traces.
 

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -98,12 +98,16 @@ module.exports = {
 const { withSentryConfig } = require("@sentry/nextjs");
 
 const moduleExports = {
-  output: {
-    path: path.join(__dirname, "dist"),
-    filename: "[name].js",
-    sourceMapFilename: "[name].js.map",
+  webpack: (config, options) => {
+    config.output = {
+      ...config.output,
+      path: path.join(__dirname, "dist"),
+      filename: "[name].js",
+      sourceMapFilename: "[name].js.map",
+    };
+    return config;
   },
-  // Other configuration.
+  // Other nextjs configuration
 };
 
 const SentryWebpackPluginOptions = {

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -77,6 +77,8 @@ Set up the `SentryWebpackPlugin` as the last running plugin, otherwise, the resu
 
 If you prefer to upload source maps manually, configure Webpack to output source maps:
 
+<PlatformSection notSupported={["javascript.nextjs"]}>
+
 ```javascript
 module.exports = {
   output: {
@@ -87,6 +89,31 @@ module.exports = {
   // other configuration
 };
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={["javascript.nextjs"]}>
+
+```javascript {filename:next.config.js}
+const { withSentryConfig } = require("@sentry/nextjs");
+
+const moduleExports = {
+  output: {
+    path: path.join(__dirname, "dist"),
+    filename: "[name].js",
+    sourceMapFilename: "[name].js.map",
+  },
+  // Other configuration.
+};
+
+const SentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin.
+};
+
+module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
+```
+
+</PlatformSection>
 
 If you use [SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin) for more fine-grained control of source map generation, turn off `noSources` so Sentry can display proper source code context in event stack traces.
 

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -113,6 +113,8 @@ const SentryWebpackPluginOptions = {
 module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
 ```
 
+Learn more about the Webpack usage for the Next.js SDK in [Extend Default Webpack Usage](/platforms/javascript/guides/nextjs/manual-setup/#extend-default-webpack-usage).
+
 </PlatformSection>
 
 If you use [SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin) for more fine-grained control of source map generation, turn off `noSources` so Sentry can display proper source code context in event stack traces.


### PR DESCRIPTION
The advanced usage of Webpack was valid in a prior version of the SDK. This PR updates that code sample, besides removing some comments to reduce noise. If a user wants to read that noise or just learn more about it, a link to the `manual-setup` page has been included.