### PR TITLE
feat(dashboards): Added Data Set section to Custom Dashboards

### DIFF
--- a/src/docs/product/dashboards/custom-dashboards/index.mdx
+++ b/src/docs/product/dashboards/custom-dashboards/index.mdx
@@ -65,7 +65,7 @@ Each chart type allows you to solve different problems:
 Table results display the top results of a [Discover Query](/product/discover-queries/). This
 visualization is well suited to showing key fields and related aggregates. For
 example 'duration percentiles for the most frequently visited transaction
-names'.
+names'. Early Adopters can also use Table vizualizations to display [Issues](/product/issues/) data through the [Data Set](#data-set) selector.
 
 ### World Map
 
@@ -77,3 +77,16 @@ on a world map. An example scenario would be 'in which countries are users exper
 A big number visualization displays the current value of a single function. This visualization is well
 suited for high-level aggregates. An example scenario would be 'p95 of all
 transactions'.
+
+
+## Data Set
+
+<Note>
+
+This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
+
+If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Select between Discover and [Issues](/product/issues/) data through the "Data Set" selector. Choosing "Issues" allows you to sort and display Issues fields and query using Issues filters, such as `is:unresolved` for unresolved issues. This feature is only enabled for "Table" visualizations.

--- a/src/docs/product/dashboards/custom-dashboards/index.mdx
+++ b/src/docs/product/dashboards/custom-dashboards/index.mdx
@@ -89,4 +89,4 @@ If you’re interested in being an Early Adopter, you can turn your organization
 
 </Note>
 
-Select between events and [issues](/product/issues/) data with the "Data Set" selector. Choosing "Issues" allows you to query using issues filters, such as `is:unresolved` for unresolved issues and to display and sort by issues fields. This feature only applies to [table](#table-results) visualizations.
+Select between events and [issues](/product/issues/) data in a widget with the "Data Set" selector. Choosing "Issues" allows you to query using issues filters, such as `is:unresolved` for unresolved issues, and to display and sort by issues fields. This feature only applies to [table](#table-results) visualizations.

--- a/src/docs/product/dashboards/custom-dashboards/index.mdx
+++ b/src/docs/product/dashboards/custom-dashboards/index.mdx
@@ -65,7 +65,7 @@ Each chart type allows you to solve different problems:
 Table results display the top results of a [Discover Query](/product/discover-queries/). This
 visualization is well suited to showing key fields and related aggregates. For
 example 'duration percentiles for the most frequently visited transaction
-names'. Early Adopters can also use Table vizualizations to display [Issues](/product/issues/) data through the [Data Set](#data-set) selector.
+names'. If you're an Early Adopter, you can also display [issues](/product/issues/) data in a table visualization using the [data set selector](#data-set-selection).
 
 ### World Map
 
@@ -79,7 +79,7 @@ suited for high-level aggregates. An example scenario would be 'p95 of all
 transactions'.
 
 
-## Data Set
+## Data Set Selection
 
 <Note>
 
@@ -89,4 +89,4 @@ If you’re interested in being an Early Adopter, you can turn your organization
 
 </Note>
 
-Select between Discover and [Issues](/product/issues/) data through the "Data Set" selector. Choosing "Issues" allows you to sort and display Issues fields and query using Issues filters, such as `is:unresolved` for unresolved issues. This feature is only enabled for "Table" visualizations.
+Select between events and [issues](/product/issues/) data with the "Data Set" selector. Choosing "Issues" allows you to query using issues filters, such as `is:unresolved` for unresolved issues and to display and sort by issues fields. This feature only applies to [table](#table-results) visualizations.

--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -32,7 +32,7 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
-If you're an Early Adopter, you can also add issues data to your [custom dashboards](/product/dashboards/custom-dashboards/) as widgets using the [data set selector](/product/dashboards/custom-dashboards/#data-set-selection).
+If you're an Early Adopter, you can also add issues data to your [custom dashboards](/product/dashboards/custom-dashboards/), as widgets, using the [data set selector](/product/dashboards/custom-dashboards/#data-set-selection).
 
 ## Learn More
 

--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -32,6 +32,8 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
+Early Adopters can also add Issues data to their [Custom Dashboards](/product/dashboards/custom-dashboards/) as widgets through a [Data Set](/product/dashboards/custom-dashboards/#data-set) selector.
+
 ## Learn More
 
 <PageGrid />

--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -32,7 +32,7 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
-Early Adopters can also add Issues data to their [Custom Dashboards](/product/dashboards/custom-dashboards/) as widgets through a [Data Set](/product/dashboards/custom-dashboards/#data-set) selector.
+If you're an Early Adopter, you can also add issues data to your [custom dashboards](/product/dashboards/custom-dashboards/) as widgets using the [data set selector](/product/dashboards/custom-dashboards/#data-set-selection).
 
 ## Learn More
 


### PR DESCRIPTION
Added **Data Set** section to Custom Dashboards page + line in **Table Results** linking to **Data Set**
![image](https://user-images.githubusercontent.com/83961295/148970729-bd252c77-21b7-49af-8cbb-9552272218d1.png)

Added a link from the Issues Page to **Data Set*.
![image](https://user-images.githubusercontent.com/83961295/148970638-9b7c6fb7-fe37-45e0-aec3-23056e0ce96a.png)

Open to feedback on wording or placement
