### PR TITLE
Ref(.NET): Mention how to set a transaction to the scope.

### DIFF
--- a/src/includes/performance/add-spans-example/dotnet.mdx
+++ b/src/includes/performance/add-spans-example/dotnet.mdx
@@ -9,6 +9,10 @@ public async Task PerformCheckoutAsync()
       "checkout", // name
       "perform-checkout" // operation
   );
+  
+  // Set transaction on scope to associate with errors and get included span instrumentation
+  // If there's currently an unfinished transaction, it may be dropped
+  SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
 
   // Validate the cart
   var validationSpan = transaction.StartChild(


### PR DESCRIPTION
Adding the mention on how to link the current scope to a new Transaction.

Related to https://github.com/getsentry/sentry-dotnet/issues/975#issuecomment-847286249
based on https://docs.sentry.io/platforms/javascript/performance/instrumentation/custom-instrumentation/