### PR TITLE
fix(browser): Mention release health in loader limitations section

### DIFF
--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -99,6 +99,7 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will not be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
-For similar reasons, the loader is not available in a form which includes performance monitoring. If you want to monitor the performance of your app, including pageload times, please [bundle the SDK with your app](../npm) or use our CDN, specifically the [bundle which includes tracing features](../cdn/#performance-bundle).
+For similar reasons, the loader is not available in a form which includes either performance monitoring or release health (sessions). If you want performance monitoriing, including pageload times, you can [bundle both `@sentry/browser` and `@sentry/tracing` with your app](../npm) or use our CDN, specifically the [bundle which includes tracing features](../cdn/#performance-bundle). For release health, bundling is the only option, though no additional package is needed.
+
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).

--- a/src/platforms/javascript/common/install/lazy-load-sentry.mdx
+++ b/src/platforms/javascript/common/install/lazy-load-sentry.mdx
@@ -99,7 +99,7 @@ The loader script includes a call to `Sentry.init` with one configuration option
 
 Because the loader injects the SDK asynchronously, only *unhandled errors* and *unhandled promise rejections* will be caught and buffered before the SDK is fully loaded. Specifically, the capturing of any [breadcrumb data](../../enriching-events/breadcrumbs/) will not be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 
-For similar reasons, the loader is not available in a form which includes either performance monitoring or release health (sessions). If you want performance monitoriing, including pageload times, you can [bundle both `@sentry/browser` and `@sentry/tracing` with your app](../npm) or use our CDN, specifically the [bundle which includes tracing features](../cdn/#performance-bundle). For release health, bundling is the only option, though no additional package is needed.
+For similar reasons, the loader is not available in a form which includes either performance monitoring or release health (sessions). If you want performance monitoring, including pageload times, you can [bundle both `@sentry/browser` and `@sentry/tracing` with your app](../npm) or use our CDN, specifically the [bundle that includes tracing features](../cdn/#performance-bundle). For release health, bundling is the only option, though no additional package is needed.
 
 
 If you want to understand the inner workings of the loader itself, you can read the documented source code in all its glory over at the [sentry-javascript repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/loader.js).


### PR DESCRIPTION
In our current implementation of the feature, a session and a pageload transaction are essentially one and the same, which means that release health doesn't work any better than tracing does when you're using the loader. This clarifies that in the loader's Limitations section.

Fixes https://github.com/getsentry/sentry-docs/issues/4722.