### PR TITLE
docs(filtering): add missing examples for Ruby

### DIFF
--- a/src/includes/configuration/before-send-fingerprint/ruby.mdx
+++ b/src/includes/configuration/before-send-fingerprint/ruby.mdx
@@ -1,7 +1,7 @@
 ```ruby
 Sentry.init do |config|
   config.before_send = lambda do |event, hint|
-    if hint[:exception]&.message.include?("database unavailable")
+    if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
       event.fingerprint = ["database-unavailable"]
     end
 

--- a/src/includes/configuration/before-send-hint/ruby.mdx
+++ b/src/includes/configuration/before-send-hint/ruby.mdx
@@ -1,7 +1,7 @@
 ```ruby
 Sentry.init do |config|
   config.before_send = lambda do |event, hint|
-    if hint[:exception]&.message.include?("database unavailable")
+    if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
       event.fingerprint = ["database-unavailable"]
     end
 


### PR DESCRIPTION
[sentry-ruby does support `before_send`](https://github.com/getsentry/sentry-ruby/blob/4.7.3/sentry-raven/spec/raven/integration_spec.rb#L72-L77), but examples for Ruby is missing.

| Before | ![image](https://user-images.githubusercontent.com/12410942/139096091-27026cd9-b423-4ee4-821a-8120c64e15bf.png) |
| --- | --- |
| After | ![image](https://user-images.githubusercontent.com/12410942/139095908-c3841f1e-ad9e-42b4-8d02-9604b324f803.png) ![image](https://user-images.githubusercontent.com/12410942/139095965-8a6b16ad-a8c1-429b-96b6-fe4f53299a0a.png) |
