### PR TITLE
feat(apidocs): update scope required description

### DIFF
--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -192,7 +192,8 @@ export default props => {
                     authenticate via bearer auth token.
                   </SmartLink>
                 </div>
-                <code>{"<auth_token>"}</code> requires the following scopes:
+                <code>{"<auth_token>"}</code> requires one of the following
+                scopes:
               </div>
 
               <ul>


### PR DESCRIPTION
With our new API tooling, we automatically grab all of the required scopes from the endpoint, of which only one scope is needed, not all of them. On the docs generation side, we should probably list them in direction of least privileged to most privileged (e.g. `project:read` before `project:admin`).