### PR TITLE
feat(ui): Add font smoothing

### DIFF
--- a/src/css/screen.scss
+++ b/src/css/screen.scss
@@ -54,6 +54,11 @@
 @import "_includes/large-definition-list";
 @import "_includes/banner";
 
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 code[class*="language-"], pre[class*="language-"] {
   font-family: 'IBM Plex', SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
     monospace !important;


### PR DESCRIPTION
Use antialiasing (instead of the default sub-pixel rendering) for font smoothing, to make docs look more in line with the main app + our designs on Figma, and reduce font bleeding in white text on dark backgrounds.

Before - with the default sub-pixel rendering:

<img width="775" alt="Screen Shot 2021-10-01 at 11 49 52 AM" src="https://user-images.githubusercontent.com/44172267/135671838-0ce9656d-3f49-4b9e-a5dd-5b9160dca2df.png">

After - with antialiasing:

<img width="775" alt="Screen Shot 2021-10-01 at 11 50 57 AM" src="https://user-images.githubusercontent.com/44172267/135671970-14b1ae83-a3df-46ed-bb27-b3a42b8be6d6.png">

