### PR TITLE
Clarify not supported Next.js features

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -15,4 +15,4 @@ Features:
 - Automatic [Performance Monitoring](/product/performance/) for both the client and server, from version `6.5.0`
 
 Under the hood the SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
-However, some Next.js features aren't currently supported, such as using a [custom server](https://nextjs.org/docs/advanced-features/custom-server).
+However, using a [custom server](https://nextjs.org/docs/advanced-features/custom-server) is not currently supported.


### PR DESCRIPTION
We should add to the docs the Next.js features we don't support. I'm not sure what the best place is, so I've added it in the paragraph after the features in the getting started page (see picture below). If the set of unsupported features grows, we can make an actual list, make another paragraph, add a section... If you can think of any other place where this section may suit better, please suggest.

![image](https://user-images.githubusercontent.com/32816711/137113499-27671886-2f61-4749-9ddc-bb0e388fef89.png)
