### PR TITLE
feat: Unity native support page

### DIFF
--- a/src/platforms/unity/configuration/native-support.mdx
+++ b/src/platforms/unity/configuration/native-support.mdx
@@ -1,12 +1,12 @@
 ---
 title: Native Support
-description: "Learn how the SDK handles native support."
+description: "Learn how the Unity SDK handles native support."
 sidebar_order: 30
 ---
 
 Our Unity SDK currently provides native support for iOS and is enabled by default. It does this by embedding the [Cocoa SDK](/platforms/apple/guides/ios/) inside the generated Xcode project and passing the options to it at build time.
 
-To opt-out simply uncheck `iOS Native Support` in the configuration window or disable it via:
+To opt out, uncheck `iOS Native Support` in the configuration window or disable it as shown below:
 
 ```csharp
 using Sentry.Unity;

--- a/src/platforms/unity/configuration/native-support.mdx
+++ b/src/platforms/unity/configuration/native-support.mdx
@@ -4,7 +4,7 @@ description: "Learn how the SDK handles native support."
 sidebar_order: 30
 ---
 
-The Sentry Unity SDK currently provides native support for iOS and is enabled by default. It does this by embedding the [Cocoa SDK](/platforms/apple/guides/ios/) inside the generated Xcode project and passing the options to it at build time.
+Our Unity SDK currently provides native support for iOS and is enabled by default. It does this by embedding the [Cocoa SDK](/platforms/apple/guides/ios/) inside the generated Xcode project and passing the options to it at build time.
 
 To opt-out simply uncheck `iOS Native Support` in the configuration window or via:
 

--- a/src/platforms/unity/configuration/native-support.mdx
+++ b/src/platforms/unity/configuration/native-support.mdx
@@ -1,0 +1,18 @@
+---
+title: Native Support
+description: "Learn how the SDK handles native support."
+sidebar_order: 30
+---
+
+The Sentry Unity SDK currently provides native support for iOS and is enabled by default. It does this by embedding the [Cocoa SDK](/platforms/apple/guides/ios/) inside the generated Xcode project and passing the options to it at build time.
+
+To opt-out simply uncheck `iOS Native Support` in the configuration window or via:
+
+```csharp
+using Sentry.Unity;
+
+SentryUnity.Init(o =>
+{
+    o.IOSNativeSupportEnabled = false;
+});
+```

--- a/src/platforms/unity/configuration/native-support.mdx
+++ b/src/platforms/unity/configuration/native-support.mdx
@@ -6,7 +6,7 @@ sidebar_order: 30
 
 Our Unity SDK currently provides native support for iOS and is enabled by default. It does this by embedding the [Cocoa SDK](/platforms/apple/guides/ios/) inside the generated Xcode project and passing the options to it at build time.
 
-To opt-out simply uncheck `iOS Native Support` in the configuration window or via:
+To opt-out simply uncheck `iOS Native Support` in the configuration window or disable it via:
 
 ```csharp
 using Sentry.Unity;


### PR DESCRIPTION
Added a `native support page` to explain how Unity gets it and to link towards Cocoa.
Also to provide a clear way to opt-out of it.