### PR TITLE
add grafana integration page

### DIFF
--- a/src/docs/product/integrations/data-visualization/grafana.mdx
+++ b/src/docs/product/integrations/data-visualization/grafana.mdx
@@ -1,0 +1,7 @@
+---
+title: Grafana
+sidebar_order: 1
+description: "Learn about Sentry's Grafana integration."
+---
+
+Visualize your Sentry [Issues](/product/issues/) and [Stats](/product/stats/) data in Grafana with the Sentry [data source plugin](https://grafana.com/grafana/plugins/grafana-sentry-datasource/). Once installed, you can combine Sentry data with that of other sources, like your infrastructure data through Prometheus or your business data from your data warehouse, in a single dashboard.

--- a/src/docs/product/integrations/data-visualization/index.mdx
+++ b/src/docs/product/integrations/data-visualization/index.mdx
@@ -7,5 +7,6 @@ description: "Learn more about Sentry's data and visualization integrations."
 Learn more about Sentry's data and visualization integrations:
 
 - [Amazon SQS](/product/integrations/data-visualization/amazon-sqs/)
+- [Grafana](/product/integrations/data-visualization/grafana/)
 - Segment
 - [Splunk](/product/integrations/data-visualization/splunk/)

--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -78,6 +78,7 @@ For more details, see the [full Integration Platform documentation](/product/int
 | Integration                                     | Data Forwarding |
 | ----------------------------------------------- | --------------- |
 | [Amazon SQS](/product/integrations/data-visualization/amazon-sqs/) | X               |
+| [Grafana](/product/integrations/data-visualization/grafana/) | X               |
 | Segment                                         | X               |
 | [Splunk](/product/integrations/data-visualization/splunk/)         | X               |
 


### PR DESCRIPTION
Adds page for Sentry's Grafana integration
Adds link to new page from Integrations index page
Adds link to new page from Data & Visualizations index page