### PR TITLE
Add UWP doc and update .NET wizard

### DIFF
--- a/src/platforms/dotnet/guides/uwp/config.yml
+++ b/src/platforms/dotnet/guides/uwp/config.yml
@@ -1,0 +1,1 @@
+title: Windows Presentation Foundation

--- a/src/platforms/dotnet/guides/uwp/config.yml
+++ b/src/platforms/dotnet/guides/uwp/config.yml
@@ -1,1 +1,1 @@
-title: Windows Presentation Foundation
+title: Universal Windows Platform

--- a/src/platforms/dotnet/guides/uwp/index.mdx
+++ b/src/platforms/dotnet/guides/uwp/index.mdx
@@ -5,7 +5,7 @@ redirect_from:
   - /platforms/dotnet/uwp/
 ---
 
-Sentry's .NET SDK works with Universal Windows platform applications through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry). It works with UWP apps running on .NET Native.
+Sentry's .NET SDK works with Universal Windows platform applications through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry).
 
 ## Configuration
 
@@ -24,29 +24,36 @@ using System.Security;
 using Windows.UI.Xaml;
 using UnhandledExceptionEventArgs = Windows.UI.Xaml.UnhandledExceptionEventArgs;
 
-
 sealed partial class App : Application
 {
     public App()
     {
-        SentrySdk.Init("___PUBLIC_DSN___");
+        SentrySdk.Init(o => 
+        {
+            // Tells which project in Sentry to send events to:
+            o.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+            // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            o.TracesSampleRate = 1.0;
+        });
         Current.UnhandledException += ExceptionHandler;
     }
 
     [HandleProcessCorruptedStateExceptions, SecurityCritical]
     internal void ExceptionHandler(object sender, UnhandledExceptionEventArgs e)
     {
-        //We need to backup the reference, because the Exception reference last for one access.
-        //After that, a new  Exception reference is going to be set into e.Exception.
+        // We need to hold the reference, because the Exception property is cleared when accessed.
         var exception = e.Exception;
         if (exception != null)
         {
+            // Tells Sentry this was an Unhandled Exception
             exception.Data[Mechanism.HandledKey] = false;
             exception.Data[Mechanism.MechanismKey] = "Application.UnhandledException";
             SentrySdk.CaptureException(exception);
-            //If you are not going to use the Cache functionality, it's recommended to flush 
-            //Sentry for forcing it to send the Exception before the app closes.
-            //  SentrySdk.FlushAsync(TimeSpan.FromSeconds(10)).Wait();
+            // Make sure the event is flushed to disk or to Sentry
+            SentrySdk.FlushAsync(TimeSpan.FromSeconds(3)).Wait();
         }
     }
 

--- a/src/platforms/dotnet/guides/uwp/index.mdx
+++ b/src/platforms/dotnet/guides/uwp/index.mdx
@@ -1,0 +1,54 @@
+---
+title: UWP
+description: "Learn more about Sentry's .NET SDK works with Universal Windows platform (UWP) applications."
+redirect_from:
+  - /platforms/dotnet/uwp/
+---
+
+Sentry's .NET SDK works with Universal Windows platform applications through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry). It works with UWP apps running on .NET Native.
+
+## Configuration
+
+In addition to [initializing the SDK with `SentrySdk.Init`](/platforms/dotnet/), you must configure the UWP specific error handler.
+
+<Note>
+
+The SDK should be initialized in the constructor of your application class (usually `App.xaml.cs`). Do not initialize the SDK in the `OnLaunched()` event of the application or the `Hub` will not be initialized correctly.
+
+</Note>
+
+```csharp
+using Sentry;
+using System.Runtime.ExceptionServices;
+using System.Security;
+using Windows.UI.Xaml;
+using UnhandledExceptionEventArgs = Windows.UI.Xaml.UnhandledExceptionEventArgs;
+
+
+sealed partial class App : Application
+{
+    public App()
+    {
+        SentrySdk.Init("___PUBLIC_DSN___");
+        Current.UnhandledException += ExceptionHandler;
+    }
+
+    [HandleProcessCorruptedStateExceptions, SecurityCritical]
+    internal void ExceptionHandler(object sender, UnhandledExceptionEventArgs e)
+    {
+        //We need to backup the reference, because the Exception reference last for one access.
+        //After that, a new  Exception reference is going to be set into e.Exception.
+        var exception = e.Exception;
+        if (exception != null)
+        {
+            exception.Data[Mechanism.HandledKey] = false;
+            exception.Data[Mechanism.MechanismKey] = "Application.UnhandledException";
+            SentrySdk.CaptureException(exception);
+            //If you are not going to use the Cache functionality, it's recommended to flush 
+            //Sentry for forcing it to send the Exception before the app closes.
+            //  SentrySdk.FlushAsync(TimeSpan.FromSeconds(10)).Wait();
+        }
+    }
+
+}
+```

--- a/src/wizard/dotnet/uwp.md
+++ b/src/wizard/dotnet/uwp.md
@@ -1,5 +1,5 @@
 ---
-name: WP
+name: UWP
 doc_link: https://docs.sentry.io/platforms/dotnet/guides/uwp/
 support_level: production
 type: language
@@ -33,12 +33,12 @@ sealed partial class App : Application
 {
     protected override void OnLaunched(LaunchActivatedEventArgs e)
     {
-        Application.Current.UnhandledException += UnhandledExceptionHandler;
         SentrySdk.Init("___PUBLIC_DSN___");
+        Current.UnhandledException += UnhandledExceptionHandler;
     }
 
     [HandleProcessCorruptedStateExceptions, SecurityCritical]
-    void UnhandledExceptionHandler(object sender, UwpUnhandledExceptionEventArgs e)
+    void UnhandledExceptionHandler(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
     {
         //We need to backup the reference, because the Exception reference last for one access.
         //After that, a new  Exception reference is going to be set into e.Exception.
@@ -48,8 +48,10 @@ sealed partial class App : Application
             exception.Data[Mechanism.HandledKey] = false;
             exception.Data[Mechanism.MechanismKey] = "Application.UnhandledException";
             SentrySdk.CaptureException(exception);
-            SentrySdk.FlushAsync(TimeSpan.FromSeconds(10)).Wait();
-            }
+            //If you are not going to use the Sentry's Cache functionality, it's recommended to flush 
+            //Sentry for forcing it to send the Exception before the app closes.
+            //  SentrySdk.FlushAsync(TimeSpan.FromSeconds(10)).Wait();
+        }
     }
 }
 ```
@@ -60,7 +62,7 @@ Once you've verified the package is initialized properly and sent a test event, 
 
 ### Samples
 
-You can find an example UWP app with Sentry integrated [on this GitHub repository.](https://github.com/sentry-demos/uwp-csharp)
+You can find an example UWP app with Sentry integrated [on this GitHub repository.](https://github.com/getsentry/examples/tree/master/dotnet/UwpCSharp)
 
 See the following examples that demonstrate how to integrate Sentry with various frameworks.
 

--- a/src/wizard/dotnet/uwp.md
+++ b/src/wizard/dotnet/uwp.md
@@ -1,0 +1,68 @@
+---
+name: WP
+doc_link: https://docs.sentry.io/platforms/dotnet/guides/uwp/
+support_level: production
+type: language
+---
+
+## Install the NuGet package
+
+```shell
+# Using Package Manager
+Install-Package Sentry -Version {{ packages.version('sentry.dotnet') }}
+
+# Or using .NET Core CLI
+dotnet add package Sentry -v {{ packages.version('sentry.dotnet') }}
+```
+
+<div class="alert alert-info" role="alert"><h5 class="no_toc">Using .NET Framework prior to 4.6.1?</h5>
+    <div class="alert-body content-flush-bottom">
+        <a href="https://docs.sentry.io/clients/csharp/">Our legacy SDK</a> supports .NET Framework as early as 3.5.
+    </div>
+</div>
+
+## Initialize the SDK
+
+Initialize the SDK as early as possible, like in the constructor of the `App`:
+
+```csharp
+using System.Windows;
+using Sentry;
+
+sealed partial class App : Application
+{
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
+        Application.Current.UnhandledException += UnhandledExceptionHandler;
+        SentrySdk.Init("___PUBLIC_DSN___");
+    }
+
+    [HandleProcessCorruptedStateExceptions, SecurityCritical]
+    void UnhandledExceptionHandler(object sender, UwpUnhandledExceptionEventArgs e)
+    {
+        //We need to backup the reference, because the Exception reference last for one access.
+        //After that, a new  Exception reference is going to be set into e.Exception.
+        var exception = e.Exception;
+        if (exception != null)
+        {
+            exception.Data[Mechanism.HandledKey] = false;
+            exception.Data[Mechanism.MechanismKey] = "Application.UnhandledException";
+            SentrySdk.CaptureException(exception);
+            SentrySdk.FlushAsync(TimeSpan.FromSeconds(10)).Wait();
+            }
+    }
+}
+```
+
+### Documentation
+
+Once you've verified the package is initialized properly and sent a test event, consider visiting our [complete UWP docs](https://docs.sentry.io/platforms/dotnet/guides/uwp/).
+
+### Samples
+
+You can find an example UWP app with Sentry integrated [on this GitHub repository.](https://github.com/sentry-demos/uwp-csharp)
+
+See the following examples that demonstrate how to integrate Sentry with various frameworks.
+
+- [Multiple samples in the `dotnet` SDK repository](https://github.com/getsentry/sentry-dotnet/tree/main/samples) (**C#**)
+- [Basic F# sample](https://github.com/sentry-demos/fsharp) (**F#**)

--- a/src/wizard/dotnet/uwp.md
+++ b/src/wizard/dotnet/uwp.md
@@ -64,6 +64,16 @@ sealed partial class App : Application
 }
 ```
 
