### PR TITLE
feat(nextjs): Document `hideSourceMaps` option

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -194,6 +194,8 @@ By default, `withSentryConfig` will add an instance of `SentryWebpackPlugin` to 
 
 To configure the plugin, pass a `SentryWebpackPluginOptions` argument to `withSentryConfig`, as seen in the example above. All available options are documented [here](https://github.com/getsentry/sentry-webpack-plugin#options).
 
+### Disable `SentryWebpackPlugin`
+
 If you want or need to handle source map uploading separately, the plugin can be disabled for either the server or client build process. To do this, add a `sentry` object to `moduleExports` above, and set the relevant options there:
 
 ```javascript {filename:next.config.js}
@@ -212,6 +214,20 @@ module.exports = withSentryConfig(moduleExports);
 ```
 
 In that case you can also skip the `sentry-cli` configuration step below.
+
+### Use `hidden-source-map`
+
+If you would like to use `hidden-source-map` rather than `souce-map` as your webpack `devtool`, so that your built files do not contain a `sourceMappingURL` comment, add a `sentry` object to `moduleExports` above, and set the `hideSourceMaps` option to `true`:
+
+```javascript {filename:next.config.js}
+const moduleExports = {
+  sentry: {
+    hideSourceMaps: true,
+  },
+};
+```
+
+Note that this only applies to client-side builds.
 
 ## Configure `sentry-cli`
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -217,6 +217,9 @@ In that case you can also skip the `sentry-cli` configuration step below.
 
 ### Use `hidden-source-map`
 
+
+_(New in version 6.17.1)_
+
 If you would like to use `hidden-source-map` rather than `souce-map` as your webpack `devtool`, so that your built files do not contain a `sourceMappingURL` comment, add a `sentry` object to `moduleExports` above, and set the `hideSourceMaps` option to `true`:
 
 ```javascript {filename:next.config.js}


### PR DESCRIPTION
This documents the option added in https://github.com/getsentry/sentry-javascript/pull/4436, to allow users to use `hidden-source-map` as their webpack `devtool` for client-side builds. (With this option enabled, the same sourcemaps are generated, but the final bundles don't have a `sourceMappingURL` comment, effectively "hiding" the sourcemaps from the browser. Doing this prevents the browser from complaining in situations where the maps are not publicly hosted.)