### PR TITLE
fix Xamarin getting started

### DIFF
--- a/src/includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-config/dotnet.xamarin.mdx
@@ -12,7 +12,7 @@ SentryXamarin.Init(o =>
     // Set TracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
-    options.TracesSampleRate = 1.0; }))
+    o.TracesSampleRate = 1.0;
 });
 // App code
 


### PR DESCRIPTION
A simple fix for the getting started config example that was using the wrong variable name for SentryOptions.