### PR TITLE
Add documentation about auto session tracking in Ruby

### DIFF
--- a/src/includes/configuration/auto-session-tracking/ruby.mdx
+++ b/src/includes/configuration/auto-session-tracking/ruby.mdx
@@ -1,0 +1,14 @@
+We create a session for every request and response cycle, and mark the session as:
+
+- `crashed` if an _unhandled error_ is raised.
+- `an error` if the SDK captures an event that contains an exception (this includes manually captured errors).
+
+Currently, web socket connections don't create sessions.
+
+By default, the Ruby SDK sends sessions. To disable sending sessions, set the `auto_session_tracking` flag to `False`:
+
+```ruby
+Sentry.init do |config|
+  config.auto_session_tracking = false
+end
+```

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -65,7 +65,7 @@ If you don't tell Sentry about a new release, Sentry will automatically create a
 
 After configuring your SDK, you can install a repository integration or manually supply Sentry with your own commit metadata. Read our documentation about [setting up releases](/product/releases/setup/) for further information about integrations, associating commits, and telling Sentry when deploying releases.
 
-<PlatformSection supported={["apple", "android", "javascript", "flutter", "native", "rust", "python", "react-native", "dotnet", "unity"]}>
+<PlatformSection supported={["apple", "android", "javascript", "flutter", "native", "rust", "python", "ruby", "react-native", "dotnet", "unity"]}>
 
 ## Release Health
 


### PR DESCRIPTION
Description about auto session tracking in Ruby. This feature is currently implemented in the Ruby SDK and will be released in about a week.