### PR TITLE
Remove SpoolTransport mention in php transports doc

### DIFF
--- a/src/platforms/php/common/configuration/transports.mdx
+++ b/src/platforms/php/common/configuration/transports.mdx
@@ -40,8 +40,6 @@ interface;
 - The `NullTransport` which is used in case you do not define a `DSN` in the options. It will not send events.
 - The `HttpTransport` which is the default and will be used when the server
   is set in the client configuration.
-- The `SpoolTransport` which can be used to defer the sending of events (e.g.
-  by putting them into a queue).
 
 The examples below pretty much replace the `\Sentry\init()` call.
 Please also keep in mind that once a Client is initialized with a Transport it cannot be


### PR DESCRIPTION
Hello, as I can see, SpoolTranspot was removed, see [#1080](https://github.com/getsentry/sentry-php/pull/1080). So the reference here may be misguiding.