### PR TITLE
remove percent keyword issue alert config

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -1,7 +1,6 @@
 ---
 title: Issue Alert Configuration
 sidebar_order: 10
-keywords: ["percent"]
 redirect_from:
  - /product/sentry-basics/guides/alert-notifications/issue-alerts/
  - /product/alerts/alert-settings/


### PR DESCRIPTION
Remove percent keyword as its addition is creating unexpected behaviour with search. Now, all the sub-headings of the issue alert configuration page are returned as search results, rather than the pages we were getting before + the issue alert config page.