### PR TITLE
fixe file i/o capitalization

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -217,7 +217,7 @@ The [Sentry Android Gradle Plugin](/platforms/android/gradle/) does tracing auto
 
 The plugin replaces the aforementioned classes with custom Sentry-specific implementations.
 
-The Sentry-specific File I/O implementation starts a span out of the active span, bound to the scope for each File I/O operation. The SDK sets the span `operation` to `file.write`/`file.read` and `description` to `filename (pretty-printed file size)`, e.g. `file.txt (123 kB)`
+The Sentry-specific file I/O implementation starts a span out of the active span, bound to the scope for each file I/O operation. The SDK sets the span `operation` to `file.write`/`file.read` and `description` to `filename (pretty-printed file size)`, e.g. `file.txt (123 kB)`
 
 In addition, the span contains other useful information such as `file.size` (raw number of bytes) and `file.path` (an absolute path to the file) as part of the `data` payload.
 
@@ -225,4 +225,4 @@ The span finishes once the operation has been executed. The span `status` is set
 
 When the operation throws an `Exception`, Sentry's SDK associates this exception to the running span. If you haven't set the SDK to swallow the exception and capture it, the span and SentryEvent will be linked when viewing it on the **Issue Details** page in sentry.io.
 
-For more information see our [File I/O integration](/platforms/android/configuration/integrations/file-io/).
+For more information see our [file I/O integration](/platforms/android/configuration/integrations/file-io/).

--- a/src/platforms/android/configuration/integrations/file-io.mdx
+++ b/src/platforms/android/configuration/integrations/file-io.mdx
@@ -14,13 +14,13 @@ Supported in Sentry Android Gradle Plugin version `3.0.0` and above.
 
 </Note>
 
-The [Sentry Android Gradle Plugin](/platforms/android/gradle/) provides File I/O support through bytecode manipulation. The source can be found [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/tree/main/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation).
+The [Sentry Android Gradle Plugin](/platforms/android/gradle/) provides file I/O support through bytecode manipulation. The source can be found [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/tree/main/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation).
 
-On this page, we get you up and running with Sentry's File I/O Integration, so that it will automatically start a span out of the active transaction, bound to the scope for each file input/output stream operation.
+On this page, we get you up and running with Sentry's file I/O integration, so that it will automatically start a span out of the active transaction, bound to the scope for each file input/output stream operation.
 
 ## Install
 
-To use the File I/O integration, add the Sentry Android Gradle plugin and the Sentry Android SDK (version `5.5.0` or above) in `build.gradle`:
+To use the file I/O integration, add the Sentry Android Gradle plugin and the Sentry Android SDK (version `5.5.0` or above) in `build.gradle`:
 
 ```groovy
 buildscript {
@@ -89,7 +89,7 @@ sentry {
 
 ## Verify
 
-Assuming you have the following (reduced) code snippet performing a File I/O operation:
+Assuming you have the following (reduced) code snippet performing a file I/O operation:
 
 ```kotlin
 import android.os.Bundle
@@ -101,7 +101,7 @@ import io.sentry.SpanStatus
 import java.io.File
 
 class LyricsActivity : ComponentActivity() {
-  
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     findViewById<Button>(R.id.load_lyrics).setOnClickListener {
@@ -110,13 +110,13 @@ class LyricsActivity : ComponentActivity() {
         operation = "ui.action.lyrics",
         bindToScope = true
       )
-      
+
       val file = File(context.filesDir, "lyrics.txt")
-      
+
       val lyricsTextView = findViewById<TextView>(R.id.lyrics)
       lyricsTextView.setText(file.readText())
-      
-      transaction.finish(SpanStatus.OK) 
+
+      transaction.finish(SpanStatus.OK)
     }
   }
 }
@@ -134,6 +134,6 @@ At the moment, we only support `java.io.FileInputStream`, `java.io.FileOutputStr
 
 ## (Optional) Manual Instrumentation
 
-Alternatively, if you are not using our Gradle Plugin, the Android SDK provides the capability to manually instrument File I/O operations through the custom Sentry-specific implementations.
+Alternatively, if you are not using our Gradle Plugin, the Android SDK provides the capability to manually instrument file I/O operations through the custom Sentry-specific implementations.
 
 <PlatformContent includePath="performance/file-io-instrumentation" />

--- a/src/platforms/java/common/performance/instrumentation/file-io.mdx
+++ b/src/platforms/java/common/performance/instrumentation/file-io.mdx
@@ -1,7 +1,7 @@
 ---
 title: File I/O Integration
 sidebar_order: 60
-description: "Learn how to capture the performance of File I/O operations."
+description: "Learn how to capture the performance of file I/O operations."
 notSupported:
   - java.logback
   - java.log4j2
@@ -14,11 +14,11 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 </Note>
 
-Sentry File I/O integration provides the `SentryFileInputStream`/`SentryFileOutputStream` and `SentryFileReader`/`SentryFileWriter`, which create a span for each File read/write operation.
+Sentry file I/O integration provides the `SentryFileInputStream`/`SentryFileOutputStream` and `SentryFileReader`/`SentryFileWriter`, which create a span for each File read/write operation.
 
 ### Install
 
-The File I/O Integration is available under the core Java SDK package.
+The file I/O Integration is available under the core Java SDK package.
 
 ```xml {tabTitle:Maven}
 <dependency>

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -116,9 +116,9 @@ transaction.finish() // Mark the transaction as finished and send it to Sentry
 
 Check out [the documentation](https://docs.sentry.io/platforms/android/performance/instrumentation/) to learn more about the API and automatic instrumentations.
 
-> Want to play with some new features? Try out our beta [Room](https://docs.sentry.io/platforms/android/configuration/integrations/room-and-sqlite/) and [File I/O](https://docs.sentry.io/platforms/android/configuration/integrations/file-io/) performance integrations.
+> Want to play with some new features? Try out our beta [Room](https://docs.sentry.io/platforms/android/configuration/integrations/room-and-sqlite/) and [file I/O](https://docs.sentry.io/platforms/android/configuration/integrations/file-io/) performance integrations.
 >  
-> This feature is available in the Beta release of the [Sentry Android Gradle plugin](https://docs.sentry.io/platforms/android/gradle); you must use version `3.0.0-beta.3`. The `tracingInstrumentation` option is enabled by default, so Sentry automatically measures the performance of the database queries done with Room as well as File I/O operations if you set a tracing sample rate. Features in Beta are still a work-in-progress and may have bugs. We recognize the irony.
+> This feature is available in the Beta release of the [Sentry Android Gradle plugin](https://docs.sentry.io/platforms/android/gradle); you must use version `3.0.0-beta.3`. The `tracingInstrumentation` option is enabled by default, so Sentry automatically measures the performance of the database queries done with Room as well as file I/O operations if you set a tracing sample rate. Features in Beta are still a work-in-progress and may have bugs. We recognize the irony.
 >
 > Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-android-gradle-plugin/issues).
 


### PR DESCRIPTION
Changes "file" in "file I/O" to lower case in most places. 
Since I reviewed previous PRs using this term, I've learned this is a generic term that's generally not capitalized in the places where it's spelled out, so we should avoid setting a precedent that doesn't align with other documentation.