### PR TITLE
update wording about spike protection being enabled

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -250,7 +250,7 @@ A spike is both a **large** and **temporary** increase in error event volume. Be
 
 Spike protection is an organization-level setting, so once it's triggered, it affects all the projects in the organization, regardless of which project triggered the spike.
 
-You can enable spike protection for your organization in **Settings > Subscription**. When it's enabled, Sentry continually monitors for spikes.
+Spike protection is enabled for your organization by default, and when it's enabled, Sentry continually monitors for spikes. If you want to disable it, you can do so in **Settings > Subscription**.
 
 ### How Does Spike Protection Work?
 


### PR DESCRIPTION
Clarifies the language around spike protection so that it's clear that it's enabled by default. Currently the language makes it sound like you have to enable it.