### PR TITLE
fix(php) Fix getting started code for PHP

### DIFF
--- a/src/wizard/php/index.md
+++ b/src/wizard/php/index.md
@@ -14,7 +14,7 @@ composer require sentry/sdk
 To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.
 
 ```php
-Sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
+\Sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
 ```
 
 One way to verify your setup is by intentionally causing an error that breaks your application.


### PR DESCRIPTION
The missing leading `\` makes the code sample not work without additional imports which are not part of the setup steps. This change makes the setup wizard shown in the product more copy/paste friendly.