### PR TITLE
feat(apple): How to init SDK when using SwiftUI

### DIFF
--- a/src/includes/getting-started-config/apple.mdx
+++ b/src/includes/getting-started-config/apple.mdx
@@ -31,6 +31,23 @@ func application(_ application: UIApplication,
 }
 ```
 
+When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](https://developer.apple.com/documentation/swiftui/app/main()):
+
+```swift
+import Sentry
+
+@main
+struct SwiftUIApp: App {
+    init() {
+        SentrySDK.start { options in
+            options.dsn = "___PUBLIC_DSN___"
+            options.debug = true // Enabled debug when first installing is always helpful
+        }
+    }
+}
+```
+<!-- You can't write SwiftUI in Objective-C. Therefore no code sample. -->
+
 ## Provide Debug Information {#debug-symbols}
 
 Before capturing crashes, you need to provide debug information to Sentry. Debug information is provided by uploading dSYM files using one of two methods, dependent on your setup:


### PR DESCRIPTION
When using SwiftUI the way of initializing the SDK is different.
This adds documentation for that case.