### PR TITLE
Add backtrace to options for `capture_message`

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -260,6 +260,7 @@ The options for these methods are also changed. Currently available options are:
 - `user`
 - `level`
 - `fingerprint`
+- `backtrace`
 
 To set `transaction_name` (`transaction` in `sentry-raven`) of the event, please use
 


### PR DESCRIPTION
It looks like `backtrace` is supported as per https://github.com/getsentry/sentry-ruby/pull/1550