+## Verify
+
+To verify your set up, you can capture a message with the SDK:
+
+```csharp
+SentrySdk.CaptureMessage("Hello Sentry");
+```
+
+If you don't want to depend on the static class, the SDK registers a client in the DI container. In this case, you can [take `IHub` as a dependency](https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/unit-testing/).
+
 ### Documentation
 
 Once you've verified the package is initialized properly and sent a test event, consider visiting our [complete UWP docs](https://docs.sentry.io/platforms/dotnet/guides/uwp/).

--- a/src/wizard/dotnet/uwp.md
+++ b/src/wizard/dotnet/uwp.md
@@ -74,6 +74,30 @@ SentrySdk.CaptureMessage("Hello Sentry");
 
 If you don't want to depend on the static class, the SDK registers a client in the DI container. In this case, you can [take `IHub` as a dependency](https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/unit-testing/).
 
+### Performance Monitoring
+
+You can measure the performance of your code by capturing transactions and spans.
+
+```csharp
+// Transaction can be started by providing, at minimum, the name and the operation
+var transaction = SentrySdk.StartTransaction(
+  "test-transaction-name",
+  "test-transaction-operation"
+);
+
+// Transactions can have child spans (and those spans can have child spans as well)
+var span = transaction.StartChild("test-child-operation");
+
+// ...
+// (Perform the operation represented by the span/transaction)
+// ...
+
+span.Finish(); // Mark the span as finished
+transaction.Finish(); // Mark the transaction as finished and send it to Sentry
+```
+
+Check out [the documentation](https://docs.sentry.io/platforms/dotnet/performance/instrumentation/) to learn more about the API and automatic instrumentations.
+
 ### Documentation
 
 Once you've verified the package is initialized properly and sent a test event, consider visiting our [complete UWP docs](https://docs.sentry.io/platforms/dotnet/guides/uwp/).

--- a/src/wizard/dotnet/winforms.md
+++ b/src/wizard/dotnet/winforms.md
@@ -36,7 +36,16 @@ static class Program
     static void Main()
     {
         // Init the Sentry SDK
-        SentrySdk.Init("___PUBLIC_DSN___");
+        SentrySdk.Init(o => 
+        {
+            // Tells which project in Sentry to send events to:
+            o.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+            // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            o.TracesSampleRate = 1.0;
+        });
         // Configure WinForms to throw exceptions so Sentry can capture them.
         Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
 
@@ -46,6 +55,38 @@ static class Program
     }
 }
 ```
+
+## Verify
+
+To verify your set up, you can capture a message with the SDK:
+
+```csharp
+SentrySdk.CaptureMessage("Hello Sentry");
+```
+
+### Performance Monitoring
+
+You can measure the performance of your code by capturing transactions and spans.
+
+```csharp
+// Transaction can be started by providing, at minimum, the name and the operation
+var transaction = SentrySdk.StartTransaction(
+  "test-transaction-name",
+  "test-transaction-operation"
+);
+
+// Transactions can have child spans (and those spans can have child spans as well)
+var span = transaction.StartChild("test-child-operation");
+
+// ...
+// (Perform the operation represented by the span/transaction)
+// ...
+
+span.Finish(); // Mark the span as finished
+transaction.Finish(); // Mark the transaction as finished and send it to Sentry
+```
+
+Check out [the documentation](https://docs.sentry.io/platforms/dotnet/performance/instrumentation/) to learn more about the API and automatic instrumentations.
 
 ### Documentation
 

--- a/src/wizard/dotnet/wpf.md
+++ b/src/wizard/dotnet/wpf.md
@@ -56,6 +56,40 @@ public partial class App : Application
 }
 ```
 
