### PR TITLE
Update Debug Information Files IA

### DIFF
--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -113,7 +113,7 @@ sentry-cli login
 sentry-cli upload-dif -o {YOUR ORGANISATION} -p {PROJECT} build/intermediates/merged_native_libs/{buildVariant}
 ```
 
-The Sentry Gradle Plugin can be [configured](/platforms/android/proguard/#gradle-configuration) to upload the debug symbols and sources automatically. You can also use [ELF](/platforms/android/data-management/debug-files/file-formats/#executable-and-linkable-format-elf) to support the compression of debug information, which can significantly reduce the time required to upload debug information files to Sentry and thus improve build times.
+The Sentry Gradle Plugin can be [configured](/platforms/android/proguard/#gradle-configuration) to upload the debug symbols and sources automatically.
 
 ## Disable NDK Integration
 

--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -113,7 +113,7 @@ sentry-cli login
 sentry-cli upload-dif -o {YOUR ORGANISATION} -p {PROJECT} build/intermediates/merged_native_libs/{buildVariant}
 ```
 
-The Sentry Gradle Plugin can be [configured](/platforms/android/proguard/#gradle-configuration) to upload the debug symbols and sources automatically.
+The Sentry Gradle Plugin can be [configured](/platforms/android/proguard/#gradle-configuration) to upload the debug symbols and sources automatically. You can also use [ELF](/platforms/android/data-management/debug-files/file-formats/#executable-and-linkable-format-elf) to support the compression of debug information, which can significantly reduce the time required to upload debug information files to Sentry and thus improve build times.
 
 ## Disable NDK Integration
 

--- a/src/platforms/common/data-management/debug-files/file-formats.mdx
+++ b/src/platforms/common/data-management/debug-files/file-formats.mdx
@@ -6,26 +6,26 @@ description: "Learn about platform-specific file formats and the debug informati
 
 Sentry differentiates four kinds of debug information:
 
-- **Debug Information:** Provides function names, paths to source files, line
+1. **Debug Information:** Provides function names, paths to source files, line
   numbers, and inline frames. The process of resolving this information from
   instruction addresses is called "symbolication". This information is
   relatively large compared to the executable and usually put into a separate
   file. In Sentry, these files are designated as _debug companions_ and show the
   `debug` tag.
 
-- **Symbol Tables:** If debug information is not available for a certain
+2. **Symbol Tables:** If debug information is not available for a certain
   library, Sentry can use symbol tables as a fallback to retrieve function
   names. Symbol tables are usually included in both the executable and debug
   companion files. However, they do not contain sufficient information to
   resolve inline functions or file names and line numbers. The `symtab` tag
   indicates symbol tables.
 
-- **Source Code:** Conventionally, source code is not part of regular debug
+3. **Source Code:** Conventionally, source code is not part of regular debug
   information files. Sentry CLI can bundle source code of your application and
   upload it to display source context in stack traces in Sentry. These bundles
   show up with the `sources` tag.
 
-- **Unwind Information:** Enables Sentry to extract stack traces from Minidumps
+4. **Unwind Information:** Enables Sentry to extract stack traces from Minidumps
   and other binary crash formats of optimized builds. This process is referred
   to as "stack unwinding" or "stack walking". Since this is also required when
   throwing exceptions in C++, this information is often included in the

--- a/src/platforms/common/data-management/debug-files/file-formats.mdx
+++ b/src/platforms/common/data-management/debug-files/file-formats.mdx
@@ -1,6 +1,12 @@
 ---
 title: "Debug File Formats"
 sidebar_order: 1
+supported:
+  - native
+  - android
+  - apple
+  - javascript.wasm
+  - rust
 description: "Learn about platform-specific file formats and the debug information they contain."
 ---
 
@@ -180,7 +186,7 @@ traces.
 
 </PlatformSection>
 
-<PlatformSection supported={["native.wasm" "javascript.wasm"]}>
+<PlatformSection supported={["native.wasm", "javascript.wasm"]}>
 
 ## WASM
 
@@ -196,7 +202,7 @@ while removing all debug information from the release binary.
 
 </PlatformSection>
 
-<PlatformSection supported={["android", "flutter", "react-native", "dart"]} notSupported={["native.wasm"]}>
+<PlatformSection supported={["android", "flutter", "react-native", "dart", "native", "rust"]} notSupported={["native.wasm"]}>
 
 ## ProGuard Mappings
 

--- a/src/platforms/common/data-management/debug-files/file-formats.mdx
+++ b/src/platforms/common/data-management/debug-files/file-formats.mdx
@@ -42,9 +42,9 @@ Still, it is always a good idea to provide all available debug information.
 `sentry-cli` can be used to list properties of supported debug files and
 validate their contents. See [_Debug Information Files in sentry-cli_](/product/cli/dif/) for more information.
 
-<PlatformSection notSupported={["native.wasm"]}>
+<PlatformSection supported={["apple", "rust", "native", "dart", "flutter", "react-native"]} notSupported={["native.wasm"]}>
 
-## MachO and dSYM
+## Mach-O and dSYM
 
 Executables, dynamic libraries and debug companions on all Apple platforms use
 the _Mach Object_, or short _MachO_, container format. This applies to iOS,
@@ -70,6 +70,10 @@ however, the dSYM file must be created using the following command:
 ```bash
 dsymutil /path/to/output[.dylib]
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={["android", "rust", "native", "dart", "flutter", "react-native"]} notSupported={["native.wasm"]}>
 
 ## Executable and Linkable Format (ELF)
 
@@ -130,6 +134,10 @@ readelf -S path/to/file
        000000000000e133  0000000000000000   C       0     0     1
 ```
 
+</PlatformSection>
+
+<PlatformSection supported={["rust", "native"]} notSupported={["native.wasm"]}>
+
 ## PE and PDB
 
 On Microsoft Windows, executables and dynamic libraries use the _Portable
@@ -170,9 +178,11 @@ that is not required to process minidumps. Most notably, inline functions are
 not declared, such that Sentry is not able to display inline frames in stack
 traces.
 
-## WASM
-
 </PlatformSection>
+
+<PlatformSection supported={["native.wasm"]}>
+
+## WASM
 
 For WebAssembly, we support [DWARF in WASM containers](https://yurydelendik.github.io/webassembly-dwarf/).
 Note that we do not support source maps, which are also a format used for WASM
@@ -184,17 +194,17 @@ add build IDs and split files called [wasm-split](https://github.com/getsentry/s
 to help you create a debug companion file ready for uploading to Sentry
 while removing all debug information from the release binary.
 
-<PlatformSection notSupported={["native.wasm"]}>
+</PlatformSection>
+
+<PlatformSection supported={["android", "flutter", "react-native", "dart"]} notSupported={["native.wasm"]}>
 
 ## ProGuard Mappings
 
-<PlatformSection supported={["android", "flutter", "react-native"]}>
 <Note>
 
 The recommended method for [Android users is to use the Gradle plugin](/platforms/android/proguard/).
 
 </Note>
-</PlatformSection>
 
 ProGuard mapping files allow Sentry to resolve obfuscated Java classpaths and
 method names into their original form. In that sense, they act as debug

--- a/src/platforms/common/data-management/debug-files/file-formats.mdx
+++ b/src/platforms/common/data-management/debug-files/file-formats.mdx
@@ -180,7 +180,7 @@ traces.
 
 </PlatformSection>
 
-<PlatformSection supported={["native.wasm"]}>
+<PlatformSection supported={["native.wasm" "javascript.wasm"]}>
 
 ## WASM
 

--- a/src/platforms/common/data-management/debug-files/identifiers.mdx
+++ b/src/platforms/common/data-management/debug-files/identifiers.mdx
@@ -41,7 +41,7 @@ files that match it in the _Debug Files_ settings screen.
 `sentry-cli` can help to print properties of debug information files like their
 debug identifier. See [_Checking Debug Information Files_](/product/cli/dif/#checking-files) for more information.
 
-<PlatformSection notSupported={["native.wasm"]}>
+<PlatformSection supported={["android", "apple", "rust", "native"]} notSupported={["native.wasm"]}>
 
 ## GNU Build Identifiers
 
@@ -58,6 +58,10 @@ _The identifier needs to be present and identical in the binary as well
 as stripped debug information files._ If the ID is missing for some reason,
 upload the files before stripping so that `sentry-cli` can compute a stable
 identifier from the unstripped file.
+
+</PlatformSection>
+
+<PlatformSection supported={["native", "rust"]} notSupported={["native.wasm"]}>
 
 ## PDB Age Mismatches
 
@@ -84,6 +88,8 @@ for symbolication.
 
 </PlatformSection>
 
+<PlatformSection supported={["native.wasm"]}>
+
 ## WASM Build IDs
 
 WebAssembly does not yet support build IDs. The option proposed to
@@ -95,7 +101,9 @@ Our recommendation is to embed a UUID in the `build_id` custom section as
 raw binary. Our [`wasm-split`](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
 tool can do this for you automatically.
 
-<PlatformSection notSupported={["native.wasm"]}>
+</PlatformSection>
+
+<PlatformSection supported={["android"]}>
 
 ## ProGuard UUIDs
 

--- a/src/platforms/common/data-management/debug-files/identifiers.mdx
+++ b/src/platforms/common/data-management/debug-files/identifiers.mdx
@@ -88,7 +88,7 @@ for symbolication.
 
 </PlatformSection>
 
-<PlatformSection supported={["native.wasm"]}>
+<PlatformSection supported={["native.wasm", "javascript.wasm"]}>
 
 ## WASM Build IDs
 

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -7,6 +7,8 @@ supported:
   - native
   - android
   - apple
+  - javascript.wasm
+  - rust
 description: "Learn about how debug information files allow Sentry to extract stack traces and provide more information about crash reports for most compiled platforms."
 ---
 
@@ -16,7 +18,7 @@ in debug files includes original function names, paths to source files and line
 numbers, source code context, or the placement of variables in memory. Sentry
 displays this information on the Issue Details page to help you triage an issue.
 
-<PlatformSection notSupported={["native.wasm"]}>
+<PlatformSection notSupported={["native.wasm", "javascript.wasm"]}>
 
 Each major platform uses different debug information files. We currently support
 the following formats:
@@ -47,7 +49,7 @@ system libraries to provide fully symbolicated crash reports. You can either
 [Symbol Server](./symbol-servers/) to be downloaded by Sentry when needed.
 
 Debug information files can be managed on the _Debug Files_ section in _Project
-Settings_. This page lists all uploaded files and allows to configure symbol
+Settings_. This page lists all uploaded files and allows you to configure symbol
 servers for automatic downloads.
 
 ProGuard files can be managed on the _ProGuard_ section in _Project

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -23,16 +23,13 @@ displays this information on the Issue Details page to help you triage an issue.
 Each major platform uses different debug information files. We currently support
 the following formats:
 
-- [_dSYM files_](./file-formats/#macho-and-dsym) for iOS, iPadOS,
-  tvOS, watchOS, and macOS
-- [_ELF symbols_](./file-formats/#executable-and-linkable-format-elf) for Linux and
-  Android (NDK)
-- [_PDB files_](./file-formats/#pe-and-pdb) for Windows
-- [_Breakpad symbols_](./file-formats/#breakpad-symbols) for all
+- _<PlatformLink to="/data-management/debug-files/file-formats/#mach-o-and-dsym">dSYM files</PlatformLink>_ for iOS, iPadOS, tvOS, watchOS, and macOS
+- _<PlatformLink to="/data-management/debug-files/file-formats/#executable-and-linkable-format-elf">ELF symbols</PlatformLink>_ for Linux and Android (NDK)
+- _<PlatformLink to="/data-management/debug-files/file-formats/#pe-and-pdb">PDB files</PlatformLink>_ for Windows
+- _<PlatformLink to="/data-management/debug-files/file-formats/#breakpad-symbols">Breakpad symbols</PlatformLink>_ for all
   platforms
-- [_WASM files_](./file-formats/#wasm) for WebAssembly
-- [_ProGuard mappings_](./file-formats/#proguard-mappings) for
-  Java and Android
+- _<PlatformLink to="/data-management/debug-files/file-formats/#wasm">WASM files</PlatformLink>_for WebAssembly
+- _<PlatformLink to="/data-management/debug-files/file-formats/#proguard-mappings">ProGuard mappings</PlatformLink>_ for Java and Android
 
 </PlatformSection>
 

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -18,16 +18,16 @@ in debug files includes original function names, paths to source files and line
 numbers, source code context, or the placement of variables in memory. Sentry
 displays this information on the Issue Details page to help you triage an issue.
 
-Each major platform uses different debug information files. We currently support
-the following formats:
+Each major platform uses different debug information files, as discussed in <PlatformLink to="/data-management/debug-files/file-formats">our Debug File Formats content</PlatformLink>. We currently support the following formats:
 
-- _<PlatformLink to="/data-management/debug-files/file-formats/#mach-o-and-dsym">dSYM files</PlatformLink>_ for iOS, iPadOS, tvOS, watchOS, and macOS
-- _<PlatformLink to="/data-management/debug-files/file-formats/#executable-and-linkable-format-elf">ELF symbols</PlatformLink>_ for Linux and Android (NDK)
-- _<PlatformLink to="/data-management/debug-files/file-formats/#pe-and-pdb">PDB files</PlatformLink>_ for Windows
-- _<PlatformLink to="/data-management/debug-files/file-formats/#breakpad-symbols">Breakpad symbols</PlatformLink>_ for all
-  platforms
-- _<PlatformLink to="/data-management/debug-files/file-formats/#wasm">WASM files</PlatformLink>_ for WebAssembly
-- _<PlatformLink to="/data-management/debug-files/file-formats/#proguard-mappings">ProGuard mappings</PlatformLink>_ for Java and Android
+- _dSYM files_ for iOS, iPadOS, tvOS, watchOS, and macOS
+- _ELF symbols_ for Linux and Android (NDK)
+- _PDB files_ for Windows
+- _Breakpad symbols_ for all platforms
+- _WASM files_ for WebAssembly
+- _ProGuard mappings_ for Java and Android
+
+Each of these formata .
 
 <Note>
 

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -18,8 +18,6 @@ in debug files includes original function names, paths to source files and line
 numbers, source code context, or the placement of variables in memory. Sentry
 displays this information on the Issue Details page to help you triage an issue.
 
-<PlatformSection notSupported={["native.wasm", "javascript.wasm"]}>
-
 Each major platform uses different debug information files. We currently support
 the following formats:
 
@@ -28,10 +26,8 @@ the following formats:
 - _<PlatformLink to="/data-management/debug-files/file-formats/#pe-and-pdb">PDB files</PlatformLink>_ for Windows
 - _<PlatformLink to="/data-management/debug-files/file-formats/#breakpad-symbols">Breakpad symbols</PlatformLink>_ for all
   platforms
-- _<PlatformLink to="/data-management/debug-files/file-formats/#wasm">WASM files</PlatformLink>_for WebAssembly
+- _<PlatformLink to="/data-management/debug-files/file-formats/#wasm">WASM files</PlatformLink>_ for WebAssembly
 - _<PlatformLink to="/data-management/debug-files/file-formats/#proguard-mappings">ProGuard mappings</PlatformLink>_ for Java and Android
-
-</PlatformSection>
 
 <Note>
 

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -6,7 +6,7 @@ redirect_from:
 supported:
   - native
   - android
-  - cocoa
+  - apple
 description: "Learn about how debug information files allow Sentry to extract stack traces and provide more information about crash reports for most compiled platforms."
 ---
 
@@ -14,7 +14,7 @@ Debug information files allow Sentry to extract stack traces and provide more
 information about crash reports for most compiled platforms. Information stored
 in debug files includes original function names, paths to source files and line
 numbers, source code context, or the placement of variables in memory. Sentry
-can use some of this information and display it on the issue details page.
+displays this information on the Issue Details page to help you triage an issue.
 
 <PlatformSection notSupported={["native.wasm"]}>
 


### PR DESCRIPTION
We had all of the content displaying in various levels across the SDKs. This PR updates the displayed content in Debug File Formats and Debug Identifiers, as noted in this [issue](https://github.com/getsentry/sentry-docs/issues/3299).

To do: 

- [ ] sort out for Flutter/Dart, React Native, and Cordova what the correct information is. 
- [ ] identify which WASM is correct (perhaps combine), though this is likely a separate PR
- [ ] review content title in Android (ProGuard) to align with title of similar in Apple (Uploading Debug Symbols)