### PR TITLE
update discover filter by table columns section

### DIFF
--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -85,11 +85,13 @@ When the "Display" selection is either "Top Period" or "Top Daily", an optional 
 
 When your "Display" selection is either "Total Period", "Previous Period", "Total Daily" or "Bar Chart", you can set up to three y-axes by selecting multiple checkboxes in the "Y-Axis" dropdown.
 
-## Filter by Table Columns
+## Group and Stack With Table Columns {#filter-by-table-columns}
 
-Above the table, click "Columns" to open a modal. This will show you a list of all the columns in the results table. You can add, delete and move basic key field columns or custom tags columns. With the same view, you can also stack events with any of the following functions:
+Above the table, click "Columns" to open the modal that shows you a list of all the columns in the results table. You can add, delete, and move basic key field columns or custom tag columns by which results are grouped.
 
 ### Stacking Functions
+
+You can also add any of the following functions as columns to stack events:
 
 - `avg(...)`
 - `count(...)`
@@ -98,7 +100,7 @@ Above the table, click "Columns" to open a modal. This will show you a list of a
 - `min(...)`
 - `sum(...)`
 
-Each function will ask you to assign a parameter. Some are required while others are optional. Functions will stack events based on the same values. If no functions are applied, the events in your Query Results will remain individually listed. Once you are done editing the columns, click "Apply" and results will be reflected in the Query Results. Keep in mind, the table may horizontall scroll if too many columns are added.
+Each function will ask you to assign a parameter. Some are required while others are optional. Functions will stack events based on the same values. If no functions are applied, the events in your "Query Results" table will remain individually listed. Once you are done editing the columns, click "Apply" and results will be reflected in the query results. Keep in mind, the table may horizontally scroll if many columns are added.
 
 ### Cell Filters
 

--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -85,7 +85,7 @@ When the "Display" selection is either "Top Period" or "Top Daily", an optional 
 
 When your "Display" selection is either "Total Period", "Previous Period", "Total Daily" or "Bar Chart", you can set up to three y-axes by selecting multiple checkboxes in the "Y-Axis" dropdown.
 
-## Group and Stack With Table Columns {#filter-by-table-columns}
+## Group & Stack With Table Columns {#filter-by-table-columns}
 
 Above the table, click "Columns" to open the modal that shows you a list of all the columns in the results table. You can add, delete, and move basic key field columns or custom tag columns by which results are grouped.
 


### PR DESCRIPTION
Updates "Filter by Table Columns" section in Discover docs to more accurate "Group and Stack With Table Columns". The results aren't being further filtered/narrowed, they're being grouped and/or stacked. 
Other minor wording and structural changes to that section.