### PR TITLE
Adjust description of ignoreErrors

### DIFF
--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -33,7 +33,7 @@ The integration is enabled by default and adds the following configuration optio
 
 - `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
 - `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
-- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages. If no message is available, the SDK will try to compare against an underlying exception type and value.
+- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
 
 To learn more and see code samples, check out:
 


### PR DESCRIPTION
This PR clarifies the fact that `ignoreErrors` matches on `"ExceptionType: exceptionValue"` as one string.

Fixes https://github.com/getsentry/sentry-docs/issues/4762