### PR TITLE
feat: Hybrid SDK options and React Native manual native initialization page

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -433,3 +433,23 @@ A function responsible for determining the percentage chance a given transaction
 </ConfigKey>
 
 </PlatformSection>
+
+<PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor"]}>
+
+## Hybrid SDK Options
+
+<ConfigKey name="enableNative">
+
+Set this boolean to `false` to disable the native SDK. This will disable all native crash and error handling and instead the SDK will only capture errors on the upper layer.
+
+</ConfigKey>
+
+<ConfigKey name="autoInitializeNativeSdk" supported={["react-native"]}>
+
+Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initalize the native SDK manually. Do not use this to disable the native layer, instead use [enableNative](#enableNative).
+
+You should follow the [guide to native initialization](/platforms/react-native/manual-setup/native-init/) if you chose to use this option.
+
+</ConfigKey>
+
+</PlatformSection>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -440,13 +440,13 @@ A function responsible for determining the percentage chance a given transaction
 
 <ConfigKey name="enableNative">
 
-Set this boolean to `false` to disable the native SDK. This will disable all native crash and error handling and instead the SDK will only capture errors on the upper layer.
+Set this boolean to `false` to disable the native SDK. This will disable all native crash and error handling and, instead, the SDK will only capture errors on the upper layer.
 
 </ConfigKey>
 
 <ConfigKey name="autoInitializeNativeSdk" supported={["react-native"]}>
 
-Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initalize the native SDK manually. Do not use this to disable the native layer, instead use [enableNative](#enableNative).
+Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer, but instead use [enableNative](#enableNative).
 
 You should follow the [guide to native initialization](/platforms/react-native/manual-setup/native-init/) if you chose to use this option.
 

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -1,0 +1,42 @@
+---
+title: Native Initialization
+sidebar_order: 4
+description: "Learn how to manually initialize the native SDKs."
+---
+
+By default, the React Native SDK will initialize the native SDK underneath when the `init` method is called on the JS layer. This currently has the limitation of not capturing native crashes that occur before the `init` method is called on the JS layer. You could also look to initialize the native SDKs yourself to be able to provide custom options above what the React Native SDK currently provides.
+
+To do so, you would set [autoInitializeNativeSdk](/platforms/react-native/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  autoInitializeNativeSdk: false,
+});
+```
+
+This will prevent the React Native SDK from initializing the native SDK automatically.
+
+<Alert level="info" title="Note">
+
+Do not use `autoInitializeNativeSdk` to disable the native layer, instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
+
+</Alert>
+
+You will then have to initialize the native SDKs yourself following the guides for Android or iOS. You do not need to install any of the native SDKs by yourself as they are already packaged with the React Native SDK.
+
+## Android Configuration
+
+To use auto-init, you would have to add the following to your `AndroidManifest.xml`.
+
+```xml
+<meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
+```
+
+then you can follow [the guide on initializing Android](/platforms/android/#configure).
+
+If you chose to manually initialize the SDK you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
+
+## iOS Configuration
+
+You can just follow the [configuration guide for iOS](/platforms/apple/guides/ios/#configure) to initialize the Sentry Cocoa SDK.

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -35,7 +35,13 @@ To use auto-init, you would have to add the following to your `AndroidManifest.x
 
 then you can follow [the guide on initializing Android](/platforms/android/#configure).
 
-If you chose to manually initialize the SDK you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
+<Note>
+
+Initializing via the above method uses a Content Provider; because the Javascript engine for React Native is also initialized via a Content Provider we cannot guarantee that Sentry would always initialize before the Javascript engine.
+
+</Note>
+
+If you chose to manually initialize the Android SDK you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
 
 ## iOS Configuration
 

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -42,4 +42,4 @@ To use auto-init, add the following to your `AndroidManifest.xml`:
 Then follow [the guide on initializing Android](/platforms/android/#configure).
 
 
-If you want to manually initialize the Android SDK without using the content provider, you can then [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag since `io.sentry.auto-init` is set to `false` by the React Native SDK.
+If you want to manually initialize the Android SDK without using the content provider, you can then [follow the manual initialization guide](/platforms/android/configuration/manual-init/) without needing to add the tag since `io.sentry.auto-init` is set to `false` by the React Native SDK.

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -37,3 +37,9 @@ To use auto-init, add the following to your `AndroidManifest.xml`:
 
 ```xml
 <meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
+```
+
+Then follow [the guide on initializing Android](/platforms/android/#configure).
+
+
+If you want to manually initialize the Android SDK without using the content provider, you can then [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag since `io.sentry.auto-init` is set to `false` by the React Native SDK.

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -17,7 +17,7 @@ Sentry.init({
 
 This will prevent the React Native SDK from initializing the native SDK automatically.
 
-<Alert level="info" title="Note">
+<Alert level="info" title="Disabling the Native Layer Entirely">
 
 Do not use `autoInitializeNativeSdk` to disable the native layer, instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
 

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -6,7 +6,7 @@ description: "Learn how to manually initialize the native SDKs."
 
 By default, the React Native SDK will initialize the native SDK underneath when the `init` method is called on the JS layer. This currently has the limitation of not capturing native crashes that occur before the `init` method is called on the JS layer. You could also look to initialize the native SDKs yourself to be able to provide custom options above what the React Native SDK currently provides.
 
-To do so, you would set [autoInitializeNativeSdk](/platforms/react-native/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
+To do this, set [autoInitializeNativeSdk](/platforms/react-native/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
 ```javascript
 Sentry.init({
@@ -19,7 +19,7 @@ This will prevent the React Native SDK from initializing the native SDK automati
 
 <Alert level="info" title="Note">
 
-Do not use `autoInitializeNativeSdk` to disable the native layer, instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
+Do not use `autoInitializeNativeSdk` to disable the native layer, but instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
 
 </Alert>
 
@@ -27,21 +27,21 @@ You will then have to initialize the native SDKs yourself following the guides f
 
 ## Android Configuration
 
-To use auto-init, you would have to add the following to your `AndroidManifest.xml`.
+To use auto-init, add the following to your `AndroidManifest.xml`.
 
 ```xml
 <meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
 ```
 
-then you can follow [the guide on initializing Android](/platforms/android/#configure).
+Then follow [the guide on initializing Android](/platforms/android/#configure).
 
 <Note>
 
-Initializing via the above method uses a Content Provider; because the Javascript engine for React Native is also initialized via a Content Provider we cannot guarantee that Sentry would always initialize before the Javascript engine.
+Initializing with the above method uses a Content Provider. Because the Javascript engine for React Native is also initialized using a Content Provider, we cannot guarantee that Sentry will always initialize before the JavaScript engine.
 
 </Note>
 
-If you chose to manually initialize the Android SDK you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
+If you chose to manually initialize the Android SDK, you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
 
 ## iOS Configuration
 

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -4,7 +4,7 @@ sidebar_order: 4
 description: "Learn how to manually initialize the native SDKs."
 ---
 
-By default, the React Native SDK will initialize the native SDK underneath when the `init` method is called on the JS layer. This currently has the limitation of not capturing native crashes that occur before the `init` method is called on the JS layer. You could also look to initialize the native SDKs yourself to be able to provide custom options above what the React Native SDK currently provides.
+By default, the React Native SDK initializes the native SDK underneath the `init` method called on the JS layer. As a result, the SDK has a current limitation of not capturing native crashes that occur prior to the `init` method being called on the JS layer. You can initialize the native SDKs yourself to overcome this limitation or if you want to provide custom options above what the React Native SDK currently provides.
 
 To do this, set [autoInitializeNativeSdk](/platforms/react-native/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
@@ -19,30 +19,21 @@ This will prevent the React Native SDK from initializing the native SDK automati
 
 <Alert level="info" title="Note">
 
-Do not use `autoInitializeNativeSdk` to disable the native layer, but instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
+Do not use `autoInitializeNativeSdk` to disable the native layer, instead use [enableNative](/platforms/react-native/configuration/options/#enableNative)
 
 </Alert>
 
-You will then have to initialize the native SDKs yourself following the guides for Android or iOS. You do not need to install any of the native SDKs by yourself as they are already packaged with the React Native SDK.
+Next, initialize the native SDKs for Android, which is documented below, or for iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the React Native SDK.
 
 ## Android Configuration
 
-To use auto-init, add the following to your `AndroidManifest.xml`.
-
-```xml
-<meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
-```
-
-Then follow [the guide on initializing Android](/platforms/android/#configure).
-
 <Note>
 
-Initializing with the above method uses a Content Provider. Because the Javascript engine for React Native is also initialized using a Content Provider, we cannot guarantee that Sentry will always initialize before the JavaScript engine.
+Initializing with this method uses a Content Provider. Because the Javascript engine for React Native is also initialized using a Content Provider, we cannot guarantee that Sentry will always initialize before the JavaScript engine.
 
 </Note>
 
-If you chose to manually initialize the Android SDK, you can [follow the guide](/platforms/android/configuration/manual-init/) without needing to add the tag as `io.sentry.auto-init` is set to `false` by the React Native SDK.
+To use auto-init, add the following to your `AndroidManifest.xml`:
 
-## iOS Configuration
-
-You can just follow the [configuration guide for iOS](/platforms/apple/guides/ios/#configure) to initialize the Sentry Cocoa SDK.
+```xml
+<meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />


### PR DESCRIPTION
Adds a "Hybrid SDK Options" section for `enableNative` for RN, Capacitor, and Cordova. And `autoInitializeNativeSdk` for RN. Maybe applicable to flutter too cc @marandaneto?

Adds a page documenting how to manually initialize the native sdks in React Native:
https://github.com/getsentry/sentry-react-native/issues/1631