### PR TITLE
fix(docs): Add more details for percent-based alerts

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -57,9 +57,15 @@ For example, an alert can be triggered when an issue is affecting 10% more uniqu
 
 You can set a trigger for when an issue affects more than {X} percent of [sessions](/product/releases/health/#session) in {time}.
 
-Note that _percent of sessions affected_ is an approximation, calculated as the ratio of the issue’s frequency to the number of sessions in the project.
+This is approximated by taking the number of sessions in the last hour and scaling it to the alerting window appropriately. For example, if the alert is configured to look at the last 5 minutes, the number of sessions is approximated by taking the number of sessions in the last hour and dividing it by 12.
 
-Also, percent-based alerts will only trigger if the number of sessions in the last hour exceeds 50
+<Note>
+
+_Percent of sessions affected_ is an approximation, calculated as the ratio of the issue’s frequency to the number of sessions in the project.
+
+</Note>
+
+Also, percent-based alerts will only trigger if the number of sessions in the last hour exceeds 50.
 
 ## "If" Conditions: Filters
 


### PR DESCRIPTION
Add more details on how the approximation of percent-based alerts.

> This is approximated by taking the number of sessions in the last hour and scaling it to the alerting window appropriately. For example, if the alert is configured to look at the last 5 minutes, the number of sessions is approximated by taking the number of sessions in the last hour and dividing it by 12.

[FIXES WOR-1187](https://getsentry.atlassian.net/browse/WOR-1187)

# Before
<img width="776" alt="Screen Shot 2021-12-29 at 6 17 38 PM" src="https://user-images.githubusercontent.com/20312973/147716528-bcb99bb4-b0b0-4175-b541-5e83b2116b0a.png">

# After
<img width="779" alt="Screen Shot 2021-12-29 at 6 15 24 PM" src="https://user-images.githubusercontent.com/20312973/147716543-14d1cb9a-8e4c-485d-8d41-7875016cb1e6.png">

