### PR TITLE
Fix function names for DiagnosticSource integration.

### DIFF
--- a/src/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -49,13 +49,13 @@ Even if your project doesn't meet any of those requirements, you'll be able to m
 
 ```csharp
 // Requires NuGet package: Sentry.DiagnosticSource
-option.AddDiagnosticListeners();
+option.AddDiagnosticSourceIntegration();
 
 ```
 
-If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticListenerIntegration();`
+If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticSourceIntegration();`
 ```csharp
-option.DisableDiagnosticListenerIntegration();
+option.DisableDiagnosticSourceIntegration();
 ```
 
 <PlatformContent includePath="performance/automatic-instrumentation-integrations" />


### PR DESCRIPTION
This PR corrects the PR names for the DisableDiagnosticSource integration.

The function definitions can be found here
https://github.com/getsentry/sentry-dotnet/blob/f47367ca406b98286aeaa0e57cbd917a1f3ea6ae/src/Sentry.DiagnosticSource/SentryOptionsDiagnosticExtensions.cs#L11-L16 for AddDiagnosticSourceIntegration

and 
https://github.com/getsentry/sentry-dotnet/blob/f47367ca406b98286aeaa0e57cbd917a1f3ea6ae/src/Sentry.DiagnosticSource/SentryOptionsDiagnosticExtensions.cs#L18-L24 for DisableDiagnosticSourceIntegration