### PR TITLE
vue: Document supported version range

### DIFF
--- a/src/includes/getting-started-primer/javascript.vue.mdx
+++ b/src/includes/getting-started-primer/javascript.vue.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-Sentry's Vue SDK enables automatic reporting of errors and exceptions.
+Sentry's Vue SDK enables automatic reporting of errors and exceptions. It targets Vue version `2.x`. Support for `3.x` is tracked by [GitHub issue #2925](https://github.com/getsentry/sentry-javascript/issues/2925).
 
 The SDK will capture the name and props state of the active component where the error was thrown. This is reported via Vue’s `config.errorHandler` hook.
 


### PR DESCRIPTION
Complements https://github.com/getsentry/sentry-docs/pull/3704.

I realized the previous PR was updating only the wizard.
This PR adds a note to the first sentence in https://docs.sentry.io/platforms/javascript/guides/vue/.