### PR TITLE
fix(dotnet): Default value of AutoSessionTracking

### DIFF
--- a/src/includes/configuration/auto-session-tracking/dotnet.mdx
+++ b/src/includes/configuration/auto-session-tracking/dotnet.mdx
@@ -4,7 +4,7 @@ We mark the session as:
 - Errored: if the SDK captures an event that contains an exception (this includes manually captured errors).
 - Crashed
 
-To enable sending sessions, set the `AutoSessionTracking` flag to `true`. When enabled, the .NET SDK is creating a session on application startup and end it on shut down. 
+To enable sending sessions, set the `AutoSessionTracking` flag to `true`. When enabled, the .NET SDK is creating a session on application startup and ending it on shut down. 
 
 ```csharp {tabTitle:C#}
 using Sentry;


### PR DESCRIPTION
The default value of AutoSessionTracking is false instead of true.
This is fixed now.

Fixes GH-4290