### PR TITLE
Add "Defold" to the list of Community Supported SDKs

### DIFF
--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -24,6 +24,7 @@ These SDKs are maintained and supported by [the Sentry community](https://forum.
 - [_Clojure_](https://github.com/sethtrain/raven-clj#alternatives)
 - [_ColdFusion_](https://github.com/coldbox-modules/sentry)
 - [_Crystal_](https://github.com/Sija/raven.cr)
+- [_Defold_](https://github.com/indiesoftby/defold-sentinel)
 - [_Fastify_](https://github.com/zentered/fastify-sentry)
 - [_Grails_](https://github.com/agorapulse/grails-sentry)
 - [_Kubernetes_](https://github.com/getsentry/sentry-kubernetes)


### PR DESCRIPTION
Hello!

We implemented quite [a basic Sentry.io SDK for the Defold engine](https://github.com/indiesoftby/defold-sentinel), i.e. it can catch errors, capture messages, collect breadcrumbs. 

I would be grateful if you added a link to the SDK to the documentation.