### PR TITLE
Mention that allow/denyUrls accept regexps

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -182,14 +182,14 @@ will attempt to auto-discover this value.
 
 <ConfigKey name="deny-urls" supported={["javascript"]} notSupported={["node"]}>
 
-A list of strings or regex patterns that match error URLs that should not be sent to Sentry. By default, all errors will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
+A list of strings or regex patterns that match error URLs that should not be sent to Sentry. By default, all errors will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. You can also use regexps to match URLs. By default, all errors will be sent.
 
 </ConfigKey>
 
 <ConfigKey name="allow-urls" supported={["javascript"]} notSupported={["node"]}>
 
 A list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. By default, all errors
-will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors will be sent.
+will be sent. This is a "contains" match to the entire file URL. As a result, if you add `foo.com` to it, it will also match on `https://bar.com/myfile/foo.com`. You can also use regexps to match URLs. By default, all errors will be sent.
 
 </ConfigKey>
 


### PR DESCRIPTION
The `allowUrls` and `denyUrls` lists [are compared to the event URL](https://github.com/getsentry/sentry-javascript/blob/74a08294122a0a900b9299919a3dd2d5a8a6e694/packages/core/src/integrations/inboundfilters.ts#L128-L145) using `isMatchingPattern`, which admits regular expression arguments. These are nice to either more precisely match, using `^` and `$`, or match a variety of e.g., subdomains.

I'd also like to add some documentation for the `ignoreErrors` option which I don't think has its own section, so any pointers on how that can be added would be appreciated! I've never used Gatsby