### PR TITLE
fix(apple): List of types of errors

### DIFF
--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -9,10 +9,12 @@ The SDK builds a crash report that persists to disk and tries to send the report
 **Features:**
 
 - Multiple types of errors are captured, including:
-  - C++ exceptions
   - Mach exceptions
+  - Fatal signals
   - Unhandled exceptions
-  - UNIX signal
+  - C++ exceptions
+  - Objective-C exceptions
+  - Main thread deadlock (experimental)
   - Out of memory
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data
 - Offline caching when a device is unable to connect; we send a report once we receive another event


### PR DESCRIPTION
Update list of types of errors based on KSCrash, as SentryCrash was
forked from [KSCrash](https://github.com/kstenerud/KSCrash#kscrash-handles-the-following-kinds-of-crashes).

[A long time ago](https://github.com/getsentry/sentry-docs/pull/3420#issuecomment-824433222) @bruno-garcia pinged me to update this. 