### PR TITLE
docs(contributing): yarn build -> yarn start

### DIFF
--- a/src/docs/contributing/environment.mdx
+++ b/src/docs/contributing/environment.mdx
@@ -48,4 +48,4 @@ yarn prettier:fix:all
 
 ## Faster builds
 
-Disable image thumbnail generation with `DISABLE_THUMBNAILS=1 yarn start`. Images will not work while in this mode, but builds will be significantly faster.
+To disable image thumbnail generation, set `DISABLE_THUMBNAILS=1` before running `yarn start` or `yarn build`. Images will not work while in this mode, but builds will be significantly faster.


### PR DESCRIPTION
For _Contributing to Docs - Development Environment_, `yarn start`, which runs a local dev server, seems more useful than `yarn build`.

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/12410942/139078722-7f5e693e-1140-47ce-b225-fa4c84d9229b.png">
