### PR TITLE
Fix broken code snippet

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -78,7 +78,7 @@ In serverless deployment environments, including Vercel, the Next.js server runs
 
 To capture these errors in Sentry, you can use the Next.js [error page customization](https://nextjs.org/docs/advanced-features/custom-error-page#reusing-the-built-in-error-page) option. To do this, create `pages/_error.js`, and include the following:
 
-````javascript {filename:pages/_error.js}
+```javascript {filename:pages/_error.js}
 import NextErrorComponent from 'next/error';
 
 import * as Sentry from '@sentry/nextjs';
@@ -178,7 +178,7 @@ const SentryWebpackPluginOptions = {
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
-````
+```
 
 <Alert level="warning" title="Serverless Environments">
 


### PR DESCRIPTION
There was one code snippet that was too long and actually spanning two code snippets causing a chunk of markdown to be sitting in the middle.

This is how it looks without the change
<img width="1062" alt="Screen Shot 2021-10-26 at 10 12 09 AM" src="https://user-images.githubusercontent.com/13033515/138896794-aa9531d7-1634-47da-8a6e-8df9cdf4bce3.png">
:
([production](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#create-a-custom-_error-page))

How it looks now
![Screen Shot 2021-10-26 at 11 07 36 AM](https://user-images.githubusercontent.com/13033515/138907595-7a79ceb6-709f-4c2a-9c86-d99e03aa0f97.png)
:
([deploy preview](https://sentry-docs-git-fork-aturkewi-patch-2.sentry.dev/platforms/javascript/guides/nextjs/manual-setup/#extend-nextjs-configuration))