### PR TITLE
open-source → self-hosted in SaaS migration guide

### DIFF
--- a/src/docs/product/sentry-basics/guides/migration/index.mdx
+++ b/src/docs/product/sentry-basics/guides/migration/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Moving to Hosted Sentry
+title: Moving to SaaS
 sidebar_order: 9
 redirect_from:
   - /guides/migration/
 description: "Learn more about the reasons to move to Sentry's SaaS solution, which for many customers is less expensive to maintain, and easier to scale and support."
 ---
 
-Sentry offers a hosted cloud solution in addition to an open-source solution, both are functionally the same. Despite open-source being a core value for us at Sentry, it isn't necessarily recommended for everyone. As Sentry evolves, many customers are finding that self-hosted Sentry can quickly become expensive to maintain, scale, and support, making our SaaS product, the better and less costly option.
+Sentry offers a cloud-hosted, software-as-a-service (SaaS) solution in addition to a self-hosted solution. Both are functionally the same. Many customers find that self-hosted Sentry can quickly become expensive to maintain, scale, and support, making our SaaS product the better and less costly option.
 
 For additional reading on considering SaaS, take a look at:
 
@@ -47,7 +47,7 @@ If you're expecting higher volumes or you're interested in our Enterprise capabi
 
 ### 3. Export your data
 
-Sentry open-source provides a command line interface that allows you to perform various operations that are unachievable within the web UI. One of those is `export`, exporting your data into a transport JSON.
+Self-hosted Sentry provides a command line interface that allows you to perform various operations that are unachievable within the web UI. One of those is `export`, exporting your data into a transport JSON.
 
 Run the following command in your terminal to start the export script and redirect the output (_containing_ the transport JSON) to a file:
 


### PR DESCRIPTION
I gather that sentry-basics is coming up for an overhaul. Short of that, here's a small revision to the SaaS migration guide. The primary motivation here is to stop referring to self-hosted Sentry as "open-source" Sentry ... _Sentry_ is open-source Sentry! 💃