### PR TITLE
feat(api-schema): Always build from master of api-schema repo

### DIFF
--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -1,10 +1,6 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 
-// SENTRY_API_SCHEMA_SHA is used in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
-// DO NOT change variable name unless you change it in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
-const SENTRY_API_SCHEMA_SHA = "4cf8276a19f412a316f9bc723a6081a1acc98ba1"
-
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
 
@@ -22,7 +18,7 @@ export default async () => {
     }
   }
   const response = await axios.get(
-    `https://raw.githubusercontent.com/getsentry/sentry-api-schema/${SENTRY_API_SCHEMA_SHA}/openapi-derefed.json`
+    `https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json`
   );
   return response.data;
 };


### PR DESCRIPTION
We are removing some security tokent from sentry-api-schema, preventing it from making commits directly to sentry-docs repo. For this reason, we are removing this variable and defaulting to `main` branch. Deploy triggers on new versions of sentry-api-schema will be done through [Vercel deploy hooks](https://vercel.com/docs/more/deploy-hooks) tied to sentry-docs repo.
