### PR TITLE
feat(nextjs): Add nextjs performance docs

### DIFF
--- a/src/includes/performance/automatic-instrumentation-intro/javascript.mdx
+++ b/src/includes/performance/automatic-instrumentation-intro/javascript.mdx
@@ -1,0 +1,1 @@
+The `@sentry/tracing` package provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications.

--- a/src/includes/performance/automatic-instrumentation-intro/javascript.nextjs.mdx
+++ b/src/includes/performance/automatic-instrumentation-intro/javascript.nextjs.mdx
@@ -1,0 +1,1 @@
+`@sentry/nextjs` provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications, which is enabled by default once you set up tracing in your app. Further, the same `withSentry` wrapper which enables error collection in your API routes also automatically measures their performance.

--- a/src/includes/performance/beforeNavigate-example/javascript.mdx
+++ b/src/includes/performance/beforeNavigate-example/javascript.mdx
@@ -1,9 +1,8 @@
-```javascript
-import * as Sentry from "@sentry/browser";
-import { Integrations } from "@sentry/tracing";
+One common use case is parameterizing transaction names. For both `pageload` and `navigation` transactions, the `BrowserTracing` integration uses the browser's `window.location` value to generate a transaction name. Using `beforeNavigate` you can modify the transaction name to make it more generic, so that, for example, transactions named `GET /users/12312012` and `GET /users/11212012` can both be renamed `GET /users/:userid`, so that they'll group together.
 
+```javascript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  // ...
   integrations: [
     new Integrations.BrowserTracing({
       beforeNavigate: context => {
@@ -19,9 +18,5 @@ Sentry.init({
       },
     }),
   ],
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 1.0,
 });
 ```

--- a/src/includes/performance/beforeNavigate-example/javascript.nextjs.mdx
+++ b/src/includes/performance/beforeNavigate-example/javascript.nextjs.mdx
@@ -1,0 +1,18 @@
+```javascript
+Sentry.init({
+  // ...
+  integrations: [
+    new Sentry.Integrations.BrowserTracing({
+      beforeNavigate: context => {
+        return {
+          ...context,
+          tags: {
+            ...context.tags,
+            resultFormat: "legacy",
+          },
+        };
+      },
+    }),
+  ],
+});
+```

--- a/src/includes/performance/configure-sample-rate/javascript.nextjs.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.nextjs.mdx
@@ -3,12 +3,11 @@ In both `sentry.server.config.js` and `sentry.client.config.js`:
 ```javascript
 import * as Sentry from "@sentry/nextjs";
 
-
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
   // To set a uniform sample rate
-  tracesSampleRate: 0.2
+  tracesSampleRate: 0.2,
 
   // Alternatively, to control sampling dynamically
   tracesSampler: samplingContext => { ... }

