### PR TITLE
Update ruby traces sample rate to align with comment and other platforms

### DIFF
--- a/src/wizard/ruby/index.md
+++ b/src/wizard/ruby/index.md
@@ -24,7 +24,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0 
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/wizard/ruby/index.md
+++ b/src/wizard/ruby/index.md
@@ -24,7 +24,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0 
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/wizard/ruby/rack.md
+++ b/src/wizard/ruby/rack.md
@@ -26,7 +26,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0 
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/wizard/ruby/rack.md
+++ b/src/wizard/ruby/rack.md
@@ -26,7 +26,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0 
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/wizard/ruby/rails.md
+++ b/src/wizard/ruby/rails.md
@@ -30,7 +30,7 @@ Sentry.init do |config|
   # Set tracesSampleRate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production
-  config.traces_sample_rate = 1.0 
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/wizard/ruby/rails.md
+++ b/src/wizard/ruby/rails.md
@@ -30,7 +30,7 @@ Sentry.init do |config|
   # Set tracesSampleRate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0 
   # or
   config.traces_sampler = lambda do |context|
     true


### PR DESCRIPTION
Every other SDK sets traces sample rate to 1.0. Ruby/Rails/Rack set it to 0.5 even though the comment says 1.0