### PR TITLE
ref(membership): Update add/remove repo role

### DIFF
--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -25,8 +25,7 @@ including notification and security settings.
 | Can edit Global Integrations                                 |         |        | X     | X       | X     |
 | Can add/remove/change members                                |         |        |       | X       | X     |
 | Can add/remove teams                                         |         |        | X     | X       | X     |
-| Can add Repositories                                         |         |        | X     | X       | X     |
-| Can delete Repositories                                      |         |        |       |         | X     |
+| Can add/remove Repositories                                  |         |        | X     | X       | X     |
 | Can change Organization Settings                             |         |        |       | X       | X     |
 | Can remove an Organization                                   |         |        |       |         | X     |
 


### PR DESCRIPTION
Update the table on the [membership](https://docs.sentry.io/product/accounts/membership/#membership
) page to reflect current member roles needed to remove a repository. I consolidated the rows since the same permissions are needed for adding and removing.

See https://github.com/getsentry/sentry/pull/18987 where we updated this in the product.

<img width="694" alt="Screen Shot 2021-06-29 at 3 55 16 PM" src="https://user-images.githubusercontent.com/29959063/123877788-ba0c8500-d8f2-11eb-8e5c-5e4c2c631632.png">
