### PR TITLE
Add link to info on .sentryclirc file

### DIFF
--- a/src/docs/product/cli/send-event.mdx
+++ b/src/docs/product/cli/send-event.mdx
@@ -102,4 +102,4 @@ eval "$(sentry-cli bash-hook)"
 # rest of the script goes here
 ```
 
-Alternatively you can use other mechanisms like a `.sentryclirc` file to configure the DSN.
+Alternatively you can use other mechanisms like [a `.sentryclirc` file] (https://docs.sentry.io/product/cli/configuration/#configuration-file) to configure the DSN.


### PR DESCRIPTION
It may seem to some that this edit (adding a link in this page to more info on the .sentryclirc file) is nit-picky or pedantic ("we can't link to EVERYTHING"), but let me share why it seems useful. 

I found this page as it's pointed to from a blog post on the Sentry site (https://blog.sentry.io/2021/11/18/monitoring-our-local-development-environment-with-sentry). The blog post talks about the bash-hook feature, showing editing of a bash script to monitor it for errors, including putting in the needed sentry env vars. It links to this docs page for more on bash hooks, but only the docs page talks about using the .sentryclirc file as an option for a more central place to put the associated env vars. 

And so, since someone may find this doc page that way--and learn of the .sentryclirc file for the first time--it seems appropriate to save them the trouble of searching the docs to find more on it. (And this is all the more useful since in using the docs page search feature, searching for the phrase .sentryclirc, this reference page would come up 4th.)

(If the blog supported comments, I'd have left one also pointing out the .sentryclirc as an option, to save folks repeatedly placing those env vars in various bash scripts they may need to edit to support the workflow discussed in the blog post. If somehow the blog post author, @armenzg, might see this discussion and agree, perhaps he may be tempted to add a brief mention to the post. And thanks to him for the post, and to Sentry for the tool, and to all involved here for managing the repo!)