### PR TITLE
fix(nextjs): Add note about lack of Next 12 support

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -1,10 +1,10 @@
 <Note>
 
-Sentry's Next.js SDK enables automatic reporting of errors and exceptions.
+Currently, the Sentry Next.js SDK supports Next.js versions `10.0.8` - `11.1.3`. The SDK may work with some projects using Next.js 12, but it is not yet officially supported.
 
 </Note>
 
-Currently, the minimum Next.js supported version is `10.0.8`.
+The Sentry Next.js SDK automatically catches errors and collects performance data from your app.
 
 Features:
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -182,7 +182,7 @@ module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
 
 <Alert level="warning" title="Serverless Environments">
 
-`@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085).
+`@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085) for apps using Next.js 10 or Next.js 11. (The Sentry SDK does not yet officially support Next.js 12.)
 
 </Alert>
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -74,14 +74,14 @@ You can include your DSN directly in these two files, or provide it in either of
 
 ## Create a Custom `_error` Page
 
-In serverless deployment environments, including Vercel, the Next.js server runs in a "minimal" mode to reduce serverless function size. As a result, some of the auto-instrumentation done by `@sentry/nextjs` doesn't run, and therefore certain errors aren't caught. In addition, Next.js includes a custom error boundary which will catch certain errors before they bubble up to our handlers. 
+In serverless deployment environments, including Vercel, the Next.js server runs in a "minimal" mode to reduce serverless function size. As a result, some of the auto-instrumentation done by `@sentry/nextjs` doesn't run, and therefore certain errors aren't caught. In addition, Next.js includes a custom error boundary which will catch certain errors before they bubble up to our handlers.
 
 To capture these errors in Sentry, you can use the Next.js [error page customization](https://nextjs.org/docs/advanced-features/custom-error-page#reusing-the-built-in-error-page) option. To do this, create `pages/_error.js`, and include the following:
 
 ```javascript {filename:pages/_error.js}
-import NextErrorComponent from 'next/error';
+import NextErrorComponent from "next/error";
 
-import * as Sentry from '@sentry/nextjs';
+import * as Sentry from "@sentry/nextjs";
 
 const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
   if (!hasGetInitialPropsRun && err) {
@@ -132,7 +132,7 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
   // information about what the error might be. This is unexpected and may
   // indicate a bug introduced in Next.js, so record it in Sentry
   Sentry.captureException(
-    new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
+    new Error(`_error.js getInitialProps missing data at path: ${asPath}`)
   );
   await Sentry.flush(2000);
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -182,7 +182,7 @@ module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
 
 <Alert level="warning" title="Serverless Environments">
 
-`@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085) for apps using Next.js 10 or Next.js 11. (The Sentry SDK does not yet officially support Next.js 12.)
+`@sentry/nextjs` does not support configurations with the `serverless` target. To use the SDK in serverless environments, switch to using the `experimental-serverless-trace` target, which is [recommended by the Next.js maintainers](https://github.com/vercel/next.js/issues/20487#issuecomment-753884085) for apps using Next.js 10 or Next.js 11.
 
 </Alert>
 


### PR DESCRIPTION
There seem to be a number of changes in Next 12 which can break the SDK (depending on how you use it), so for the moment, let's make it clear that we're not expecting that combo to work out of the box.