### PR TITLE
move alert best practices up one level

### DIFF
--- a/src/docs/product/alerts/best-practices.mdx
+++ b/src/docs/product/alerts/best-practices.mdx
@@ -1,7 +1,9 @@
 ---
 title: Alerts Best Practices
 keywords: ["best practice", "alerting", "manage noise"]
-sidebar_order: 40
+sidebar_order: 30
+redirect_from:
+  - /product/alerts/create-alerts/best-practices/
 description: "Learn best practices for creating alerts."
 ---
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -42,7 +42,7 @@ You can find a full list of available metric alerts in [Metric Alerts](/product/
 
 ## Creating Alerts
 
-When you create a new project in [sentry.io](https://sentry.io), you can select a default issue alert. However, you can also [create your own alerts](/product/alerts/create-alerts/) to suit your team’s needs, using these [best practices](/product/alerts/create-alerts/best-practices/) as a guide.
+When you create a new project in [sentry.io](https://sentry.io), you can select a default issue alert. However, you can also [create your own alerts](/product/alerts/create-alerts/) to suit your team’s needs, using these [best practices](/product/alerts/best-practices/) as a guide.
 
 ## Notifications
 

--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Notifications
-sidebar_order: 30
+sidebar_order: 40
 redirect_from:
   - /workflow/alerts-notifications/notifications/
   - /workflow/notifications/workflow/
@@ -29,7 +29,7 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 - **Regressions**: A regression happens when the state of an issue changes from Resolved back to Unresolved. An email is sent to all project team members.
 - **Comments**: When a team member adds a new comment in the “Activity” tab of the detail page for the issue.
 - **Assignment**: When an issue is assigned or unassigned.
-- **User Feedback**: When an issue has new <PlatformLink to="/enriching-events/user-feedback/">user feedback</PlatformLink>. 
+- **User Feedback**: When an issue has new <PlatformLink to="/enriching-events/user-feedback/">user feedback</PlatformLink>.
 - **Event Processing Problems**: When there's a problem with processing error events you've sent to Sentry.
 
 You receive workflow notifications when you’re subscribed to an issue, and you subscribe to issues by:


### PR DESCRIPTION
Moves Alerts Best Practices up one level in navigation
Adds required redirect
Updates sidebar order of pages under Alerts