### PR TITLE
docs(js): Add RewriteFrames iteratee reference

### DIFF
--- a/src/includes/configuration/rewrite-frames/javascript.mdx
+++ b/src/includes/configuration/rewrite-frames/javascript.mdx
@@ -43,6 +43,8 @@ Sentry.init({
       prefix: string;
 
       // function that takes the frame, applies a transformation, and returns it
+      // See the default implementation for some inspiration:
+      // https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/rewriteframes.ts
       iteratee: (frame) => frame;
     }
   )],


### PR DESCRIPTION
Adding a reference to our default implementation will help people understand how their custom `iteratee` should look.