### PR TITLE
Update text for default grouping algorithm

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -39,7 +39,7 @@ When you create a Sentry project, the most recent version of the grouping algori
 
 To upgrade an existing project to a new grouping algorithm version, navigate to **Settings > Projects > [project] > Issue Grouping > Upgrade Grouping**. After upgrading to a new grouping algorithm, you will very likely see new groups being created.
 
-All versions consider the `stacktrace`, `exception` and `message`, in sequential order.
+All versions consider the `stack trace` first, the `exception` next, and then finally the `message`.
 
 ### Grouping by Stack Trace
 

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -39,7 +39,7 @@ When you create a Sentry project, the most recent version of the grouping algori
 
 To upgrade an existing project to a new grouping algorithm version, navigate to **Settings > Projects > [project] > Issue Grouping > Upgrade Grouping**. After upgrading to a new grouping algorithm, you will very likely see new groups being created.
 
-All versions consider the `stacktrace`, `exception` and `message`.
+All versions consider the `stacktrace`, `exception` and `message`, in sequential order.
 
 ### Grouping by Stack Trace
 


### PR DESCRIPTION
Mention that it works in sequential order, from stacktrace to message and not all at the same time.

@imatwawana Not sure if that's the best way to phrase this. It's important to specify that basically we base the grouping decision initially by stack trace and if that is not detected, then we will check exception info, and if that's missing too then we fallback to message.