+## Verify
+
+To verify your set up, you can capture a message with the SDK:
+
+```csharp
+SentrySdk.CaptureMessage("Hello Sentry");
+```
+
+### Performance Monitoring
+
+You can measure the performance of your code by capturing transactions and spans.
+
+```csharp
+// Transaction can be started by providing, at minimum, the name and the operation
+var transaction = SentrySdk.StartTransaction(
+  "test-transaction-name",
+  "test-transaction-operation"
+);
+
+// Transactions can have child spans (and those spans can have child spans as well)
+var span = transaction.StartChild("test-child-operation");
+
+// ...
+// (Perform the operation represented by the span/transaction)
+// ...
+
+span.Finish(); // Mark the span as finished
+transaction.Finish(); // Mark the transaction as finished and send it to Sentry
+```
+
+Check out [the documentation](https://docs.sentry.io/platforms/dotnet/performance/instrumentation/) to learn more about the API and automatic instrumentations.
+
+If you don't want to depend on the static class, the SDK registers a client in the DI container. In this case, you can [take `IHub` as a dependency](https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/unit-testing/).
+
 ### Documentation
 
 Once you've verified the package is initialized properly and sent a test event, consider visiting our [complete WPF docs](https://docs.sentry.io/platforms/dotnet/guides/wpf/).

--- a/src/wizard/dotnet/wpf.md
+++ b/src/wizard/dotnet/wpf.md
@@ -34,7 +34,16 @@ public partial class App : Application
     public App()
     {
         DispatcherUnhandledException += App_DispatcherUnhandledException;
-        SentrySdk.Init("___PUBLIC_DSN___");
+        SentrySdk.Init(o => 
+        {
+            // Tells which project in Sentry to send events to:
+            o.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+            // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            o.TracesSampleRate = 1.0;
+        });
     }
 
     void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/src/wizard/dotnet/xamarin.md
+++ b/src/wizard/dotnet/xamarin.md
@@ -31,7 +31,13 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
     {
         SentryXamarin.Init(options =>
         {
+            // Tells which project in Sentry to send events to:
             options.Dsn = "___PUBLIC_DSN___";
+            // When configuring for the first time, to see what the SDK is doing:
+            options.Debug = true;
+            // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            options.TracesSampleRate = 1.0;
             options.AddXamarinFormsIntegration();
         });
 ```

--- a/src/wizard/dotnet/xamarin.md
+++ b/src/wizard/dotnet/xamarin.md
@@ -85,6 +85,30 @@ You can Verify Sentry by raising an unhandled exception. For example, you can us
 
 You might need to open the app again for the crash report to be sent to the server.
 
+### Performance Monitoring
+
+You can measure the performance of your code by capturing transactions and spans.
+
+```csharp
+// Transaction can be started by providing, at minimum, the name and the operation
+var transaction = SentrySdk.StartTransaction(
+  "test-transaction-name",
+  "test-transaction-operation"
+);
+
+// Transactions can have child spans (and those spans can have child spans as well)
+var span = transaction.StartChild("test-child-operation");
+
+// ...
+// (Perform the operation represented by the span/transaction)
+// ...
+
+span.Finish(); // Mark the span as finished
+transaction.Finish(); // Mark the transaction as finished and send it to Sentry
+```
+
+Check out [the documentation](https://docs.sentry.io/platforms/dotnet/performance/instrumentation/) to learn more about the API and automatic instrumentations.
+
 ### Documentation
 
 Once you've verified the package is initialized properly and sent a test event, consider visiting our [complete Xamarin Forms docs](https://docs.sentry.io/platforms/dotnet/guides/xamarin/).

--- a/src/wizard/dotnet/xamarin.md
+++ b/src/wizard/dotnet/xamarin.md
@@ -74,13 +74,12 @@ NOTE: It's recommended to not setup the CacheDirectory for UWP.
             });
 ```
 
-### Verifying Your Setup
+## Verify
 
-You can Verify Sentry by raising an unhandled exception. For example, you can use the following snippet to raise a NullReferenceException:
+To verify your set up, you can capture a message with the SDK:
 
 ```csharp
-    throw null;
-}
+SentrySdk.CaptureMessage("Hello Sentry");
 ```
 
 You might need to open the app again for the crash report to be sent to the server.


### PR DESCRIPTION
By default, if you use the .NET SDK as is. It'll not register unhandled exceptions, this PR provides documentation on how to register unhandled exceptions on a UWP application.

Additionally, the following frameworks got their wizard updated with a more complete setup including SDK initialization with performance monitoring, Verify, and performance monitoring sample.

- Xamarin
- WPF
- WinForms
- UWP