### PR TITLE
chore(platformicons): updated to 4.3.0 in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "^4.2.0",
+    "platformicons": "^4.3.0",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.23.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13796,10 +13796,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.2.0.tgz#021d3fe576ff688e03352e1dbcc6edba4be05ef5"
-  integrity sha512-Sw87CXTWtILfzHEebziuvl4V7Oe604o+Xw2ueOR4XbHnRbyso0c1SxNy5VxasWEXtTQlc2r1NpAX59SvFwOlkA==
+platformicons@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.3.0.tgz#ab579cd48cc6e3126fbd1f1a45779b9b0ff0e587"
+  integrity sha512-eH/mJRiOpDA03Ky65tTw9NNm0b5zWJZvCB5vMIrmtENAh565DC12PN+XmjX+7bpAIvWEmGS4YZD/0FVcfwkIyQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Related to https://github.com/getsentry/platformicons/pull/45/ and https://github.com/getsentry/platformicons/pull/46