### PR TITLE
chore(JS): Spell out JS in snippet language headers

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -11,7 +11,7 @@ The Sentry Integration Platform provides developers with the ability to define U
 
 The UI components are specified in the schema section of integration details. The required form of this schema is:
 
-```js
+```javascript
 {
     "elements": [
         // Each element is a specification for a component the developer wants to use.
@@ -32,7 +32,7 @@ The Issue Link component displays "Link &lt;Service&gt; Issue" in the Issue side
 
 ### Schema
 
-```js
+```javascript
 {
     "type": "issue-link",
     "link": {
@@ -56,7 +56,7 @@ A `FormField` can be one of three types (which behave like their HTML equivalent
 
 ## Select
 
-```js
+```javascript
 {
     "type": "select",
     "label": <String>,
@@ -82,7 +82,7 @@ A `FormField` can be one of three types (which behave like their HTML equivalent
 
 The request sent to the `uri` to load options is a `GET` request. The parameters are encoded into the query parameters as such:
 
-```js
+```javascript
 {
     "installationId": <String>,
     "projectSlug": <String>,
@@ -100,7 +100,7 @@ The request sent to the `uri` to load options is a `GET` request. The parameters
 
 Response from `uri`, when specified, _must_ be in the following format:
 
-```js
+```javascript
 [
     {
         "label": <String>,
@@ -115,7 +115,7 @@ Response from `uri`, when specified, _must_ be in the following format:
 
 ### Schema
 
-```js
+```javascript
 {
     "type": "text",
     "label": <String>,
@@ -136,7 +136,7 @@ Response from `uri`, when specified, _must_ be in the following format:
 
 ### Schema
 
-```js
+```javascript
 {
     "type": "textarea",
     "label": <String>,
@@ -155,7 +155,7 @@ Response from `uri`, when specified, _must_ be in the following format:
 
 ### Example of a complete issue-link schema
 
-```js
+```javascript
 {
     "elements": [
         {
@@ -203,7 +203,7 @@ This feature allows the developer to insert a link within a stack trace frame. T
 
 ### Schema
 
-```js
+```javascript
 {
     "type": "stacktrace-link",
     "uri": <URI>,
@@ -220,7 +220,7 @@ This feature allows the developer to insert a link within a stack trace frame. T
 
 ### Example
 
-```js
+```javascript
 "elements": [
     {
         "type": "stacktrace-link",
@@ -243,7 +243,7 @@ The request that is sent is a `POST` request, so all the information is stored i
 
 ### Schema
 
-```js
+```javascript
 {
     "fields": <Object>,
     "installationId": <String>,
@@ -273,7 +273,7 @@ When creating or linking an issue, the response format _must_ have the following
 
 ### Schema
 
-```js
+```javascript
 {
     "webUrl": <String>,
     "project": <String>,

--- a/src/includes/getting-started-config/javascript.vue.mdx
+++ b/src/includes/getting-started-config/javascript.vue.mdx
@@ -2,7 +2,7 @@ To initialize Sentry in your Vue application, add this to your `app.js`:
 
 ### Vue 2
 
-```js
+```javascript
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -39,7 +39,7 @@ new Vue({
 
 ### Vue 3
 
-```js
+```javascript
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -75,7 +75,7 @@ Additionally, Vue 3 allows you to use multiple apps with the same Sentry SDK ins
 
 ### Vue 3 - Multiple Apps
 
-```js
+```javascript
 const appOne = Vue.createApp(App);
 const appTwo = Vue.createApp(App);
 const appThree = Vue.createApp(App);
@@ -87,7 +87,7 @@ Sentry.init({
 
 ### Vue 3 - Manual Initialization
 
-```js
+```javascript
 import * as Sentry from "@sentry/vue";
 
 // ...

--- a/src/includes/getting-started-verify/javascript.electron.mdx
+++ b/src/includes/getting-started-verify/javascript.electron.mdx
@@ -2,7 +2,7 @@ One way to verify your setup is by intentionally causing an error that breaks yo
 
 Calling an undefined function will throw an exception:
 
-```js
+```javascript
 myUndefinedFunction();
 ```
 

--- a/src/includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -49,7 +49,7 @@ If you want to track child components or use additional hooks to see more detail
 - `timeout` (defaults to `2000`) - Time in milliseconds dictating how long to wait until the tracked root activity is marked as finished and sent off to Sentry.
 - `hooks` (defaults to `['activate', 'mount', 'update']`) - List of hooks to keep track of during component lifecycle `'activate' | 'create' | 'destroy' | 'mount' | 'unmount' | 'update'`.
 
-```js
+```javascript
 Sentry.init({
   Vue,
   tracesSampleRate: 0.1,

--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -46,7 +46,7 @@ This integration wraps native APIs to capture breadcrumbs. By default, the Sentr
 
 Available options:
 
-```js
+```javascript
 {
   // Log calls to `console.log`, `console.debug`, etc
   console: boolean;
@@ -106,18 +106,20 @@ Available options:
 Here is a code example of how this could be implemented:
 
 ```javascript
-document.querySelector('#get-reviews-btn').addEventListener('click', async (event) => {
-  const movie = event.target.dataset.title;
-  try {
-    const reviews = await fetchMovieReviews(movie);
-    renderMovieReviews(reviews);
-  } catch (e) {
-    const fetchError = new Error(`Failed to fetch reviews for: ${movie}`);
-    fetchError.cause = e;
-    Sentry.captureException(fetchError);
-    renderMovieReviewsError(fetchError);
-  }
-});
+document
+  .querySelector("#get-reviews-btn")
+  .addEventListener("click", async event => {
+    const movie = event.target.dataset.title;
+    try {
+      const reviews = await fetchMovieReviews(movie);
+      renderMovieReviews(reviews);
+    } catch (e) {
+      const fetchError = new Error(`Failed to fetch reviews for: ${movie}`);
+      fetchError.cause = e;
+      Sentry.captureException(fetchError);
+      renderMovieReviewsError(fetchError);
+    }
+  });
 ```
 
 ### UserAgent

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -84,7 +84,7 @@ Starting with version `6.7.0` of the JavaScript SDK, you can use the `tunnel` op
 
 To enable the `tunnel` option, provide either a relative or an absolute URL in your `Sentry.init` call. When you use a relative URL, it's relative to the current origin, and this is the form that we recommend. Using a relative URL will not trigger a preflight CORS request, so no events will be blocked, because the ad-blocker will not treat these events as third-party requests.
 
-```js
+```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tunnel: "/tunnel",
@@ -255,7 +255,7 @@ hub.withScope(function(scope) {
 Integrations are setup on the `Client`, if you need to deal with multiple clients and hubs you have to make sure to also do the integration handling correctly.
 Here is a working example of how to use multiple clients with multiple hubs running global integrations.
 
-```js
+```javascript
 import * as Sentry from "@sentry/browser";
 
 // Very happy integration that'll prepend and append very happy stick figure to the message

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -21,7 +21,7 @@ We support integrations for React Router 3, 4 and 5.
 
 To use the router integration, import and set a custom routing instrumentation using a custom history. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
-```js
+```javascript
 import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 
@@ -66,7 +66,7 @@ To get parameterized transaction names (ex. `/teams/:teamid/user/:userid` instea
 
 You can pass an array of route config objects as per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config). to the instrumentation function call. You will also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
 
-```js
+```javascript
 import { Route, Router, Switch, matchPath } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 
@@ -108,7 +108,7 @@ render() {
 
 Use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render.
 
-```js
+```javascript
 import {Route, Router, Switch } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 
@@ -149,7 +149,7 @@ render() {
 
 To use the router integration, import and set a custom routing instrumentation and pass it the history, your routes and a match function. React Router v3 support is maintained for React Router >= 3.2.0 and < 4.0.0.
 
-```js
+```javascript
 import * as Router from "react-router";
 
 import * as Sentry from "@sentry/react";

--- a/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/redux.mdx
@@ -9,7 +9,7 @@ _(Available in version 5.20.0 and above)_
 
 Redux support is included in the `@sentry/react` package since version `5.20.0`. To apply Sentry to Redux, use `Sentry.createReduxEnhancer` at the same place that you initialize your Redux store.
 
-```js
+```javascript
 import { createStore, compose } from "redux";
 import * as Sentry from "@sentry/react";
 
@@ -26,7 +26,7 @@ const store = createStore(rootReducer, sentryReduxEnhancer);
 
 If you have other enhancers or middleware such as `thunk`:
 
-```js
+```javascript
 const store = createStore(
   rootReducer,
   compose(applyMiddleware(thunk), sentryReduxEnhancer)
@@ -43,7 +43,7 @@ Sentry uses a redux **enhancer**. Pass the enhancer, as indicated above. Don't p
 
 By default Sentry SDKs normalize any context to a depth of 3, which in the case of sending Redux state you probably will want to increase that. You do so by passing `normalizeDepth` to the `Sentry.init` call:
 
-```js
+```javascript
 Sentry.init({
   dsn: "___DSN___",
   normalizeDepth: 10, // Or however deep you want your state context to be.
@@ -64,7 +64,7 @@ We advise against sending sensitive information to Sentry, but if you do, we wil
 
 : Used to remove sensitive information from actions. The first parameter passed to the function is the Redux action. Return `null` to not send the action to Sentry. By default we send all actions.
 
-```js
+```javascript
 const sentryReduxEnhancer = Sentry.createReduxEnhancer({
   actionTransformer: action => {
     if (action.type === "GOVERNMENT_SECRETS") {
@@ -88,7 +88,7 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
 
 : Used to remove sensitive information from state. The first parameter passed to the function is the Redux state. Return `null` to not attach the state to events sent to Sentry. Note that if you choose not to send state to Sentry, your errors might not have the latest version of the state attached. By default, we attach all state changes.
 
-```js
+```javascript
 const sentryReduxEnhancer = Sentry.createReduxEnhancer({
   stateTransformer: state => {
     if (state.topSecret.doNotSend) {
@@ -119,7 +119,7 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
 
 : Called on every state update, configure the Sentry Scope with the Redux state. The first parameter is the scope, which is the same scope instance that you would get when you call `Sentry.configureScope`, and the second parameter is the latest Redux state.
 
-```js
+```javascript
 const sentryReduxEnhancer = Sentry.createReduxEnhancer({
   configureScopeWithState: (scope, state) => {
     // Set tag if the user is using imperial units.

--- a/src/platforms/javascript/guides/vue/configuration/integrations/vue-router.mdx
+++ b/src/platforms/javascript/guides/vue/configuration/integrations/vue-router.mdx
@@ -22,7 +22,7 @@ Sentry built the new tracing capabilities into the original Vue error handler in
 
 The most basic configuration for tracing your Vue app, which would track only the top-level component, looks like this:
 
-```js
+```javascript
 import Vue from "vue";
 import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
@@ -39,7 +39,7 @@ Sentry.init({
 
 If you want to track child components, and see more details about the rendering process, configure the integration to track them all:
 
-```js
+```javascript
 Sentry.init({
   Vue,
   trackComponents: true,
@@ -48,7 +48,7 @@ Sentry.init({
 
 Or, you can choose more granularity:
 
-```js
+```javascript
 Sentry.init({
   Vue,
   integrations: [new Integrations.BrowserTracing()],
@@ -64,7 +64,7 @@ Sentry.init({
 
 If you want to know if some components are, for example, removed during the initial page load, add a `destroy` hook to the default:
 
-```js
+```javascript
 Sentry.init({
   Vue,
   integrations: [new Integrations.BrowserTracing()],
@@ -82,7 +82,7 @@ Sentry.init({
 You can specify how long a top-level activity should wait for the last component to render.
 Every new rendering cycle is debouncing the timeout, and it starts counting from the beginning. Once the timeout is reached, tracking is completed, and all the information is sent to Sentry.
 
-```js
+```javascript
 Sentry.init({
   Vue,
   integrations: [new Integrations.BrowserTracing()],
@@ -93,7 +93,7 @@ Sentry.init({
 
 **Configuration**
 
-```js
+```javascript
 tracingOptions: {
   /**
    * Decides whether to track components by hooking into its lifecycle methods.
@@ -120,7 +120,7 @@ tracingOptions: {
 
 If you are using Vue Router, you can use our provided integration for better transaction names. Here is a full example how to use it:
 
-```js
+```javascript
 import Vue from "vue";
 import App from "./App";
 import * as Sentry from "@sentry/vue";

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -58,7 +58,7 @@ This integration wraps `http` and `https` modules to capture all network request
 
 Available options:
 
-```js
+```javascript
 {
   breadcrumbs: boolean; // default: true
   tracing: boolean; // default: false
@@ -80,7 +80,7 @@ Be aware that if you overwrite this setting, you will lose the default implement
 
 Available options:
 
-```js
+```javascript
 {
   onFatalError: (firstError: Error, secondError?: Error) => void;
 }
@@ -94,7 +94,7 @@ This integration attaches a global unhandled rejection handler. By default, all 
 
 Available options:
 
-```js
+```javascript
 {
   mode: "none" | "warn" | "strict"; // default: "warn"
 }
@@ -108,7 +108,7 @@ This integration allows you to configure linked errors. They'll be recursively r
 
 Available options:
 
-```js
+```javascript
 {
   key: string; // default: "cause"
   limit: number; // default: 5

--- a/src/platforms/node/guides/connect/index.mdx
+++ b/src/platforms/node/guides/connect/index.mdx
@@ -62,7 +62,7 @@ connect(
 
 Possible options are:
 
-```js
+```javascript
 // keys to be extracted from the request
 request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
 
@@ -90,7 +90,7 @@ flushTimeout?: number; // default: 2000
 
 For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.requestHandler({
     serverName: false,
@@ -101,7 +101,7 @@ app.use(
 
 By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts a middleware error as its argument, decides whether an event should be sent to Sentry or not, and returns the appropriate boolean value.
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.errorHandler({
     shouldHandleError(error) {

--- a/src/platforms/node/guides/express/index.mdx
+++ b/src/platforms/node/guides/express/index.mdx
@@ -54,7 +54,7 @@ app.listen(3000);
 
 You can verify the Sentry integration by creating a route that will throw an error:
 
-```js
+```javascript
 app.get("/debug-sentry", function mainHandler(req, res) {
   throw new Error("My first Sentry error!");
 });
@@ -103,7 +103,7 @@ app.use(
 
 By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts middleware errors as its argument and decides, whether an error should be sent or not, by returning an appropriate boolean value.
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.errorHandler({
     shouldHandleError(error) {
@@ -163,11 +163,11 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({ 
+    new Tracing.Integrations.Express({
       // to trace all requests to the default router
-      app, 
+      app,
       // alternatively, you can specify the routes you want to trace:
-      // router: someRouter, 
+      // router: someRouter,
     }),
   ],
 

--- a/src/platforms/react-native/touchevents.mdx
+++ b/src/platforms/react-native/touchevents.mdx
@@ -109,7 +109,7 @@ Sentry.withTouchEventBoundary(App, { maxComponentTreeSize: 15 });
 
 When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that you won't get the full original component names in your Touch Event breadcrumbs. A way to work with this is to set the `displayName` on all the components you want to track. However, you can also configure Metro bundler to not minify function names by setting these options in `metro.config.js`:
 
-```js
+```javascript
 module.exports = {
   transformer: {
     minifierConfig: {

--- a/src/wizard/cordova/index.md
+++ b/src/wizard/cordova/index.md
@@ -24,6 +24,6 @@ One way to verify your setup is by intentionally causing an error that breaks yo
 
 Calling an undefined function will throw an exception:
 
-```js
+```javascript
 myUndefinedFunction();
 ```

--- a/src/wizard/electron/index.md
+++ b/src/wizard/electron/index.md
@@ -28,7 +28,7 @@ One way to verify your setup is by intentionally causing an error that breaks yo
 
 Calling an undefined function will throw an exception:
 
-```js
+```javascript
 myUndefinedFunction();
 ```
 

--- a/src/wizard/javascript/backbone.md
+++ b/src/wizard/javascript/backbone.md
@@ -37,7 +37,7 @@ We recommend adjusting the value of `tracesSampleRate` in production. Learn more
 
 Then create an intentional error, so you can test that everything is working:
 
-```js
+```javascript
 myUndefinedFunction();
 ```
 

--- a/src/wizard/javascript/browser.md
+++ b/src/wizard/javascript/browser.md
@@ -37,7 +37,7 @@ We recommend adjusting the value of `tracesSampleRate` in production. Learn more
 
 Then create an intentional error, so you can test that everything is working:
 
-```js
+```javascript
 myUndefinedFunction();
 ```
 

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -37,7 +37,7 @@ We recommend adjusting the value of `tracesSampleRate` in production. Learn more
 
 This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
 
-```js
+```javascript
 myUndefinedFunction();
 ```
 

--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -30,7 +30,7 @@ Next, initialize Sentry in your app entry point before you initialize your root 
 
 #### Vue 2
 
-```js
+```javascript
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -54,22 +54,22 @@ Sentry.init({
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production
-  tracesSampleRate: 1.0
+  tracesSampleRate: 1.0,
 });
 
 // ...
 
 new Vue({
   router,
-  render: h => h(App)
+  render: h => h(App),
 }).$mount("#app");
 ```
 
 #### Vue 3
 
-```js
+```javascript
 import { createApp } from "vue";
-import { createRouter } from 'vue-router'
+import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
 import { Integrations } from "@sentry/tracing";
 
@@ -92,7 +92,7 @@ Sentry.init({
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production
-  tracesSampleRate: 1.0
+  tracesSampleRate: 1.0,
 });
 
 app.use(router);

--- a/src/wizard/node/connect.md
+++ b/src/wizard/node/connect.md
@@ -57,7 +57,7 @@ connect(
 
 Possible options are:
 
-```js
+```javascript
 // keys to be extracted from req
 request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
 // server name
@@ -79,7 +79,7 @@ flushTimeout?: number; // default: 2000
 
 For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.requestHandler({
     serverName: false,
@@ -90,7 +90,7 @@ app.use(
 
 By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts middleware errors as its argument and decides, whether an error should be sent or not, by returning an appropriate boolean value.
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.errorHandler({
     shouldHandleError(error) {

--- a/src/wizard/node/express.md
+++ b/src/wizard/node/express.md
@@ -73,7 +73,7 @@ The above configuration captures both error and performance data. To reduce the 
 
 You can verify the Sentry integration is working by creating a route that will throw an error:
 
-```js
+```javascript
 app.get("/debug-sentry", function mainHandler(req, res) {
   throw new Error("My first Sentry error!");
 });
@@ -83,7 +83,7 @@ app.get("/debug-sentry", function mainHandler(req, res) {
 
 Possible options are:
 
-```js
+```javascript
 // keys to be extracted from req
 request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
 // server name
@@ -105,7 +105,7 @@ flushTimeout?: number; // default: undefined
 
 For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.requestHandler({
     serverName: false,
@@ -116,7 +116,7 @@ app.use(
 
 By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts middleware errors as its argument and decides, whether an error should be sent or not, by returning an appropriate boolean value.
 
-```js
+```javascript
 app.use(
   Sentry.Handlers.errorHandler({
     shouldHandleError(error) {


### PR DESCRIPTION
For consistency and appropriate casing. Follow-up to https://github.com/getsentry/sentry-docs/pull/3965, which I accidentally closed by changing the branch name.