### PR TITLE
update email IP ranges content to indicate IPs are dedicated

### DIFF
--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -86,7 +86,7 @@ To allow access to source maps with Apache you can use this example. It can eith
 
 ## Email Delivery
 
-All email is delivered from [SendGrid](https://sendgrid.com/) from the following dedicated static IP addresses:
+All email is delivered from [SendGrid](https://sendgrid.com/) from the following dedicated, static IP addresses:
 
 ```
 167.89.86.73


### PR DESCRIPTION
Adds text in email ip content to indicate that the ip addresses are dedicated and for Sentry use only