### PR TITLE
ref: Fix a broken link

### DIFF
--- a/src/platforms/common/data-management/debug-files/file-formats.mdx
+++ b/src/platforms/common/data-management/debug-files/file-formats.mdx
@@ -180,7 +180,7 @@ debugging, but have shortcomings that make them impractical for a crash reportin
 tool like Sentry.
 
 Since WASM does not specify debug/build IDs yet, we provide a separate tool to
-add build IDs and split files called [wasm-split](https://github.com/getsentry/symbolicator/tree/master/wasm-split)
+add build IDs and split files called [wasm-split](https://github.com/getsentry/symbolicator/blob/master/crates/wasm-split)
 to help you create a debug companion file ready for uploading to Sentry
 while removing all debug information from the release binary.
 


### PR DESCRIPTION
This fixes a broken link to a part of symbolicator. Pretty straightforward stuff.