### PR TITLE
Added EA docs for Slack personal and team notifications

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -80,7 +80,7 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Issue Owners
 
-[Issue owners](/product/issues/issue-owners/) can receive can receive notifications (emails only) when an alert is triggered. 
+[Issue owners](/product/issues/issue-owners/) can receive notifications (emails only) when an alert is triggered.
 
 <Note>
 

--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -104,7 +104,7 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-You can configure Slack channels to receive alert notifications for teams. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
+Teams can configure a Slack channel to receive alert notifications. This can be done by typing `/sentry link team` in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 
 ## Action Interval (Rate Limit)
 

--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -80,7 +80,13 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Issue Owners
 
-[Issue owners](/product/issues/issue-owners/) can receive notifications when an alert is triggered. These notifications will be received via email or Slack depending on the [notification settings](/product/alerts/notifications/notification-settings/) of the issue owner.
+[Issue owners](/product/issues/issue-owners/) can receive can receive notifications (emails only) when an alert is triggered. 
+
+<Note>
+
+For early adopters, these notifications are received by email or Slack depending on the [notification settings](/product/alerts/notifications/notification-settings/) of the issue owner.
+
+</Note>
 
 If an issue owner is not configured or not found, either the notification won’t be sent or it’ll be sent to all project members, depending on the following setting in **[Project] > Settings > Issue Owners**.
 
@@ -98,7 +104,7 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-You can configure Slack channels to receive alert notifications for teams. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in Sentry navigate to *Settings > Teams > [Team] > Notifications*.
+You can configure Slack channels to receive alert notifications for teams. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 
 ## Action Interval (Rate Limit)
 

--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -80,9 +80,25 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Issue Owners
 
-[Issue owners](/product/issues/issue-owners/) can receive notifications (emails only) when an alert is triggered. If an issue owner is not configured or not found, either the email notification won’t be sent or it’ll be sent to all project members, depending on the following setting in **[Project] > Settings > Issue Owners**.
+[Issue owners](/product/issues/issue-owners/) can receive notifications when an alert is triggered. These notifications will be received via email or Slack depending on the [notification settings](/product/alerts/notifications/notification-settings/) of the issue owner.
+
+If an issue owner is not configured or not found, either the notification won’t be sent or it’ll be sent to all project members, depending on the following setting in **[Project] > Settings > Issue Owners**.
 
 ![A toggle indicating if all users are issue owners or not.](issue_owners2.png)
+
+### Team Slack Notifications
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+You can configure Slack channels to receive alert notifications for teams. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in Sentry navigate to *Settings > Teams > [Team] > Notifications*.
 
 ## Action Interval (Rate Limit)
 

--- a/src/docs/product/alerts/notifications/notification-settings.mdx
+++ b/src/docs/product/alerts/notifications/notification-settings.mdx
@@ -22,21 +22,19 @@ You can also fine tune your alert notifications on a per-project basis by choosi
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
 </Note>
 
-Personal notifications can be sent to:
-- Email
-- [Slack](/product/integrations/notification-incidents/slack/)
+You can decide where you receive personal alert notifications by choosing from the options:
+- Send to Email
+- Send to [Slack](/product/integrations/notification-incidents/slack/)
+- Send to Email and Slack
 
-You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
 
