### PR TITLE
Fix koa tracing code snippet to trace database queries

### DIFF
--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -119,18 +119,17 @@ const tracingMiddleWare = async (ctx, next) => {
     scope.setSpan(transaction);
   });
 
-  ctx.res.on('finish',()=>{
-    // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
-    // closes
-    setImmediate(()=>{
+  ctx.res.on("finish", () => {
+    // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction closes
+    setImmediate(() => {
       // if using koa router, a nicer way to capture transaction using the matched route
       if (ctx._matchedRoute) {
-        const mountPath = ctx.mountPath || '';
+        const mountPath = ctx.mountPath || "";
         transaction.setName(`${reqMethod} ${mountPath}${ctx._matchedRoute}`);
       }
       transaction.setHttpStatus(ctx.status);
       transaction.finish();
-    })
+    });
   });
 
   await next();

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -115,7 +115,7 @@ const tracingMiddleWare = async (ctx, next) => {
   ctx.__sentry_transaction = transaction;
   
   // We put the transaction on the scope so users can attach children to it
-  Sentry.getCurrentHub().configureScope(async scope => {
+  Sentry.getCurrentHub().configureScope(scope => {
     scope.setSpan(transaction);
   });
 

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -113,15 +113,22 @@ const tracingMiddleWare = async (ctx, next) => {
   });
 
   ctx.__sentry_transaction = transaction;
-  await next();
 
-  // if using koa router, a nicer way to capture transaction using the matched route
-  if (ctx._matchedRoute) {
-    const mountPath = ctx.mountPath || "";
-    transaction.setName(`${reqMethod} ${mountPath}${ctx._matchedRoute}`);
-  }
-  transaction.setHttpStatus(ctx.status);
-  transaction.finish();
+  ctx.res.on('finish',()=>{
+    // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
+    // closes
+    setImmediate(()=>{
+      // if using koa router, a nicer way to capture transaction using the matched route
+      if (ctx._matchedRoute) {
+        const mountPath = ctx.mountPath || '';
+        transaction.setName(`${reqMethod} ${mountPath}${ctx._matchedRoute}`);
+      }
+      transaction.setHttpStatus(ctx.status);
+      transaction.finish();
+    })
+  });
+
+  await next();
 };
 
 app.use(requestHandler);

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -113,6 +113,11 @@ const tracingMiddleWare = async (ctx, next) => {
   });
 
   ctx.__sentry_transaction = transaction;
+  
+  // We put the transaction on the scope so users can attach children to it
+  Sentry.getCurrentHub().configureScope(async scope => {
+    scope.setSpan(transaction);
+  });
 
   ctx.res.on('finish',()=>{
     // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction


### PR DESCRIPTION
The previous implementation didn't trace database queries performance. The current implementation gives the chance of finishing spans before closing the transaction.