### PR TITLE
ref(apple): Move warning for min 7.x to migration

### DIFF
--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -9,7 +9,7 @@ To upgrade from the 4.x version of the SDK to the 7.x version of the SDK, you mu
 
 <Alert level="info" title="Important">
 
-The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1448)). We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3) or [disabling the feature](#http-instrumentation).
+We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3), because the HTTP instrumentation can lead to crashes. Alternatively, you can also <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#http-instrumentation">disable the feature</PlatformLink>.
 
 </Alert>
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -7,6 +7,12 @@ To upgrade from the 4.x version of the SDK to the 7.x version of the SDK, you mu
 
 ## Migrating from 6.x to 7.x
 
+<Alert level="info" title="Important">
+
+The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1448)). We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3) or [disabling the feature](#http-instrumentation).
+
+</Alert>
+
 Migrating to 7.x from 6.x includes a few breaking changes. We provide this guide to help you to update your SDK.
 
 ### Configuration Changes

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -10,12 +10,6 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 </Note>
 
-<Alert level="info" title="Important">
-
-The HTTP instrumentation can lead to crashes due to a bug in the SDK (see [GitHub Issue](https://github.com/getsentry/sentry-cocoa/issues/1448)). We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3) or [disabling the feature](#http-instrumentation).
-
-</Alert>
-
 ## UIViewController Instrumentation
 
 This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UIViewControllers.


### PR DESCRIPTION
We can move the warning for using minimum 7.5.3 to avoid crashes
with Cocoa to the migration page as we already released 7.9.0.