### PR TITLE
feat: Add missing instrumentation copy for React Native

### DIFF
--- a/src/wizard/react-native/tracing.md
+++ b/src/wizard/react-native/tracing.md
@@ -1,0 +1,16 @@
+---
+name: React-Native
+doc_link: https://docs.sentry.io/platforms/react-native/performance/
+support_level: production
+type: language
+---
+
+To manually instrument certain regions of your code, you can create a transaction to capture them.
+
+```javascript
+const transaction = Sentry.startTransaction({ name: "test-transaction" });
+const span = transaction.startChild({ op: "functionX" }); // This function returns a Span
+// functionCallX
+span.finish(); // Remember that only finished spans will be sent with the transaction
+transaction.finish(); // Finishing the transaction will send it to Sentry
+```


### PR DESCRIPTION
This will be copy that will be displayed for React Native projects. 

Currently, we do not show any copy for React Native within the span view: 
<img width="633" alt="Screen Shot 2021-09-09 at 3 15 45 PM" src="https://user-images.githubusercontent.com/139499/132748850-8e20eb98-e043-475d-b397-1887d888f094.png">
