### PR TITLE
add note about Spark 3 support

### DIFF
--- a/src/platforms/python/guides/pyspark/index.mdx
+++ b/src/platforms/python/guides/pyspark/index.mdx
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 
 ### Worker
 
-The spark worker integration is supported for Spark 2.4.0 and above.
+The spark worker integration is supported for Spark 2.4.x. It is **not supported for Spark 3**.
 
 Create a file called `sentry-daemon.py` with the following content:
 

--- a/src/platforms/python/guides/pyspark/index.mdx
+++ b/src/platforms/python/guides/pyspark/index.mdx
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 
 ### Worker
 
-The spark worker integration is supported for Spark 2.4.x. It is **not supported for Spark 3**.
+The spark worker integration is supported for Spark 2.4.x. It is **not supported** for Spark 3.
 
 Create a file called `sentry-daemon.py` with the following content:
 


### PR DESCRIPTION
We've got some users asking about this. Let's make sure we are clear that the worker integration is not support for Spark 3.