### PR TITLE
docs: update Ignore paragraph

### DIFF
--- a/src/docs/product/issues/states-triage/index.mdx
+++ b/src/docs/product/issues/states-triage/index.mdx
@@ -46,6 +46,12 @@ The "Auto Resolve" feature allows you to specify an interval after the last occu
 
 Ignore an issue **permanently** (the default action when you press the button) if it's just noise and you'll likely never care about it. Or ignore it until a condition is met, at which point it becomes Unresolved. You can also ignore an issue if you're working on it and want to silence alerts in the meantime.
 
+<Note>
+  
+Note: Metric Alerts can be triggered by ignored Issues.
+  
+</Note>
+
 ### Mark Reviewed
 
 Mark an issue as reviewed when you want to acknowledge that you've seen the issue but don't want to ignore it; that is, you intend to fix it at some point in the future. Marking an issue reviewed removes the reason label and removes it from the **Review List** in the "For Review" tab. The "Mark Reviewed" action is only available on issues flagged for review.


### PR DESCRIPTION
Currently Metric Alerts can trigger ignored Issues so it would be helpful to add it in the docs in order set the right expectations and avoid unnecessary escalations