### PR TITLE
Update: .NET replacing WithScope with Capture overload

### DIFF
--- a/src/includes/enriching-events/attachment-upload/dotnet.mdx
+++ b/src/includes/enriching-events/attachment-upload/dotnet.mdx
@@ -8,11 +8,9 @@ SentrySdk.ConfigureScope(scope =>
 });
 
 // Local Scope
-SentrySdk.WithScope(scope =>
+SentrySdk.CaptureMessage("my message", configureScope =>
 {
     scope.AddAttachment("log.txt");
-
-    SentrySdk.CaptureMessage("my message");
 });
 
 // Clear all attachments in the global scope

--- a/src/includes/enriching-events/scopes/with-scope/dotnet.mdx
+++ b/src/includes/enriching-events/scopes/with-scope/dotnet.mdx
@@ -1,12 +1,11 @@
 ```csharp
 using Sentry;
 
-SentrySdk.WithScope(scope =>
+// will be tagged with my-tag="my value"
+SentrySdk.CaptureException(new Exception("my error"), configureScope =>
 {
     scope.SetTag("my-tag", "my value");
     scope.Level = SentryLevel.Warning;
-    // will be tagged with my-tag="my value"
-    SentrySdk.CaptureException(new Exception("my error"));
 });
 
 // will not be tagged with my-tag
@@ -16,12 +15,11 @@ SentrySdk.CaptureException(new Exception("my other error"));
 ```fsharp
 open Sentry
 
-SentrySdk.WithScope (
+// will be tagged with my-tag="my value"
+SentrySdk.CaptureException (exn "my error",
   fun scope ->
     scope.SetTag("my-tag", "my value")
     scope.Level <- SentryLevel.Warning
-    // will be tagged with my-tag="my value"
-    SentrySdk.CaptureException(exn "my error")
   )
 
 // will not be tagged with my-tag


### PR DESCRIPTION
WithScope will be replaced by the individual Capture methods that have a callback for a local scope.