### PR TITLE
feat(RN): Move production bundles to troubleshooting and link to it from profiler page

### DIFF
--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -460,7 +460,7 @@ const SomeComponent = () => {
 
 #### Minified Names in Production
 
-When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that **you won't get the full original component names in your Profiler spans** and instead you will see minified names. See our [troubleshooting guide for minified production bundles](/platforms/react-native/troubleshooting/#minified-names-in-production) to solve this.
+When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that **you won't get the full original component names in your Profiler spans** and instead you will see minified names. Check out our [troubleshooting guide for minified production bundles](/platforms/react-native/troubleshooting/#minified-names-in-production) documentation to solve this.
 
 ## Opt Out
 

--- a/src/platforms/react-native/touchevents.mdx
+++ b/src/platforms/react-native/touchevents.mdx
@@ -107,4 +107,4 @@ Sentry.withTouchEventBoundary(App, { maxComponentTreeSize: 15 });
 
 ## Minified Names in Production
 
-When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that **you won't get the full original component names in your touch event breadcrumbs** and instead you will see minified names. See our [troubleshooting guide for minified production bundles](/platforms/react-native/troubleshooting/#minified-names-in-production) to solve this.
+When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that **you won't get the full original component names in your touch event breadcrumbs** and instead you will see minified names. Check out our [troubleshooting guide for minified production bundles](/platforms/react-native/troubleshooting/#minified-names-in-production) documentation to solve this.

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -52,7 +52,7 @@ If you use the [sentry-expo](https://github.com/expo/sentry-expo) SDK, make sure
 
 When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that you won't get the full original component names in your Touch Event breadcrumbs or Profiler spans.
 
-A way to work around this is to set the `displayName` on all the components you want to track with touch events or passing the `name` prop to the Profiler components. However, you can also configure Metro bundler to not minify function names by setting these options in `metro.config.js`:
+A way to work around this is to set the `displayName` on all the components you want to track with touch events or to pass the `name` prop to the Profiler components. However, you can also configure Metro bundler to not minify function names by setting these options in `metro.config.js`:
 
 ```javascript {filename:metro.config.js}
 module.exports = {


### PR DESCRIPTION
Had a customer run into minified names in their React Profiler while using RN in production, so we should mention the minified production bundles fix we use with touch events for the profiler as well.