### PR TITLE
PHP improvements

### DIFF
--- a/src/includes/configuration/before-send-fingerprint/php.symfony.mdx
+++ b/src/includes/configuration/before-send-fingerprint/php.symfony.mdx
@@ -8,7 +8,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getBeforeSend']
 ```
 
-The service need for the `before_send` option can be implemented as follows:
+The service needed for the `before_send` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/configuration/before-send-fingerprint/php.symfony.mdx
+++ b/src/includes/configuration/before-send-fingerprint/php.symfony.mdx
@@ -1,0 +1,31 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        before_send: 'sentry_before_send'
+
+services:
+    sentry_before_send:
+        factory: ['@\App\Service\Sentry', 'getBeforeSend']
+```
+
+The service need for the `before_send` option can be implemented as follows:
+
+```php {filename:src/Service/Sentry.php}
+<?php
+
+namespace App\Service;
+
+class Sentry
+{
+    public function getBeforeSend(): callable
+    {
+        return function(\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
+            if ($hint !== null && $hint->exception !== null && str_contains($hint->exception->getMessage(), 'database unavailable')) {
+                $event->setFingerprint(['database-unavailable']);
+            }
+
+            return $event;
+        };
+    }
+}
+```

--- a/src/includes/configuration/before-send-hint/php.symfony.mdx
+++ b/src/includes/configuration/before-send-hint/php.symfony.mdx
@@ -1,0 +1,32 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        before_send: 'sentry_before_send'
+
+services:
+    sentry_before_send:
+        factory: ['@\App\Service\Sentry', 'getBeforeSend']
+```
+
+The service need for the `before_send` option can be implemented as follows:
+
+```php {filename:src/Service/Sentry.php}
+<?php
+
+namespace App\Service;
+
+class Sentry
+{
+    public function getBeforeSend(): callable
+    {
+        return function (\Sentry\Event $event): ?\Sentry\Event {
+            // Ignore the event if the original exception is an instance of MyException
+            if ($hint !== null && $hint->exception instanceof MyException) {
+              return null;
+            }
+
+            return $event;
+        };
+    }
+}
+```

--- a/src/includes/configuration/before-send-hint/php.symfony.mdx
+++ b/src/includes/configuration/before-send-hint/php.symfony.mdx
@@ -8,7 +8,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getBeforeSend']
 ```
 
-The service need for the `before_send` option can be implemented as follows:
+The service needed for the `before_send` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/configuration/before-send/php.symfony.mdx
+++ b/src/includes/configuration/before-send/php.symfony.mdx
@@ -10,7 +10,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getBeforeSend']
 ```
 
-The service need for the `before_send` option can be implemented as follows:
+The service needed for the `before_send` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/configuration/before-send/php.symfony.mdx
+++ b/src/includes/configuration/before-send/php.symfony.mdx
@@ -1,0 +1,29 @@
+In the Symfony config, a service can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
+
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        before_send: 'sentry_before_send'
+
+services:
+    sentry_before_send:
+        factory: ['@\App\Service\Sentry', 'getBeforeSend']
+```
+
+The service need for the `before_send` option can be implemented as follows:
+
+```php {filename:src/Service/Sentry.php}
+<?php
+
+namespace App\Service;
+
+class Sentry
+{
+    public function getBeforeSend(): callable
+    {
+        return function (\Sentry\Event $event): ?\Sentry\Event {
+            return $event;
+        };
+    }
+}
+```

--- a/src/includes/configuration/config-intro/php.laravel.mdx
+++ b/src/includes/configuration/config-intro/php.laravel.mdx
@@ -3,9 +3,3 @@ Options are configured in the `config/sentry.php` config file:
 ```php {filename:config/sentry.php}
 'max_breadcrumbs' => 50,
 ```
-
-<Note>
-
-Some of the options listed below that are marked as _not available_ may be available in another form; see [PHP specific documentation](/product/releases/).
-
-</Note>

--- a/src/includes/configuration/config-intro/php.mdx
+++ b/src/includes/configuration/config-intro/php.mdx
@@ -6,9 +6,3 @@ Options are passed to the `init()` method as an array:
     'max_breadcrumbs' => 50,
 ]);
 ```
-
-<Note>
-
-Some of the options listed below that are marked as _not available_ may be available in another form; see [PHP specific documentation](/product/releases/).
-
-</Note>

--- a/src/includes/configuration/config-intro/php.symfony.mdx
+++ b/src/includes/configuration/config-intro/php.symfony.mdx
@@ -1,0 +1,8 @@
+Options are configured in the `config/packages/sentry.yaml` config file:
+
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    dsn: "%env(SENTRY_DSN)%"
+    options:
+        max_breadcrumbs: 50
+```

