### PR TITLE
feat(billing): Update documentation surrounding on-demand budgets

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which can be configured on either a shared, or per-category (errors, transactions, attachments) basis. Learn more in [On-demand Budgets](#on-demand-cap).
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which can be configured on either a shared, or per-category (errors, transactions, attachments) basis. Learn more in [On-Demand Budgets](#on-demand-cap).
 
 #### Prepaid (Reserved) Capacity
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -44,6 +44,12 @@ The second is the **On-Demand Period**. The On-Demand Period reflects a one mont
 
 You can set a maximum monthly on-demand invoice amount by setting an on-demand budget. Once you reach the maximum budget capacity, you will still be able to access Sentry and prior event data. However, any additional events you send will be rejected.
 
+<Note>
+
+Customers on legacy plans will only be able to use the shared on-demand budget strategy. Per-category on-demand budgets is only available on plans with Performance Monitoring features.
+
+</Note>
+
 You will have two choices on setting your on-demand budget strategy:
 
 **Shared:** The on-demand budget is shared among errors, transactions, and attachments.

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. See [On-demand spending cap](#on-demand-cap) for more information.
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. See [On-demand budgets](#on-demand-cap) for more information.
 
 #### Prepaid (Reserved) Capacity
 
@@ -40,9 +40,9 @@ The second is the **On-Demand Period**. The On-Demand Period reflects a one mont
 
 ### Billing Controls
 
-#### On-Demand Spending Cap {#on-demand-cap}
+#### On-Demand Budgets {#on-demand-cap}
 
-You can set a maximum monthly on-demand bill amount by setting an on-demand spending cap. Once you reach the spending cap, you will still be able to access Sentry and prior event data. However, any additional events you send will be rejected.
+You can set a maximum monthly on-demand bill amount by setting an on-demand budget. Once you reach the maximum budget capacity, you will still be able to access Sentry and prior event data. However, any additional events you send will be rejected.
 
 #### Rate Limits
 
@@ -309,19 +309,19 @@ The slider on the [pricing](https://sentry.io/pricing/) page allows you to choos
 
 Downgrades and cancellations are processed as the end of the current contract cycle and cannot be refunded.
 
-#### What happens if I continue to send events after my on-demand spending cap is consumed?
+#### What happens if I continue to send events after my on-demand budget is consumed?
 
 All additional events are rejected.
 
-#### If I raise my on-demand spending cap mid-month, when will my organization start accepting events again?
+#### If I raise my on-demand budget mid-month, when will my organization start accepting events again?
 
-Your organization will start accepting additional events as soon as your new cap is applied. We guarantee new caps will be applied within 24 hours. However, in most cases your organization will start accepting events within minutes.
+Your organization will start accepting additional events as soon as your new budget is applied. We guarantee new budgets will be applied and effective within 24 hours. However, in most cases your organization will start accepting events within minutes.
 
-#### If I lower my on-demand spending cap mid-month below this month’s existing bill, when will the new cap take effect? What will my on-demand bill be?
+#### If I lower my on-demand budget mid-month below this month’s existing bill, when will the new budget take effect? What will my on-demand bill be?
 
-We guarantee your new, lowered on-demand spending cap will be applied within 24 hours. In the meantime, the old on-demand spending cap will remain in effect. However, in most cases, the new spending cap will be applied within minutes.
+We guarantee your new, lowered on-demand budget will be applied within 24 hours. In the meantime, the old on-demand budget will remain in effect. However, in most cases, the new budget will be applied within minutes.
 
-After the new spending cap is in effect, all additional events will be rejected and no additional on-demand capacity will be added. At end of billing month, you will be charged for any on-demand capacity consumed.
+After the new budget is in effect, all additional events will be rejected and no additional on-demand capacity will be added. At end of billing month, you will be charged for any on-demand capacity consumed.
 
 #### If I want to cancel monthly billing, what happens?
 
@@ -340,6 +340,7 @@ You must have either `Billing` or `Owner` permissions to access and/or make chan
 #### Why am I being charged for sales tax?
 
 As of December 1, 2020, customers with a US-based billing address may be subject to state and local sales tax. Sales tax will apply to billing addresses located in the following states/localities:
+
 - Connecticut
 - District of Columbia
 - Massachusetts
@@ -360,11 +361,13 @@ No. We do not adjust the billing or invoicing of a closed billing period. Any pr
 #### Do I qualify for a tax exemption?
 
 If your company or non-profit organization qualifies for a sales tax exemption, you can reach out to tax@sentry.io with the following information to have sales tax removed from any future invoices:
-  - Organization Name
-  - Copy of a signed tax exempt certificate
+
+- Organization Name
+- Copy of a signed tax exempt certificate
 
 #### I submitted an exemption form, why am I still being charged sales tax?
 
 Taxes could still be included in your bill if either:
-  - The exemption certificate was still in review after the billing period was closed
-  - The exemption certificate covers a state that is different from your billing address
+
+- The exemption certificate was still in review after the billing period was closed
+- The exemption certificate covers a state that is different from your billing address

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,15 +46,15 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on legacy plans can only use the shared on-demand budget strategy. 
+Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on legacy plans can only use the shared on-demand budget strategy.
 
 </Note>
 
 You have two choices for setting your on-demand budget strategy:
 
-**Shared:** Your on-demand budget is shared among errors, transactions, and attachments.
+- **Shared:** Your on-demand budget is shared among errors, transactions, and attachments.
 
-**Per-category:** Separate on-demand budgets for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
+- **Per-category:** Separate on-demand budgets for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
 
 #### Rate Limits
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -52,7 +52,7 @@ Customers on legacy plans will only be able to use the shared on-demand budget s
 
 You will have two choices on setting your on-demand budget strategy:
 
-**Shared:** The on-demand budget is shared among errors, transactions, and attachments.
+**Shared:** Your on-demand budget is shared among errors, transactions, and attachments.
 
 **Per-category:** Dedicated on-demand budget for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. See [On-demand budgets](#on-demand-cap) for more information.
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is detemined by your on-demand budget, which may be configured on either a shared, or per-category basis. See [On-demand budgets](#on-demand-cap) for more information.
 
 #### Prepaid (Reserved) Capacity
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,7 +46,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on legacy plans can only use the shared on-demand budget strategy.
+Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -42,7 +42,13 @@ The second is the **On-Demand Period**. The On-Demand Period reflects a one mont
 
 #### On-Demand Budgets {#on-demand-cap}
 
-You can set a maximum monthly on-demand bill amount by setting an on-demand budget. Once you reach the maximum budget capacity, you will still be able to access Sentry and prior event data. However, any additional events you send will be rejected.
+You can set a maximum monthly on-demand invoice amount by setting an on-demand budget. Once you reach the maximum budget capacity, you will still be able to access Sentry and prior event data. However, any additional events you send will be rejected.
+
+You will have two choices on setting your on-demand budget strategy:
+
+**Shared:** The on-demand budget is shared among errors, transactions, and attachments.
+
+**Per-category:** Dedicated on-demand budget for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
 
 #### Rate Limits
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which can be configured on either a shared, or per-category (errors, transactions, attachments) basis. Learn more in [On-Demand Budgets](#on-demand-cap).
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which can be configured on either a shared or per-category (errors, transactions, attachments) basis. Learn more in [On-Demand Budgets](#on-demand-cap).
 
 #### Prepaid (Reserved) Capacity
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is detemined by your on-demand budget, which may be configured on either a shared, or per-category basis. See [On-demand budgets](#on-demand-cap) for more information.
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which may be configured on either a shared, or per-category basis. See [On-demand budgets](#on-demand-cap) for more information.
 
 #### Prepaid (Reserved) Capacity
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -50,7 +50,7 @@ Per-category on-demand budgets are only available on plans with [performance mon
 
 </Note>
 
-You will have two choices on setting your on-demand budget strategy:
+You have two choices for setting your on-demand budget strategy:
 
 **Shared:** Your on-demand budget is shared among errors, transactions, and attachments.
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -54,7 +54,7 @@ You will have two choices on setting your on-demand budget strategy:
 
 **Shared:** Your on-demand budget is shared among errors, transactions, and attachments.
 
-**Per-category:** Dedicated on-demand budget for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
+**Per-category:** Separate on-demand budgets for errors, transactions, and attachments. Any overages in one category will not consume the budget of another category.
 
 #### Rate Limits
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,7 +46,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Customers on legacy plans will only be able to use the shared on-demand budget strategy. Per-category on-demand budgets is only available on plans with Performance Monitoring features.
+Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on legacy plans can only use the shared on-demand budget strategy. 
 
 </Note>
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -22,7 +22,7 @@ Capacity is the total number of events sent by and billed to your organization. 
 
 #### On-Demand Capacity
 
-On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which may be configured on either a shared, or per-category basis. See [On-demand budgets](#on-demand-cap) for more information.
+On-demand capacity is billed at the end of each billing cycle. You are charged per processed event, rounded up to the nearest cent. You have the ability to set on-demand caps so you can stay on budget. Your on-demand capacity is determined by your on-demand budget, which can be configured on either a shared, or per-category (errors, transactions, attachments) basis. Learn more in [On-demand Budgets](#on-demand-cap).
 
 #### Prepaid (Reserved) Capacity
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,7 +46,9 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features. Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
+Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features and if you're in the Early Adopter program.
+If you opted out of the Early Adopter program while on the per-category on-demand budget strategy, you will still retain this on-demand budget until you switch to the shared on-demand budget strategy.
+Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -47,7 +47,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 <Note>
 
 Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features and if you're in the Early Adopter program.
-If you opted out of the Early Adopter program while on the per-category on-demand budget strategy, you will still retain this on-demand budget until you switch to the shared on-demand budget strategy.
+If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -150,11 +150,11 @@ If this is your first time exceeding quota, however, you'll be entered into a on
 
 ### On-Demand Capacity
 
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum spending cap. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared, or per-category basis.. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
 
 ### Reserved Capacity
 
-If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available rather than just setting a maximum spending cap. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
+If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
 
 You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -150,7 +150,7 @@ If this is your first time exceeding quota, however, you'll be entered into a on
 
 ### On-Demand Capacity
 
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared, or per-category basis.. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared, or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
 
 ### Reserved Capacity
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -150,7 +150,7 @@ If this is your first time exceeding quota, however, you'll be entered into a on
 
 ### On-Demand Capacity
 
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared, or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
 
 ### Reserved Capacity
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -141,7 +141,7 @@ Many times, an unexpected spike is caused by a new error (or errors) introduced 
 
 If an account depletes its event capacity and has never previously triggered a grace period, we continue to accept events for the next three days at a maximum rate of 10,000 events per hour. If you choose not to increase your capacity, Sentry will stop accepting events for the remainder of the current billing month. However, if you increase your capacity, events accepted during the grace period will be counted as consumed capacity.
 
-Once you've used your grace period, we recommend using our on-demand spending caps to ensure you have time to adjust your capacity in the event of a future spike in errors.
+Once you've used your grace period, we recommend setting up an on-demand budget to ensure you have time to adjust your capacity in the event of a future spike in errors.
 
 Also, consider doing the following:
 


### PR DESCRIPTION
This pull request updates the current on-demand budget documentation in anticipation of the rollout of the new on-demand budgets feature to all performance plans on the week of April 4, 2022.  This pull request should not be merged until this roll out completes.

Changelog:

- I've renamed "On-Demand Spending Cap" to "On-Demand Budget"
- Added blurbs on shared and per-category on-demand budget strategies. 