### PR TITLE
feat(dashboards): Issue Widgets Links column

### DIFF
--- a/src/docs/product/dashboards/widget-library/index.mdx
+++ b/src/docs/product/dashboards/widget-library/index.mdx
@@ -75,7 +75,7 @@ You can track the impact of issues assigned to you or your team by counting the 
 
 - Search condition: `is:unresolved is:for_review assigned_or_suggested:me`
 
-Update columns to add `project` so you can see the associated project with each issue, and change the "Sort by" to `Events` so the widget displays issues with the most error events in descending order:
+Update "Columns" to add `project` so you can see the associated project with each issue, and change the "Sort by" to `Events` so the widget displays issues with the most error events in descending order:
 
 - Columns: `issue, assignee, events, title, project`
 - Sort by: `Events`
@@ -86,6 +86,7 @@ The issues data set is unique in that you can add a free form [token](/product/s
 
 - Search condition: `is:unresolved is:for_review {token}`
 
-Update the "Sort by" to `Priority` so the widget displays issues that have been trending upward recently:
+Update "Columns" to add `links` so you can see seen any external links related to the issue, such as Github or Jira tickets. Update the "Sort by" to `Priority` so the widget displays issues that have been trending upward recently:
 
+- Columns: `issue, assignee, events, title, links`
 - Sort by: `Priority`

--- a/src/docs/product/dashboards/widget-library/index.mdx
+++ b/src/docs/product/dashboards/widget-library/index.mdx
@@ -86,7 +86,7 @@ The issues data set is unique in that you can add a free form [token](/product/s
 
 - Search condition: `is:unresolved is:for_review {token}`
 
-Update "Columns" to add `links` so you can see seen any external links related to the issue, such as Github or Jira tickets. Update the "Sort by" to `Priority` so the widget displays issues that have been trending upward recently:
+Update "Columns" to add `links` so you can see seen any external links related to the issue, such as GitHub or Jira issues. Update the "Sort by" to `Priority` so the widget displays issues that have been trending upward recently:
 
 - Columns: `issue, assignee, events, title, links`
 - Sort by: `Priority`


### PR DESCRIPTION
Adds a reference to the new `links` column in Issue Widgets that allows displaying Jira and Github tickets.