### PR TITLE
fix(dashboards): changed a line to better reflect issue widget condition

### DIFF
--- a/src/docs/product/dashboards/widget-library/index.mdx
+++ b/src/docs/product/dashboards/widget-library/index.mdx
@@ -19,7 +19,7 @@ The library includes the following widgets:
 - **LCP by Country**: World map showing the p75 of page load times for each country
 - **Miserable Users**: The total number of unique users who have experienced slow transactions (transaction duration greater than 1200ms)
 - **Slow vs Fast Transactions**: Bar chart comparing the percentage of transactions that are over 300ms (slow) and under 300ms (fast)
-- **Issues For Review**: A table of unresolved issues for review ordered by the most recently seen issues
+- **Issues For Review**: A table of unresolved issues for review, ordered by the most recently seen issues
 - **Top Unhandled Error Types**: The top five most frequently encountered unhandled errors
 - **Users Affected by Errors**: A comparison of the total number of errors and the number of unique users affected by the errors
 

--- a/src/docs/product/dashboards/widget-library/index.mdx
+++ b/src/docs/product/dashboards/widget-library/index.mdx
@@ -19,7 +19,7 @@ The library includes the following widgets:
 - **LCP by Country**: World map showing the p75 of page load times for each country
 - **Miserable Users**: The total number of unique users who have experienced slow transactions (transaction duration greater than 1200ms)
 - **Slow vs Fast Transactions**: Bar chart comparing the percentage of transactions that are over 300ms (slow) and under 300ms (fast)
-- **Issues For Review**: A table of unresolved issues for you or your team to review ordered by the most recently seen issues
+- **Issues For Review**: A table of unresolved issues for review ordered by the most recently seen issues
 - **Top Unhandled Error Types**: The top five most frequently encountered unhandled errors
 - **Users Affected by Errors**: A comparison of the total number of errors and the number of unique users affected by the errors
 


### PR DESCRIPTION
We removed the `assigned_or_suggested:[me, none]` condition in the prebuilt widget. Updating documentation to better reflect this.
https://github.com/getsentry/sentry/pull/31427