### PR TITLE
Only show tracing sampling config for supported platforms

### DIFF
--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -35,7 +35,7 @@ Changing the error sample rate requires re-deployment. In addition, setting an S
 
 </Note>
 
-<PlatformSection supported={["dotnet", "go", "java", "javascript", "android", "react-native", "apple", "node", "python", "php", "ruby"]} notSupported={["javascript.electron"]}>
+<PlatformSection notSupported={["dart", "elixir", "flutter", "javascript.electron", "native", "perl", "rust"]}>
 
 ## Sampling Transaction Events
 


### PR DESCRIPTION
This removes a section from the docs of platforms that do not support tracing yet, hopefully avoiding confusion.

Unfortunately, it is clear that as new platforms are supported, adding docs is a complex process requiring similar changes in multiple places to update lists of supported platforms.

The list in https://docs.sentry.io/product/performance/getting-started/ is maintained manually, and so is the new list added here.

Fixes https://github.com/getsentry/sentry-docs/issues/3944.