### PR TITLE
Fix typo for ANR manifest meta-data name

### DIFF
--- a/src/platforms/android/configuration/app-not-respond.mdx
+++ b/src/platforms/android/configuration/app-not-respond.mdx
@@ -24,6 +24,6 @@ You can also specify how long the thread should be blocked before the ANR is rep
 
 ```xml {filename:AndroidManifest.xml}
 <application>
-    <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
+    <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="2000" />
 </application>
 ```


### PR DESCRIPTION
The current docs say the name of the meta-data element is
`io.sentry.anr.timeout-interval-mills`
however I think this might be a typo for (note the "i" near the end):
`io.sentry.anr.timeout-interval-millis`

Assuming this is the constant for the name:
https://github.com/getsentry/sentry-java/blob/dd6f9dbe69575869b94c85d03411285ea932a829/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java#L27