### PR TITLE
remove advanced search plan note

### DIFF
--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -10,9 +10,9 @@ description: "Learn more about Search, which is available in several Sentry feat
 
 Search is available on several features throughout [sentry.io](https://sentry.io) such as **Issues** and **Discover**.
 
-<Alert title="Looking for information on searching and Discover?" level="info">
+<Alert title="Looking for information on searching and Discover?">
 
-**Discover** is Sentry's powerful query builder for aggregating raw event data and has its own unique syntax not covered here. For more information, see [full Discover documentation](/product/discover-queries/).
+**Discover** is Sentry's powerful query builder for aggregating raw event data and has its own unique search syntax not covered here. Learn more in the [full Discover documentation](/product/discover-queries/).
 
 </Alert>
 
@@ -85,11 +85,7 @@ tags[project_id]:tag_value
 
 ### Advanced
 
-<Alert title="Note" level="info">
-
-Advanced search is available for organizations on the Developer, Team, and Business plans.
-
-</Alert>
+Sentry also offers the following advanced search options:
 
 #### Exclusion
 


### PR DESCRIPTION
Removes note indicating that advanced search is plan gated.
Fixes styling of another note.