### PR TITLE
docs(js): Enhance release health document

### DIFF
--- a/src/includes/configuration/auto-session-tracking/javascript.mdx
+++ b/src/includes/configuration/auto-session-tracking/javascript.mdx
@@ -4,7 +4,7 @@ We mark the session as:
 - crashed if an _unhandled error_ or _unhandled promise rejection_ bubbled up to the global handler.
 - an error if the SDK captures an event that contains an exception (this includes manually captured errors).
 
-To receive data on User Adoption such as users crash free rate percentage, and the number of users that have adopted a specific release, set the user on [`initialScope`](/platforms/javascript/configuration/options/#initial-scope) when initializing the SDK.
+To receive data on user adoption, such as users crash free rate percentage, and the number of users that have adopted a specific release, set the user on the [`initialScope`](/platforms/javascript/configuration/options/#initial-scope) when initializing the SDK.
 
 By default, the JavaScript SDKs are sending sessions. To disable sending sessions, set the `autoSessionTracking` flag to `false`:
 

--- a/src/includes/configuration/auto-session-tracking/javascript.mdx
+++ b/src/includes/configuration/auto-session-tracking/javascript.mdx
@@ -1,8 +1,10 @@
 We create a session for every page load. For single-page applications, we will create a new session for every navigation change (History API).
 
 We mark the session as:
-- crashed if an _unhandled error_ or _unhandled promise rejection_ bubbled up to the global handler. 
+- crashed if an _unhandled error_ or _unhandled promise rejection_ bubbled up to the global handler.
 - an error if the SDK captures an event that contains an exception (this includes manually captured errors).
+
+To receive data on User Adoption such as users crash free rate percentage, and the number of users that have adopted a specific release, set the user on [`initialScope`](/platforms/javascript/configuration/options/#initial-scope) when initializing the SDK.
 
 By default, the JavaScript SDKs are sending sessions. To disable sending sessions, set the `autoSessionTracking` flag to `false`:
 


### PR DESCRIPTION
Documents that users should be set on initialScope when initialising the SDK to receive user adoption release health data due to recent change on the SDK that drops user data from session if user is defined after `Sentry.init` 
Ref: https://github.com/getsentry/sentry-javascript/pull/3701