### PR TITLE
fix(js): Clarify that loader does not include tracing features

### DIFF
--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -97,6 +97,8 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 ## **Limitations**
 
-Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, neither our [performance features](/product/performance/) nor the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
+Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
+
+For similar reasons, the loader is not available in a form which includes performance monitoring. If you want to monitor the performance of your app, including pageload times, please [bundle the SDK with your app](../npm) or use our CDN, specifically the [bundle which includes tracing features](../cdn/#performance-bundle).
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).


### PR DESCRIPTION
The way we're currently phrasing this, it makes it seem like tracing will start working once the SDK is loaded, which isn't true.

Fixes https://github.com/getsentry/sentry-javascript/issues/3054#issuecomment-827214249.