### PR TITLE
Unity: Updated log debounce

### DIFF
--- a/src/platforms/unity/configuration/event-debouncing.mdx
+++ b/src/platforms/unity/configuration/event-debouncing.mdx
@@ -6,7 +6,7 @@ sidebar_order: 20
 
 Because gameplay updates at a very high frequency of 60 times a second or even higher, an optional debouncing mechanism is in place. Every type of log has its own time slot. If `EnableLogDebounce` is enabled and the game triggers too many events of the same type in quick succession, Sentry will only capture the first of its kind, then ignore (debounce) the other events of the same type.
 
-Event debouncing is `disabled by default`.
+Event debouncing is `disabled` by default.
 
 The time that needs to pass after an event has been triggered to be captured again:
 


### PR DESCRIPTION
Log debouncing is now disabled by default but received a flag to be enabled by the user.