### PR TITLE
fix: Mention the minimum symbol server download speed

### DIFF
--- a/src/platforms/common/data-management/debug-files/symbol-servers.mdx
+++ b/src/platforms/common/data-management/debug-files/symbol-servers.mdx
@@ -54,7 +54,9 @@ repositories:
 
 - **HTTP Symbol Server**: An HTTP server that serves debug files at a
   configurable path. Lookups in the server should generally be case-insensitive,
-  although an explicit casing can be configured in the settings.
+  although an explicit casing can be configured in the settings.  Note
+  that sentry requires a minimum download speed of 4Mb/s to fetch DIFs
+  from custom HTTP symbol servers.
 
 - **Amazon S3 Bucket**: Either an entire S3 bucket or a subdirectory. This
   requires `s3:GetObject`, and optionally `s3:ListBucket` permissions for the


### PR DESCRIPTION
For custom symbols servers we have a minimum download speed in order
to protect our own infrastructure.  Document this publicly.