### PR TITLE
Update hermes.mdx info about OS-BIN

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -36,7 +36,7 @@ npx react-native bundle --platform android --dev false --entry-file index.js --b
 
  <Note>
  
- `OS-BIN` is `osx-bin`, `win64-bin`, or `linux-bin`, depending on which operating system you are using.
+ `OS-BIN` is `osx-bin`, `win64-bin`, or `linux64-bin`, depending on which operating system you are using.
  
  </Note>
 


### PR DESCRIPTION
Current binary available for linux is stored in `linux64-bin` directory, not `linux-bin`