### PR TITLE
fix(elixir): add required hackney dependency to installation steps

### DIFF
--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -24,6 +24,7 @@ defp deps do
     # ...
     {:sentry, "~> 8.0"},
     {:jason, "~> 1.1"},
+    {:hackney, "~> 1.8"},
     # if you are using plug_cowboy
     {:plug_cowboy, "~> 2.3"}
   ]

--- a/src/wizard/elixir/index.md
+++ b/src/wizard/elixir/index.md
@@ -15,6 +15,7 @@ defp deps do
     # ...
     {:sentry, "~> 8.0"},
     {:jason, "~> 1.1"},
+    {:hackney, "~> 1.8"},
     # if you are using plug_cowboy
     {:plug_cowboy, "~> 2.3"}
   ]


### PR DESCRIPTION
As of version 8, [the Elixir plugin has an additional dependency](https://github.com/getsentry/sentry-elixir#installation).