### PR TITLE
[React Native] Fix integration example for shouldCreateSpanForRequest

### DIFF
--- a/src/includes/performance/filter-span-example/react-native.mdx
+++ b/src/includes/performance/filter-span-example/react-native.mdx
@@ -1,0 +1,13 @@
+```javascript
+Sentry.init({
+  // ...
+  integrations: [
+    new Sentry.ReactNativeTracing({
+      shouldCreateSpanForRequest: url => {
+        // Do not create spans for outgoing requests to a `/health/` endpoint
+        return !url.match(/\/health\/?$/);
+      },
+    }),
+  ],
+});
+```


### PR DESCRIPTION
The documentation for the [`shouldCreateSpanForRequest`](https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/#shouldcreatespanforrequest) section shows the `BrowserTracing` integration, which may lead to confusion (as seen in the screenshot below). This PR adds a snippet for the `react-native` platform so the correct integration shows

![image](https://user-images.githubusercontent.com/10366495/144318626-2e1cb359-9023-4266-9bf7-cd2a11ddb85f.png)