### PR TITLE
docs: Add Slack TS step

### DIFF
--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -107,7 +107,7 @@ If you're attempting to save a Slack alert rule and are receiving the following 
 
 To find a channel's ID in Slack click the name of the channel at the top of the application and the channel ID will be shown at the bottom of the pop up. To find a user's ID click on their avatar >>  "View full profile" >>  ... >> "Copy member ID".
 
-#### Can't add alert rule to channel
+#### Can't Add Alert Rule to Channel
 
 If you receive an error “The slack resource `example-channel` does not exist or has not been granted access in the `example-workspace` Slack workspace” while trying to add an alert rule, we recommend checking whether our app is installed in the channel. In Slack, right click on your channel's name from the left bar and select "Open channel settings". Then click on the "Integrations" tab; the Sentry app should be listed under "Apps".
 


### PR DESCRIPTION
Move from https://help.sentry.io/product-features/integrations/slack-can-t-add-alert-rule-to-channel/ and modify