### PR TITLE
fix: Document {{auto}} properly [ISSUE-737]

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -37,7 +37,7 @@ Users consist of a few critical pieces of information that construct a unique id
 
 : The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
 
-If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. For certain SDKs, particularly iOS and frontend JavaScript, this is the default behavior and requires no further configuration. For most other SDKs the default is not to collect any IP address. If you find that you're missing the user's IP address, setting this value to `"{{auto}}"` explicitly might help.
+If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. For certain SDKs, particularly iOS and frontend JavaScript, this is the default behavior and requires no further configuration. For most other SDKs the default is to not collect any IP address. If you find that you're missing the user's IP address, setting this value to `"{{auto}}"` explicitly might help.
 
 <!--
 SDK devs who read this and wonder why their SDK does not behave like the JS
@@ -49,7 +49,7 @@ default. We don't really want to special-case more platforms.
 See https://github.com/getsentry/relay/blob/54fc479259c5c8a70c48ad1994d5e8eb8629ba32/relay-general/src/store/normalize.rs#L380-L383
 -->
 
-To opt-out from collecting user's IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt-out of collecting users' IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -11,45 +11,41 @@ description: "Learn how to configure the SDK to capture the user and gain critic
 
 Users consist of a few critical pieces of information that construct a unique identity in Sentry. Each of these is optional, but one **must** be present for the Sentry SDK to capture the user:
 
+<DefinitionList>
+
 <PlatformSection notSupported={["apple"]}>
 
-`id`
+### `id`
 
-: Your internal identifier for the user.
+Your internal identifier for the user.
 </PlatformSection>
 
 <PlatformSection supported={["apple"]}>
 
-`userId`
+### `userId`
 
-: Your internal identifier for the user.
+Your internal identifier for the user.
 </PlatformSection>
 
-`username`
+### `username`
 
-: The username. Typically used as a better label than the internal id.
+The username. Typically used as a better label than the internal id.
 
-`email`
+### `email`
 
-: An alternative, or addition, to the username. Sentry is aware of email addresses and can display things such as Gravatars and unlock messaging capabilities.
+An alternative, or addition, to the username. Sentry is aware of email addresses and can display things such as Gravatars and unlock messaging capabilities.
 
-`ip_address`
+### `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
+The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
 
-If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. For certain SDKs, particularly iOS and frontend JavaScript, this is the default behavior and requires no further configuration. For most other SDKs the default is to not collect any IP address. If you find that you're missing the user's IP address, setting this value to `"{{auto}}"` explicitly might help.
+If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server.
 
-<!--
-SDK devs who read this and wonder why their SDK does not behave like the JS
-SDK: Relay changes the default value from `null` to `{{auto}}` for the
-platforms javascript, cocoa, objc. If you want to collect IP addresses by
-default because you're building a frontend/desktop SDK, just send {{auto}} by
-default. We don't really want to special-case more platforms.
-
-See https://github.com/getsentry/relay/blob/54fc479259c5c8a70c48ad1994d5e8eb8629ba32/relay-general/src/store/normalize.rs#L380-L383
--->
+If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value of `"{{auto}}"`. SDKs and other clients are strongly discouraged from relying on this behavior and should set IP-addresses or `"{{auto}}"` explicitly.
 
 To opt-out of collecting users' IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+
+</DefinitionList>
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -35,13 +35,21 @@ Users consist of a few critical pieces of information that construct a unique id
 
 `ip_address`
 
-: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data, if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options. <PlatformSection notSupported={["php"]}> If set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server, which is useful for client-side applications such as JavaScript applications running on Web browsers, desktop applications, or mobile apps. </PlatformSection>
+: The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Sentry will attempt to pull this from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
 
-<PlatformSection supported={["apple"]}>
+If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. For certain SDKs, particularly iOS and frontend JavaScript, this is the default behavior and requires no further configuration. For most other SDKs the default is not to collect any IP address. If you find that you're missing the user's IP address, setting this value to `"{{auto}}"` explicitly might help.
 
-Events from the SDK for Apple already consider the incoming connection as the user's IP address. To opt-out from this, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`.
+<!--
+SDK devs who read this and wonder why their SDK does not behave like the JS
+SDK: Relay changes the default value from `null` to `{{auto}}` for the
+platforms javascript, cocoa, objc. If you want to collect IP addresses by
+default because you're building a frontend/desktop SDK, just send {{auto}} by
+default. We don't really want to special-case more platforms.
 
-</PlatformSection>
+See https://github.com/getsentry/relay/blob/54fc479259c5c8a70c48ad1994d5e8eb8629ba32/relay-general/src/store/normalize.rs#L380-L383
+-->
+
+To opt-out from collecting user's IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -41,9 +41,9 @@ The user's IP address. If the user is unauthenticated, Sentry uses the IP addres
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server.
 
-If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value of `"{{auto}}"`. SDKs and other clients are strongly discouraged from relying on this behavior and should set IP-addresses or `"{{auto}}"` explicitly.
+If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt-out of collecting users' IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of collecting users' IP addresses, you can use Sentry's [server-side data](/product/data-management-settings/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 


### PR DESCRIPTION
We special-case some platform identifiers in Relay when it comes to the
default value of `user.ip_address`. This causes a bunch of confusion for
customers and SDK authors.

This problem came up in an old customer issue involving the native SDK, and it appears that the native SDK does not send `ip_address={{auto}}` when running as part of a desktop application (which it could maybe try to detect)

