### PR TITLE
fix: Use correct clubhouse image links

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -28,7 +28,7 @@ With issue linking, the developer can connect Sentry issues with a task in their
 
 The Issue Link component displays "Link &lt;Service&gt; Issue" in the Issue sidebar, which opens a modal allowing the user to create or link the issue to a task in the external service. For example, this is what our Clubhouse integration looks like.
 
-![Sentry modal that creates a Clubhouse Story that's linked to a Sentry issue.](../../clubhouse/clubhouse_create_story_with_issue.png)
+![Sentry modal that creates a Clubhouse Story that's linked to a Sentry issue.](../../project-mgmt/clubhouse/clubhouse_create_story_with_issue.png)
 
 ### Schema
 
@@ -289,7 +289,7 @@ When creating or linking an issue, the response format _must_ have the following
 
 When an external issue is created or linked in Sentry, Sentry shows a display name that links back to the service where it was either created or linked. The display name is composed of two pieces: the `project` and the `identifier`. A hash (#) connects each piece. Here's an example of what it looks like in Sentry:
 
-![Sentry's sidebar button illustrating that an issue is linked.](../../clubhouse/clubhouse_story_in_linked_issues_82.png)
+![Sentry's sidebar button illustrating that an issue is linked.](../../project-mgmt/clubhouse/clubhouse_story_in_linked_issues_82.png)
 
 # Supplementary Information
 


### PR DESCRIPTION
See: https://docs.sentry.io/product/integrations/integration-platform/ui-components/#issue-link for image not loading.

![image](https://user-images.githubusercontent.com/18689448/126355881-e5c22932-5124-460a-9a8a-ff01f36b7b94.png)

Can see that this is fixed in https://sentry-docs-git-abhi-fix-clubhouse-links.sentry.dev/product/integrations/integration-platform/ui-components/#issue-link