### PR TITLE
replace text with PlatformIdentifier 

### DIFF
--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -17,9 +17,9 @@ These are some great examples for data scrubbing that every company should think
 
 We offer the following options depending on your legal and operational needs:
 
-- filtering or scrubbing sensitive data within the SDK, so that data is *not sent to* Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
-- [configuring server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/) to ensure Sentry does *not store* data. Configuration changes are done in the Sentry UI and apply immediately for new events.
-- [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is *not sent to* Sentry while configuration can still be applied without deploying.
+- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- [configuring server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
+- [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
 <Note>
 
@@ -85,7 +85,7 @@ Doing this will ensure you still benefit from user-impact related features.
 As a best practice you should always avoid logging confidential information. If you have legacy systems you need to work around, consider the following:
 
 - Anonymize the confidential information within the log statements (for example, swap out email addresses -> for internal identifiers)
-- Use `beforeBreadcrumb` to filter it out from breadcrumbs before it is attached
+- Use <PlatformIdentifier name="before-breadcrumb" /> to filter it out from breadcrumbs before it is attached
 - Disable logging breadcrumb integration (for example, as described [here](/platforms/javascript/configuration/integrations/default/#breadcrumbs))
 
 </PlatformSection>

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -50,7 +50,7 @@ The available breadcrumb keys are `type`, `category`, `message`, `level`, `times
 
 ## Customize Breadcrumbs
 
-SDKs allow you to customize breadcrumbs through the `before_breadcrumb` hook.
+SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook.
 
 <PlatformSection supported={["javascript", "node"]}>
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -12,13 +12,13 @@ notSupported:
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. You can collect feedback according to the method supported by the SDK.
 
-<PlatformSection supported={["java", "apple", "android", "dart", "flutter"]} >
+<PlatformSection supported={["python", "java", "apple", "android", "dart", "flutter"]} >
 
 ## User Feedback API
 
 The user feedback API provides the ability to collect user information when an event occurs. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. To get the `eventId`, for example, you can use the <PlatformLink to="/configuration/options/#before-send">beforeSend</PlatformLink> or the return value of the methods capturing an event.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. To get the `eventId`, for example, you can use the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>, or the return value of the methods capturing an event.
 
 <PlatformContent includePath="enriching-events/user-feedback/sdk-api-example" />
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -12,7 +12,7 @@ notSupported:
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. You can collect feedback according to the method supported by the SDK.
 
-<PlatformSection supported={["python", "java", "apple", "android", "dart", "flutter"]} >
+<PlatformSection supported={["java", "apple", "android", "dart", "flutter"]} >
 
 ## User Feedback API
 


### PR DESCRIPTION
Replaced remaining text with PlatformIdentifier for before-send, before-breadcrumb
Mostly fixed on [PR 4422](https://github.com/getsentry/sentry-docs/pull/4422)