### PR TITLE
ASP.NET troubleshooting for global tags.

### DIFF
--- a/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
@@ -31,4 +31,17 @@ using System.Net;
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
 ```
 
+### Tags not showing if set on Application_Start
+
+That happens because the `scope` from `requests` will be different from the one executed during the execution of Application_Start.
+To apply `Tags` globally. It's recommended to set them into SentryOptions as shown in the example below.
+
+```csharp
+SentrySdk.Init(options =>
+{
+  options.Dsn = "__YOUR__PUBLIC__DSN__";
+  options.DefaultTags.Add("TagName", "value");
+});
+```
+
 <PlatformContent includePath="troubleshooting" />

--- a/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
@@ -39,7 +39,7 @@ To apply `Tags` globally. It's recommended to set them into SentryOptions as sho
 ```csharp
 SentrySdk.Init(options =>
 {
-  options.Dsn = "__YOUR__PUBLIC__DSN__";
+  options.Dsn = "___PUBLIC_DSN___";
   options.DefaultTags.Add("TagName", "value");
 });
 ```

--- a/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
@@ -31,10 +31,10 @@ using System.Net;
 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
 ```
 
-### Tags not showing if set on Application_Start
+### Tags Not Showing if Set on Application_Start
 
-That happens because the `scope` from `requests` will be different from the one executed during the execution of Application_Start.
-To apply `Tags` globally. It's recommended to set them into SentryOptions as shown in the example below.
+This happens because the `scope` from `requests` will be different from the one executed during the execution of Application_Start.
+To apply `Tags` globally, it's recommended that you set them in `SentryOptions`, as shown in the example below:
 
 ```csharp
 SentrySdk.Init(options =>


### PR DESCRIPTION
This will help users that try to set their tags into Application_Start thinking it'll be available to all requests, but turned out they are only available on the scope from the framework initialization.