### PR TITLE
Consistently tag JavaScript code snippets

### DIFF
--- a/src/docs/clients/javascript/integrations.mdx
+++ b/src/docs/clients/javascript/integrations.mdx
@@ -186,7 +186,7 @@ Below are instructions for [SystemJS](https://github.com/systemjs/systemjs), fol
 
 First, configure SystemJS to locate the Raven.js package:
 
-```js
+```javascript
 System.config({
   packages: {
     /* ... existing packages above ... */
@@ -203,7 +203,7 @@ System.config({
 
 Then, in your main module file (where `@NgModule` is called, e.g. app.module.ts):
 
-```js
+```javascript
 import Raven = require('raven-js');
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, ErrorHandler } from '@angular/core';
@@ -238,7 +238,7 @@ Once you’ve completed these two steps, you are done.
 
 Angular CLI now uses Webpack to build instead of SystemJS. All you need to do is modify your main module file (where `@NgModule` is called, e.g. app.module.ts):
 
-```js
+```javascript
 import * as Raven from "raven-js";
 import { BrowserModule } from "@angular/platform-browser";
 import { NgModule, ErrorHandler } from "@angular/core";
@@ -553,7 +553,7 @@ Raven.addPlugin(Raven.Plugins.Vue, Vue);
 
 In your main application file, import and configure both Raven.js and the Raven.js Vue plugin as follows:
 
-```js
+```javascript
 import Vue from "vue";
 import Raven from "raven-js";
 import RavenVue from "raven-js/plugins/vue";

--- a/src/docs/clients/react-native/sourcemaps.mdx
+++ b/src/docs/clients/react-native/sourcemaps.mdx
@@ -48,7 +48,7 @@ is set for your release. So for instance `com.example.myapp-1.0`.
 
 If you set the release name within your app, the `RELEASE_NAME` should be the same value. e.g.
 
-```js
+```javascript
 Sentry.setRelease(RELEASE_NAME);
 ```
 


### PR DESCRIPTION
The language name is rendered in the HTML output. Use "JavaScript" everywhere, instead of a mix of "JavaScript" and "Js".

Follows up on #3966.

Before:

![image](https://user-images.githubusercontent.com/88819/130938875-167d68b4-065a-4878-8e29-ed1953a03bde.png)


After:

![image](https://user-images.githubusercontent.com/88819/130939011-8261277a-ddee-46d8-a395-7aaa0925a190.png)
