### PR TITLE
Remove beta note from dart withScope

### DIFF
--- a/src/includes/enriching-events/scopes/with-scope/dart.mdx
+++ b/src/includes/enriching-events/scopes/with-scope/dart.mdx
@@ -1,9 +1,3 @@
-<Note>
-
-This feature is available in 5.1 beta version of the Sentry Dart SDK.
-
-</Note>
-
 ```dart
 import 'package:sentry/sentry.dart';
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-dart/releases/tag/5.1.0

cc @ueman