### PR TITLE
Update span operations in docs

### DIFF
--- a/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
+++ b/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
@@ -190,7 +190,7 @@ _Note:_ Before the transaction is sent, the `tags` and `data` properties will ge
 The majority of the data in a transaction resides in the individual spans the transaction contains. Span data includes:
 
 - `parent_span_id`: ties the span to its parent span
-- `op`: short string identifying the type or category of operation the span is measuring
+- `op`: short string identifying the type or category of operation the span is measuring. Details on the structure of span operations can be [found in the Sentry developer documentation](https://develop.sentry.dev/sdk/performance/span-operations/).
 - `start_timestamp`: when the span was opened
 - `end_timestamp`: when the span was closed
 - `description`: longer description of the span's operation, which uniquely identifies the span but is consistent across instances of the span (optional)
@@ -198,7 +198,7 @@ The majority of the data in a transaction resides in the individual spans the tr
 - `tags`: key-value pairs holding additional data about the span (optional)
 - `data`: arbitrarily-structured additional data about the span (optional)
 
-An example use of the `op` and `description` properties together is `op: sql.query` and `description: SELECT * FROM users WHERE last_active < %s`. The `status` property is often used to indicate the success or failure of the span's operation, or for a response code in the case of HTTP requests. Finally, `tags` and `data` allow you to attach further contextual information to the span, such as `function: middleware.auth.is_authenticated` for a function call or `request: {url: ..., headers: ... , body: ...}` for an HTTP request.
+An example use of the `op` and `description` properties together is `op: db.query` and `description: SELECT * FROM users WHERE last_active < %s`. The `status` property is often used to indicate the success or failure of the span's operation, or for a response code in the case of HTTP requests. Finally, `tags` and `data` allow you to attach further contextual information to the span, such as `function: middleware.auth.is_authenticated` for a function call or `request: {url: ..., headers: ... , body: ...}` for an HTTP request.
 
 ### Further Information
 

--- a/src/includes/performance/control-data-truncation/javascript.mdx
+++ b/src/includes/performance/control-data-truncation/javascript.mdx
@@ -11,7 +11,7 @@ const parameters = {
 };
 
 const span = transaction.startChild({
-  op: "http",
+  op: "http.client",
   description: "setup form",
 });
 

--- a/src/includes/performance/control-data-truncation/javascript.mdx
+++ b/src/includes/performance/control-data-truncation/javascript.mdx
@@ -11,7 +11,7 @@ const parameters = {
 };
 
 const span = transaction.startChild({
-  op: "request",
+  op: "http",
   description: "setup form",
 });
 

--- a/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
+++ b/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
@@ -74,7 +74,7 @@ const boostrapSpan =
   activeTransaction &&
   activeTransaction.startChild({
     description: 'platform-browser-dynamic',
-    op: 'angular.bootstrap',
+    op: 'ui.angular.bootstrap',
   });
 
 platformBrowserDynamic()

--- a/src/platforms/javascript/guides/react/components/profiler.mdx
+++ b/src/platforms/javascript/guides/react/components/profiler.mdx
@@ -26,17 +26,17 @@ class App extends React.Component {
 export default Sentry.withProfiler(App);
 ```
 
-The React Profiler currently generates spans with three different kinds of op-codes: `react.mount`, `react.render`, and `react.update`.
+The React Profiler currently generates spans with three different kinds of op-codes: `ui.react.mount`, `ui.react.render`, and `ui.react.update`.
 
-`react.mount`
+`ui.react.mount`
 
 : The span that represents how long it took for the profiled component to mount.
 
-`react.render`
+`ui.react.render`
 
 : The span that represents how long the profiled component was on a page. This span is only generated if the profiled component mounts and unmounts while a transaction is occurring.
 
-`react.update`
+`ui.react.update`
 
 : The span that represents when the profiled component updated. This span is only generated if the profiled component has mounted.
 


### PR DESCRIPTION
Update the span operations for performance monitoring in docs based on
what has been outlined in https://develop.sentry.dev/sdk/performance/span-operations/.