### PR TITLE
Remove unneccessary `{ }` from the fallback prop

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -10,7 +10,7 @@ The React SDK exports an error boundary component that leverages [React componen
 import React from "react";
 import * as Sentry from "@sentry/react";
 
-<Sentry.ErrorBoundary fallback={"An error has occurred"}>
+<Sentry.ErrorBoundary fallback="An error has occurred">
   <Example />
 </Sentry.ErrorBoundary>;
 ```


### PR DESCRIPTION
This is going to throw an error in most people's linters, including the default rules in create-react-app and create-next-app