### PR TITLE
Add Next.js to the performance setup landing page

### DIFF
--- a/src/docs/product/performance/getting-started.mdx
+++ b/src/docs/product/performance/getting-started.mdx
@@ -36,6 +36,7 @@ Customers on legacy plans must add transaction events to their subscription in o
 - [JavaScript](/platforms/javascript/performance/)
   - [Angular](/platforms/javascript/guides/angular/performance/)
   - [Ember](/platforms/javascript/guides/ember/performance/)
+  - [Next.js](/platforms/javascript/guides/nextjs/performance/)
   - [React](/platforms/javascript/guides/react/performance/)
   - [Vue](/platforms/javascript/guides/vue/performance/)
 


### PR DESCRIPTION
With the popularity of Next.js we should highlight that it's there.