### PR TITLE
Update default log level typo

### DIFF
--- a/src/docs/product/cli/configuration.mdx
+++ b/src/docs/product/cli/configuration.mdx
@@ -143,7 +143,7 @@ The following settings are available (first is the environment variable, the val
 
 `SENTRY_LOG_LEVEL` (_log.level_):
 
-: Configures the log level for the SDK. The default is `warning`. If you want to see what the library is doing you can set it to `info` which will spit out more information which might help to debug some issues with permissions.
+: Configures the log level for the SDK. The default is `warn`. If you want to see what the library is doing you can set it to `info` which will spit out more information which might help to debug some issues with permissions.
 
 (_dsym.max_upload_size_):
 


### PR DESCRIPTION
not sure if `warning` is an alias for `warn` but seeing sentry-clis code, its wrong: https://github.com/getsentry/sentry-cli/blob/e51e11302567dba927abc7f8383cf2d5b22c517b/src/commands/mod.rs#L231