### PR TITLE
Remove invalid suggestion for PHP SDK and clarify where ip_address={{auto}} makes sense

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -25,7 +25,7 @@ Users consist of a few critical pieces of information that construct a unique id
 
 `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might require `sendDefaultPii` set to `true` in the SDK options. <PlatformSection notSupported={["php"]}> If set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server, which is useful for client applications such as a website, desktop, or mobile. </PlatformSection>
+: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might require `sendDefaultPii` set to `true` in the SDK options. <PlatformSection notSupported={["php"]}> If set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server, which is useful for client-side applications such as JavaScript applications running on Web browsers, desktop applications, or mobile apps. </PlatformSection>
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 


### PR DESCRIPTION
The [PHP SDK validates that IP addresses](https://github.com/getsentry/sentry-php/blob/bfab90c7ef921221b52b75b5108201e87f0f4661/src/UserDataBag.php#L175-L182) conform to a regular expression and does not accept the string "{{auto}}".

This option doesn't make sense for PHP applications as it would infer and use the IP address of the PHP server for all events, instead of the IP address of the end user, which is the intended use of the ip_address field.

Fixes https://github.com/getsentry/sentry-php/issues/1215.