### PR TITLE
add links between mobile vitals and react native docs

### DIFF
--- a/src/docs/product/performance/mobile-vitals.mdx
+++ b/src/docs/product/performance/mobile-vitals.mdx
@@ -17,7 +17,7 @@ App start metrics track how long your mobile application takes to launch. For th
 - **Cold Start**: A cold start refers to when the app launches for the first time, after a reboot or update. The app is not in memory and no process exists.
 - **Warm Start**: A warm start refers to when the app has already launched at least once and is partially in memory. For instance, the user backs out of your app, but then re-launches it. The process may have continued to run, but the app must recreate the activity from scratch.
 
-On iOS, Apple recommends your app take at most 400ms to render the first frame. On Android, the [Google Play console](https://developer.android.com/topic/performance/vitals/launch-time#av) warns you when a cold start takes longer than five seconds or a warm start longer than two seconds. The exact definitions differ slightly per platform. Learn more in our [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/) and [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/) SDK docs.
+On iOS, Apple recommends your app take at most 400ms to render the first frame. On Android, the [Google Play console](https://developer.android.com/topic/performance/vitals/launch-time#av) warns you when a cold start takes longer than five seconds or a warm start longer than two seconds. The exact definitions differ slightly per platform. Learn more in our [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/), [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/), and [React Native](/platforms/react-native/performance/instrumentation/automatic-instrumentation/) SDK docs.
 
 In the example below, the detail view of a transaction displays the warm start measurement in the right sidebar.
 
@@ -32,7 +32,7 @@ To track the responsiveness of the user interface, Sentry measures *slow frames*
 - **Slow Frames**: Using 60 fps, slow frames are frames that take more than 16 ms (Android) or 16.67 ms (iOS) to render.
 - **Frozen Frames**: Frozen frames are frames that take longer than 700 ms to render.
 
-For Apple, the frame rate can be higher, especially as 120 fps displays are becoming more popular. For these apps, Sentry detects the frame rate and adjusts the slow frame calculation accordingly.  
+For Apple, the frame rate can be higher, especially as 120 fps displays are becoming more popular. For these apps, Sentry detects the frame rate and adjusts the slow frame calculation accordingly.
 
 In the example below, the detail view of the transaction displays the slow, frozen, and total frames in an iOS application:
 

--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -153,8 +153,8 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are *slow frames* and *frozen frames*. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the [Android's Activity](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation) transactions.
 
-- **Slow frames** are captured by the SDK when the app takes more than 16 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps). At 60 fps, every frame has 16 ms to render; slower than that, and the app has slow frames.
-- **Frozen frames** are UI frames that take longer than 700 ms to render.
+- **Slow frames**: Slow frames are captured by the SDK when the app takes more than 16 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps). At 60 fps, every frame has 16 ms to render; slower than that, and the app has slow frames.
+- **Frozen frames**: Frozen frames are UI frames that take longer than 700 ms to render.
 
 Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -23,7 +23,7 @@ The UIViewController Instrumentation, once enabled, captures transactions whenev
 This feature is available for iOS, tvOS, and Mac Catalyst.
 
 The App Start Instrumentation provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
-To enable this feature enable `AutoUIPerformanceTracking`. The SDK differentiates between a cold and a warm start, and doesn't track hot starts/resumes.
+To enable this feature enable `AutoUIPerformanceTracking`. The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 * __Cold start__: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
 * __Warm start__: App launched at least once, is partially in memory, and no process exists.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -40,10 +40,10 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 This feature is available for iOS, tvOS, and Mac Catalyst.
 
-Unresponsive UI, animation hitches, or just jank annoy users and degrade the user experience. Two measurements to track this unwanted experience are slow frames and frozen frames. A smoothly running app should try to avoid both. That's why the SDK adds these two measurements for the transactions you capture.
+Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are *slow frames* and *frozen frames*. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-- **Slow frames** are captured by the SDK when the app needs more than 16.67 ms for a frame. Typically, a phone or tablet renders with 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. With 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
-- **Frozen frames** are UI frames that take longer than 700 ms.
+- **Slow frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders with 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
+- **Frozen frames**: Frozen frames are UI frames that take longer than 700 ms to render.
 
 The detail view of the transaction displays the slow, frozen, and total frames:
 

--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -236,8 +236,6 @@ Sentry offers the following automatic instrumentation features.
 
 ### App Start Instrumentation
 
-_Type: **Measurement, Span**_
-
 The App Start Instrumentation provides insight into how long your application takes to launch. It tracks the length of time from the **earliest native process initialization** until the **React Native root component mounts**.
 
 <Note>
@@ -251,18 +249,18 @@ The SDK differentiates between a cold and a warm start, but doesn't track hot st
 - **Cold start**: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
 - **Warm start**: App launched at least once, is partially in memory, and no process exists.
 
-### Slow and Frozen Frames
+Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
-_Type: **Measurement**_
+### Slow and Frozen Frames
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
 - **Slow Frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
-- **Frozen Frames** Frozen frames are UI frames that take longer than 700 ms to render.
+- **Frozen Frames**: Frozen frames are UI frames that take longer than 700 ms to render.
+
+Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
 ### Stall Tracking
-
-_Type: **Measurement**_
 
 A stall is when the JavaScript event loop takes longer than expected to complete. A stall in your JavaScript code will not just make your UI unresponsive, but also slow down the logic that is contained within JavaScript. This slows everything down, creating a bad experience for your users.
 
@@ -273,8 +271,6 @@ We track stalls that occur in your React Native app during a transaction and pro
 - **Stall Count**: The total number of stalls that occurred during the transaction.
 
 ### Fetch/XML Request Instrumentation
-
-_Type: **Span**_
 
 The tracing integration creates a child span for every `XMLHttpRequest` or `fetch` request on the Javascript layer that occurs while those transactions are open. Learn more about [traces, transactions, and spans](/product/sentry-basics/tracing/distributed-tracing/).
 


### PR DESCRIPTION
Adds links between React Native docs and Mobile Vitals page
Makes mobile vitals sections of SDK docs a bit more consistent