### PR TITLE
fix(nextjs): Remove note about API routes not working

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -15,9 +15,3 @@ Features:
 - Automatic [Performance Monitoring](/product/performance/) for both the client and server, from version `6.5.0`
 
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
-
-<Alert level="info" title="Early Adopter">
-
-We are working to resolve [this issue](https://github.com/getsentry/sentry-javascript/issues/3643) in Vercel production environments. The SDK is currently unable to pick up errors and/or transactions when calling serverless API routes.
-
-</Alert>


### PR DESCRIPTION
As of https://github.com/getsentry/sentry-javascript/pull/3811, the SDK should now work in API routes.