### PR TITLE
Update Ruby SDK's doc for version 4.6.0

### DIFF
--- a/src/includes/getting-started-config/ruby.delayed_job.mdx
+++ b/src/includes/getting-started-config/ruby.delayed_job.mdx
@@ -1,8 +1,0 @@
-Initialize the SDK:
-
-```ruby
-Sentry.init do |config|
-  config.dsn = '___PUBLIC_DSN___'
-  config.breadcrumbs_logger = [:sentry_logger, :http_logger]
-end
-```

--- a/src/includes/getting-started-config/ruby.mdx
+++ b/src/includes/getting-started-config/ruby.mdx
@@ -1,13 +1,14 @@
 ```ruby
 Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'
+  config.breadcrumbs_logger = [:sentry_logger, :http_logger]
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
   config.traces_sample_rate = 0.5
   # or
   config.traces_sampler = lambda do |context|
-    true
+    0.5
   end
 end
 ```

--- a/src/includes/getting-started-config/ruby.sidekiq.mdx
+++ b/src/includes/getting-started-config/ruby.sidekiq.mdx
@@ -1,8 +1,0 @@
-Initialize the SDK:
-
-```ruby
-Sentry.init do |config|
-  config.dsn = '___PUBLIC_DSN___'
-  config.breadcrumbs_logger = [:sentry_logger, :http_logger]
-end
-```

--- a/src/includes/getting-started-install/ruby.resque.mdx
+++ b/src/includes/getting-started-install/ruby.resque.mdx
@@ -1,0 +1,6 @@
+Add `sentry-ruby` and `sentry-resque` to your `Gemfile`:
+
+```ruby {filename:Gemfile}
+gem "sentry-ruby"
+gem "sentry-resque"
+```

--- a/src/platforms/ruby/guides/resque/config.yml
+++ b/src/platforms/ruby/guides/resque/config.yml
@@ -1,0 +1,2 @@
+title: Resque
+sdk: "sentry.ruby.resque"


### PR DESCRIPTION
Mainly for adding an entry for the new `sentry-resque` integration.