### PR TITLE
Improve Ruby docs

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -75,6 +75,9 @@ config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
 : Whether to capture local variables from the raised exception's frame. Default is `false`.
 
+`context_lines`
+
+: How many lines to display before/after the line where issue occurs. Default is `3`.
 
 `debug`
 

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -270,7 +270,7 @@ Sentry.get_current_scope.set_transaction_name("NewTransaction")
 
 ### `Exception#raven_context`
 
-`sentry-ruby` doesn't capture `raven_context` from exceptions anymore. But you can use `before_send` to replicate the same behavior:
+`sentry-ruby` doesn't capture `raven_context` from exceptions anymore. However, you can use `before_send` to replicate the same behavior:
 
 ```rb
 config.before_send = lambda do |event, hint|

--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -268,6 +268,24 @@ To set `transaction_name` (`transaction` in `sentry-raven`) of the event, please
 Sentry.get_current_scope.set_transaction_name("NewTransaction")
 ```
 
+### `Exception#raven_context`
+
+`sentry-ruby` doesn't capture `raven_context` from exceptions anymore. But you can use `before_send` to replicate the same behavior:
+
+```rb
+config.before_send = lambda do |event, hint|
+  if exception = hint[:exception]
+    exception.raven_context.each do |key, value|
+      # here I assume the event would be a Sentry::Event object
+      # it'll be a hash if you use the async callback though (which will be removed in version 5.0)
+      event.send("#{key}=", value)
+    end
+  end
+
+  event
+end
+```
+
 ## Example Apps
 
 - [Rails example](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)


### PR DESCRIPTION
- Add missing `context_lines` to Ruby document
- Add `Exception#raven_context` migration guide