### PR TITLE
DO NOT MERGE feat(notification platform): Remove EA mention

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -88,16 +88,6 @@ If an issue owner is not configured or not found, either the notification won’
 
 ### Team Slack Notifications
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
-
 Teams can configure a Slack channel to receive alert notifications. This can be done by typing `/sentry link team` in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 
 ## Action Interval (Rate Limit)

--- a/src/docs/product/alerts/notifications/notification-settings.mdx
+++ b/src/docs/product/alerts/notifications/notification-settings.mdx
@@ -20,14 +20,6 @@ You can also fine tune your alert notifications on a per-project basis by choosi
 
 ### Delivery Method
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
-
 You can decide where you receive personal alert notifications by choosing from the options:
 - Send to Email
 - Send to [Slack](/product/integrations/notification-incidents/slack/)
@@ -47,14 +39,6 @@ The global settings for workflow notifications are:
 You can fine tune your workflow notifications on a per-project basis by choosing one of the three options above or "Default”. If you select “Default”, the setting for the project will be the same as your global setting.
 
 ### Delivery Method
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
 
 You can decide where you receive personal workflow notifications by choosing from the options:
 - Send to Email
@@ -86,14 +70,6 @@ The global settings for deploy notifications are:
 You can fine tune your deploy notifications on a per-organization basis by choosing one of the three options above or "Default”. If you select “Default”, the setting for the organization will be the same as your global setting.
 
 ### Delivery Method
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
 
 You can decide where you receive personal deploy notifications by choosing from the options:
 - Send to Email

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -53,14 +53,6 @@ Use Slack for notifications and [alerts](#alert-rules) regarding issues, environ
 
 ### Personal Notifications
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
-
 You can receive personal workflow, deploy, and issue alert notifications from our Slack integration. Manage your [personal notification settings](/product/alerts/notifications/notification-settings/) by navigating to **User Settings > Notifications**.
 
 #### Linking Your Slack and Sentry Accounts
@@ -68,14 +60,6 @@ You can receive personal workflow, deploy, and issue alert notifications from ou
 In order to receive personal notifications from our Slack integration, your Slack identity must be linked with your Sentry account. This can be done by typing `/sentry link` in Slack.
 
 ### Team Notifications
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
-
-</Note>
 
 You can receive [team alert notifications](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions) from our Slack integration. To enable this feature, type `/sentry link team` in the desired Slack channel. To view a team's associated Slack channel in [sentry.io](https://sentry.io), navigate to **Settings > Teams > [Team] > Notifications**.
 


### PR DESCRIPTION
Do not merge until GA! 

This PR removes the note about needing to be on EA to use the features, as when it's merged it will be released to GA. 