### PR TITLE
ref(codeowners): Remove EA mention in Gitlab docs

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -151,8 +151,6 @@ Stack trace linking takes you from a file in your Sentry stack trace to that sam
 
 <Note>
 
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
 </Note>
@@ -194,12 +192,12 @@ For more details, see the full documentation for [Code Owners](/product/issues/i
 
 - Who has permission to install this?
   - You must have both owner/manager/admin permissions in Sentry and owner permissions in GitLab to successfully install this integration.
- 
+
 - Why am I getting a `500` response during installation or configuration?
   - First, make sure you’ve allowed our IPs, which can be found [here](/product/security/ip-ranges/). The 500 response is coming from GitLab, so you may need to try again or double-check that your settings and permissions are correct in GitLab. You must have both owner/manager/admin permissions in Sentry as well as owner permissions in GitLab to successfully install this integration.
-  
+
 - Why am I seeing an "Invalid Repository Names" error?
   - GitLab takes into account the whitespace before and after the `/` . On the Repositories page (Organization Settings > Repositories), you’ll notice a space (for example, "Owner / Repo" as opposed to "Owner/Repo"), which will need to be included in any command you’re running. If you are using GitLab’s [environment variables](https://docs.gitlab.com/ee/ci/variables/#debug-tracing) to pass the repository as `CI_PROJECT_PATH` in a cURL request for example, it may not include the spaces and you’ll need to hardcode the name in order for it to work.
-  
+
 - Why am I always the reporter?
   - When using the GitLab integration to create issues, the “reporter” field is populated as the person who set up the integration by default — this is not configurable.


### PR DESCRIPTION
Remove EA mention of codeowners feature in Gitlab docs. I missed this previously when removing them here: https://github.com/getsentry/sentry-docs/pull/4131 and just happened to notice now.