### PR TITLE
Document INSTALL_DIR for get-cli

### DIFF
--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -18,7 +18,7 @@ If you are on OS X or Linux, you can use the automated downloader which will fet
 curl -sL https://sentry.io/get-cli/ | bash
 ```
 
-This will automatically download the correct version of `sentry-cli` for your operating system and install it. If necessarily, it will prompt for your admin password for `sudo`.
+This will automatically download the correct version of `sentry-cli` for your operating system and install it. If necessary, it will prompt for your admin password for `sudo`. For a different installation location or for systems without `sudo` (like Windows), you can `export INSTALL_DIR=/custom/installation/path` before running this command.
 
 To verify it’s installed correctly you can bring up the help:
 


### PR DESCRIPTION
Windows (mingw bash) complains about sudo missing, manually specifying the installation path helps here.
Also includes another small change, if I'm not mistaken, it's "if necessary", not "if necessarily".