### PR TITLE
fix wording about page links 

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -7,7 +7,7 @@ redirect_from:
 description: "Get started with Sentry's Performance Monitoring, which allows you to see macro-level metrics to micro-level spans, cross-reference transactions with related issues, and customize queries."
 ---
 
-If you don't already have performance monitoring enabled, use the supported SDK links below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.
+If you don't already have performance monitoring enabled, use the links for supported SDKs below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.
 
 <Alert>
 

--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -7,7 +7,7 @@ redirect_from:
 description: "Get started with Sentry's Performance Monitoring, which allows you to see macro-level metrics to micro-level spans, cross-reference transactions with related issues, and customize queries."
 ---
 
-If you don't already have performance monitoring enabled, use the link below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.
+If you don't already have performance monitoring enabled, use the supported SDK links below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/product/performance/event-detail/), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/discover-queries/query-builder/) based on your personal needs, and substantially more.
 
 <Alert>
 


### PR DESCRIPTION
Fixes wording of first sentence of this page to make clearer that we mean the list of Supported SDKs links