### PR TITLE
fix(css): Remove extra spacing from nested ul [INGEST-506]

### DIFF
--- a/src/css/screen.scss
+++ b/src/css/screen.scss
@@ -92,11 +92,13 @@ a .icon {
 
 ul p,
 ol p,
-ul ul,
-ul ol,
 ol,
 ul {
   margin-bottom: 1rem;
+}
+
+ul ul, ul ol {
+  margin-bottom: 0;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {


### PR DESCRIPTION
Fix https://github.com/getsentry/sentry-docs/issues/3662

the way the code is structured this looks very intentional, but I think this looks better...

<img width="646" alt="Screenshot 2021-10-28 at 16 45 33" src="https://user-images.githubusercontent.com/837573/139280339-38b26061-8458-45f0-8ecc-bf8bd8c555d7.png">
