### PR TITLE
feat(release-health): Add missing doc on server mode sessions

### DIFF
--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -27,7 +27,7 @@ Sentry distinguishes between two kinds of sessions:
 
 A user- or application-mode session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 
-A session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
+This type of session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 
 #### Server-mode/Request-mode sessions
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -19,21 +19,23 @@ Once you configure your SDK, Sentry connects the data to the specific release of
 ### Session
 
 The primary component Sentry uses to monitor health is a _session_, which represents the interaction between the user and the application.
-Sentry distinguishes between two kinds of sessions: 
-- User-mode/application-mode sessions 
+
+Sentry distinguishes between two kinds of sessions:
+
+- User-mode/application-mode sessions
 - Server-mode/request-mode sessions
 
-#### User-Mode/Application-Mode Sessions
+  #### User-Mode/Application-Mode Sessions {#application-mode-sessions}
 
-A user- or application-mode session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
+  A user- or application-mode session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 
-This type of session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
+  This type of session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 
-#### Server-Mode/Request-Mode Sessions
+  #### Server-Mode/Request-Mode Sessions {#request-mode-sessions}
 
-Server- or request-mode sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started when the server receives a request, and terminates when the server sends a response.
+  Server- or request-mode sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started when the server receives a request, and terminates when the server sends a response.
 
-These are typically high in volume since each session corresponds to a single request.
+  These are typically high in volume since each session corresponds to a single request.
 
 Sessions, whether application-mode or request-mode, are submitted to Sentry so you can track the usage and adoption of your application. When a user of your application experiences a crash, error, or abnormal exit, the session will be flagged accordingly, and Sentry calculates derived metrics. The metrics include data such as the number of users that didn't experience a crash in the specified time range.
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -21,7 +21,7 @@ Once you configure your SDK, Sentry connects the data to the specific release of
 The primary component Sentry uses to monitor health is a _session_, which represents the interaction between the user and the application.
 Sentry distinguishes between two kinds of sessions; user-mode/application-mode sessions and server-mode/request-mode sessions.
 
-#### User-mode/Application-mode sessions
+#### User-Mode/Application-Mode Sessions
 
 A session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -25,13 +25,13 @@ Sentry distinguishes between two kinds of sessions:
 - User-mode/application-mode sessions
 - Server-mode/request-mode sessions
 
-  #### User-Mode/Application-Mode Sessions {#application-mode-sessions}
+#### User-Mode/Application-Mode Sessions {#application-mode-sessions}
 
   A user- or application-mode session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 
   This type of session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 
-  #### Server-Mode/Request-Mode Sessions {#request-mode-sessions}
+#### Server-Mode/Request-Mode Sessions {#request-mode-sessions}
 
   Server- or request-mode sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started when the server receives a request, and terminates when the server sends a response.
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -19,7 +19,9 @@ Once you configure your SDK, Sentry connects the data to the specific release of
 ### Session
 
 The primary component Sentry uses to monitor health is a _session_, which represents the interaction between the user and the application.
-Sentry distinguishes between two kinds of sessions; user-mode/application-mode sessions and server-mode/request-mode sessions.
+Sentry distinguishes between two kinds of sessions: 
+- User-mode/application-mode sessions 
+- Server-mode/request-mode sessions
 
 #### User-Mode/Application-Mode Sessions
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -19,12 +19,23 @@ Once you configure your SDK, Sentry connects the data to the specific release of
 ### Session
 
 The primary component Sentry uses to monitor health is a _session_, which represents the interaction between the user and the application.
+Sentry distinguishes between two kinds of sessions; user-mode/application-mode sessions and server-mode/request-mode sessions.
+
+#### User-mode/Application-mode sessions
 
 A session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 
 A session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 
-Sessions are submitted to Sentry so you can track the usage and adoption of your application. When a user of your application experiences a crash, error, or abnormal exit, the session will be flagged accordingly, and Sentry calculates derived metrics. The metrics include data such as the number of users that didn't experience a crash in the specified time range.
+#### Server-mode/Request-mode sessions
+
+These kind of sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started upon the server receiving a request, and terminates upon the server sending a response.
+
+These are typically high in volume since each session corresponds to a single request.
+
+Sessions, whether application-mode or request-mode, are submitted to Sentry so you can track the usage and adoption of your application. When a user of your application experiences a crash, error, or abnormal exit, the session will be flagged accordingly, and Sentry calculates derived metrics. The metrics include data such as the number of users that didn't experience a crash in the specified time range.
+
+In terms of which mode a project runs in, Sentry is able to automatically detect if it is in a server setting and so should run in server-mode/request-mode or if it is in an application setting and so should run in user-mode/application-mode
 
 ### Active Sessions/Users
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -29,7 +29,7 @@ A user- or application-mode session begins with the start of the application. Or
 
 This type of session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 
-#### Server-mode/Request-mode sessions
+#### Server-Mode/Request-Mode Sessions
 
 These kind of sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started upon the server receiving a request, and terminates upon the server sending a response.
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -31,7 +31,7 @@ This type of session ends with the closing of the application or with the applic
 
 #### Server-Mode/Request-Mode Sessions
 
-These kind of sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started upon the server receiving a request, and terminates upon the server sending a response.
+Server- or request-mode sessions roughly correspond to HTTP requests or RPC calls in a server setting. A session is started when the server receives a request, and terminates when the server sends a response.
 
 These are typically high in volume since each session corresponds to a single request.
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -25,7 +25,7 @@ Sentry distinguishes between two kinds of sessions:
 
 #### User-Mode/Application-Mode Sessions
 
-A session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
+A user- or application-mode session begins with the start of the application. Or, it begins with bringing the already started application back from background to the foreground.
 
 A session ends with the closing of the application or with the application being sent to the background. If the application is in the background for less than 30 seconds, we do not start the session again. Applications that are active even on the background (for example, a music player) should track the sessions manually for the background process.
 


### PR DESCRIPTION
This PR adds missing documentation on server mode sessions in `releases/health`

fixes #4070 