### PR TITLE
Add supported version to Sanic integration

### DIFF
--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -12,8 +12,12 @@ The Sanic integration adds support for the [Sanic Web Framework](https://sanicfr
 - `0.8`
 - `18.12`
 - `19.12`
-- Any version of the form `x.12` (LTS versions).
-- `21.3`+ (With `sentry-sdk` version 1.3.0 or higher)
+- `21.3` *
+- `21.6` *
+
+_* Requires `sentry-sdk` v1.3.0 or higher_
+
+The SDK will support any Sanic version of the form `x.12` (LTS versions). If the latest version of Sanic is not explicitly listed here, it _might_ not be supported.
 
 A Python version of 3.6 or greater is also required.
 

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -13,6 +13,7 @@ The Sanic integration adds support for the [Sanic Web Framework](https://github.
 - `18.12`
 - `19.12`
 - Any version of the form `x.12` (LTS versions).
+- `21.3`+ (With `sentry-sdk` version 1.3.0 or higher)
 
 **We do not support the latest version of Sanic.** Versions between LTS releases [have introduced breaking changes in the past](https://github.com/huge-success/sanic/issues/1532) without prior notice, so we cannot support them as they are too fast of a moving target.
 

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -15,8 +15,6 @@ The Sanic integration adds support for the [Sanic Web Framework](https://github.
 - Any version of the form `x.12` (LTS versions).
 - `21.3`+ (With `sentry-sdk` version 1.3.0 or higher)
 
-**We do not support the latest version of Sanic.** Versions between LTS releases [have introduced breaking changes in the past](https://github.com/huge-success/sanic/issues/1532) without prior notice, so we cannot support them as they are too fast of a moving target.
-
 A Python version of 3.6 or greater is also required.
 
 ## Install

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -7,7 +7,7 @@ description: "Learn about using Sentry with Sanic."
 
 _(New in version 0.3.6)_
 
-The Sanic integration adds support for the [Sanic Web Framework](https://github.com/huge-success/sanic). We support the following versions:
+The Sanic integration adds support for the [Sanic Web Framework](https://sanicframework.org). We support the following versions:
 
 - `0.8`
 - `18.12`


### PR DESCRIPTION
[Version 1.3](https://github.com/getsentry/sentry-python/releases/tag/1.3.0) included support for Sanic 21.3+