### PR TITLE
fix(typo): Angular custom span creation example

### DIFF
--- a/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
+++ b/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
@@ -49,7 +49,7 @@ import { AppModule } from './app/app.module';
 // ...
 
 const activeTransaction = Sentry.getActiveTransaction();
-const boostrapSpan =
+const bootstrapSpan =
   activeTransaction &&
   activeTransaction.startChild({
     description: 'platform-browser-dynamic',
@@ -59,12 +59,12 @@ const boostrapSpan =
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
   .then(() => console.log(`Bootstrap success`))
-  .catch(err => console.error(err));
+  .catch(err => console.error(err))
   .finally(() => {
     if (bootstrapSpan) {
       boostrapSpan.finish();
     }
-  })
+  });
 ```
 
 3. `TraceDirective` tracks a duration between `OnInit` and `AfterViewInit` lifecycle hooks in template:


### PR DESCRIPTION
This PR fixes two typos in the code example to add a custom span to the active transaction. It changes a variable name in the declaration from `boostrapSpan` to `bootstrapSpan` and repositions the semicolon to the end of the promise chain.