### PR TITLE
docs(cli): Add no-upload option for dif-upload command

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -150,6 +150,12 @@ sense to specify `--wait` to ensure that debug files are ready before sending
 crashes to Sentry. This may slow down the command and is not recommended for
 CI builds.
 
+`--no-upload`
+
+: Disables the actual upload. This runs all steps for the processing but does
+not trigger the upload (this also automatically disables reprocessing). This is
+useful if you just want to verify the setup or skip the upload in tests.
+
 `--no-unwind`
 
 : Do not scan for stack unwinding information. Specify this flag for builds with
@@ -291,7 +297,7 @@ meantime trigger reprocessing from the UI.
 `--no-upload`
 
 : Disables the actual upload. This runs all steps for the processing but does
-not trigger the upload (this also automatically disables reprocessing. This is
+not trigger the upload (this also automatically disables reprocessing). This is
 useful if you just want to verify the mapping files and write the ProGuard
 UUIDs into a properties file.
 


### PR DESCRIPTION
This change was introduced 2 months ago but forgot to add docs here.

Closes https://github.com/getsentry/sentry-cli/issues/1075