### PR TITLE
Fix Next.js intro note to account for Next.js 12 support

### DIFF
--- a/src/includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/includes/getting-started-primer/javascript.nextjs.mdx
@@ -1,10 +1,10 @@
 <Note>
 
-Currently, the Sentry Next.js SDK supports Next.js versions `10.0.8` - `11.1.3`. The SDK may work with some projects using Next.js 12, but it is not yet officially supported.
+Sentry's Next.js SDK enables automatic reporting of errors and exceptions.
 
 </Note>
 
-The Sentry Next.js SDK automatically catches errors and collects performance data from your app.
+Currently, the minimum Next.js supported version is `10.0.8`.
 
 Features:
 


### PR DESCRIPTION
Reverts message back to what it originally was now that [Next.js 12 is supported](https://github.com/getsentry/sentry-javascript/pull/4093)