### PR TITLE
chore(perfmon): Remove compile time requirement to use performance monitoring in the native SDK

### DIFF
--- a/src/includes/performance/enable-tracing/native.mdx
+++ b/src/includes/performance/enable-tracing/native.mdx
@@ -1,5 +1,0 @@
-To enable tracing, set the `SENTRY_PERFORMANCE_MONITORING` compile flag to `YES`. This will expose the performance monitoring API for use in your app, and is required to set up performance monitoring.
-
-```shell
-cmake -B build -D SENTRY_PERFORMANCE_MONITORING=YES
-```


### PR DESCRIPTION
One of the requirements to enable perfmon in the native SDK was removed (https://github.com/getsentry/sentry-native/pull/678) which means it's enabled by default. This updates the docs to reflect that change. Apologies that this came in a bit late relative to the actual change itself 😔 