### PR TITLE
ref(serverless): new options for ignoring sentry errors

### DIFF
--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -100,6 +100,19 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 // `first` and `second` errors are captured
 ```
 
+## Ignore Sentry errors
+_(New in version 6.17.10)_
+
+By default, Sentry fails lambda invocation if it unable to send reports to the server.
+In this case, even if all reported erros were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
+
+The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry itself
+
+```javascript {tabTitle:ignoreSentryErrors}
+exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, { ignoreSentryErrors: true });
+// it will ignore any errors raised by sentry sdk on attempt to send reports to the server
+```
+
 ## Behavior
 
 With the AWS Lambda integration enabled, the Node SDK will:

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -104,7 +104,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 _(New in version 6.17.10)_
 
 By default, Sentry fails Lambda invocation if it is unable to send events to Sentry.
-In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
+In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail the whole Lambda invocation.
 
 The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry
 

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -109,8 +109,10 @@ In this case, even if all reported errors were handled and your handler executed
 The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry
 
 ```javascript {tabTitle:ignoreSentryErrors}
-exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, { ignoreSentryErrors: true });
-// it will ignore any errors raised by sentry sdk on attempt to send reports to the server
+exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, {
+  // Ignore any errors raised by the Sentry SDK on attempts to send events to Sentry
+  ignoreSentryErrors: true,
+});
 ```
 
 ## Behavior

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -104,9 +104,9 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 _(New in version 6.17.10)_
 
 By default, Sentry fails lambda invocation if it unable to send reports to the server.
-In this case, even if all reported erros were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
+In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
 
-The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry itself
+The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry
 
 ```javascript {tabTitle:ignoreSentryErrors}
 exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, { ignoreSentryErrors: true });

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -100,7 +100,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 // `first` and `second` errors are captured
 ```
 
-## Ignore Sentry errors
+## Ignore Sentry Errors
 _(New in version 6.17.10)_
 
 By default, Sentry fails lambda invocation if it is unable to send events to Sentry.

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -103,7 +103,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 ## Ignore Sentry Errors
 _(New in version 6.17.10)_
 
-By default, Sentry fails lambda invocation if it is unable to send events to Sentry.
+By default, Sentry fails Lambda invocation if it is unable to send events to Sentry.
 In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
 
 The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -103,7 +103,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 ## Ignore Sentry errors
 _(New in version 6.17.10)_
 
-By default, Sentry fails lambda invocation if it unable to send reports to the server.
+By default, Sentry fails lambda invocation if it is unable to send events to Sentry.
 In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail whole lambda invocation.
 
 The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -101,7 +101,7 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 ```
 
 ## Ignore Sentry Errors
-_(New in version 6.17.10)_
+_(New in version 6.18.0)_
 
 By default, Sentry fails Lambda invocation if it is unable to send events to Sentry.
 In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail the whole Lambda invocation.


### PR DESCRIPTION
this pr was built on top of https://github.com/getsentry/sentry-javascript/pull/4620