### PR TITLE
feat(RN): Add expo warnings and troubleshooting

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -8,9 +8,13 @@ npm install --save @sentry/react-native
 yarn add @sentry/react-native
 ```
 
-<Note>
+### Expo
 
 If you are using Expo, see [How to Add Sentry to Your Expo Project](https://docs.expo.io/guides/using-sentry/). This SDK works for both managed and bare projects.
+
+<Note>
+
+Make sure that the version of `@sentry/react-native` matches what `sentry-expo` depends on, [read more on our troubleshooting page](http://localhost:3000/platforms/react-native/troubleshooting/#expo).
 
 </Note>
 

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -37,3 +37,13 @@ Try passing `--force-foreground` to the Sentry CLI command in the build script. 
 
 - If your release health statistics are being attributed to the wrong release, confirm that you [pass the `release` and `dist` to the `init` call](/platforms/react-native/configuration/releases/#bind-the-version).
 - If you are using Code Push, check that you are not using `setRelease` and `setDist` as they will break release health. You can read more on the [CodePush guide](/platforms/react-native/manual-setup/codepush/).
+
+## Expo
+
+<Alert level="warning" title="Version 3.x">
+
+We have received reports of it being incompatible with `@sentry/react-native: 3.x`. Please stay on `@sentry/react-native: 2.6.2` if you use `sentry-expo`.
+
+</Alert>
+
+If you use the [sentry-expo](https://github.com/expo/sentry-expo) SDK, make sure that you do not manually upgrade the version of the `@sentry/react-native` SDK and instead rely on the version that the `sentry-expo` SDK depends on. Upgrading could cause a version mismatch that could lead to errors being unreported and other undefined behavior. This is due to the `sentry-expo` SDK not being officially maintained by Sentry but instead by the Expo team.


### PR DESCRIPTION
Warn users about incompatibilities and version mismatch when using `sentry-expo` along with a warning about the current version `3.x` not working with `sentry-expo`.

https://github.com/getsentry/sentry-react-native/issues/1773