### PR TITLE
Fix integrations example

### DIFF
--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -43,7 +43,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // this assumes your build process sets "npm_package_version" in the env
   release: "my-project-name@" + process.env.npm_package_version,
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [new Sentry.Integrations.BrowserTracing()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control


### PR DESCRIPTION
The example used (call to `new Sentry.BrowserTracing()`) gave errors in the browser. The correct code seems to be `new Sentry.Integrations.BrowserTracing()`.