### PR TITLE
Write Properties is not recommended. Use --uuid

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -274,7 +274,7 @@ sentry-cli upload-proguard \
 
 Since the Android SDK needs to know the UUID of the mapping file, you need
 to associate it with the upload. If you supply
-`--uuid` sets that value:
+`--uuid`, it sets that value:
 
 ```bash
 sentry-cli upload-proguard \

--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -273,12 +273,12 @@ sentry-cli upload-proguard \
 ```
 
 Since the Android SDK needs to know the UUID of the mapping file, you need
-to embed it in a `sentry-debug-meta.properties` file. If you supply
-`--write-properties` that is done automatically:
+to associate it with the upload. If you supply
+`--uuid` sets that value:
 
 ```bash
 sentry-cli upload-proguard \
-    --write-properties app/build/generated/assets/sentry/{BuildVariant}/sentry-debug-meta.properties \
+    --uuid A_VALID_UUID \
     app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 


### PR DESCRIPTION
Based on this comment from @marandaneto, the --write-properties syntax is no longer preferred. Instead, use --uuid https://github.com/getsentry/sentry-cli/issues/914#issuecomment-1050023401