### PR TITLE
Remove issue display options from docs

### DIFF
--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -32,21 +32,6 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
-## Display Options
-
-<Note>
-  The "Events as %" display option is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-  If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-</Note>
-
-The Display dropdown lets you toggle between viewing the event count for each issue or viewing the events as a percentage of [sessions](/product/releases/health/#session).
-
-![Issues display dropdown](issues-dropdown.png)
-
-This option is available when you select a project that has [release health set up](/product/releases/health/setup) and there are issues and sessions in the selected period.
-
-
 ## Learn More
 
 <PageGrid />


### PR DESCRIPTION
This was in EA but we didn't release it for GA