### PR TITLE
docs(cli): Explain how to add ProGuard UUID to Android SDK

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -273,13 +273,20 @@ sentry-cli upload-proguard \
 ```
 
 Since the Android SDK needs to know the UUID of the mapping file, you need
-to associate it with the upload. If you supply
-`--uuid`, it sets that value:
+to associate it with the upload. If you supply `--uuid`, it sets that value:
 
 ```bash
 sentry-cli upload-proguard \
     --uuid A_VALID_UUID \
     app/build/outputs/mapping/{BuildVariant}/mapping.txt
+```
+
+Which then also needs to be included in your `AndroidManifest.xml` file:
+
+```xml
+<application>
+  <meta-data android:name="io.sentry.proguard-uuid" android:value="A_VALID_UUID" />
+</application>
 ```
 
 After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in _Project Settings > ProGuard_.


### PR DESCRIPTION
An extension of https://github.com/getsentry/sentry-docs/pull/4764
Closes https://github.com/getsentry/sentry-docs/issues/4431