### PR TITLE
fix(RN): Rework RN installation linking section to include wizard

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -48,13 +48,6 @@ For React Native versions 0.60 and after, you will need to execute the Sentry Wi
 npx @sentry/wizard -i reactNative -p ios android
 ```
 
-### Install Pods
-
-As the Sentry React Native SDK relies on native modules, make sure that you run `pod install` every time you install or update the SDK.
-
-```
-npx pod-install
-```
 The call to the [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [link manually](/platforms/react-native/manual-setup/manual-setup/) if you prefer. You need to do this only once, then the created files can go into your version control system.
 
 The following changes will be performed by Sentry Wizard:
@@ -65,6 +58,14 @@ The following changes will be performed by Sentry Wizard:
 - patch _*MainApplication.java*_ for Android
 - configure Sentry for the supplied DSN in your _*index.js/App.js*_ files
 - store build credentials in _*ios/sentry.properties*_ and _*android/sentry.properties*_.
+
+### Install Pods
+
+As the Sentry React Native SDK relies on native modules, make sure that you run `pod install` every time you install or update the SDK.
+
+```
+npx pod-install
+```
 
 ### iOS Specifics
 

--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -20,27 +20,41 @@ Make sure that the version of `@sentry/react-native` matches what `sentry-expo` 
 
 ### Linking
 
+#### For React Native versions < 0.60.0
+
 <Note>
 
 If you are running a project with `react-native` prior to 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` version 0.60 and above does this automatically.
 
 </Note>
 
-Link the SDK to your native projects to enable native crash reporting.
+Link the SDK to your native projects to enable native crash reporting. The `react-native link` step will run the Sentry Wizard automatically after linking.
 
-```bash
+```npm
+npm install --save-dev @sentry/wizard
 react-native link @sentry/react-native
 ```
 
-Execute the Sentry Wizard.
+```yarn
+yarn add --dev @sentry/wizard
+react-native link @sentry/react-native
+```
+
+#### For React Native versions >= 0.60.0
+
+For React Native versions 0.60 and after, you will need to execute the Sentry Wizard yourself. This handy wizard will set up everything needed to get the SDK up and running.
 
 ```bash
 npx @sentry/wizard -i reactNative -p ios android
-
-cd ios
-pod install
 ```
 
+### Install Pods
+
+As the Sentry React Native SDK relies on native modules, make sure that you run `pod install` every time you install or update the SDK.
+
+```
+npx pod-install
+```
 The call to the [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [link manually](/platforms/react-native/manual-setup/manual-setup/) if you prefer. You need to do this only once, then the created files can go into your version control system.
 
 The following changes will be performed by Sentry Wizard:

--- a/src/wizard/react-native/index.md
+++ b/src/wizard/react-native/index.md
@@ -20,21 +20,46 @@ yarn add @sentry/react-native
 
 ### Linking
 
-Link the SDK to your native projects to enable native crash reporting. If you are running a project with `react-native < 0.60`, you still need to call `react-native link`, otherwise you can skip this step as `react-native >=0.60` does this automatically.
+#### For React Native versions < 0.60.0
+
+<Note>
+
+If you are running a project with `react-native` prior to 0.60, you still need to call `react-native link`, otherwise you can skip this step as `react-native` version 0.60 and above does this automatically.
+
+</Note>
+
+Link the SDK to your native projects to enable native crash reporting. The `react-native link` step will run the Sentry Wizard automatically after linking.
+
+```npm
+npm install --save-dev @sentry/wizard
+react-native link @sentry/react-native
+```
+
+```yarn
+yarn add --dev @sentry/wizard
+react-native link @sentry/react-native
+```
+
+#### For React Native versions >= 0.60.0
+
+For React Native versions 0.60 and after, you will need to execute the Sentry Wizard yourself. This handy wizard will set up everything needed to get the SDK up and running.
 
 ```bash
 npx @sentry/wizard -i reactNative -p ios android
-# or
-yarn sentry-wizard -i reactNative -p ios android
-
-cd ios
-pod install
 ```
 
 The call to the [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [link manually](https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/) if you prefer.
 
 - iOS Specifics: When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However, if you are using bitcode, you will need to disable the “Upload Debug Symbols to Sentry” build phase and then separately upload debug symbols from iTunes Connect to Sentry.
 - Android Specifics: We hook into Gradle for the source map build process. When you run `react-native link`, the Gradle files are automatically updated. When you run `./gradlew assembleRelease`, source maps are automatically built and uploaded to Sentry. If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build by setting `org.gradle.configureondemand=false` or remove it.
+
+### Install Pods
+
+As the Sentry React Native SDK relies on native modules, make sure that you run `pod install` every time you install or update the SDK.
+
+```
+npx pod-install
+```
 
 ### Initialize the SDK
 


### PR DESCRIPTION
When working with older RN versions that require the linking step, an error is thrown when calling `react-native link` when it tries to auto-run the sentry wizard because we no longer include it as a dependency of the RN SDK. Currently in newer versions we have users run `npx` which will also fetch the sentry wizard dependency but it does not exist for older versions. Instead, for RN <0.60 we include the installation of sentry wizard as a dev dependency in the linking step to avoid this error. This PR also updates the RN wizard.