### PR TITLE
Add a template for build issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/build-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-issue.yml
@@ -1,0 +1,33 @@
+name: 🏭 Build Issue
+description: Problems trying to build Sentry's docs.
+body:
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. foo
+        2. bar
+        3. baz
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots? Yes, please.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Info
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Use our dedicated support channel for paid accounts.
   - name: Ask a question about self-hosted Sentry
     url: https://github.com/getsentry/self-hosted/issues/new
-    about: Please use GitHub Issues for questions about self-hosted Sentry.
+    about: Please use the `self-hosted` repo for questions about self-hosted Sentry.
   - name: An issue with one of the SDKs
     url: https://git.io/JtlVm
     about: Please use the relevant SDK repository to report any issues.


### PR DESCRIPTION
@imatwawana Here is that additional issue template we discussed a few weeks ago, for issues related to the docs build pipeline.