### PR TITLE
ref(appconnect): Tweaks, EA and pricing updates (NATIVE-188)

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -21,6 +21,7 @@ This feature is currently available as an early access preview.
 
 <Alert level="Note">
 Looking for the upload methods when using this intergration?
+
 - [Upload BCSymbolMaps Using Fastlane](#symbolmap-fastlane)
 - [Upload BCSymbolMaps Using sentry-cli](#symbolmap-sentrycli)
 </Alert>

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -16,14 +16,18 @@ Alternatively, the dSYM files can be downloaded either with [Fastlane](#bitcode-
 ### Using App Store Connect {#bitcode-appstore}
 
 <Alert level="Note">
+
 This feature is currently available as an early access preview.
+
 </Alert>
 
 <Alert level="Note">
+
 Looking for the upload methods when using this intergration?
 
 - [Upload BCSymbolMaps Using Fastlane](#symbolmap-fastlane)
 - [Upload BCSymbolMaps Using sentry-cli](#symbolmap-sentrycli)
+
 </Alert>
 
 When you use the App Store Connect integration, Sentry will automatically discover and fetch dSYM files for Bitcode builds as they become available on App Store Connect. These dSYM files however contain obfuscated symbol names and paths. An additional BCSymbolMap file needs to be uploaded to provide properly symbolicated crash reports. These BCSymbolMap files can be uploaded using either [sentry-cli](#symbolmap-sentrycli) or [Fastlane](#symbolmap-fastlane).
@@ -37,7 +41,9 @@ Once the integration is set up it will ensure that new builds are detected and f
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
 <Alert level="Note">
+
 Free subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+
 </Alert>
 
 Setting up App Store Connect currently requires two separate credentials.

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -15,12 +15,15 @@ Alternatively, the dSYM files can be downloaded either with [Fastlane](#bitcode-
 
 ### Using App Store Connect {#bitcode-appstore}
 
-This section covers the necessary setup for upload methods:
+<Alert level="Note">
+This feature is currently available as an early access preview.
+</Alert>
+
+<Alert level="Note">
+Looking for the upload methods when using this intergration?
 - [Upload BCSymbolMaps Using Fastlane](#symbolmap-fastlane)
 - [Upload BCSymbolMaps Using sentry-cli](#symbolmap-sentrycli)
-
-
-_NOTE_: This feature will be available as an early access preview soon.
+</Alert>
 
 When you use the App Store Connect integration, Sentry will automatically discover and fetch dSYM files for Bitcode builds as they become available on App Store Connect. These dSYM files however contain obfuscated symbol names and paths. An additional BCSymbolMap file needs to be uploaded to provide properly symbolicated crash reports. These BCSymbolMap files can be uploaded using either [sentry-cli](#symbolmap-sentrycli) or [Fastlane](#symbolmap-fastlane).
 
@@ -32,25 +35,27 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
-During Early Access, the App Store Connect integration is limited to a single source per project. Free subscription plans will remain limited to one App Store Connect source per project, though subscribers to our Business plan will in future be able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+<Alert level="info">
+Free subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+</Alert>
 
 Setting up App Store Connect currently requires two separate credentials.
 
-**App Store Connect API Key**:
+1. **App Store Connect API Key**:
 
 Follow the documentation on [Creating API Keys for App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) and provide the _Issuer_, _Key ID_, and _Private Key_. The API Key needs to have the _Developer_ role in order to fetch build details.
 
-**App Store Connect Credentials**:
+2. **iTunes Credentials**:
 
-An App Store Connect user and password are required, in addition to the normal App Store Connect API Key, due to limitations of the App Store Connect API. The App Store Connect API Key alone will only allow detection of new builds; an App Store Connect user is required to fetch the associated dSYM files.
+An iTunes user and password are required, in addition to the normal App Store Connect API Key, due to limitations of the App Store Connect API. The App Store Connect API Key alone will only allow detection of new builds; an iTunes user is required to fetch the associated dSYM files.
 
 [Create a new Apple ID](https://support.apple.com/en-us/HT204316) specifically for this integration and provide its credentials. The user needs to have the _Developer_ role in the appropriate App Store Organization.
 
 <Alert level="warning">
 
-We highly recommend that you create a dedicated App Store Connect user account for the purpose of this integration, and that you **not** use a regular user account.
+We highly recommend that you create a dedicated iTunes user account for the purpose of this integration, and that you **not** use a regular user account.
 
-Using the configured App Store Connect account on a different device will disrupt Sentry's ability to use it in order to download dSYM files.
+Using the configured iTunes account on a different device will disrupt Sentry's ability to use it in order to download dSYM files.
 
 </Alert>
 
@@ -58,7 +63,7 @@ These credentials will need to be verified by a two-factor authentication token 
 
 **Re-authentication**
 
-The App Store Connect credentials and two-factor authentication are short-lived and need to be refreshed on a regular basis. Sentry will prompt users to re-authenticate in the **Issue Details** pages of a project, in the settings menu of a project, as well as in the "Custom Repositories" section of a project's "Debug Files" settings once their App Store Connect credentials expire.
+The iTunes credentials and two-factor authentication are short-lived and need to be refreshed on a regular basis. Sentry will prompt users to re-authenticate in the **Issue Details** pages of a project, in the settings menu of a project, as well as in the "Custom Repositories" section of a project's "Debug Files" settings once their iTunes credentials expire.
 
 ![Warning to update credentials in sidebar](sidebar-warning.png)
 
@@ -83,7 +88,7 @@ When using the _upload_to_testflight_ action, it is recommended to pass the _ski
 
 #### Upload BCSymbolMaps Using `sentry-cli` {#symbolmap-sentrycli}
 
-The `sentry-cli upload-dif` command will automatically find and upload all _BCSymbolMap_ files, given the path to the `.xcarchive`.
+The `sentry-cli upload-dif` command will automatically find and upload all _BCSymbolMap_ files, given the path to the app's `.xcarchive`.
 
 ### Using Fastlane {#bitcode-fastlane}
 

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -36,7 +36,7 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
-<Alert level="info">
+<Alert level="Note">
 Free subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
 </Alert>
 


### PR DESCRIPTION
Update the state of EA and pricing.  A number of smaller tweaks:

- Some notes and callouts to make the document read more natural.

- Switch back to iTunes credentials naming since that is what is used
  in the UI as well.