### PR TITLE
fix(scim): fix broken mailto rendering

### DIFF
--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -76,7 +76,7 @@ description: "Set up Azure Active Directory Single Sign-On (SSO) on Sentry."
 
 <Note>
 
-This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
+This feature is not currently available to all Sentry users. If you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
 
 </Note>
 

--- a/src/docs/product/accounts/sso/azure-sso.mdx
+++ b/src/docs/product/accounts/sso/azure-sso.mdx
@@ -75,7 +75,9 @@ description: "Set up Azure Active Directory Single Sign-On (SSO) on Sentry."
 ## SCIM Integration
 
 <Note>
-This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to support [support@sentry.io](mailto:support@sentry.io).
+
+This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
+
 </Note>
 
 Sentry users can manage provisioning using Azure with SCIM. You'll need to have Azure SSO set up and configured for your organization already. Sentry supports User and Group provisioning with Azure.

--- a/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
+++ b/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
@@ -5,7 +5,7 @@ description: "Set up Okta's SCIM Integration for Member and Team Provisioning"
 ---
 <Note>
 
-This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
+This feature is not currently available to all Sentry users. If you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
 
 </Note>
 

--- a/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
+++ b/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
@@ -4,7 +4,9 @@ sidebar_order: 3
 description: "Set up Okta's SCIM Integration for Member and Team Provisioning"
 ---
 <Note>
-This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to support [support@sentry.io](mailto:support@sentry.io).
+
+This feature is not currently available to all Sentry users. if you are interested in participating in SCIM's beta, please reach out to [support@sentry.io](mailto:support@sentry.io).
+
 </Note>
 
 ### Supported Features


### PR DESCRIPTION
it seems like unless you add a new line at the beginning and end of the content of an HTML element in our markdown docs, it will not render the contents as markdown. interesting. anyways, this fixes the broken mailto link on the SCIM pages.