### PR TITLE
feat(apidocs): show schema enums on param fields if they exist

### DIFF
--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, Fragment } from "react";
 import { graphql } from "gatsby";
 import Prism from "prismjs";
 
@@ -23,11 +23,23 @@ const Params = ({ params }) => (
             <code data-index>{param.name}</code>
             {!!param.schema?.type && <em> ({param.schema.type})</em>}
           </div>
-
           {!!param.required && <div className="required">REQUIRED</div>}
         </dt>
+
         {!!param.description && (
           <dd>
+            {param.schema?.enum && (
+              <Fragment>
+                <b>choices</b>:
+                <ul>
+                  <code>
+                    {param.schema?.enum.map(e => {
+                      return <li key={e}>{e}</li>;
+                    })}
+                  </code>
+                </ul>
+              </Fragment>
+            )}
             <Content file={param} />
           </dd>
         )}


### PR DESCRIPTION
If the parameter has a fixed number of choices via the openapi `enum` field, show them along with the description.
![Screen Shot 2022-02-28 at 1 56 48 PM](https://user-images.githubusercontent.com/1976777/156065464-e8dd4c83-f339-4b6e-9bc0-179f17b1e14e.png)
