### PR TITLE
feat(apple): Clarify ViewController Methods

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -23,7 +23,7 @@ This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UI
 
 The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads a ViewController. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
-The SDK creates spans to provide insight into the time consumed by each of the methods below in the screenshot. Due to implementation details, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, no matter if you implement them in your view controller or not.
+The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 
 ![UIViewController Transaction](ui-view-controller-transaction.png)
 


### PR DESCRIPTION
Clarify for which view controller methods the SDK adds spans, as this
changed with Cocoa 7.4.3, which is going to be released soon.

Related to https://github.com/getsentry/sentry-cocoa/pull/1361