### PR TITLE
ref(spans): Rename span exclusive time to span self time

### DIFF
--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -61,7 +61,7 @@ Currently, only transaction data — the transaction name and any attributes the
 
 ### Suspect Spans
 
-The transaction summary includes a list of suspect spans that correspond to where most of the time in a transaction is spent. By default, we sort spans by the total exclusive time. When you click the "Example Transaction" event, it takes you directly to the span in question.
+The transaction summary includes a list of suspect spans that correspond to where most of the time in a transaction is spent. By default, we sort spans by the total self time. When you click the "Example Transaction" event, it takes you directly to the span in question.
 
 ### Suspect Tags
 
@@ -105,23 +105,23 @@ Choose from one of several [metrics](#metrics) to sort spans and identify differ
 
 Clicking on a span will give you more details about the specific span [group](#grouping). You can see the performance of the span over time and see a list of transaction events that contain the span.
 
-### Exclusive Time
+### Self Time
 
-Suspect spans are determined using a span's exclusive time rather than its duration. To calculate a span's exclusive time, take the interval of the span and subtract the intervals of any child spans. The duration of the remaining interval is the span's exclusive time.
+Suspect spans are determined using a span's self time rather than its duration. To calculate a span's self time, take the interval of the span and subtract the intervals of any child spans. The duration of the remaining interval is the span's self time.
 
-In the example below, the exclusive time of each span is highlighted by the darker areas. For example, the `http.server` has an exclusive time of 10ms + 15ms = 25ms.
+In the example below, the self time of each span is highlighted by the darker areas. For example, the `http.server` has a self time of 10ms + 15ms = 25ms.
 
-![Span Exclusive Time](./exclusive-time.png)
+![Span Self Time](./exclusive-time.png)
 
 ### Metrics
 
-- **Total Exclusive Time**: The sum of the [exclusive time](#exclusive-time) for a span. This metric is useful to identify the span where the majority of the time is being spent.
+- **Total Self Time**: The sum of the [self time](#self-time) for a span. This metric is useful to identify the span where the majority of the time is being spent.
 - **Average Count**: The average number of times a span appears in a transaction. This metric is useful to identify redundant work being done within a transaction. It is often indicative of an n + 1 problem.
 - **Total Count**: The total number of times a span appears across all transactions. This metric is useful to identify spans that appear most frequently.
-- **p50 Exclusive Time**: The 50th percentile of the [exclusive time](#exclusive-time) for a span. This metric is useful to identify spans that take a long time individually.
-- **p75 Exclusive Time**: The 75th percentile of the [exclusive time](#exclusive-time) for a span. This metric is useful to identify spans that take a long time individually.
-- **p95 Exclusive Time**: The 95th percentile of the [exclusive time](#exclusive-time) for a span. This metric is useful to identify spans that take a long time individually.
-- **p99 Exclusive Time**: The 99th percentile of the [exclusive time](#exclusive-time) for a span. This metric is useful to identify spans that take a long time individually.
+- **p50 Self Time**: The 50th percentile of the [self time](#self-time) for a span. This metric is useful to identify spans that take a long time individually.
+- **p75 Self Time**: The 75th percentile of the [self time](#self-time) for a span. This metric is useful to identify spans that take a long time individually.
+- **p95 Self Time**: The 95th percentile of the [self time](#self-time) for a span. This metric is useful to identify spans that take a long time individually.
+- **p99 Self Time**: The 99th percentile of the [self time](#self-time) for a span. This metric is useful to identify spans that take a long time individually.
 
 ### Grouping
 


### PR DESCRIPTION
Rename `exclusive time` to `self time`. Self time conveys the meaning of the term better and, thus, should be used everywhere instead of old `exclusive time`, as was discussed by the performance team.

Mirrors changes in https://github.com/getsentry/sentry/pull/32049