### PR TITLE
fix(unity): Attachment upload sample

### DIFF
--- a/src/includes/enriching-events/attachment-upload/unity.mdx
+++ b/src/includes/enriching-events/attachment-upload/unity.mdx
@@ -1,0 +1,15 @@
+```csharp
+using Sentry;
+
+// Global Scope
+SentrySdk.ConfigureScope(scope =>
+{
+    scope.AddAttachment("log.txt");
+});
+
+// Clear all attachments in the global scope
+SentrySdk.ConfigureScope(scope =>
+{
+    scope.ClearAttachments();
+});
+```


### PR DESCRIPTION
Came up here: https://github.com/getsentry/sentry-unity/issues/448
The Unity SDK has the Global Hub Mode set by default which prevents `WithScope` from working as it relies on `PushScope`. 