### PR TITLE
fix circular link on common breadcrumbs page

### DIFF
--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -64,6 +64,6 @@ This hook is passed an already assembled breadcrumb and, in some SDKs, an option
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />
 
-For information about what can be done with the hint, see <PlatformLink to="/enriching-events/breadcrumbs/">Filtering Events</PlatformLink>.
+For information about what can be done with the hint, see <PlatformLink to="/configuration/filtering/#using-hints">Filtering Events</PlatformLink>.
 
 </PlatformSection>

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -62,8 +62,12 @@ You'll first need to import the SDK, as usual:
 
 This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
-<PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" / notSupported={["apple"]}>
+<PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />
+
+<PlatformSection notSupported={["apple", "dotnet", "unity"]}>
 
 For information about what can be done with the hint, see <PlatformLink to="/configuration/filtering/#using-hints">Filtering Events</PlatformLink>.
+
+</PlatformSection>
 
 </PlatformSection>

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -62,7 +62,7 @@ You'll first need to import the SDK, as usual:
 
 This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
-<PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />
+<PlatformContent notSupported={["apple"]} includePath="enriching-events/breadcrumbs/before-breadcrumb" />
 
 For information about what can be done with the hint, see <PlatformLink to="/configuration/filtering/#using-hints">Filtering Events</PlatformLink>.
 

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -62,7 +62,7 @@ You'll first need to import the SDK, as usual:
 
 This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
-<PlatformContent notSupported={["apple"]} includePath="enriching-events/breadcrumbs/before-breadcrumb" />
+<PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" / notSupported={["apple"]}>
 
 For information about what can be done with the hint, see <PlatformLink to="/configuration/filtering/#using-hints">Filtering Events</PlatformLink>.
 


### PR DESCRIPTION
Fixes link at the end of the Breadcrumbs SDK page that links back to the same page:
https://docs.sentry.io/platforms/python/guides/django/enriching-events/breadcrumbs/

_For information about what can be done with the hint, see Filtering Events._