### PR TITLE
fix(apple): Set tag parameters for with-scope

### DIFF
--- a/src/includes/enriching-events/scopes/with-scope/apple.mdx
+++ b/src/includes/enriching-events/scopes/with-scope/apple.mdx
@@ -4,7 +4,7 @@ import Sentry
 SentrySDK.capture(error: error) { scope in
     scope.setLevel(.warning)
     // will be tagged with my-tag="my value"
-    scope.setTag(value: "my-tag", key: "my value")
+    scope.setTag(value: "my value", key: "my-tag")
 }
 
 // will not be tagged with my-tag
@@ -17,7 +17,7 @@ SentrySDK.capture(error: error)
 [SentrySDK captureError:error withScopeBlock:^(SentryScope * _Nonnull scope) {
     [scope setLevel:kSentryLevelWarning];
     // will be tagged with my-tag="my value"
-    [scope setTagValue:@"my-tag" forKey:@"my value"];
+    [scope setTagValue:@"my value" forKey:@"my-tag"];
 }];
 
 // will not be tagged with my-tag


### PR DESCRIPTION
Searched for other occurrences of reversed parameters for scope.setTag for Cocoa. Brought up in https://github.com/getsentry/sentry-docs/pull/4377