### PR TITLE
feat: Enable maxCacheItems for Mobile

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -140,7 +140,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </ConfigKey>
 
-<ConfigKey name="max-cache-items" supported={[ "dotnet" ]} >
+<ConfigKey name="max-cache-items" supported={[ "android", "apple", "flutter", "java", "dotnet" ]} >
 
 The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, such as events, attachments, user feedback, and sessions to sentry.io. An envelope can contain multiple items, such as an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. If the number of envelopes in the local cache exceeds `max-cache-items`, the SDK deletes the oldest envelope and migrates the sessions to the next envelope to maintain the integrity of your release health stats. The default is `30`.
 


### PR DESCRIPTION
Android, Apple, Flutter, and Java support the basic option
maxCacheItems.

Fixes GH-3307