### PR TITLE
Add documentation for Quart based on the sanic documentation

### DIFF
--- a/src/platforms/python/guides/quart/index.mdx
+++ b/src/platforms/python/guides/quart/index.mdx
@@ -1,17 +1,15 @@
 ---
 title: Quart
-redirect_from:
-  - /platforms/python/quart/
 description: "Learn about using Sentry with Quart."
 ---
 
 _(New in version ???)_
 
-The Quart integration adds support for the [Quart Web Framework](https://gitlab.com/pgjones/quart). We support Quart >= 0.16.1.
+The Quart integration adds support for the [Quart Web Framework](https://gitlab.com/pgjones/quart). We support Quart versions 0.16.1 and higher. 
 
-_* Requires `sentry-sdk` ??? or higher_
+Requires `sentry-sdk` ??? or higher.
 
-A Python version of 3.7 or greater is also required.
+A Python version of 3.7 or higher is also required.
 
 ## Install
 
@@ -44,10 +42,8 @@ app = Quart(__name__)
 
 - All exceptions leading to an Internal Server Error, from before/after serving functions, and background tasks are reported.
 
-- Request data is attached to all events: **HTTP method, URL, headers**. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+- Request data is attached to all events: **HTTP method, URL, headers**. Sentry also excludes personally identifiable information (such as user IDs, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
 - Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.
 
-- Logging with any logger will create breadcrumbs when
-  the [Logging](/platforms/python/guides/logging/)
-  integration is enabled (done by default).
+- Logging with any logger will create breadcrumbs when the [Logging](/platforms/python/guides/logging/) integration is enabled (done by default).

--- a/src/platforms/python/guides/quart/index.mdx
+++ b/src/platforms/python/guides/quart/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Quart
+redirect_from:
+  - /platforms/python/quart/
+description: "Learn about using Sentry with Quart."
+---
+
+_(New in version ???)_
+
+The Quart integration adds support for the [Quart Web Framework](https://gitlab.com/pgjones/quart). We support Quart >= 0.16.1.
+
+_* Requires `sentry-sdk` ??? or higher_
+
+A Python version of 3.7 or greater is also required.
+
+## Install
+
+Install `sentry-sdk` from PyPI:
+
+```bash
+pip install --upgrade sentry-sdk
+```
+
+## Configure
+
+To configure the SDK, initialize it with the integration before or after your app has been initialized:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.quart import QuartIntegration
+from quart import Quart
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[QuartIntegration()]
+)
+
+app = Quart(__name__)
+```
+
+## Behavior
+
+- The Sentry Python SDK will install the Quart integration for all of your apps.
+
+- All exceptions leading to an Internal Server Error, from before/after serving functions, and background tasks are reported.
+
+- Request data is attached to all events: **HTTP method, URL, headers**. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+
+- Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.
+
+- Logging with any logger will create breadcrumbs when
+  the [Logging](/platforms/python/guides/logging/)
+  integration is enabled (done by default).

--- a/src/wizard/python/quart.md
+++ b/src/wizard/python/quart.md
@@ -1,0 +1,34 @@
+---
+name: Quart
+doc_link: https://docs.sentry.io/platforms/python/guides/quart/
+support_level: production
+type: framework
+---
+
+The Quart integration adds support for the [Quart Web
+Framework](https://gitlab.com/pgjones/quart). We support Quart >= 0.16.1.
+
+A Python version of 3.7 or greater is also required.
+
+1. Install `sentry-sdk` from PyPI:
+
+   ```bash
+   $ pip install --upgrade sentry-sdk
+   ```
+
+2. To configure the SDK, initialize it with the integration before or after your app has been initialized:
+
+   ```python
+   import sentry_sdk
+   from sentry_sdk.integrations.quart import QuartIntegration
+   from quart import Quart
+
+   sentry_sdk.init(
+       dsn="___PUBLIC_DSN___",
+       integrations=[QuartIntegration()]
+   )
+
+   app = Quart(__name__)
+   ```
+
+<!-- TODO-ADD-VERIFICATION-EXAMPLE -->

--- a/src/wizard/python/quart.md
+++ b/src/wizard/python/quart.md
@@ -6,9 +6,9 @@ type: framework
 ---
 
 The Quart integration adds support for the [Quart Web
-Framework](https://gitlab.com/pgjones/quart). We support Quart >= 0.16.1.
+Framework](https://gitlab.com/pgjones/quart). We support Quart versions 0.16.1 and higher.
 
-A Python version of 3.7 or greater is also required.
+A Python version of 3.7 or higher is also required.
 
 1. Install `sentry-sdk` from PyPI:
 


### PR DESCRIPTION
This should guide a new user how to integrate Sentry with Quart.

See also https://github.com/getsentry/sentry-python/pull/1248

I've left `???` in as I'm unsure what versions to put in.