### PR TITLE
feat(unity): Added automated Android symbol upload

### DIFF
--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -24,7 +24,7 @@ Sentry requires [debug information files](/platforms/android/data-management/deb
 
 The automated debug symbols upload is enabled by default but requires configuration. Go to `Tools -> Sentry -> Editor` to enter the [Auth Token](https://sentry.io/api/), Org Slug and the Project Name. Be aware that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration that should not be made publicly available.
 
-## iOS
+### iOS
 
 Debug information files on the iOS platform are called dSYM, and the way to obtain them differs depending on whether `Enable Bitcode` is set to `true` in your Xcode project.
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -16,7 +16,7 @@ Native support is `enabled` by default. The Unity SDK passes the options defined
 
 You can opt out of native support by unchecking `iOS Native Support` and `Android Native Support` in the configuration window.
 
-# Debug Symbols
+## Debug Symbols
 
 Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. To upload these the Unity SDK relies on [sentry-cli](/product/cli/). We included the executables for Windows, macOS and Linux inside the Sentry SDK package.
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -18,7 +18,7 @@ You can opt out of native support by unchecking `iOS Native Support` and `Androi
 
 ## Debug Symbols
 
-Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. To upload these the Unity SDK relies on [sentry-cli](/product/cli/). We included the executables for Windows, macOS and Linux inside the Sentry SDK package.
+Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. To upload these, the Unity SDK relies on the [sentry-cli](/product/cli/). We included the executables for Windows, macOS, and Linux inside the Sentry SDK package.
 
 ### Android
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -16,30 +16,26 @@ Native support is `enabled` by default. The Unity SDK passes the options defined
 
 You can opt out of native support by unchecking `iOS Native Support` and `Android Native Support` in the configuration window.
 
-## Debug Symbols
+# Debug Symbols
 
-Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. Our Unity SDK does not yet support the automated upload of debug symbols, but since it's using other Sentry SDKs, this can be set up manually.
+Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. To upload these the Unity SDK relies on [sentry-cli](/product/cli/). We included the executables for Windows, macOS and Linux inside the Sentry SDK package.
 
-After downloading and installing [sentry-cli](/product/cli/installation/), you can run:
+## Android
 
-```bash
-sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_SYMBOLS
-```
+The automated debug symbols upload is enabled by default but requires configuration. Go to `Tools -> Sentry -> Editor` to enter the [Auth Token](https://sentry.io/api/), Org Slug and the Project Name. Be aware that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration that should not be made publicly available.
 
-<Note>
-
-You can [create the Auth Token here](https://sentry.io/api/).
-
-</Note>
-
-### Android
-
-To upload debug symbols for Android, just make sure `Create symbols.zip` is enabled in the build settings. Unity will generate them in the same directory as the build output, and sentry-cli accepts .zip files. Check out our [Android documentation](/platforms/android/proguard/) for more details.
-
-### iOS
+## iOS
 
 Debug information files on the iOS platform are called dSYM, and the way to obtain them differs depending on whether `Enable Bitcode` is set to `true` in your Xcode project.
 
 With Bitcode disabled, make sure the `Debug Information Format` is set to `DWARF with dSYM file`. When building the game, Xcode will then place the dSYM folders together with the build output and you can run the sentry-cli command there. By default the output path will look similar to: _~/Library/Developer/Xcode/DerivedData/BUILD_ID/Build/Products/BUILD_TYPE/_.
 
 If you have Bitcode enabled, please refer to our [iOS documentation](/platforms/apple/guides/ios/dsym/).
+
+## Manual upload using sentry-cli
+
+You can either use the provided executables from within the package or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols run it with:
+
+```bash
+sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_SYMBOLS
+```

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -32,7 +32,7 @@ With Bitcode disabled, make sure the `Debug Information Format` is set to `DWARF
 
 If you have Bitcode enabled, please refer to our [iOS documentation](/platforms/apple/guides/ios/dsym/).
 
-## Manual upload using sentry-cli
+### Manual Upload Using sentry-cli
 
 You can either use the provided executables from within the package or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols run it with:
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -34,7 +34,7 @@ If you have Bitcode enabled, please refer to our [iOS documentation](/platforms/
 
 ### Manual Upload Using sentry-cli
 
-You can either use the provided executables from within the package or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols run it with:
+You can either use the provided executables from within the package or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols, run it with:
 
 ```bash
 sentry-cli --auth-token YOUR_AUTH_TOKEN upload-dif --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_SYMBOLS

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -22,7 +22,7 @@ Sentry requires [debug information files](/platforms/android/data-management/deb
 
 ### Android
 
-The automated debug symbols upload is enabled by default but requires configuration. Go to `Tools -> Sentry -> Editor` to enter the [Auth Token](https://sentry.io/api/), Org Slug and the Project Name. Be aware that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration that should not be made publicly available.
+The automated debug symbols upload is enabled by default but requires configuration. Go to **Tools -> Sentry -> Editor** to enter the [Auth Token](https://sentry.io/api/), Org Slug, and the Project Name. Note that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration, that should not be made publicly available.
 
 ### iOS
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -20,7 +20,7 @@ You can opt out of native support by unchecking `iOS Native Support` and `Androi
 
 Sentry requires [debug information files](/platforms/android/data-management/debug-files/) to symbolicate your crash logs. To upload these the Unity SDK relies on [sentry-cli](/product/cli/). We included the executables for Windows, macOS and Linux inside the Sentry SDK package.
 
-## Android
+### Android
 
 The automated debug symbols upload is enabled by default but requires configuration. Go to `Tools -> Sentry -> Editor` to enter the [Auth Token](https://sentry.io/api/), Org Slug and the Project Name. Be aware that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration that should not be made publicly available.
 

--- a/src/platforms/unity/native-support.mdx
+++ b/src/platforms/unity/native-support.mdx
@@ -22,7 +22,7 @@ Sentry requires [debug information files](/platforms/android/data-management/deb
 
 ### Android
 
-The automated debug symbols upload is enabled by default but requires configuration. Go to **Tools -> Sentry -> Editor** to enter the [Auth Token](https://sentry.io/api/), Org Slug, and the Project Name. Note that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration, that should not be made publicly available.
+The automated debug symbols upload is enabled by default but requires configuration. Go to **Tools > Sentry > Editor** to enter the [Auth Token](https://sentry.io/api/), Org Slug, and the Project Name. Note that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration, that should not be made publicly available.
 
 ### iOS
 


### PR DESCRIPTION
Android does not have to be done manually (but still can be).
So I've split the Debug Symbols section into Android, iOS, and Manual upload.

Will be reworked once more when the automated upload for iOS gets added.