### PR TITLE
feat(aws-lambda): Add docs on using Sentry as a Container Image

### DIFF
--- a/src/platforms/node/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/container-image/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: AWS Lambda Container Image (Node)
-description: "Learn how to set up Sentry with a Container Image"
+description: "Learn how to set up Sentry with a Container Image."
 ---
 
 You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
@@ -9,7 +9,7 @@ You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/la
 COPY --from=public.ecr.aws/sentry/sentry-node-serverless-sdk:<VERSION> /opt/ /opt
 ```
 
-Replace **VERSION** with a specific version number (for example, 28). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-node-serverless-sdk).
+Replace `VERSION` with a specific version number (for example, 28). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-node-serverless-sdk).
 
 ## Function Configuration {#function-configuration}
 
@@ -18,7 +18,7 @@ Set the following environment variables in AWS:
 - Set `SENTRY_DSN` to your Sentry's DSN
 - Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
 
-Alternatively, you can also set the environment vairables in the Dockerfile:
+Alternatively, you can also set the environment variables in the Dockerfile:
 
 ```{tabTitle: Dockerfile}
 ENV NODE_OPTIONS="-r @sentry/serverless/dist/awslambda-auto"
@@ -26,4 +26,8 @@ ENV SENTRY_DSN="___PUBLIC_DSN___"
 ENV SENTRY_TRACES_SAMPLE_RATE="1.0"
 ```
 
-**NOTE:** The values you set in AWS overrides the value in the Dockerfile if both are set.
+<Note>
+
+The values you set in AWS override the value in the Dockerfile if both are set.
+
+</Note>

--- a/src/platforms/node/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/container-image/index.mdx
@@ -1,0 +1,29 @@
+---
+title: AWS Lambda Container Image (Node)
+description: "Learn how to set up Sentry with a Container Image"
+---
+
+You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
+
+```{tabTitle: Dockerfile}
+COPY --from=public.ecr.aws/sentry/sentry-node-serverless-sdk:<VERSION> /opt/ /opt
+```
+
+Replace **VERSION** with a specific version number (for example, 28). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-node-serverless-sdk).
+
+## Function Configuration {#function-configuration}
+
+Set the following environment variables in AWS:
+- Set `NODE_OPTIONS` to `-r @sentry/serverless/dist/awslambda-auto`
+- Set `SENTRY_DSN` to your Sentry's DSN
+- Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
+
+Alternatively, you can also set the environment vairables in the Dockerfile:
+
+```{tabTitle: Dockerfile}
+ENV NODE_OPTIONS="-r @sentry/serverless/dist/awslambda-auto"
+ENV SENTRY_DSN="___PUBLIC_DSN___"
+ENV SENTRY_TRACES_SAMPLE_RATE="1.0"
+```
+
+**NOTE:** The values you set in AWS overrides the value in the Dockerfile if both are set.

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -26,7 +26,7 @@ npm install --save @sentry/serverless
 yarn add @sentry/serverless
 ```
 
