### PR TITLE
Mention vue 3 incompatibility

### DIFF
--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -12,6 +12,8 @@ To begin collecting error and performance data from your Vue application, you'll
 - `@sentry/vue` (Sentry's Vue SDK)
 - `@sentry/tracing` (instruments performance data)
 
+Note: Vue 3 is not yet officially supported ([see issue](https://github.com/getsentry/sentry-javascript/issues/2925)).
+
 Below are instructions for using your favorite package manager, or alternatively loaded directly from our CDN.
 
 ### Using yarn or npm


### PR DESCRIPTION
Prevents users from adding sentry to vue 3 project.

This saves users from going through with the current tutorial if they have vue 3 project.

Relevant issue: https://github.com/getsentry/sentry-javascript/issues/2925