### PR TITLE
fix: Display body parameter information in API docs

### DIFF
--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -52,7 +52,7 @@ export const getApiTypeDefs = () => {
         required: Boolean
       }
 
-      type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter, openApiBodyParameter"], mimeTypes: ["text/markdown"]) {
+      type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter", "openApiBodyParameter"], mimeTypes: ["text/markdown"]) {
         body: String
       }
       `,

--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -23,17 +23,17 @@ export const getApiTypeDefs = () => {
         query_parameters: [ApiParam]
         warning: String
       }
-      
+
       type ApiParameterSchema {
         enum: [String]
         format: String
         type: String
       }
-      
+
       type openApiPathDescription implements Node @childOf(types: ["openAPI"], ) {
         id: ID!
       }
-      
+
       type openApiPathParameter implements Node @childOf(types: ["openAPI"], many: true) {
         id: ID!
         schema: ApiParameterSchema
@@ -42,7 +42,14 @@ export const getApiTypeDefs = () => {
         description: String
         required: Boolean
       }
-      
+
+      type openApiBodyParameter implements Node @childOf(types: ["openAPI"], many: true) {
+        id: ID!
+        name: String
+        description: String
+        type: String
+      }
+
       type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter"], mimeTypes: ["text/markdown"]) {
         body: String
       }

--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -51,7 +51,8 @@ export const getApiTypeDefs = () => {
         description: String
         required: Boolean
       }
-      type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter"], mimeTypes: ["text/markdown"]) {
+
+      type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter, openApiBodyParameter"], mimeTypes: ["text/markdown"]) {
         body: String
       }
       `,

--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -51,7 +51,6 @@ export const getApiTypeDefs = () => {
         description: String
         required: Boolean
       }
-
       type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter"], mimeTypes: ["text/markdown"]) {
         body: String
       }

