### PR TITLE
upgrade(trim-newlines): Upgrade trim-newlines to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "trim": ">=1.0.1",
     "ssri": ">=8.0.1",
     "glob-parent": ">=5.1.2",
-    "normalize-url": "^4.5.1"
+    "normalize-url": "^4.5.1",
+    "trim-newlines": "^4.0.2"
   },
   "scripts": {
     "clean": "gatsby clean",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17158,10 +17158,10 @@ trim-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.3.tgz#839514be82428fd9e7ec89e35081afe8f6f93115"
   integrity sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.0.2.tgz#d6aaaf6a0df1b4b536d183879a6b939489808c7c"
+  integrity sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==
 
 trim-repeated@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes a security issue: https://github.com/advisories/GHSA-7p7h-4mm5-852v
