### PR TITLE
feat: Troubleshooting page for Capacitor with iOS Deployment Version fix

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -3,6 +3,7 @@ title: Troubleshooting
 description: "Troubleshoot and resolve edge cases."
 keywords: ["adblocker", "blocked", "tunnel"]
 excerpt: ""
+notSupported: ["javascript.capacitor"]
 sidebar_order: 1000
 ---
 
@@ -148,7 +149,6 @@ WebHost.CreateDefaultBuilder(args).Configure(a =>
 Check out our [examples repository](https://github.com/getsentry/examples/tree/master/tunneling) to learn more about it.
 
 If your use-case is related to the SDK package itself being blocked, any of the following solutions will help you resolve this issue.
-
 
 ### Using Package Directly
 

--- a/src/platforms/javascript/common/troubleshooting/supported-browsers.mdx
+++ b/src/platforms/javascript/common/troubleshooting/supported-browsers.mdx
@@ -2,6 +2,7 @@
 title: Supported Browsers
 excerpt: ""
 description: "We support a variety of browsers; check out our list."
+notSupported: ["javascript.capacitor"]
 ---
 
 Sentry's JavaScript SDK supports the following browsers:

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -1,0 +1,28 @@
+---
+title: Troubleshooting
+description: "Troubleshoot and resolve common issues with the Capacitor SDK."
+sidebar_order: 1000
+---
+
+## Using with Capacitor 2 on iOS
+
+Because Capacitor 3 has a minimum requirement of iOS 12.0, the Sentry SDK needs to match this requirement to support Capacitor 3. Sadly, users on older versions my run into an error such as
+
+> Specs satisfying the SentryCapacitor (from ../../node_modules/@sentry/capacitor) dependency were found, but they required a higher minimum deployment target.
+
+You can fix this by bumping your iOS deployment target up. Add the below snippet to your `capacitor.config.json`:
+
+```json
+// capacitor.config.json
+{
+  "ios": {
+    "minVersion": "12.0"
+  }
+}
+```
+
+You can then update your iOS settings by running
+
+```bash
+npx cap sync
+```

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -4,13 +4,13 @@ description: "Troubleshoot and resolve common issues with the Capacitor SDK."
 sidebar_order: 1000
 ---
 
-## Using with Capacitor 2 on iOS
+## Capacitor 2 on iOS
 
-Because Capacitor 3 has a minimum requirement of iOS 12.0, the Sentry SDK needs to match this requirement to support Capacitor 3. Sadly, users on older versions my run into an error such as
+Capacitor 3 has a minimum requirement of iOS 12.0. As a result, the Sentry SDK needs to match this requirement to support Capacitor 3. Users on older versions may run into an error similar to:
 
 > Specs satisfying the SentryCapacitor (from ../../node_modules/@sentry/capacitor) dependency were found, but they required a higher minimum deployment target.
 
-You can fix this by bumping your iOS deployment target up. Add the below snippet to your `capacitor.config.json`:
+You can fix this by bumping your iOS deployment target. Add the snippet below to your `capacitor.config.json`:
 
 ```json
 // capacitor.config.json
@@ -21,7 +21,7 @@ You can fix this by bumping your iOS deployment target up. Add the below snippet
 }
 ```
 
-You can then update your iOS settings by running
+Then update your iOS settings:
 
 ```bash
 npx cap sync

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 description: "Troubleshoot and resolve common issues with the Capacitor SDK."
+keywords: ["minimum version", "deployment target"]
 sidebar_order: 1000
 ---
 


### PR DESCRIPTION
Fix for users on Capacitor 2 who run into a deployment target issue.

Includes the error as a quote so users who search with the error text might hit this page.