### PR TITLE
docs(cli): Add build checksums table for CLI executables

### DIFF
--- a/src/components/cliChecksumTable.tsx
+++ b/src/components/cliChecksumTable.tsx
@@ -3,8 +3,8 @@ import { graphql, useStaticQuery } from "gatsby";
 import styled from "@emotion/styled";
 
 const query = graphql`
-  query JsBundleList {
-    package(id: { eq: "sentry.javascript.browser" }) {
+  query CliExecutableChecksums {
+    app(id: { eq: "sentry-cli" }) {
       files {
         name
         checksums {
@@ -25,7 +25,7 @@ const ChecksumValue = styled.code`
 
 export default (): JSX.Element => {
   const {
-    package: { files },
+    app: { files },
   } = useStaticQuery(query);
 
   return (
@@ -38,7 +38,7 @@ export default (): JSX.Element => {
       </thead>
       <tbody>
         {files
-          .filter(file => file.name.endsWith(".js"))
+          .filter(file => !file.name.endsWith(".tgz"))
           .map(file => (
             <tr key={file.name}>
               <td
@@ -53,7 +53,7 @@ export default (): JSX.Element => {
               <td style={{ verticalAlign: "middle" }}>
                 <ChecksumValue>
                   {`sha384-${
-                    file.checksums.find(c => c.name === "sha384-base64").value
+                    file.checksums.find(c => c.name === "sha256-hex").value
                   }`}
                 </ChecksumValue>
               </td>

--- a/src/components/cliChecksumTable.tsx
+++ b/src/components/cliChecksumTable.tsx
@@ -17,10 +17,8 @@ const query = graphql`
 `;
 
 const ChecksumValue = styled.code`
-  font-size: 0.8em;
+  font-size: 0.75em;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
 export default (): JSX.Element => {
@@ -50,7 +48,7 @@ export default (): JSX.Element => {
               >
                 {file.name}
               </td>
-              <td style={{ verticalAlign: "middle" }}>
+              <td style={{ verticalAlign: "middle", width: "100%" }}>
                 <ChecksumValue>
                   {`sha384-${
                     file.checksums.find(c => c.name === "sha256-hex").value

--- a/src/components/jsBundleList.tsx
+++ b/src/components/jsBundleList.tsx
@@ -17,10 +17,8 @@ const query = graphql`
 `;
 
 const ChecksumValue = styled.code`
-  font-size: 0.8em;
+  font-size: 0.75em;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
 export default (): JSX.Element => {
@@ -50,7 +48,7 @@ export default (): JSX.Element => {
               >
                 {file.name}
               </td>
-              <td style={{ verticalAlign: "middle" }}>
+              <td style={{ verticalAlign: "middle", width: "100%" }}>
                 <ChecksumValue>
                   {`sha384-${
                     file.checksums.find(c => c.name === "sha384-base64").value

--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -4,6 +4,8 @@ sidebar_order: 0
 description: "Learn about the different methods available to install `sentry-cli`."
 ---
 
+import CliChecksumTable from "~src/components/cliChecksumTable";
+
 Depending on your platform, there are different methods available to install `sentry-cli`.
 
 ## Manual Download
@@ -100,3 +102,7 @@ docker run --rm -v $(pwd):/work getsentry/sentry-cli --help
 ## Updating and Uninstalling
 
 You can use `sentry-cli update` and `sentry-cli uninstall` to update or uninstall the `sentry-cli` binary. These commands may be unavailable in certain situations, generally when `sentry-cli` has been installed by a tool like homebrew or yarn, either directly or as a dependency of another package. In those cases, the same tool will need to be used for updating and removal. If you find that `sentry-cli update` and `sentry-cli uninstall` aren't working and you don't know how the package was installed, running `which sentry-cli` will often provide a clue as to which tool to use.
+
+## Build Checksums
+
+<CliChecksumTable />

--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -105,4 +105,8 @@ You can use `sentry-cli update` and `sentry-cli uninstall` to update or uninstal
 
 ## Build Checksums
 
+When downloading an executable from a remote server, it's often a good practice to verify, that what has been downloaded, is in fact what we expect it to be. To make sure that this is the case, we can use checksum validation. A checksum is the value calculated from the contents of a file, in a form of hash, in our case SHA256, and it acts as the data integrity check, as it's always producing the same output, for a given input.
+
+Below is the table of SHA256 checksums for all available build targets that our CLI supports. To calculate the hash of a downloaded file, you can use `sha256sum` utility, which is preinstalled in OSX and most Linux distributions.
+
 <CliChecksumTable />

--- a/src/gatsby/createSchemaCustomization/appSchema.ts
+++ b/src/gatsby/createSchemaCustomization/appSchema.ts
@@ -1,0 +1,25 @@
+export const getAppTypeDefs = () => {
+  return [
+    `
+      type AppFileChecksum {
+        name: String!
+        value: String!
+      }
+
+      type AppFile {
+        name: String!
+        checksums: [AppFileChecksum!]
+      }
+
+      type App implements Node {
+        key: String!
+        name: String!
+        canonical: String!
+        url: String
+        repoUrl: String!
+        version: String!
+        files: [AppFile!]
+      }
+      `,
+  ];
+};

--- a/src/gatsby/createSchemaCustomization/index.ts
+++ b/src/gatsby/createSchemaCustomization/index.ts
@@ -1,6 +1,7 @@
 import { getApiTypeDefs } from "./apiSchema";
 import { getPlatformTypeDefs } from "./platformSchema";
 import { getPackageTypeDefs } from "./packageSchema";
+import { getAppTypeDefs } from "./appSchema";
 
 // TODO(dcramer): move frontmatter out of ApiEndpoint and into Frontmatter
 export default ({ actions, schema }) => {
@@ -109,5 +110,6 @@ export default ({ actions, schema }) => {
     ...getApiTypeDefs(),
     ...getPlatformTypeDefs(),
     ...getPackageTypeDefs(),
+    ...getAppTypeDefs(),
   ]);
 };

--- a/src/gatsby/sourceNodes/appRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/appRegistryNodes.ts
@@ -1,0 +1,57 @@
+import AppRegistry from "../utils/appRegistry";
+
+export const sourceAppRegistryNodes = async ({
+  actions,
+  createContentDigest,
+}) => {
+  const { createNode } = actions;
+
+  const registry = new AppRegistry();
+  const allApps = await registry.getList();
+
+  Object.keys(allApps).forEach(async appName => {
+    const sdkData = (await registry.getData(appName)) as any;
+
+    const data = {
+      canonical: sdkData.canonical,
+      name: sdkData.name,
+      version: sdkData.version,
+      url: sdkData.package_url,
+      repoUrl: sdkData.repo_url,
+      files: sdkData.files
+        ? Object.entries(sdkData.files).map(
+            ([fileName, fileData]: [string, any]) =>
+              fileData.checksums
+                ? {
+                    name: fileName,
+                    checksums: Object.entries(fileData.checksums).map(
+                      ([key, value]) => ({
+                        name: key,
+                        value: value,
+                      })
+                    ),
+                  }
+                : {}
+          )
+        : [],
+    };
+
+    const content = JSON.stringify(data);
+    const nodeMeta = {
+      id: appName,
+      parent: null,
+      children: [],
+      internal: {
+        type: `App`,
+        // mediaType: `text/html`,
+        content,
+        contentDigest: createContentDigest(data),
+      },
+    };
+
+    createNode({
+      ...data,
+      ...nodeMeta,
+    });
+  });
+};

--- a/src/gatsby/sourceNodes/index.ts
+++ b/src/gatsby/sourceNodes/index.ts
@@ -1,5 +1,6 @@
 import { sourcePlatformNodes } from "./platformNodes";
 import { sourcePackageRegistryNodes } from "./packageRegistryNodes";
+import { sourceAppRegistryNodes } from "./appRegistryNodes";
 import { sourceAwsLambdaLayerRegistryNodes } from "./awsLambdLayerRegistryNodes";
 import { relayMetricsNodes } from "./relayMetricsNodes";
 
@@ -8,6 +9,7 @@ export default async params => {
     relayMetricsNodes(params),
     sourcePlatformNodes(params),
     sourcePackageRegistryNodes(params),
+    sourceAppRegistryNodes(params),
     sourceAwsLambdaLayerRegistryNodes(params),
   ]);
 };

--- a/src/gatsby/utils/appRegistry.ts
+++ b/src/gatsby/utils/appRegistry.ts
@@ -33,7 +33,6 @@ export default class AppRegistry {
         const result = await axios({
           url: `${BASE_REGISTRY_URL}/apps`,
         });
-        console.log(result.data);
         this.indexCache = result.data;
       } catch (err) {
         console.error(`Unable to fetch index for app registry: ${err.message}`);

--- a/src/gatsby/utils/appRegistry.ts
+++ b/src/gatsby/utils/appRegistry.ts
@@ -1,0 +1,61 @@
+import axios from "axios";
+
+import { BASE_REGISTRY_URL } from "./shared";
+
+type FileData = {
+  checksums: {
+    [name: string]: string;
+  };
+};
+
+type VersionData = {
+  canonical: string;
+  files?: {
+    [name: string]: FileData;
+  };
+  main_docs_url: string;
+  name: string;
+  package_url?: string;
+  repo_url: string;
+  version: string;
+};
+
+export default class AppRegistry {
+  indexCache: { [name: string]: VersionData } | null;
+
+  constructor() {
+    this.indexCache = null;
+  }
+
+  getList = async () => {
+    if (!this.indexCache) {
+      try {
+        const result = await axios({
+          url: `${BASE_REGISTRY_URL}/apps`,
+        });
+        console.log(result.data);
+        this.indexCache = result.data;
+      } catch (err) {
+        console.error(`Unable to fetch index for app registry: ${err.message}`);
+        this.indexCache = {};
+      }
+    }
+    return this.indexCache;
+  };
+
+  getData = async (name: string) => {
+    await this.getList();
+    return this.indexCache[name];
+  };
+
+  version = async (name: string, defaultValue: string = "") => {
+    const data = (await this.getData(name)) as VersionData;
+    return (data && data.version) || defaultValue;
+  };
+
+  checksum = async (name: string, fileName: string, checksum: string) => {
+    const data = (await this.getData(name)) as VersionData;
+    if (!data.files) return "";
+    return data.files[fileName].checksums[checksum] || "";
+  };
+}


### PR DESCRIPTION
Query our release registry and display checksums for all available sentry-cli builds.

![image](https://user-images.githubusercontent.com/1523305/154319995-0dadcd39-b835-40bc-960a-d0f8e37f33ac.png)
