### PR TITLE
feat(browser): Add section for capturing resource 404s

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: "Troubleshoot and resolve edge cases."
-keywords: ["adblocker", "blocked", "tunnel", "non-Error exception"]
+keywords: ["adblocker", "blocked", "tunnel", "non-Error exception", "404"]
 excerpt: ""
 notSupported: ["javascript.capacitor"]
 sidebar_order: 1000
@@ -375,3 +375,31 @@ If you’re seeing errors with the message “Non-Error exception (or promise re
 You can see the contents of the non-Error object in question in the `__serialized__` entry of the “Additional Data” section.
 
 To get better insight into these error events, we recommend finding where the plain object is being passed or thrown to Sentry based on the contents of the `__serialized__` data, and then turning the plain object into an Error object.
+
+## Capturing Resource 404s
+
+By default, Sentry does not capture errors when a resource (like an image or a css file) fails to load. If you would like it to do so, you can use the following code. (Note: We recommend loading Sentry as early as possible in any case, but this method in particular will only work if Sentry is loaded before other resources.)
+
+```javascript
+document.body.addEventListener(
+  "error",
+  event => {
+    if (!event.target) return;
+
+    if (event.target.tagName === "IMG") {
+      Sentry.captureMessage(
+        `Failed to load image: ${event.target.src}`,
+        Sentry.Severity.Warning
+      );
+    } else if (event.target.tagName === "LINK") {
+      Sentry.captureMessage(
+        `Failed to load css: ${event.target.href}`,
+        Sentry.Severity.Warning
+      );
+    }
+  },
+  true // useCapture - necessary for resource loading errors
+);
+```
+
+Don't forget the `true` at the end, passed as a second parameter to `addEventListener()`. Without it, the event handler won't be called, since it's being added to the event target's ancestor rather than the event target itself, and unlike JavaScript runtime errors, `error` events resulting from load failures don't bubble, and therefore must be captured during the `capture` phase. For more information, see [the W3C spec](https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/events.html#Events-phases).

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -402,4 +402,4 @@ document.body.addEventListener(
 );
 ```
 
-Don't forget the `true` at the end, passed as a second parameter to `addEventListener()`. Without it, the event handler won't be called, since it's being added to the event target's ancestor rather than the event target itself, and unlike JavaScript runtime errors, `error` events resulting from load failures don't bubble, and therefore must be captured during the `capture` phase. For more information, see [the W3C spec](https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/events.html#Events-phases).
+Remember to pass in `true` as the second parameter to `addEventListener()`. Without it, the event handler won't be called, since it's being added to the event target's ancestor rather than the event target itself, and unlike JavaScript runtime errors, `error` events resulting from load failures don't bubble, and therefore must be captured during the `capture` phase. For more information, see [the W3C spec](https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/events.html#Events-phases).


### PR DESCRIPTION
From time to time we get asked how to capture an error when a static resource fails to load. This moves a solution provided in a GitHub comment into the docs, so that it's easier to find.

Fixes https://github.com/getsentry/sentry-javascript/issues/4499
Fixes https://github.com/getsentry/sentry-javascript/issues/3382