### PR TITLE
ref: Sentry dotnet doc

### DIFF
--- a/src/includes/enriching-events/user-feedback/example-widget/dotnet.aspnet.mdx
+++ b/src/includes/enriching-events/user-feedback/example-widget/dotnet.aspnet.mdx
@@ -13,7 +13,7 @@ If you are rendering the page from the server, for example on ASP.NET MVC, the `
 ```cshtml
 @if (SentrySdk.LastEventId != SentryId.Empty) {
   <script>
-    Sentry.init({ dsn: "___PUBLIC_KEY___" });
+    Sentry.init({ dsn: "___PUBLIC_DSN___" });
     Sentry.showReportDialog({ eventId: "@SentrySdk.LastEventId" });
   </script>
 }

--- a/src/includes/getting-started-config/dotnet.mdx
+++ b/src/includes/getting-started-config/dotnet.mdx
@@ -1,14 +1,16 @@
 For example, initialize in the `Main` method in `Program.cs`:
 
 ```csharp {filename:Program.cs}
-using (SentrySdk.Init(o => {
+using (SentrySdk.Init(o => 
+{
     // Tells which project in Sentry to send events to:
     o.Dsn = "___PUBLIC_DSN___";
     // When configuring for the first time, to see what the SDK is doing:
     o.Debug = true;
     // Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
     // We recommend adjusting this value in production.
-    o.TracesSampleRate = 1.0; }))
+    o.TracesSampleRate = 1.0; 
+}))
 {
     // App code goes here - Disposing will flush events out
 }

--- a/src/includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/includes/getting-started-config/dotnet.xamarin.mdx
@@ -2,6 +2,8 @@ You should initialize the SDK as early as possible, for an example, the start of
 on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate for iOS).
 
 ```csharp
+using Sentry;
+
 SentryXamarin.Init(o =>
 {
     o.AddXamarinFormsIntegration();

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -79,7 +79,7 @@ By default the SDK will read from `Application.productName` and `Application.ver
 
 <ConfigKey name="environment">
 
-<PlatformSection notSupported={["unity"]}>
+<PlatformSection notSupported={["unity", "dotnet"]}>
 
 Sets the environment. This string is freeform and not set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 
@@ -92,6 +92,16 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 Sets the environment. This string is freeform and set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 
 By default, the SDK reports `editor` when running inside the Unity Editor. Otherwise, the default environment is `production`.
+
+</PlatformSection>
+
+<PlatformSection supported={["dotnet"]}>
+
+Sets the environment. This string is freeform and set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
+
+By default, the SDK reports `debug` when running in debug mode. Otherwise, the default environment is `production`.
+
+Additionally, If you are running with the .Asp NET Core integration, you will also see the environment named as `staging` if running in Staging or `development` if running in development mode.
 
 </PlatformSection>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -99,9 +99,9 @@ By default, the SDK reports `editor` when running inside the Unity Editor. Other
 
 Sets the environment. This string is freeform and set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 
-By default, the SDK reports `debug` when running in debug mode. Otherwise, the default environment is `production`.
+By default, the SDK reports `debug` when the debugger is attached. Otherwise, the default environment is `production`.
 
-Additionally, If you are running with the .Asp NET Core integration, you will also see the environment named as `staging` if running in Staging or `development` if running in development mode.
+Additionally, if you are running with the ASP.NET Core integration, you will also see the environment named as `staging`, if running in staging, or `development`, if running in development mode.
 
 </PlatformSection>
 

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -128,7 +128,7 @@ If you're not able to capture events from ASP.NET to Sentry,
 on older versions of Windows Server, with older .NET Framework you must enable TLS 1.2.
 
 ```
-Using System.Net;
+using System.Net;
 
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
 ```

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -49,7 +49,7 @@ public class MvcApplication : HttpApplication
             // of transactions for performance monitoring.
             // We recommend adjusting this value in production
             o.TracesSampleRate = 1.0;
-            // If you are using EF (and installed the NuGet package):
+            // if you also installed the Sentry.EntityFramework package
             o.AddEntityFramework();
         });
     }
@@ -82,14 +82,13 @@ public class MvcApplication : HttpApplication
 
 When opting-in to [SendDefaultPii](#senddefaultpii), the SDK will automatically read the user from the request by inspecting `HttpContext.User`. Default claim values like `NameIdentifier` for the _Id_ will be used.
 
-If you wish to change the behavior of how to read the user from the request, you can register a new `IUserFactory` into the container:
-
 ```csharp
 SentrySdk.Init(o =>
 {
   o.AddAspNet();
-  o.UserFactory = new MyUserFactory();
-}
+  o.Dsn = "___PUBLIC_DSN___";
+  o.SendDefaultPii = true;
+});
 ```
 
 ### SendDefaultPii

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -10,11 +10,11 @@ Sentry provides an integration with _ASP.NET_ through the [Sentry.AspNet NuGet p
 Add the Sentry dependency:
 
 ```powershell {tabTitle:Package Manager}
-Install-Package Sentry.AspNet
+Install-Package Sentry.AspNet -Version {{ packages.version('sentry.dotnet.aspnet') }}
 ```
 
 ```shell {tabTitle:.NET Core CLI}
-dotnet add package Sentry.AspNet
+dotnet add package Sentry.AspNet  -v {{ packages.version('sentry.dotnet.aspnet') }}
 ```
 
 You can combine this integration with a logging library like `log4net`, `NLog` or `Serilog` to include both request data
@@ -25,10 +25,12 @@ as well as your logs as breadcrumbs. The logging integrations also capture event
 You configure the SDK in the `Global.asax.cs`:
 
 ```csharp
+using System;
 using System.Web;
 using Sentry;
 using Sentry.AspNet;
 using Sentry.EntityFramework; // if you also installed Sentry.EntityFramework
+using Sentry.Extensibility;
 
 public class MvcApplication : HttpApplication
 {
@@ -46,7 +48,7 @@ public class MvcApplication : HttpApplication
             // Set TracesSampleRate to 1.0 to capture 100%
             // of transactions for performance monitoring.
             // We recommend adjusting this value in production
-            options.TracesSampleRate = 1.0;
+            o.TracesSampleRate = 1.0;
             // If you are using EF (and installed the NuGet package):
             o.AddEntityFramework();
         });
