### PR TITLE
Update options.mdx

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -171,7 +171,7 @@ A list of strings or regex patterns that match error URLs that should not be sen
 
 <ConfigKey name="allow-urls" supported={["javascript"]} notSupported={["node"]}>
 
-A legacy alias for a list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
+A list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
 will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
 
 </ConfigKey>


### PR DESCRIPTION
"legacy" is a leftover word from then it was called whitelistUrl instead of allowUrl which is now called. So the legacy word can be omitted.