### PR TITLE
Docs: Add Custom Payload Text for Webhooks

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -109,7 +109,11 @@ actor
       'name': 'Sentry',
     },
 ```
-Note: You cannot set up a custom payloal. Instead, we suggest setting up a server/service that proxies our webhook into a request that fits your use case.
+<Note>
+
+You cannot set up a custom payload. Instead, we suggest setting up a server/service that proxies our webhook into a request that fits your use case.
+
+</Note>
 
 ## Event Types
 


### PR DESCRIPTION
Move from https://help.sentry.io/product-features/integrations/can-i-set-up-a-custom-payload-for-the-webhook-integration/