### PR TITLE
fix(apple): SentrySDK.span

### DIFF
--- a/src/includes/performance/retrieve-transaction/apple.mdx
+++ b/src/includes/performance/retrieve-transaction/apple.mdx
@@ -1,11 +1,11 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.span`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
 
 ```swift {tabTitle:Swift}
 import Sentry
 
-var span = SentrySDK.getSpan()
+var span = SentrySDK.span
 
 if span == nil {
     span = SentrySDK.startTransaction(name: "task", operation: "op")
@@ -17,7 +17,7 @@ if span == nil {
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-id<Span> span = [SentrySDK getSpan];
+id<Span> span = SentrySDK.span;
 
 if (span == nil) {
     span = [SentrySDK startTransactionWithName:@"task" operation:@"op"];


### PR DESCRIPTION
The code sample for retrieving the current span was wrong. Instead of
SentrySDK.span it stated SentrySDK.getSpan(), which doesn't
exist in the SDK. This is fixed now.