### PR TITLE
Fix yarn getting started instructions for RN

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -32,15 +32,8 @@ If you are running a project with `react-native` prior to 0.60, you still need t
 
 </Note>
 
-```npx
+```bash
 npx @sentry/wizard -i reactNative -p ios android
-
-cd ios
-pod install
-```
-
-```yarn
-yarn sentry-wizard -i reactNative -p ios android
 
 cd ios
 pod install


### PR DESCRIPTION
The user's project doesn't have a @sentry/wizard dependency at the time it was suggested to run `yarn sentry-wizard`.
Switching to `npx` instead as suggested by Jenn Mueng.

Fixes #4195