### PR TITLE
Unity: Native support limited to config window

### DIFF
--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -1,3 +1,9 @@
+<Alert level="warning" title="Note">
+
+The native support is currently limited to the configuration via the editor window. This is due to the SDK relying on the configuration options to be available at build time to set up the Android and iOS SDKs.
+  
+</Note>
+
 We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method, which will pass the option object along for modifications:
 
 ```csharp

--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -2,7 +2,7 @@
 
 The native support is currently limited to the configuration via the editor window. This is due to the SDK relying on the configuration options to be available at build time to set up the Android and iOS SDKs.
   
-</Note>
+</Alert>
 
 We are providing the helper class `SentryUnity` to allow for programmatic configuration of the SDK. You can set options by passing a callback to the `Init()` method, which will pass the option object along for modifications:
 


### PR DESCRIPTION
To at least document our current limitation to have to use the config window to get native support.