### PR TITLE
fix(api-docs): Correctly display badge for requred and optional body parameters

### DIFF
--- a/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
+++ b/src/gatsby/plugins/gatsby-plugin-openapi/gatsby-node.ts
@@ -197,13 +197,7 @@ export const onCreateNode = async ({
       const bodyParameterSchema: RequestBodySchema = JSON.parse(
         bodyParameterSchemaString
       );
-      const bodyParameterRequired = (bodyParameterSchema.required || []).reduce(
-        (requiredMap, param) => {
-          requiredMap[param] = true;
-          return requiredMap;
-        },
-        {}
-      );
+      const bodyParameterRequired = new Set(bodyParameterSchema.required || []);
       Object.entries(bodyParameterSchema.properties || []).map(
         ([name, { type, description }], index) => {
           if (description) {
@@ -211,7 +205,7 @@ export const onCreateNode = async ({
               name,
               description,
               schema: { type, format: null, enum: null },
-              required: !!bodyParameterRequired[name],
+              required: bodyParameterRequired.has(name),
               in: "body",
               id: createNodeId(`openApiBodyParameter-${node.id}-${index}`),
               parent: node.id,


### PR DESCRIPTION
See [ISSUE-1294](https://getsentry.atlassian.net/browse/ISSUE-1294)

Prior to this PR, all body parameters appeared as required, even if only a select few actually were. Now they only appear required if specified like that in the getsentry/sentry api-docs.


**before**
<img width="1423" alt="before" src="https://user-images.githubusercontent.com/35509934/138503516-7899baa5-d058-4db8-ba1a-3bfc575390fd.png">


**after**
<img width="1423" alt="after" src="https://user-images.githubusercontent.com/35509934/138503545-e46cd3d4-b68b-4c37-bc41-44e6c003b020.png">

