### PR TITLE
docs: add steps in troubleshooting

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -279,7 +279,7 @@ If you’re having issues adding a GitHub repository:
 
 - Make sure you are the Owner of your GitHub organization.
 - Make sure you are either an Admin, Manager, or Owner of your Sentry organization.
-- [Disconnect](https://sentry.io/account/settings/identities/) your GitHub Identity, then [reconnect](https://sentry.io/account/settings/social/associate/github/) your GitHub Identity.
+- [Disconnect](https://sentry.io/account/settings/identities/), and then [reconnect](https://sentry.io/account/settings/social/associate/github/) your GitHub Identity.
 
 If you're having trouble setting up Sentry with your on-premises integration, verify the following:
 

--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -17,7 +17,7 @@ This integration needs to set up only once per organization, then it is availabl
 
 <Note>
 
-Sentry owner or manager permissions, and GitHub owner permissions are required to install this integration.
+Sentry owner, manager or admin permissions, and GitHub owner permissions are required to install this integration.
 
 </Note>
 
@@ -274,6 +274,12 @@ Single Sign-On (or SSO) allows you to manage your organization’s entire member
 For more details, see the full documentation for [Single Sign-on](/product/accounts/sso/).
 
 ## Troubleshooting
+
+If you’re having issues adding a GitHub repository:
+
+- Make sure you are the Owner of your GitHub organization.
+- Make sure you are either an Admin, Manager, or Owner of your Sentry organization.
+- [Disconnect](https://sentry.io/account/settings/identities/) your GitHub Identity, then [reconnect](https://sentry.io/account/settings/social/associate/github/) your GitHub Identity.
 
 If you're having trouble setting up Sentry with your on-premises integration, verify the following:
 


### PR DESCRIPTION
- Move the troubleshooting steps from https://help.sentry.io/product-features/integrations/github-why-can-t-i-add-a-repository/
- Make a minor adjustment to the access level required to setup the integration