### PR TITLE
feat(discover): Connect Discover and Dashboards documentation

### DIFF
--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -38,4 +38,4 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Dashboard widgets can also be viewed in [Discover](/product/discover-queries/) for further inspection by clicking the <i>Open in Discover</i> button within a widget's context menu. If a widget contains more than one widget, you will be prompted to select which query to view in Discover.
+Dashboard widgets can also be viewed in [Discover](/product/discover-queries/) for further inspection by clicking the <i>Open in Discover</i> button within a widget's context menu. If a widget contains more than one query, you will be prompted to select which query to view in Discover.

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -38,4 +38,4 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Each Dashboard widget has an ellipsis that will open a context menu. From here you can open the widget in [Discover](/product/discover-queries/) for further inspection. If a widget contains more than one query, you will be prompted to select which query to view in Discover.
+Each Dashboard widget has an ellipsis that opens a context menu. From here, you can open the widget in [Discover](/product/discover-queries/) for to get more information. If a widget contains more than one query, you'll be prompted to select which query to view in **Discover**.

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -38,4 +38,4 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Dashboard widgets can also be viewed in [Discover](/product/discover-queries/) for further inspection by clicking the <i>Open in Discover</i> button within a widget's context menu. If a widget contains more than one query, you will be prompted to select which query to view in Discover.
+Each Dashboard widget has an ellipsis that will open a context menu. From here you can open the widget in [Discover](/product/discover-queries/) for further inspection. If a widget contains more than one query, you will be prompted to select which query to view in Discover.

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -29,3 +29,13 @@ The default dashboard includes the following widgets:
 If you’d like to edit the default dashboard or build out multiple ones, each with their own set of unique widgets, you may want to consider our [Custom Dashboards](/product/dashboards/custom-dashboards/) feature which enables you to create more robust views such as the one below.
 
 ![Widgets visualizing key page performance, web vitals, and user misery.](dashboard-custom.png)
+
+## Open Dashboard Widgets in Discover
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Dashboard widgets can also be viewed in [Discover](/product/discover-queries/) for further inspection by clicking the <i>Open in Discover</i> button within a widget's context menu. If a widget contains more than one widget, you will be prompted to select which query to view in Discover.

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -86,7 +86,7 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu dropdown on the Discover homepage or within the Query Results view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
+Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu in the Discover homepage or within the Query Results view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
 
 ## Query Results
 

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -78,6 +78,16 @@ Share your queries as often as you want. You can share URLs with other users who
 
 On the Discover homepage, each saved query card has an ellipsis that will open a context menu. From here, you can delete the query. This action is irreversible. You can also delete the query within the Query Results view by clicking the trash can in the upper right.
 
+### Add to Dashboard
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu dropdown on the Discover homepage or within the Query Results view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
+
 ## Query Results
 
 ![Page displaying a graph of error spikes by URL, the event tag summary, and results of the query.](./discover-results.png)

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -86,7 +86,7 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu in the Discover homepage or within the Query Results view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
+Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu in the Discover homepage or within the [Query Results](#query-results) view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
 
 ## Query Results
 

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -86,7 +86,7 @@ This feature is available only if you're in the Early Adopter program. Features 
 
 </Note>
 
-Queries can also be added to Custom Dashboards as widgets. The <i>Add to Dashboard</i> button can be found by opening the context menu in the Discover homepage or within the [Query Results](#query-results) view. Clicking <i>Add to Dashboard</i> reveals a modal form where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
+Queries can also be added to custom dashboards as widgets. You can find the "Add to Dashboard" button by opening the context menu in the **Discover** homepage or within the [query results](#query-results) view. When you click "Add to Dashboard", a form opens where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
 
 ## Query Results
 


### PR DESCRIPTION
Added `Open Dashboard Widgets in Discover` section in Dashboards page. 
Added `Add to Dashboard` section in Discover Queries page. (Added this under the `Delete Queries` section since `Delete Queries` makes references to ellipsis context menu first)