### PR TITLE
docs(perf): Remove EA note from suspect tags

### DIFF
--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -43,14 +43,6 @@ _Note_: Currently, only transaction data - the transaction name and any attribu
 
 ### Suspect Tags
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 The transaction summary includes a list of suspect tags that often correspond to slower transactions. By default, we sort tags by the total time lost. The list includes additional information:
 
 - **Tag Key**: The tag category (for example, device, geo)
@@ -75,12 +67,6 @@ The sidebar contains helpful supplementary information about this transaction's 
 Frontend transactions will have a "Web Vitals" tab. Clicking on the tab will take you to the [Web Vitals page](/product/performance/web-vitals), where you can see a detailed view of the web vitals associated with this transaction.
 
 ## Tags
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
 
 The **Tags** tab displays a list of suspect tag keys that often correspond to slower transactions. Toggle through them to have the corresponding tag values reflected in the heat map. Similar to a histogram, events are distributed by duration. Click on any purple box to view a list of events or continue to filter down the events by adding values to the filter in the table below the heat map.
 


### PR DESCRIPTION
### Summary
Segment explorer is now GA'ing so we should remove the EA notes.