### PR TITLE
Fix/Update 'Advanced Data Scrubbing' Link

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -56,7 +56,7 @@ You can re-enable it by setting:
 config.send_default_pii = true
 ```
 
-As for scrubbing sensitive data, please use Sentry's [Advanced Data Scrubbing](https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/) feature.
+As for scrubbing sensitive data, please use Sentry's [Advanced Data Scrubbing](https://docs.sentry.io/product/data-management-settings/scrubbing/advanced-datascrubbing/) feature.
 
 #### New Components and Structure
 


### PR DESCRIPTION
Just updated the URL for the link to 'Advanced Data Scrubbing' in the ruby migration guide