### PR TITLE
Update `sentry-debug-meta.properties` location

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -263,7 +263,7 @@ Example:
 
 ```bash
 sentry-cli upload-proguard \
-    app/build/outputs/mapping/release/mapping.txt
+    app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 
 Since the Android SDK needs to know the UUID of the mapping file, you need
@@ -272,8 +272,8 @@ to embed it in a `sentry-debug-meta.properties` file. If you supply
 
 ```bash
 sentry-cli upload-proguard \
-    --write-properties app/build/intermediates/assets/release/sentry-debug-meta.properties \
-    app/build/outputs/mapping/release/mapping.txt
+    --write-properties app/build/generated/assets/sentry/{BuildVariant}/sentry-debug-meta.properties \
+    app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 
 After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in _Project Settings > ProGuard_.


### PR DESCRIPTION
This change updates the directory location of `sentry-debug-meta.properties` to where is can currently be found as the previous location seems invalid. It also provides a more adequate description of directory paths.