### PR TITLE
fix(nextjs): Indicate that the serverless target is not supported

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -62,7 +62,7 @@ export default withSentry(handler);
 
 You can include your DSN directly in these two files, or provide it in either of two environment variables, `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`.
 
-<Alert level="warning" title="Note">
+<Alert level="warning" title="Serverless Environments">
 
 `@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085).
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -62,6 +62,12 @@ export default withSentry(handler);
 
 You can include your DSN directly in these two files, or provide it in either of two environment variables, `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`.
 
+<Alert level="warning" title="Note">
+
+`@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085).
+
+</Alert>
+
 ## Extend Default Webpack Usage
 
 Use `withSentryConfig` to extend the default Next.js usage of Webpack. This will do two things:


### PR DESCRIPTION
@sentry/nextjs does not support the serverless target. This patch
adds a note to the manual configuration section of the nextjs docs
that surfaces this. It also recommends user's use the
experimental-serverless-trace option as an alternative.

The note was put in an alert under manual configuration as only a few
users will hit this situation.