### PR TITLE
fix(apple): Getting Started  Verify

### DIFF
--- a/src/includes/getting-started-verify/apple.mdx
+++ b/src/includes/getting-started-verify/apple.mdx
@@ -1,31 +1,15 @@
 ```swift {tabTitle:Swift}
 import Sentry
 
-SentrySDK.crash()
+let error = NSError(domain: "YourErrorDomain", code: 0, userInfo: nil)
+SentrySDK.capture(error: error)
 ```
 
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-[SentrySDK crash];
+NSError *error = [NSError errorWithDomain:@"YourErrorDomain"
+                                   code:0
+                               userInfo: nil];
+[SentrySDK captureError:error];
 ```
-
-## Crash Handling
-
-Our SDK hooks into all signal and exception handlers, except for MacOS. If you are using MacOS, please follow the additional steps documented in [Capturing Uncaught Exceptions in macOS](/platforms/apple/usage/#capturing-uncaught-exceptions-in-macos).
-
-To try it out, the SDK provides a test crash function:
-
-```swift
-import Sentry
-
-SentrySDK.crash()
-```
-
-```objective-C
-@import Sentry;
-
-[SentrySDK crash];
-```
-
-Crashes are submitted only upon re-launch of the application. If you crash with a debugger attached, nothing will happen. To view the crash in Sentry, close your app and re-launch it.


### PR DESCRIPTION
The getting started verify section of Apple described crashing the app
SentrySDK.crash(). WatchOS doesn't support crashes though. Therefore,
the page now explains how to capture an error instead,
like Android or Java.

This came up in https://github.com/getsentry/sentry-cocoa/issues/406#issuecomment-982414653.