### PR TITLE
fix(react native): Add `maxTransactionDuration` to tracing config options

### DIFF
--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -435,6 +435,12 @@ This function can be used to filter out unwanted spans, such as XHR's running he
 
 <PlatformContent includePath="performance/filter-span-example" />
 
+### maxTransactionDuration
+
+The maximum duration of a transaction, measured in seconds, before it will be marked as "deadline_exceeded". If you never want transactions marked that way, set `maxTransactionDuration` to 0.
+
+The default is `600`.
+
 ## Recipes
 
 Currently, by default, the React Native SDK will only create child spans for fetch/XHR transactions out of the box. This means once you are done setting up your routing instrumentation, you will either see just a few fetch/XHR child spans or no children at all. To find out how to customize instrumentation your app, review our <PlatformLink to="/performance/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink>.


### PR DESCRIPTION
We [support the `maxTransactionDuration` option](https://github.com/getsentry/sentry-react-native/blob/4fd13137fe71984d1166c33198076da9db28f158/src/js/tracing/reactnativetracing.ts#L53) in the React Native SDK, but it's missing from the docs.