### PR TITLE
docs: Add PHP Troubleshooting

### DIFF
--- a/src/platforms/php/common/troubleshooting.mdx
+++ b/src/platforms/php/common/troubleshooting.mdx
@@ -6,6 +6,6 @@ description: "Troubleshooting steps for PHP"
 
 ## Missing Variables in Stack Traces
 
-This is caused by the PHP configuration. PHP 7.4 introduced a new .ini setting, `zend.exception_ignore_args`, that will ignore stack trace arguments. Please check your .ini file to ensure this setting is set to `Off` or `0`.
+This is caused by the PHP configuration. PHP 7.4 introduced a new .ini setting, `zend.exception_ignore_args`, that will ignore stack trace arguments. Check your .ini file to ensure this setting is set to `Off` or `0`.
 
 


### PR DESCRIPTION
- Move from https://help.sentry.io/sdks/configuration/why-are-the-variables-missing-in-php-event-stack-traces/
- Make some adjustments