### PR TITLE
update plan notes for sso features

### DIFF
--- a/src/docs/product/accounts/sso/index.mdx
+++ b/src/docs/product/accounts/sso/index.mdx
@@ -13,10 +13,6 @@ Single Sign-On (or SSO) allows you to manage your organization’s entire member
 
 Before you get around to actually turning on SSO, you’ll want to keep in mind that once it’s activated, all existing users will need to link their account before they are able to continue using Sentry. Because of that we recommend coordinating with your team during off-peak hours. That said, it’s super quick to link accounts, so we don’t consider it a true hurdle.
 
-<Alert title="Note" level="warning">
-  SSO is not available on free, trial or certain other plans.
-</Alert>
-
 ## Getting Started
 
 With that out of the way, head on over to your organization home. You’ll see an “Auth” link in the sidebar if you have access to SSO. Start by hitting that, and then continue to the “Configure” link next to provider you wish to configure.

--- a/src/docs/product/accounts/sso/index.mdx
+++ b/src/docs/product/accounts/sso/index.mdx
@@ -35,7 +35,7 @@ Sessions last for [Django's default session length](https://docs.djangoproject.c
 
 <Note>
 
-This feature is available only if your organization is on a Team or Trial plan.
+This feature is available only if your organization is on a Team plan or higher, or a Trial plan.
 
 </Note>
 

--- a/src/docs/product/accounts/sso/index.mdx
+++ b/src/docs/product/accounts/sso/index.mdx
@@ -35,29 +35,35 @@ Sessions last for [Django's default session length](https://docs.djangoproject.c
 
 <Note>
 
-This feature is available only if your organization is on either a Team or Trial plan.
+This feature is available only if your organization is on a Team or Trial plan.
 
 </Note>
 
 Enabling the Google integration will ask you to authenticate against a Google Apps account. Once done, membership will be restricted to only members of the given Apps domain (i.e. `sentry.io`).
 
-<Alert title="Note" level="warning">
+<Alert level="info">
+
 If you need to allow users across multiple domains to access your organization or change your Google domain, please contact our support team.
+
 </Alert>
 
 ### GitHub Organizations
 
 <Note>
 
-This feature is available only if your organization is on either a Team or Trial plan.
+This feature is available only if your organization is on a Team or Trial plan.
 
 </Note>
 
 The GitHub integration will authenticate against all organizations, and once complete prompt you for the organization which you wish to restrict access by.
 
-### SAML2 Identity Provider
+### SAML2 Identity Providers {#smal2-identity-provider}
 
-SSO is not available on free, trial or certain other plans.
+<Note>
+
+This feature is only available if your organization is on a Business or Enterprise plan. This feature is not available on Trial plans.
+
+</Note>
 
 Sentry provides [SAML2 based authentication](https://en.wikipedia.org/wiki/SAML_2.0) which may be configured manually using the generic SAML2 provider, or a specific provider listed below that provides defaults specific to that identity provider:
 
@@ -104,9 +110,6 @@ Sentry’s SAML endpoints are as follows, where the `[organization_slug]` is sub
     </tr>
   </tbody>
 </table>
-<Alert title="Note" level="warning">
-  SAML2 SSO requires a Business or Enterprise Plan.
-</Alert>
 
 #### Auth0
 

--- a/src/docs/product/accounts/sso/index.mdx
+++ b/src/docs/product/accounts/sso/index.mdx
@@ -33,6 +33,12 @@ Sessions last for [Django's default session length](https://docs.djangoproject.c
 
 ### Google Business App
 
+<Note>
+
+This feature is available only if your organization is on either a Team or Trial plan.
+
+</Note>
+
 Enabling the Google integration will ask you to authenticate against a Google Apps account. Once done, membership will be restricted to only members of the given Apps domain (i.e. `sentry.io`).
 
 <Alert title="Note" level="warning">
@@ -41,9 +47,17 @@ If you need to allow users across multiple domains to access your organization o
 
 ### GitHub Organizations
 
+<Note>
+
+This feature is available only if your organization is on either a Team or Trial plan.
+
+</Note>
+
 The GitHub integration will authenticate against all organizations, and once complete prompt you for the organization which you wish to restrict access by.
 
 ### SAML2 Identity Provider
+
+SSO is not available on free, trial or certain other plans.
 
 Sentry provides [SAML2 based authentication](https://en.wikipedia.org/wiki/SAML_2.0) which may be configured manually using the generic SAML2 provider, or a specific provider listed below that provides defaults specific to that identity provider:
 

--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -8,8 +8,10 @@ description: "Learn about how to integrate the Custom SAML Provider."
 
 Sentry provides a generic auth provider for [SAML2 based authentication](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language), which allows Owners of a Sentry organization to manually configure any SAML2-enabled IdP system. Documented below are the general steps for integration.
 
-<Alert title="Note" level="warning">
-SAML2 SSO requires a Business or Enterprise Plan.
+<Alert level="info">
+
+This feature is only available if your organization is on a Business or Enterprise plan. This feature is not available on Trial plans.
+
 </Alert>
 
 # Setup


### PR DESCRIPTION
Add and remove notes pertaining to plan-based availability for SSO features

- Github and Google - Team+ and Trial
- SAML2 - Biz+, no Trial