### PR TITLE
chore(performance): Remove EA note for key transactions

### DIFF
--- a/src/docs/product/performance/filters-display.mdx
+++ b/src/docs/product/performance/filters-display.mdx
@@ -71,10 +71,4 @@ The [Display Filter](#display-filter) controls what displays in the table column
 
 ### Starring Key Transactions
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 If you have transactions you frequently return to, you can mark them as a key transaction for any of your teams by clicking the star in the corresponding row. Each team can mark up to 100 transactions as a key transaction. These key transactions are shared with all members of the team ensuring the most important information is surfaced to the top of the list. You can also mark a transaction as a key transaction in its corresponding [summary view](/product/performance/transaction-summary/#starring-key-transactions).


### PR DESCRIPTION
There was an extra EA note that was missed in #3850.