### PR TITLE
escape asterisk on integrations page

### DIFF
--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -61,7 +61,8 @@ For more details, see the [full Integration Platform documentation](/product/int
 | [Shortcut](/product/integrations/project-mgmt/shortcut/)                    | X                      |            |
 | [Teamwork](/product/integrations/project-mgmt/teamwork/)                      | X                      |            |
 | Trello                                                           | X                      |            |
-* Jira Server not supported
+
+\* Jira Server not supported
 
 ## Deployment
 


### PR DESCRIPTION
Asterisk escaped so it is not rendered as a bullet list.