-To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
+[Slack](/product/integrations/notification-incidents/slack/) is only available as a delivery method if your organization has the integration installed and your [Slack identity is linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
 ## Workflow
 
@@ -52,9 +50,7 @@ You can fine tune your workflow notifications on a per-project basis by choosing
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
@@ -64,7 +60,7 @@ Personal notifications can be sent to:
 - Email
 - [Slack](/product/integrations/notification-incidents/slack/)
 
-You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
+You can decide where personal workflow notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
 
 To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
@@ -94,9 +90,7 @@ You can fine tune your deploy notifications on a per-organization basis by choos
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
@@ -106,7 +100,7 @@ Personal notifications can be sent to:
 - Email
 - [Slack](/product/integrations/notification-incidents/slack/)
 
-You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
+You can decide where personal deploy notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
 
 To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 

--- a/src/docs/product/alerts/notifications/notification-settings.mdx
+++ b/src/docs/product/alerts/notifications/notification-settings.mdx
@@ -56,13 +56,12 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-Personal notifications can be sent to:
-- Email
-- [Slack](/product/integrations/notification-incidents/slack/)
+You can decide where you receive personal workflow notifications by choosing from the options:
+- Send to Email
+- Send to [Slack](/product/integrations/notification-incidents/slack/)
+- Send to Email and Slack
 
-You can decide where personal workflow notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
-
-To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
+[Slack](/product/integrations/notification-incidents/slack/) is only available as a delivery method if your organization has the integration installed and your [Slack identity is linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
 ### Unsubscribe
 
@@ -96,13 +95,12 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-Personal notifications can be sent to:
-- Email
-- [Slack](/product/integrations/notification-incidents/slack/)
+You can decide where you receive personal deploy notifications by choosing from the options:
+- Send to Email
+- Send to [Slack](/product/integrations/notification-incidents/slack/)
+- Send to Email and Slack
 
-You can decide where personal deploy notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
-
-To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
+[Slack](/product/integrations/notification-incidents/slack/) is only available as a delivery method if your organization has the integration installed and your [Slack identity is linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
 ## My Activity
 Use the toggles to control whether or not you receive notifications about:

--- a/src/docs/product/alerts/notifications/notification-settings.mdx
+++ b/src/docs/product/alerts/notifications/notification-settings.mdx
@@ -18,6 +18,26 @@ In **Notifications**, you can toggle [issue alert](/product/alerts/alert-types/#
 
 You can also fine tune your alert notifications on a per-project basis by choosing "Default”, “On”, or “Off”. If you select “Default”, the setting for the project will be the same as your global setting.
 
+### Delivery Method
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+Personal notifications can be sent to:
+- Email
+- [Slack](/product/integrations/notification-incidents/slack/)
+
+You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
+
+To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
+
 ## Workflow
 
 The global settings for workflow notifications are:
@@ -27,6 +47,26 @@ The global settings for workflow notifications are:
 - Never
 
 You can fine tune your workflow notifications on a per-project basis by choosing one of the three options above or "Default”. If you select “Default”, the setting for the project will be the same as your global setting.
+
+### Delivery Method
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+Personal notifications can be sent to:
+- Email
+- [Slack](/product/integrations/notification-incidents/slack/)
+
+You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
+
+To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
 ### Unsubscribe
 
@@ -49,6 +89,26 @@ The global settings for deploy notifications are:
 - Off
 
 You can fine tune your deploy notifications on a per-organization basis by choosing one of the three options above or "Default”. If you select “Default”, the setting for the organization will be the same as your global setting.
+
+### Delivery Method
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+Personal notifications can be sent to:
+- Email
+- [Slack](/product/integrations/notification-incidents/slack/)
+
+You can decide where personal notifications are sent by choosing "Send to Email", "Send to Slack", or "Send to Email and Slack".
+
+To have [Slack](/product/integrations/notification-incidents/slack/) as a delivery method, your organization must have the integration installed and your [Slack identity must be linked to your Sentry account](/product/integrations/notification-incidents/slack/#linking-your-slack-and-sentry-accounts).
 
 ## My Activity
 Use the toggles to control whether or not you receive notifications about:

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -65,7 +65,7 @@ You can receive personal workflow, deploy, and issue alert notifications from ou
 
 #### Linking Your Slack and Sentry Accounts
 
-In order to receive personal notifications from our Slack integration, your Slack identity must be linked with your Sentry account. This can be done in Slack by using the `/sentry link` command.
+In order to receive personal notifications from our Slack integration, your Slack identity must be linked with your Sentry account. This can be done by typing `/sentry link` in Slack.
 
 ### Team Notifications
 
@@ -77,7 +77,7 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack integration. To enable this feature, use the `/sentry link team` command in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
+You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack integration. To enable this feature, type `/sentry link team` in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 
 ### Alert Rules
 

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -65,7 +65,7 @@ You can receive personal workflow, deploy, and issue alert notifications from ou
 
 #### Linking Your Slack and Sentry Accounts
 
-In order to receive personal notifications from our Slack app, your Slack identity must be linked with your Sentry account. This can be done in Slack by using the `/sentry link` command.
+In order to receive personal notifications from our Slack integration, your Slack identity must be linked with your Sentry account. This can be done in Slack by using the `/sentry link` command.
 
 ### Team Notifications
 

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -49,7 +49,39 @@ In the next section, we'll walk you through configuring your notification settin
 
 ## Configure
 
-Use Slack for [alerts](#alert-rules) regarding issues, environments, deployment, etc.
+Use Slack for notifications and [alerts](#alert-rules) regarding issues, environments, deployment, etc.
+
+### Personal Notifications
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+You can receive personal workflow, deploy, and issue alert notifications from our Slack app. You can manage your [personal notification settings](/product/alerts/notifications/notification-settings/) by navigating to *User Settings > Notifications*.
+
+#### Linking your Slack and Sentry accounts
+
+In order to receive personal notifications from our Slack app, your Slack identity must be linked with your Sentry account. This can be done in Slack by using the `/sentry link` command.
+
+### Team Notifications
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+
+You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack app. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in Sentry navigate to *Settings > Teams > [Team] > Notifications*.
 
 ### Alert Rules
 
@@ -91,58 +123,4 @@ Use Slack for [alerts](#alert-rules) regarding issues, environments, deployment,
 
 We recommend disabling the legacy project-based integration after setting up the global integration.
 
-Once you configure the global Slack integration and Alert Rules, you can disable the old project-based Slack integration. Go to each project that has the old project-based Slack enabled and disable it. If you're looking to upgrade your global integration, please refer to the information below under **Upgrading Slack**.
-
-## Upgrading Slack
-
-### How do I know if I need to upgrade?
-
-You need to upgrade if you installed the global Slack integration on a Sentry organization before May 8, 2020. Unsure whether or not that includes your organization? Please visit your integration's page via **Organization Settings > Integrations**. You will see a call to action for the Slack integration.
-
-![](slack-migration-integration-directory.png)
-
-Please note we are still rolling this out, if you don't see this yet you may be in a later wave.
-
-If you installed the Slack integration on a Sentry organization after May 8, 2020, your integration will be up-to-date, and no upgrade is needed.
-
-### Why do I need to upgrade?
-
-Sentry built its previous Slack integration on top of Slack's workspace apps. Unfortunately, Slack deprecated the workspace apps shortly afterward. You can find more details about that decision on [the Slack blog](https://medium.com/slack-developer-blog/an-update-on-workspace-apps-aabc9e42a98b).
-
-While we were able to maintain the integration in the past, our workspace app relies on Slack APIs that will soon deprecate. We now need to move to Slack's newly supported bot app framework.
-
-### What changes after my integration is upgraded?
-
-Previously, Slack workspace apps allowed you to give Sentry access to whichever channels you chose, including public or specific channels -- which could be either public or private.
-
-Bot apps in Slack work differently. By default, the Sentry bot will be able to post alerts in public channels, but in order to be able to post to private channels, you'll need to add the bot to that specific channel.
-
-In terms of your alert rule configurations, if your current Slack integration only uses public channels, then nothing needs to change after you upgrade.
-
-Going forward, if you want to add private channels to alert rules, you'll need to add the Sentry bot to the channel first before making the Sentry rule.
-
-If you have any private channels currently used in your alert rules, for the alerts to work, you'll need to add the Sentry bot after you've upgraded. In the upgrade flow, you'll have a chance to review which private channels you're using. Sentry will send a message to each channel, once you've upgraded, as a reminder to add the Sentry bot to that channel.
-
-### How do I upgrade?
-
-1. Go to your Slack configurations page in Sentry. Click "Upgrade Now".
-
-   ![](slack-migration-configurations.png)
-
-2. Click "Continue".
-
-   ![](slack-migration-intro.png)
-
-3. If you have any private channels in use, you'll see them listed.
-
-   ![](slack-migration-private-channels.png)
-
-   Otherwise, you'll see:
-
-   ![](slack-migration-no-private-channels.png)
-
-   Either way, when you're ready, Click "Upgrade".
-
-### When do I need to migrate by?
-
-All Sentry organizations will have until October 1, 2020, to upgrade their Slack integration. If you have any questions or concerns, please email us at [partners@sentry.io](mailto:partners@sentry.io).
+Once you configure the global Slack integration and Alert Rules, you can disable the old project-based Slack integration. Go to each project that has the old project-based Slack enabled and disable it.

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -55,17 +55,15 @@ Use Slack for notifications and [alerts](#alert-rules) regarding issues, environ
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
 </Note>
 
-You can receive personal workflow, deploy, and issue alert notifications from our Slack app. You can manage your [personal notification settings](/product/alerts/notifications/notification-settings/) by navigating to *User Settings > Notifications*.
+You can receive personal workflow, deploy, and issue alert notifications from our Slack integration. Manage your [personal notification settings](/product/alerts/notifications/notification-settings/) by navigating to **User Settings > Notifications**.
 
-#### Linking your Slack and Sentry accounts
+#### Linking Your Slack and Sentry Accounts
 
 In order to receive personal notifications from our Slack app, your Slack identity must be linked with your Sentry account. This can be done in Slack by using the `/sentry link` command.
 
@@ -73,15 +71,13 @@ In order to receive personal notifications from our Slack app, your Slack identi
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
 </Note>
 
-You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack app. This can be done in Slack by using the `/sentry link team` command in the desired channel. To view a team's associated Slack channel in Sentry navigate to *Settings > Teams > [Team] > Notifications*.
+You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack integration. To enable this feature, use the `/sentry link team` command in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 
 ### Alert Rules
 
@@ -123,4 +119,4 @@ You can receive [team alert notifications](/product/alerts/create-alerts/issue-a
 
 We recommend disabling the legacy project-based integration after setting up the global integration.
 
-Once you configure the global Slack integration and Alert Rules, you can disable the old project-based Slack integration. Go to each project that has the old project-based Slack enabled and disable it.
+Once you configure the global Slack integration and alert rules, you can disable the old project-based Slack integration. Go to each project that has the old project-based Slack enabled and disable it.


### PR DESCRIPTION
Added EA docs for Slack personal and team notifications

### Slack
Changes:

- Added Personal and Team Notifications sections
- Removed section on upgrading Slack

![screencapture-localhost-3000-product-integrations-notification-incidents-slack-2021-07-18-14_33_39](https://user-images.githubusercontent.com/7978631/126082770-5970eb48-e549-4006-916d-8b02c19258ab.png)

### Personal Notification Settings
Changes:

- Added a Delivery Method section to Alerts, Workflow, and Deploy sections

![screencapture-localhost-3000-product-alerts-notifications-notification-settings-2021-07-18-14_35_48](https://user-images.githubusercontent.com/7978631/126082817-1ec31f35-16de-4aec-bae5-83d2771aac5b.png)

### Issue Alert Configuration
Changes:

- Removed specific language mentioning "emails only"
- Added section for Team Slack Notifications

![screencapture-localhost-3000-product-alerts-create-alerts-issue-alert-config-2021-07-18-14_38_19](https://user-images.githubusercontent.com/7978631/126082862-b30a9794-948b-4739-9d74-1927e42927f3.png)
