### PR TITLE
docs: add troubleshooting step

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -196,4 +196,4 @@ For more details, see the full documentation for [Code Owners](/product/issues/i
   - You must have both owner/manager/admin permissions in Sentry and owner permissions in GitLab to successfully install this integration.
  
 - Why am I getting a `500` response during installation or configuration?
-  - First, make sure you’ve allowed our IPs which can be found [ here ](/product/security/ip-ranges/). Additionally, the 500 response is coming from GitLab so you may need to try again or double-check that your settings and permissions are correct in GitLab. You must have both owner/manager/admin permissions in Sentry as well as owner permissions in GitLab to successfully install this integration.
+  - First, make sure you’ve allowed our IPs, which can be found [here](/product/security/ip-ranges/). The 500 response is coming from GitLab, so you may need to try again or double-check that your settings and permissions are correct in GitLab. You must have both owner/manager/admin permissions in Sentry as well as owner permissions in GitLab to successfully install this integration.

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -16,7 +16,7 @@ This integration needs to set up only once per organization, then it is availabl
 
 <Note>
 
-Sentry owner or manager permissions and GitLab owner or maintainer permissions are required to install this integration.
+Sentry owner, manager or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
 
 </Note>
 
@@ -193,4 +193,7 @@ For more details, see the full documentation for [Code Owners](/product/issues/i
   - This integration is available for organizations on the [Team, Business, or Enterprise plan](https://sentry.io/pricing/).
 
 - Who has permission to install this?
-  - You must have both owner/manager permissions in Sentry and owner permissions in GitLab to successfully install this integration.
+  - You must have both owner/manager/admin permissions in Sentry and owner permissions in GitLab to successfully install this integration.
+ 
+- Why am I getting a `500` response during installation or configuration?
+  - First, make sure you’ve allowed our IPs which can be found [ here ](/product/security/ip-ranges/). Additionally, the 500 response is coming from GitLab so you may need to try again or double-check that your settings and permissions are correct in GitLab. You must have both owner/manager/admin permissions in Sentry as well as owner permissions in GitLab to successfully install this integration.

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -16,7 +16,7 @@ This integration needs to set up only once per organization, then it is availabl
 
 <Note>
 
-Sentry owner, manager or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
+Sentry owner, manager, or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
 
 </Note>
 


### PR DESCRIPTION
- Move troubleshooting step from https://help.sentry.io/product-features/integrations/gitlab-why-am-i-getting-a-500-response-during-installation-or-configuration/
- Minor correction to the Sentry user level access that is requred