### PR TITLE
feat(apple): Update state of APM HTTP issue

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -12,7 +12,7 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 <Alert level="info" title="Important">
 
-The HTTP instrumentation can lead to crashes due to a bug in the SDK, see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1328). We recommend updating to at least [7.4.1](https://github.com/getsentry/sentry-cocoa/releases/tag/7.4.1) or [disabling the feature](#http-instrumentation).
+The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1328)). We recommend updating to at least [7.4.1](https://github.com/getsentry/sentry-cocoa/releases/tag/7.4.1) or [disabling the feature](#http-instrumentation).
 
 </Alert>
 


### PR DESCRIPTION
We fixed the issue for the http crash in Cocoa 7.4.1.