### PR TITLE
fix(nextjs): Correct format of `.sentryclirc`

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -167,7 +167,8 @@ defaults.project=___PROJECT_SLUG___
 Add the token to `.sentryclirc`:
 
 ```ini {filename:.sentryclirc}
-auth.token=___TOKEN___
+[auth]
+token=___TOKEN___
 ```
 
 And don't forget to ignore `.sentryclirc` in your VCS.


### PR DESCRIPTION
Fixes the format of the `.sentryclirc` file.