### PR TITLE
Remove duplicate entry for Fingerprint Rules in documentation

### DIFF
--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -91,29 +91,3 @@ Here's how to set the match based on the error **message** where you want to inc
 ![ConnectionTimeoutMessageExample](connection-timeout-message-example.png)
 
 You could also do this based on the file path of the erroring function, or on the function name itself. See [Fingerprint Rules](/platform-redirect/?next=/usage/sdk-fingerprinting/).
-
-1. Identify the match logic for grouping issues together. We'll use either the error's **type** or **message**
-2. Set the match logic and its fingerprint for it, in your Project's Settings.
-
-#### 1. Identify Match Logic
-
-Let's say you want the following 2 issues to group together:
-![ConnectionTimeouts](connection-timeouts-2.png)
-
-You can do it based on the **type** as in:
-![ConnectionTimeoutType](connection-timeout-type.png)
-
-Or you can do it based on the **message** as in any value after the word host:
-![ConnectionTimeoutMessage](connection-timeout-message.png)
-
-#### 2. Implement
-
-Here's how to set the match based on the error **type**
-![ConnectionTimeoutTypeExample](connection-timeout-type-example.png)
-
-Now, all events coming in with ConnectionTimeout will get a fingerprint of connection-timeout-type and will get grouped into a single issue. This only applies to future events coming in. Each event for this issue could have a different stack trace, but stack trace is no longer used as the default grouping rule.
-
-Here's how to set the match based on the error **message** where you want to include all hosts.
-![ConnectionTimeoutMessageExample](connection-timeout-message-example.png)
-
-You could also do this based on the file path of the erroring function, or on the function name itself. See [Fingerprint Rules](/platform-redirect/?next=/usage/sdk-fingerprinting/).


### PR DESCRIPTION
The section was duplicated in the docs which is confusing.