### PR TITLE
Make sentry wizard its own bash instead of a tab

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -32,6 +32,8 @@ Link the SDK to your native projects to enable native crash reporting.
 react-native link @sentry/react-native
 ```
 
+Execute the Sentry Wizard.
+
 ```bash
 npx @sentry/wizard -i reactNative -p ios android
 


### PR DESCRIPTION
<img width="834" alt="Screenshot 2021-11-30 at 09 30 29" src="https://user-images.githubusercontent.com/5731772/144012084-7608d95a-fdf4-43ab-b7c3-025b9229122d.png">
