### PR TITLE
feat(docs): Release adoption stages filtering

### DIFF
--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -83,7 +83,7 @@ Each release is represented by a line in the chart, and you can navigate to the 
 The chart does not display if you don't select a project or if you select multiple projects.
 
 
-### Adoption Stage
+### Adoption Stages
 
 <Note>
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -96,10 +96,9 @@ Adoption stage is a high-level overview of the usage your release is seeing rela
 - "Low Adoption" - the release's percentage of sessions across all session that are below the threshold
 - "Replaced" -  the release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "High Adoption".
 
-
 <Note>
 
-Adoption Stage elements in sentry.io are displayed only when filtered to a single environment.
+Adoption Stage labels are only displayed when filtered down to a single environment.
 
 </Note>
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -92,14 +92,14 @@ This feature is available only if you're in the Early Adopter program. Features 
 </Note>
 
 Adoption stage is a high-level overview of the usage your release is seeing relative to other releases. It is calculated every hour by processing your sessions over the last six hours.
-For each release, the release's percentage of sessions against all sessions in the same environment and project is calculated and marked as being in one of three stages based on a threshold of 10%. These stages are:
-- "Adopted" - the release's percentage of sessions across all sessions is above the threshold, ie. the release was seen in 10% or more of sessions over all the releases in the last six hours.
-- "Low Adoption" - the release's percentage of sessions across all session that are below the threshold, ie. the release was seen in less than 10% of sessions over all the releases in the last six hours.
-- "Replaced" -  the release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "Adopted".
+For each release, the release's percentage of sessions is calculated against all sessions in the same environment and project. It's then marked as being in one of three stages, based on a threshold of 10%. These stages are:
+- Adopted - The release's percentage of sessions compared to all sessions is above the threshold. That is, the release was seen in 10% or more of sessions over all releases in the last six hours.
+- Low Adoption - The release's percentage of sessions compared to all sessions that are below the threshold. That is, the release was seen in less than 10% of sessions over all the releases in the last six hours.
+- Replaced -  The release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "Adopted".
 
 <Note>
 
-Adoption Stage labels are only displayed when filtered down to a single environment.
+Adoption Stage labels are only displayed when you filter down to a single environment.
 
 </Note>
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -91,10 +91,11 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Adoption stage is a high-level overview of the usage your release is seeing relative to other releases. It is calculated every hour by processing your sessions over the last six hours. For each release, we calculate the release's percentage of sessions against all sessions in the same environment and project, and mark it as being in one of three stages:
-- "Adopted" - the release's percentage of sessions across all sessions is above a threshold (which is 10% divided by the number of releases in the last six hours)
-- "Low Adoption" - the release's percentage of sessions across all session that are below the threshold
-- "Replaced" -  the release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "High Adoption".
+Adoption stage is a high-level overview of the usage your release is seeing relative to other releases. It is calculated every hour by processing your sessions over the last six hours.
+For each release, the release's percentage of sessions against all sessions in the same environment and project is calculated, and mark it as being in one of three stages based on a threshold of 10%:
+- "Adopted" - the release's percentage of sessions across all sessions is above a threshold, meaning the release was seen in 10% or more of sessions over all the releases in the last six hours.
+- "Low Adoption" - the release's percentage of sessions across all session that are below the threshold, meaning the release was seen in less than 10% of sessions over all the releases in the last six hours.
+- "Replaced" -  the release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "Adopted".
 
 <Note>
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -92,9 +92,9 @@ This feature is available only if you're in the Early Adopter program. Features 
 </Note>
 
 Adoption stage is a high-level overview of the usage your release is seeing relative to other releases. It is calculated every hour by processing your sessions over the last six hours.
-For each release, the release's percentage of sessions against all sessions in the same environment and project is calculated, and mark it as being in one of three stages based on a threshold of 10%:
-- "Adopted" - the release's percentage of sessions across all sessions is above a threshold, meaning the release was seen in 10% or more of sessions over all the releases in the last six hours.
-- "Low Adoption" - the release's percentage of sessions across all session that are below the threshold, meaning the release was seen in less than 10% of sessions over all the releases in the last six hours.
+For each release, the release's percentage of sessions against all sessions in the same environment and project is calculated and marked as being in one of three stages based on a threshold of 10%. These stages are:
+- "Adopted" - the release's percentage of sessions across all sessions is above the threshold, ie. the release was seen in 10% or more of sessions over all the releases in the last six hours.
+- "Low Adoption" - the release's percentage of sessions across all session that are below the threshold, ie. the release was seen in less than 10% of sessions over all the releases in the last six hours.
 - "Replaced" -  the release was previously tagged as "Adopted", but no longer meets the minimum threshold. "Replaced" releases that reach the threshold will once again be marked as "Adopted".
 
 <Note>

--- a/src/docs/product/releases/health/release-details.mdx
+++ b/src/docs/product/releases/health/release-details.mdx
@@ -37,7 +37,7 @@ Hover over specific dates and times in the overview graph for a quick perspectiv
 
 <Note>
 
