### PR TITLE
fix: Split consecutive code blocks in Go migration guide

### DIFF
--- a/src/platforms/go/common/migration.mdx
+++ b/src/platforms/go/common/migration.mdx
@@ -386,9 +386,13 @@ sentry-go
 go get github.com/getsentry/sentry-go/http
 ```
 
+<Break />
+
 ```go
 import sentryhttp "github.com/getsentry/sentry-go/http"
 ```
+
+<Break />
 
 ```go
 sentryHandler := sentryhttp.New(sentryhttp.Options{


### PR DESCRIPTION
Similar to #2040.

Affected page https://docs.sentry.io/platforms/go/migration/#integrations

# Before

![image](https://user-images.githubusercontent.com/88819/146768143-7156205d-0342-4e18-b873-a15d55af3aa0.png)

# After

![image](https://user-images.githubusercontent.com/88819/146771447-69e572d6-1520-40f7-ad98-8eee22a7286a.png)
