### PR TITLE
Ref: replace DebugDiagnosticLogger by TraceDiagnosticLogger on .NET doc

### DIFF
--- a/src/platforms/dotnet/configuration/diagnostic-logger.mdx
+++ b/src/platforms/dotnet/configuration/diagnostic-logger.mdx
@@ -31,7 +31,7 @@ To use a custom implementation of `IDiagnosticLogger`, you can pass it to the `D
 options.DiagnosticLogger = new TraceDiagnosticLogger(SentryLevel.Debug);
 ```
 
-The logger `TraceDiagnosticLogger` in the example uses the [.NET's Trace class](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.trace). As a result, you can view the SDK logs inside Visual Studio's Debug log window, which is useful for technologies that don't have a Console to see the log messages, such as `WPF` and `ASP.NET`.
+The logger `TraceDiagnosticLogger` in the example above uses the [.NET's Trace class](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.trace). As a result, you can view the SDK logs inside Visual Studio's Debug log window, which is useful for technologies that don't have a Console to see the log messages, such as `WPF` and `ASP.NET`.
 
 You can also create your own implementation of `IDiagnosticLogger` to fully customize logging behavior. For example, to naively append diagnostic messages to a file:
 

--- a/src/platforms/dotnet/configuration/diagnostic-logger.mdx
+++ b/src/platforms/dotnet/configuration/diagnostic-logger.mdx
@@ -24,14 +24,14 @@ options =>
 
 By default, Sentry will write diagnostic messages to console. This may not be optimal in some circumstances; for example, when running applications that don't have a visible console window attached.
 
-To use a custom implementation of `IDiagnosticLogger`, you can pass it to the `DiagnosticLogger` option. Sentry comes with two implementations out of the box: `ConsoleDiagnosticLogger` and `DebugDiagnosticLogger`.
+To use a custom implementation of `IDiagnosticLogger`, you can pass it to the `DiagnosticLogger` option. Sentry comes with two implementations out of the box: `ConsoleDiagnosticLogger` and `TraceDiagnosticLogger`.
 
 ```csharp
 // Provide a custom logger
-options.DiagnosticLogger = new DebugDiagnosticLogger(SentryLevel.Debug);
+options.DiagnosticLogger = new TraceDiagnosticLogger(SentryLevel.Debug);
 ```
 
-The logger `DebugDiagnosticLogger` in the example uses the [.NET's Debug class](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.debug). As a result, you can view the SDK logs inside Visual Studio's Debug log window, which is useful for technologies that don't have a Console to see the log messages, such as `WPF` and `ASP.NET`.
+The logger `TraceDiagnosticLogger` in the example uses the [.NET's Trace class](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.trace). As a result, you can view the SDK logs inside Visual Studio's Debug log window, which is useful for technologies that don't have a Console to see the log messages, such as `WPF` and `ASP.NET`.
 
 You can also create your own implementation of `IDiagnosticLogger` to fully customize logging behavior. For example, to naively append diagnostic messages to a file:
 


### PR DESCRIPTION
DebugDiagnosticLogger is obsolete and the functionality is replaced by TraceDiagnosticLogger.