### PR TITLE
chore(thresholds): Remove EA note for Per-txn thresholds

### DIFF
--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -82,11 +82,6 @@ User Misery is a user-weighted performance metric to assess the relative magnitu
 In our Early Adopter program, you can set satisfactory thresholds for each project with [custom thresholds](#custom-thresholds).
 
 ## Custom Thresholds
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
 
 For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at the transaction level in **Transaction Summary > Settings**.
 

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -20,7 +20,7 @@ Below are the components of Apdex and its formula:
 * **Frustrated**: Users are frustrated with the app when their page load times are greater than 4T.
 * **Apdex**: (Number of Satisfactory Requests + (Number of Tolerable Requests/2)) / (Number of Total Requests)
 
-Configure what a satisfactory response time threshold (ms) is for Apdex in **Settings > Performance**. In our Early Adopter program, you can set this for each project with [custom thresholds](#custom-thresholds).
+Configure what a satisfactory response time threshold (ms) is for Apdex in **Settings > Performance**. You can set this for each project with [custom thresholds](#custom-thresholds).
 
 ## Failure Rate
 
@@ -79,7 +79,7 @@ Each of these functions is calculated with respect to the collection of transact
 
 User Misery is a user-weighted performance metric to assess the relative magnitude of your application performance. While you can examine the ratio of various response time threshold levels with [Apdex](#apdex), User Misery counts the number of unique users who were frustrated based on four times the satisfactory response time threshold (ms). User Misery highlights transactions that have the highest impact on users.
 
-In our Early Adopter program, you can set satisfactory thresholds for each project with [custom thresholds](#custom-thresholds).
+You can set satisfactory thresholds for each project with [custom thresholds](#custom-thresholds).
 
 ## Custom Thresholds
 


### PR DESCRIPTION
As we rollout GA, this feature is no longer
restricted to early adopters.