### PR TITLE
fix(nextjs): Clarify vercel integration webpack plugin instructions for nextjs apps

### DIFF
--- a/src/docs/product/integrations/deployment/vercel/index.mdx
+++ b/src/docs/product/integrations/deployment/vercel/index.mdx
@@ -54,7 +54,7 @@ Use Vercel to [link projects](#project-linking) for uploading source maps and no
 
 - If you have not already done so, [instrument your code with Sentry](/platforms/javascript/).
 - Ensure you have [installed a repository integration](/product/releases/setup/release-automation/) and added the relevant repository.
-- Add the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) to your configuration. For NextJS, use `next.config.js`.
+- Add the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) to your Webpack configuration. For Next.js, if you followed the `@sentry/nextjs` [set-up guide](platforms/javascript/guides/nextjs/), this will already have been done.
 - If you already have a Vercel project integrated with Sentry, ensure the Sentry project you link is the one you're already using to report errors.
 
 ## Uninstallation

--- a/src/docs/product/integrations/deployment/vercel/index.mdx
+++ b/src/docs/product/integrations/deployment/vercel/index.mdx
@@ -54,7 +54,7 @@ Use Vercel to [link projects](#project-linking) for uploading source maps and no
 
 - If you have not already done so, [instrument your code with Sentry](/platforms/javascript/).
 - Ensure you have [installed a repository integration](/product/releases/setup/release-automation/) and added the relevant repository.
-- Add the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) to your Webpack configuration. For Next.js, if you followed the `@sentry/nextjs` [set-up guide](platforms/javascript/guides/nextjs/), this will already have been done.
+- Add the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) to your Webpack configuration. For Next.js apps, if you followed the `@sentry/nextjs` [set-up guide](/platforms/javascript/guides/nextjs/), this will already have been done.
 - If you already have a Vercel project integrated with Sentry, ensure the Sentry project you link is the one you're already using to report errors.
 
 ## Uninstallation


### PR DESCRIPTION
This fixes the note about using the webpack plugin as part of the vercel integration if you're running a nextjs app, to correctly indicate that for those folks, the step is unnecessary.