### PR TITLE
feat(SDKs): Add second nestjs SDK to community SDK list

### DIFF
--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -27,7 +27,7 @@ These SDKs are maintained and supported by [the Sentry community](https://forum.
 - [_Grails_](https://github.com/agorapulse/grails-sentry)
 - [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)
 - [_Lua_](https://github.com/cloudflare/raven-lua)
-- [_NestJS_](https://github.com/ntegral/nestjs-sentry)
+- [_NestJS_](https://github.com/ntegral/nestjs-sentry) or [_NestJS_](https://github.com/mentos1386/nest-raven)
 - [_Nuxt_](https://github.com/nuxt-community/sentry-module)
 - [_OCaml_](https://github.com/brendanlong/sentry-ocaml)
 - [_Scrapy_](https://github.com/llonchj/scrapy-sentry)


### PR DESCRIPTION
In spite of the name, it's no longer based on `raven`, thankfully.