### PR TITLE
fix release sourcemap param typo

### DIFF
--- a/src/platforms/react-native/sourcemaps.mdx
+++ b/src/platforms/react-native/sourcemaps.mdx
@@ -81,7 +81,7 @@ The source map's name must be the bundle's name appended with ".map" for source 
 ```bash {tabTitle:Android}
 node_modules/@sentry/cli/bin/sentry-cli releases \
     files <release> \
-    upload-source maps \
+    upload-sourcemaps \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
     --rewrite index.android.bundle index.android.bundle.map
@@ -90,7 +90,7 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
 ```bash {tabTitle:iOS}
 node_modules/@sentry/cli/bin/sentry-cli releases \
     files <release> \
-    upload-source maps \
+    upload-sourcemaps \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
     --rewrite main.jsbundle main.jsbundle.map
@@ -98,7 +98,7 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
 
 <Note>
 
-If you're using `sentry-cli` prior to version 1.59.0, pass `--rewrite` to the `upload-source maps` command to fix up the source maps before the upload (inlines sources and so forth). Version 1.59.0 does this automatically.
+If you're using `sentry-cli` prior to version 1.59.0, pass `--rewrite` to the `upload-sourcemaps` command to fix up the source maps before the upload (inlines sources and so forth). Version 1.59.0 does this automatically.
 
 </Note>
 


### PR DESCRIPTION
As per the CLI --help command, it should be `upload-sourcemaps`. There is an extra space between 'source' and 'maps'. Based on https://docs.sentry.io/product/cli/releases/ page.