### PR TITLE
Unity: Added troubleshooting for ReflectionTypeLoadException 

### DIFF
--- a/src/platforms/unity/troubleshooting.mdx
+++ b/src/platforms/unity/troubleshooting.mdx
@@ -33,7 +33,7 @@ If you're still encountering this issue on a version later than 0.7.0, please le
 
 ### Sentry.Unity.Editor.iOS - System.Reflection.ReflectionTypeLoadException
 
-The `Sentry.Unity.Editor.iOS.dll` is responsible for adding native support to your iOS builds. For that it relies on editor functionality that Unity provides in form of their iOS module. If you don't have the iOS module installed and for example `Assembly.GetTypes()` gets called then this leads to a `ReflectionTypeLoadException`. To resolve this you can install the iOS module via the Unity Hub or, if you don't intend to build for iOS, you can [embed](https://docs.unity3d.com/Manual/upm-embed.html) the Sentry SDK package and savely remove the `Sentry.Unity.Editor.iOS.dll`.
+The `Sentry.Unity.Editor.iOS.dll` is responsible for adding native support to your iOS builds. For that, it relies on editor functionality that Unity provides in the form of their iOS module. If you don't have the iOS module installed and, for example, `Assembly.GetTypes()` gets called, this leads to a `ReflectionTypeLoadException`. To resolve this, you can install the iOS module using the Unity Hub or, if you don't intend to build for iOS, you can [embed](https://docs.unity3d.com/Manual/upm-embed.html) the Sentry SDK package and safely remove the `Sentry.Unity.Editor.iOS.dll`.
 
 ## Build Issues
 

--- a/src/platforms/unity/troubleshooting.mdx
+++ b/src/platforms/unity/troubleshooting.mdx
@@ -29,6 +29,12 @@ Unity has resolved this issue on newer releases. Learn more by checking the [Uni
 This issue was resolved in the release 0.7.0 of the Sentry SDK for Unity.
 If you're still encountering this issue on a version later than 0.7.0, please let us know [with an issue report](https://github.com/getsentry/sentry-unity/issues/new?assignees=&labels=&template=BUG_REPORT.md).
 
+## Editor Issues
+
+### Sentry.Unity.Editor.iOS - System.Reflection.ReflectionTypeLoadException
+
+The `Sentry.Unity.Editor.iOS.dll` is responsible for adding native support to your iOS builds. For that it relies on editor functionality that Unity provides in form of their iOS module. If you don't have the iOS module installed and for example `Assembly.GetTypes()` gets called then this leads to a `ReflectionTypeLoadException`. To resolve this you can install the iOS module via the Unity Hub or, if you don't intend to build for iOS, you can [embed](https://docs.unity3d.com/Manual/upm-embed.html) the Sentry SDK package and savely remove the `Sentry.Unity.Editor.iOS.dll`.
+
 ## Build Issues
 
 ### Failed to locate the Sentry package


### PR DESCRIPTION
Added a section to troubleshooting explaining how to deal with `ReflectionTypeLoadException` due to Sentry.Unity.Editor.iOS