### PR TITLE
Add missing link to Flask integration

### DIFF
--- a/src/platforms/python/common/configuration/integrations/index.mdx
+++ b/src/platforms/python/common/configuration/integrations/index.mdx
@@ -8,6 +8,7 @@ Sentry provides a number of additional integrations which are designed to change
 
 - [Default Integrations](default-integrations/)
 - [Django](django/)
+- [Flask](flask/)
 - [GNU Backtrace](gnu_backtrace/)
 - [pure_eval](pure_eval/)
 - [Redis](redis/)


### PR DESCRIPTION
Links in the integrations index are currently maintained manually, and a link to the Flask integration is missing.