### PR TITLE
docs(ios): Remove force-foreground note

### DIFF
--- a/src/platforms/apple/common/dsym.mdx
+++ b/src/platforms/apple/common/dsym.mdx
@@ -197,8 +197,6 @@ fi
 ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
 ```
 
-If the upload never completes you can try to pass `--force-foreground` to the Sentry CLI command in the build script. This is possibly due to a bug [we are investigating](https://github.com/getsentry/sentry-cli/issues/932).
-
 <Alert level="" title="On Prem">
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:


### PR DESCRIPTION
This is no longer relevant, as we fixed the issue in https://github.com/getsentry/sentry-cli/pull/1104