### PR TITLE
docs(elixir): add missing example for before_send

### DIFF
--- a/src/includes/configuration/before-send/elixir.mdx
+++ b/src/includes/configuration/before-send/elixir.mdx
@@ -1,0 +1,19 @@
+```elixir
+# sentry.ex
+defmodule MyApp.Sentry do
+  def before_send(%{user: user} = event) do
+    # Don't send user's email address
+    user = Map.delete(user, :email)
+    %{event | user: user}
+  end
+
+  def before_send(event) do
+    event
+  end
+end
+
+# config.exs
+config :sentry,
+  before_send_event: {MyApp.Sentry, :before_send},
+  # ...
+```


### PR DESCRIPTION
Elixir SDK support before_send_event, but missing example

ref: #2854

|before|after|
|:---:|:----:|
|<img width="791" alt="スクリーンショット 2021-10-29 0 31 19" src="https://user-images.githubusercontent.com/16176282/139288300-1dacabea-7717-40e4-a255-d4be78c449a9.png">|<img width="770" alt="スクリーンショット 2021-10-29 0 34 23" src="https://user-images.githubusercontent.com/16176282/139288635-91fcc15f-9f75-4008-8874-61a54268f7c4.png">|

