### PR TITLE
fix(integrations): Clarify Vercel/Sentry project-linking step

### DIFF
--- a/src/docs/product/integrations/deployment/vercel/index.mdx
+++ b/src/docs/product/integrations/deployment/vercel/index.mdx
@@ -34,7 +34,7 @@ Use Vercel to [link projects](#project-linking) for uploading source maps and no
 
 ### Project Linking
 
-1. Select a Sentry project and a Vercel project to link together.
+1. When prompted by the installer, select a Sentry project and a Vercel project to link together.
 
    ![Sentry modal showing linking Sentry project to Vercel project](vercel_link_project.png)
 


### PR DESCRIPTION
It's currently not obvious that this step isn't independent of installation but part of it.

Fixes https://github.com/getsentry/sentry-docs/issues/4308.