### PR TITLE
feat(performance): Per-Project Thresholds

### DIFF
--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -8,6 +8,17 @@ description: "Learn more about Sentry's Performance metrics such as, Apdex, fail
 
 Metrics provide insight about how users are experiencing your application. In [Performance](/product/performance/), we'll set you up with a few of the basic metrics to get you started. For further customizations on target thresholds, feel free to build out a query using the Discover [Query Builder](/product/discover-queries/query-builder/). By identifying useful thresholds to measure your application, you have a quantifiable measurement of your application's health. This means you can more easily identify when errors occur or if performance issues are emerging.
 
+## Set Thresholds per Project
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+You can configure response time thresholds per Project for the [Apdex](#apdex) and [User Misery](#user-misery) scores. Additionally, you can also set which response time metric (e.g. Transaction Duration, [Largest Contentful Paint](/product/performance/web-vitals/#largest-contentful-paint-lcp)) is used in the calculations. This allows you to use different standards for gauging performance across multiple projects.
+
+Configure Project-level thresholds in **[Project] > Settings > Performance**.
+
 ## Apdex
 
 Apdex is an industry-standard metric used to track and measure user satisfaction based on your application response times. The Apdex score provides the ratio of satisfactory, tolerable, and frustrated requests in a specific transaction or endpoint. This metric provides a standard for you to compare transaction performance, understand which ones may require additional optimization or investigation, and set targets or goals for performance.
@@ -20,7 +31,7 @@ Below are the components of Apdex and its formula:
 * **Frustrated**: Users are frustrated with the app when their page load times are greater than 4T.
 * **Apdex**: (Number of Satisfactory Requests + (Number of Tolerable Requests/2)) / (Number of Total Requests)
 
-You can configure the Apdex threshold in **Settings > Performance**.
+You can configure the Apdex threshold in **Settings > Performance**. If you're in the Early Adopter program, you can set response time [thresholds per Project](#set-thresholds-per-project).
 
 ## Failure Rate
 
@@ -78,3 +89,5 @@ Each of these functions is calculated with respect to the collection of transact
 ## User Misery
 
 User Misery is a user-weighted performance metric to assess the relative magnitude of your application performance. While you can examine the ratio of various response time threshold levels with [Apdex](#apdex), User Misery counts the number of unique users who were frustrated based on the specified response time threshold. User Misery highlights transactions that have the highest impact on users.
+
+If you're in the Early Adopter program, you can set response time [thresholds per Project](#set-thresholds-per-project).

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -15,7 +15,7 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-You can configure response time thresholds per Project for the [Apdex](#apdex) and [User Misery](#user-misery) scores. Additionally, you can also set which response time metric (e.g. Transaction Duration, [Largest Contentful Paint](/product/performance/web-vitals/#largest-contentful-paint-lcp)) is used in the calculations. This allows you to use different standards for gauging performance across multiple projects.
+You can configure response time thresholds per Project for the [Apdex](#apdex) and [User Misery](#user-misery) scores. Additionally, you can set which response time metric (for example, Transaction Duration, [Largest Contentful Paint](/product/performance/web-vitals/#largest-contentful-paint-lcp)) is used in the calculation, which allows you to use different standards for gauging performance across multiple projects.
 
 Configure Project-level thresholds in **[Project] > Settings > Performance**.
 


### PR DESCRIPTION
Users can now set Apdex/User Misery thresholds per Project
as opposed to a single org level threshold if they have
the feature flag enabled.