### PR TITLE
chore(performence): Removed EA note from All Events tab documentation

### DIFF
--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -88,12 +88,6 @@ The **Tags** tab displays a list of suspect tag keys that often correspond to sl
 
 ## All Events
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 The table in **All Events** tab offers a full list of transactions broken down similar to the abbreviated table in the overview. Filters are carried across from other views. You can also narrow the events down by percentile.
 
 ## Additional Actions


### PR DESCRIPTION
The Performance All Events tab has been GA'd. The EA note on the All Events documentation is no longer needed so we're removing in this pr.