### PR TITLE
docs(apple): note XCode 13 and missing Info.plist file

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -10,8 +10,8 @@ Sentry requires a dSYM upload to symbolicate your crash logs. The symbolication 
 
 <Note>
 
-Starting XCode 13, newly generated projects do not automatically create a required `Info.plist` configuration file.
-If that is your case, please read [Info.plist Is Missing in Xcode 13 — Here’s How To Get It Back](https://betterprogramming.pub/info-plist-is-missing-in-xcode-13-heres-how-to-get-it-back-1a7abf3e2514) article.
+Starting with XCode 13, newly generated projects do not automatically create a required `Info.plist` configuration file.
+If this is your situation, please read [Info.plist Is Missing in Xcode 13 — Here’s How To Get It Back](https://betterprogramming.pub/info-plist-is-missing-in-xcode-13-heres-how-to-get-it-back-1a7abf3e2514).
 
 </Note>
 


### PR DESCRIPTION
Tbh I'm not sure how feasible is to put a link to an external article in our docs, but I didn't want to pull a whole thing down. If someone feels like writing it from scratch, I'd be more than happy.

ref: https://github.com/getsentry/sentry-cli/issues/1049