### PR TITLE
Remove redundant check from Laravel code example

### DIFF
--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -27,7 +27,7 @@ Enable capturing unhandled exception to report to Sentry by making the following
 public function register()
 {
     $this->reportable(function (Throwable $e) {
-        if ($this->shouldReport($e) && app()->bound('sentry')) {
+        if (app()->bound('sentry')) {
             app('sentry')->captureException($e);
         }
     });


### PR DESCRIPTION
Laravel's exception handler does not call the report(able) callbacks for exceptions that should not be reported. See https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Exceptions/Handler.php#L223-L225