### PR TITLE
add short transaction definition

### DIFF
--- a/src/docs/product/performance/index.mdx
+++ b/src/docs/product/performance/index.mdx
@@ -10,7 +10,7 @@ redirect_from:
 description: "Performance Monitoring helps you to see everything from macro-level metrics to micro-level spans, and you'll be able to cross-reference transactions with related issues, and customize queries."
 ---
 
-With <SandboxLink scenario="performance" projectSlug="react">performance monitoring</SandboxLink>, Sentry tracks application performance, measures metrics like throughput and latency, and displays the impact of errors across multiple services. Sentry captures [distributed traces](/product/sentry-basics/tracing/distributed-tracing/) consisting of [transactions](/product/performance/transaction-summary/#what-is-a-transaction) and spans to measure individual services and individual operations within those services.
+With <SandboxLink scenario="performance" projectSlug="react">performance monitoring</SandboxLink>, Sentry tracks application performance, measures metrics like throughput and latency, and displays the impact of errors across multiple services. Sentry captures [distributed traces](/product/sentry-basics/tracing/distributed-tracing/) consisting of [transactions](/product/performance/transaction-summary/#what-is-a-transaction) and spans to measure individual services and operations within those services.
 
 <Note>
 

--- a/src/docs/product/performance/index.mdx
+++ b/src/docs/product/performance/index.mdx
@@ -10,7 +10,7 @@ redirect_from:
 description: "Performance Monitoring helps you to see everything from macro-level metrics to micro-level spans, and you'll be able to cross-reference transactions with related issues, and customize queries."
 ---
 
-With <SandboxLink scenario="performance" projectSlug="react">performance monitoring</SandboxLink>, Sentry tracks application performance, measures metrics like throughput and latency, and displays the impact of errors across multiple services. Sentry captures [distributed traces](/product/sentry-basics/tracing/distributed-tracing/) consisting of [transactions and spans](/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans) to measure individual services and individual operations within those services.
+With <SandboxLink scenario="performance" projectSlug="react">performance monitoring</SandboxLink>, Sentry tracks application performance, measures metrics like throughput and latency, and displays the impact of errors across multiple services. Sentry captures [distributed traces](/product/sentry-basics/tracing/distributed-tracing/) consisting of [transactions](/product/performance/transaction-summary/#what-is-a-transaction) and spans to measure individual services and individual operations within those services.
 
 <Note>
 
@@ -18,7 +18,7 @@ Learn more about traces in the [full Tracing documentation](/product/sentry-basi
 
 </Note>
 
-The **Performance** page is the main view in [sentry.io](https://sentry.io) where you can search or browse for <SandboxLink scenario="oneTransaction" projectSlug="react">transaction</SandboxLink> data. The page displays graphs that visualize transactions or trends, as well as a table where you can view relevant transactions and drill down to more information about them.
+The **Performance** page is the main view in [sentry.io](https://sentry.io) where you can search or browse for <SandboxLink scenario="oneTransaction" projectSlug="react">transaction</SandboxLink> data. A transaction represents a single instance of an activity you want to measure or track, like a page load, page navigation, or an asynchronous task. The page displays graphs that visualize transactions or trends, as well as a table where you can view relevant transactions and drill down to more information about them.
 
 ![Performance homepage with All Transactions tab selected.](01_full_widget_all.png)
 


### PR DESCRIPTION
Adds short definition of a transaction to main Performance page
Updates link 
Task from [issue 4270](https://github.com/getsentry/sentry-docs/issues/4270)