### PR TITLE
Improve Ruby SDK's migration guide

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -37,9 +37,7 @@ Currently available integrations are:
 - [sentry-rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails)
 - [sentry-sidekiq](https://github.com/getsentry/sentry-ruby/tree/master/sentry-sidekiq)
 - [sentry-delayed_job](https://github.com/getsentry/sentry-ruby/tree/master/sentry-delayed_job)
-
-We'll also support these in the near future:
-- resque
+- [sentry-resque](https://github.com/getsentry/sentry-ruby/tree/master/sentry-resque)
 
 #### Removed Processors
 
@@ -162,6 +160,7 @@ gem "sentry-ruby"
 gem "sentry-rails"
 gem "sentry-sidekiq"
 gem "sentry-delayed_job"
+gem "sentry-resque"
 ```
 
 **Configuration**

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -135,7 +135,7 @@ config.faraday_builder #=> config.transport.faraday_builder
 
 #### Added
 
-This section only lists a few important additions. See the full list of configuration options [here](http://localhost:3000/platforms/ruby/configuration/options/)
+This section only lists a few important additions. See the full list of configuration options [here](/platforms/ruby/configuration/options/)
 
 ```ruby
 # this behaves similar to the old config.scheme option

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -45,6 +45,7 @@ In `sentry-raven` we have different processor classes for data scrubbing. But up
 - user ip
 - user cookie
 - request body
+- query parameters
 
 will **not** be sent to Sentry.
 

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -135,9 +135,19 @@ config.faraday_builder #=> config.transport.faraday_builder
 
 #### Added
 
+This section only lists a few important additions. See the full list of configuration options [here](http://localhost:3000/platforms/ruby/configuration/options/)
+
 ```ruby
 # this behaves similar to the old config.scheme option
 config.transport.transport_class = MyTransportClass
+
+# sentry-ruby sends events asynchronously with its own background workers
+# the default number of workers equals to your machine's processor count
+# you can adjust the number with
+config.background_worker_threads = 10
+
+# to send events synchronously like sentry-raven does, set it to 0
+config.background_worker_threads = 0
 ```
 
 ## API Changes

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -241,6 +241,21 @@ New:
 Sentry.capture_message("test", extra: { debug: true })
 ```
 
+The options for these methods are also changed. Currently available options are:
+
+- `contexts`
+- `tags`
+- `extra`
+- `user`
+- `level`
+- `fingerprint`
+
+To set `transaction_name` (`transaction` in `sentry-raven`) of the event, please use
+
+```ruby
+Sentry.get_current_scope.set_transaction_name("NewTransaction")
+```
+
 ## Example Apps
 
 - [Rails example](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)


### PR DESCRIPTION
Keeps the document up-to-date and addresses the feedback in https://github.com/getsentry/sentry-docs/issues/3823.