### PR TITLE
ref(apple): Move in app frames to platform page

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
@@ -204,50 +204,6 @@ For instance, the following marks all frames that are below a specific C++ names
 stack.function:myapplication::* +app
 ```
 
-#### Considerations for `sentry-cocoa`
-
-The `sentry-cocoa` SDK always marks public frameworks such as UIKitCore, CoreFoundation, GraphicsServices, and so forth as `not inApp`. Before version 7.0.0, the sentry-cocoa SDK marks all private frameworks and the main executable inside the application bundle as `inApp`. Since version 7.0.0, the sentry-cocoa SDK sets the `inApp` flag only for frames originating from the main executable by using the [CFBundleExecutable]. For private frameworks, such as Sentry, dynamic and static frameworks differ. If you are not familiar with these terms, you can learn more:
-
-- [CFBundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable)
-- [Dynamic Library Programming Topics](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/000-Introduction/Introduction.html)
-
-##### Dynamic Frameworks
-
-If you use dynamic frameworks, such as, for example, Sentry, the SDK marks these as `not inApp`. In case you have a private framework that should be `inApp`, you can use [`inAppInclude`](/platforms/apple/configuration/options/#in-app-include) or [`inAppExclude`](/platforms/apple/configuration/options/#in-app-exclude) of the SentryOptions.
-
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-
-    // The SDK marks all frameworks starting with MyBusinessLogic as inApp
-    options.add(inAppInclude: "MyBusinessLogic")
-
-    // The SDK marks all frameworks starting with MyFramework as not inApp
-    options.add(inAppExclude: "MyFramework")
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-
-    // The SDK marks all frameworks starting with MyBusinessLogic as inApp
-    [options addInAppInclude:@"MyBusinessLogic"];
-
-    // The SDK marks all framework starting with MyFramework as not inApp
-    [options addInAppExclude:@"MyFramework"];
-}];
-```
-
-##### Static Frameworks
-
-When using static frameworks, the frameworks end up in the main executable. Therefore, the SDK currently can't detect if a frame of the main executable
-originates from your application or a private framework and marks all of them as `inApp`. To improve your experience, use the below explained stack trace rules on the server to tell Sentry which should be marked as `not inApp`.
-
 #### Stack Trace Rules
 
 The following marks frames from libdispatch starting with `_dispatch_` as `inApp`.

--- a/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
@@ -204,6 +204,8 @@ For instance, the following marks all frames that are below a specific C++ names
 stack.function:myapplication::* +app
 ```
 
+See [in-app frames for Apple](/platforms/apple/usage/in-app-frames) to find out how the `sentry-cocoa` SDK marks frames as in-app.
+
 #### Stack Trace Rules
 
 The following marks frames from libdispatch starting with `_dispatch_` as `inApp`.

--- a/src/includes/in-app-frames/apple.mdx
+++ b/src/includes/in-app-frames/apple.mdx
@@ -1,0 +1,41 @@
+The `sentry-cocoa` SDK always marks public frameworks such as UIKitCore, CoreFoundation, GraphicsServices, and so forth as `not inApp`. Before version 7.0.0, the sentry-cocoa SDK marks all private frameworks and the main executable inside the application bundle as `inApp`. Since version 7.0.0, the sentry-cocoa SDK sets the `inApp` flag only for frames originating from the main executable by using the [CFBundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable). For private frameworks, such as Sentry, dynamic and static frameworks differ. If you are not familiar with these terms, you can learn more:
+
+- [CFBundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable)
+- [Dynamic Library Programming Topics](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/000-Introduction/Introduction.html)
+
+## Dynamic Frameworks
+
+If you use dynamic frameworks, such as, for example, Sentry, the SDK marks these as `not inApp`. In case you have a private framework that should be `inApp`, you can use [`inAppInclude`](/platforms/apple/configuration/options/#in-app-include) or [`inAppExclude`](/platforms/apple/configuration/options/#in-app-exclude) of the SentryOptions.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+
+    // The SDK marks all frameworks starting with MyBusinessLogic as inApp
+    options.add(inAppInclude: "MyBusinessLogic")
+
+    // The SDK marks all frameworks starting with MyFramework as not inApp
+    options.add(inAppExclude: "MyFramework")
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+
+    // The SDK marks all frameworks starting with MyBusinessLogic as inApp
+    [options addInAppInclude:@"MyBusinessLogic"];
+
+    // The SDK marks all framework starting with MyFramework as not inApp
+    [options addInAppExclude:@"MyFramework"];
+}];
+```
+
+## Static Frameworks
+
+When using static frameworks, the frameworks end up in the main executable. Therefore, the SDK currently can't detect if a frame of the main executable
+originates from your application or a private framework and marks all of them as `inApp`. To improve your experience, use the below explained stack trace rules on the server to tell Sentry which should be marked as `not inApp`.

--- a/src/platforms/common/usage/in-app-frames.mdx
+++ b/src/platforms/common/usage/in-app-frames.mdx
@@ -1,7 +1,7 @@
 ---
 title: "In-App Frames"
 sidebar_order: 40
-description: "Learn about your SDK marks frames as in app."
+description: "Learn about how your SDK marks frames as in-app."
 supported:
   - apple
 ---

--- a/src/platforms/common/usage/in-app-frames.mdx
+++ b/src/platforms/common/usage/in-app-frames.mdx
@@ -1,5 +1,5 @@
 ---
-title: "In App Frames"
+title: "In-App Frames"
 sidebar_order: 40
 description: "Learn about your SDK marks frames as in app."
 supported:

--- a/src/platforms/common/usage/in-app-frames.mdx
+++ b/src/platforms/common/usage/in-app-frames.mdx
@@ -1,0 +1,9 @@
+---
+title: "In App Frames"
+sidebar_order: 40
+description: "Learn about your SDK marks frames as in app."
+supported:
+  - apple
+---
+
+<PlatformContent includePath="in-app-frames" />


### PR DESCRIPTION
The content on marking frames as in app for Cocoa/Apple was on the
common product docs. This is fixed now by moving it to an
extra platform page.

Fixes GH-4371