--- a/src/gatsby/createSchemaCustomization/apiSchema.ts
+++ b/src/gatsby/createSchemaCustomization/apiSchema.ts
@@ -45,9 +45,11 @@ export const getApiTypeDefs = () => {
 
       type openApiBodyParameter implements Node @childOf(types: ["openAPI"], many: true) {
         id: ID!
+        schema: ApiParameterSchema
         name: String
+        in: String
         description: String
-        type: String
+        required: Boolean
       }
 
       type Mdx implements Node @childOf(types: ["openApiPathDescription", "openApiPathParameter"], mimeTypes: ["text/markdown"]) {

--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -4,9 +4,8 @@ import {
   DeRefedOpenAPI,
   OpenApiPath,
   RequestBody,
+  RequestBodySchema,
 } from "./types";
-
-import { RequestBodySchema } from "~src/gatsby/plugins/gatsby-plugin-openapi/types";
 
 export const sourceNodes = async (
   { actions, createNodeId, createContentDigest },
@@ -188,10 +187,12 @@ export const onCreateNode = async ({
       });
     });
 
+    // Optional chaining seems to affect the Vercel build process
     const bodyParameterSchemaString =
       node.path.requestBody !== null &&
       node.path.requestBody.content !== null &&
       node.path.requestBody.content.schema;
+
     if (bodyParameterSchemaString) {
       const bodyParameterSchema: RequestBodySchema = JSON.parse(
         bodyParameterSchemaString

--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -188,13 +188,18 @@ export const onCreateNode = async ({
       });
     });
 
-    const bodyParameterSchemaString = node.path?.requestBody?.content?.schema;
+    const bodyParameterSchemaString =
+      node.path.requestBody !== null &&
+      node.path.requestBody.content !== null &&
+      node.path.requestBody.content.schema;
     if (bodyParameterSchemaString) {
       const bodyParameterSchema: RequestBodySchema = JSON.parse(
         bodyParameterSchemaString
       );
-      const bodyParameterRequired = { ...bodyParameterSchema?.required };
-      Object.entries(bodyParameterSchema?.properties).map(
+      const bodyParameterRequired = {
+        ...(bodyParameterSchema.required || []),
+      };
+      Object.entries(bodyParameterSchema.properties || []).map(
         ([name, { type, description }], index) => {
           if (description) {
             const bodyParamNode = {

--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -167,6 +167,7 @@ export const onCreateNode = async ({
       parent: node,
       child: descriptionNode,
     });
+
     node.path.parameters.map((param, index) => {
       const paramNode = {
         id: createNodeId(`openApiPathParameter-${node.id}-${index}`),
@@ -187,21 +188,24 @@ export const onCreateNode = async ({
       });
     });
 
-    const bodyParameterSchema = node.path?.requestBody?.content?.schema;
-    if (bodyParameterSchema) {
-      const bodyParameters: RequestBodySchema = JSON.parse(bodyParameterSchema);
-      Object.entries(bodyParameters?.properties).map(
+    const bodyParameterSchemaString = node.path?.requestBody?.content?.schema;
+    if (bodyParameterSchemaString) {
+      const bodyParameterSchema: RequestBodySchema = JSON.parse(
+        bodyParameterSchemaString
+      );
+      const bodyParameterRequired = { ...bodyParameterSchema?.required };
+      Object.entries(bodyParameterSchema?.properties).map(
         ([name, { type, description }], index) => {
           if (description) {
             const bodyParamNode = {
-              // TODO: Add required field
-
+              name,
+              description,
+              schema: { type, format: null, enum: null },
+              required: bodyParameterRequired[name] !== null,
+              in: "body",
               id: createNodeId(`openApiBodyParameter-${node.id}-${index}`),
               parent: node.id,
               children: [],
-              name,
-              type,
-              description,
               internal: {
                 type: "openApiBodyParameter",
                 content: description,

--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -189,8 +189,8 @@ export const onCreateNode = async ({
 
     // Optional chaining seems to affect the Vercel build process
     const bodyParameterSchemaString =
-      node.path.requestBody !== null &&
-      node.path.requestBody.content !== null &&
+      !!node.path.requestBody &&
+      !!node.path.requestBody.content &&
       node.path.requestBody.content.schema;
 
     if (bodyParameterSchemaString) {

--- a/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/types.ts
@@ -25,13 +25,13 @@ type Markdown = {
 };
 
 type Tag = {
-  name: string,
-  description: string,
+  name: string;
+  description: string;
   externalDocs: {
-    description: string,
-    url: string
-  }
-}
+    description: string;
+    url: string;
+  };
+};
 
 export type DeRefedOpenAPI = {
   paths: {
@@ -62,8 +62,8 @@ export type DeRefedOpenAPI = {
         };
       };
     };
-  },
-  tags: Tag[]
+  };
+  tags: Tag[];
 };
 
 export type ResponseContent = {
@@ -106,4 +106,5 @@ export type OpenAPI = {
   path: OpenApiPath;
   childOpenApiPathDescription: Markdown;
   childrenOpenApiPathParameter: (Parameter & Markdown)[];
+  childrenOpenApiBodyParameter: (Parameter & Markdown)[];
 };

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -97,7 +97,7 @@ export default props => {
   useEffect(() => {
     Prism.highlightAll();
   }, []);
-
+  console.log(bodyParameters);
   return (
     <BasePage sidebar={<ApiSidebar />} {...props}>
       <div className="row">
@@ -124,7 +124,7 @@ export default props => {
             </div>
           )}
 
-          {bodyParameters && (
+          {!!bodyParameters.length && (
             <div className="api-info-row">
               <h3>Body Parameters</h3>
               <Params params={bodyParameters} />

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -72,7 +72,7 @@ export default props => {
     apiExample.push(` -H 'Content-Type: ${contentType}'`);
   }
 
-  if (bodyParameters.length > 0) {
+  if (bodyParameters.length) {
     const requestBodyExample =
       (requestBodyContent?.example && JSON.parse(requestBodyContent.example)) ||
       {};
@@ -97,7 +97,6 @@ export default props => {
   useEffect(() => {
     Prism.highlightAll();
   }, []);
-  console.log(bodyParameters);
   return (
     <BasePage sidebar={<ApiSidebar />} {...props}>
       <div className="row">

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -4,13 +4,13 @@ import Prism from "prismjs";
 
 import ApiSidebar from "~src/components/apiSidebar";
 import BasePage from "~src/components/basePage";
-import Content from "~src/components/content"
+import Content from "~src/components/content";
 import SmartLink from "~src/components/smartLink";
 
 import {
   OpenAPI,
   RequestBodySchema,
-} from "~src/gatsby/plugins/gatsby-plugin-openapi/types.ts";
+} from "~src/gatsby/plugins/gatsby-plugin-openapi/types";
 
 import "prismjs/components/prism-json";
 
@@ -24,17 +24,18 @@ const Params = ({ params }) => (
             {!!param.schema?.type && <em> ({param.schema.type})</em>}
           </div>
 
-          {!!param.required && <div className="required">REQUIRED</div>}
-        </dt>
-        {!!param.description && (
-          <dd>
-            <Content file={param} />
-          </dd>
-        )}
-      </React.Fragment>
-    ))}
-  </dl>
-);
+            {!!param.required && <div className="required">REQUIRED</div>}
+          </dt>
+          {!!param.description && (
+            <dd>
+              <Content file={param} />
+            </dd>
+          )}
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+};
 
 const getScopes = (data, securityScheme) => {
   const obj = data.security.find(e => e[securityScheme]);
@@ -56,6 +57,8 @@ export default props => {
   const bodyParameters: RequestBodySchema | null =
     (requestBodyContent?.schema && JSON.parse(requestBodyContent.schema)) ||
     null;
+
+  const bodyParameters2 = openApi.childrenOpenApiBodyParameter || [];
   const pathParameters = (openApi.childrenOpenApiPathParameter || []).filter(
     param => param.in === "path"
   );
@@ -125,7 +128,6 @@ export default props => {
           {!!queryParameters.length && (
             <div className="api-info-row">
               <h3>Query Parameters:</h3>
-
               <Params params={queryParameters} />
             </div>
           )}
@@ -133,19 +135,7 @@ export default props => {
           {bodyParameters && (
             <div className="api-info-row">
               <h3>Body Parameters</h3>
-              <Params
-                params={Object.entries(bodyParameters.properties).map(
-                  ([name, { type, description }]) => ({
-                    schema: { type },
-                    description,
-                    name,
-                    required:
-                      (bodyParameters.required &&
-                        bodyParameters.required.includes(name)) ||
-                      false,
-                  })
-                )}
-              />
+              <Params params={bodyParameters2} />
             </div>
           )}
 
@@ -274,6 +264,14 @@ export const pageQuery = graphql`
         in
         description
         required
+      }
+      childrenOpenApiBodyParameter {
+        id
+        childMdx {
+          body
+        }
+        name
+        description
       }
       path {
         description

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -7,10 +7,7 @@ import BasePage from "~src/components/basePage";
 import Content from "~src/components/content";
 import SmartLink from "~src/components/smartLink";
 
-import {
-  OpenAPI,
-  RequestBodySchema,
-} from "~src/gatsby/plugins/gatsby-plugin-openapi/types";
+import { OpenAPI } from "~src/gatsby/plugins/gatsby-plugin-openapi/types";
 
 import "prismjs/components/prism-json";
 
@@ -24,18 +21,17 @@ const Params = ({ params }) => (
             {!!param.schema?.type && <em> ({param.schema.type})</em>}
           </div>
 
-            {!!param.required && <div className="required">REQUIRED</div>}
-          </dt>
-          {!!param.description && (
-            <dd>
-              <Content file={param} />
-            </dd>
-          )}
-        </React.Fragment>
-      ))}
-    </dl>
-  );
-};
+          {!!param.required && <div className="required">REQUIRED</div>}
+        </dt>
+        {!!param.description && (
+          <dd>
+            <Content file={param} />
+          </dd>
+        )}
+      </React.Fragment>
+    ))}
+  </dl>
+);
 
 const getScopes = (data, securityScheme) => {
   const obj = data.security.find(e => e[securityScheme]);
@@ -54,11 +50,7 @@ export default props => {
   const openApi: OpenAPI = props.data?.openApi || ({} as any);
   const data = openApi?.path;
   const requestBodyContent = data.requestBody?.content;
-  const bodyParameters: RequestBodySchema | null =
-    (requestBodyContent?.schema && JSON.parse(requestBodyContent.schema)) ||
-    null;
-
-  const bodyParameters2 = openApi.childrenOpenApiBodyParameter || [];
+  const bodyParameters = openApi.childrenOpenApiBodyParameter || [];
   const pathParameters = (openApi.childrenOpenApiPathParameter || []).filter(
     param => param.in === "path"
   );
@@ -80,7 +72,7 @@ export default props => {
     apiExample.push(` -H 'Content-Type: ${contentType}'`);
   }
 
-  if (bodyParameters) {
+  if (bodyParameters.length > 0) {
     const requestBodyExample =
       (requestBodyContent?.example && JSON.parse(requestBodyContent.example)) ||
       {};
@@ -135,7 +127,7 @@ export default props => {
           {bodyParameters && (
             <div className="api-info-row">
               <h3>Body Parameters</h3>
-              <Params params={bodyParameters2} />
+              <Params params={bodyParameters} />
             </div>
           )}
 
@@ -270,8 +262,15 @@ export const pageQuery = graphql`
         childMdx {
           body
         }
+        schema {
+          enum
+          format
+          type
+        }
         name
+        in
         description
+        required
       }
       path {
         description


### PR DESCRIPTION
See: [API-1671](https://getsentry.atlassian.net/browse/API-1671)

Request body parameters for the in the API provide descriptions for how to use them that should render in markdown but were not appearing. To remedy this, I added a type that recognized body parameters as nodes to 'markdownify' and modified the static query on API Pages. I referred to the node `openApiPathParameter` when creating `openApiBodyParameter`, which is why there may be some redundant fields on the node.

_Note to reviewers:_ It also looks like these files hadn't been touched in a while, and my linter auto-corrected some spaces, semi-colons, etc. I double checked, and it was linting according to the tsconfig file, if that changes anything 👍 

**Before**
![image](https://user-images.githubusercontent.com/35509934/129915534-6f340b8b-15bf-405e-9123-16cf90916d1d.png)
https://docs.sentry.io/api/integration/create-an-external-issue/

![image](https://user-images.githubusercontent.com/35509934/129915656-5388e77d-04e9-4967-8fa1-214a2f12f60b.png)
https://docs.sentry.io/api/events/update-an-issue/

**After**
![image](https://user-images.githubusercontent.com/35509934/129915786-1d2273b8-b84a-4cf6-be11-32f3f752e30f.png)

![image](https://user-images.githubusercontent.com/35509934/129915898-86bc36ab-35c7-47b6-bb24-3544ca193644.png)
_Note the rendered markdown in the above example 👀_