### PR TITLE
ref/apple primer

### DIFF
--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -18,31 +18,9 @@
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
 - [Release Health](/product/releases/health/) tracks crash free users and sessions
+- <PlatformLink to="/performance/instrumentation/">Measure the performance of your app</PlatformLink>
+  - Automatically measures rendering for UIViewControllers
+  - <PlatformLink to="/performance/instrumentation/??">Performance of HTTP requests</PlatformLink>
+  - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs
-
-**Features using Swizzling:**
-
-The Cocoa SDK uses [swizzling](https://nshipster.com/method-swizzling/) to provide some features out of the box without boilerplate code. The following features use swizzling:
-
-
-
-Since Cocoa 7.5.0, you can opt out of swizzling using options. When you disable swizzling, the SDK disables the features above:
-
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.enableSwizzling = false
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-    options.enableSwizzling = NO;
-}];
-```

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -22,7 +22,7 @@
   - Rendering of UIViewControllers
   - Performance of HTTP requests
   - Distributed tracing
-  - [Mobile Vitals](https://blog.sentry.io/2021/08/23/mobile-vitals-four-metrics-every-mobile-developer-should-care-about)
+  - [Mobile Vitals](https://docs.sentry.io/product/performance/mobile-vitals/)
     - Cold and warm start
     - Slow and frozen frames
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -18,11 +18,11 @@
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
 - [Release Health](/product/releases/health/) tracks crash free users and sessions
-- <PlatformLink to="/performance/instrumentation/">Automatic Performance Tracking</PlatformLink>
-  - Rendering of UIViewControllers
-  - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
-  - Performance of HTTP requests
-  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation">Cold and warm start</PlatformLink>
-  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
+- [Automatic Performance Tracking](/performance/instrumentation/)
+  - [Rendering of UIViewControllers](/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation)
+  - [Cold and warm start](/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+  - [Slow and frozen frames](/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
+  - [Performance of HTTP requests](/performance/instrumentation/automatic-instrumentation/#http-instrumentation)
+  - [Distributed tracing](/performance/connect-services/)
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -19,11 +19,11 @@
   - Outgoing HTTP requests
 - [Release Health](/product/releases/health/) tracks crash free users and sessions
 - <PlatformLink to="/performance/instrumentation/">Automatic Performance Tracking</PlatformLink>
-  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation">Rendering of UIViewControllers</PlatformLink>
-  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#http-instrumentation">Performance of HTTP requests</PlatformLink>
+  - Rendering of UIViewControllers
   - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
+  - Performance of HTTP requests
   - Mobile Vitals
-    - <PlatformLink to="/performance/connect-services/#app-start-instrumentation">Cold and warm start</PlatformLink>
-    - <PlatformLink to="/performance/connect-services/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
+    - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation">Cold and warm start</PlatformLink>
+    - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -18,11 +18,12 @@
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
 - [Release Health](/product/releases/health/) tracks crash free users and sessions
-- [Automatic Performance Tracking](/performance/instrumentation/)
-  - [Rendering of UIViewControllers](/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation)
-  - [Cold and warm start](/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
-  - [Slow and frozen frames](/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
-  - [Performance of HTTP requests](/performance/instrumentation/automatic-instrumentation/#http-instrumentation)
-  - [Distributed tracing](/performance/connect-services/)
+- Automatic <PlatformLink to="/performance/instrumentation/">Performance Tracking</PlatformLink>
+  - Rendering of UIViewControllers
+  - Performance of HTTP requests
+  - Distributed tracing
+  - [Mobile Vitals](https://blog.sentry.io/2021/08/23/mobile-vitals-four-metrics-every-mobile-developer-should-care-about)
+    - Cold and warm start
+    - Slow and frozen frames
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -23,7 +23,7 @@
   - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#http-instrumentation">Performance of HTTP requests</PlatformLink>
   - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
   - Mobile Vitals
-    - <PlatformLink to="/performance/connect-services/">Cold and warm start</PlatformLink>
-    - <PlatformLink to="/performance/connect-services/">Slow and frozen frames</PlatformLink>
+    - <PlatformLink to="/performance/connect-services/#app-start-instrumentation">Cold and warm start</PlatformLink>
+    - <PlatformLink to="/performance/connect-services/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -18,9 +18,12 @@
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
 - [Release Health](/product/releases/health/) tracks crash free users and sessions
-- <PlatformLink to="/performance/instrumentation/">Measure the performance of your app</PlatformLink>
-  - Automatically measures rendering for UIViewControllers
-  - <PlatformLink to="/performance/instrumentation/??">Performance of HTTP requests</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/">Automatic Performance Tracking</PlatformLink>
+  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-instrumentation">Rendering of UIViewControllers</PlatformLink>
+  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#http-instrumentation">Performance of HTTP requests</PlatformLink>
   - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
+  - Mobile Vitals
+    - <PlatformLink to="/performance/connect-services/">Cold and warm start</PlatformLink>
+    - <PlatformLink to="/performance/connect-services/">Slow and frozen frames</PlatformLink>
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -22,8 +22,7 @@
   - Rendering of UIViewControllers
   - <PlatformLink to="/performance/connect-services/">Distributed tracing</PlatformLink>
   - Performance of HTTP requests
-  - Mobile Vitals
-    - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation">Cold and warm start</PlatformLink>
-    - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
+  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation">Cold and warm start</PlatformLink>
+  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames">Slow and frozen frames</PlatformLink>
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs


### PR DESCRIPTION
I don't think the most important information about our product is the fact it uses Swizzling so I suggest we remove from the primer.
Instead, I added more information about features we added recently.

We could add a note to the foot of the Getting started page saying:

> * To learn more about what features use Swizzling and how to control that: click here.