### PR TITLE
Unity: Added troubleshooting for unhandled exceptions 

### DIFF
--- a/src/includes/getting-started-verify/unity.mdx
+++ b/src/includes/getting-started-verify/unity.mdx
@@ -12,7 +12,7 @@ public class TestMonoBehaviour : MonoBehaviour
         Debug.LogWarning("Captured Warning");   // Breadcrumb
         Debug.LogError("Captured Error");       // Captured Error
 
-        // This will throw a Null Reference Exception
+        // This will throw an unhandled Null Reference Exception
         testObject.GetComponent<Transform>();   // Captured error
     }
 }

--- a/src/platforms/unity/troubleshooting.mdx
+++ b/src/platforms/unity/troubleshooting.mdx
@@ -57,8 +57,12 @@ This can happen if you've copied some of the SDK files directly to the Assets fo
 
 You can resolve this issue by installing the SDK with UPM.
 
-## Events Not Sent
+## Events
 
-### Universal Windows Platform
+### Unhandled Excpetions - Debug.LogException
+
+Currenty it is not possible for the SDK to distiguish between the user calling `Debug.LogException` and the SDK capturing an unhandled excpetion through the Unity logging integration. To capture an exception as handled you can call `SentrySDK.CaptureException` instead.
+
+### Universal Windows Platform - Events Not Sent
 
 In order to send events to Sentry, you will need to activate the InternetClient Capability in your Player Settings.

--- a/src/platforms/unity/troubleshooting.mdx
+++ b/src/platforms/unity/troubleshooting.mdx
@@ -61,7 +61,7 @@ You can resolve this issue by installing the SDK with UPM.
 
 ### Unhandled Excpetions - Debug.LogException
 
-Currenty it is not possible for the SDK to distiguish between the user calling `Debug.LogException` and the SDK capturing an unhandled excpetion through the Unity logging integration. To capture an exception as handled you can call `SentrySDK.CaptureException` instead.
+Currenty, it is not possible for the SDK to distiguish between the user calling `Debug.LogException` and the SDK capturing an unhandled excpetion through the Unity logging integration. To capture an exception and mark it as handled you can call `SentrySDK.CaptureException` instead.
 
 ### Universal Windows Platform - Events Not Sent
 


### PR DESCRIPTION
Unity logged exceptions are now marked as `unhandled` by default.