### PR TITLE
change resolve with commit link from gitlab to github

### DIFF
--- a/src/docs/product/issues/states-triage/index.mdx
+++ b/src/docs/product/issues/states-triage/index.mdx
@@ -38,7 +38,7 @@ Triage typically involves one or more of the following actions.
 
 ### Resolve
 
-Resolve an issue when it's fixed or you don't expect it to happen again. You can do this manually or by [including the issue ID in a commit](/product/integrations/source-code-mgmt/gitlab/#resolve-via-commit-or-pull-request). In addition, you can resolve issues by setting the auto-resolve value.
+Resolve an issue when it's fixed or you don't expect it to happen again. You can do this manually or by [including the issue ID in a commit](/product/integrations/source-code-mgmt/github/#resolve-via-commit-or-pull-request). In addition, you can resolve issues by setting the auto-resolve value.
 
 The "Auto Resolve" feature allows you to specify an interval after the last occurrence of an issue when it should be automatically resolved. To check if this has been defined for a project, go to **[Project] > Settings > General Settings** and check the "Event Settings" section.
 
@@ -50,7 +50,7 @@ Ignore an issue **permanently** (the default action when you press the button) i
 
 Mark an issue as reviewed when you want to acknowledge that you've seen the issue but don't want to ignore it; that is, you intend to fix it at some point in the future. Marking an issue reviewed removes the reason label and removes it from the **Review List** in the "For Review" tab. The "Mark Reviewed" action is only available on issues flagged for review.
 
-While you can work to have zero unresolved issues ("Inbox Zero") by resolving or ignoring all issues, this usually isn't feasible for any non-trivial production application. However, it is feasible to have zero for-review issues by triaging the issues in the **Review List**. 
+While you can work to have zero unresolved issues ("Inbox Zero") by resolving or ignoring all issues, this usually isn't feasible for any non-trivial production application. However, it is feasible to have zero for-review issues by triaging the issues in the **Review List**.
 **We recommend triaging these issues once a day to keep your issues manageable.**
 
 ### Assign


### PR DESCRIPTION
Changes link to content about resolving issues with commits from GitLab to GitHub