### PR TITLE
Sandbox btn

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -22,7 +22,7 @@ import PlatformLink from "./platformLink";
 import PlatformSection from "./platformSection";
 import PlatformIdentifier from "./platformIdentifier";
 import RelayMetrics from "./relayMetrics";
-import SandboxLink from "./sandboxLink";
+import SandboxLink, { SandboxOnly } from "./sandboxLink";
 import { VimeoEmbed, YouTubeEmbed } from "./video";
 
 const mdxComponents = {
@@ -48,6 +48,7 @@ const mdxComponents = {
   VimeoEmbed,
   YouTubeEmbed,
   SandboxLink,
+  SandboxOnly,
 };
 
 export default ({ value }) => {

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -6,7 +6,7 @@ import Search from "./search";
 import SmartLink from "./smartLink";
 
 import NavbarPlatformDropdown from "./navbarPlatformDropdown";
-import { getSandboxURL } from "./sandboxLink";
+import { getSandboxURL, SandboxOnly } from "./sandboxLink";
 
 type Props = {
   platforms?: string[];
@@ -26,9 +26,11 @@ export default ({ platforms }: Props): JSX.Element => {
               API
             </SmartLink>
           </Nav.Item>
-          <Nav.Item>
-            <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
-          </Nav.Item>
+          <SandboxOnly>
+            <Nav.Item>
+              <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
+            </Nav.Item>
+          </SandboxOnly>
           <Nav.Item>
             <Nav.Link href="https://sentry.io/">
               Sign In

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -27,8 +27,8 @@ export default ({ platforms }: Props): JSX.Element => {
             </SmartLink>
           </Nav.Item>
           <Nav.Item>
-              <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
-              </Nav.Item>
+            <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
+          </Nav.Item>
           <Nav.Item>
             <Nav.Link href="https://sentry.io/">
               Sign In

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -6,6 +6,7 @@ import Search from "./search";
 import SmartLink from "./smartLink";
 
 import NavbarPlatformDropdown from "./navbarPlatformDropdown";
+import { getSandboxURL } from "./sandboxLink";
 
 type Props = {
   platforms?: string[];
@@ -25,6 +26,9 @@ export default ({ platforms }: Props): JSX.Element => {
               API
             </SmartLink>
           </Nav.Item>
+          <Nav.Item>
+              <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
+              </Nav.Item>
           <Nav.Item>
             <Nav.Link href="https://sentry.io/">
               Sign In

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -83,3 +83,11 @@ export default function SandboxLink({ children, platform, ...params }: Props) {
 
     return <a href={getSandboxURL(params).toString()}>{children}</a>;
 }
+
+export function SandboxOnly({children}) {
+  //kill switch for sandbox
+  if (isSandboxHidden()) {
+    return null;
+  }
+  return children;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ import NavbarPlatformDropdown from "../components/navbarPlatformDropdown";
 import SentryWordmarkSVG from "../logos/sentry-wordmark-dark.svg";
 
 import Banner from "../components/banner";
+import { getSandboxURL } from "~src/components/sandboxLink";
 
 const HIGHLIGHTED_PLATFORMS = [
   "javascript",
@@ -73,6 +74,9 @@ const IndexPage = () => {
                 <SmartLink className="nav-link" to="/api/">
                   API
                 </SmartLink>
+              </Nav.Item>
+              <Nav.Item>
+                <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
               </Nav.Item>
               <Nav.Item>
                 <Nav.Link href="https://sentry.io/">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import NavbarPlatformDropdown from "../components/navbarPlatformDropdown";
 import SentryWordmarkSVG from "../logos/sentry-wordmark-dark.svg";
 
 import Banner from "../components/banner";
-import { getSandboxURL } from "~src/components/sandboxLink";
+import { getSandboxURL, SandboxOnly } from "~src/components/sandboxLink";
 
 const HIGHLIGHTED_PLATFORMS = [
   "javascript",
@@ -75,9 +75,11 @@ const IndexPage = () => {
                   API
                 </SmartLink>
               </Nav.Item>
-              <Nav.Item>
-                <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
-              </Nav.Item>
+              <SandboxOnly>
+                <Nav.Item>
+                  <Nav.Link className="text-primary" href={getSandboxURL().toString()}>Demo</Nav.Link>
+                </Nav.Item>
+              </SandboxOnly>
               <Nav.Item>
                 <Nav.Link href="https://sentry.io/">
                   Sign In


### PR DESCRIPTION
This PR adds a Demo button to the navbar. When you click on it, it takes you to the Sentry sandbox.
![image](https://user-images.githubusercontent.com/8980455/139960886-4bc3786d-c419-4500-b8d4-64583e0b3f74.png)
![image](https://user-images.githubusercontent.com/8980455/139960947-4d012f82-bbc5-4061-9c73-04c513353d3b.png)



Meanwhile, this PR also adds the `SandboxOnly` component so that it's available to use in mdx files also.