### PR TITLE
update proguard.mdx

### DIFF
--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -40,7 +40,7 @@ buildscript {
 }
 ```
 
-The plugin will automatically generate appropriate ProGuard mapping files and upload them when you run `gradle assemble{BuildVariant}`. For example, `assembleRelease` — Release is the default, but the plugin works for others if you have enabled ProGuard/R8. The credentials for the upload step are loaded via environment variables or from a `sentry.properties` file in your project root.
+The plugin will automatically generate appropriate ProGuard mapping files and upload them when you run `gradle assemble{BuildVariant}`. For example, `assembleRelease` — Release is the default, but the plugin works for others if you have enabled ProGuard/R8. The credentials for the upload step are loaded via environment variables or from a `sentry.properties` file in your Android project root.
 
 For more information, see the [full sentry-cli documentation](/product/cli/configuration/#configuration-values).
 
@@ -51,6 +51,13 @@ defaults.project=your-project
 defaults.org=your-org
 auth.token=YOUR_AUTH_TOKEN
 ```
+
+<Note>
+
+Values inside `sentry.properties` file should not be wrapped around quotes, you should only replace the placeholders. Otherwise, it may lead to authentication or resource errors.
+
+</Note>
+
 <Note>
 
 You can find your authentication token [on the Sentry API page](https://sentry.io/api/). For more information about the available configuration options, see the [full sentry-cli documentation](/product/cli/configuration/#configuration-values).

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -54,7 +54,7 @@ auth.token=YOUR_AUTH_TOKEN
 
 <Note>
 
-Values inside `sentry.properties` file should not be wrapped around quotes, you should only replace the placeholders. Otherwise, it may lead to authentication or resource errors.
+Values inside `sentry.properties` file should not be wrapped around quotes; you should only replace the placeholders. Otherwise, it may lead to authentication or resource errors.
 
 </Note>
 


### PR DESCRIPTION
- make it clear that the sentry.properties file should be in Android project root (it can be misleading for flutter projects setup)
- make it clear that properties should not be declared around quotes