### PR TITLE
fix(user feedback): Update notification docs

### DIFF
--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -29,7 +29,6 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 - **Regressions**: A regression happens when the state of an issue changes from Resolved back to Unresolved. An email is sent to all project team members.
 - **Comments**: When a team member adds a new comment in the “Activity” tab of the detail page for the issue.
 - **Assignment**: When an issue is assigned or unassigned.
-- **User Feedback**: When an issue has new <PlatformLink to="/enriching-events/user-feedback/">user feedback</PlatformLink>. 
 - **Event Processing Problems**: When there's a problem with processing error events you've sent to Sentry.
 
 You receive workflow notifications when you’re subscribed to an issue, and you subscribe to issues by:
@@ -47,6 +46,10 @@ These notifications may have some overlap with alerts that are configured for a 
 Sentry sends deploy notifications to users who have committed to the release that was deployed. Learn more in the [deploy documentation](/product/releases/setup/#notify-sentry).
 
 ![An example of an email describing deployed features](deploy-emails.png)
+
+## User Feedback
+
+Sentry sends an email when an issue has new <PlatformLink to="/enriching-events/user-feedback/">user feedback</PlatformLink>.
 
 ## Quota Notifications
 


### PR DESCRIPTION
Update the notifications page to put user feedback into it's own section as it is not actually a workflow notification and has caused confusion around what to expect as a Slack notification if that is enabled. 