### PR TITLE
fix(nextjs): Add `.sentryclirc` to list of created files in the getting started page

### DIFF
--- a/src/includes/getting-started-config/javascript.nextjs.mdx
+++ b/src/includes/getting-started-config/javascript.nextjs.mdx
@@ -9,6 +9,7 @@ You'll be prompted to log in to Sentry. The wizard will then automatically add t
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`
 - create `next.config.js` with the default configuration
 - create `sentry.properties` with configuration for `sentry-cli` (which is used when automatically uploading source maps)
+- create `.sentryclirc` with the auth token for `sentry-cli` (which is automatically added to the `.gitignore`)
 
 See [manual configuration](/platforms/javascript/guides/nextjs/manual-setup/) for examples of the files created by the wizard. If any of these files already exists, it will be created with a leading underscore and you will need to merge it with the existing file manually.
 


### PR DESCRIPTION
The new `.sentryclirc` file was added to the manual setup page on https://github.com/getsentry/sentry-docs/pull/4105, but not to the getting started page. This PR adds it there.

Closes https://github.com/getsentry/sentry-docs/issues/4122.