### PR TITLE
feat(apple): App hangs can lead to false OOMs

### DIFF
--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -4,6 +4,12 @@ sidebar_order: 10
 description: "Learn how to turn off Out Of Memory"
 ---
 
+<Alert level="info" title="Important">
+
+The SDK might falsely report out-of-memory crashes when an app hangs, and the user kills it manually. You can follow [this GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/1645) for more information.
+
+</Alert>
+
 This integration tracks out-of-memory (OOM) crashes based on heuristics. This feature is available for iOS, tvOS, and Mac Catalyst and works only if the application was in the foreground.
 
 When your application uses too much RAM, the operating system kills your app without a normal termination process. Your process doesn't receive a signal or any other type of information to ensure an OOM occurs. As a result, in the Apple SDK, we track out-of-memory crashes during the app start based on heuristics.


### PR DESCRIPTION
Add a warning to the OOM page for Cocoa about falsely reported
OOMs.

Related to https://github.com/getsentry/sentry-cocoa/issues/1645.