### PR TITLE
docs(discover): removed ea notes for Connect Discover and Dashboards sections

### DIFF
--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -32,10 +32,4 @@ If you’d like to edit the default dashboard or build out multiple ones, each w
 
 ## Open Dashboard Widgets in Discover
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 Each Dashboard widget has an ellipsis that opens a context menu. From here, you can open the widget in [Discover](/product/discover-queries/) for to get more information. If a widget contains more than one query, you'll be prompted to select which query to view in **Discover**.

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -80,12 +80,6 @@ On the Discover homepage, each saved query card has an ellipsis that will open a
 
 ### Add to Dashboard
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 Queries can also be added to custom dashboards as widgets. You can find the "Add to Dashboard" button by opening the context menu in the **Discover** homepage or within the [query results](#query-results) view. When you click "Add to Dashboard", a form opens where you can name your widget, select your target dashboard, and make other changes before saving your new widget.
 
 ## Query Results


### PR DESCRIPTION
Removed EA notes from the following two sections for GA release

![image](https://user-images.githubusercontent.com/83961295/138723007-97aee478-4632-4352-90f8-7cb671493c2f.png)
![image](https://user-images.githubusercontent.com/83961295/138723059-0e1166c1-27fa-4c64-88b4-5c541fd782f7.png)
