### PR TITLE
feat: Add alert for Identifier field

### DIFF
--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -28,7 +28,7 @@ description: "Set up Azure Active Directory Single Sign-On (SSO) on Sentry."
 
 1. For Section (1), labeled "Basic SAML Configuration", enter the following data in each line and save your changes.
 
-   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/` <Alert level="warning">Ensure that the URL includes a trailing slash to avoid causing a misconfiguration error (AADSTS650056).</Alert>
+   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/` <Alert level="warning">Ensure that the URL includes a trailing slash to prevent Azure from throwing a misconfiguration error (AADSTS650056).</Alert>
 
    - Reply URL (Assertion Consumer Service URL): `https://sentry.io/saml/acs/YOUR_ORG_SLUG/`
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -28,7 +28,7 @@ description: "Set up Azure Active Directory Single Sign-On (SSO) on Sentry."
 
 1. For Section (1), labeled "Basic SAML Configuration", enter the following data in each line and save your changes.
 
-   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/`
+   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/` <Alert level="warning" title="Include Trailing Slash">Confirm the URL includes a trailing slash at the end, otherwise it will cause a misconfiguration error (AADSTS650056).</Alert>
 
    - Reply URL (Assertion Consumer Service URL): `https://sentry.io/saml/acs/YOUR_ORG_SLUG/`
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -28,7 +28,7 @@ description: "Set up Azure Active Directory Single Sign-On (SSO) on Sentry."
 
 1. For Section (1), labeled "Basic SAML Configuration", enter the following data in each line and save your changes.
 
-   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/` <Alert level="warning" title="Include Trailing Slash">Confirm the URL includes a trailing slash at the end, otherwise it will cause a misconfiguration error (AADSTS650056).</Alert>
+   - Identifier (Entity ID): `https://sentry.io/saml/metadata/YOUR_ORG_SLUG/` <Alert level="warning">Ensure that the URL includes a trailing slash to avoid causing a misconfiguration error (AADSTS650056).</Alert>
 
    - Reply URL (Assertion Consumer Service URL): `https://sentry.io/saml/acs/YOUR_ORG_SLUG/`
 


### PR DESCRIPTION
Users will encounter `Error AADSTS650056 - Misconfigured application` if they didn't include a trailing slash in the Identifier field when setting up Sentry on Azure AD. It causes some back-and-forth between them and support, which isn't ideal.

This adds an explicit alert for it so users can be warned of this subtle error.

<img width="761" alt="Screen Shot 2021-07-15 at 11 51 24 AM" src="https://user-images.githubusercontent.com/1748388/125841644-743ace30-2d9e-42fc-90ba-a245d0402a5a.png">
