### PR TITLE
Add ClearAttachments to .NET doc

### DIFF
--- a/src/includes/enriching-events/attachment-upload/dotnet.mdx
+++ b/src/includes/enriching-events/attachment-upload/dotnet.mdx
@@ -14,4 +14,10 @@ SentrySdk.WithScope(scope =>
 
     SentrySdk.CaptureMessage("my message");
 });
+
+// Clear all attachments in the global Scope
+SentrySdk.ConfigureScope(scope =>
+{
+    scope.ClearAttachments();
+});
 ```

--- a/src/includes/enriching-events/attachment-upload/dotnet.mdx
+++ b/src/includes/enriching-events/attachment-upload/dotnet.mdx
@@ -15,7 +15,7 @@ SentrySdk.WithScope(scope =>
     SentrySdk.CaptureMessage("my message");
 });
 
-// Clear all attachments in the global Scope
+// Clear all attachments in the global scope
 SentrySdk.ConfigureScope(scope =>
 {
     scope.ClearAttachments();


### PR DESCRIPTION
Doc for this feature: https://github.com/getsentry/sentry-dotnet/issues/1041 (being able to clear attachments from Sentry's scope.

Merge once a new release of the SDK with the feature is made.