### PR TITLE
fix(sourcemaps): Small fixes in webpack snippets

### DIFF
--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
@@ -1,4 +1,4 @@
-```javascript
+```javascript {filename:webpack.config.js}
 module.exports = {
   output: {
     // Make maps auto-detectable by sentry-cli

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
@@ -7,6 +7,6 @@ module.exports = {
     sourceMapFilename: "[name].js.map",
     // Other `output` configuration
   },
-  // Other configuration
+  // Other webpack configuration
 };
 ```

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.mdx
@@ -1,5 +1,6 @@
 ```javascript {filename:webpack.config.js}
 module.exports = {
+  devtool = 'source-map',
   output: {
     // Make maps auto-detectable by sentry-cli
     filename: "[name].js",

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -3,7 +3,7 @@ const { withSentryConfig } = require("@sentry/nextjs");
 
 const moduleExports = {
   webpack: (config, options) => {
-    devtool = 'source-map',
+    config.devtool = "source-map";
     config.output = {
       ...config.output,
       // Make maps auto-detectable by sentry-cli

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -18,4 +18,4 @@ const moduleExports = {
 module.exports = withSentryConfig(moduleExports);
 ```
 
-Learn more about the Webpack usage for the Next.js SDK in [Extend Default Webpack Usage](/platforms/javascript/guides/nextjs/manual-setup/#extend-nextjs-configuration).
+Learn more about the Webpack usage for the Next.js SDK in our [Manual Setup Guide](/platforms/javascript/guides/nextjs/manual-setup/#extend-nextjs-configuration).

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -12,7 +12,6 @@ const moduleExports = {
     };
     return config;
   },
-  productionBrowserSourceMaps: true,
   // Other nextjs configuration
 };
 

--- a/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
+++ b/src/includes/configuration/sourcemaps/tools/webpack/advanced-usage/javascript.nextjs.mdx
@@ -16,11 +16,7 @@ const moduleExports = {
   // Other nextjs configuration
 };
 
-const SentryWebpackPluginOptions = {
-  // Additional config options for the Sentry Webpack plugin.
-};
-
-module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
+module.exports = withSentryConfig(moduleExports);
 ```
 
 Learn more about the Webpack usage for the Next.js SDK in [Extend Default Webpack Usage](/platforms/javascript/guides/nextjs/manual-setup/#extend-nextjs-configuration).

--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -49,22 +49,20 @@ You may configure [sentry-cli](/product/cli/configuration/) through its document
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
-  // other configuration
-  configureWebpack: {
-    plugins: [
-      new SentryWebpackPlugin({
-        // sentry-cli configuration
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: "___ORG_SLUG___",
-        project: "___PROJECT_SLUG___",
-        release: process.env.SENTRY_RELEASE,
+  // other webpack configuration
+  plugins: [
+    new SentryWebpackPlugin({
+      // sentry-cli configuration
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+      release: process.env.SENTRY_RELEASE,
 
-        // webpack specific configuration
-        include: ".",
-        ignore: ["node_modules", "webpack.config.js"],
-      }),
-    ],
-  },
+      // webpack-specific configuration
+      include: ".",
+      ignore: ["node_modules", "webpack.config.js"],
+    }),
+  ],
 };
 ```
 

--- a/src/platforms/javascript/common/sourcemaps/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/index.mdx
@@ -50,6 +50,7 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
   // other webpack configuration
+  devtool = 'source-map',
   plugins: [
     new SentryWebpackPlugin({
       // sentry-cli configuration

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -36,6 +36,7 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
   // other webpack configuration
+  devtool = 'source-map',
   plugins: [
     new SentryWebpackPlugin({
       // sentry-cli configuration

--- a/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/tools/webpack.mdx
@@ -35,21 +35,19 @@ You may configure [sentry-cli](/product/cli/configuration/) through it's documen
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
-  // other configuration
-  configureWebpack: {
-    plugins: [
-      new SentryWebpackPlugin({
-        // sentry-cli configuration
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: "___ORG_SLUG___",
-        project: "___PROJECT_SLUG___",
+  // other webpack configuration
+  plugins: [
+    new SentryWebpackPlugin({
+      // sentry-cli configuration
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
 
-        // webpack specific configuration
-        include: "./dist",
-        ignore: ["node_modules", "webpack.config.js"],
-      }),
-    ],
-  },
+      // webpack-specific configuration
+      include: "./dist",
+      ignore: ["node_modules", "webpack.config.js"],
+    }),
+  ],
 };
 ```
 


### PR DESCRIPTION
Nothing major here, mostly just carryover from comments on https://github.com/getsentry/sentry-docs/pull/3677 which didn't get in before it was merged.

- Use `devtool` in all snippets so that sourcemaps are generated correctly
- Fix setting `devtool` in nextjs (set it on `config`)
- Remove stray `configureWebpack` wrapper in two snippets
- Remove `productionBrowserSourceMaps` from nextjs config since [we no longer use it](https://github.com/getsentry/sentry-javascript/pull/3765)
- Remove `SentryWebpackPluginOptions` from nextjs snippet not using plugin