### PR TITLE
Feat: index guides for search

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -15,6 +15,10 @@ type Props = {
       name?: string;
       [key: string]: any;
     };
+    guide?: {
+      name?: string;
+      [key: string]: any;
+    };
   };
 };
 
@@ -23,6 +27,11 @@ export default ({
   sidebar,
   pageContext = {},
 }: Props): JSX.Element => {
+  const searchPlatforms = [
+    pageContext.platform?.name,
+    pageContext.guide?.name,
+  ].filter(Boolean);
+
   return (
     <div className="document-wrapper">
       <div className="sidebar">
@@ -44,8 +53,8 @@ export default ({
         <div className="flex-grow-1">
           <div className="d-none d-md-block navbar-right-half">
             <Navbar
-              {...(pageContext.platform && {
-                platforms: [pageContext.platform.name],
+              {...(searchPlatforms.length > 0 && {
+                platforms: searchPlatforms,
               })}
             />
           </div>

--- a/src/gatsby/createPages/createPlatformPages.ts
+++ b/src/gatsby/createPages/createPlatformPages.ts
@@ -373,14 +373,13 @@ export default async ({ actions, graphql, reporter, getNode }) => {
         pathRoot
       )}`;
       reporter.verbose(`${guide.key}: Creating global common - ${path}`);
-      // XXX: we dont index or add redirects for guide-common pages
+      // XXX: we dont add redirects for guide-common pages
       pages.push([
         node,
         path,
         {
           ...guidePageContext,
           title: path === pathRoot ? guide.title : undefined,
-          noindex: true,
           redirect_from: [],
         },
       ]);
@@ -394,14 +393,13 @@ export default async ({ actions, graphql, reporter, getNode }) => {
         pathRoot
       )}`;
       reporter.verbose(`${guide.key}: Creating common - ${path}`);
-      // XXX: we dont index or add redirects for guide-common pages
+      // XXX: we dont add redirects for guide-common pages
       pages.push([
         node,
         path,
         {
           ...guidePageContext,
           title: path === pathRoot ? guide.title : undefined,
-          noindex: true,
           redirect_from: [],
         },
       ]);

--- a/src/gatsby/utils/algolia.ts
+++ b/src/gatsby/utils/algolia.ts
@@ -19,6 +19,9 @@ const pageQuery = `{
             platform {
               name
             }
+            guide {
+              name
+            }
           }
         }
       }
@@ -36,7 +39,14 @@ const flatten = (arr: any[]) =>
       let platforms = [];
       if (context.platform) {
         const { slug } = standardSDKSlug(context.platform.name);
-        platforms = extrapolate(slug, ".");
+
+        let fullSlug = slug;
+
+        if (context.guide) {
+          const { slug } = standardSDKSlug(context.guide.name);
+          fullSlug += `.${slug}`;
+        }
+        platforms = extrapolate(fullSlug, ".");
       }
 
       return {


### PR DESCRIPTION
This PR addresses a couple of issues:

- Allow guide pages to be indexed. This was previously disabled because our filtering was bad, but now that it's improved, there's no reason to do this.
- Send the guide along with the platform to allow for biasing search results. This will let us float contextual results higher if you're searching within a platform or guide.

I tested this change within the Angular guide, ensuring that searching "options" would yield the Angular configuration options when in the angular guide pages, and Javascript configuration options when in the javascript docs.

This PR _does not_ address keywording platforms, so searching "angular options" still won't get what you want.