### PR TITLE
Document the variant filtering feature

### DIFF
--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -140,7 +140,7 @@ If you experience issues like `Could not find class` on devices running the `Dal
 
 ### Variant Filtering
 
-If you wish, you can specify which variant/flavor/build-type should be ignored by Sentry. Specifically you can do so inside your `app/build.gradle` file:
+You can specify which variant/flavor/build-type should be ignored by Sentry in your `app/build.gradle` file:
 
 ```groovy
 sentry {

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -137,3 +137,33 @@ And, add to `multidex-config.pro` the following lines:
 ```
 
 If you experience issues like `Could not find class` on devices running the `Dalvik VM`, you may expand the above rules to keep the necessary classes in the main dex file.
+
+### Variant Filtering
+
+If you wish, you can specify which variant/flavor/build-type should be ignored by Sentry. Specifically you can do so inside your `app/build.gradle` file:
+
+```groovy
+sentry {
+    // List the build types that should be ignored (e.g. "release").
+    ignoredBuildTypes = ["release"]
+
+    // List the build flavors that should be ignored (e.g. "production").
+    ignoredFlavors = ["production"]
+
+    // List the build variant that should be ignored (e.g. "productionRelease").
+    ignoredVariants = ["productionRelease"]
+}
+```
+
+```kotlin
+sentry {
+    // List the build types that should be ignored (e.g. "release").
+    ignoredBuildTypes = listOf("release")
+
+    // List the build flavors that should be ignored (e.g. "production").
+    ignoredFlavors = listOf("production")
+
+    // List the build variant that should be ignored (e.g. "productionRelease").
+    ignoredVariants = listOf("productionRelease")
+}
+```


### PR DESCRIPTION
Fixes #3893

This PR adds documentation for the variant filtering feature shipped with the Gradle plugin: https://github.com/getsentry/sentry-android-gradle-plugin/pull/140