### PR TITLE
ref(app-store-connect): Update plan alert note

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -43,7 +43,7 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 <Alert level="Note">
 
-Free subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+App Store Connect integration is available only for organizations on the Business and Enterprise plans. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) for more information.
 
 </Alert>
 


### PR DESCRIPTION
Users on a non-Bussiness Plan or above were getting backend errors when trying to add a custom repository. This bug (regression) was fixed in the PR https://github.com/getsentry/sentry/pull/30820

This PR updates the App Store Connect documentation informing the users that they needed to be on the business plan or above to have access to the integration.