### PR TITLE
Add troubleshooting for SSL error for Xamarin Android

### DIFF
--- a/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
@@ -67,18 +67,18 @@ More information about this problem can be found here: https://github.com/mono/m
 
 ## Android 
 
-### Event/Transaction not sent
+### Event/Transaction Not Sent
 
 You may encounter the following issue when sending Events or Envelopes:
 
 `The SSL connection could not be established, CERTIFICATE_VERIFY_FAILED`
 
-A quick solution is to alter your DSN with an alternative one, for that, remove the values between `@` and `sentry.io` of your DSN.
+One solution is to alter your DSN; to do this, remove the values between `@` and `sentry.io` in your DSN.
 
 * Before: `https://abc@1234.ingest.sentry.io/1234`
 * After: `https://abc@sentry.io/1234`
 
-More information can be found here: https://github.com/xamarin/xamarin-android/issues/6351
+Find more information here: https://github.com/xamarin/xamarin-android/issues/6351
 
 ## tvOS
 

--- a/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
@@ -65,6 +65,21 @@ Using Reference will not work, it must be PackageReference.
 
 More information about this problem can be found here: https://github.com/mono/mono/issues/20805
 
+## Android 
+
+### Errors when sending an Event or Envelope
+
+You may encounter the following issue when sending Events or Envelopes:
+
+`The SSL connection could not be established, CERTIFICATE_VERIFY_FAILED`
+
+A quick solution is to alter your DSN with an alternative one, for that, remove the values between `@` and `sentry.io` of your DSN.
+
+* Before: `https://abc@1234.ingest.sentry.io/1234`
+* After: `https://abc@sentry.io/1234`
+
+More information can be found ([here](https://github.com/xamarin/xamarin-android/issues/6351#issuecomment-932944425)).
+
 ## tvOS
 
 You may encounter the following issue on a tvOS project:

--- a/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
@@ -78,7 +78,7 @@ A quick solution is to alter your DSN with an alternative one, for that, remove 
 * Before: `https://abc@1234.ingest.sentry.io/1234`
 * After: `https://abc@sentry.io/1234`
 
-More information can be found ([here](https://github.com/xamarin/xamarin-android/issues/6351#issuecomment-932944425)).
+More information can be found ([here](https://github.com/xamarin/xamarin-android/issues/6351)).
 
 ## tvOS
 

--- a/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
@@ -67,7 +67,7 @@ More information about this problem can be found here: https://github.com/mono/m
 
 ## Android 
 
-### Errors when sending an Event or Envelope
+### Event/Transaction not sent
 
 You may encounter the following issue when sending Events or Envelopes:
 

--- a/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/xamarin/troubleshooting.mdx
@@ -78,7 +78,7 @@ A quick solution is to alter your DSN with an alternative one, for that, remove 
 * Before: `https://abc@1234.ingest.sentry.io/1234`
 * After: `https://abc@sentry.io/1234`
 
-More information can be found ([here](https://github.com/xamarin/xamarin-android/issues/6351)).
+More information can be found here: https://github.com/xamarin/xamarin-android/issues/6351
 
 ## tvOS
 


### PR DESCRIPTION
This PR adds an additional solution for users unable to send Events/Envelopes due to an issue with Xamarin for Android.

The URL path `...ingest.sentry.io...` uses Let's encrypt certificate where `sentry.io...` doesn't.

More information can be found here: https://github.com/xamarin/xamarin-android/issues/6351