### PR TITLE
Add note that in Sentry Log4j2 integration, the async mode is not supported

### DIFF
--- a/src/includes/getting-started-config/java.log4j2.mdx
+++ b/src/includes/getting-started-config/java.log4j2.mdx
@@ -25,7 +25,7 @@ The `ConsoleAppender` is provided only as an example of a non-Sentry appender se
 </Configuration>
 ```
 
-`SentryAppender` does not support Log4j2's [async mode](https://logging.apache.org/log4j/2.x/manual/async.html). Sentry Java SDK itself is already asynchronous and does not perform any blocking operation on the calling thread.
+`SentryAppender` does not support Log4j2's [async mode](https://logging.apache.org/log4j/2.x/manual/async.html). The Sentry Java SDK itself is already asynchronous and does not perform any blocking operation on the calling thread.
 
 ### DSN Configuration
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-java/issues/1746