### PR TITLE
fix: Add fallback userID to mobile SDKs

### DIFF
--- a/src/includes/enriching-events/set-user/android.mdx
+++ b/src/includes/enriching-events/set-user/android.mdx
@@ -19,6 +19,6 @@ Sentry.setUser(user)
 
 <Note>
 
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>

--- a/src/includes/enriching-events/set-user/android.mdx
+++ b/src/includes/enriching-events/set-user/android.mdx
@@ -19,6 +19,6 @@ Sentry.setUser(user)
 
 <Note>
 
-Sentry will by fallback to a random generated `installationId` if you do not provide a user identity.
+If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
 
 </Note>

--- a/src/includes/enriching-events/set-user/apple.mdx
+++ b/src/includes/enriching-events/set-user/apple.mdx
@@ -16,6 +16,6 @@ user.email = @"john.doe@example.com";
 
 <Note>
 
-Since 6.0.1: If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+Since 6.0.1: If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>

--- a/src/includes/enriching-events/set-user/apple.mdx
+++ b/src/includes/enriching-events/set-user/apple.mdx
@@ -14,4 +14,8 @@ user.email = @"john.doe@example.com";
 [SentrySDK setUser:user];
 ```
 
-Since 6.0.1: Sentry will by fallback to `installationId` if you do not provide a user identity.
+<Note>
+
+Since 6.0.1: If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+
+</Note>

--- a/src/includes/enriching-events/set-user/dart.mdx
+++ b/src/includes/enriching-events/set-user/dart.mdx
@@ -5,9 +5,3 @@ Sentry.configureScope(
   (scope) => scope.user = SentryUser(id: '1234', email: 'jane.doe@example.com'),
 );
 ```
-
-<Note>
-
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
-
-</Note>

--- a/src/includes/enriching-events/set-user/flutter.mdx
+++ b/src/includes/enriching-events/set-user/flutter.mdx
@@ -1,0 +1,13 @@
+```dart
+import 'package:sentry/sentry.dart';
+
+Sentry.configureScope(
+  (scope) => scope.user = SentryUser(id: '1234', email: 'jane.doe@example.com'),
+);
+```
+
+<Note>
+
+If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+
+</Note>

--- a/src/includes/enriching-events/set-user/flutter.mdx
+++ b/src/includes/enriching-events/set-user/flutter.mdx
@@ -8,6 +8,6 @@ Sentry.configureScope(
 
 <Note>
 
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>

--- a/src/includes/enriching-events/set-user/react-native.mdx
+++ b/src/includes/enriching-events/set-user/react-native.mdx
@@ -1,9 +1,5 @@
-```dart
-import 'package:sentry/sentry.dart';
-
-Sentry.configureScope(
-  (scope) => scope.user = SentryUser(id: '1234', email: 'jane.doe@example.com'),
-);
+```javascript
+Sentry.setUser({ email: "john.doe@example.com" });
 ```
 
 <Note>

--- a/src/includes/enriching-events/set-user/react-native.mdx
+++ b/src/includes/enriching-events/set-user/react-native.mdx
@@ -4,6 +4,6 @@ Sentry.setUser({ email: "john.doe@example.com" });
 
 <Note>
 
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK once randomly generates during an app's installation.
+If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>


### PR DESCRIPTION
Align or add info on fallback for userID to installationID for
Android, Apple, Dart, and ReactNative.