-We also support [installing Sentry in Lambda Layer](/platforms/node/guides/aws-lambda/layer/).
+We also support [installing Sentry in Lambda Layer](/platforms/node/guides/aws-lambda/layer/) and [installing Sentry as a Container Image](/platforms/node/guides/aws-lambda/container-image/).
 
 You can use the AWS Lambda integration for the Node like this:
 

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -26,7 +26,7 @@ npm install --save @sentry/serverless
 yarn add @sentry/serverless
 ```
 
-We also support [installing Sentry in Lambda Layer](/platforms/node/guides/aws-lambda/layer/) and [installing Sentry as a Container Image](/platforms/node/guides/aws-lambda/container-image/).
+We also support [installing Sentry as a Container Image](/platforms/node/guides/aws-lambda/container-image/) and [installing Sentry in Lambda Layer](/platforms/node/guides/aws-lambda/layer/).
 
 You can use the AWS Lambda integration for the Node like this:
 

--- a/src/platforms/python/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/container-image/index.mdx
@@ -1,0 +1,34 @@
+---
+title: AWS Lambda Container Image (Python)
+description: "Learn how to set up Sentry with a Container Image"
+---
+
+You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
+
+```{tabTitle: Dockerfile}
+COPY --from=public.ecr.aws/sentry/sentry-python-serverless-sdk:<VERSION> /opt/ /opt
+```
+
+Replace **VERSION** with a specific version number (for example, 6). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-python-serverless-sdk).
+
+## Function Configuration {#function-configuration}
+
+Set your image’s CMD value to the Sentry Handler:
+```{tabTitle: Dockerfile}
+CMD ["sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"]
+```
+
+Also, Set the following environment variables in AWS:
+- Set `SENTRY_INITIAL_HANDLER` to the path of your function handler
+- Set `SENTRY_DSN` to your Sentry's DSN
+- Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
+
+Alternatively, you can also set the environment vairables in the Dockerfile:
+
+```{tabTitle: Dockerfile}
+ENV SENTRY_INITIAL_HANDLER="<PATH_TO_FUNCTION_HANDLER>"
+ENV SENTRY_DSN="___PUBLIC_DSN___"
+ENV SENTRY_TRACES_SAMPLE_RATE="1.0"
+```
+
+**NOTE:** The values you set in AWS overrides the value in the Dockerfile if both are set.

--- a/src/platforms/python/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/container-image/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: AWS Lambda Container Image (Python)
-description: "Learn how to set up Sentry with a Container Image"
+description: "Learn how to set up Sentry with a Container Image."
 ---
 
 You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
@@ -9,7 +9,7 @@ You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/la
 COPY --from=public.ecr.aws/sentry/sentry-python-serverless-sdk:<VERSION> /opt/ /opt
 ```
 
-Replace **VERSION** with a specific version number (for example, 6). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-python-serverless-sdk).
+Replace `VERSION` with a specific version number (for example, 6). You can see a complete list of available versions in Sentry's [Amazon ECR repository](https://gallery.ecr.aws/sentry/sentry-python-serverless-sdk).
 
 ## Function Configuration {#function-configuration}
 
@@ -18,12 +18,12 @@ Set your image’s CMD value to the Sentry Handler:
 CMD ["sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"]
 ```
 
-Also, Set the following environment variables in AWS:
+Also, set the following environment variables in AWS:
 - Set `SENTRY_INITIAL_HANDLER` to the path of your function handler
-- Set `SENTRY_DSN` to your Sentry's DSN
+- Set `SENTRY_DSN` to your Sentry DSN
 - Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
 
-Alternatively, you can also set the environment vairables in the Dockerfile:
+Alternatively, you can also set the environment variables in the Dockerfile:
 
 ```{tabTitle: Dockerfile}
 ENV SENTRY_INITIAL_HANDLER="<PATH_TO_FUNCTION_HANDLER>"
@@ -31,4 +31,8 @@ ENV SENTRY_DSN="___PUBLIC_DSN___"
 ENV SENTRY_TRACES_SAMPLE_RATE="1.0"
 ```
 
-**NOTE:** The values you set in AWS overrides the value in the Dockerfile if both are set.
+<Note>
+
+The values you set in AWS override the value in the Dockerfile if both are set.
+
+</Note>

--- a/src/platforms/python/guides/aws-lambda/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/index.mdx
@@ -23,7 +23,7 @@ Install our Python SDK using `pip`:
 ```bash
 pip install --upgrade sentry-sdk
 ```
-We also support [installing Sentry in Lambda Layer](/platforms/python/guides/aws-lambda/layer/).
+We also support [installing Sentry in Lambda Layer](/platforms/python/guides/aws-lambda/layer/) and [installing Sentry as a Container Image](/platforms/python/guides/aws-lambda/container-image/).
 
 You can use the AWS Lambda integration for the Python SDK like this:
 

--- a/src/platforms/python/guides/aws-lambda/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/index.mdx
@@ -23,7 +23,7 @@ Install our Python SDK using `pip`:
 ```bash
 pip install --upgrade sentry-sdk
 ```
-We also support [installing Sentry in Lambda Layer](/platforms/python/guides/aws-lambda/layer/) and [installing Sentry as a Container Image](/platforms/python/guides/aws-lambda/container-image/).
+We also support [installing Sentry as a Container Image](/platforms/python/guides/aws-lambda/container-image/) and [installing Sentry in Lambda Layer](/platforms/python/guides/aws-lambda/layer/).
 
 You can use the AWS Lambda integration for the Python SDK like this:
 


### PR DESCRIPTION
This PR adds docs for both Python and Node on how to use Sentry's AWS Layer as a container image on AWS