### PR TITLE
Describe the 1h timeperiod for AppStoreConnect

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -24,6 +24,8 @@ When you use the App Store Connect integration, Sentry will automatically discov
 
 To configure the integration, go to **[Project] > Settings > Debug Files** and add App Store Connect as a new "Custom Repository". Note that setting up the integration will currently result in two identical audit entries being created.
 
+Once setup the integration will ensure that new builds are detected and fetched within an hour of being available on App Store Connect.
+
 During Early Access, App Store Connect integration is limited to a single source per project. Free subscription plans will remain limited to one App Store Connect source per project, though subscribers to our Business plan will in future be able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
 
 Setting up App Store Connect currently requires two separate credentials.


### PR DESCRIPTION
Users need to be aware of when builds will become available.