### PR TITLE
fix(apple): Use YES/NO in samples

### DIFF
--- a/src/includes/configuration/config-intro/apple.mdx
+++ b/src/includes/configuration/config-intro/apple.mdx
@@ -22,7 +22,7 @@ func application(_ application: UIApplication,
 
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"___PUBLIC_DSN___";
-        options.debug = @YES; // Enabled debug when first installing is always helpful
+        options.debug = YES; // Enabled debug when first installing is always helpful
     }];
 
     return YES;

--- a/src/includes/getting-started-config/apple.mdx
+++ b/src/includes/getting-started-config/apple.mdx
@@ -24,7 +24,7 @@ func application(_ application: UIApplication,
 
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"___PUBLIC_DSN___";
-        options.debug = @YES; // Enabled debug when first installing is always helpful
+        options.debug = YES; // Enabled debug when first installing is always helpful
     }];
 
     return YES;

--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -24,7 +24,7 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableOutOfMemoryTracking = @NO;
+    options.enableOutOfMemoryTracking = NO;
 }];
 
 ```


### PR DESCRIPTION
Use YES/NO (BOOL) instead of @YES/@NO (NSNumber).