### PR TITLE
docs: clarify message filtering

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -230,6 +230,10 @@ If you discover a problematic release causing excessive noise, Sentry supports i
 
 Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] » Project Settings » Inbound Filters**, then add the error message to **Filter errors by error message**.
 
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field towards the bottom.
+
+The Error Message field in a project's inbound filter settings recognizes "*" as a wildcard matcher at the beginning or end of the string.
+
 ### Filter by Issue
 
 <Alert level="info">

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -272,7 +272,7 @@ The 24-hour window ends at the beginning of the current hour, not at the current
 
 This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
 
-For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
+For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 * 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
 
 1. Spike protection becomes "active".
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -230,9 +230,7 @@ If you discover a problematic release causing excessive noise, Sentry supports i
 
 Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] » Project Settings » Inbound Filters**, then add the error message to **Filter errors by error message**.
 
-To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field towards the bottom.
-
-The Error Message field in a project's inbound filter settings recognizes "*" as a wildcard matcher at the beginning or end of the string.
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
 
 ### Filter by Issue
 
@@ -274,7 +272,7 @@ The 24-hour window ends at the beginning of the current hour, not at the current
 
 This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
 
-For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 * 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
+For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
 
 1. Spike protection becomes "active".
 

--- a/src/docs/product/data-management-settings/filtering/index.mdx
+++ b/src/docs/product/data-management-settings/filtering/index.mdx
@@ -49,7 +49,7 @@ Inbound data filters are not case sensitive.
 To use inbound data filters for error messages, keep the following in mind:
 
 - You can provide multiple patterns, one per line. The filter applies if any of the patterns match.
-- On error events, the filter matches the entire error description in the format `{exception.type}: {exception.value}`. We do not recommend matching the full error description including the colon, and suggest you match with wildcards. For example, to match any "ConnectionError", use the filter `*ConnectionError*`.
+- On error events, the filter matches the entire error description in the format `{exception.type}: {exception.value}`. We do not recommend matching the full error description including the colon, and suggest you match with wildcards. For example, to match any "ConnectionError", use the filter `*ConnectionError*`. The wildcard matcher can be used at the beginning or end of the string.
 - On message events, the filter matches the fully formatted message.
 - Transactions are never matched by this filter.
 

--- a/src/docs/product/data-management-settings/filtering/index.mdx
+++ b/src/docs/product/data-management-settings/filtering/index.mdx
@@ -55,8 +55,6 @@ To use inbound data filters for error messages, keep the following in mind:
 
 To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
 
-The "Error Message" field in a project's inbound filter settings recognizes "\*" as a wildcard matcher at the beginning or end of the string.
-
 ### Releases
 
 To filter releases, keep the following in mind:

--- a/src/docs/product/data-management-settings/filtering/index.mdx
+++ b/src/docs/product/data-management-settings/filtering/index.mdx
@@ -53,6 +53,10 @@ To use inbound data filters for error messages, keep the following in mind:
 - On message events, the filter matches the fully formatted message.
 - Transactions are never matched by this filter.
 
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
+
+The "Error Message" field in a project's inbound filter settings recognizes "\*" as a wildcard matcher at the beginning or end of the string.
+
 ### Releases
 
 To filter releases, keep the following in mind:


### PR DESCRIPTION
Add details about which value to set and where to get it from for inbound filtering errors by message.

Unfortunately, there's no clear indication in the docs as to what is the correct value to set for filtering errors by message. It took me 30 minutes to find out why message filtering with the help of this [help center article](https://help.sentry.io/product-features/configuration/why-isn-t-filter-by-error-message-working/). The obvious place for that information would be here IMHO.