### PR TITLE
feat(performance): Per-transaction thresholds

### DIFF
--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -88,6 +88,6 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level through the settings on the transaction's summary page.
+For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level through **Transaction Summary > Settings**.
 
 The calculation method determines if duration is defined as the entire length of the transaction or as a specific [Web Vital](/product/performance/web-vitals/) such as LCP. The response time threshold determines what the satisfactory baseline duration is in milliseconds. This threshold may vary across projects depending on how user-facing a project is.

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -88,6 +88,6 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**.
+For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level through the settings on the transaction's summary page.
 
 The calculation method determines if duration is defined as the entire length of the transaction or as a specific [Web Vital](/product/performance/web-vitals/) such as LCP. The response time threshold determines what the satisfactory baseline duration is in milliseconds. This threshold may vary across projects depending on how user-facing a project is.

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -88,6 +88,6 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level through **Transaction Summary > Settings**.
+For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level in **Transaction Summary > Settings**.
 
 The calculation method determines if duration is defined as the entire length of the transaction or as a specific [Web Vital](/product/performance/web-vitals/) such as LCP. The response time threshold determines what the satisfactory baseline duration is in milliseconds. This threshold may vary across projects depending on how user-facing a project is.

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -88,6 +88,6 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at a transaction level in **Transaction Summary > Settings**.
+For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at the transaction level in **Transaction Summary > Settings**.
 
 The calculation method determines if duration is defined as the entire length of the transaction or as a specific [Web Vital](/product/performance/web-vitals/) such as LCP. The response time threshold determines what the satisfactory baseline duration is in milliseconds. This threshold may vary across projects depending on how user-facing a project is.


### PR DESCRIPTION
Users can now set thresholds for User Misery and Apdex
per transaction.

Screenshot:
![Screen Shot 2021-07-08 at 10 10 48 AM](https://user-images.githubusercontent.com/63818634/124936995-fe73e100-dfd4-11eb-9543-701d70e2956b.png)

