### PR TITLE
fix issues page headings and link in mdx components page

### DIFF
--- a/src/docs/contributing/pages/components.mdx
+++ b/src/docs/contributing/pages/components.mdx
@@ -112,9 +112,10 @@ Use this for these types of content:
 
 - **Prerequisite(s):** Use these to list things that are required to finish. Place them prior to the procedure/process that follows so a user doesn't start and stop.
 - **Note:** to document information that's relevant to the topic, but isn't part of the larger point of the content. This might include a piece of information that should be highlighted, but isn't necessarily more important than other information. These include calling out early adopter features or providing clarification. Use sparingly.
-See also the [Alert component](#alert).
 
 Don't use a title with this type of note.
+
+See also the [Alert component](#alert).
 
 ## PageGrid
 

--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -32,7 +32,7 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
-### Display Options
+## Display Options
 
 <Note>
   The "Events as %" display option is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.


### PR DESCRIPTION
Fixes heading level in Issues page so that RH sidebar renders properly
Moves placement of link text in Notes section of mdx components page in Contributing to Docs