### PR TITLE
Update link to display properly

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -17,5 +17,7 @@ Features:
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
 
 <Alert level="info" title="Early Adopter">
-In Vercel production environments, the SDK is currently unable to pick up errors and/or transactions when calling serverless API routes. We are working to resolve [this issue](https://github.com/getsentry/sentry-javascript/issues/3643).
+
+We are working to resolve [this issue](https://github.com/getsentry/sentry-javascript/issues/3643) in Vercel production environments. The SDK is currently unable to pick up errors and/or transactions when calling serverless API routes.
+
 </Alert>


### PR DESCRIPTION
In the Alert component, linking sometimes doesn't work as expected. Moving the content so that the link is earlier on the line seems to fix the issue.