### PR TITLE
.NET: Added to the list of supported SDKs for release health

### DIFF
--- a/src/docs/product/releases/health/setup.mdx
+++ b/src/docs/product/releases/health/setup.mdx
@@ -17,3 +17,4 @@ To enable reporting of release health, use the link below to quickly configure y
 - [React Native](/platforms/react-native/configuration/releases/#release-health)
 - [Rust](/platforms/rust/configuration/releases/#release-health)
 - [.NET](/platforms/dotnet/configuration/releases/#release-health)
+- [Unity](/platforms/unity/configuration/releases/#release-health)

--- a/src/docs/product/releases/health/setup.mdx
+++ b/src/docs/product/releases/health/setup.mdx
@@ -16,3 +16,4 @@ To enable reporting of release health, use the link below to quickly configure y
 - [Python](/platforms/python/configuration/releases/#release-health)
 - [React Native](/platforms/react-native/configuration/releases/#release-health)
 - [Rust](/platforms/rust/configuration/releases/#release-health)
+- [.NET](/platforms/dotnet/configuration/releases/#release-health)


### PR DESCRIPTION
I missed adding .NET to the list when I extended the release health docs for it.
Closes https://github.com/getsentry/sentry-docs/issues/3895