### PR TITLE
chore(docs): UI Component page typos

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -52,7 +52,7 @@ The Issue Link component displays "Link &lt;Service&gt; Issue" in the Issue side
 
 - uri - (Required) The URI to request when the User submits the Link/Create Issue form.
 - required_fields - (Required) List of `FormField` components the User is required to complete.
-- optional*fields - List of optional `Form Field` components the User \_may* complete.
+- optional_fields - List of optional `Form Field` components the User may complete.
 
 A `FormField` can be one of three types (which behave like their HTML equivalents) — `Select`, `Text`, and `TextArea,` described below.
 

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -247,8 +247,8 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 The Alert Rule Action component allows the developer to get parameters to define routing or configuration in alert rules for their service. When alert rules are triggered for a user, the configured service will receive [Issue Alert](/product/integrations/integration-platform/webhooks/#issue-alerts) and [Metric Alert](/product/integrations/integration-platform/webhooks/#metric-alerts) webhook events with the specified settings for that service to further route the alert.
 
-
 ### Schema
+
 ```javascript
  {
     "type": "alert-rule-action",
@@ -264,13 +264,15 @@ The Alert Rule Action component allows the developer to get parameters to define
 ```
 
 ### Attributes
+
 - `title` - (Required) The title shown in the UI component.
 - `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form. If the services fails to process the request (status code >= 400), this component will bubble up the error to the User with the provided response text.
 - `required_fields` - (Required) List of `FormField` components the User is required to complete.
-- `optional fields` - List of optional `Form Field` components the User may complete.
+- `optional_fields` - List of optional `Form Field` components the User may complete.
 - `description` - Optional text that will be displayed above the form. Limited to 140 characters.
 
 ### Example
+
 ```javascript
 
 "elements": [
@@ -292,6 +294,7 @@ The Alert Rule Action component allows the developer to get parameters to define
 ]
 
 ```
+
 # Create/Link Issue
 
 If you have a UI component for issue linking and a user attempts to create or link an issue, it will send a request to your service based on the `uri` you provide.


### PR DESCRIPTION
Small typo correction with underscores and italics.

Fixes: 

<img width="638" alt="image" src="https://user-images.githubusercontent.com/35509934/152248128-170f22c6-93f8-423d-839a-bdcb8df8a3ec.png">


<img width="298" alt="image" src="https://user-images.githubusercontent.com/35509934/152248067-6a969902-a843-4b10-bcca-c0e05b46dd16.png">
