### PR TITLE
feat(apple): Clarify why OOMs don't have much context

### DIFF
--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -12,7 +12,9 @@ The SDK might falsely report out-of-memory crashes when an app hangs, and the us
 
 This integration tracks out-of-memory (OOM) crashes based on heuristics. This feature is available for iOS, tvOS, and Mac Catalyst, works only if the application was in the foreground, and doesn't track OOMs for unit tests.
 
-When your application uses too much RAM, the operating system kills your app without a normal termination process. Your process doesn't receive a signal or any other type of information to ensure an OOM occurs. As a result, in the Apple SDK, we track out-of-memory crashes during the app start based on heuristics.
+When a typical unhandled error occurs, the Apple SDK writes a report to disk with the current state of your application, like the stack trace, tags, breadcrumbs, etc., before the app terminates. For OOMs, the operating system can kill your app without further notice, and the SDK can't write a report to disk.
+As a result, in the Apple SDK, we track out-of-memory crashes during the app start based on heuristics, and getting the state of the app when an OOM occurs is challenging. To provide the same state as for a typical crash, we would periodically need to store the app state to disk, causing a lot of IO, a tradeoff we are unwilling to accept. Therefore OOM events have less context than typical unhandled errors.
+
 When a user launches the app, the SDK checks the following statements and reports an OOM if all of them are true:
 
 * The app didn't crash on the previous run.

--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -12,8 +12,8 @@ The SDK might falsely report out-of-memory crashes when an app hangs, and the us
 
 This integration tracks out-of-memory (OOM) crashes based on heuristics. This feature is available for iOS, tvOS, and Mac Catalyst, works only if the application was in the foreground, and doesn't track OOMs for unit tests.
 
-When a typical unhandled error occurs, the Apple SDK writes a report to disk with the current state of your application, like the stack trace, tags, breadcrumbs, etc., before the app terminates. For OOMs, the operating system can kill your app without further notice, and the SDK can't write a report to disk.
-As a result, in the Apple SDK, we track out-of-memory crashes during the app start based on heuristics, and getting the state of the app when an OOM occurs is challenging. To provide the same state as for a typical crash, we would periodically need to store the app state to disk, causing a lot of IO, a tradeoff we are unwilling to accept. Therefore OOM events have less context than typical unhandled errors.
+When a typical unhandled error occurs, the Apple SDK writes a report to disk with the current state of your application, with details like the stack trace, tags, breadcrumbs, and so on, before the app terminates. With OOM crashes, the operating system can kill your app without further notice, which means the SDK can't write a report to disk.
+As a result, in the Apple SDK, we track OOM crashes during the app start based on heuristics, but getting the state of the app when an OOM occurs is challenging. To provide the same state as we do for a typical crash, we would periodically need to store the app state to disk. This would cause a lot of I/O, which in turn could negatively affect the application's performance. To avoid this, OOM events have less context than typical unhandled errors.
 
 When a user launches the app, the SDK checks the following statements and reports an OOM if all of them are true:
 


### PR DESCRIPTION
OOM events don't that much context as typical unhandled errors.
We frequently get asked why that is. This PR adds clarification
for that.