### PR TITLE
feat(ue4): Enable enriching events content for UE4

### DIFF
--- a/src/includes/enriching-events/set-context/native.ue4.mdx
+++ b/src/includes/enriching-events/set-context/native.ue4.mdx
@@ -1,0 +1,13 @@
+```cpp
+TSharedPtr<FJsonObject> character = MakeShareable(new FJsonObject);
+character->SetStringField("name", "Mighty Fighter");
+character->SetNumberField("age", 19.0);
+
+TSharedPtr<FJsonObject> contexts = MakeShareable(new FJsonObject);
+contexts->SetObjectField("character", character);
+
+TSharedPtr<FJsonObject> config = MakeShareable(new FJsonObject);
+config->SetObjectField("contexts", contexts);
+```
+
+Provide this configuration to the crash reporter [during initialization](/platforms/native/guides/ue4/advanced-config/).

--- a/src/includes/enriching-events/set-tag/native.ue4.mdx
+++ b/src/includes/enriching-events/set-tag/native.ue4.mdx
@@ -1,0 +1,10 @@
+```cpp
+TSharedPtr<FJsonObject> tags = MakeShareable(new FJsonObject);
+tags->SetStringField("tag1", "value1");
+tags->SetStringField("tag2", "value2");
+
+TSharedPtr<FJsonObject> config = MakeShareable(new FJsonObject);
+config->SetObjectField("tags", tags);
+```
+
+Provide this configuration to the crash reporter [during initialization](/platforms/native/guides/ue4/advanced-config/).

--- a/src/includes/enriching-events/set-user/native.ue4.mdx
+++ b/src/includes/enriching-events/set-user/native.ue4.mdx
@@ -1,0 +1,11 @@
+```cpp
+TSharedPtr<FJsonObject> user = MakeShareable(new FJsonObject);
+user->SetStringField("ip_address", "{{auto}}");
+user->SetStringField("email", "jane.doe@example.com");
+
+TSharedPtr<FJsonObject> config = MakeShareable(new FJsonObject);
+config->SetObjectField("user", user);
+}
+```
+
+Provide this configuration to the crash reporter [during initialization](/platforms/native/guides/ue4/advanced-config/).

--- a/src/includes/enriching-events/unset-user/native.ue4.mdx
+++ b/src/includes/enriching-events/unset-user/native.ue4.mdx
@@ -1,0 +1,1 @@
+Create a new `__sentry` config object without the `"user"` field. Then, call `FGenericCrashContext::SetGameData` from the [initialization function](/platforms/native/guides/ue4/advanced-config/) with the new JSON data. You have to provide all other fields again, as call overrides the previously registered data.

--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -6,7 +6,6 @@ notSupported:
   - native.crashpad
   - native.minidumps
   - native.wasm
-  - native.ue4
 description: "Custom contexts allow you to attach arbitrary data (strings, lists, dictionaries) to an event."
 ---
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -6,7 +6,6 @@ notSupported:
   - native.crashpad
   - native.minidumps
   - native.wasm
-  - native.ue4
 description: "Learn how to configure the SDK to capture the user and gain critical pieces of information that construct a unique identity in Sentry."
 ---
 

--- a/src/platforms/common/enriching-events/tags.mdx
+++ b/src/platforms/common/enriching-events/tags.mdx
@@ -4,7 +4,6 @@ sidebar_order: 3
 notSupported:
   - native.breakpad
   - native.crashpad
-  - native.ue4
 description: "Tags power UI features such as filters and tag-distribution maps. Tags also help you quickly access related events and view the tag distribution for a set of events."
 ---
 
@@ -14,7 +13,7 @@ We’ll automatically index all tags for an event, as well as the frequency and 
 
 _Tag keys_ have a maximum length of 32 characters, while _tag values_ have a maximum length of 200 characters.
 
-<PlatformSection notSupported={["native.minidumps", "native.wasm", "php", "php.laravel", "php.symfony", "flutter"]}>
+<PlatformSection notSupported={["native.minidumps", "native.ue4", "native.wasm", "php", "php.laravel", "php.symfony", "flutter"]}>
 
 Defining tags is easy, and will bind them to the [current scope](../scopes/) ensuring all future events within scope contain the same tags.
 

--- a/src/platforms/common/enriching-events/transaction-name.mdx
+++ b/src/platforms/common/enriching-events/transaction-name.mdx
@@ -12,6 +12,7 @@ notSupported:
   - javascript.nextjs
   - javascript.electron
   - native.minidumps
+  - native.ue4
 description: "Learn how to set or override the transaction name to capture the user and gain critical pieces of information that construct a unique identity in Sentry."
 ---
 

--- a/src/platforms/native/guides/ue4/advanced-config.mdx
+++ b/src/platforms/native/guides/ue4/advanced-config.mdx
@@ -15,9 +15,19 @@ void ConfigureCrashReporter()
 {
     TSharedPtr<FJsonObject> config = MakeShareable(new FJsonObject);
 
-    // sentry specific attributes to here
+    // sentry specific attributes go here
     config->SetStringField("release", "my-project-name@2.3.12");
     config->SetStringField("environment", "production");
+    
+    TSharedPtr<FJsonObject> tags = MakeShareable(new FJsonObject);
+    tags->SetStringField("tag1", "value1");
+    tags->SetStringField("tag2", "value2");
+    config->SetObjectField("tags", tags);
+    
+    TSharedPtr<FJsonObject> user = MakeShareable(new FJsonObject);
+    user->SetStringField("ip_address", "{{auto}}");
+    user->SetStringField("email", "jane.doe@example.com");
+    config->SetObjectField("user", user);
 
     FString jsonConfig;
     TSharedRef<TJsonWriter<>> jsonWriter = TJsonWriterFactory<>::Create(&jsonConfig);


### PR DESCRIPTION
Expands the existing Advanced Configuration code snippet with more examples for
configuring tags and custom contexts. Also enables the Enriching Events section
for supported functions.

Since performance monitoring is not supported on UE4, this also disables the
transaction name document for UE4.

