### PR TITLE
feat(perfmon): Polish up native performance monitoring 

### DIFF
--- a/src/includes/performance/add-spans-example/native.mdx
+++ b/src/includes/performance/add-spans-example/native.mdx
@@ -36,4 +36,4 @@ void perform_checkout() {
 }
 ```
 
-This example will send a transaction named `checkout` to Sentry. The transaction will contain a `validation` span that measures how long `validate_shopping_cart()` took and a `process` span that measures `process_shopping_cart()`. Finally, the call to `transaction.finish()` will finish the transaction and send it to Sentry.
+This example will send a transaction named `checkout` to Sentry. The transaction will contain a `validation` span that measures how long `validate_shopping_cart()` took and a `process` span that measures `process_shopping_cart()`. Finally, the call to `sentry_transaction_finish()` will finish the transaction and send it to Sentry.

--- a/src/includes/performance/always-inherit-sampling-decision/native.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/native.mdx
@@ -1,4 +1,4 @@
-<Alert level="warning" title="Sampling Functions">
+<Alert level="warning">
 
 The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
 

--- a/src/includes/performance/always-inherit-sampling-decision/native.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/native.mdx
@@ -1,4 +1,4 @@
-<Alert level="warning">
+<Alert level="info">
 
 The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
 

--- a/src/includes/performance/concurrency/native.mdx
+++ b/src/includes/performance/concurrency/native.mdx
@@ -34,17 +34,3 @@ Following up on that warning, `sentry_transaction_context_set_name()`, which ope
  */
 
 ```
-
-While you can use scopes to work with concurrency on other platforms, this isn't the case for the native SDK. This, as well as the what you can expect if you add manual instrumentation to your app using the native, is discussed in the following two sections.
-
-### Single Scope, Multiple Transactions
-
-The native SDK makes a major compromise in an attempt to follow a server-like model despite having a single scope: A user may create multiple concurrent transactions and multiple concurrent spans, at the cost of making it their responsibility to manage the transactions and spans. It is on them to ensure that no unsafe mutations are being made to transactions while they are being used. In comparison, other SDKs either follow a single (hidden) scope, single transaction model where all spans across multiple threads are collapsed into one single transaction.
-
-Currently, the SDK doesn't support associating events with specific spans or transactions in a multi-threaded environment. All events will be linked to the single span or transaction that is set through `sentry_set_span` or `sentry_set_transaction_object`.
-
-### Spans on the Scope
-
-Unlike the Python SDK, if a transaction or a span is on the scope, any new child spans spun off of that will **not** update the scope to point to the newly created span.
-
-You must manually set spans on the scope if you're are interested in associating events (errors, messages) with a specific span. To fully mimic the Python SDK’s behaviour, you need to manually set spans, and re-set parent spans and/or transactions on the scope when a child span finishes. Note that since there is a single global scope in the native SDK, there is a possibility that an event may be associated with the wrong span in a multi-threaded environment.

--- a/src/includes/performance/concurrency/native.mdx
+++ b/src/includes/performance/concurrency/native.mdx
@@ -41,7 +41,7 @@ Those familiar with performance monitoring on other platforms may note that scop
 
 The native SDK makes a major compromise in an attempt to follow a server-like model despite having a single scope: A user may create multiple concurrent transactions and multiple concurrent spans, at the cost of making it their responsibility to manage the transactions and spans. It is on them to ensure that no unsafe mutations are being made to transactions while they are being used. In comparison, other SDKs either follow a single (hidden) scope, single transaction model where all spans across multiple threads are collapsed into one single transaction.
 
-The ability to associate Events with specific spans or transactions in a multi-threaded environment is not available.
+The ability to associate Events with specific spans or transactions in a multi-threaded environment is not available. All events will be linked to the single span or transaction that is set via `sentry_set_span` or `sentry_set_transaction_object`.
 
 ### Spans on the Scope
 

