### PR TITLE
docs(cli): Add dotenv support config options

### DIFF
--- a/src/docs/product/cli/configuration.mdx
+++ b/src/docs/product/cli/configuration.mdx
@@ -153,7 +153,7 @@ The following settings are available (first is the environment variable, the val
 
 `SENTRY_LOAD_DOTENV`:
 
-: Prevent sentry-cli from loading `.env` file.
+Set to `0` to prevent sentry-cli from loading an `.env` file.
 
 `SENTRY_DOTENV_PATH`:
 


### PR DESCRIPTION
Merge after https://github.com/getsentry/sentry-cli/pull/1046 and `1.70` release.

Removed unnecessary details about versions support, as they are from 2017.