### PR TITLE
add mode notes in relay docs

### DIFF
--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -57,7 +57,7 @@ _"create custom config"_ and customizing these parameters:
 
   <Alert level="warning">
 
-  Currently, only `proxy` and `static` mode are available to all organizations.
+  Currently, only `proxy` and `static` mode are available to all organizations. Relay in `managed` mode is available only on the [Business and Enterprise plans](https://sentry.io/pricing/).
 
   </Alert>
 

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -15,11 +15,11 @@ Relay is specifically designed to:
 - Improve event response time in regions with low bandwidth or limited connectivity
 - Act as an opaque proxy for organizations that restrict all HTTP communication to a custom domain name
 
-<Alert>
+<Note>
 
-Relay in `managed` mode is available on the [Business and Enterprise plans](https://sentry.io/pricing/).
+Relay in `managed` mode is available only on the [Business and Enterprise plans](https://sentry.io/pricing/).
 
-</Alert>
+</Note>
 
 ## Use Cases for Relay
 

--- a/src/docs/product/relay/modes.mdx
+++ b/src/docs/product/relay/modes.mdx
@@ -10,6 +10,12 @@ Relay can operate in one of several major modes, and it is critical to understan
 
 The mode is stored in the configuration file, which contains the `relay.mode` field. This field specifies the mode in which Relay will run: `managed`, `static`, or `proxy`. The Relay mode controls the way Relay obtains project settings for events.
 
+<Note>
+
+Relay in `managed` mode is available only on the [Business and Enterprise plans](https://sentry.io/pricing/).
+
+</Note>
+
 In Sentry, event processing is configured according to both project and organization settings. Some settings, such as privacy controls, are set at the organization level, then inherited by all projects in that organization; other settings are specified per project. For Relay, events are processed according to the inherited project settings to which the event is sent.
 
 Configuration for Relay is refreshed in regular intervals by polling Sentry. Sentry does not need line-of-sight to your Relays. See [Configuration Options](/product/relay/options/) regarding configuration of intervals, timeouts, and retries.

--- a/src/docs/product/relay/projects.mdx
+++ b/src/docs/product/relay/projects.mdx
@@ -8,6 +8,12 @@ redirect_from:
 
 When running Relay in either `static` or `proxy` mode, you can configure project settings on the file system. Static project configurations are found under the `projects` subdirectory of the Relay configuration directory, By default, this is located at `.relay/projects`.
 
+<Note>
+
+Relay in `managed` mode is available only on the [Business and Enterprise plans](https://sentry.io/pricing/).
+
+</Note>
+
 To configure projects, add files named `<PROJECT_ID>.json` in that location:
 
 ```

--- a/src/docs/product/security/index.mdx
+++ b/src/docs/product/security/index.mdx
@@ -10,7 +10,7 @@ Sentry provides self-serve access to various documentation and tools to help you
 
 In addition:
 - Our [Security Program Overview](https://sentry.io/security/) provides insight into how we view security and compliance at Sentry because they are fundamental to your experience with the product.
-- We also maintain a [Privacy Shield Certification](https://www.privacyshield.gov/participant?id=a2zt0000000TNDzAAO).
+- We also maintain a [Privacy Shield Certification](https://www.privacyshield.gov/participant?id=a2zt0000000YdenAAC&status=Active).
 
 
 If you have any additional inquiries, please see our [options for contacting support](https://sentry.io/contact/support/).


### PR DESCRIPTION
Adds more notes re: managed mode in Relay
Fixes a broken link in the Security page