### PR TITLE
fix(ue4): Fix UE4 crash reporting config info

### DIFF
--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -60,7 +60,7 @@ checking the box for: `Include Debug Files`.
 Now that the _Crash Reporter_ and _Debug Files_ are included, UE4 needs to know where to send the
 crash. For that, we add the Sentry _Unreal Engine Endpoint_ from the _Client Keys_ settings page to game's configuration file. This will
 include which project within Sentry you want to see the crashes arriving in real time.
-That's accomplished by configuring the `CrashReportClient` in the _DefaultEngine.ini_ file. Changing engine is necessary for this to work.
+That's accomplished by configuring the `CrashReportClient` in the _DefaultEngine.ini_ file. Changing the engine is necessary for this to work.
 
 Edit the file:
 

--- a/src/platforms/native/guides/ue4/index.mdx
+++ b/src/platforms/native/guides/ue4/index.mdx
@@ -60,11 +60,11 @@ checking the box for: `Include Debug Files`.
 Now that the _Crash Reporter_ and _Debug Files_ are included, UE4 needs to know where to send the
 crash. For that, we add the Sentry _Unreal Engine Endpoint_ from the _Client Keys_ settings page to game's configuration file. This will
 include which project within Sentry you want to see the crashes arriving in real time.
-That's accomplished by configuring the `CrashReportClient` in the _DefaultEngine.ini_ file.
+That's accomplished by configuring the `CrashReportClient` in the _DefaultEngine.ini_ file. Changing engine is necessary for this to work.
 
 Edit the file:
 
-> project-root\Config\DefaultEngine.ini
+> engine-dir\Engine\Programs\CrashReportClient\Config\DefaultEngine.ini
 
 Add the configuration section:
 


### PR DESCRIPTION
Changing config file in project directory will NOT result sending data to provided DataRouterUrl (at least on 4.27). 
Way for this to work, its change engine installation CrashReporterClient config.

Forum attached below in document suggests same solution: 
https://forum.sentry.io/t/unreal-engine-crash-reporter-cant-get-it-to-work/7643/2

So I propose to change main documentation to avoid confusion. 