### PR TITLE
Release Health for Unity

### DIFF
--- a/src/includes/configuration/auto-session-tracking/dotnet.mdx
+++ b/src/includes/configuration/auto-session-tracking/dotnet.mdx
@@ -1,0 +1,21 @@
+We mark the session as:
+- Health
+- Abnormal
+- Errored: if the SDK captures an event that contains an exception (this includes manually captured errors).
+- Crashed
+
+By default, the .NET SDK is creating a session on application startup and end it on shut down. To disable sending sessions, set the `AutoSessionTracking` flag to `false`.
+
+```csharp {tabTitle:C#}
+using Sentry;
+
+// Add this to the SDK initialization callback
+options.AutoSessionTracking = false; // default: true
+```
+
+```fsharp {tabTitle:F#}
+open Sentry
+
+// Add this to the SDK initialization callback
+options.Release <- true
+```

--- a/src/includes/configuration/auto-session-tracking/unity.mdx
+++ b/src/includes/configuration/auto-session-tracking/unity.mdx
@@ -1,0 +1,11 @@
+<PlatformContent includePath="configuration/auto-session-tracking/dotnet" />
+
+Sentry SDK subscribes to `OnApplicationPause` and `OnApplicationFocus` events to track if the application has focus or if it has been put in the background. On resume within `AutoSessionTrackingInterval` the session will be continued. The default value is `30 seconds`. Otherwise, the previous session will be ended and we create a new one.
+
+```csharp {tabTitle:C#}
+using System;
+using Sentry;
+
+// Add this to the SDK initialization callback
+options.AutoSessionTrackingInterval = TimeSpan.FromSeconds(30);
+```

--- a/src/includes/getting-started-primer/unity.mdx
+++ b/src/includes/getting-started-primer/unity.mdx
@@ -3,6 +3,7 @@ Our Unity SDK builds on top of the [.NET SDK](/platforms/dotnet/) and extends it
 **Additional Features:**
 
 - [Offline caching](/platforms/unity/configuration/options/#cache-directory-path) stores event data to disk in case the device is not online
+- [Release Health](/platforms/unity/configuration/releases/) to keep track of crash free users and sessions
 - [Breadcrumbs automatically](/platforms/unity/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for
   - Unity's `Debug.Log` and `Debug.LogWarning`
   - Scene load, unload, active change

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -44,7 +44,7 @@ This tags each event with the release value. We recommend that you tell Sentry a
 
 After configuring your SDK, you can install a repository integration or manually supply Sentry with your own commit metadata. Read our documentation about [setting up releases](/product/releases/setup/) for further information about integrations, associating commits, and telling Sentry when deploying releases.
 
-<PlatformSection supported={["apple", "android", "javascript", "flutter", "native", "rust", "python", "react-native"]}>
+<PlatformSection supported={["apple", "android", "javascript", "flutter", "native", "rust", "python", "react-native", "dotnet", "unity"]}>
 
 ## Release Health
 


### PR DESCRIPTION
Worth noting:

1. I didn't link to `https://docs.sentry.io/platforms/unity/configuration/releases/` as we did on other pages (like [.NET](https://docs.sentry.io/platforms/dotnet/), [Apple](https://docs.sentry.io/platforms/apple/guides/ios/), ..) but instead linked to the ["Release and Health" part of the SDK itself](https://docs.sentry.io/platforms/unity/configuration/releases/). The reason is that we have more specific information like for example we detect release automatically from Unity.

Would it make sense to edit the common content for Release and Health and link to `https://docs.sentry.io/platforms/unity/configuration/releases/` from there instead?

2. I rephrased it. On the other docs we say:

> Release Health tracks crash free users and sessions

So to be clear we're not "tracking users"([see this answer](https://stackoverflow.com/questions/68067822/is-it-possible-to-avoid-collecting-specific-data-in-sentry/68108641#68108641)) I reworded as:

> Release Health to keep track of crash free users and sessions

Downside is that Unity would differ from the rest so like best we agree on one approach and apply everywhere.