### PR TITLE
feat(sentry apps): Add docs for comment webhooks

### DIFF
--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -372,7 +372,7 @@ Currently, webhooks must be configured per-project, which is unnecessary overhea
 
 **New Event Types**
 
-Sentry Integration apps expose a richer set of events that are not available via the legacy service hooks API. Currently, this includes Issue Created, Issue Resolved, Issue Ignored, and Issue Assigned. In the future, we’ll add more types of webhooks to Sentry Integration apps.
+Sentry Integration apps expose a richer set of events that are not available via the legacy service hooks API. Currently, this includes Issue Created, Issue Resolved, Issue Ignored, Issue Assigned, Comment Created, Comment Updated, and Comment Deleted. In the future, we’ll add more types of webhooks to Sentry Integration apps.
 
 **Custom UI Components**
 

--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -372,7 +372,16 @@ Currently, webhooks must be configured per-project, which is unnecessary overhea
 
 **New Event Types**
 
-Sentry Integration apps expose a richer set of events that are not available via the legacy service hooks API. Currently, this includes Issue Created, Issue Resolved, Issue Ignored, Issue Assigned, Comment Created, Comment Updated, and Comment Deleted. In the future, we’ll add more types of webhooks to Sentry Integration apps.
+Sentry Integration apps expose a richer set of events that are not available via the legacy service hooks API. Currently, this includes the following webhooks:
+* Issue Created
+* Issue Resolved
+* Issue Ignored
+* Issue Assigned
+* Comment Created
+* Comment Updated
+* Comment Deleted
+
+In the future, we’ll add more types of webhooks to Sentry Integration apps.
 
 **Custom UI Components**
 

--- a/src/docs/product/integrations/integration-platform/index.mdx
+++ b/src/docs/product/integrations/integration-platform/index.mdx
@@ -372,7 +372,7 @@ Currently, webhooks must be configured per-project, which is unnecessary overhea
 
 **New Event Types**
 
-Sentry Integration apps expose a richer set of events that are not available via the legacy service hooks API. Currently, this includes the following webhooks:
+Sentry Integration apps expose a richer set of events that are not available using the legacy service hooks API. Currently, this includes the following webhooks:
 * Issue Created
 * Issue Resolved
 * Issue Ignored

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -686,10 +686,10 @@ Note: The webhook payload stack frame order lists the oldest frame to the most r
 - type: int
 - description: the id of the comment
 
-##### data["group_id"]
+##### data["issue_id"]
 
 - type: int
-- description: the id of the group/issue
+- description: the id of the issue
 
 
 ##### data["timestamp"]
@@ -707,7 +707,7 @@ Note: The webhook payload stack frame order lists the oldest frame to the most r
       'comment': 'adding a comment',
       'project_slug': 'sentry',
       'comment_id': 1234,
-      'group_id': 100,
+      'issue_id': 100,
       'timestamp': '2022-03-02T21:51:44.118160Z'
   },
   'installation': {'uuid': 'eac5a0ae-60ec-418f-9318-46dc5e7e52ec'},

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -702,16 +702,16 @@ Note: The webhook payload stack frame order lists the oldest frame to the most r
 
 ```json
 {
-  'action': 'created',
-  'data': {
-      'comment': 'adding a comment',
-      'project_slug': 'sentry',
-      'comment_id': 1234,
-      'issue_id': 100,
-      'timestamp': '2022-03-02T21:51:44.118160Z'
+  "action": "created",
+  "data": {
+      "comment": "adding a comment",
+      "project_slug": "sentry",
+      "comment_id": 1234,
+      "issue_id": 100,
+      "timestamp": "2022-03-02T21:51:44.118160Z"
   },
-  'installation': {'uuid': 'eac5a0ae-60ec-418f-9318-46dc5e7e52ec'},
-  'actor': {'type': 'user', 'id': 1, 'name': 'colleen'}
+  "installation": {"uuid": "eac5a0ae-60ec-418f-9318-46dc5e7e52ec"},
+  "actor": {"type": "user", "id": 1, "name": "colleen"}
 }
 ```
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -659,6 +659,63 @@ Note: The webhook payload stack frame order lists the oldest frame to the most r
 }
 ```
 
+### Comments
+
+`'Sentry-Hook-Resource': 'comment'`
+
+#### Attributes
+
+##### action
+
+- type: string
+- description: can be `created`, `updated`, or `deleted`
+
+##### data["comment"]
+
+- type: string
+- description: the content of the issue's comment
+
+##### data["project slug"]
+
+- type: string
+- description: the slug of the project the comment's issue belongs to
+
+
+##### data["comment_id"]
+
+- type: int
+- description: the id of the comment
+
+##### data["group_id"]
+
+- type: int
+- description: the id of the group/issue
+
+
+##### data["timestamp"]
+
+- type: datetime
+- description: when the comment was created, updated, or deleted
+
+
+#### Payload
+
+```json
+{
+  'action': 'created',
+  'data': {
+      'comment': 'adding a comment',
+      'project_slug': 'sentry',
+      'comment_id': 1234,
+      'group_id': 100,
+      'timestamp': '2022-03-02T21:51:44.118160Z'
+  },
+  'installation': {'uuid': 'eac5a0ae-60ec-418f-9318-46dc5e7e52ec'},
+  'actor': {'type': 'user', 'id': 1, 'name': 'colleen'}
+}
+```
+
+
 ### Error
 
 The `error.created` resource subscription is only available for Business plans and above.


### PR DESCRIPTION
Add documentation for the new Sentry app comment webhooks that were added in https://github.com/getsentry/sentry/pull/32245