### PR TITLE
.NET 6 Add minimal API description.

### DIFF
--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -138,6 +138,37 @@ let CreateHostBuilder args =
         )
 ```
 
+ASP.NET Core 6.0 With minimal API:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseSentry();
+
+var app = builder.Build();
+
+app.UseSentryTracing();
+```
+
+```fsharp
+open Microsoft.AspNetCore.Builder
+open Microsoft.Extensions.Hosting
+open Microsoft.AspNetCore.Hosting
+
+[<EntryPoint>]
+let main args =
+    let builder = WebApplication.CreateBuilder(args)
+    builder.WebHost.UseSentry() // you'll need to include Microsoft.AspNetCore.Hosting.
+    
+    let app = builder.Build()
+    app.UseSentryTracing()
+
+    app.Run()
+
+    0 // Exit code
+
+```
+
 Some of the settings require actual code. For those, like the `BeforeSend` callback you can simply:
 
 ```csharp

--- a/src/platforms/dotnet/guides/aspnetcore/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/performance/instrumentation/automatic-instrumentation.mdx
@@ -46,7 +46,8 @@ public class Startup
         app.UseRouting();
 
         // Enable automatic tracing integration.
-        // Make sure to put this middleware right after `UseRouting()`.
+        // If running with .NET 5 or below, make sure to put this middleware
+        // right after `UseRouting()`.
         app.UseSentryTracing();
 
         app.UseAuthorization();

--- a/src/wizard/dotnet/aspnetcore.md
+++ b/src/wizard/dotnet/aspnetcore.md
@@ -69,7 +69,8 @@ public class Startup
         app.UseRouting();
 
         // Enable automatic tracing integration.
-        // Make sure to put this middleware right after `UseRouting()`.
+        // If running with .NET 5 or below, make sure to put this middleware
+        // right after `UseRouting()`.
         app.UseSentryTracing();
 
         app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Adds initialization sample for .NET 6 with Minimal API in C# and F#

About the wizard, should we add another wizard for the Minimal API model or stick with the ASP.NET Core one and mention how to set up the Minimal API?

Close https://github.com/getsentry/sentry-dotnet/issues/1453