### PR TITLE
fix(apple): Reverse parameters for scope.setTag

### DIFF
--- a/src/includes/enriching-events/set-tag/apple.mdx
+++ b/src/includes/enriching-events/set-tag/apple.mdx
@@ -2,7 +2,7 @@
 import Sentry
 
 SentrySDK.configureScope { scope in
-    scope.setTag(value: "page_locale", key: "de-at")
+    scope.setTag(value: "de-at", key: "page_locale")
 }
 ```
 
@@ -10,6 +10,6 @@ SentrySDK.configureScope { scope in
 @import Sentry;
 
 [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-    [scope setTagValue:@"page_locale" forKey:@"de-at"];
+    [scope setTagValue:@"de-at" forKey:@"page_locale"];
 }];
 ```


### PR DESCRIPTION
Hi,

Looking at https://docs.sentry.io/platforms/apple/guides/ios/enriching-events/tags/, it looked like the parameters key and value for `setTag` where reversed (probably due to them be in the reverse order in other languages).