### PR TITLE
fix: Encourage paramaterization in react router integration docs

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -19,7 +19,7 @@ We support integrations for React Router 3, 4 and 5.
 
 ## React Router v4/v5
 
-The react router instrumentation uses the react router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
+The React router instrumentation uses the React router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
 ### Parameterized transaction names
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -19,44 +19,7 @@ We support integrations for React Router 3, 4 and 5.
 
 ## React Router v4/v5
 
-To use the router integration, import and set a custom routing instrumentation using a custom history. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
-
-```javascript
-import { Router } from 'react-router-dom';
-import { createBrowserHistory } from 'history';
-
-import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
-
-const history = createBrowserHistory();
-
-Sentry.init({
-  integrations: [
-    new BrowserTracing({
-      // Can also use reactRouterV3Instrumentation or reactRouterV4Instrumentation
-      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
-    }),
-  ],
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 1.0,
-});
-
-// ...
-
-// In your App render:
-render() {
-  return (
-    // Use custom history with a Router component
-    <Router history={history}>
-      <Components />
-    </Router>
-  );
-}
-```
-
-Now you should be generating `pageload`/`navigation` transactions from the `BrowserTracing` integration using react router instrumentation.
+The react router instrumentation uses the react router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
 ### Parameterized transaction names
 


### PR DESCRIPTION
To encourage users to enable paramaterization functionality with the react router integration, we remove the initial code snippet showing setting up the integration. This is as some users may stop at this point and not continue reading (after copy pasting the initial code snippet into their application). With this change, users now should read into the `Parameterized transaction names` section and select a method appropriately to use.