### PR TITLE
docs(azure): Update the note about permissions

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -17,7 +17,7 @@ This integration needs to set up only once per organization, then it is availabl
 
 <Note>
 
-Sentry organization owner or manager permissions and Azure organization owner permissions are required to install this integration.
+Sentry organization owner or manager permissions and Azure organization owner permissions or a user in the Project Collections Administrators group are required to install this integration.
 
 </Note>
 

--- a/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -17,7 +17,7 @@ This integration needs to set up only once per organization, then it is availabl
 
 <Note>
 
-Sentry organization owner or manager permissions and Azure organization owner permissions or a user in the Project Collections Administrators group are required to install this integration.
+To install this integration, Sentry organization owner or manager permissions and Azure organization owner permissions or being a user in the Project Collections Administrators group are required.
 
 </Note>
 


### PR DESCRIPTION
ADO allows a user in the Project Collections Administrators group to install integrations. The sentry integration now correctly allows this as well.