### PR TITLE
fix(apple): Clarify ViewController Instrumentation

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -20,7 +20,7 @@ The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHu
 
 This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UIViewControllers.
 
-The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIViewControllers of UIKit, other 3rd party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
+The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIKits UIViewControllers, other 3rd party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
 The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -20,7 +20,7 @@ The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHu
 
 This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UIViewControllers.
 
-The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads a ViewController. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
+The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIViewControllers of UIKit, other 3rd party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
 The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -20,7 +20,7 @@ The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHu
 
 This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UIViewControllers.
 
-The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIKits UIViewControllers, other 3rd party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
+The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIKits UIViewControllers, other third-party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
 The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 


### PR DESCRIPTION
Clarify that the UIViewController Instrumentation only creates
transactions for in-app UIViewControllers.