### PR TITLE
fix(nextjs) Clarify that hideSourceMaps requires the webpack plugin to be enabled

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -230,7 +230,7 @@ const moduleExports = {
 };
 ```
 
-Note that this only applies to client-side builds.
+Note that this only applies to client-side builds, and requires the `SentryWebpackPlugin` to be enabled.
 
 ## Configure `sentry-cli`
 


### PR DESCRIPTION
In order to use `hideSourceMaps`, the sentry webpack plugin [must be enabled](https://github.com/getsentry/sentry-javascript/blob/fa992bdea7589526ab1e321d340bda63be3ac350/packages/nextjs/src/config/webpack.ts#L77-L91).

Since this section in the docs is underneath the section on disabling the webpack plugin, I was confused about whether this flag required the webpack plugin to be enabled or not. Furthermore, passing `hideSourceMaps: true` with the webpack plugin disabled appears to not do anything or show any warnings.