### PR TITLE
chore(shortcut): Add redirect from sentry app details page

### DIFF
--- a/src/docs/product/integrations/project-mgmt/shortcut/index.mdx
+++ b/src/docs/product/integrations/project-mgmt/shortcut/index.mdx
@@ -7,6 +7,7 @@ redirect_from:
   - /workflow/integrations/global-integrations/clubhouse/
   - /product/integrations/clubhouse/
   - /product/integrations/project-mgmt/clubhouse/
+  - /product/integrations/shortcut/
 description: "Learn more about Sentry's Shortcut integration and how it can create a more efficient workflow by linking your Sentry Issues with your Shortcut Stories."
 ---
 


### PR DESCRIPTION
This PR will fix the broken link for Documentation on the Shortcut sentry app. The redirect to the page was never added after the slug was changed from `clubhouse` to `shortcut`. This should work (even though it's untested) since the code that create's these links is shared for all sentry apps, and is structured the same as Linear and Rookout's links.

This is the `getsentry/sentry` code:

https://github.com/getsentry/sentry/blob/master/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx#L87-L98

This is what redirects look like for other sentry-apps:

https://github.com/getsentry/sentry-docs/blob/leander/shortcut-docs/src/docs/product/integrations/project-mgmt/linear/index.mdx#L5