### PR TITLE
add percent-based alerts terminology

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -35,7 +35,7 @@ Give your alert a descriptive name, such as the team affected and the topic of t
 - Seen by more than a certain number of unique users in an interval
 - An issue affects more than {X} percent of [sessions](/product/releases/health/#session) in {time}
   - Percent of sessions affected is an approximation, calculated as the ratio of the issue’s frequency to the number of sessions in the project
-  - The alert will only trigger if the number of sessions in the last hour exceeds 50
+  - Percent-based alerts will only trigger if the number of sessions in the last hour exceeds 50
 
 Triggers are optional. If you don’t select a trigger, the "When" conditions are considered met by default. That is, _all_ events will meet this condition.
 


### PR DESCRIPTION
Adds the term "percent-based alerts" to page for improved search