### PR TITLE
Add setSpan to custom instrumentation

### DIFF
--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -67,6 +67,9 @@ $transactionContext->setName('External Call');
 $transactionContext->setOp('http.caller');
 $transaction = \Sentry\startTransaction($transactionContext);
 
+// Setting the transaction to the current Hub, this allows you to retrieve the current transaction
+SentrySdk::getCurrentHub()->setSpan($transaction);
+
 $spanContext = new \Sentry\Tracing\SpanContext();
 $spanContext->setOp('functionX');
 $span1 = $transaction->startChild($spanContext);

--- a/src/platforms/php/common/performance.mdx
+++ b/src/platforms/php/common/performance.mdx
@@ -67,8 +67,8 @@ $transactionContext->setName('External Call');
 $transactionContext->setOp('http.caller');
 $transaction = \Sentry\startTransaction($transactionContext);
 
-// Setting the transaction to the current Hub, this allows you to retrieve the current transaction
-SentrySdk::getCurrentHub()->setSpan($transaction);
+// Setting the transaction to the current Hub allows you to retrieve it later
+\Sentry\SentrySdk::getCurrentHub()->setSpan($transaction);
 
 $spanContext = new \Sentry\Tracing\SpanContext();
 $spanContext->setOp('functionX');


### PR DESCRIPTION
In PHP the transaction is not automatically set to the Hub when it is created. I added the manual call to setSpan() that allow users to retrieve it later with getTransaction()

Tagging @stayallive for additional review as SDK mainteiner.  