### PR TITLE
ref(apple): Rename option for enabling auto performance

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -44,7 +44,7 @@ import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableAutoUIPerformanceTracking = false
+    options.enableAutoPerformanceTracking = false
 }
 ```
 
@@ -53,7 +53,7 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableAutoUIPerformanceTracking = NO;
+    options.enableAutoPerformanceTracking = NO;
 }];
 ```
 


### PR DESCRIPTION
enableAutoUIPerformanceTracking was renamed to enableAutoPerformanceTracking.

Only merge after https://github.com/getsentry/sentry-cocoa/pull/1209 is released.