### PR TITLE
ref(python): Update alert for celery with v5 of celery released

### DIFF
--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -34,6 +34,6 @@ To verify if your SDK is initialized on worker start, you can pass `debug=True` 
 
 Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, for [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken and Celery fails to propagate custom headers to the worker. Protocol version 2, which is default since Celery version 4.0, is not affected.
 
-Fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) since version 5.0.1. However, the fix was not backported to versions 4.x.
+The fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
 
 </Alert>

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -32,7 +32,7 @@ To verify if your SDK is initialized on worker start, you can pass `debug=True` 
 
 <Alert level="info" title="Note on distributed tracing">
 
-Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, for [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken and Celery fails to propagate custom headers to the worker. Protocol version 2, which is default since Celery version 4.0, is not affected.
+Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
 
 The fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -29,3 +29,11 @@ Generally, make sure that the **call to `init` is loaded on worker startup**, an
 There are many valid ways to do this like, for example, using a signal like [`worker_process_init`](https://docs.celeryproject.org/en/stable/userguide/signals.html#worker-process-init), or by initializing the SDK in the configuration file loaded with Celery's `--config` parameter.
 
 To verify if your SDK is initialized on worker start, you can pass `debug=True` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly.
+
+<Alert level="info" title="Note on distributed tracing">
+
+Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, for [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken and Celery fails to propagate custom headers to the worker. Protocol version 2, which is default since Celery version 4.0, is not affected.
+
+Fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) since version 5.0.1. However, the fix was not backported to versions 4.x.
+
+</Alert>

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -29,11 +29,3 @@ Generally, make sure that the **call to `init` is loaded on worker startup**, an
 There are many valid ways to do this like, for example, using a signal like [`worker_process_init`](https://docs.celeryproject.org/en/stable/userguide/signals.html#worker-process-init), or by initializing the SDK in the configuration file loaded with Celery's `--config` parameter.
 
 To verify if your SDK is initialized on worker start, you can pass `debug=True` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly.
-
-<Alert level="info" title="Note on distributed tracing">
-
-Sentry uses custom message headers for distributed tracing. Since Celery version 4.0, for [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken and Celery fails to propagate custom headers to the worker. Protocol version 2, which is default since Celery version 4.0, is not affected.
-
-Fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) and hopefully will be included in the upcoming release.
-
-</Alert>


### PR DESCRIPTION
Celery v5 has already been released and the Alert still said to wait for an "upcoming release"