### PR TITLE
fix(metrics): Remove Apdex ambiguity in tolerable cases

### DIFF
--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -16,7 +16,7 @@ Below are the components of Apdex and its formula:
 
 * **T**: Threshold for the target response time.
 * **Satisfactory**: Users are satisfied using the app when their page load times are less than or equal to T.
-* **Tolerable**: Users consider the app tolerable to use when their page load times are between T and 4T.
+* **Tolerable**: Users consider the app tolerable to use when their page load times are greater than T and less than or equal to 4T.
 * **Frustrated**: Users are frustrated with the app when their page load times are greater than 4T.
 * **Apdex**: (Number of Satisfactory Requests + (Number of Tolerable Requests/2)) / (Number of Total Requests)
 


### PR DESCRIPTION
"between T and 4T" leads to ambiguity in inclusive/exclusive ranges,
that can only be resolved by reading the other alternatives. This PR
removes that ambiguity.