### PR TITLE
added intro text to proguard docs

### DIFF
--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -1,7 +1,7 @@
 ---
 title: ProGuard
 sidebar_order: 100
-description: "Learn about using ProGuard to upload the ProGuard/R8 mappings, source bundle, and native symbols to Sentry."
+description: "Learn about using the Sentry Gradle Plugin or sentry-cli to upload ProGuard/R8 mappings, source bundle, and native symbols to Sentry."
 ---
 
 If you want to see de-obfuscated stack traces, you'll need to use ProGuard with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our Gradle integration or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -4,7 +4,7 @@ sidebar_order: 100
 description: "Learn about using ProGuard to upload the ProGuard/R8 mappings, source bundle, and native symbols to Sentry."
 ---
 
-If you want to see de-obfuscated logs, you'll need to to use ProGuard with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our Gradle integration or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
+If you want to see de-obfuscated stack traces, you'll need to use ProGuard with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our Gradle integration or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 
 <Note>
 

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -1,10 +1,10 @@
 ---
 title: ProGuard
 sidebar_order: 100
-description: "Learn about using ProGuard to upload the ProGuard/R8 mappings, source bundle, and native symbols Sentry."
+description: "Learn about using ProGuard to upload the ProGuard/R8 mappings, source bundle, and native symbols to Sentry."
 ---
 
-To use ProGuard with Sentry, upload the ProGuard mapping files by either the recommended method of using our Gradle integration or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
+If you want to see de-obfuscated logs, you'll need to to use ProGuard with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our Gradle integration or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 
 <Note>
 


### PR DESCRIPTION
Adds more intro text to ProGuard page
Fixes typo in page description
Addresses (in part) [issue 4421](https://github.com/getsentry/sentry-docs/issues/4421)