### PR TITLE
Java: Add BOM docs.

### DIFF
--- a/src/includes/getting-started-install/android.mdx
+++ b/src/includes/getting-started-install/android.mdx
@@ -26,4 +26,6 @@ dependencies {
 
 Sentry's Android SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
 
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
 </Note>

--- a/src/includes/getting-started-install/java.jul.mdx
+++ b/src/includes/getting-started-install/java.jul.mdx
@@ -15,3 +15,11 @@ libraryDependencies += "io.sentry" % "sentry-jul" % "{{ packages.version('sentry
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-jul).
+
+<Note>
+
+Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
+
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
+</Note>

--- a/src/includes/getting-started-install/java.log4j2.mdx
+++ b/src/includes/getting-started-install/java.log4j2.mdx
@@ -15,3 +15,11 @@ libraryDependencies += "io.sentry" % "sentry-log4j2" % "{{ packages.version('sen
 ```
 
 For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-log4j2).
+
+<Note>
+
+Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
+
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
+</Note>

--- a/src/includes/getting-started-install/java.logback.mdx
+++ b/src/includes/getting-started-install/java.logback.mdx
@@ -15,3 +15,11 @@ libraryDependencies += "io.sentry" % "sentry-logback" % "{{ packages.version('se
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-logback).
+
+<Note>
+
+Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
+
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
+</Note>

--- a/src/includes/getting-started-install/java.mdx
+++ b/src/includes/getting-started-install/java.mdx
@@ -26,4 +26,6 @@ libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.jav
 
 Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
 
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
 </Note>

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -22,4 +22,6 @@ For other dependency managers, see the [central Maven repository](https://search
 
 Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
 
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
 </Note>

--- a/src/includes/getting-started-install/java.spring-boot.mdx
+++ b/src/includes/getting-started-install/java.spring-boot.mdx
@@ -14,4 +14,6 @@ implementation 'io.sentry:sentry-spring-boot-starter:{{ packages.version('sentry
 
 Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
 
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
 </Note>

--- a/src/includes/getting-started-install/java.spring.mdx
+++ b/src/includes/getting-started-install/java.spring.mdx
@@ -20,4 +20,6 @@ For other dependency managers see the [central Maven repository](https://search.
 
 Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
 
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
 </Note>

--- a/src/platforms/android/configuration/bill-of-materials.mdx
+++ b/src/platforms/android/configuration/bill-of-materials.mdx
@@ -9,7 +9,7 @@ When you are using multiple Sentry dependencies, you can avoid specifying the ve
 Using Gradle 5.0 or higher, you can add the following to the `dependencies` section in your `build.gradle`:
 
 ```groovy {filename:build.gradle}
-implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java', '5.1.0') }}') //import bom
+implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java.bom', '5.1.0-beta.8') }}') //import bom
 implementation('io.sentry:sentry-android') //no version specified
 implementation('io.sentry:sentry-android-fragment') //no version specified
 ```

--- a/src/platforms/android/configuration/bill-of-materials.mdx
+++ b/src/platforms/android/configuration/bill-of-materials.mdx
@@ -1,0 +1,15 @@
+---
+title: Using a BOM
+description: "Learn more about using a bill of materials with multiple Sentry dependencies."
+sidebar_order: 1000
+---
+
+When you are using multiple Sentry dependencies, you can avoid specifying the version of each dependency with a *BOM* or *Bill Of Materials*.
+
+Using Gradle 5.0 or higher, you can add the following to the `dependencies` section in your `build.gradle`:
+
+```groovy {filename:build.gradle}
+implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java', '5.1.0') }}') //import bom
+implementation('io.sentry:sentry-android') //no version specified
+implementation('io.sentry:sentry-android-fragment') //no version specified
+```

--- a/src/platforms/java/common/configuration/bill-of-materials.mdx
+++ b/src/platforms/java/common/configuration/bill-of-materials.mdx
@@ -13,7 +13,7 @@ Using Maven, add the following to the `dependencyManagement` section in your `po
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-bom</artifactId>
-            <version>{{ packages.version('sentry.java', '5.1.0') }}</version>
+            <version>{{ packages.version('sentry.java.bom', '5.1.0-beta.8') }}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -37,7 +37,7 @@ Then use dependencies without specifying a version, for example:
 Using Gradle 5.0 or higher, you can add the following to the `dependencies` section in your `build.gradle`:
 
 ```groovy {filename:build.gradle}
-implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java', '5.1.0') }}') //import bom
+implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java.bom', '5.1.0-beta.8') }}') //import bom
 implementation('io.sentry:sentry') //no version specified
 implementation('io.sentry:sentry-logback') //no version specified
 ```

--- a/src/platforms/java/common/configuration/bill-of-materials.mdx
+++ b/src/platforms/java/common/configuration/bill-of-materials.mdx
@@ -1,0 +1,43 @@
+---
+title: Using a BOM
+sidebar_order: 1000
+---
+
+When you are using multiple Sentry dependencies, you can avoid specifying the version of each dependency with a *BOM* or *Bill Of Materials*.
+
+Using Maven, add the following to the `dependencyManagement` section in your `pom.xml`:
+
+```xml {tabTitle:Maven}{filename:pom.xml}
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-bom</artifactId>
+            <version>{{ packages.version('sentry.java', '5.1.0') }}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Then use dependencies without specifying a version, for example:
+
+```xml {tabTitle:Maven}{filename:pom.xml}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-logback</artifactId>
+</dependency>
+```
+
+Using Gradle 5.0 or higher, you can add the following to the `dependencies` section in your `build.gradle`:
+
+```groovy {filename:build.gradle}
+implementation platform('io.sentry:sentry-bom:{{ packages.version('sentry.java', '5.1.0') }}') //import bom
+implementation('io.sentry:sentry') //no version specified
+implementation('io.sentry:sentry-logback') //no version specified
+```


### PR DESCRIPTION
To be merged once Sentry Java BOM is shipped passed a preview phase i.e: 5.1.0

/cc @maciejwalkowiak 

See: https://github.com/getsentry/sentry-docs/pull/3832

:trollface: 

![image](https://user-images.githubusercontent.com/1633368/127071982-66660c3b-bccd-48c4-9a28-8bfd6cac9ab5.png)
