### PR TITLE
feat(nextjs): Add section about custom `_error.js` to manual setup page

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -72,9 +72,11 @@ export default withSentry(handler);
 
 You can include your DSN directly in these two files, or provide it in either of two environment variables, `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN`.
 
-## Create Custom `_error` Page
+## Create a Custom `_error` Page
 
-In serverless deployment environments, including Vercel, the Next.js server runs in a "minimal" mode to reduce serverless function size. As a result, some of the auto-instrumentation done by `@sentry/nextjs` doesn't run, and therefore certain errors aren't caught. Further, Next.js includes a custom error boundary which will catch certain errors before they bubble up to our handlers. In order to capture these errors in Sentry, you can take advantage of the Next.js [error page customization](https://nextjs.org/docs/advanced-features/custom-error-page#reusing-the-built-in-error-page) option. To do this, create `pages/_error.js`, and include the following:
+In serverless deployment environments, including Vercel, the Next.js server runs in a "minimal" mode to reduce serverless function size. As a result, some of the auto-instrumentation done by `@sentry/nextjs` doesn't run, and therefore certain errors aren't caught. In addition, Next.js includes a custom error boundary which will catch certain errors before they bubble up to our handlers. 
+
+To capture these errors in Sentry, you can use the Next.js [error page customization](https://nextjs.org/docs/advanced-features/custom-error-page#reusing-the-built-in-error-page) option. To do this, create `pages/_error.js`, and include the following:
 
 ````javascript {filename:pages/_error.js}
 import NextErrorComponent from 'next/error';


### PR DESCRIPTION
In https://github.com/getsentry/sentry-wizard/pull/140, we update `@sentry/wizard` to include a custom `_error.js` page, which is necessary to catch certain errors when an app is deployed to Vercel. (The contents of the page come from Vercel's [example Sentry app](https://github.com/vercel/next.js/tree/canary/examples/with-sentry).) This updates the manual setup docs to reflect this additional step.