### PR TITLE
fix(angular): mention `TraceDirective` bug and workaround in Angular SDK

### DIFF
--- a/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
+++ b/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
@@ -4,28 +4,7 @@ title: Track Angular Components
 
 To track Angular components as part of your transactions, use any of these three options:
 
-1. `TraceDirective` to track a duration between `OnInit` and `AfterViewInit` lifecycle hooks in template:
-
-```javascript
-import * as Sentry from "@sentry/angular";
-
-@NgModule({
-  // ...
-  declarations: [Sentry.TraceDirective],
-  // ...
-})
-export class AppModule {}
-```
-
-Then, inside your components template, (remember that the directive name attribute is required):
-
-```html
-<app-header [trace]="'header'"></app-header>
-<articles-list [trace]="'articles-list'"></articles-list>
-<app-footer [trace]="'footer'"></app-footer>
-```
-
-2. `TraceClassDecorator` tracks a duration between `OnInit` and `AfterViewInit` lifecycle hooks in components:
+1. `TraceClassDecorator` tracks a duration between `OnInit` and `AfterViewInit` lifecycle hooks in components:
 
 ```javascript
 import { Component } from "@angular/core";
@@ -41,7 +20,7 @@ export class HeaderComponent {
 }
 ```
 
-3. `TraceMethodDecorator` tracks a specific lifecycle hooks as point-in-time spans in components:
+2. `TraceMethodDecorator` tracks a specific lifecycle hooks as point-in-time spans in components:
 
 ```javascript
 import { Component, OnInit } from "@angular/core";
@@ -86,4 +65,40 @@ platformBrowserDynamic()
       boostrapSpan.finish();
     }
   })
+```
+
+3. `TraceDirective` to track a duration between `OnInit` and `AfterViewInit` lifecycle hooks in template:
+
+<Alert level="warning" title="Important">
+
+The usage of `TraceDirective` or `TraceModule` currently causes a compiler error at application compile
+time of your Angular application if AOT compilation is enabled in your application config (which it is by default).
+This is a [known limitation](https://github.com/getsentry/sentry-javascript/issues/3282) of our current
+Angular SDK (v6.*) and it will be [adressed and fixed](https://github.com/getsentry/sentry-javascript/issues/4644)
+in our next major Angular SDK release (v7).
+In the meantime, please refer to Options 1 (`TraceClassDecorator`) and 2 (`TraceMethodDecorator`)
+above to track your Angular components.
+
+</Alert>
+
+Import `TraceModule` either globally in your application's `app.module.ts` file or locally in the module(s)
+you want to track your components:
+
+```javascript
+import * as Sentry from "@sentry/angular";
+
+@NgModule({
+  // ...
+  imports: [Sentry.TraceModule],
+  // ...
+})
+export class AppModule {}
+```
+
+Then, inside your components template, (remember that the directive name attribute is required):
+
+```html
+<app-header [trace]="'header'"></app-header>
+<articles-list [trace]="'articles-list'"></articles-list>
+<app-footer [trace]="'footer'"></app-footer>
 ```


### PR DESCRIPTION
This PR adds a warning alert to `tracehelpers.mdx` in the Angular SDK guide to make users
aware that the usage of `TraceDirective` will currently most likely cause a compiler error
on their end. The alert links to the original issue (getsentry/sentry-javascript#3282) and our intended fix (getsentry/sentry-javascript#4644) which will ship with the v7 major of the JS/Angular SDK.

The `TraceDirective` option was moved down from the top option to the last one as it is essentially unusable
due to the compiler error. The other two options are suggested as workarounds until the bug is fixed and released in the next major.

Additionally, the PR fixes the suboptimal usage instruction of `TraceDirective`: Instead of declaring `TraceDirective` in the users' Angular module(s), `TraceModule` (which wraps the directive) should in fact be imported in the module(s). This conforms to the way how Angular components or directives from libraries should be used.
