### PR TITLE
clarify auto ip address

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -26,7 +26,8 @@ Users consist of a few critical pieces of information that construct a unique id
 
 `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. Set to `"{{auto}}"` to let Sentry infer the IP address from the connection.
+: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might required `sendDefaultPii` set to `true` in the SDK options.
+You can set to `"{{auto}}"` to let Sentry infer the IP address from the connection between your app and Sentry's server. This is useful for client application such as a website, desktop and mobile.
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -26,8 +26,7 @@ Users consist of a few critical pieces of information that construct a unique id
 
 `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might required `sendDefaultPii` set to `true` in the SDK options.
-You can set to `"{{auto}}"` to let Sentry infer the IP address from the connection between your app and Sentry's server. This is useful for client application such as a website, desktop and mobile.
+: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might required `sendDefaultPii` set to `true` in the SDK options. If set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server, which is useful for client applications such as a website, desktop, or mobile.
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 


### PR DESCRIPTION
"the connection" for users can read as: The connection between my users and my server. But we mean here exclusively: The connection between Sentry's SDK and Sentry's server.