### PR TITLE
fix(grouping): Remove useless byline about being consistent with discover

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
@@ -16,7 +16,7 @@ The syntax for stack trace rules is similar to:
 matcher-name:expression other-matcher:expression ... action1 action2 ...
 ```
 
-The syntax is the same as the syntax used for [Discover queries](/product/discover-queries/). If you want to negate the match, prefix the expression with an exclamation mark (`!`). If a line is prefixed with a hash (`#`), it's ignored and treated as a comment.
+If you want to negate the match, prefix the expression with an exclamation mark (`!`). If a line is prefixed with a hash (`#`), it's ignored and treated as a comment.
 
 The following is a practical example of how this looks:
 


### PR DESCRIPTION

It does not help the user and implies more than it needs to (as not all
attributes are available). It's like saying "this button has style
consistent with this other button someplace else in the product". It
would belong in internal design docs.