### PR TITLE
fix(billing): Clarify spike protection inactivation

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -280,9 +280,9 @@ When the next minute begins, we again record up to 60 events, dropping the rest 
 
 If, instead of a single big spike (or an overall, permanent, increase in traffic), you experience many small spikes, there may be many days in a row when at least a few events are dropped. In that scenario, spike protection remains active the entire time.
 
-### When Does Spike Protection Become Inactive?
+### When Does Spike Protection Become "Inactive?"
 
-Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes inactive again.
+Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
 ## Size Limits
 


### PR DESCRIPTION
Our nomenclature with respect to spike protection being "active" or "inactive" is very misleading. This aims to clarify, at least a little, what it means to be "inactive."