### PR TITLE
chore/update-platform-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "^4.3.0",
+    "platformicons": "4.3.1",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.25.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13808,10 +13808,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.3.0.tgz#ab579cd48cc6e3126fbd1f1a45779b9b0ff0e587"
-  integrity sha512-eH/mJRiOpDA03Ky65tTw9NNm0b5zWJZvCB5vMIrmtENAh565DC12PN+XmjX+7bpAIvWEmGS4YZD/0FVcfwkIyQ==
+platformicons@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.3.1.tgz#3865fe04a06781e80c1a5a7812d8373fec478915"
+  integrity sha512-yI7WObwyB0v7uBNWAoiSuSjzJTKMqlUjQj4Bd79AoHfpkeenCyopq0i1MW+zJvJu9PONE/TPmh7ZB2WZVqUVmw==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Updating the java logo in https://github.com/getsentry/platformicons/pull/50

Before:
![Screen Shot 2022-01-14 at 9 44 36 AM](https://user-images.githubusercontent.com/4830259/149561010-6a10811f-746b-4262-bd91-ad2174f76e1a.png)

After:
![Screen Shot 2022-01-14 at 9 41 21 AM](https://user-images.githubusercontent.com/4830259/149560831-0ac7fc0e-d983-4bfd-8e89-477049edbd10.png)