### PR TITLE
change order of JS source maps troubleshooting steps

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -49,37 +49,6 @@ If you’ve uploaded source maps and they aren’t applying to your code in an i
 
 If you have **dynamic values in your path** (for example, `https://www.site.com/{some_value}/scripts/script.js`), you may want to use the <PlatformLink to="/configuration/integrations/plugin/#rewriteframes">`rewriteFrames` integration</PlatformLink> to change your `abs_path` values.
 
-## Verify artifact names match `sourceMappingURL` value
-
-The `sourceMappingURL` comment on the last line of your bundled or minified JavaScript file tells Sentry (or the browser) where to locate the corresponding source map. This can either be a fully qualified URL, a relative path, or the filename itself. When uploading artifacts to Sentry, you must name your source map files with the value the file resolves to.
-
-That is, if your file is similar to:
-
-```javascript
-// -- end script.min.js
-//# sourceMappingURL=script.min.js.map
-```
-
-and is hosted at http://example.com/js/script.min.js, then Sentry will look for that source map file at http://example.com/js/script.min.js.map. Your uploaded artifact must therefore be named `http://example.com/js/script.min.js.map` (or `~/js/script.min.js.map`).
-
-Or, if your file is similar to:
-
-```javascript
-//-- end script.min.js
-//# sourceMappingURL=https://example.com/dist/js/script.min.js.map
-```
-
-then your uploaded artifact should also be named `https://example.com/dist/js/script.min.js.map` (or `~/dist/js/script.min.js.map`).
-
-Finally, if your file is similar to:
-
-```javascript
-//-- end script.min.js
-//# sourceMappingURL=../maps/script.min.js.map
-```
-
-then your uploaded artifact should be named `https://example.com/dist/maps/script.min.js.map` (or `~/dist/maps/script.min.js.map`).
-
 ### Using sentry-cli
 
 If your `sourceMappingURL` comment is similar to:
@@ -135,6 +104,37 @@ The `~` is used in Sentry to replace the scheme and domain. It is not a glob!
 `http://example.com/dist/js/script.js` will match `~/dist/js/script.js` or `http://example.com/dist/js/script.js`
 
 but will NOT match `~/script.js`.
+
+## Verify artifact names match `sourceMappingURL` value
+
+The `sourceMappingURL` comment on the last line of your bundled or minified JavaScript file tells Sentry (or the browser) where to locate the corresponding source map. This can either be a fully qualified URL, a relative path, or the filename itself. When uploading artifacts to Sentry, you must name your source map files with the value the file resolves to.
+
+That is, if your file is similar to:
+
+```javascript
+// -- end script.min.js
+//# sourceMappingURL=script.min.js.map
+```
+
+and is hosted at http://example.com/js/script.min.js, then Sentry will look for that source map file at http://example.com/js/script.min.js.map. Your uploaded artifact must therefore be named `http://example.com/js/script.min.js.map` (or `~/js/script.min.js.map`).
+
+Or, if your file is similar to:
+
+```javascript
+//-- end script.min.js
+//# sourceMappingURL=https://example.com/dist/js/script.min.js.map
+```
+
+then your uploaded artifact should also be named `https://example.com/dist/js/script.min.js.map` (or `~/dist/js/script.min.js.map`).
+
+Finally, if your file is similar to:
+
+```javascript
+//-- end script.min.js
+//# sourceMappingURL=../maps/script.min.js.map
+```
+
+then your uploaded artifact should be named `https://example.com/dist/maps/script.min.js.map` (or `~/dist/maps/script.min.js.map`).
 
 ## Verify artifacts are uploaded before errors occur
 

--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -43,6 +43,12 @@ To verify that the distribution has been set correctly in the SDK, open an issue
 
 </PlatformSection>
 
+## Verify artifact names match stack trace frames
+
+If you’ve uploaded source maps and they aren’t applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we’re attempting to resolve the file - for example, `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
+
+If you have **dynamic values in your path** (for example, `https://www.site.com/{some_value}/scripts/script.js`), you may want to use the <PlatformLink to="/configuration/integrations/plugin/#rewriteframes">`rewriteFrames` integration</PlatformLink> to change your `abs_path` values.
+
 ## Verify artifact names match `sourceMappingURL` value
 
 The `sourceMappingURL` comment on the last line of your bundled or minified JavaScript file tells Sentry (or the browser) where to locate the corresponding source map. This can either be a fully qualified URL, a relative path, or the filename itself. When uploading artifacts to Sentry, you must name your source map files with the value the file resolves to.
@@ -73,12 +79,6 @@ Finally, if your file is similar to:
 ```
 
 then your uploaded artifact should be named `https://example.com/dist/maps/script.min.js.map` (or `~/dist/maps/script.min.js.map`).
-
-## Verify artifact names match stack trace frames
-
-If you’ve uploaded source maps and they aren’t applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we’re attempting to resolve the file - for example, `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
-
-If you have **dynamic values in your path** (for example, `https://www.site.com/{some_value}/scripts/script.js`), you may want to use the <PlatformLink to="/configuration/integrations/plugin/#rewriteframes">`rewriteFrames` integration</PlatformLink> to change your `abs_path` values.
 
 ### Using sentry-cli
 


### PR DESCRIPTION
Per @souredoutlook 
Currently we list the "Verify artifact names match sourceMappingURL value" step in our source maps troubleshooting guide above the "Verify Artifact Names Match Stack Trace Frames". Given that we've tightened source map fetch timeouts and recommend to always upload, switching the order of these two steps, as "Verify Artifact Names Match Stack Trace Frames" is the advice that's more relevant to users that upload.