### PR TITLE
ref(apple): Mention other install methods sooner

### DIFF
--- a/src/includes/getting-started-install/apple.ios.mdx
+++ b/src/includes/getting-started-install/apple.ios.mdx
@@ -1,6 +1,6 @@
 The minimum version for iOS is 9.0.
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
 platform :ios, '9.0'
@@ -12,5 +12,3 @@ end
 ```
 
 Then run `pod install`.
-
-We also support alternate [installation methods](install/).

--- a/src/includes/getting-started-install/apple.macos.mdx
+++ b/src/includes/getting-started-install/apple.macos.mdx
@@ -1,6 +1,6 @@
 The minimum version for macOS is 10.10.
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
 platform :macos, '10.10'
@@ -12,5 +12,3 @@ end
 ```
 
 Then run `pod install`.
-
-We also support alternate [installation methods](install/).

--- a/src/includes/getting-started-install/apple.mdx
+++ b/src/includes/getting-started-install/apple.mdx
@@ -1,4 +1,4 @@
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
 platform :ios, '9.0'
@@ -10,5 +10,3 @@ end
 ```
 
 Then run `pod install`.
-
-We also support alternate [installation methods](install/).

--- a/src/includes/getting-started-install/apple.tvos.mdx
+++ b/src/includes/getting-started-install/apple.tvos.mdx
@@ -1,6 +1,6 @@
 The minimum version for tvOS is 9.0.
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
 platform :tvos, '9.0'
@@ -12,5 +12,3 @@ end
 ```
 
 Then run `pod install`.
-
-We also support alternate [installation methods](install/).

--- a/src/includes/getting-started-install/apple.watchos.mdx
+++ b/src/includes/getting-started-install/apple.watchos.mdx
@@ -1,6 +1,6 @@
 The minimum version for watchOS is 2.0. Our SDK has limited symbolication support and no crash handling for watchOS.
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby
 platform :watchos, '2.0'
@@ -12,5 +12,3 @@ end
 ```
 
 Then run `pod install`.
-
-We also support alternate [installation methods](install/).

--- a/src/wizard/apple/index.md
+++ b/src/wizard/apple/index.md
@@ -5,7 +5,7 @@ support_level: production
 type: language
 ---
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
 platform :ios, '9.0'
@@ -17,8 +17,6 @@ end
 ```
 
 Afterwards run `pod install`.
-
-For other installation methods, please see our [documentation](/platforms/apple/install/).
 
 ## Configuration
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -5,7 +5,7 @@ support_level: production
 type: language
 ---
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
 platform :ios, '9.0'
@@ -17,8 +17,6 @@ end
 ```
 
 Afterwards run `pod install`.
-
-For other installation methods, please see our [documentation](/platforms/apple/install/).
 
 ## Configuration
 

--- a/src/wizard/apple/macos.md
+++ b/src/wizard/apple/macos.md
@@ -5,7 +5,7 @@ support_level: production
 type: language
 ---
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
 platform :ios, '9.0'
@@ -17,8 +17,6 @@ end
 ```
 
 Afterwards run `pod install`.
-
-For other installation methods, please see our [documentation](/platforms/apple/install/).
 
 ## Configuration
 


### PR DESCRIPTION
The wizard and getting started page mentions that we support
alternate installation methods after explaining how to install the
SDK with CocoaPods. I hypothesize that most people don't read
the hint because they see CocoaPods and then skip the whole
section. This happened to me, and I wondered where we point
out SPM and Carthage. Mentioning the other installation
methods earlier could fix this problem.