### PR TITLE
fix(js): Fix deprecation version for `whitelistUrls` and `blacklistUrls`

### DIFF
--- a/src/includes/configuration/decluttering/javascript.mdx
+++ b/src/includes/configuration/decluttering/javascript.mdx
@@ -12,7 +12,7 @@ You can also use `denyUrls` if you want to block specific URLs forever.
 
 <Alert level="warning" title="Note">
 
-Prior to version 5.17.0, `allowUrls` and `denyUrls` were called `whitelistUrls` and `blacklistUrls` respectively. These options are still supported for backwards compatibility reasons, but they will be removed in version 6.0. For more information, please see our [Inclusive Language Policy](https://develop.sentry.dev/inclusion/).
+Prior to version 5.17.0, `allowUrls` and `denyUrls` were called `whitelistUrls` and `blacklistUrls` respectively. These options are still supported for backwards compatibility reasons, but they will be removed in version 7.0. For more information, please see our [Inclusive Language Policy](https://develop.sentry.dev/inclusion/).
 
 </Alert>
 


### PR DESCRIPTION
What was once v6 has become v7 in our planning, and this updates the note about the removal of `whitelistUrls` and `blacklistUrls` to reflect that.