### PR TITLE
add note about issue owners precedence over codeowners

### DIFF
--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -83,11 +83,11 @@ This feature supports GitHub and GitLab CODEOWNERS file syntax with the followin
  - [GitLab Premium syntax](https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections)
  - [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
- <Alert>
+<Alert level="info">
 
- Issue ownership rules take precedence over the information provided by your CODEOWNERS file in issue assignment.
+Issue ownership rules take precedence over the information provided by your CODEOWNERS file when Sentry assigns issues.
 
- </Alert>
+</Alert>
 
 ### External Team/User Mappings
 

--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -83,6 +83,12 @@ This feature supports GitHub and GitLab CODEOWNERS file syntax with the followin
  - [GitLab Premium syntax](https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections)
  - [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
+ <Alert>
+
+ Issue ownership rules take precedence over the information provided by your CODEOWNERS file in issue assignment.
+
+ </Alert>
+
 ### External Team/User Mappings
 
 <Note>


### PR DESCRIPTION
Adds a note indicating that issue ownership rules take precedence over codeowners info