### PR TITLE
fix(csp) Improve CSP docs around policy requirements

### DIFF
--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -28,6 +28,8 @@ Alternatively you can setup CSP reports to simply send reports rather than actua
 Content-Security-Policy-Report-Only: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
 ```
 
+When defining your policy it is important to ensure that __ORG_INGEST_DOMAIN__ is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.
+
 For more information, see the article on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
 
 ## Expect-CT {#id2}

--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -28,7 +28,7 @@ Alternatively you can setup CSP reports to simply send reports rather than actua
 Content-Security-Policy-Report-Only: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
 ```
 
-When defining your policy it is important to ensure that __ORG_INGEST_DOMAIN__ is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.
+When defining your policy it is important to ensure that `sentry.io` or your self-hosted sentry domain is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.
 
 For more information, see the article on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
 


### PR DESCRIPTION
Include a note that sentry needs to be in the allowed host list or submitting a CSP report will also fail.

Fixes getsentry/sentry#27524