### PR TITLE
Show ReactElement as fallback in ErrorBoundary example

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -10,7 +10,7 @@ The React SDK exports an error boundary component that leverages [React componen
 import React from "react";
 import * as Sentry from "@sentry/react";
 
-<Sentry.ErrorBoundary fallback={"An error has occurred"}>
+<Sentry.ErrorBoundary fallback={<p>An error has occurred</p>}>
   <Example />
 </Sentry.ErrorBoundary>;
 ```
@@ -21,7 +21,7 @@ The Sentry Error Boundary is also available as a higher order component.
 import React from "react";
 import * as Sentry from "@sentry/react";
 
-Sentry.withErrorBoundary(Example, { fallback: "an error has occurred" });
+Sentry.withErrorBoundary(Example, { fallback: <p>an error has occurred</p> });
 ```
 
 <Alert level="warning" title="Note">


### PR DESCRIPTION
Docs fix as a follow-up from https://github.com/getsentry/sentry-javascript/pull/3857