### PR TITLE
Refactor DiagnosticSource docs.

### DIFF
--- a/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
+++ b/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
@@ -1,3 +1,27 @@
+## DiagnosticSource Integration
+
+Starting with version 3.9.0, the SDK will automatically integrate with Entity Framework Core and SQLClient whenever available. Those integrations will automatically be activated if your project matches one of the following conditions:
+* Includes `Sentry.AspNet` 3.9.0 or higher
+* Includes `Sentry.AspNetCore` 3.9.0 or higher
+* Targets .NET Core 3.0 or higher (for example .NET 5)
+
+Even if your project doesn't meet any of those requirements, you'll be able to manually activate those instrumentations by including the package 'Sentry.DiagnosticSource' and enabling it during on the SDK's initialization.
+
+```csharp
+// Requires NuGet package: Sentry.DiagnosticSource
+using Sentry;
+
+option.AddDiagnosticSourceIntegration();
+
+```
+
+If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticSourceIntegration();`
+```csharp
+using Sentry;
+
+option.DisableDiagnosticSourceIntegration();
+```
+
 ### Entity Framework Core Integration
 
 ![Sample transaction  with Entity Framework Core Integration.](dotnet-ef-core-integration.png)

--- a/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
+++ b/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
@@ -1,11 +1,11 @@
 ## DiagnosticSource Integration
 
-Starting with version 3.9.0, the SDK will automatically integrate with Entity Framework Core and SQLClient whenever available. Those integrations will automatically be activated if your project matches one of the following conditions:
+Starting with version 3.9.0, the SDK automatically integrates with Entity Framework Core and SQLClient whenever available. Those integrations are automatically activated if your project matches one of the following conditions:
 * Includes `Sentry.AspNet` 3.9.0 or higher
 * Includes `Sentry.AspNetCore` 3.9.0 or higher
-* Targets .NET Core 3.0 or higher (for example .NET 5)
+* Targets .NET Core 3.0 or higher (for example, .NET 5)
 
-Even if your project doesn't meet any of those requirements, you'll be able to manually activate those instrumentations by including the package 'Sentry.DiagnosticSource' and enabling it during on the SDK's initialization.
+Even if your project doesn't meet any of those requirements, you can manually activate those instrumentations by including the package `Sentry.DiagnosticSource` and enabling it during on the SDK's initialization.
 
 ```csharp
 // Requires NuGet package: Sentry.DiagnosticSource

--- a/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
+++ b/src/includes/performance/automatic-instrumentation-integrations/dotnet.mdx
@@ -1,27 +1,27 @@
 ## DiagnosticSource Integration
 
 Starting with version 3.9.0, the SDK automatically integrates with Entity Framework Core and SQLClient whenever available. Those integrations are automatically activated if your project matches one of the following conditions:
+
 * Includes `Sentry.AspNet` 3.9.0 or higher
 * Includes `Sentry.AspNetCore` 3.9.0 or higher
-* Targets .NET Core 3.0 or higher (for example, .NET 5)
-
-Even if your project doesn't meet any of those requirements, you can manually activate those instrumentations by including the package `Sentry.DiagnosticSource` and enabling it during on the SDK's initialization.
-
-```csharp
-// Requires NuGet package: Sentry.DiagnosticSource
-using Sentry;
-
-option.AddDiagnosticSourceIntegration();
-
-```
+* Includes `Sentry` 3.9.0 and targets .NET Core 3.0 or higher (for example, .NET 5)
 
 If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticSourceIntegration();`
+
 ```csharp
 using Sentry;
 
 option.DisableDiagnosticSourceIntegration();
 ```
 
+If your project doesn't match any of the conditions above, (for example, it targets .NET Framework 4.6.1 and uses only the `Sentry` package), you can still manually activate those instrumentations by including the package `Sentry.DiagnosticSource` and enabling it during on the SDK's initialization.
+
+```csharp
+// Requires NuGet package: Sentry.DiagnosticSource
+using Sentry;
+
+option.AddDiagnosticSourceIntegration();
+```
 ### Entity Framework Core Integration
 
 ![Sample transaction  with Entity Framework Core Integration.](dotnet-ef-core-integration.png)

--- a/src/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -38,24 +38,4 @@ var sentryHttpHandler = new SentryHttpMessageHandler(innerHttpHandler);
 var httpClient = new HttpClient(sentryHttpHandler);
 ```
 
-## DiagnosticSource Integration
-
-Starting with version 3.9.0, the SDK will automatically integrate with Entity Framework Core and SQLClient whenever available. Those integrations will automatically be activated if your project matches one of the following conditions:
-* Includes `Sentry.AspNet` 3.9.0 or higher
-* Includes `Sentry.AspNetCore` 3.9.0 or higher
-* Targets .NET Core 3.0 or higher (for example .NET 5)
-
-Even if your project doesn't meet any of those requirements, you'll be able to manually activate those instrumentations by including the package 'Sentry.DiagnosticSource' and enabling it during on the SDK's initialization.
-
-```csharp
-// Requires NuGet package: Sentry.DiagnosticSource
-option.AddDiagnosticSourceIntegration();
-
-```
-
-If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticSourceIntegration();`
-```csharp
-option.DisableDiagnosticSourceIntegration();
-```
-
 <PlatformContent includePath="performance/automatic-instrumentation-integrations" />


### PR DESCRIPTION
- Moved Diagnostic Source explanation to the include file, by that, the AspNET Core will also include the documentation of it.
- Added the missing using Sentry into the sample for disabling/enabling Diagnostic Source.