### PR TITLE
replace platform links with platform redirects

### DIFF
--- a/src/docs/product/data-management-settings/filtering/index.mdx
+++ b/src/docs/product/data-management-settings/filtering/index.mdx
@@ -12,7 +12,7 @@ This feature is available only if your organization is on either a Business or T
 
 </Note>
 
-Sentry provides several methods to filter data in your project. Using sentry.io to filter events is a simple method since you don't have to <PlatformLink to="/configuration/filtering/">configure and deploy your SDK to filter projects</PlatformLink>.
+Sentry provides several methods to filter data in your project. Using sentry.io to filter events is a simple method since you don't have to [configure and deploy your SDK to filter projects](/platform-redirect/?next=/configuration/filtering/).
 
 ## Inbound Data Filters
 

--- a/src/docs/product/sentry-basics/environments/index.mdx
+++ b/src/docs/product/sentry-basics/environments/index.mdx
@@ -7,7 +7,7 @@ redirect_from:
 description: "Learn more about how environments can help you better filter issues, releases, and user feedback in the Issue Details page on sentry.io."
 ---
 
-`Environment` is a Sentry-supported tag that you can (and should) add to your SDK. Generally, the tag accepts any value, but it's intended to refer to your code deployments' naming convention, such as *development*, *testing*, *staging*, or *production*. 
+`Environment` is a Sentry-supported tag that you can (and should) add to your SDK. Generally, the tag accepts any value, but it's intended to refer to your code deployments' naming convention, such as *development*, *testing*, *staging*, or *production*.
 
 Environments help you better filter issues, releases, and user feedback in the **Issue Details** page of [sentry.io](https://sentry.io). On that page, you can view information about a specific environment, focusing on the most recent release. If you’re using a multi-staged release process, you can also select a different default environment and set conditions that match the `environment` attribute to restrict alerts to only specific release stages.
 
@@ -19,7 +19,7 @@ Environments are unique to each organization. Environment settings, however, are
 
 ## Creating Environments
 
-Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. You can also create an environment when you first `init` your SDK, <PlatformLink to="/configuration/environments/">as documented for each SDK</PlatformLink>.
+Sentry automatically creates environments when it receives an event with the environment tag. Environments are case sensitive. You can also create an environment when you first `init` your SDK, [as documented for each SDK](/platform-redirect/?next=/configuration/environments/).
 
 ## Environment Filter
 


### PR DESCRIPTION
Replaces platform links to JavaScript-specific content with platform redirects so users can choose their platform on the following pages:
https://docs.sentry.io/product/sentry-basics/environments/#creating-environments
https://docs.sentry.io/product/data-management-settings/filtering/