### PR TITLE
Add business plan note for code owners

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -257,6 +257,12 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
 Import your existing GitHub CODEOWNERS files to automatically assign Sentry issues and route alerts to the responsible individuals and teams.
 
 For more details, see the full documentation for [Code Owners](/product/issues/issue-owners/#code-owners).

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -157,6 +157,12 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
 Import your existing GitLab CODEOWNERS files to automatically assign Sentry issues and route alerts to the responsible individuals and teams.
 
 For more details, see the full documentation for [Code Owners](/product/issues/issue-owners/#code-owners).

--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -68,6 +68,12 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
 ![Code Owners in UI](code_owners.png)
 
 Import your CODEOWNERS file and use it alongside your Ownership Rules to assign Sentry issues. You can import and incrementally add the mappings between your source control teams/users to Sentry Teams/Users using [External Team/User Mappings](/product/issues/issue-owners/#external-teamuser-mappings). Sentry will automatically ignore rules that are missing team/user mappings.


### PR DESCRIPTION
Add business plan note to code owners docs

<img width="784" alt="Screen Shot 2021-07-29 at 6 14 39 AM" src="https://user-images.githubusercontent.com/7978631/127498439-00e6d808-2aad-4a41-af53-e04550c8e6ba.png">
