### PR TITLE
Update cocoapods.mdx

### DIFF
--- a/src/platforms/react-native/install/cocoapods.mdx
+++ b/src/platforms/react-native/install/cocoapods.mdx
@@ -13,7 +13,7 @@ npm install --save react react-native @sentry/react-native
 yarn add react react-native @sentry/react-native
 ```
 
-After that, change your `Podfile` to reference to the packages in your `node_modules` folder. For the latest reference on how to use react-native with CocoaPods see: [Integration with existing apps](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html#configuring-cocoapods-dependencies)
+After that, change your `Podfile` to reference to the packages in your `node_modules` folder. For the latest reference on how to use react-native with CocoaPods see: [Integration with existing apps](https://reactnative.dev/docs/integration-with-existing-apps#configuring-cocoapods-dependencies)
 
 ```ruby
 target 'YOUR-TARGET' do


### PR DESCRIPTION
Updated the "Integration with existing apps" hyperlink which was redirecting to a 404 page.