### PR TITLE
docs(ember): Update Ember docs for new config

### DIFF
--- a/src/includes/configuration/config-intro/javascript.ember.mdx
+++ b/src/includes/configuration/config-intro/javascript.ember.mdx
@@ -1,12 +1,13 @@
 Options are passed to `sentry` inside your environment:
 
 ```javascript
-ENV['@sentry/ember'] = {
-  sentry: {
-    dsn: '___PUBLIC_DSN___',
-    tracesSampleRate: 1.0, // We recommend adjusting this in production
-    maxBreadcrumbs: 50,
-    debug: true,
-  }
-};
+import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  tracesSampleRate: 1.0, // We recommend adjusting this in production
+  maxBreadcrumbs: 50,
+  debug: true,
+});
 ```

--- a/src/includes/getting-started-config/javascript.ember.mdx
+++ b/src/includes/getting-started-config/javascript.ember.mdx
@@ -8,28 +8,20 @@ import config from "./config/environment";
 
 import * as Sentry from "@sentry/ember";
 
-Sentry.InitSentryForEmber();
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production,
+  tracesSampleRate: 1.0,
+});
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
 }
-```
-
-Then add the following config to your `config/environment.js`:
-
-```javascript
-ENV["@sentry/ember"] = {
-  sentry: {
-    dsn: "___PUBLIC_DSN___",
-
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production,
-    tracesSampleRate: 1.0,
-  },
-};
 ```
 
 <Note>

--- a/src/includes/performance/beforeNavigate-example/javascript.ember.mdx
+++ b/src/includes/performance/beforeNavigate-example/javascript.ember.mdx
@@ -1,0 +1,20 @@
+One common use case is parameterizing transaction names. For both `pageload` and `navigation` transactions, the `BrowserTracing` integration uses the browser's `window.location` value to generate a transaction name. Using `beforeNavigate` you can modify the transaction name to make it more generic, so that, for example, transactions named `GET /users/12312012` and `GET /users/11212012` can both be renamed `GET /users/:userid`, so that they'll group together.
+
+```javascript
+Sentry.init({
+  // ...
+  browserTracingOptions: {
+    beforeNavigate: context => {
+      return {
+        ...context,
+        // You could use your UI's routing library to find the matching
+        // route template here. We don't have one right now, so do some basic
+        // parameter replacements.
+        name: location.pathname
+          .replace(/\/[a-f0-9]{32}/g, "/<hash>")
+          .replace(/\/\d+/g, "/<digits>"),
+      };
+    },
+  },
+});
+```

--- a/src/includes/performance/configure-sample-rate/javascript.ember.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.ember.mdx
@@ -1,0 +1,13 @@
+```javascript
+import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2,
+
+  // Alternatively, to control sampling dynamically
+  tracesSampler: samplingContext => { ... }
+});
+```

--- a/src/includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
+++ b/src/includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
@@ -1,0 +1,17 @@
+The Ember addon automatically adds the tracing integration for you with additional routing details by hooking into your applications router. If you are not seeing transactions appear, you may need change the configuration passed to Ember's default tracing integration.
+
+After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
+
+```javascript
+import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2,
+  browserTracingOptions: {
+    tracingOrigins: ["localhost", "my-site-url.com", /^\//],
+  },
+});
+```

--- a/src/includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
+++ b/src/includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
@@ -1,4 +1,4 @@
-The Ember addon automatically adds the tracing integration for you with additional routing details by hooking into your applications router. If you are not seeing transactions appear, you may need change the configuration passed to Ember's default tracing integration.
+The Ember addon automatically adds the tracing integration for you with additional routing details by hooking into your applications router. If you are not seeing transactions appear, you may need change the configuration passed to Ember's default tracing integration. The options for the default integration can be passed by using `browserTracingOptions`.
 
 After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
 
@@ -10,6 +10,8 @@ Sentry.init({
 
   // To set a uniform sample rate
   tracesSampleRate: 0.2,
+
+  // Configuration for Ember's default tracing integration.
   browserTracingOptions: {
     tracingOrigins: ["localhost", "my-site-url.com", /^\//],
   },

--- a/src/includes/performance/enable-tracing/javascript.ember.mdx
+++ b/src/includes/performance/enable-tracing/javascript.ember.mdx
@@ -1,0 +1,3 @@
+The tracing integration is enabled by default for Ember, if you would like to disable it, the option can be found under <PlatformLink to="/configuration/ember-options/#performance-monitoring-considerations">Ember options</PlatformLink>.
+
+To pass options to Ember's default tracing integration, see <PlatformLink to="/performance/instrumentation/automatic-instrumentation/">Automatic instrumentation</PlatformLink>

--- a/src/includes/performance/filter-span-example/javascript.ember.mdx
+++ b/src/includes/performance/filter-span-example/javascript.ember.mdx
@@ -1,0 +1,11 @@
+```javascript
+Sentry.init({
+  // ...
+  browserTracingOptions: {
+    shouldCreateSpanForRequest: url => {
+      // Do not create spans for outgoing requests to a `/health/` endpoint
+      return !url.match(/\/health\/?$/);
+    },
+  },
+});
+```

--- a/src/includes/performance/tracingOrigins-example/javascript.ember.mdx
+++ b/src/includes/performance/tracingOrigins-example/javascript.ember.mdx
@@ -1,0 +1,22 @@
+For example:
+
+- A frontend application is served from `example.com`
+- A backend service is served from `api.example.com`
+- The frontend application makes API calls to the backend
+- The option can be configured for the built-in ember browser tracing: `browserTracingOptions: { tracingOrigins: ['api.example.com'] }}`
+- Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
+
+```javascript
+import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // To set a uniform sample rate
+  tracesSampleRate: 0.2,
+
+  browserTracingOptions: {
+    tracingOrigins: ["localhost", "my-site-url.com", "api.example.com"],
+  },
+});
+```

--- a/src/platforms/javascript/guides/ember/configuration/ember-options.mdx
+++ b/src/platforms/javascript/guides/ember/configuration/ember-options.mdx
@@ -4,14 +4,22 @@ description: "Additional configuration options for the Ember addon."
 sidebar_order: 1
 ---
 
-The `@sentry/ember` addon includes options to manage Ember specific instrumentation; these options are set on the addon config directly. All Sentry SDK options that would be passed to `init` should instead be set in the `sentry` key inside your addon config as in this example:
+All Sentry SDK options can be passed to `init`:
 
 ```javascript
