### PR TITLE
feat(releases): Add how versioning scheme is determined

### DIFF
--- a/src/docs/product/releases/setup/index.mdx
+++ b/src/docs/product/releases/setup/index.mdx
@@ -20,6 +20,17 @@ You must have the environment [configured in your SDK](/platform-redirect/?next=
 
 Notifying Sentry of a release enables auto discovery of which commits to associate with a release and identifies what we consider "the most recent release" when searching in sentry.io. In addition, telling Sentry of a release helps identify new issues, regressions, and whether an issue is resolved in the next release. You do not need a repository integration for any of these features, though we recommend [installing a repository integration](/product/releases/setup/release-automation/) for efficiency.
 
+The behavior of a few features depends on whether a project is using semantic or time-based versioning.
+
+- Regression detection
+- `release:latest`
+
+We automatically detect whether a project is using semantic or time-based versioning based on:
+
+- If ≤ 2 releases total: we look at most recent release.
+- If 3-10 releases total: if any of the most recent 3 releases is semver, project is semver.
+- If 10+ releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+
 ### Using Release Automation
 
 If you're using [Release Automation](/product/releases/setup/release-automation/), let Sentry know you’ve deployed by sending an additional request after creating a release:


### PR DESCRIPTION
Document on how a project's versioning scheme is determined and what it's based on.

> The behavior of a few features depends on whether a project is using semantic or time-based versioning.
> 
> - Regression detection
> - `release:latest`
> 
> We automatically detect whether a project is using semantic or time-based versioning based on:
> 
> - If ≤ 2 releases total: we look at most recent release.
> - If 3-10 releases total: if any of the most recent 3 releases is semver, project is semver.
> - If 10+ releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.

[FIXES WOR-1285](https://getsentry.atlassian.net/browse/WOR-1285)

<img width="769" alt="Screen Shot 2022-01-05 at 12 30 09 PM" src="https://user-images.githubusercontent.com/20312973/148285455-afc34e6c-1cf8-450d-af94-02ec62ed230d.png">

