### PR TITLE
ref(integration platform): Link to additional webhook info

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -856,3 +856,11 @@ If you've set up user identification you can find the user attributes under `dat
   }
 }
 ```
+
+### External Issues
+
+See the [full documentation on Creating/Linking Issues](/product/integrations/integration-platform/ui-components/#createlink-issue).
+
+### Select Options
+
+See the [full documentation on Select Options](/product/integrations/integration-platform/ui-components/#select).


### PR DESCRIPTION
Rather than rewriting this information, I simply added a link to the UI component docs for select options and external issues. Since it doesn't exactly follow the format outlined on the webhook docs page (For example, we claim that all webhooks will contain Sentry-Hook-Resource and Sentry-Hook-Signature headers. I set this up locally and we don't send the same headers) it felt both redundant and incorrect to rewrite what's in the UI component docs. 

See [API-641](https://getsentry.atlassian.net/browse/API-641)