### PR TITLE
Fix missing highlight of the Sentry wizard section for RN

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -32,7 +32,7 @@ Link the SDK to your native projects to enable native crash reporting.
 react-native link @sentry/react-native
 ```
 
-### Execute the Sentry Wizard.
+### Run the Sentry Wizard.
 
 ```bash
 npx @sentry/wizard -i reactNative -p ios android


### PR DESCRIPTION
https://forum.sentry.io/t/sentry-wizard-in-react-native-0-60-x/16013