### PR TITLE
fix(RN): Remove broken manual linking install option for React Native

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -17,11 +17,15 @@ Before you begin, you need to have already created a `sentry.properties` file at
 
 ## iOS
 
-### Linking the Native Library
+### Linking the Native Library via CocoaPods
 
-You must link the native Sentry project with your project. This can be done by following the [Linking Libraries](https://facebook.github.io/react-native/docs/linking-libraries-ios.html) steps described in React Native documentation.
+You must link to the native module in your Podfile. In React Native versions 0.60 and above the podspec should be automatically linked. In earlier versions calling `react-native link @sentry/react-native` will add the podspec for you.
 
-Link to this library: `node_modules/@sentry/react-native/ios/RNSentry.xcodeproj`.
+Otherwise, you can manually link the native module by adding the `RNSentry.podspec` to your podfile like below:
+
+```rb
+pod 'RNSentry', :path => '../node_modules/@sentry/react-native/RNSentry.podspec'
+```
 
 ### Upload Debug Symbols
 


### PR DESCRIPTION
Since the git submodule to sentry-cocoa was removed in https://github.com/getsentry/sentry-react-native/commit/6c3d4cf8da2b3168b29695417177cb49587cb84f#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584, manually linking the xcodeproj no longer worked. This PR removes the instructions saying so and instead instructs how to manually link with cocoapods.