### PR TITLE
chore(react-native): needs double dash

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -52,6 +52,10 @@ export SENTRY_PROPERTIES=../sentry.properties
   ../node_modules/react-native/packager/react-native-xcode.sh
 ```
 
+# If your project was previously passing args to react-native-xcode.sh, add a --
+../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \
+  ../node_modules/react-native/scripts/react-native-xcode.sh -- ./path/to/some/file.tsx
+
 Additionally, we add a build script named “Upload Debug Symbols to Sentry” to upload debug symbols to Sentry.
 
 #### Upload Debug Symbols to Sentry

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -50,7 +50,6 @@ export SENTRY_PROPERTIES=../sentry.properties
 # For RN < 0.46
 ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \
   ../node_modules/react-native/packager/react-native-xcode.sh
-```
 
 # If your project was previously passing args to react-native-xcode.sh, add a --
 ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \


### PR DESCRIPTION
The build phase script for bundling react native may have been passing arguments to react-native-xcode.sh.  If so, you need to add `--` to separate the new command from the existing arguments.