### PR TITLE
Add a docker example for tunneling requests

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -164,6 +164,14 @@ WebHost.CreateDefaultBuilder(args).Configure(a =>
 
 Check out our [examples repository](https://github.com/getsentry/examples/tree/master/tunneling) to learn more about it.
 
+An other option is to use a docker image running [sentry_tunnel](https://github.com/gbip/sentry_tunnel/), a proxy server that forwards tunneled sentry request to a sentry relay.
+
+```bash
+docker run -e 'TUNNEL_REMOTE_HOST=https://sentry.example.com' -e 'TUNNEL_PROJECT_IDS=1,5' sigalen/sentry_tunnel
+```
+
+Take a look at the [README](https://github.com/gbip/sentry_tunnel/blob/main/README.md) for more information about this docker image.
+
 If your use-case is related to the SDK package itself being blocked, any of the following solutions will help you resolve this issue.
 
 ### Using Package Directly


### PR DESCRIPTION
I added an example on how to use a Docker image to forward tunneled sentry request to a sentry relay.

Please note that I am the maintainer of this image.