--- a/src/includes/configuration/sample-rate/php.symfony.mdx
+++ b/src/includes/configuration/sample-rate/php.symfony.mdx
@@ -1,0 +1,5 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        sample_rate: 0.25
+```

--- a/src/includes/enriching-events/breadcrumbs/before-breadcrumb/php.laravel.mdx
+++ b/src/includes/enriching-events/breadcrumbs/before-breadcrumb/php.laravel.mdx
@@ -3,3 +3,9 @@
     return $breadcrumb;
 },
 ```
+
+<Note>
+
+Learn more in [Closures and Config Caching](/platforms/php/guides/laravel/configuration/laravel-options/#closures-and-config-caching).
+
+</Note>

--- a/src/includes/enriching-events/breadcrumbs/before-breadcrumb/php.symfony.mdx
+++ b/src/includes/enriching-events/breadcrumbs/before-breadcrumb/php.symfony.mdx
@@ -1,0 +1,27 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        before_breadcrumb: 'sentry_before_breadcrumb'
+
+services:
+    sentry_before_breadcrumb:
+        factory: ['@\App\Service\Sentry', 'getBeforeBreadcrumb']
+```
+
+The service needed for the `before_breadcrumb` option can be implemented as follows:
+
+```php {filename:src/Service/Sentry.php}
+<?php
+
+namespace App\Service;
+
+class Sentry
+{
+    public function getBeforeBreadcrumb(): callable
+    {
+        return function(\Sentry\Breadcrumb $breadcrumb): ?\Sentry\Breadcrumb {
+            return $breadcrumb;
+        };
+    }
+}
+```

--- a/src/includes/performance/always-inherit-sampling-decision/php.symfony.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/php.symfony.mdx
@@ -1,14 +1,10 @@
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:
-        # Specify a fixed sample rate:
-        traces_sample_rate: 1.0
-        # Or provide a custom sampler:
-        traces_sampler: 'sentry_tracer_sampler'
+        traces_sampler: 'sentry_traces_sampler'
 
-# Only needed when using the `traces_sampler`
 services:
-    sentry_tracer_sampler:
+    sentry_traces_sampler:
         factory: ['@\App\Service\Sentry', 'getTracesSampler']
 ```
 
@@ -23,8 +19,13 @@ class Sentry
 {
     public function getTracesSampler(): callable
     {
-        return function(\Sentry\Tracing\SamplingContext $context): float {
-            // return a number between 0 and 1
+        return function (\Sentry\Tracing\SamplingContext $context): float {
+            // always inherit
+            if ($context->getParentSampled()) {
+                return 1.0;
+            }
+
+            // the rest of sampling logic
         };
     }
 }

--- a/src/includes/performance/always-inherit-sampling-decision/php.symfony.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/php.symfony.mdx
@@ -8,7 +8,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getTracesSampler']
 ```
 
-The service need for the `traces_sampler` option can be implemented as follows:
+The service needed for the `traces_sampler` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/performance/configure-sample-rate/php.symfony.mdx
+++ b/src/includes/performance/configure-sample-rate/php.symfony.mdx
@@ -12,7 +12,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getTracesSampler']
 ```
 
-The service need for the `traces_sampler` option can be implemented as follows:
+The service needed for the `traces_sampler` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/performance/traces-sample-rate/php.symfony.mdx
+++ b/src/includes/performance/traces-sample-rate/php.symfony.mdx
@@ -1,0 +1,5 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        traces_sample_rate: 0.2
+```

--- a/src/includes/performance/traces-sampler-as-filter/php.symfony.mdx
+++ b/src/includes/performance/traces-sampler-as-filter/php.symfony.mdx
@@ -1,0 +1,39 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        traces_sampler: 'sentry_traces_sampler'
+
+services:
+    sentry_traces_sampler:
+        factory: ['@\App\Service\Sentry', 'getTracesSampler']
+```
+
+The service need for the `traces_sampler` option can be implemented as follows:
+
+```php {filename:src/Service/Sentry.php}
+<?php
+
+namespace App\Service;
+
+class Sentry
+{
+    public function getTracesSampler(): callable
+    {
+        return function (\Sentry\Tracing\SamplingContext $context): float {
+            if ($context->getParentSampled()) {
+                // If the parent transaction (for example a JavaScript front-end)
+                // is sampled, also sample the current transaction
+                return 1.0;
+            }
+
+            if (some_condition()) {
+                // Drop this transaction, by setting its sample rate to 0
+                return 0;
+            }
+
+            // Default sample rate for all other transactions (replaces `traces_sample_rate`)
+            return 0.25;
+        };
+    }
+}
+```

--- a/src/includes/performance/traces-sampler-as-filter/php.symfony.mdx
+++ b/src/includes/performance/traces-sampler-as-filter/php.symfony.mdx
@@ -8,7 +8,7 @@ services:
         factory: ['@\App\Service\Sentry', 'getTracesSampler']
 ```
 
-The service need for the `traces_sampler` option can be implemented as follows:
+The service needed for the `traces_sampler` option can be implemented as follows:
 
 ```php {filename:src/Service/Sentry.php}
 <?php

--- a/src/includes/set-environment/php.symfony.mdx
+++ b/src/includes/set-environment/php.symfony.mdx
@@ -1,0 +1,7 @@
+The environment option defaults to the same environment of your Symfony application.
+
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        environment: "%kernel.environment%"
+```

--- a/src/includes/set-release/php.symfony.mdx
+++ b/src/includes/set-release/php.symfony.mdx
@@ -1,0 +1,5 @@
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    options:
+        release: "my-project-name@2.3.12"
+```

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -49,7 +49,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ## Scrubbing Data
 
-SDKs provide a `before-send` hook, which is invoked before an event is sent and can be used to modify event data to remove sensitive information. Using `before-send` in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, so sensitive data never leaves the local environment.
+SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an event is sent and can be used to modify event data to remove sensitive information. Using <PlatformIdentifier name="before-send" /> in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, so sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send" />
 

--- a/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -6,7 +6,7 @@ redirect_from:
   - /platforms/php/guides/symfony/config/
 ---
 
-In addition to the [configuration available in the PHP SDK](../configuration/options/), there are some Symfony-specific options.
+In addition to the [configuration available in the PHP SDK](../options/), there are some Symfony-specific options.
 
 All configuration for Symfony is done in `config/packages/sentry.yaml`.
 
@@ -57,8 +57,7 @@ left empty, it disables Sentry reporting. Because Sentry enables the bundle in a
 disable it in the `test` and `dev` environments.
 
 All the possible configurations under the `options` key map directly to the correspondent options from the base SDK;
-you can read more about those in the [general configuration docs](../configuration/),
-and on the [PHP specific SDK docs](../config/).
+you can read more about those in the [general configuration docs](../options/).
 
 Below you can find additional documentation that is specific to the bundle usage, or information about the sensible default
 values that you can use in some cases.

--- a/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Symfony Options
 sidebar_order: 1
-description: "Learn about Sentry's integration with Symfony and its options for breadcrumbs, and performance."
+description: "Learn about Sentry's integration with Symfony and its options."
 redirect_from:
   - /platforms/php/guides/symfony/config/
 ---

--- a/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -1,6 +1,9 @@
 ---
-title: Config
-description: "Learn about Symfony-specific configuration options."
+title: Symfony Options
+sidebar_order: 1
+description: "Learn about Sentry's integration with Symfony and its options for breadcrumbs, and performance."
+redirect_from:
+  - /platforms/php/guides/symfony/config/
 ---
 
 In addition to the [configuration available in the PHP SDK](../configuration/options/), there are some Symfony-specific options.

--- a/src/platforms/php/index.mdx
+++ b/src/platforms/php/index.mdx
@@ -54,20 +54,4 @@ try {
 \Sentry\captureLastError();
 ```
 
-## Performance Monitoring
-
-Just set `traces_sample_rate` to a value greater than `0.0` after that, Performance Monitoring will be enabled.
-
-```php
-\Sentry\init([
-    'dsn' => '___PUBLIC_DSN___',
-    // Be sure to lower this in production to prevent quota issues
-    'traces_sample_rate' => 1.0,
-]);
-```
-
-Performance data is transmitted using a new event type called "transactions", which you can learn about in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans). **To capture transactions, you must install and configure your SDK to set the `traces_sample_rate` option to a nonzero value.** The example configuration above will transmit 100% of captured traces. Be sure to lower this value in production otherwise you could burn through your quota quickly.
-
-Learn more about sampling in [Using Your SDK to Filter Events](configuration/filtering/).
-
 <PageGrid header="Next Steps" nextSteps />


### PR DESCRIPTION
I got this done quicker than expected :)

- Added a bunch of Symfony specific snippets (basically everywhere we had them for Laravel)
- Moved the Symfony specific config options page to a more logical place (mirroring Laravel)
- Remove the performance monitoring section from the general getting started page for PHP (because it makes no sense having it there)
- Remove a weird note in the PHP docs mentioning specific config docs but linking to `/product/releases/`
- Simplified some Symfony snippets to be more concise

Fixes #4613.