### PR TITLE
Fix: Unity options clarification

### DIFF
--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -1,4 +1,4 @@
-We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method which will pass the option object along for modifications:
+We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method, which will pass the option object along for modifications:
 
 ```csharp
 using Sentry.Unity;

--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -1,5 +1,4 @@
-We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method which will
-pass the option object along for modifications:
+We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method which will pass the option object along for modifications:
 
 ```csharp
 using Sentry.Unity;
@@ -11,3 +10,8 @@ SentryUnity.Init(o =>
     o.Debug = true;
 });
 ```
+<Note>
+
+To prevent the SKD from initializing itself make sure to disable Sentry in the configuration window.
+
+</Note>

--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -12,6 +12,6 @@ SentryUnity.Init(o =>
 ```
 <Note>
 
-To prevent the SKD from initializing itself make sure to disable Sentry in the configuration window.
+To prevent the SKD from initializing itself, make sure to disable Sentry in the configuration window.
 
 </Note>


### PR DESCRIPTION
Clarified to disable the SDK via config window if the user decides to initialize it programmatically. (and removed random line break)