### PR TITLE
feat(apple): Warning about HTTP instrumentation

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,11 +8,13 @@ description: "Learn what transactions are captured after tracing is enabled."
 
 Capturing transactions requires that you first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink> if you haven't already.
 
-Warning: The HTTP instrumentation can lead to crashes due to a bug in the SDK, see [GitHub Issue][HTTP Instrumentation Bug]. We recommend [disabling the feature](#http-instrumentation), while we are working on a bugfix.
-
-[HTTP Instrumentation Bug]: https://github.com/getsentry/sentry-cocoa/issues/1328
-
 </Note>
+
+<Alert level="info" title="Important">
+
+The HTTP instrumentation can lead to crashes due to a bug in the SDK, see [GitHub Issue][HTTP Instrumentation Bug]. We recommend [disabling the feature](#http-instrumentation), while we are working on a bugfix. [HTTP Instrumentation Bug](https://github.com/getsentry/sentry-cocoa/issues/1328)
+
+</Alert>
 
 ## UIViewController Instrumentation
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,6 +8,10 @@ description: "Learn what transactions are captured after tracing is enabled."
 
 Capturing transactions requires that you first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink> if you haven't already.
 
+Warning: The HTTP instrumentation can lead to crashes due to a bug in the SDK, see [GitHub Issue][HTTP Instrumentation Bug]. We recommend [disabling the feature](#http-instrumentation), while we are working on a bugfix.
+
+[HTTP Instrumentation Bug]: https://github.com/getsentry/sentry-cocoa/issues/1328
+
 </Note>
 
 ## UIViewController Instrumentation
@@ -54,6 +58,26 @@ Slow and frozen frames are Mobile Vitals, which you can learn about in the [full
 ## HTTP Instrumentation
 
 The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection] yet. The SDK attaches auto-generated transactions automatically to the Scope if there is no other transaction bound. When starting a transaction, you can use `bindToScope` to indicate whether the SDK should bind the new transaction to the Scope or not.
+
+To disabe the HTTP Instrumentation:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enableNetworkTracking = false
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enableNetworkTracking = NO;
+}];
+```
 
 [NSURLSession]: https://developer.apple.com/documentation/foundation/nsurlsession
 [NSURLConnection]: https://developer.apple.com/documentation/foundation/nsurlconnection

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -61,7 +61,7 @@ Slow and frozen frames are Mobile Vitals, which you can learn about in the [full
 
 The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection] yet. The SDK attaches auto-generated transactions automatically to the Scope if there is no other transaction bound. When starting a transaction, you can use `bindToScope` to indicate whether the SDK should bind the new transaction to the Scope or not.
 
-To disabe the HTTP Instrumentation:
+To disable the HTTP instrumentation:
 
 ```swift {tabTitle:Swift}
 import Sentry


### PR DESCRIPTION
The HTTP instrumentation on Apple can lead to crashes. We want to point this
out in the docs to warn our users.

Only merge after https://github.com/getsentry/sentry-cocoa/pull/1349 is released.