### PR TITLE
fix broken links from apple and android docs to mobile vitals

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -147,7 +147,7 @@ You can opt out of Android's Activity Instrumentation and App Start Instrumentat
 </manifest>
 ```
 
-Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](https://docs.sentry.io/product/performance/mobile-vitals.mdx).
+Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals/).
 
 ### Slow and Frozen Frames
 
@@ -156,7 +156,7 @@ Unresponsive UI and animation hitches annoy users and degrade the user experienc
 - **Slow frames** are captured by the SDK when the app takes more than 16 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps). At 60 fps, every frame has 16 ms to render; slower than that, and the app has slow frames.
 - **Frozen frames** are UI frames that take longer than 700 ms to render.
 
-Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](https://docs.sentry.io/product/performance/mobile-vitals.mdx).
+Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals/).
 
 ### OkHttp library Instrumentation
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -34,7 +34,7 @@ The SDK uses the process start time as the beginning of the app start and the [`
 
 ![App Start Transaction](app-start-transaction.png)
 
-Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](https://docs.sentry.io/product/performance/mobile-vitals.mdx).
+Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals/).
 
 ## Slow and Frozen Frames
 
@@ -49,7 +49,7 @@ The detail view of the transaction displays the slow, frozen, and total frames:
 
 ![Slow and Frozen Frames](slow-frozen-frames.png)
 
-Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](https://docs.sentry.io/product/performance/mobile-vitals.mdx).
+Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals/).
 
 ## HTTP Instrumentation
 


### PR DESCRIPTION
Using relative vs full pathways