### PR TITLE
fix(angular): change NPM link from `@sentry/browser` to `@sentry/angular`

### DIFF
--- a/src/platforms/javascript/guides/angular/config.yml
+++ b/src/platforms/javascript/guides/angular/config.yml
@@ -1,3 +1,7 @@
 title: Angular
+caseStyle: camelCase
+sdk: sentry.javascript.angular
+fallbackPlatform: javascript
 categories:
   - browser
+description: "Learn about Sentry's Angular SDK and how it automatically reports errors and exceptions in your application."


### PR DESCRIPTION
This PR changes the NPM package link in the right nav component in the platform SDK
details panel. Instead of linking to the generic `@sentry/browser` SDK package,
it now links to the Sentry Angular SDK package (`@sentry/angular`).

Additionally, the `description` property is added to the `config.yml` file. 

All changes are based on the `@sentry/react` `config.yml`