### PR TITLE
fix: Fix the Release and Dist content in the capacitor init for angular

### DIFF
--- a/src/includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/includes/getting-started-config/javascript.capacitor.mdx
@@ -8,9 +8,10 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    // To set your release and dist versions
-    release: "my-project-name@" + process.env.npm_package_version,
-    dist: "1"
+    // Set your release version, such as "getsentry@1.0.0"
+    release: "my-project-name@<release-name>",
+    // Set your dist version, such as "1"
+    dist: "<dist>"
   },
   // Forward the init method from @sentry/angular
   SentryAngular.init


### PR DESCRIPTION
We fixed the incorrect release/dist example in the "Other Platforms" tab but not the Angular tab.