### PR TITLE
Fix unescaped backslash

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -18,7 +18,7 @@ Because releases work on projects you will need to specify the organization and 
 
 Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
 
-- contain newlines, tabulator characters, forward slashes(/), or back slashes(\)
+- contain newlines, tabulator characters, forward slashes(/), or back slashes(\\)
 - be (in their entirety) period (.), double period (..), or space ( )
 - exceed 200 characters
 


### PR DESCRIPTION
Unescaped, the backslash does not appear in the docs either on GitHub or live at https://docs.sentry.io/product/cli/releases/#creating-releases. This change escapes it so that it appears.