### PR TITLE
Fix typo in method example

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -80,7 +80,7 @@ Configure data in a local scope
 
 ```ruby
 # Before
-Raven.tag_context(foo: "bar") do
+Raven.tags_context(foo: "bar") do
   Raven.capture_message("test")
 end
 


### PR DESCRIPTION
Method tag_context do not exist in sentry-raven gem

Correct method is `tags_context`

Source: https://github.com/getsentry/sentry-ruby/tree/master/sentry-raven#context

PS: Thanks for your work :)