### PR TITLE
Improve App start docs

### DIFF
--- a/src/docs/product/performance/mobile-vitals.mdx
+++ b/src/docs/product/performance/mobile-vitals.mdx
@@ -14,8 +14,7 @@ Mobile Vitals are summarized in several graphs on the **Performance** page in [s
 
 App start metrics track how long your mobile application takes to launch. For this, Sentry measures *cold starts* and *warm starts*.
 
-- **Cold Start**: A cold start refers to when the app launches for the first time, after a reboot or update. The app is not in memory and no process exists.
-- **Warm Start**: A warm start refers to when the app has already launched at least once and is partially in memory. For instance, the user backs out of your app, but then re-launches it. The process may have continued to run, but the app must recreate the activity from scratch.
+The definition of **Cold Start** and **Warm Start** slighly changes depending on the Operation System, check the [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) and [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) docs.
 
 On iOS, Apple recommends your app take at most 400ms to render the first frame. On Android, the [Google Play console](https://developer.android.com/topic/performance/vitals/launch-time#av) warns you when a cold start takes longer than five seconds or a warm start longer than two seconds. The exact definitions differ slightly per platform. Learn more in our [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/), [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/), and [React Native](/platforms/react-native/performance/instrumentation/automatic-instrumentation/) SDK docs.
 

--- a/src/docs/product/performance/mobile-vitals.mdx
+++ b/src/docs/product/performance/mobile-vitals.mdx
@@ -14,7 +14,7 @@ Mobile Vitals are summarized in several graphs on the **Performance** page in [s
 
 App start metrics track how long your mobile application takes to launch. For this, Sentry measures *cold starts* and *warm starts*.
 
-The definition of **Cold Start** and **Warm Start** slighly changes depending on the Operation System, check the [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) and [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) docs.
+The definitions of cold start and warm start change slightly depending on the operating system. For definitions by operating system, check out the [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) and [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation) docs.
 
 On iOS, Apple recommends your app take at most 400ms to render the first frame. On Android, the [Google Play console](https://developer.android.com/topic/performance/vitals/launch-time#av) warns you when a cold start takes longer than five seconds or a warm start longer than two seconds. The exact definitions differ slightly per platform. Learn more in our [iOS](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/), [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/), and [React Native](/platforms/react-native/performance/instrumentation/automatic-instrumentation/) SDK docs.
 

--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -128,9 +128,9 @@ The App Start Instrumentation provides insight into how long your application ta
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 * __Cold start__: A cold start refers to an app’s starting from scratch: the system’s process has not, until this start, created the app’s process. Cold starts happen in cases such as your app’s being launched for the first time since the device booted, or since the system killed the app.
-* __Warm start__: A warm start encompasses some subset of the operations that take place during a cold start; at the same time, it represents more overhead than a hot start. For instance: The user backs out of your app, but then re-launches it. The process may have continued to run, but the app must recreate the activity from scratch via a call to `onCreate()`.
+* __Warm start__: A warm start encompasses some subset of the operations that take place during a cold start; at the same time, it represents more overhead than a hot start. For instance: The system evicts your app from memory, and then the user re-launches it. The process and the activity need to be restarted, but the task can benefit somewhat from the saved instance state bundle passed into `onCreate()`.
 
-The SDK sets the Span operation to `app.start.cold` for *Cold start_* and `app.start.warm` for *Warm start*.
+The SDK sets the Span operation to `app.start.cold` for *Cold start* and `app.start.warm` for *Warm start*.
 
 The SDK uses the `SentryPerformanceProvider` (ContentProvider) creation time as the beginning of the app start and the first `Activity#onResume` call as the end.
 

--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -294,9 +294,6 @@ If you don't [wrap your root component with Sentry](#wrap-your-root-component), 
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
-- **Cold start**: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
-- **Warm start**: App launched at least once, is partially in memory, and no process exists.
-
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
 ### Slow and Frozen Frames


### PR DESCRIPTION
Cold and Warm start descriptions change for Android and iOS and this is confusing.
Removing descriptions from Product Mobile vitals and React Native pages.
Adding a redirect link to the Native SDKs helps to get the most accurate description, also there's a single source of truth.