### PR TITLE
Correct link to spike.sh page

### DIFF
--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -30,7 +30,7 @@ For more details, see the [full Integration Platform documentation](/product/int
 | [PagerDuty](/product/integrations/notification-incidents/pagerduty/)     | X            | X             |                |
 | Pushover                                          | X            |               |                |
 | [Slack](/product/integrations/notification-incidents/slack/)             | X            | X             | X              |
-| [Spike.sh](/product/integrations/notification-incidents/slack/)          | X             | X              |                |
+| [Spike.sh](/product/integrations/notification-incidents/spikesh/)        | X             | X              |                |
 | Twilio                                            | X            |               |                |
 | VictorOps                                         | X            |               |                |
 


### PR DESCRIPTION
Corrected the destination for the link for ```spike.sh```.