### PR TITLE
feat(relay): Document outcomes endpoint for request routing [INGEST-973]

### DIFF
--- a/src/docs/product/relay/operating-guidelines.mdx
+++ b/src/docs/product/relay/operating-guidelines.mdx
@@ -169,6 +169,7 @@ Proxies often set a default maximum body size for requests. Especially native cr
 Internally, Relay makes requests to the configured upstream to forward data and retrieve project configuration. We **highly recommend against** constraining these requests. At present, Relay makes requests to the following endpoints for basic operation:
 
 - All of the above endpoints
+- `/api/0/relays/outcomes/`
 - `/api/0/relays/projectconfigs/`
 - `/api/0/relays/publickeys/`
 - `/api/0/relays/register/challenge/`


### PR DESCRIPTION
Since Relay version 21.12.0 (https://github.com/getsentry/relay/pull/1119),
managed untrusted Relays ("customer Relays") send outcomes to a public endpoint.
This PR adds this endpoint to the operating guidelines.

cc @jjbayer