-ENV['@sentry/ember'] = {
+import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  // Sentry options
+  dsn: "___PUBLIC_DSN___",
+});
+```
+
+The `@sentry/ember` addon includes options to manage Ember specific instrumentation; these options are set on the addon config directly.
+
+```javascript
+ENV["@sentry/ember"] = {
   // Ember specific options
-  sentry: {
-    // Sentry options
-  }
 };
 ```
 
@@ -22,8 +30,8 @@ The following documentation is for Ember specific configuration, for Sentry opti
 The Sentry tracing integration is already set up via the Ember addon with custom Ember instrumentation for routing, components, and the runloop. It sideloads `@sentry/tracing` as a chunk to instrument your application. If you would like to disable this automatic instrumentation and no longer receive the associated transactions, you can set `disablePerformance` in your config as in this example:
 
 ```javascript
-ENV['@sentry/ember'] = {
-  disablePerformance: true
+ENV["@sentry/ember"] = {
+  disablePerformance: true,
 };
 ```
 
@@ -32,8 +40,8 @@ ENV['@sentry/ember'] = {
 If you would like to capture timings for the `beforeModel`, `model`, `afterModel` hooks as well as `setupController` in one of your Routes, `@sentry/ember` exports a `instrumentRoutePerformance` function which can be used by replacing the default export with a wrapped Route.
 
 ```javascript
-import Route from '@ember/routing/route';
-import { instrumentRoutePerformance } from '@sentry/ember';
+import Route from "@ember/routing/route";
+import { instrumentRoutePerformance } from "@sentry/ember";
 
 class MyRoute extends Route {
   model() {
@@ -45,33 +53,37 @@ export default instrumentRoutePerformance(MyRoute);
 ```
 
 ### Classic Components
+
 The render times of classic components are also enabled by default, with a setting to capture render timings only above a certain duration. To change this minimum, you can modify `minimumComponentRenderDuration` in your config.
 
 ```javascript
-  ENV['@sentry/ember'] = {
-    minimumComponentRenderDuration: 0, // Setting this to zero will capture all classic components.
-  };
+ENV["@sentry/ember"] = {
+  minimumComponentRenderDuration: 0, // Setting this to zero will capture all classic components.
+};
 ```
 
 To disable component instrumentation you can set `disableInstrumentComponents` in your config.
+
 ```javascript
-ENV['@sentry/ember'] = {
-  disableInstrumentComponents: true
+ENV["@sentry/ember"] = {
+  disableInstrumentComponents: true,
 };
 ```
 
 ### Runloop
+
 The duration of each queue in your application's runloop is instrumented by default, as long as the duration of the queue is longer than a threshold defined in your config by `minimumRunloopQueueDuration`
 
 ```javascript
-  ENV['@sentry/ember'] = {
-    minimumRunloopQueueDuration: 0, // Setting this to zero will capture all runloop queue durations
-  };
+ENV["@sentry/ember"] = {
+  minimumRunloopQueueDuration: 0, // Setting this to zero will capture all runloop queue durations
+};
 ```
 
 If you would like to disable runloop instrumentation you can set `disableRunloopPerformance` in your config.
+
 ```javascript
-ENV['@sentry/ember'] = {
-  disableRunloopPerformance: true
+ENV["@sentry/ember"] = {
+  disableRunloopPerformance: true,
 };
 ```

--- a/src/wizard/javascript/ember.md
+++ b/src/wizard/javascript/ember.md
@@ -22,28 +22,20 @@ import config from "./config/environment";
 
 import * as Sentry from "@sentry/ember";
 
-Sentry.InitSentryForEmber();
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
 }
-```
-
-Then add the following config to your `config/environment.js`:
-
-```javascript
-ENV["@sentry/ember"] = {
-  sentry: {
-    dsn: "___PUBLIC_DSN___",
-
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    tracesSampleRate: 1.0,
-  },
-};
 ```
 
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/configuration/sampling/).


### PR DESCRIPTION
### Summary
Now that sdk 6.5+ is out, we can use Sentry.init and pass config options similar to how the other frameworks work. This will split the config for Sentry itself from Ember specific config. 

The Ember config will still be set in the config files, but the Sentry options can now be sent when init is called. The only exception is that browser tracing options need to be passed as a special option (under browserTracingOptions) since Ember provides a custom integration which currently needs to be setup after the app is initialized.

#### Note
I still need to go through and check each page since I worked on it before putting up another PR, wanted to see any initial feedback.

