### PR TITLE
update SCIM docs for SAML2 Providers

### DIFF
--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -113,8 +113,8 @@ Once the SAML integration flow is complete, the related Auth page will reflect t
 Because Sentry uses Just-In-Time (JIT) provisioning, new members are registered with Sentry automatically during their first login attempt with SAML SSO. These accounts will have their membership types delegated based on what the default membership role is in your Organization Settings in Sentry.
 
 ## SCIM Provisioning
-SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. See the Sentry configuration guide [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and follow your IdP's documentation for further setup. For more information about the Sentry SCIM API endpoints, see [here](https://docs.sentry.io/api/scim/).
 
+SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. [Configure Sentry for SCIM](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and then follow your IdP's documentation for further setup. Learn more about the Sentry SCIM API endpoints in the [SCIM API documentation](https://docs.sentry.io/api/scim/).
 
 ## FAQ
 

--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -112,7 +112,7 @@ Once the SAML integration flow is complete, the related Auth page will reflect t
 
 Because Sentry uses Just-In-Time (JIT) provisioning, new members are registered with Sentry automatically during their first login attempt with SAML SSO. These accounts will have their membership types delegated based on what the default membership role is in your Organization Settings in Sentry.
 
-## SCIM provisioning
+## SCIM Provisioning
 SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. See the Sentry configuration guide [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and follow your IdP's documentation for further setup. For more information about the Sentry SCIM API endpoints, see [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration).
 
 

--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -112,6 +112,10 @@ Once the SAML integration flow is complete, the related Auth page will reflect t
 
 Because Sentry uses Just-In-Time (JIT) provisioning, new members are registered with Sentry automatically during their first login attempt with SAML SSO. These accounts will have their membership types delegated based on what the default membership role is in your Organization Settings in Sentry.
 
+## SCIM provisioning
+SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. See the Sentry configuration guide [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and follow your IdP's documentation for further setup. For more information about the Sentry SCIM API endpoints, see [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration).
+
+
 ## FAQ
 
 #### What is the process for adding new members to a SAML2-enabled Sentry organization?

--- a/src/docs/product/accounts/sso/saml2.mdx
+++ b/src/docs/product/accounts/sso/saml2.mdx
@@ -113,7 +113,7 @@ Once the SAML integration flow is complete, the related Auth page will reflect t
 Because Sentry uses Just-In-Time (JIT) provisioning, new members are registered with Sentry automatically during their first login attempt with SAML SSO. These accounts will have their membership types delegated based on what the default membership role is in your Organization Settings in Sentry.
 
 ## SCIM Provisioning
-SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. See the Sentry configuration guide [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and follow your IdP's documentation for further setup. For more information about the Sentry SCIM API endpoints, see [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration).
+SCIM is available for automatic user provisioning, deprovisioning, and team assignment for SAML2 IdPs. See the Sentry configuration guide [here](https://docs.sentry.io/product/accounts/sso/okta-sso/okta-scim/#sentry-configuration), and follow your IdP's documentation for further setup. For more information about the Sentry SCIM API endpoints, see [here](https://docs.sentry.io/api/scim/).
 
 
 ## FAQ


### PR DESCRIPTION
Generic SAML2 providers can now use SCIM, so let's reflect that in the docs.