### PR TITLE
feat(apple): fatalError, assert, and precondition

### DIFF
--- a/src/includes/getting-started-primer/apple.macos.mdx
+++ b/src/includes/getting-started-primer/apple.macos.mdx
@@ -8,6 +8,7 @@
   - Unhandled exceptions
   - C++ exceptions
   - Objective-C exceptions
+  - Error messages of fatalError, assert, and precondition
   - Main thread deadlock (experimental)
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data
 - Offline caching when a device is unable to connect; we send a report once we receive another event

--- a/src/includes/getting-started-primer/apple.mdx
+++ b/src/includes/getting-started-primer/apple.mdx
@@ -8,6 +8,7 @@
   - Unhandled exceptions
   - C++ exceptions
   - Objective-C exceptions
+  - Error messages of fatalError, assert, and precondition
   - Main thread deadlock (experimental)
   - Out of memory
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data


### PR DESCRIPTION
With https://github.com/getsentry/sentry-cocoa/pull/1596
the Cocoa SDK has support for fatalError, assert, and precondition.
This PR mentions this in the features list.

Only merge after sentry-cocoa 7.8.0 is released.