### PR TITLE
Docs: Fix `MaxRequestBodySize` values

### DIFF
--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -234,10 +234,10 @@ Methods that take precedence over `IHostingEnvironment` are:
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
-- `never`: Request bodies are never sent.
-- `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
-- `medium`: Medium and small requests will be captured (typically 10KB).
-- `always`: The SDK will always capture the request body as long as Sentry can make sense of it.
+- `None`: Request bodies are never sent.
+- `Small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
+- `Medium`: Medium and small requests will be captured (typically 10KB).
+- `Always`: The SDK will always capture the request body as long as Sentry can make sense of it.
 
 If the request bodies should be captured, all requests will have the `EnableRewind` method invoked. This is done so that the request data can be read later, in case an error happens while processing the request.
 


### PR DESCRIPTION
Update the values listed on this page for the `MaxRequestBodySize` option for `appsettings.json` to match those available in the `Sentry.Extensibility.RequestSize` enumeration (https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Extensibility/RequestSize.cs). The current value `never` is not a valid value and the values should start with an uppercase letter.