### PR TITLE
feat(dashboards): Remove EA note for widget dataset selection

### DIFF
--- a/src/docs/product/dashboards/custom-dashboards/index.mdx
+++ b/src/docs/product/dashboards/custom-dashboards/index.mdx
@@ -81,12 +81,4 @@ transactions'.
 
 ## Data Set Selection
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 Select between events and [issues](/product/issues/) data in a widget with the "Data Set" selector. Choosing "Issues" allows you to query using issues filters, such as `is:unresolved` for unresolved issues, and to display and sort by issues fields. This feature only applies to [table](#table-results) visualizations.


### PR DESCRIPTION
Removing EA note around Data Set selection due to GA'ing feature
![image](https://user-images.githubusercontent.com/83961295/150822884-dabd34ab-c62e-468a-8599-5065f1639f05.png)
