### PR TITLE
chore(JS): Fix javascript label in snippet headers on troubleshooting page

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -84,7 +84,7 @@ Starting with version `6.7.0` of the JavaScript SDK, you can use the `tunnel` op
 
 To enable the `tunnel` option, provide either a relative or an absolute URL in your `Sentry.init` call. When you use a relative URL, it's relative to the current origin, and this is the form that we recommend. Using a relative URL will not trigger a preflight CORS request, so no events will be blocked, because the ad-blocker will not treat these events as third-party requests.
 
-```js
+```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tunnel: "/tunnel",
@@ -255,7 +255,7 @@ hub.withScope(function(scope) {
 Integrations are setup on the `Client`, if you need to deal with multiple clients and hubs you have to make sure to also do the integration handling correctly.
 Here is a working example of how to use multiple clients with multiple hubs running global integrations.
 
-```js
+```javascript
 import * as Sentry from "@sentry/browser";
 
 // Very happy integration that'll prepend and append very happy stick figure to the message


### PR DESCRIPTION
Elsewhere we have it spelled out as "JavaScript," and this way it gets capitalized correctly.