### PR TITLE
Update triage link to point to triage section

### DIFF
--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -6,7 +6,7 @@ redirect_from:
 description: "Learn more about the Issues page and how you can use it to efficiently triage issues."
 ---
 
-The **Issues** page displays information about errors in your application. Filter by properties such as browser, device, impacted users, or whether the error is unhandled. You can then inspect issue details to better understand the problem and [triage](/product/issues/issue-details/) effectively.
+The **Issues** page displays information about errors in your application. Filter by properties such as browser, device, impacted users, or whether the error is unhandled. You can then inspect issue details to better understand the problem and [triage](/product/issues/states-triage/) effectively.
 
 ![Issues homepage](issues-homepage.png)
 


### PR DESCRIPTION
When starting to look into Issues the triage links us to the Issue Details section which doesn't mention anything about triaging an issue.