### PR TITLE
feat(apple): Update alert on web APM

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -12,7 +12,7 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 <Alert level="info" title="Important">
 
-The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1328)). We recommend updating to at least [7.4.1](https://github.com/getsentry/sentry-cocoa/releases/tag/7.4.1) or [disabling the feature](#http-instrumentation).
+The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1448)). We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3) or [disabling the feature](#http-instrumentation).
 
 </Alert>
 


### PR DESCRIPTION
We released a new fix for an issue with HTTP instrumentation on Apple.
The warning now states to update to 7.5.3.

Only merge after 7.5.3 is released, see https://github.com/getsentry/publish/issues/668.