### PR TITLE
ASP.NET: Replace global error catcher with new extension:

### DIFF
--- a/src/includes/getting-started-config/dotnet.aspnet.mdx
+++ b/src/includes/getting-started-config/dotnet.aspnet.mdx
@@ -32,13 +32,8 @@ namespace AspNetMvc
         }
 
         // Global error catcher
-        protected void Application_Error()
-        {
-            var exception = Server.GetLastError();
+        protected void Application_Error() => Server.CaptureLastError();
 
-            // Capture unhandled exceptions
-            SentrySdk.CaptureException(exception);
-        }
 
         protected void Application_End()
         {

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -54,11 +54,8 @@ public class MvcApplication : HttpApplication
         });
     }
 
-    protected void Application_Error()
-    {
-        var exception = Server.GetLastError();
-        SentrySdk.CaptureException(exception);
-    }
+    // Global error catcher
+    protected void Application_Error() => Server.CaptureLastError();
 
     protected void Application_BeginRequest()
     {

--- a/src/platforms/dotnet/guides/aspnet/performance/included-instrumentation.mdx
+++ b/src/platforms/dotnet/guides/aspnet/performance/included-instrumentation.mdx
@@ -46,13 +46,7 @@ namespace AspNetMvc
         }
 
         // Global error catcher
-        protected void Application_Error()
-        {
-            var exception = Server.GetLastError();
-
-            // Capture unhandled exceptions
-            SentrySdk.CaptureException(exception);
-        }
+        protected void Application_Error() => Server.CaptureLastError();
 
         protected void Application_End()
         {

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -59,11 +59,7 @@ public class MvcApplication : System.Web.HttpApplication
     }
 
     // Global error catcher
-    protected void Application_Error()
-    {
-        var exception = Server.GetLastError();
-        SentrySdk.CaptureException(exception);
-    }
+    protected void Application_Error() => Server.CaptureLastError();
 
     public override void Dispose()
     {

--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -42,6 +42,7 @@ For example, configuring an ASP.NET app with _global.asax_:
 using System;
 using System.Configuration;
 using Sentry;
+using Sentry.AspNet;
 
 public class MvcApplication : System.Web.HttpApplication
 {

--- a/src/wizard/dotnet/aspnet.md
+++ b/src/wizard/dotnet/aspnet.md
@@ -58,11 +58,8 @@ public class MvcApplication : HttpApplication
         });
     }
 
-    protected void Application_Error()
-    {
-        var exception = Server.GetLastError();
-        SentrySdk.CaptureException(exception);
-    }
+    // Global error catcher
+    protected void Application_Error() => Server.CaptureLastError();
 
     protected void Application_BeginRequest()
     {


### PR DESCRIPTION
This simplifies the error capture for users and also adds the Unhandled tag to the errors.
Closes https://github.com/getsentry/sentry-dotnet/issues/1413