### PR TITLE
feat(browser): Add note about ES6 tracing bundle

### DIFF
--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -2,8 +2,6 @@
 title: CDN
 sidebar_order: 5
 description: "Learn how Sentry supports loading its JavaScript SDK via a CDN."
-notSupported:
- - javascript.cordova
 ---
 
 import JsBundleList from "~src/components/jsBundleList";
@@ -32,7 +30,7 @@ To use Sentry's performance tracing an alternative bundle is needed. This allows
 
 <Note>
 
-You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring.
+You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring. There is also an ES6 version of the tracing bundle, `bundle.tracing.es6.min.js`.
 
 </Note>
 


### PR DESCRIPTION
As of https://github.com/getsentry/sentry-javascript/pull/4674, we now host both ES5 and ES6 tracing bundles. This adds a note saying so to the CDN docs.

NOTE: Marking as draft just so it doesn't get merged before that change is released.