### PR TITLE
fix(apple): Features for macOS and watchOS

### DIFF
--- a/src/includes/getting-started-primer/apple.macos.mdx
+++ b/src/includes/getting-started-primer/apple.macos.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS, tvOS, and watchOS SDK hook into all signal and exception handlers, except for MacOS.
+Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS, tvOS, and watchOS SDK hook into all signal and exception handlers, except for macOS.
 
 The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
 

--- a/src/includes/getting-started-primer/apple.macos.mdx
+++ b/src/includes/getting-started-primer/apple.macos.mdx
@@ -1,10 +1,4 @@
-<Note>
-
-Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS, tvOS, and watchOS SDK hook into all signal and exception handlers, except for macOS.
-
-The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
-
-</Note>
+<PlatformContent includePath="getting-started-primer/note" />
 
 **Features:**
 

--- a/src/includes/getting-started-primer/apple.macos.mdx
+++ b/src/includes/getting-started-primer/apple.macos.mdx
@@ -15,7 +15,6 @@ The SDK builds a crash report that persists to disk and tries to send the report
   - C++ exceptions
   - Objective-C exceptions
   - Main thread deadlock (experimental)
-  - Out of memory
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data
 - Offline caching when a device is unable to connect; we send a report once we receive another event
 - [Breadcrumbs automatically](/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -1,10 +1,4 @@
-<Note>
-
-Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS, tvOS, and watchOS SDK hook into all signal and exception handlers, except for MacOS.
-
-The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
-
-</Note>
+<PlatformContent includePath="getting-started-primer/note" />
 
 **Features:**
 

--- a/src/includes/getting-started-primer/apple.watchos.mdx
+++ b/src/includes/getting-started-primer/apple.watchos.mdx
@@ -8,21 +8,8 @@ The SDK builds a crash report that persists to disk and tries to send the report
 
 **Features:**
 
-- Multiple types of errors are captured, including:
-  - Mach exceptions
-  - Fatal signals
-  - Unhandled exceptions
-  - C++ exceptions
-  - Objective-C exceptions
-  - Main thread deadlock (experimental)
-  - Out of memory
+- Limited symbolication support and no crash handling
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data
 - Offline caching when a device is unable to connect; we send a report once we receive another event
-- [Breadcrumbs automatically](/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for
-  - Application lifecycle events (`didBecomeActive`, `didEnterBackground`, `viewDidAppear`)
-  - Touch events
-  - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
-  - Outgoing HTTP requests
-- [Release Health](/product/releases/health/) tracks crash free users and sessions
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.watchos.mdx
+++ b/src/includes/getting-started-primer/apple.watchos.mdx
@@ -1,11 +1,3 @@
-<Note>
-
-Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS, tvOS, and watchOS SDK hook into all signal and exception handlers, except for MacOS.
-
-The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
-
-</Note>
-
 **Features:**
 
 - Limited symbolication support and no crash handling

--- a/src/includes/getting-started-primer/note/apple.mdx
+++ b/src/includes/getting-started-primer/note/apple.mdx
@@ -1,0 +1,7 @@
+<Note>
+
+Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS and tvOS SDK hook into all signal and exception handlers, except for macOS.
+
+The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
+
+</Note>


### PR DESCRIPTION
The feature set of MacOS and WatchOS included too many features
and confuses users.
This is fixed now by removing the nonsupported features.

@imatwawana, I had to copy the pages. Is there maybe a way to reuse some common text of the pages?