### PR TITLE
docs(js): Enhance initialScope options docs

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -281,7 +281,31 @@ The number of context lines for each frame when loading a file.
 
 <ConfigKey name="initial-scope" supported={["javascript","node"]}>
 
-Data to be set to the initial scope.
+Data to be set to the initial scope. Initial scope can be defined either as an object as follows
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  debug: true,
+  initialScope: {
+    scope.setTag("my-tag", "my value");
+    scope.setUser({id: 42, email: "john.doe@example.com"});
+  }
+});
+```
+
+Or as a callback function
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  debug: true,
+  initialScope: scope => {
+    scope.setTags({ a: 'b' });
+    return scope;
+  },
+});
+```
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -288,8 +288,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   debug: true,
   initialScope: {
-    scope.setTag("my-tag", "my value");
-    scope.setUser({id: 42, email: "john.doe@example.com"});
+    tags: {"my-tag": "my value"},
+    user: {id: 42, email: "john.doe@example.com"},
   }
 });
 ```

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -281,7 +281,9 @@ The number of context lines for each frame when loading a file.
 
 <ConfigKey name="initial-scope" supported={["javascript","node"]}>
 
-Data to be set to the initial scope. Initial scope can be defined either as an object as follows
+Data to be set to the initial scope. Initial scope can be defined either as an object or a callback function, as shown below.
+
+Object:
 
 ```javascript
 Sentry.init({
@@ -294,7 +296,7 @@ Sentry.init({
 });
 ```
 
-Or as a callback function
+Callback function
 
 ```javascript
 Sentry.init({

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -296,7 +296,7 @@ Sentry.init({
 });
 ```
 
-Callback function
+Callback function:
 
 ```javascript
 Sentry.init({


### PR DESCRIPTION
This PR enhances the documentation on how to use the `initialScope` option by providing two code snippets; one to use it as an object and another to use it as a callback function