### PR TITLE
docs(elixir): add elixir example for environment name configuration

### DIFF
--- a/src/includes/set-environment/elixir.mdx
+++ b/src/includes/set-environment/elixir.mdx
@@ -1,0 +1,10 @@
+```elixir
+# config/prod.exs
+config :sentry,
+  environment_name: :prod
+
+# or from Mix.env
+# config/config.exs
+config :sentry,
+  environment_name: Mix.env()
+```


### PR DESCRIPTION
Hi! Thanks for awesome library and documents ✨ 

`environment_name` configuration example missing in Elixir.
I think better  example has both `:prod` and `Mix.env()` configuration 👍 
Is ok??

<img width="783" alt="スクリーンショット 2021-11-08 0 15 31" src="https://user-images.githubusercontent.com/16176282/140650930-61634f47-c9f3-419a-89ac-2f5aefb97cf8.png">


