### PR TITLE
ref(slack): Add troubleshooting section

### DIFF
--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -47,6 +47,12 @@ Your Slack integration is now available to all projects in your Sentry organizat
 
 In the next section, we'll walk you through configuring your notification settings.
 
+### Troubleshooting
+
+#### Rate Limiting Error
+
+If you're attempting to save a Slack alert rule and are receiving the following error: "Requests to slack were rate limited. Please try again later.", you may enter in the channel or user ID in addition to the channel name.
+
 ## Configure
 
 Use Slack for notifications and [alerts](#alert-rules) regarding issues, environments, deployment, etc.


### PR DESCRIPTION
Add a troubleshooting section to the Slack setup docs telling users what to do if they are trying to save an alert rule and are getting rate limited. This will be linked to in the product as well. 