### PR TITLE
Fix typo in Relay docs

### DIFF
--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -104,7 +104,7 @@ These settings control the network-related configuration.
 
   Maximum interval between failed request retries in seconds.
 
-`host.header`
+`http.host_header`
 
 : _String, default: `null`_
 


### PR DESCRIPTION
The correct configuration key is `host_header` inside the `http` section.