-The adoption stage feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+The adoption stages feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
 
 </Note>
 

--- a/src/docs/product/releases/health/release-details.mdx
+++ b/src/docs/product/releases/health/release-details.mdx
@@ -48,7 +48,7 @@ Use the **Release Details** page to view issues associated with this release and
 - All Issues
 - New Issues
 - Unhandled Issues
-- Resolved Issues 
+- Resolved Issues
 
 ## Sessions Adopted
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -29,7 +29,7 @@ The releases index page provides a high-level view of:
 
 - Each release version
 - The associated project
-- The adoption status of each release
+- The adoption stage of each release
 - The authors of each commit
 - The percentage of crash-free users
 - The percentage of crash-free sessions

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -29,7 +29,7 @@ The releases index page provides a high-level view of:
 
 - Each release version
 - The associated project
-- The adoption status of the release
+- The adoption status of each release
 - The authors of each commit
 - The percentage of crash-free users
 - The percentage of crash-free sessions

--- a/src/docs/product/releases/usage/sorting-filtering.mdx
+++ b/src/docs/product/releases/usage/sorting-filtering.mdx
@@ -22,11 +22,30 @@ On the **Releases** page, you can use the "Sort By" dropdown to sort releases by
 
 ## Filtering Releases
 
-Search on the **Releases** page, which supports both raw text and query syntax. If you are using our [Semantic Versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:
+Search on the **Releases** page, which supports both raw text and query syntax.
+
+### Semantic Versioning
+
+If you are using our [Semantic Versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:
 
 - `release` - Search based on string comparison
 - `release.package` - Search releases with matching package names
 - `release.version` - Search releases with matching semantic version. Supports ranges and wildcards (for example, `release.version:>7.8` or `release.version:1.2.*`)
 - `release.build` - Search releases with matching build numbers
+
+#### Release Stages
+
+<Note>
+
+  Release Stages are available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+If you select a single environment on the releases page, each project will be labeled with one of the following:
+- Adopted (`adopted`): when a release is adopted, meaning it was seen in a high percentage of sessions for the project
+- Low adoption (`low_adoption`): when a release has low adoption, meaning it was seen in a low percentage of sessions for the project
+- Replaced (`replaced`): when a release was replaced by a release before it was adopted, meaning later releases were seen at a higher percentage of sessions before this release
+
+You can use the following query with one of the release  labels, ie. `adopted`, `low_adoption`, `replaced`:
 
 Learn more about search queries in our [full Search documentation](/product/sentry-basics/search/).

--- a/src/docs/product/releases/usage/sorting-filtering.mdx
+++ b/src/docs/product/releases/usage/sorting-filtering.mdx
@@ -22,30 +22,12 @@ On the **Releases** page, you can use the "Sort By" dropdown to sort releases by
 
 ## Filtering Releases
 
-Search on the **Releases** page, which supports both raw text and query syntax.
-
-### Semantic Versioning
-
-If you are using our [Semantic Versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:
+Search on the **Releases** page, which supports both raw text and query syntax. If you are using our [Semantic Versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:
 
 - `release` - Search based on string comparison
 - `release.package` - Search releases with matching package names
 - `release.version` - Search releases with matching semantic version. Supports ranges and wildcards (for example, `release.version:>7.8` or `release.version:1.2.*`)
 - `release.build` - Search releases with matching build numbers
-
-#### Release Stages
-
-<Note>
-
-  Release Stages are available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
-If you select a single environment on the releases page, each project will be labeled with one of the following:
-- Adopted (`adopted`): when a release is adopted, meaning it was seen in a high percentage of sessions for the project
-- Low adoption (`low_adoption`): when a release has low adoption, meaning it was seen in a low percentage of sessions for the project
-- Replaced (`replaced`): when a release was replaced by a release before it was adopted, meaning later releases were seen at a higher percentage of sessions before this release
-
-You can use the following query with one of the release  labels, ie. `adopted`, `low_adoption`, `replaced`:
+- `release.stage` - Search releases with matching adoption stage, can be one of `adopted`, `low_adoption` or `replaced`. Learn more about [Release Adoption Stages](product/releases/health/#adoption-stage).
 
 Learn more about search queries in our [full Search documentation](/product/sentry-basics/search/).

--- a/src/docs/product/releases/usage/sorting-filtering.mdx
+++ b/src/docs/product/releases/usage/sorting-filtering.mdx
@@ -28,6 +28,6 @@ Search on the **Releases** page, which supports both raw text and query syntax. 
 - `release.package` - Search releases with matching package names
 - `release.version` - Search releases with matching semantic version. Supports ranges and wildcards (for example, `release.version:>7.8` or `release.version:1.2.*`)
 - `release.build` - Search releases with matching build numbers
-- `release.stage` - Search releases with matching adoption stage, can be one of `adopted`, `low_adoption` or `replaced`. Learn more about [Release Adoption Stages](product/releases/health/#adoption-stage).
+- `release.stage` - Search releases with matching adoption stage, can be one of `adopted`, `low_adoption` or `replaced`. Learn more about [Release Adoption Stages](product/releases/health/#adoption-stages).
 
 Learn more about search queries in our [full Search documentation](/product/sentry-basics/search/).

--- a/src/docs/product/releases/usage/sorting-filtering.mdx
+++ b/src/docs/product/releases/usage/sorting-filtering.mdx
@@ -28,6 +28,6 @@ Search on the **Releases** page, which supports both raw text and query syntax. 
 - `release.package` - Search releases with matching package names
 - `release.version` - Search releases with matching semantic version. Supports ranges and wildcards (for example, `release.version:>7.8` or `release.version:1.2.*`)
 - `release.build` - Search releases with matching build numbers
-- `release.stage` - Search releases with matching adoption stage, can be one of `adopted`, `low_adoption` or `replaced`. Learn more about [Release Adoption Stages](product/releases/health/#adoption-stages).
+- `release.stage` - Search releases with matching adoption stage. Can be `adopted`, `low_adoption` or `replaced`. Learn more about [Release Adoption Stages](/product/releases/health/#adoption-stages).
 
 Learn more about search queries in our [full Search documentation](/product/sentry-basics/search/).

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -50,6 +50,7 @@ Below is a list of event-level keys and tokens reserved and known to Sentry:
 | environment | Restrict results to events tagged with the matching environment. |
 | release | Restrict results to events tagged with the matching release. You can create a token with an exact match on the version of a release, or `release:latest` to pick the most recent release. |
 | release.package<br /> release.version<br /> release.build | Restrict results to events tagged with the matching semantic version. Supports ranges and wildcards. Learn more in [Sorting & Filtering Releases](/product/releases/usage/sorting-filtering/). |
+| release.stage | Restrict results to releases that are tagged with the matching release stage. |
 | transaction | Restrict results to events tagged with a URL template/job name. |
 | geo.country_code<br /> geo.region geo.city | Restrict results to events triggered by a geographic area. |
 | http.method<br /> http.referer<br /> http.url | Restrict results based on the HTTP request context. |
@@ -64,7 +65,7 @@ Below is a list of event-level keys and tokens reserved and known to Sentry:
 
 Additionally, you can use any tag you’ve specified as a token. Tags are various key/value pairs that get assigned to an event, and you can use them later as a breakdown or quick access to finding related events.
 
-Most SDKs generally support configuring tags by <PlatformLink to="/enriching-events/tags/">configuring the scope</PlatformLink>. 
+Most SDKs generally support configuring tags by <PlatformLink to="/enriching-events/tags/">configuring the scope</PlatformLink>.
 
 Several common uses for tags include:
 

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -50,7 +50,7 @@ Below is a list of event-level keys and tokens reserved and known to Sentry:
 | environment | Restrict results to events tagged with the matching environment. |
 | release | Restrict results to events tagged with the matching release. You can create a token with an exact match on the version of a release, or `release:latest` to pick the most recent release. |
 | release.package<br /> release.version<br /> release.build | Restrict results to events tagged with the matching semantic version. Supports ranges and wildcards. Learn more in [Sorting & Filtering Releases](/product/releases/usage/sorting-filtering/). |
-| release.stage | Restrict results to releases that are tagged with the matching release stage. |
+| release.stage | Restrict results to releases that are tagged with the matching release stage. See [Filtering Releases](product/releases/usage/sorting-filtering/#filtering-releases) for supported values. |
 | transaction | Restrict results to events tagged with a URL template/job name. |
 | geo.country_code<br /> geo.region geo.city | Restrict results to events triggered by a geographic area. |
 | http.method<br /> http.referer<br /> http.url | Restrict results based on the HTTP request context. |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -50,7 +50,7 @@ Below is a list of event-level keys and tokens reserved and known to Sentry:
 | environment | Restrict results to events tagged with the matching environment. |
 | release | Restrict results to events tagged with the matching release. You can create a token with an exact match on the version of a release, or `release:latest` to pick the most recent release. |
 | release.package<br /> release.version<br /> release.build | Restrict results to events tagged with the matching semantic version. Supports ranges and wildcards. Learn more in [Sorting & Filtering Releases](/product/releases/usage/sorting-filtering/). |
-| release.stage | Restrict results to releases that are tagged with the matching release stage. See [Filtering Releases](product/releases/usage/sorting-filtering/#filtering-releases) for supported values. |
+| release.stage | Restrict results to releases that are tagged with the matching release stage. See [Filtering Releases](/product/releases/usage/sorting-filtering/#filtering-releases) for supported values. |
 | transaction | Restrict results to events tagged with a URL template/job name. |
 | geo.country_code<br /> geo.region geo.city | Restrict results to events triggered by a geographic area. |
 | http.method<br /> http.referer<br /> http.url | Restrict results based on the HTTP request context. |


### PR DESCRIPTION
This adds search features for the `release.stage` feature to the #3903