--- a/src/includes/performance/concurrency/native.mdx
+++ b/src/includes/performance/concurrency/native.mdx
@@ -35,16 +35,16 @@ Following up on that warning, `sentry_transaction_context_set_name()`, which ope
 
 ```
 
-Those familiar with performance monitoring on other platforms may note that scopes are one of the tools to work around concurrency. This is not the case for the native SDK, and is discussed in the following two sections. Expectations for users adding manual instrumentation to their app that are exclusive to the native SDK due to scopes are also detailed below.
+While you can use scopes to work with concurrency on other platforms, this isn't the case for the native SDK. This, as well as the what you can expect if you add manual instrumentation to your app using the native, is discussed in the following two sections.
 
 ### Single Scope, Multiple Transactions
 
 The native SDK makes a major compromise in an attempt to follow a server-like model despite having a single scope: A user may create multiple concurrent transactions and multiple concurrent spans, at the cost of making it their responsibility to manage the transactions and spans. It is on them to ensure that no unsafe mutations are being made to transactions while they are being used. In comparison, other SDKs either follow a single (hidden) scope, single transaction model where all spans across multiple threads are collapsed into one single transaction.
 
-The ability to associate Events with specific spans or transactions in a multi-threaded environment is not available. All events will be linked to the single span or transaction that is set via `sentry_set_span` or `sentry_set_transaction_object`.
+Currently, the SDK doesn't support associating events with specific spans or transactions in a multi-threaded environment. All events will be linked to the single span or transaction that is set through `sentry_set_span` or `sentry_set_transaction_object`.
 
 ### Spans on the Scope
 
 Unlike the Python SDK, if a transaction or a span is on the scope, any new child spans spun off of that will **not** update the scope to point to the newly created span.
 
-The user is expected to manually set spans on the scope if they are interested in associating events (errors, messages) with a specific span. To fully mimic the Python SDK’s behaviour, they need to manually set spans, and re-set parent spans and/or transactions on the scope when a child span finishes. Note that since there is a single global scope in the native SDK, there is a possibility that an event may be associated with the wrong span in a multi-threaded environment.
+You must manually set spans on the scope if you're are interested in associating events (errors, messages) with a specific span. To fully mimic the Python SDK’s behaviour, you need to manually set spans, and re-set parent spans and/or transactions on the scope when a child span finishes. Note that since there is a single global scope in the native SDK, there is a possibility that an event may be associated with the wrong span in a multi-threaded environment.

--- a/src/includes/performance/concurrency/native.mdx
+++ b/src/includes/performance/concurrency/native.mdx
@@ -34,3 +34,17 @@ Following up on that warning, `sentry_transaction_context_set_name()`, which ope
  */
 
 ```
+
+Those familiar with performance monitoring on other platforms may note that scopes are one of the tools to work around concurrency. This is not the case for the native SDK, and is discussed in the following two sections. Expectations for users adding manual instrumentation to their app that are exclusive to the native SDK due to scopes are also detailed below.
+
+### Single Scope, Multiple Transactions
+
+The native SDK makes a major compromise in an attempt to follow a server-like model despite having a single scope: A user may create multiple concurrent transactions and multiple concurrent spans, at the cost of making it their responsibility to manage the transactions and spans. It is on them to ensure that no unsafe mutations are being made to transactions while they are being used. In comparison, other SDKs either follow a single (hidden) scope, single transaction model where all spans across multiple threads are collapsed into one single transaction.
+
+The ability to associate Events with specific spans or transactions in a multi-threaded environment is not available.
+
+### Spans on the Scope
+
+Unlike the Python SDK, if a transaction or a span is on the scope, any new child spans spun off of that will **not** update the scope to point to the newly created span.
+
+The user is expected to manually set spans on the scope if they are interested in associating events (errors, messages) with a specific span. To fully mimic the Python SDK’s behaviour, they need to manually set spans, and re-set parent spans and/or transactions on the scope when a child span finishes. Note that since there is a single global scope in the native SDK, there is a possibility that an event may be associated with the wrong span in a multi-threaded environment.

--- a/src/includes/performance/concurrency/native.mdx
+++ b/src/includes/performance/concurrency/native.mdx
@@ -4,7 +4,7 @@ Be careful when spawning operations as independent threads or asynchronous tasks
 
 APIs provided by the SDK are not inherently thread-safe. Several constructors will contain a warning regarding thread-safety in their docstrings. Functions that operate on the return values of such constructors will also mention any locking requirements.
 
