### PR TITLE
Clarify send_attempts option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -417,7 +417,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 <ConfigKey name="send-attempts" supported={["php"]}>
 
-Controls how many times the SDK will attempt to send an event to Sentry. The default is `3`.
+Controls how many times the SDK will attempt to resend an event to Sentry. The default is `3`.
 
 </ConfigKey>
 


### PR DESCRIPTION
Followup for #4579: Clarify that this setting is for resend attempts.

Perhaps there should also be some clarification around which circumstances will lead to resend attempts (something like 5xx errors, connection failures or DNS failures, but I'm just guessing here :)