### PR TITLE
docs(cordova): Remove relative path from SENTRY_COMMAND variable

### DIFF
--- a/src/platforms/javascript/guides/cordova/upload-debug.mdx
+++ b/src/platforms/javascript/guides/cordova/upload-debug.mdx
@@ -33,6 +33,6 @@ if [ ! -f $SENTRY_PROPERTIES ]; then
 fi
 echo "# Reading property from $SENTRY_PROPERTIES"
 SENTRY_CLI=$(getProperty "cli.executable")
-SENTRY_COMMAND="../../$SENTRY_CLI upload-dif \"$DWARF_DSYM_FOLDER_PATH\""
+SENTRY_COMMAND="$SENTRY_CLI upload-dif \"$DWARF_DSYM_FOLDER_PATH\""
 $SENTRY_COMMAND
 ```


### PR DESCRIPTION
I don't know why we had it there in the first place tbh?

Closes https://github.com/getsentry/sentry-docs/issues/4267