### PR TITLE
feat(unity): Attachment docs

### DIFF
--- a/src/includes/enriching-events/attachment-init-with-path/unity.mdx
+++ b/src/includes/enriching-events/attachment-init-with-path/unity.mdx
@@ -3,7 +3,6 @@ using Sentry;
 
 SentrySdk.ConfigureScope(scope =>
 {
-    // Add a file attachment to the current scope
     scope.AddAttachment(Path.Combine(Application.persistentDataPath, "file.log"));
 });
 ```

--- a/src/includes/enriching-events/attachment-init-with-path/unity.mdx
+++ b/src/includes/enriching-events/attachment-init-with-path/unity.mdx
@@ -1,0 +1,11 @@
+```csharp
+using Sentry;
+
+SentrySdk.ConfigureScope(scope =>
+{
+    // Add a file attachment to the current scope
+    scope.AddAttachment(Path.Combine(Application.persistentDataPath, "file.log"));
+});
+```
+
+Note that there are restrictions in place when using paths in combination with [StreamingAssets](https://docs.unity3d.com/2019.4/Documentation/Manual/StreamingAssets.html) and the [Resource folder](https://docs.unity3d.com/ScriptReference/Resources.html).

--- a/src/includes/enriching-events/attachment-upload/unity.mdx
+++ b/src/includes/enriching-events/attachment-upload/unity.mdx
@@ -1,13 +1,11 @@
 ```csharp
 using Sentry;
 
-// Global Scope
 SentrySdk.ConfigureScope(scope =>
 {
-    scope.AddAttachment("log.txt");
+    scope.AddAttachment(Path.Combine(Application.persistentDataPath, "file.log"));
 });
 
-// Clear all attachments in the global scope
 SentrySdk.ConfigureScope(scope =>
 {
     scope.ClearAttachments();

--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -86,9 +86,17 @@ You'll first need to import the SDK, as usual:
 
 </PlatformSection>
 
-<PlatformSection supported={["android", "apple", "java", "dotnet", "dart", "flutter"]}>
+<PlatformSection notSupported={["unity"]} supported={["android", "apple", "java", "dotnet", "dart", "flutter"]}>
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.
+
+<PlatformContent includePath="enriching-events/attachment-upload" />
+
+</PlatformSection>
+
+<PlatformSection supported={["unity"]}>
+
+Unity features a global <PlatformLink to="/enriching-events/scopes/">scope</PlatformLink> to which you add an attachment that will be sent with every event.
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 


### PR DESCRIPTION
Modified snippets and replaced lines about `local scope` to be more Unity-specific. Unity has only a global scope.