--- a/src/includes/performance/configure-sample-rate/javascript.nextjs.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.nextjs.mdx
@@ -1,0 +1,16 @@
+In both `sentry.server.config.js` and `sentry.client.config.js`:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2
+
+  // Alternatively, to control sampling dynamically
+  tracesSampler: samplingContext => { ... }
+});
+```

--- a/src/includes/performance/enable-automatic-instrumentation/javascript.mdx
+++ b/src/includes/performance/enable-automatic-instrumentation/javascript.mdx
@@ -1,3 +1,5 @@
+To enable tracing, include the `BrowserTracing` integration in your SDK configuration options. (Note that when using ESM modules, the main `@sentry/*` import must come before the `@sentry/tracing` import.)
+
 After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
 
 ```javascript {tabTitle: ESM}

--- a/src/includes/performance/enable-automatic-instrumentation/javascript.nextjs.mdx
+++ b/src/includes/performance/enable-automatic-instrumentation/javascript.nextjs.mdx
@@ -1,0 +1,1 @@
+To enable tracing, simply set either a `tracesSampleRate` or a `tracesSampler` in your SDK configuration options, as detailed in <PlatformLink to="/performance/">Set Up Tracing</PlatformLink>.

--- a/src/includes/performance/enable-tracing/javascript.nextjs.mdx
+++ b/src/includes/performance/enable-tracing/javascript.nextjs.mdx
@@ -1,0 +1,1 @@
+`@sentry/nextjs` comes with performance monitoring included. To enable it, you just need to configure your sample rate as detailed below.

--- a/src/includes/performance/filter-span-example/javascript.nextjs.mdx
+++ b/src/includes/performance/filter-span-example/javascript.nextjs.mdx
@@ -2,7 +2,7 @@
 Sentry.init({
   // ...
   integrations: [
-    new Integrations.BrowserTracing({
+    new Sentry.Integrations.BrowserTracing({
       shouldCreateSpanForRequest: url => {
         // Do not create spans for outgoing requests to a `/health/` endpoint
         return !url.match(/\/health\/?$/);

--- a/src/includes/performance/group-transaction-example/javascript.mdx
+++ b/src/includes/performance/group-transaction-example/javascript.mdx
@@ -1,12 +1,11 @@
 An example of doing this in a node.js application:
 
 ```javascript
-// all JavaScript-based SDKs include this function, so it's safe to replace `@sentry/node`
+// All JavaScript-based SDKs include this function, so it's safe to replace `@sentry/node`
 // with your particular SDK
 import { addGlobalEventProcessor } from "@sentry/node";
 
 addGlobalEventProcessor(event => {
-  // if event is a transaction event
   if (event.type === "transaction") {
     event.transaction = sanitizeTransactionName(event.transaction);
   }

--- a/src/includes/performance/group-transaction-example/javascript.mdx
+++ b/src/includes/performance/group-transaction-example/javascript.mdx
@@ -1,6 +1,8 @@
 An example of doing this in a node.js application:
 
 ```javascript
+// all JavaScript-based SDKs include this function, so it's safe to replace `@sentry/node`
+// with your particular SDK
 import { addGlobalEventProcessor } from "@sentry/node";
 
 addGlobalEventProcessor(event => {

--- a/src/includes/performance/retrieve-transaction/javascript.mdx
+++ b/src/includes/performance/retrieve-transaction/javascript.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing transaction, such as when grouping transactions, you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` object when there is a running transaction on the scope, otherwise it returns `undefined`. If you are using our BrowserTracing integration, by default we attach the transaction to the Scope, so you could do something like this:
+In cases where you want to attach spans to an already ongoing transaction, such as when grouping transactions, you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` object when there is a running transaction on the scope, otherwise it returns `undefined`. If you are using our `BrowserTracing` integration, by default we attach the transaction to the Scope, so you could do something like this:
 
 ```javascript
 function myJsFunction() {

--- a/src/includes/performance/tracingOrigins-example/javascript.mdx
+++ b/src/includes/performance/tracingOrigins-example/javascript.mdx
@@ -1,10 +1,10 @@
 For example:
 
-- A frontend application is served from `example.com`
-- A backend service is served from `api.example.com`
-- The frontend application makes API calls to the backend
-- Set the `tracingOrigins` option to `['api.example.com']`
-- Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
+- A frontend application is served from `example.com`.
+- A backend service is served from `api.example.com`.
+- The frontend application makes API calls to the backend.
+- Set the `tracingOrigins` option to `['api.example.com']`.
+- Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached.
 
 ```javascript
 Sentry.init({

--- a/src/includes/performance/tracingOrigins-example/javascript.nextjs.mdx
+++ b/src/includes/performance/tracingOrigins-example/javascript.nextjs.mdx
@@ -10,7 +10,7 @@ For example:
 Sentry.init({
   // ...
   integrations: [
-    new Integrations.BrowserTracing({
+    new Sentry.Integrations.BrowserTracing({
       tracingOrigins: ["api.example.com"],
     }),
   ],

--- a/src/includes/performance/what-instrumentation-provides/javascript.mdx
+++ b/src/includes/performance/what-instrumentation-provides/javascript.mdx
@@ -1,0 +1,1 @@
+The `BrowserTracing` integration creates a new transaction for each page load and navigation event, and creates a child span for every `XMLHttpRequest` or `fetch` request that occurs while those transactions are open. Learn more about [traces, transactions, and spans](/product/performance/distributed-tracing/).

--- a/src/includes/performance/what-instrumentation-provides/javascript.nextjs.mdx
+++ b/src/includes/performance/what-instrumentation-provides/javascript.nextjs.mdx
@@ -1,0 +1,1 @@
+The `BrowserTracing` integration creates a new transaction for each page load and navigation event, and creates a child span for every `XMLHttpRequest` or `fetch` request that occurs while those transactions are open. The `withSentry` wrapper creates a transaction for every API request. Learn more about [traces, transactions, and spans](/product/performance/distributed-tracing/).

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -12,14 +12,15 @@ To connect backend and frontend transactions into a single coherent trace, Sentr
 
 ### Navigation and Other XHR Requests
 
-For traces that begin in JavaScript, any requests it makes (and any requests your backend makes as a result) are linked through a request header.
+For traces that begin in the front end, any requests made (and any requests your backend makes as a result) are linked through a request header.
 
-All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`) either generate or pick up and propagate the trace header automatically as appropriate for all transactions and spans that they generate.
+All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`), as well as the Next.JS SDK either generate or pick up and propagate the trace header automatically as appropriate, for all transactions and spans that they generate.
 
-The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination contains a string in or matches a regex in the <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#tracingorigins">tracingOrigins</PlatformLink> list.
+The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination is a substring or regex match to the <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#tracingorigins">tracingOrigins</PlatformLink> list.
 
 <!-- copied from automatic-instrumentation to emphasize this point -->
-You will need to configure your web server [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) to allow the sentry-trace header. The configuration might look like "Access-Control-Allow-Headers: sentry-trace", but the configuration depends on your set up. If you do not allow the sentry-trace header, the request might be blocked.
+
+You will need to configure your web server [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) to allow the `sentry-trace` header. The configuration might look like `"Access-Control-Allow-Headers: sentry-trace"`, but the configuration depends on your set up. If you do not allow the `sentry-trace` header, the request might be blocked.
 
 ### Pageload
 

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -14,7 +14,7 @@ To connect backend and frontend transactions into a single coherent trace, Sentr
 
 For traces that begin in the front end, any requests made (and any requests your backend makes as a result) are linked through a request header.
 
-All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`), as well as the Next.JS SDK either generate or pick up and propagate the trace header automatically as appropriate, for all transactions and spans that they generate.
+All of Sentry's tracing-related integrations (`BrowserTracing`, `Http`, and `Express`), as well as the Next.JS SDK, either generate or pick up and propagate the trace header automatically as appropriate, for all transactions and spans that they generate.
 
 The JavaScript SDK will only attach the trace header to outgoing HTTP requests whose destination is a substring or regex match to the <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#tracingorigins">tracingOrigins</PlatformLink> list.
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -17,18 +17,17 @@ supported:
   - unity
 notSupported:
   - javascript.cordova
-  - javascript.nextjs
   - javascript.electron
 description: "Learn how to enable performance monitoring in your app if it is not already set up."
 redirect_from:
   - /platforms/javascript/performance/apm-to-tracing/
 ---
 
-<Alert level="info" title="Do you need to set up?">
+<!-- Include in `notSupported` any SDK which enables tracing automatically -->
 
-Getting Started includes code samples to both enable and configure Performance Monitoring; proceed straight to our content about instrumentation.
+<Alert level="info" title="Note">
 
-If you're adding tracing, enable and configure it as documented here. If you’re on a legacy plan, you'll also need to add transaction events to your [plan](https://sentry.io/pricing/).
+If you’re on a legacy plan, you'll need to add transaction events to your [subscription](https://sentry.io/pricing/) in order to use performance monitoring.
 
 </Alert>
 
@@ -63,9 +62,9 @@ Learn more about how the options work in <PlatformLink to="/configuration/sampli
 
 ## Verify
 
-<PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android"]} notSupported={["javascript"]}>
+<PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript"]} >
 
-Test out tracing using our <PlatformLink to="/performance/instrumentation/automatic-instrumentation/">automatic instrumentation</PlatformLink> or by starting and finishing a transaction using <PlatformLink to="/performance/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink>.
+Verify that performance monitoring is working correctly by using our <PlatformLink to="/performance/instrumentation/automatic-instrumentation/">automatic instrumentation</PlatformLink> or by starting and finishing a transaction using <PlatformLink to="/performance/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink>.
 
 </PlatformSection>
 
@@ -75,13 +74,13 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 </PlatformSection>
 
-Verify that performance monitoring is working correctly by setting <PlatformIdentifier name="traces-sample-rate" /> to `1.0` as that ensures that every transaction will be sent to Sentry.
+While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry.
 
 Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to dynamically sample and filter your transactions.
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
-Leaving the sample rate at `1.0` means that automatic instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables representative data without overwhelming either your system or your Sentry transaction quota.
+Leaving the sample rate at `1.0` means that automatic instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables you to collect representative data without overwhelming either your system or your Sentry transaction quota.
 
 </PlatformSection>
 
@@ -104,7 +103,7 @@ Otherwise, backend services with Performance Monitoring connect automatically.
 
 ## React Router
 
-If you are using `react-router`, we provide <PlatformLink to="/configuration/integrations/react-router/">instrumentation</PlatformLink> to use with our `@sentry/tracing` package.
+If you are using `react-router`, we provide <PlatformLink to="/configuration/integrations/react-router/">React Router instrumentation</PlatformLink> to use with our `@sentry/tracing` package.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/instrumentation/index.mdx
+++ b/src/platforms/common/performance/instrumentation/index.mdx
@@ -4,7 +4,6 @@ sidebar_order: 20
 description: "Learn how to instrument performance in your app."
 notSupported:
   - javascript.cordova
-  - javascript.nextjs
   - javascript.electron
   - node
   - php

--- a/src/platforms/common/performance/troubleshooting-performance.mdx
+++ b/src/platforms/common/performance/troubleshooting-performance.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript
   - react-native
   - python
-description: "Learn about troubleshooting transactions, including how to manage maximum character limits for tags."
+description: "Learn how to troubleshoot your performance monitoring setup."
 ---
 
 If you need help managing transactions, you can read more here. If you need additional help, please view our forums. Customers on a paid plan may also contact support.

--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -14,21 +14,41 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 </Note>
 
-The `@sentry/tracing` package provides a `BrowserTracing` integration to add _automatic_ instrumentation for monitoring the performance of browser applications.
+<PlatformContent includePath="performance/automatic-instrumentation-intro" />
 
 ## What Our Instrumentation Provides
 
-The `BrowserTracing` integration creates a new transaction for each page load and navigation event, and creates a child span for every `XMLHttpRequest` or `fetch` request that occurs while those transactions are open. Learn more about [traces, transactions, and spans](/product/performance/distributed-tracing/).
+<PlatformContent includePath="performance/what-instrumentation-provides" />
 
 ## Enable Instrumentation
-
-To enable this tracing, include the `BrowserTracing` integration in your SDK configuration options. (Note that when using ESM modules, the main `@sentry/*` import must come before the `@sentry/tracing` import.)
 
 <PlatformContent includePath="performance/enable-automatic-instrumentation" />
 
 ## Configuration Options
 
-You can pass many different options to the `BrowserTracing` integration (as an object of the form `{optionName: value}`), but it comes with reasonable defaults out of the box. For all possible options, see [TypeDocs](https://getsentry.github.io/sentry-javascript/interfaces/tracing.browsertracingoptions.html).
+<PlatformSection supported={["javascript.nextjs"]} notSupported={["javascript"]}>
+
+Though the `BrowserTracing` integration is automatically enabled in `@sentry/nextjs`, in order to customize its options you must include it in your `Sentry.init` in `sentry.client.config.js`:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  integrations: [
+    new Sentry.Integrations.BrowserTracing({
+      // custom options
+    }),
+  ],
+
+  tracesSampleRate: 1.0,
+});
+```
+
+</PlatformSection>
+
+Supported options:
 
 ### tracingOrigins
 
@@ -40,37 +60,39 @@ You will need to configure your web server [CORS](https://developer.mozilla.org/
 
 ### beforeNavigate
 
-For `pageload` and `navigation` transactions, the `BrowserTracing` integration uses the browser's `window.location` API to generate a transaction name. To customize the name of the `pageload` and `navigation` transactions, you can supply a `beforeNavigate` option to the `BrowserTracing` integration. This option allows you to modify the transaction name to make it more generic, so that, for example, transactions named `GET /users/12312012` and `GET /users/11212012` can both be renamed `GET /users/:userid`, so that they'll group together.
+`beforeNavigate` is called at the start of every `pageload` or `navigation` transaction, and is passed the an object containing the data with with the transaction will be started. Using `beforeNavigate` gives you the option to modify that data, or drop the transaction entirely by returning `undefined`.
 
 <PlatformContent includePath="performance/beforeNavigate-example" />
 
 ### shouldCreateSpanForRequest
 
-This function can be used to filter out unwanted spans such as XHR's running health checks or something similar. By default `shouldCreateSpanForRequest` already filters out everything but what was defined in `tracingOrigins`.
+This function can be used to filter out unwanted spans such as XHR's running health checks or something similar. Whether specified or not, `shouldCreateSpanForRequest` filters out everything but what was defined in `tracingOrigins`.
 
 <PlatformContent includePath="performance/filter-span-example" />
 
 ### idleTimeout
 
-The time, measured in ms, to wait until the transaction will be finished. The transaction will use the end timestamp of the last finished span as the endtime for the transaction.
+The idle time, measured in ms, to wait until the transaction will be finished. The transaction will use the end timestamp of the last finished span as the endtime for the transaction.
 
-The default is 1000.
+The default is `1000`.
 
 ### startTransactionOnLocationChange
 
 This flag enables or disables creation of `navigation` transaction on history changes.
 
-The default value is `true`.
+The default is `true`.
 
 ### startTransactionOnPageLoad
 
-The default value of `startTransactionOnPageLoad` is `true`. This flag enables or disables creation of `navigation` transaction on first pageload.
+This flag enables or disables creation of `pageload` transaction on first pageload.
+
+The default is `true`.
 
 ### maxTransactionDuration
 
-The maximum duration of a transaction before it will be marked as "deadline_exceeded", measured in seconds. If you never want to mark a transaction, set `maxTransactionDuration` to 0.
+The maximum duration of a transaction, measured in seconds, before it will be marked as "deadline_exceeded". If you never want transactions marked that way, set `maxTransactionDuration` to 0.
 
-The default is 600.
+The default is `600`.
 
 ### markBackgroundTransactions
 


### PR DESCRIPTION
This follows up on https://github.com/getsentry/sentry-docs/pull/3653, which added mentions of performance to the nextjs docs, but didn't actually add the performance docs themselves. This does so, and includes the following changes:

- add nextjs-specific code samples where required
- turn spots where nextjs needs to override the main JS content into includes
- simplify example code for `BrowserTracing` options
- remove note about skipping setup page, as it contains useful information about sampling and testing
- do general wordsmithing