@@ -103,7 +105,6 @@ Opt-in to send the request body to Sentry:
 SentrySdk.Init(o =>
 {
   o.AddAspNet(RequestSize.Always);
-  o.MaxRequestBodySize = RequestSize.Always;
 }
 ```
 
@@ -127,8 +128,10 @@ If you're not able to capture events from ASP.NET to Sentry,
 on older versions of Windows Server, with older .NET Framework you must enable TLS 1.2.
 
 ```
+Using System.Net;
+
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
 ```
 
-- A [sample with ASP.NET and EF 6](https://github.com/getsentry/sentry-dotnet-samples/tree/master/AspNetMvc5Ef6).
-- [More samples](https://github.com/getsentry/sentry-dotnet-samples) of the .NET SDKs
+- A [sample with ASP.NET and EF 6](https://github.com/getsentry/examples/tree/master/dotnet/AspNetMvc5Ef6).
+- [More samples](https://github.com/getsentry/examples/tree/master/dotnet) of the .NET SDKs

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -87,6 +87,7 @@ SentrySdk.Init(o =>
 {
   o.AddAspNet();
   o.Dsn = "___PUBLIC_DSN___";
+  // Opt-in to send things like UserId and UserName if a user is logged-in
   o.SendDefaultPii = true;
 });
 ```
@@ -132,5 +133,4 @@ Using System.Net;
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
 ```
 
-- A [sample with ASP.NET and EF 6](https://github.com/getsentry/examples/tree/master/dotnet/AspNetMvc5Ef6).
-- [More samples](https://github.com/getsentry/examples/tree/master/dotnet) of the .NET SDKs
+- A [sample with ASP.NET and EF 6](https://github.com/getsentry/examples/tree/master/dotnet/AspNetMvc5Ef6) and additional samples of the [.NET SDKs](https://github.com/getsentry/examples/tree/master/dotnet)

--- a/src/platforms/dotnet/guides/aws-lambda/index.mdx
+++ b/src/platforms/dotnet/guides/aws-lambda/index.mdx
@@ -36,9 +36,15 @@ public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFu
             // Add Sentry
             .UseSentry(o =>
             {
-              o.Dsn = "___PUBLIC_DSN___";
-              // Required in Serverless environments
-              o.FlushOnCompletedRequest = true;
+                o.Dsn = "___PUBLIC_DSN___";
+                // When configuring for the first time, to see what the SDK is doing:
+                o.Debug = true;
+                // Set TracesSampleRate to 1.0 to capture 100%
+                // of transactions for performance monitoring.
+                // We recommend adjusting this value in production
+                o.TracesSampleRate = 1.0;
+                // Required in Serverless environments
+                o.FlushOnCompletedRequest = true;
             })
             .UseStartup<Startup>();
     }

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -30,7 +30,7 @@ All queries executed are added as breadcrumbs and are sent with any event which 
 
 ## Configuration
 
-There is 1 step to adding Entity Framework 6 support to your project:
+Add the Entity Framework 6 support to your project in one step:
 
 - When initializing the SDK, call the extension method `AddEntityFramework()` on `SentryOptions`. This will register all error processors to extract extra data, such as validation errors, from the exceptions thrown by Entity Framework.
 

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -30,9 +30,8 @@ All queries executed are added as breadcrumbs and are sent with any event which 
 
 ## Configuration
 
-There are 2 steps to adding Entity Framework 6 support to your project:
+There is 1 step to adding Entity Framework 6 support to your project:
 
-- Call `SentryDatabaseLogging.UseBreadcrumbs()` to either your application's startup method, or into a static constructor inside your Entity Framework object. Make sure you only call this method once! This will add the interceptor to Entity Framework to log database queries.
 - When initializing the SDK, call the extension method `AddEntityFramework()` on `SentryOptions`. This will register all error processors to extract extra data, such as validation errors, from the exceptions thrown by Entity Framework.
 
 ### Example configuration
@@ -40,14 +39,16 @@ There are 2 steps to adding Entity Framework 6 support to your project:
 For example, configuring an ASP.NET app with _global.asax_:
 
 ```csharp {filename:global.asax}
+using System;
+using System.Configuration;
+using Sentry;
+
 public class MvcApplication : System.Web.HttpApplication
 {
     private IDisposable _sentrySdk;
 
     protected void Application_Start()
     {
-        // We add the query logging here so multiple DbContexts in the same project are supported
-        SentryDatabaseLogging.UseBreadcrumbs();
         _sentrySdk = SentrySdk.Init(o =>
         {
             // We store the DSN inside Web.config

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -92,7 +92,7 @@ Example using `appsettings.json`:
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",
     "MinimumBreadcrumbLevel": "Warning",
-    "MinimumEventLevel": "Critical",
+    "MinimumEventLevel": "Error",
     "MaxBreadcrumbs": 50
   }
 }
@@ -105,7 +105,7 @@ Above we set the application wide minimum log level to `Debug`. Sentry specific 
 ```csharp
 using (var loggerFactory = new LoggerFactory()
             .AddConsole(LogLevel.Trace)
-            .AddSentry(o => o.Dsn = "___PUBLIC_KEY___"))
+            .AddSentry(o => o.Dsn = "___PUBLIC_DSN___"))
 {
     var logger = loggerFactory.CreateLogger<Program>();
 }

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -91,8 +91,8 @@ Example using `appsettings.json`:
   },
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",
-    "MinimumBreadcrumbLevel": "Warning",
-    "MinimumEventLevel": "Error",
+    "MinimumBreadcrumbLevel": "Debug",
+    "MinimumEventLevel": "Warning",
     "MaxBreadcrumbs": 50
   }
 }

--- a/src/wizard/dotnet/uwp.md
+++ b/src/wizard/dotnet/uwp.md
@@ -27,6 +27,7 @@ Initialize the SDK as early as possible, like in the constructor of the `App`:
 
 ```csharp
 using System.Windows;
+using Sentry.Protocol;
 using Sentry;
 
 sealed partial class App : Application

--- a/src/wizard/dotnet/wpf.md
+++ b/src/wizard/dotnet/wpf.md
@@ -26,6 +26,7 @@ dotnet add package Sentry -v {{ packages.version('sentry.dotnet') }}
 Initialize the SDK as early as possible, like in the constructor of the `App`:
 
 ```csharp
+using System.Windows.Threading;
 using System.Windows;
 using Sentry;
 


### PR DESCRIPTION
This is a small refactor to the dotnet docs, fixing some code snippets, removing deprecated references, and also other minor fixes.

Some notes below are related to things that I didn't edit at the moment and I would like an opinion on what todo:

* https://docs.sentry.io/platforms/dotnet/guides/wpf/configuration/options/#environment
- [x]  By default the Environment is being set on .NET (perhaps it's not set on other platforms by default), what should we do in this specific case?


* https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#overview-of-the-features
* [x] "Tested on .NET Core, .NET Framework and Mono" was the ASP.NET Core SDK tested on .NET Framework and Mono? (if not I'll just get rid of this line)

* https://docs.sentry.io/platforms/dotnet/guides/aspnet/#configuring
* [x] There's a mention to the EF integration, how can I link the line '
![image](https://user-images.githubusercontent.com/8229322/122111622-56fcf780-cdf6-11eb-8473-80c97cb32947.png)
' to the EF doc?

* https://docs.sentry.io/platforms/dotnet/guides/aspnet/#capturing-the-affected-user
* [x] There's no UserFactory for ASP.NET, should I remove it from the doc or create an issue to Sentry .NET ?

* https://github.com/getsentry/sentry-dotnet-ef/tree/main/samples/Sentry.Samples.AspNet.Mvc
- [ ] Project wasn't moved to the new sample project.

* https://docs.sentry.io/platforms/dotnet/guides/log4net/#configuration

- [x]  Add environment and tracing sample rate to the XML file?