### PR TITLE
move event processors to common content

### DIFF
--- a/src/platforms/common/enriching-events/event-processors.mdx
+++ b/src/platforms/common/enriching-events/event-processors.mdx
@@ -4,7 +4,12 @@ sidebar_order: 300
 redirect_from:
   - /node/event-processors/
   - /platforms/node/guides/connect/event-processors/
+  - /platforms/node/enriching-events/event-processors/
 description: "Learn more about how you can add your own `eventProcessor` on the current scope."
+supported:
+  - javascript
+  - node
+  - react-native
 ---
 
 With `eventProcessors` you can hook into the process of enriching the event with additional data. You can add your own `eventProcessor` on the current scope. The difference between `beforeSend` and `eventProcessors` is that `eventProcessors` run on the scope level whereas `beforeSend` runs globally, no matter which scope you're in.

--- a/src/platforms/common/enriching-events/event-processors.mdx
+++ b/src/platforms/common/enriching-events/event-processors.mdx
@@ -16,6 +16,7 @@ notSupported:
   - go
   - java
   - kotlin
+  - native
   - perl
   - php
   - python

--- a/src/platforms/common/enriching-events/event-processors.mdx
+++ b/src/platforms/common/enriching-events/event-processors.mdx
@@ -6,10 +6,22 @@ redirect_from:
   - /platforms/node/guides/connect/event-processors/
   - /platforms/node/enriching-events/event-processors/
 description: "Learn more about how you can add your own `eventProcessor` on the current scope."
-supported:
-  - javascript
-  - node
-  - react-native
+notSupported:
+  - android
+  - apple
+  - dart
+  - dotnet
+  - elixir
+  - flutter
+  - go
+  - java
+  - kotlin
+  - perl
+  - php
+  - python
+  - ruby
+  - rust
+  - unity
 ---
 
 With `eventProcessors` you can hook into the process of enriching the event with additional data. You can add your own `eventProcessor` on the current scope. The difference between `beforeSend` and `eventProcessors` is that `eventProcessors` run on the scope level whereas `beforeSend` runs globally, no matter which scope you're in.


### PR DESCRIPTION
Moved the Event Processors page that was under Node.js to the common content for all platforms so it can be shared by JavaScript and React Native. 