### PR TITLE
Update errorboundary.mdx

### DIFF
--- a/src/platforms/javascript/guides/react/components/errorboundary.mdx
+++ b/src/platforms/javascript/guides/react/components/errorboundary.mdx
@@ -162,7 +162,7 @@ function App({ props }) {
   return (
     <React.Fragment>
       <Sentry.ErrorBoundary
-        beforeCapture={scope => {
+        beforeCapture={(scope) => {
           scope.setTag("location", "first");
           scope.setTag("anotherTag", "anotherValue");
         }}
@@ -170,7 +170,7 @@ function App({ props }) {
         <Route to="path/to/first" component={First} />
       </Sentry.ErrorBoundary>
       <Sentry.ErrorBoundary
-        beforeCapture={scope => {
+        beforeCapture={(scope) => {
           scope.setTag("location", "second");
         }}
       >


### PR DESCRIPTION
fix highlighting on example about multiple error boundaries and we can't return multiple components in react like previous example