### PR TITLE
Fix two performance typos

### DIFF
--- a/src/includes/getting-started-primer/python.mdx
+++ b/src/includes/getting-started-primer/python.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-Sentry's Python SDK enables automatic reporting of errors and exceptions as well as identifies perfomance issues in your application.
+Sentry's Python SDK enables automatic reporting of errors and exceptions as well as identifies performance issues in your application.
 
 Sentry's Python SDK includes powerful hooks that let you get more out of Sentry, and helps you bind data like tags, users, or contexts. Our SDK supports Python 2.7, then 3.4 and above; specific versions for each framework are documented on the respective framework page. Migrating from older versions is documented [here](./migration/).
 

--- a/src/platforms/php/guides/laravel/other-versions/lumen.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/lumen.mdx
@@ -27,7 +27,7 @@ $app->register('Sentry\Laravel\ServiceProvider');
 require __DIR__ . '/../app/Http/routes.php';
 ```
 
-To enable Sentry Perfomance Monitoring, the TracingServiceProvider has to be registered additionally in `bootstrap/app.php`:
+To enable Sentry Performance Monitoring, the TracingServiceProvider has to be registered additionally in `bootstrap/app.php`:
 
 ```php {filename:bootstrap/app.php}
 $app->register('Sentry\Laravel\Tracing\ServiceProvider');
@@ -45,6 +45,7 @@ public function report(Exception $exception)
     parent::report($exception);
 }
 ```
+
 ## Configure
 
 Copy the Sentry configuration file from the vendor directory:


### PR DESCRIPTION
We spelled Performance `Perfomance` in two separate places. This fixes it. 