### PR TITLE
add percent to keywords for issue alert configuration

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -1,6 +1,7 @@
 ---
 title: Issue Alert Configuration
 sidebar_order: 10
+keywords: ["percent"]
 redirect_from:
  - /product/sentry-basics/guides/alert-notifications/issue-alerts/
  - /product/alerts/alert-settings/


### PR DESCRIPTION
Adds "percent" to keywords for issue alert configuration so users can find percent-based issuer alerts when searching "percent." Currently, pages with the word "percentage" are favoured by the search engine because of the space after the word "percent" in the issue alert content.