-For example, the documentation of `sentry_transaction_context_new()`, which constructs a `sentry_transaction_context_t`, includes a warning in its final paragraph:
+For example, the documentation of `sentry_transaction_context_new()`, which constructs a `sentry_transaction_context_t`, includes a [warning in its final paragraph](https://github.com/getsentry/sentry-native/blob/0.4.14/include/sentry.h#L1288-L1309):
 
 ```c
 /**
@@ -19,10 +19,9 @@ For example, the documentation of `sentry_transaction_context_new()`, which cons
  * Transaction Context will mention what kind of expectations they carry if they
  * need to mutate or access the object in a thread-safe way.
  */
-
 ```
 
-Following up on that warning, `sentry_transaction_context_set_name()`, which operates on a `sentry_transaction_context_t`, notes that it requires a lock:
+Following up on that warning, `sentry_transaction_context_set_name()`, which operates on a `sentry_transaction_context_t`, [notes that it requires a lock](https://github.com/getsentry/sentry-native/blob/0.4.14/include/sentry.h#L1311-L1319):
 
 ```c
 /**
@@ -32,5 +31,4 @@ Following up on that warning, `sentry_transaction_context_set_name()`, which ope
  * The Transaction Context should not be mutated by other functions while
  * setting a name on it.
  */
-
 ```

--- a/src/includes/performance/configure-sample-rate/native.mdx
+++ b/src/includes/performance/configure-sample-rate/native.mdx
@@ -5,4 +5,6 @@ sentry_options_t *options = sentry_options_new();
 
 // The native SDK currently only supports uniform sample rates.
 sentry_options_set_traces_sample_rate(options, 0.2);
+...
+sentry_init(options);
 ```

--- a/src/includes/performance/connect-errors-spans/native.mdx
+++ b/src/includes/performance/connect-errors-spans/native.mdx
@@ -1,8 +1,8 @@
-## Connect Errors With Transactions
+## Connect Errors With Spans
 
-Sentry errors can be linked with transactions.
+Sentry errors can be linked with transactions and spans.
 
-Errors reported to Sentry are automatically linked to any running transaction that is **bound to the scope**:
+Errors reported to Sentry are automatically linked to any running transaction or span that is **bound to the scope**. There is only one global scope in the native SDK, and only one transaction or span can be bound to the scope at once. In a multi-threaded application, all errors are linked to the single transaction or span bound to the scope.
 
 ```c
 sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(

--- a/src/includes/performance/uniform-sample-rate/native.mdx
+++ b/src/includes/performance/uniform-sample-rate/native.mdx
@@ -1,9 +1,3 @@
 To do this, set the <PlatformIdentifier name="traces-sample-rate" /> option to a number between 0 and 1. With this option set, every transaction created will have that percentage chance of being sent to Sentry. For example, if you set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`, approximately 20% of your transactions will be recorded and sent. That looks like this:
 
 <PlatformContent includePath="performance/traces-sample-rate" />
-
-<Alert level="warning" title="Sampling Functions">
-
-The Native SDK currently does not support setting a sampling function (<PlatformIdentifier name="traces-sampler" />).
-
-</Alert>

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -39,7 +39,7 @@ Changing the error sample rate requires re-deployment. In addition, setting an S
 
 </Note>
 
-<PlatformSection notSupported={["elixir", "javascript.electron", "perl", "rust", "native"]}>
+<PlatformSection notSupported={["elixir", "javascript.electron", "perl", "rust"]}>
 
 ## Sampling Transaction Events
 
@@ -64,12 +64,22 @@ The Sentry SDKs have two configuration options to control the volume of transact
    - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out some transactions entirely
    - Modifies default [precedence](#precedence) and [inheritance](#inheritance) behavior
 
+<PlatformSection supported={["rust", "native"]}>
+
+<Alert level="warning" title="Sampling Functions">
+
+Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by your selected SDK.
+
+</Alert>
+
+<PlatformSection/>
+
 ### Setting a Uniform Sample Rate
 
 <!-- TODO: once PlatformInline is a thing, the text from this include can move back here (the only difference is `Sentry`.init()`) -->
 <PlatformContent includePath="performance/uniform-sample-rate" />
 
-<PlatformSection notSupported={["rust", "native"]}>
+<PlatformSection notSupported={["rust"]}>
 
 ### Setting a Sampling Function
 
@@ -106,11 +116,15 @@ In some SDKs, for convenience, the <PlatformIdentifier name="traces-sampler" /> 
 
 If you're using a <PlatformIdentifier name="traces-sample-rate" /> rather than a <PlatformIdentifier name="traces-sampler" />, the decision will always be inherited.
 
+<PlatformSection notSupported={["native"]}>
+
 ## Forcing a Sampling Decision
 
 If you know at transaction creation time whether or not you want the transaction sent to Sentry, you also have the option of passing a sampling decision directly to the transaction constructor (note, not in the <PlatformIdentifier name="custom-sampling-context" /> object). If you do that, the transaction won't be subject to the <PlatformIdentifier name="traces-sample-rate" />, nor will <PlatformIdentifier name="traces-sampler" /> be run, so you can count on the decision that's passed not to be overwritten.
 
 <PlatformContent includePath="performance/force-sampling-decision" />
+
+</PlatformSection>
 
 ## Precedence
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -138,10 +138,19 @@ There are multiple ways for a transaction to end up with a sampling decision.
 
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
-
 1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" />, that decision will be used, overriding everything else.
 1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
+
+<PlatformSection supported={["native"]}>
+
+<Alert level="warning" title="Forced Sampling Decisions">
+
+Forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" /> is currently not supported by this platform.
+
+</Alert>
+
+</PlatformSection>
 
 </PlatformSection>

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -66,7 +66,7 @@ The Sentry SDKs have two configuration options to control the volume of transact
 
 <PlatformSection supported={["rust", "native"]}>
 
-<Alert level="warning">
+<Alert level="info">
 
 Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by this platform.
 
@@ -145,7 +145,7 @@ When there's the potential for more than one of these to come into play, the fol
 
 <PlatformSection supported={["rust", "native"]}>
 
-<Alert level="warning">
+<Alert level="info">
 
 Forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" /> is currently not supported by this platform.
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -138,9 +138,15 @@ There are multiple ways for a transaction to end up with a sampling decision.
 
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
+
+<PlatformSection notSupported={["native"]}>
+
 1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" /> (see [Forcing a Sampling Decision](#forcing-a-sampling-decision) above), that decision will be used, regardlesss of anything else
-2. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction.
-3. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
-4. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
+
+</PlatformSection>
+
+1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction.
+1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
+1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 
 </PlatformSection>

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -116,7 +116,7 @@ In some SDKs, for convenience, the <PlatformIdentifier name="traces-sampler" /> 
 
 If you're using a <PlatformIdentifier name="traces-sample-rate" /> rather than a <PlatformIdentifier name="traces-sampler" />, the decision will always be inherited.
 
-<PlatformSection notSupported={["native"]}>
+<PlatformSection notSupported={["rust", "native"]}>
 
 ## Forcing a Sampling Decision
 
@@ -143,7 +143,7 @@ When there's the potential for more than one of these to come into play, the fol
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 
-<PlatformSection supported={["native"]}>
+<PlatformSection supported={["rust", "native"]}>
 
 <Alert level="warning" title="Forced Sampling Decisions">
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -39,7 +39,7 @@ Changing the error sample rate requires re-deployment. In addition, setting an S
 
 </Note>
 
-<PlatformSection notSupported={["elixir", "javascript.electron", "perl", "rust"]}>
+<PlatformSection notSupported={["elixir", "javascript.electron", "perl"]}>
 
 ## Sampling Transaction Events
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -66,7 +66,7 @@ The Sentry SDKs have two configuration options to control the volume of transact
 
 <PlatformSection supported={["rust", "native"]}>
 
-<Alert level="warning" title="Sampling Functions">
+<Alert level="warning">
 
 Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by this platform.
 
@@ -145,7 +145,7 @@ When there's the potential for more than one of these to come into play, the fol
 
 <PlatformSection supported={["rust", "native"]}>
 
-<Alert level="warning" title="Forced Sampling Decisions">
+<Alert level="warning">
 
 Forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" /> is currently not supported by this platform.
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -72,7 +72,7 @@ Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently 
 
 </Alert>
 
-<PlatformSection/>
+</PlatformSection>
 
 ### Setting a Uniform Sample Rate
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -68,7 +68,7 @@ The Sentry SDKs have two configuration options to control the volume of transact
 
 <Alert level="warning" title="Sampling Functions">
 
-Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by your selected SDK.
+Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by this platform.
 
 </Alert>
 
@@ -79,7 +79,7 @@ Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently 
 <!-- TODO: once PlatformInline is a thing, the text from this include can move back here (the only difference is `Sentry`.init()`) -->
 <PlatformContent includePath="performance/uniform-sample-rate" />
 
-<PlatformSection notSupported={["rust"]}>
+<PlatformSection notSupported={["rust", "native"]}>
 
 ### Setting a Sampling Function
 
@@ -139,12 +139,7 @@ There are multiple ways for a transaction to end up with a sampling decision.
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
 
-<PlatformSection notSupported={["native"]}>
-
-1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" /> (see [Forcing a Sampling Decision](#forcing-a-sampling-decision) above), that decision will be used, regardlesss of anything else
-
-</PlatformSection>
-
+1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" />, that decision will be used, overriding everything else.
 1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -39,7 +39,7 @@ redirect_from:
 
 <Alert level="info" title="Important">
 
-This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API is still subject to change in the near future. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
 
 </Alert>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -35,6 +35,16 @@ redirect_from:
 
 <!-- Include in `notSupported` any SDK which enables tracing automatically -->
 
+<PlatformSection supported={["native"]}>
+
+<Alert level="info" title="Important">
+
+This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API is still subject to change in the near future. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+
+</Alert>
+
+</PlatformSection >
+
 <Note>
 
 If you’re on a legacy plan, you'll need to add transaction events to your [subscription](https://sentry.io/pricing/) to use performance monitoring.

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -39,7 +39,7 @@ redirect_from:
 
 <Note>
 
-Performance monitoring is still an experimental, work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+Performance monitoring is still an experimental, work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the repository linked on the right side of this page.
 
 </Note>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -37,11 +37,11 @@ redirect_from:
 
 <PlatformSection supported={["native"]}>
 
-<Alert level="info" title="Important">
+<Note>
 
 This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
 
-</Alert>
+</Note>
 
 </PlatformSection >
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -39,7 +39,7 @@ redirect_from:
 
 <Note>
 
-This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+Performance monitoring is still an experimental, work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
 
 </Note>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -90,13 +90,13 @@ Learn more about how the options work in <PlatformLink to="/configuration/sampli
 
 ## Verify
 
-<PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript", "apple", "dart"]} >
+<PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript", "apple", "dart", "rust"]} >
 
 Verify that performance monitoring is working correctly by using our <PlatformLink to="/performance/instrumentation/automatic-instrumentation/">automatic instrumentation</PlatformLink> or by starting and finishing a transaction using <PlatformLink to="/performance/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink>.
 
 </PlatformSection>
 
-<PlatformSection supported={["dotnet", "go", "java", "android", "ruby", "apple", "dart", "flutter", "rust", "native"]} notSupported={["javascript", "react-native", "java.spring", "java.spring-boot"]}>
+<PlatformSection supported={["dotnet", "go", "java", "android", "ruby", "apple", "dart", "flutter", "native"]} notSupported={["javascript", "react-native", "java.spring", "java.spring-boot"]}>
 
 Test out tracing by starting and finishing a transaction, which you _must_ do so transactions can be sent to Sentry. Learn how in our <PlatformLink to="/performance/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink> content.
 

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -38,11 +38,11 @@ To capture transactions customized to your organization's needs, you must first 
 
 <PlatformSection supported={["native"]}>
 
-<Alert level="info" title="Important">
+<Note>
 
 This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
 
-</Alert>
+</Note>
 
 </PlatformSection >
 

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -40,7 +40,7 @@ To capture transactions customized to your organization's needs, you must first 
 
 <Note>
 
-This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+Performance monitoring is still an experimental, work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the repository linked on the right side of this page.
 
 </Note>
 

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -40,7 +40,7 @@ To capture transactions customized to your organization's needs, you must first 
 
 <Alert level="info" title="Important">
 
-This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API is still subject to change in the near future. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
 
 </Alert>
 

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -36,6 +36,16 @@ To capture transactions customized to your organization's needs, you must first 
 
 </Note>
 
+<PlatformSection supported={["native"]}>
+
+<Alert level="info" title="Important">
+
+This is currently an experimental feature. Performance monitoring is still a work-in-progress feature, and its API is still subject to change in the near future. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the appropriate repository.
+
+</Alert>
+
+</PlatformSection >
+
 To instrument certain regions of your code, you can create transactions to capture them.
 
 <PlatformContent includePath="performance/enable-manual-instrumentation" />


### PR DESCRIPTION
Some additional content has been added that is important for users of the native SDK. This explains the rationale behind a decision made during its implementation, and what it means for the end user once they start using the SDK. 

Also forgot to add in an early access/experimental flag at the beginning of the docs as a warning that the API may be unstable.

Also fixed a minor copy-paste error.

A bunch of warnings all over the sampling-related document have been added because the native SDK doesn't implement half of the tools described in it.

handy links to pages changed to see how it Really Looks Like to users:
- https://sentry-docs-git-native-perf-ea.sentry.dev/platforms/native/performance/
- https://sentry-docs-git-native-perf-ea.sentry.dev/platforms/native/configuration/sampling/
- https://sentry-docs-git-native-perf-ea.sentry.dev/platforms/native/performance/instrumentation/custom-instrumentation/