### PR TITLE
add missing redirect for old alerts & settings page

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -4,6 +4,7 @@ sidebar_order: 10
 redirect_from:
  - /product/sentry-basics/guides/alert-notifications/issue-alerts/
  - /product/alerts/alert-settings/
+ - /product/alerts-notifications/alert-settings/
 description: "Learn more about the options for configuring an issue alert."
 ---
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -15,7 +15,7 @@ Releases also offer significant additional features when you fully [configure yo
 - Determine the issues and regressions introduced in a new release
 - Predict which commit caused an issue and who is likely responsible
 - Resolve issues by including the issue number in your commit message
-- Receiving email notifications when your code gets deployed
+- [Receiving email notifications when your code gets deployed](/product/alerts/notifications/#deploy-notifications)
 
 <Note>
 


### PR DESCRIPTION
Adds missing redirect from old Alerts & Settings to Issue Alert Configuration 
Adds link to deploy notifications from Releases page