### PR TITLE
fix(android): can't assign val ListProperty in Kotlin

### DIFF
--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -158,12 +158,12 @@ sentry {
 ```kotlin
 sentry {
     // List the build types that should be ignored (e.g. "release").
-    ignoredBuildTypes = listOf("release")
+    ignoredBuildTypes.set(listOf("release"))
 
     // List the build flavors that should be ignored (e.g. "production").
-    ignoredFlavors = listOf("production")
+    ignoredFlavors.set(listOf("production"))
 
     // List the build variant that should be ignored (e.g. "productionRelease").
-    ignoredVariants = listOf("productionRelease")
+    ignoredVariants.set(listOf("productionRelease"))
 }
 ```


### PR DESCRIPTION
I just tried setting ignored build types in Kotlin/Gradle following the existing documentation and got an error "Val cannot be reassigned".

Instead, `set` in Kotlin works.