### PR TITLE
fix: Add --force-foreground to Xcode Run Script

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -197,7 +197,7 @@ fi
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 
-If the upload never completes you can try to pass `--force-foreground` to the Sentry CLI command in the build script. This is possibly due to a bug [we are investigating](https://github.com/getsentry/sentry-react-native/issues/1424).
+If the upload never completes you can try to pass `--force-foreground` to the Sentry CLI command in the build script. This is possibly due to a bug [we are investigating](https://github.com/getsentry/sentry-cli/issues/932).
 
 <Alert level="" title="On Prem">
 

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -179,7 +179,7 @@ if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
 export SENTRY_AUTH_TOKEN=YOUR_AUTH_TOKEN
-ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
+ERROR=$(sentry-cli upload-dif --force-foreground "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
 echo "warning: sentry-cli - $ERROR"
 fi

--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -179,7 +179,7 @@ if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
 export SENTRY_AUTH_TOKEN=YOUR_AUTH_TOKEN
-ERROR=$(sentry-cli upload-dif --force-foreground "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
+ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
 echo "warning: sentry-cli - $ERROR"
 fi
@@ -196,6 +196,8 @@ fi
 ```text
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
+
+If the upload never completes you can try to pass `--force-foreground` to the Sentry CLI command in the build script. This is possibly due to a bug [we are investigating](https://github.com/getsentry/sentry-react-native/issues/1424).
 
 <Alert level="" title="On Prem">
 


### PR DESCRIPTION
Add --force-foreground for calling sentry-cli in the Xcode run script
phase. This flag lets Xcode wait for the upload process to finish.

I had issues with uploading dSYMS with Xcode. Adding this flag fixed it for me and it also makes sense to wait until the dSYMS are uploaded.