### PR TITLE
docs(js): Filter out JS bundle files

### DIFF
--- a/src/components/jsBundleList.tsx
+++ b/src/components/jsBundleList.tsx
@@ -37,8 +37,9 @@ export default (): JSX.Element => {
         </tr>
       </thead>
       <tbody>
-        {files.map(file => {
-          return (
+        {files
+          .filter(file => file.name.endsWith(".js"))
+          .map(file => (
             <tr key={file.name}>
               <td style={{ fontSize: "0.9em", verticalAlign: "middle" }}>
                 {file.name}
@@ -51,8 +52,7 @@ export default (): JSX.Element => {
                 </ChecksumValue>
               </td>
             </tr>
-          );
-        })}
+          ))}
       </tbody>
     </table>
   );


### PR DESCRIPTION
`.tgz` and `.map` files should not be listed, as there is no use for them in CDN.