### PR TITLE
chore(android): Mention that Timber.tag is not supported

### DIFF
--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -13,6 +13,12 @@ The `sentry-android-timber` library provides [Timber](https://github.com/JakeWha
 
 The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-android-timber/src/main/java/io/sentry/android/timber).
 
+<Note>
+
+Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK. Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.
+
+</Note>
+
 ## Install
 
 To add the Timber integration, [manually initialize](/platforms/android/configuration/manual-init/) the Android SDK, then add the `sentry-android-timber` dependency. Using Gradle:

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -6,7 +6,7 @@ redirect_from:
 description: "Migrating between versions of Sentry's SDK for Android."
 ---
 
-## Migrating to `io.sentry:sentry-android 5.6.2`
+## Migrating to `io.sentry:sentry-android-timber 5.6.2`
 
 Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK (the tag will not be captured and reflected on Sentry). Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -6,6 +6,10 @@ redirect_from:
 description: "Migrating between versions of Sentry's SDK for Android."
 ---
 
+## Migrating to `io.sentry:sentry-android 5.6.2`
+
+Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK (the tag will not be captured and reflected on Sentry). Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.
+
 ## Migrating from `io.sentry:sentry-android-gradle-plugin 2.x` to `io.sentry:sentry-android-gradle-plugin 3.0.0`
 
 The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0.0](https://developer.android.com/studio/releases/gradle-plugin#7-0-0).


### PR DESCRIPTION
Merge after this is shipped https://github.com/getsentry/sentry-java/pull/1898