### PR TITLE
fix status unknown in example

### DIFF
--- a/src/includes/performance/add-spans-example/javascript.mdx
+++ b/src/includes/performance/add-spans-example/javascript.mdx
@@ -27,7 +27,6 @@ shopCheckout() {
     throw err;
   } finally {
     span.finish();
-    transaction.finish();
   }
 }
 ```


### PR DESCRIPTION
transaction.finish() overrides status set for the last span resulting in the last span always sending unknown status

related to https://github.com/getsentry/sentry-dotnet/issues/919