### PR TITLE
Update tips.mdx to use updated ignoreErrors and denyOptions

### DIFF
--- a/src/docs/clients/javascript/tips.mdx
+++ b/src/docs/clients/javascript/tips.mdx
@@ -24,34 +24,40 @@ Since this accepts a regular expression, that would catch anything \*.example.co
 
 Next, check out the list of [_integrations_](/clients/javascript/integrations/) we provide and see which are applicable to you.
 
-The community has compiled a list of common ignore rules for common things, like Facebook, Chrome extensions, etc. So it’s recommended to at least check these out and see if they apply to you. [Check out the original gist](https://gist.github.com/impressiver/5092952).
+The community has compiled a list of common ignore rules for common things, like Facebook, Chrome extensions, etc. So it’s recommended to at least check these out and see if they apply to you. [Check out the original gist](https://gist.github.com/Chocksy/e9b2cdd4afc2aadc7989762c4b8b495a).
 
 ```javascript
-var ravenOptions = {
+const sentryOptions = {
   ignoreErrors: [
     // Random plugins/extensions
-    "top.GLOBALS",
+    'top.GLOBALS',
     // See: http://blog.errorception.com/2012/03/tale-of-unfindable-js-error.html
-    "originalCreateNotification",
-    "canvas.contentDocument",
-    "MyApp_RemoveAllHighlights",
-    "http://tt.epicplay.com",
-    "Can't find variable: ZiteReader",
-    "jigsaw is not defined",
-    "ComboSearch is not defined",
-    "http://loading.retry.widdit.com/",
-    "atomicFindClose",
+    'originalCreateNotification',
+    'canvas.contentDocument',
+    'MyApp_RemoveAllHighlights',
+    'http://tt.epicplay.com',
+    'Can\'t find variable: ZiteReader',
+    'jigsaw is not defined',
+    'ComboSearch is not defined',
+    'http://loading.retry.widdit.com/',
+    'atomicFindClose',
     // Facebook borked
-    "fb_xd_fragment",
-    // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to
-    // reduce this. (thanks @acdha)
-    // See http://stackoverflow.com/questions/4113268
-    "bmi_SafeAddOnload",
-    "EBCallBackMessageReceived",
+    'fb_xd_fragment',
+    // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to reduce this. (thanks @acdha)
+    // See http://stackoverflow.com/questions/4113268/how-to-stop-javascript-injection-from-vodafone-proxy
+    'bmi_SafeAddOnload',
+    'EBCallBackMessageReceived',
     // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
-    "conduitPage",
+    'conduitPage',
+    // Generic error code from errors outside the security sandbox
+    // You can delete this if using raven.js > 1.0, which ignores these automatically.
+    'Script error.',
+    // Avast extension error
+    "_avast_submit"
   ],
-  ignoreUrls: [
+  denyUrls: [
+    // Google Adsense
+    /pagead\/js/i,
     // Facebook flakiness
     /graph\.facebook\.com/i,
     // Facebook blocked
@@ -63,10 +69,10 @@ var ravenOptions = {
     /extensions\//i,
     /^chrome:\/\//i,
     // Other plugins
-    /127\.0\.0\.1:4001\/isrunning/i, // Cacaoweb
+    /127\.0\.0\.1:4001\/isrunning/i,  // Cacaoweb
     /webappstoolbarba\.texthelp\.com\//i,
-    /metrics\.itunes\.apple\.com\.edgesuite\.net\//i,
-  ],
+    /metrics\.itunes\.apple\.com\.edgesuite\.net\//i
+  ]
 };
 ```
 


### PR DESCRIPTION
Update tips.mdx to use updated `ignoreErrors` and `denyUrls`, also update gist link to a version that is compatible. If you try to use the code given here, it will error in typescript, or simply do nothing as far as URLs go in javascript, since the `ignoreUrls` option was renamed to `denyUrls`