### PR TITLE
Added worked example of using an authentication token

### DIFF
--- a/src/api/auth.mdx
+++ b/src/api/auth.mdx
@@ -11,7 +11,10 @@ Authentication tokens are passed using an auth header, and are used to authentic
 curl -H 'Authorization: Bearer {TOKEN}' https://sentry.io/api/0/projects/
 ```
 
-You can [find or create authentication tokens within Sentry](https://sentry.io/api/).
+You can [find or create authentication tokens within Sentry](https://sentry.io/api/). Replace `{TOKEN}` with your authentiation token, for instance if your authentication token is `1a2b3c` then the command would need to be:
+```bash
+curl -H 'Authorization: Bearer 1a2b3c' https://sentry.io/api/0/projects/
+```
 
 For self-hosted, you can find or create authentication tokens by visiting `{instance_url_prefix}/settings/account/api/auth-tokens/`
 


### PR DESCRIPTION
I struggled for a bit trying to make sense of how to format the command line with my authentication token. Here's a suggested change to the documentation to make the details of what to do clearer.