### PR TITLE
fix(JS): Update `rrweb` docs for nextjs

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
@@ -45,13 +45,19 @@ Sentry.init({
 });
 ```
 
+<PlatformSection supported={["javascript.nextjs"]}>
+
+Since this integration only works in the browser, make sure to add it only in `sentry.client.config.js`, not in `sentry.server.config.js`.
+
+</PlatformSection>
+
+Once a replay is captured with an event, you'll find it visible within Issue Details under the Replay section of the event.
+
 <Note>
 
 For more information on configuration, see the [@sentry/rrweb project on GitHub](https://github.com/getsentry/sentry-rrweb).
 
 </Note>
-
-Once a replay is captured with an event, you'll find it visible within Issue Details under the Replay section of the event.
 
 ## Sampling
 

--- a/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/rrweb.mdx
@@ -29,6 +29,8 @@ npm install --save @sentry/rrweb rrweb
 Next register the integration with the Sentry SDK. This will vary based on the framework you're using:
 
 ```javascript
+// If you're using one of our integration packages, like `@sentry/react` or
+// `@sentry/angular`, substitute its name for `@sentry/browser` here
 import * as Sentry from "@sentry/browser";
 import SentryRRWeb from "@sentry/rrweb";
 


### PR DESCRIPTION
Two fixes to the [rrweb docs](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/integrations/rrweb/) here:

- So as not to have to copy-paste the snippet into multiple includes, for the sole purpose of changing the import, this adds a comment letting folks know to use their main SDK.
- Since nextjs is cross-platform, this also adds a note reminding people that the integration is browser-only.

Fixes #3703.