### PR TITLE
Update traces-sampler-as-filter/javascript.mdx

### DIFF
--- a/src/includes/performance/traces-sampler-as-filter/javascript.mdx
+++ b/src/includes/performance/traces-sampler-as-filter/javascript.mdx
@@ -10,6 +10,6 @@ Sentry.init({
       // Default sample rate for all others (replaces tracesSampleRate)
       return 0.1;
     }
-  };
+  }
 });
 ```


### PR DESCRIPTION
removed a ```;``` from javascript object