### PR TITLE
replace hardcoded link with platform redirect

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -12,7 +12,7 @@ All events have a fingerprint. Events with the same fingerprint are grouped toge
 
 By default, Sentry will run one of our built-in grouping algorithms to generate a fingerprint based on information available within the event such as `stacktrace`, `exception`, and `message`. To extend the default grouping behavior or change it completely, you can use a combination of the following options:
 
-1. In your SDK, using <PlatformLink to="/usage/sdk-fingerprinting/">SDK Fingerprinting</PlatformLink>. Note that is not supported in WebAssembly.
+1. In your SDK, using [SDK Fingerprinting](/platform-redirect/?next=/usage/sdk-fingerprinting/). Note that is not supported in WebAssembly.
 2. In your project, using [Fingerprint Rules](./fingerprint-rules/)
 3. In your project, using [Stack Trace Rules](./stack-trace-rules/)
 


### PR DESCRIPTION
Replaces hardcoded link to SDK Fingerprinting content in Issue Grouping docs with platform redirect 