### PR TITLE
fix(js): Fix option name typos in `InboundFilters` description

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -23,7 +23,7 @@ message, or URLs in a given exception.
 It ignores errors that start with `Script error` or `Javascript error: Script error` by default.
 
 To configure this integration, use `ignoreErrors`, `denyUrls`,
-and `allowUrls` SDK options directly. Keep in mind that `denyURL` and `allowURL`
+and `allowUrls` SDK options directly. Keep in mind that `denyURLs` and `allowURLs`
 work only for captured exceptions, not raw message events.
 
 ### FunctionToString


### PR DESCRIPTION
`s/denyUrl/denyUrls` and `s/allowUrl/allowUrls`.