### PR TITLE
Remove indentation from Alert in React profiler page

### DIFF
--- a/src/platforms/javascript/guides/react/components/profiler.mdx
+++ b/src/platforms/javascript/guides/react/components/profiler.mdx
@@ -42,8 +42,7 @@ The React Profiler currently generates spans with three different kinds of op-co
 
 <Alert>
 
-
-    In [React Strict Mode](https://reactjs.org/docs/strict-mode.html), certain component methods will be [invoked twice](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects). This may lead to duplicate `react.mount` spans appearing in a transaction. React Strict Mode only runs in development mode, so this will have no impact on your production traces.
+In [React Strict Mode](https://reactjs.org/docs/strict-mode.html), certain component methods will be [invoked twice](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects). This may lead to duplicate `react.mount` spans appearing in a transaction. React Strict Mode only runs in development mode, so this will have no impact on your production traces.
 
 </Alert>
 


### PR DESCRIPTION
👋 I noticed that content in an `Alert` is being styled as code block due to indenting on https://docs.sentry.io/platforms/javascript/guides/react/components/profiler/. 

This PR removes the indentation.

<img width="775" alt="2021-06-23 at 1 24 PM" src="https://user-images.githubusercontent.com/2180540/123141560-80d1a200-d426-11eb-8667-27c531cca65b.png">