### PR TITLE
chore(android): Update SAGP versions and re-add deprecated flag

### DIFF
--- a/src/platforms/android/common/gradle.mdx
+++ b/src/platforms/android/common/gradle.mdx
@@ -51,17 +51,26 @@ We expose the following configuration values directly in your `app/build.gradle`
 import io.sentry.android.gradle.InstrumentationFeature
 
 sentry {
+    // Enables or disables the automatic upload of mapping files
+    // during a build. If you disable this, you'll need to manually
+    // upload the mapping files with sentry-cli when you do a release.
+    // Default is enabled.
+    // Deprecated in v3.0.0 and above
+    autoUpload = true
+    
     // Disables or enables the handling of Proguard mapping for Sentry.
     // If enabled the plugin will generate a UUID and will take care of
     // uploading the mapping to Sentry. If disabled, all the logic
     // related to proguard mapping will be excluded.
     // Default is enabled.
+    // Only available v3.0.0 and above.    
     includeProguardMapping = true
 
     // Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
     // If disabled the plugin will run a dry-run and just generate a UUID.
     // The mapping file has to be uploaded manually via sentry-cli in this case.
     // Default is enabled.
+    // Only available v3.0.0 and above.    
     autoUploadProguardMapping = true
 
     // Disables or enables the automatic configuration of Native Symbols
@@ -94,17 +103,26 @@ sentry {
 import io.sentry.android.gradle.InstrumentationFeature
 
 sentry {
+    // Enables or disables the automatic upload of mapping files
+    // during a build. If you disable this, you'll need to manually
+    // upload the mapping files with sentry-cli when you do a release.
+    // Default is enabled.
+    // Deprecated in v3.0.0 and above
+    autoUpload.set(true)
+    
     // Disables or enables the handling of Proguard mapping for Sentry.
     // If enabled the plugin will generate a UUID and will take care of
     // uploading the mapping to Sentry. If disabled, all the logic
     // related to proguard mapping will be excluded.
     // Default is enabled.
+    // Only available v3.0.0 and above.       
     includeProguardMapping.set(true)
     
     // Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
     // If disabled the plugin will run a dry-run and just generate a UUID.
     // The mapping file has to be uploaded manually via sentry-cli in this case.
     // Default is enabled.
+    // Only available v3.0.0 and above.       
     autoUploadProguardMapping.set(true)
 
     // Disables or enables the automatic configuration of Native Symbols

--- a/src/platforms/android/configuration/integrations/file-io.mdx
+++ b/src/platforms/android/configuration/integrations/file-io.mdx
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.android.gradle" version "3.0.0-beta.3"
+  id "io.sentry.android.gradle" version "3.0.0-beta.4"
 }
 
 dependencies {
@@ -46,7 +46,7 @@ buildscript {
 }
 
 plugins {
-  id("io.sentry.android.gradle") version "3.0.0-beta.3"
+  id("io.sentry.android.gradle") version "3.0.0-beta.4"
 }
 
 dependencies {

--- a/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
+++ b/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.android.gradle" version "3.0.0-beta.3"
+  id "io.sentry.android.gradle" version "3.0.0-beta.4"
 }
 
 dependencies {
@@ -46,7 +46,7 @@ buildscript {
 }
 
 plugins {
-  id("io.sentry.android.gradle") version "3.0.0-beta.3"
+  id("io.sentry.android.gradle") version "3.0.0-beta.4"
 }
 
 dependencies {

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -118,7 +118,7 @@ Check out [the documentation](https://docs.sentry.io/platforms/android/performan
 
 > Want to play with some new features? Try out our beta [Room](https://docs.sentry.io/platforms/android/configuration/integrations/room-and-sqlite/) and [file I/O](https://docs.sentry.io/platforms/android/configuration/integrations/file-io/) performance integrations.
 >  
-> This feature is available in the Beta release of the [Sentry Android Gradle plugin](https://docs.sentry.io/platforms/android/gradle); you must use version `3.0.0-beta.3`. The `tracingInstrumentation` option is enabled by default, so Sentry automatically measures the performance of the database queries done with Room as well as file I/O operations if you set a tracing sample rate. Features in Beta are still a work-in-progress and may have bugs. We recognize the irony.
+> This feature is available in the Beta release of the [Sentry Android Gradle plugin](https://docs.sentry.io/platforms/android/gradle); you must use version `3.0.0-beta.4`. The `tracingInstrumentation` option is enabled by default, so Sentry automatically measures the performance of the database queries done with Room as well as file I/O operations if you set a tracing sample rate. Features in Beta are still a work-in-progress and may have bugs. We recognize the irony.
 >
 > Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-android-gradle-plugin/issues).
 


### PR DESCRIPTION
* Update to the latest beta
* I removed the deprecated flag a bit too early, as the `3.0.0` is still not GA'd, so had to revert it back