### PR TITLE
fix(scim): correct okta api token instructions

### DIFF
--- a/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
+++ b/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
@@ -36,14 +36,12 @@ Okta SCIM provisioning requires:
 1. Select the "Provisioning" tab, then "Configure API integration".
    ![Okta configure SCIM API](scim-okta-configure.png)
 
-1. Select "Enable API Integration", provide the SCIM URL from the auth settings page as the Base URL field. For the API Token, copy the Auth Token value from the auth settings page, including `Bearer` in the value you copy.
+1. Select "Enable API Integration", provide the SCIM URL from the auth settings page as the Base URL field. For the API Token, copy the Auth Token value from the auth settings page.
 
-1. Select "Test API Credentials", and confirm the message "the app was verified successfully" displays:
-   ![Okta Test SCIM Credentials](scim-okta-test.png)
+1. Select "Test API Credentials", and confirm the message "the app was verified successfully" displays.
    ![SCIM Verified Sucessfully](scim-okta-verified.png)
 
-1. Select "Save" to be directed to SCIM App settings:
-   ![Okta Save SCIM Settings](scim-okta-save.png)
+1. Select "Save" to be directed to SCIM App settings.
 
 1. On the Provisioning page, select "To App", then "edit":
    ![Okta Save SCIM Settings](scim-okta-edit.png)


### PR DESCRIPTION
After okta pushed our integration to production, how the token was supplied slightly changed and you no longer have to provide "Bearer " in the token. We remove that part of the instruction and also remove screenshots, as they can become outdated and didn't provide much added benefit here in these instructions.