### PR TITLE
Update codepush.mdx to clarify 'release' and 'dist' parameters

### DIFF
--- a/src/platforms/react-native/manual-setup/codepush.mdx
+++ b/src/platforms/react-native/manual-setup/codepush.mdx
@@ -8,6 +8,8 @@ redirect_from:
 
 To use Sentry together with CodePush, pass `release` and `dist` to `Sentry.init`. Our suggestion is to store them in an `app.json`, or you can just use the `package.json`. These values need to be unique to each version of your codebase and match the version on the source maps exactly, or they might not be symbolicated.
 
+For more information on the 'release' and 'dist' parameters, see the section on [Source Maps](/platforms/react-native/sourcemaps/).
+
 We recommend using the format `${BUNDLE_ID}@${APP_VERSION}+codepush:${DIST}` for release names.
 
 ```javascript


### PR DESCRIPTION
The Codepush documentation is quite confusing because it immediately mentions needing to pass a `release` and `dist` property but does not explain what they are.

They are covered later on in the Source Maps section, but that would not have been read if the user is reading docs in a linear fashion, leaving them confused.

I have added a link to the source maps section so the user is able to get some more context on what they are for.