### PR TITLE
docs: Update userid for Cocoa SDK

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -12,18 +12,18 @@ description: "Learn how to configure the SDK to capture the user and gain critic
 Users consist of a few critical pieces of information that construct a unique identity in Sentry. Each of these is optional, but one **must** be present for the Sentry SDK to capture the user:
 
 <PlatformSection notSupported={["apple"]}>
-  
+
 `id`
 
+: Your internal identifier for the user.
 </PlatformSection>
 
 <PlatformSection supported={["apple"]}>
 
 `userId`
 
-</PlatformSection>
-
 : Your internal identifier for the user.
+</PlatformSection>
 
 `username`
 


### PR DESCRIPTION
the Cocoa SDK is using userid instead of id