### PR TITLE
fix Gradle plugin code snippet order

### DIFF
--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -17,26 +17,26 @@ The Android SDK ships with ProGuard rules automatically defined; no further conf
 Using Gradle (Android Studio) in your `app/build.gradle` add:
 
 ```groovy
-plugins {
-    id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '2.0.0') }}"
-}
-
 buildscript {
     repositories {
         mavenCentral()
     }
+}
+
+plugins {
+    id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '2.0.0') }}"
 }
 ```
 
 ```kotlin
-plugins {
-    id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '2.0.0') }}"
-}
-
 buildscript {
     repositories {
         mavenCentral()
     }
+}
+
+plugins {
+    id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '2.0.0') }}"
 }
 ```
 


### PR DESCRIPTION
all buildscript {} blocks must appear before any plugins {} blocks in the script