### PR TITLE
feat(alert-rules): Docs on Alert Rule UI Components

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -233,6 +233,64 @@ Any time a component supports a `uri` attribute, Sentry will make a request to t
 
 For a more complete description of the grammar, see the [source code](https://github.com/getsentry/sentry/blob/master/src/sentry/api/validators/sentry_apps/schema.py).
 
+## Alert Rule Action
+
+<Note>
+
+Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
+
+</Note>
+<Note>
+
+This feature is available only if your organization is an Early Adoptor.
+
+</Note>
+
+This feature allows the developer to get parameters to define routing or configuration in alert rules for their service. When alert rules are triggered for a user, your service will receive [Issue Alert](/product/integrations/integration-platform/webhooks/#issue-alerts) and [Metric Alert](/product/integrations/integration-platform/webhooks/#metric-alerts) webhook events with the specified settings for your service to further route the alert.
+
+
+### Schema
+```javascript
+ {
+    "type": "alert-rule-action",
+    "title": <String>,
+    "settings": {
+        "type": "alert-rule-settings",
+        "uri": <URI>,
+        "required_fields": <Array<FormField>>,
+        "optional_fields": <Array<FormField>>
+    }
+}
+```
+
+### Attributes
+- `title` - (Required) The title show in the UI Component
+- `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form.
+- `required_fields` - (Required) List of `FormField` components the User is required to complete.
+- `optional fields` - List of optional `Form Field` components the User may complete.
+
+### Example
+```javascript
+
+"elements": [
+    {
+        "type": "alert-rule-action",
+        "title": "Send Alerts to",
+        "settings": {
+        "type": "alert-rule-settings",
+        "uri": "/sentry/alert-rule",
+            "required_fields": [
+                {
+                "type": "text",
+                "label": "Channel",
+                "name": "channel"
+                }
+            ]
+        }
+    }
+]
+
+```
 # Create/Link Issue
 
 If you have a UI component for issue linking and a user attempts to create or link an issue, it will send a request to your service based on the `uri` you provide.

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -237,16 +237,13 @@ For a more complete description of the grammar, see the [source code](https://gi
 
 <Note>
 
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
 Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosystem-feedback@sentry.io).
 
 </Note>
-<Note>
 
-This feature is available only if your organization is an Early Adopter.
-
-</Note>
-
-This feature allows the developer to get parameters to define routing or configuration in alert rules for their service. When alert rules are triggered for a user, your service will receive [Issue Alert](/product/integrations/integration-platform/webhooks/#issue-alerts) and [Metric Alert](/product/integrations/integration-platform/webhooks/#metric-alerts) webhook events with the specified settings for your service to further route the alert.
+The Alert Rule Action component allows the developer to get parameters to define routing or configuration in alert rules for their service. When alert rules are triggered for a user, the configured service will receive [Issue Alert](/product/integrations/integration-platform/webhooks/#issue-alerts) and [Metric Alert](/product/integrations/integration-platform/webhooks/#metric-alerts) webhook events with the specified settings for that service to further route the alert.
 
 
 ### Schema
@@ -264,7 +261,7 @@ This feature allows the developer to get parameters to define routing or configu
 ```
 
 ### Attributes
-- `title` - (Required) The title show in the UI Component
+- `title` - (Required) The title shown in the UI component.
 - `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form.
 - `required_fields` - (Required) List of `FormField` components the User is required to complete.
 - `optional fields` - List of optional `Form Field` components the User may complete.

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -262,7 +262,7 @@ The Alert Rule Action component allows the developer to get parameters to define
 
 ### Attributes
 - `title` - (Required) The title shown in the UI component.
-- `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form.
+- `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form. If the services fails to process the request (status code >= 400), this component will bubble up the error to the User with the provided response text.
 - `required_fields` - (Required) List of `FormField` components the User is required to complete.
 - `optional fields` - List of optional `Form Field` components the User may complete.
 

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -281,9 +281,9 @@ This feature allows the developer to get parameters to define routing or configu
         "uri": "/sentry/alert-rule",
             "required_fields": [
                 {
-                "type": "text",
-                "label": "Channel",
-                "name": "channel"
+                    "type": "text",
+                    "label": "Channel",
+                    "name": "channel"
                 }
             ]
         }

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -242,7 +242,7 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 </Note>
 <Note>
 
-This feature is available only if your organization is an Early Adoptor.
+This feature is available only if your organization is an Early Adopter.
 
 </Note>
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -208,7 +208,7 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
 
 <Note>
 
-The following fields will only be for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action)
+The following two fields are for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action) only.
 
 </Note>
 
@@ -474,7 +474,7 @@ The following fields will only be for [Alert Rule Action UI Components](/product
 ##### data['metric_alert']['alert_rule']['triggers'][0]['actions']
 
 - type: array of objects
-- description: the actions that will be performed when a trigger's threshold has been met.
+- description: the actions that will be performed when a trigger's threshold has been met
 
 ##### data['description_text']
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -493,7 +493,7 @@ The following two fields are for [Alert Rule Action UI Components](/product/inte
 
 <Note>
 
-The following fields will only be for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action)
+The following field is for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action) only.
 
 </Note>
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -204,7 +204,7 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
 ##### data['triggered_rule']
 
 - type: string
-- description: The label of the rule that was triggered
+- description: the label of the rule that was triggered
 
 <Note>
 
@@ -215,7 +215,7 @@ The following fields will only be for [Alert Rule Action UI Components](/product
 ##### data['issue_alert']['title']
 
 - type: string
-- description: The label of the rule that was triggered
+- description: the label of the rule that was triggered
 
 ##### data['issue_alert']['settings']
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -206,6 +206,23 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
 - type: string
 - description: The label of the rule that was triggered
 
+<Note>
+
+The following fields will only be for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action)
+
+</Note>
+
+##### data['issue_alert']['title']
+
+- type: string
+- description: The label of the rule that was triggered
+
+##### data['issue_alert']['settings']
+
+- type: object
+- description: the saved configurations for routing the alert within the external service
+
+
 #### Payload
 
 ```json
@@ -415,6 +432,12 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
       "web_url": "https://sentry.io/organizations/test-org/issues/1117540176/events/e4874d664c3540c1a32eab185f12c5ab/"
     },
     "triggered_rule": "Very Important Alert Rule!"
+    "issue_alert": {
+      "title": "Very Important Alert Rule!",
+      "settings": {
+         "channel": "#general",
+      }
+    }
   },
   "installation": {
     "uuid": "a8e5d37a-696c-4c54-adb5-b3f28d64c7de"
@@ -438,6 +461,21 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
 - type: object
 - description: the incident that triggered the alert rule
 
+##### data['metric_alert']['alert_rule']
+
+- type: object
+- description: the alert rule
+
+##### data['metric_alert']['alert_rule']['triggers']
+
+- type: array of objects
+- description: the thresholds to trigger the alert
+
+##### data['metric_alert']['alert_rule']['triggers'][0]['actions']
+
+- type: array of objects
+- description: the actions that will be performed when a trigger's threshold has been met.
+
 ##### data['description_text']
 
 - type: string
@@ -452,6 +490,18 @@ You cannot set up a custom payload. Instead, we suggest setting up a server/serv
 
 - type: string
 - description: the api url for the incident
+
+<Note>
+
+The following fields will only be for [Alert Rule Action UI Components](/product/integrations/integration-platform/ui-components/#alert-rule-action)
+
+</Note>
+
+##### data['metric_alert']['alert_rule']['triggers'][0]['actions'][0]['settings']
+
+- type: object
+- description: the saved configuration for routing the alert within the external service
+
 
 #### Payload
 


### PR DESCRIPTION
## Objective:
Docs describes the required/optional fields for the Alert Rule Action UI component, provides an example and the webhook payload.