### PR TITLE
Clarify disabling auto session tracking on React Native

### DIFF
--- a/src/includes/configuration/auto-session-tracking/react-native.mdx
+++ b/src/includes/configuration/auto-session-tracking/react-native.mdx
@@ -2,13 +2,13 @@ To benefit from the health data, you must use at least version 1.4.0 of the Reac
 
 We mark the session as an error if the SDK captures an event that contains an exception (this includes manually captured errors) or an unhandled promise rejection, but for unhandled errors and native crashes (Android and iOS), they will be marked as crashed.
 
+By default, the SDK sends sessions. To disable this, set the `enableAutoSessionTracking` flag to `false`:
+
 ```javascript
 Sentry.init({
-  autoSessionTracking: true
+  enableAutoSessionTracking: false // default: true
 });
 ```
-
-By default, the SDK sends sessions. To disable this toggle the flag `enableAutoSessionTracking` to `false`.
 
 The session terminates once the application is in the background for more than 30 seconds. To change the timeout, use the option `sessionTrackingIntervalMillis`. For example:
 


### PR DESCRIPTION
This improves instructions on how to disable auto session tracking.

Most importantly, the correct attribute is used in the code block, which is most likely to be copy/pasted.