### PR TITLE
ref: Remove next.js EA alert

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -15,9 +15,3 @@ Features:
 - Automatic [Performance Monitoring](/product/performance/) for both the client and server, from version `6.5.0`
 
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
-
-<Alert level="info" title="Early Adopter">
-
-The SDK is in the early stages of being released. This means changes are possible and may prevent the SDK from working as expected. We recognize the irony.
-
-</Alert>

--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -17,5 +17,5 @@ Features:
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
 
 <Alert level="info" title="Early Adopter">
-In Vercel production environments, the SDK is currently unable to pick up errors and/or transactions when calling serverless API routes. We are working to resolve this issue.
+In Vercel production environments, the SDK is currently unable to pick up errors and/or transactions when calling serverless API routes. We are working to resolve [this issue](https://github.com/getsentry/sentry-javascript/issues/3643).
 </Alert>

--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -15,3 +15,7 @@ Features:
 - Automatic [Performance Monitoring](/product/performance/) for both the client and server, from version `6.5.0`
 
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
+
+<Alert level="info" title="Early Adopter">
+When using the SDK on Vercel production environment, there currently is a known issue with Sentry not being able to pick up errors/transaction when calling serverless API routes. We are working on resolving this.
+</Alert>

--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -17,5 +17,5 @@ Features:
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
 
 <Alert level="info" title="Early Adopter">
-When using the SDK on Vercel production environment, there currently is a known issue with Sentry not being able to pick up errors/transaction when calling serverless API routes. We are working on resolving this.
+In Vercel production environments, the SDK is currently unable to pick up errors and/or transactions when calling serverless API routes. We are working to resolve this issue.
 </Alert>


### PR DESCRIPTION
We still have a few known limitations when deploying on Vercel that the team hopefully is able to resolve with the help of Vercel next week.