### PR TITLE
chore(react): Update details about ErrorBoundary resetError

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -97,7 +97,7 @@ _(Available in version 5.20.0 and above)_
 
 #### Setting a Fallback Function (Render Props)
 
-Below is an example where a fallback prop, using the [render props approach](https://reactjs.org/docs/render-props.html), is used to display a fallback UI on error, and gracefully return to a standard component state when reset.
+Below is an example where a fallback prop, using the [render props approach](https://reactjs.org/docs/render-props.html), is used to display a fallback UI on error. The fallback UI returns to a standard component state when reset using the `resetError()` API provided by the component through render props.
 
 ```javascript
 import React from "react";
@@ -122,6 +122,8 @@ class App extends React.Component {
             <button
               onClick={() => {
                 this.setState({ message: "This is my app" });
+                {/* When resetError() is called it will remove the Fallback component */}
+                {/* and render the Sentry ErrorBoundary's children in their initial state */}
                 resetError();
               }}
             >


### PR DESCRIPTION
Addressing feedback brought up in https://github.com/getsentry/sentry-docs/issues/3874

Add some more context on what `resetError()` is doing and how it works.