### PR TITLE
Java: adjust docs on default value for Spring's `exceptionResolverOrder`

### DIFF
--- a/src/includes/getting-started-config/java.spring-boot.mdx
+++ b/src/includes/getting-started-config/java.spring-boot.mdx
@@ -11,7 +11,7 @@ sentry:
   dsn: ___PUBLIC_DSN___
 ```
 
-By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring `sentry.exception-resolver-order` property. For example, setting it to `-2147483647` (the value of `org.springframework.core.Ordered#HIGHEST_PRECEDENCE`) makes sure exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
+By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring the `sentry.exception-resolver-order` property. For example, setting it to `-2147483647` (the value of `org.springframework.core.Ordered#HIGHEST_PRECEDENCE`) ensures exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
 
 ```properties {filename:application.properties}
 sentry.exception-resolver-order=2147483647

--- a/src/includes/getting-started-config/java.spring-boot.mdx
+++ b/src/includes/getting-started-config/java.spring-boot.mdx
@@ -11,7 +11,7 @@ sentry:
   dsn: ___PUBLIC_DSN___
 ```
 
-By default, every unhandled exception is sent to Sentry, even those captured with `@ExceptionHandler` annotated methods. This behavior can be tuned through configuring `sentry.exception-resolver-order` property. For example, setting it to `2147483647` (the value of `org.springframework.core.Ordered#LOWEST_PRECEDENCE`) makes sure only exceptions that have not been handled by exception resolvers with higher order are sent to Sentry.
+By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring `sentry.exception-resolver-order` property. For example, setting it to `-2147483647` (the value of `org.springframework.core.Ordered#HIGHEST_PRECEDENCE`) makes sure exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
 
 ```properties {filename:application.properties}
 sentry.exception-resolver-order=2147483647

--- a/src/includes/getting-started-config/java.spring.mdx
+++ b/src/includes/getting-started-config/java.spring.mdx
@@ -23,7 +23,7 @@ The DSN can be also provided through the system property `sentry.dsn`, environme
 
 Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), to record breadcrumbs, set the current user, or manually send events, for example.
 
-By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring `exceptionResolverOrder` property. For example, setting it to `Ordered#HIGHEST_PRECEDENCE` makes sure exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
+By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring the `exceptionResolverOrder` property. For example, setting it to `Ordered#HIGHEST_PRECEDENCE` ensures exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
 
 ```java {tabTitle:Java}
 import io.sentry.spring.EnableSentry;

--- a/src/includes/getting-started-config/java.spring.mdx
+++ b/src/includes/getting-started-config/java.spring.mdx
@@ -23,7 +23,7 @@ The DSN can be also provided through the system property `sentry.dsn`, environme
 
 Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), to record breadcrumbs, set the current user, or manually send events, for example.
 
-By default, every unhandled exception is sent to Sentry, even those captured with `@ExceptionHandler` annotated methods. This behavior can be tuned through configuring `exceptionResolverOrder` property on `@EnableSentry` annotation. For example, setting it to `Ordered.LOWEST_PRECEDENCE` makes sure only exceptions that have not been handled by exception resolvers with higher order are sent to Sentry.
+By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring `exceptionResolverOrder` property. For example, setting it to `Ordered#HIGHEST_PRECEDENCE` makes sure exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
 
 ```java {tabTitle:Java}
 import io.sentry.spring.EnableSentry;


### PR DESCRIPTION
The behavior has changed in https://github.com/getsentry/sentry-java/commit/a13796d05828bb40c96231ff25067d53b6b5ac92