### PR TITLE
ref: React Native support for React Navigation V6

### DIFF
--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -22,9 +22,11 @@ export default Sentry.wrap(App);
 
 ### Enable Routing Instrumentation
 
-We currently provide two routing instrumentations out of the box to instrument route changes for React Navigation V5 and V4. In the future, we will add support for other libraries such as [react-native-navigation](https://github.com/wix/react-native-navigation). Otherwise, if you have a custom routing instrumentation, or use a routing library we don't yet support, you can use the bare bones routing instrumentation or create your own by extending it.
+We currently provide two routing instrumentations out of the box to instrument route changes for React Navigation. In the future, we will add support for other libraries such as [react-native-navigation](https://github.com/wix/react-native-navigation). Otherwise, if you have a custom routing instrumentation, or use a routing library we don't yet support, you can use the bare bones routing instrumentation or create your own by extending it.
 
-#### React Navigation V5
+#### React Navigation
+
+This instrumentation supports React Navigation version 5 and above. If you use React Navigation version 4, see the [instrumentation for React Navigation V4](#react-navigation-v4).
 
 <Note>
 
@@ -38,7 +40,7 @@ Note that this routing instrumentation will create a transaction on every route 
 import * as Sentry from "@sentry/react-native";
 
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
-const routingInstrumentation = new Sentry.ReactNavigationV5Instrumentation();
+const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
 
 Sentry.init({
   ...

--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -22,7 +22,7 @@ export default Sentry.wrap(App);
 
 ### Enable Routing Instrumentation
 
-We currently provide two routing instrumentations out of the box to instrument route changes for React Navigation. In the future, we will add support for other libraries such as [react-native-navigation](https://github.com/wix/react-native-navigation). Otherwise, if you have a custom routing instrumentation, or use a routing library we don't yet support, you can use the bare bones routing instrumentation or create your own by extending it.
+We currently provide two routing instrumentations out of the box to instrument route changes for React Navigation. In the future, we will add support for other libraries such as [react-native-navigation](https://github.com/wix/react-native-navigation). If you have a custom routing instrumentation or use a routing library we don't yet support, you can use the bare bones routing instrumentation or create your own by extending it.
 
 #### React Navigation
 


### PR DESCRIPTION
The RN SDK now supports React Navigation V6 using the same instrumentation as V5 in https://github.com/getsentry/sentry-react-native/pull/1768. So we remove the V5 prefix and just call it the React Navigation instrumentation.