### PR TITLE
fix(dashboards): Removes ea note from issue widget text

### DIFF
--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -38,7 +38,7 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 
-If you're an Early Adopter, you can also add issues data to your [custom dashboards](/product/dashboards/custom-dashboards/), as widgets, using the [data set selector](/product/dashboards/custom-dashboards/#data-set-selection).
+You can also add issues data to your [custom dashboards](/product/dashboards/custom-dashboards/), as widgets, using the [data set selector](/product/dashboards/custom-dashboards/#data-set-selection).
 
 ## Learn More
 


### PR DESCRIPTION
Issue Widgets has already GA'd which means this EA note is no longer needed.