### PR TITLE
Update quota notification docs

### DIFF
--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -52,7 +52,7 @@ Sentry sends deploy notifications to users who have committed to the release tha
 
 Sentry sends quota notifications to all owners of an organization when:
 
-- 80% of the organization's error, transaction, and attachment volume has been depleted **and** there is a projected overage for the billing period. If it’s not projected that your account will go over quota before the end of the billing period, you won’t receive this notification.
+- 80% of the organization's error, transaction, and attachment volume has been depleted.
 - Errors or transactions have exceeded the organization's quota, which includes on-demand capacity
 
 You cannot change or disable these notifications. Learn more in the [full Quotas documentation](/product/accounts/quotas/).


### PR DESCRIPTION
We no longer check for projected overage anymore. Notifications are always sent when an account reaches 80% usage.