### PR TITLE
Remove EA note from appstore connect.

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -17,12 +17,6 @@ Alternatively, the dSYM files can be downloaded either with [Fastlane](#bitcode-
 
 <Alert level="Note">
 
-This feature is currently available as an early access preview.
-
-</Alert>
-
-<Alert level="Note">
-
 Looking for the upload methods when using this intergration?
 
 - [Upload BCSymbolMaps Using Fastlane](#symbolmap-fastlane)


### PR DESCRIPTION
It is supposed to be GA, at least by the time we merge this.