### PR TITLE
Add SandboxLinks component

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -22,6 +22,7 @@ import PlatformLink from "./platformLink";
 import PlatformSection from "./platformSection";
 import PlatformIdentifier from "./platformIdentifier";
 import RelayMetrics from "./relayMetrics";
+import SandboxLink from "./sandboxLink";
 import { VimeoEmbed, YouTubeEmbed } from "./video";
 
 const mdxComponents = {
@@ -46,6 +47,7 @@ const mdxComponents = {
   LambdaLayerDetail,
   VimeoEmbed,
   YouTubeEmbed,
+  SandboxLink,
 };
 
 export default ({ value }) => {

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import usePlatform from "./hooks/usePlatform";
+
+type Props = {
+    children: React.ReactNode;
+    scenario: string;
+    projectSlug: string;
+    errorType: string;
+    platform?: string;
+}
+
+/**
+ * 
+ * @param param0.scenario: One of the scenarios. Available scenarios include:
+ * performance, releases, alerts, discover, dashboards, projects,
+ * oneDiscoverQuery, oneIssue, oneBreadcrumb, oneStackTrace, oneTransaction,
+ * oneWebVitals, oneTransactionSummary, oneRelease
+ * @param param0.projectSlug:
+ * One of react, python, react-native, android, iOS
+ * @param param0.errorType: A string matching the title of the error.
+ * @returns URL to the sandbox start endpoint
+ */
+export function getSandboxURL({ scenario, projectSlug, errorType }: {
+  scenario?: string,
+  projectSlug?: string,
+  errorType?: string,
+} = {}) {
+  const url = new URL('https://try.sentry-demo.com/demo/start/');
+
+  if (scenario) url.searchParams.append('scenario', scenario);
+
+  if (projectSlug) url.searchParams.append('projectSlug', projectSlug);
+
+  if (errorType) url.searchParams.append('errorType', errorType);
+  url.searchParams.append('source', 'docs');
+
+  return url;
+};
+
+export const isSandboxHidden = () => process.env.GATSBY_HIDE_SANDBOX === '1';
+
+const SANDBOX_PLATFORMS: string[] = [
+    'react',
+    'python',
+    'react-native',
+    'android',
+    'ios',
+];
+
+const SANDBOX_PLATFORM_MAP: { [key: string]: string } = {
+    apple: 'ios',
+    javascript: 'react',
+    node: 'react',
+};
+
+export default function SandboxLink({ children, platform, ...params }: Props) {
+    if (isSandboxHidden()) {
+        return children;
+    }
+    const [currentPlatform] = usePlatform(platform);
+    if (!params.projectSlug) {
+        if (SANDBOX_PLATFORMS.includes(currentPlatform.key)) {
+            params.projectSlug = currentPlatform.key;
+        } else if (SANDBOX_PLATFORM_MAP[currentPlatform.key]) {
+            params.projectSlug = SANDBOX_PLATFORM_MAP[currentPlatform.key];
+        }
+    }
+
+    return <a href={getSandboxURL(params).toString()}>{children}</a>;
+}

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -9,7 +9,7 @@ type Props = {
     platform?: string;
 }
 
-enum Scenario {
+export enum Scenario {
     Performance = 'performance',
     Releases = 'releases',
     Alerts = 'alerts',

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -1,13 +1,6 @@
 import React from "react";
 import usePlatform from "./hooks/usePlatform";
 
-type Props = {
-    children: React.ReactNode;
-    scenario?: string;
-    projectSlug?: string;
-    errorType?: string;
-    platform?: string;
-}
 
 export enum Scenario {
     Performance = 'performance',
@@ -24,6 +17,14 @@ export enum Scenario {
     OneWebVitals = 'oneWebVitals',
     OneTransactionSummary = 'oneTransactionSummary',
     OneRelease = 'oneRelease',
+}
+
+type Props = {
+    children: React.ReactNode;
+    scenario?: Scenario;
+    projectSlug?: string;
+    errorType?: string;
+    platform?: string;
 }
 
 /**

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -1,27 +1,26 @@
 import React from "react";
 import usePlatform from "./hooks/usePlatform";
 
-
-export enum Scenario {
-    Performance = 'performance',
-    Releases = 'releases',
-    Alerts = 'alerts',
-    Discover = 'discover',
-    Dashboards = 'dashboards',
-    Projects = 'projects',
-    OneDiscoverQuery = 'oneDiscoverQuery',
-    OneIssue = 'oneIssue',
-    OneBreadcrumb = 'oneBreadcrumb',
-    OneStackTrace = 'oneStackTrace',
-    OneTransaction = 'oneTransaction',
-    OneWebVitals = 'oneWebVitals',
-    OneTransactionSummary = 'oneTransactionSummary',
-    OneRelease = 'oneRelease',
-}
+const scenarios = [
+    'performance',
+    'releases',
+    'alerts',
+    'discover',
+    'dashboards',
+    'projects',
+    'oneDiscoverQuery',
+    'oneIssue',
+    'oneBreadcrumb',
+    'oneStackTrace',
+    'oneTransaction',
+    'oneWebVitals',
+    'oneTransactionSummary',
+    'oneRelease',
+  ] as const;
 
 type Props = {
     children: React.ReactNode;
-    scenario?: Scenario;
+    scenario?: typeof scenarios[number];
     projectSlug?: string;
     errorType?: string;
     platform?: string;
@@ -37,7 +36,7 @@ type Props = {
  * @returns URL to the sandbox start endpoint
  */
 export function getSandboxURL({ scenario, projectSlug, errorType }: {
-  scenario?: Scenario,
+  scenario?: typeof scenarios[number],
   projectSlug?: string,
   errorType?: string,
 } = {}) {
@@ -55,13 +54,13 @@ export function getSandboxURL({ scenario, projectSlug, errorType }: {
 
 export const isSandboxHidden = () => process.env.GATSBY_HIDE_SANDBOX === '1';
 
-const SANDBOX_PLATFORMS: string[] = [
+const SANDBOX_PLATFORMS = [
     'react',
     'python',
     'react-native',
     'android',
     'ios',
-];
+] as const;
 
 const SANDBOX_PLATFORM_MAP: { [key: string]: string } = {
     apple: 'ios',
@@ -75,7 +74,7 @@ export default function SandboxLink({ children, platform, ...params }: Props) {
     }
     const [currentPlatform] = usePlatform(platform);
     if (!params.projectSlug) {
-        if (SANDBOX_PLATFORMS.includes(currentPlatform.key)) {
+        if ((SANDBOX_PLATFORMS as readonly string[]).includes(currentPlatform.key)) {
             params.projectSlug = currentPlatform.key;
         } else if (SANDBOX_PLATFORM_MAP[currentPlatform.key]) {
             params.projectSlug = SANDBOX_PLATFORM_MAP[currentPlatform.key];

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -3,25 +3,40 @@ import usePlatform from "./hooks/usePlatform";
 
 type Props = {
     children: React.ReactNode;
-    scenario: string;
-    projectSlug: string;
-    errorType: string;
+    scenario?: string;
+    projectSlug?: string;
+    errorType?: string;
     platform?: string;
 }
 
+enum Scenario {
+    Performance = 'performance',
+    Releases = 'releases',
+    Alerts = 'alerts',
+    Discover = 'discover',
+    Dashboards = 'dashboards',
+    Projects = 'projects',
+    OneDiscoverQuery = 'oneDiscoverQuery',
+    OneIssue = 'oneIssue',
+    OneBreadcrumb = 'oneBreadcrumb',
+    OneStackTrace = 'oneStackTrace',
+    OneTransaction = 'oneTransaction',
+    OneWebVitals = 'oneWebVitals',
+    OneTransactionSummary = 'oneTransactionSummary',
+    OneRelease = 'oneRelease',
+}
+
 /**
- * 
- * @param param0.scenario: One of the scenarios. Available scenarios include:
- * performance, releases, alerts, discover, dashboards, projects,
- * oneDiscoverQuery, oneIssue, oneBreadcrumb, oneStackTrace, oneTransaction,
- * oneWebVitals, oneTransactionSummary, oneRelease
+ * Obtains the URL to the sandbox start endpoint.
+ * @param param0.scenario: One of the scenarios. Determins where in the sandbox 
+ * the user will be landed.
  * @param param0.projectSlug:
  * One of react, python, react-native, android, iOS
  * @param param0.errorType: A string matching the title of the error.
  * @returns URL to the sandbox start endpoint
  */
 export function getSandboxURL({ scenario, projectSlug, errorType }: {
-  scenario?: string,
+  scenario?: Scenario,
   projectSlug?: string,
   errorType?: string,
 } = {}) {

--- a/src/docs/contributing/linking.mdx
+++ b/src/docs/contributing/linking.mdx
@@ -50,7 +50,9 @@ Sandbox allows the user to explore the feature in an actual Sentry application w
 
 `Learn more about this feature in our <SandboxLink scenario="releases">sandbox</SandboxLink>.`
 
-This will take the user to a project based on the current platform selection. `scenario` specifies the landing page within the Sandbox application that the user will see, and if it is not specified, we default to the `issues` page. Possible values are:
+This will take the user to a project based on the current platform selection. However, you can also manually specify the target project using the `projectSlug` parameter.
+
+The `scenario` parameter specifies the landing page within the Sandbox application that the user will see, and if it is not specified, we default to the `issues` page. Possible values are:
 
 - `performance`
 - `releases`
@@ -66,6 +68,10 @@ This will take the user to a project based on the current platform selection. `s
 - `oneWebVitals`
 - `oneTransactionSummary`
 - `oneRelease`
+
+Additionally, you can use the `errorType` parameter to select a particular type of error.
+
+`Learn more about breadcrumbs in our <SandboxLink scenario="oneBreadcrumb" errorType="EXC_BAD_ACCESS" projectSlug="ios">sandbox</SandboxLink>.`
 
 ## Anchor Links
 

--- a/src/docs/contributing/linking.mdx
+++ b/src/docs/contributing/linking.mdx
@@ -44,6 +44,29 @@ We use this format when linking to external pages. Most typically, this is to th
 
 `The **Performance** page is the main view in [sentry.io](https://sentry.io) where you can search or browse for transaction data.`
 
+### To Sandbox
+
+Sandbox allows the user to explore the feature in an actual Sentry application with mocked data.
+
+`Learn more about this feature in our <SandboxLink scenario="releases">sandbox</SandboxLink>.`
+
+This will take the user to a project based on the current platform selection. `scenario` specifies the landing page within the Sandbox application that the user will see, and if it is not specified, we default to the `issues` page. Possible values are:
+
+- `performance`
+- `releases`
+- `alerts`
+- `discover`
+- `dashboards`
+- `projects`
+- `oneDiscoverQuery`
+- `oneIssue`
+- `oneBreadcrumb`
+- `oneStackTrace`
+- `oneTransaction`
+- `oneWebVitals`
+- `oneTransactionSummary`
+- `oneRelease`
+
 ## Anchor Links
 
 Anchor links (appended by the # symbol) further direct users to a specific section (rather than the general page).

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -67,7 +67,7 @@ For app models that don't have a console to print to, you can <PlatformLink to="
 
 <ConfigKey name="release">
 
-Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/).
+Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/) or the <SandboxLink scenario="releases">sandbox</SandboxLink>.
 
 <PlatformSection notSupported={["unity"]}>
 


### PR DESCRIPTION
This allows you to add links to the sandbox in docs.
Usage:

```
<SandboxLink scenario="releases">sandbox</SandboxLink>
```

This will automatically take you to the correct project based on the current project selection so there's usually no need to specify `projectSlug`.