### PR TITLE
Fix per event level description

### DIFF
--- a/src/includes/set-level/javascript.mdx
+++ b/src/includes/set-level/javascript.mdx
@@ -17,6 +17,12 @@ or per event:
 ```javascript
 Sentry.withScope(function(scope) {
   scope.setLevel("info");
-  Sentry.captureException("info");
+
+  // The exception has the event level set by the scope (info).
+  Sentry.captureException(new Error("custom error"));
+
 });
+// Outside of withScope, the Event level will have their previous value restored.
+// The exception has the event level set (error).
+Sentry.captureException(new Error("custom error 2"));
 ```


### PR DESCRIPTION
The current sample is a bit confusing
resulting on an <unknown> error

The refactored sample will describe that an error inside of WithScope will have the event level set by the defined setlevel where events outside of WithScope will have their default values set

Before
![image](https://user-images.githubusercontent.com/8229322/157492166-f2785066-89bd-440b-96c6-d340a2df9e19.png)

After
![image](https://user-images.githubusercontent.com/8229322/157492024-789f8fc7-0a97-42bf-99b4-6bfc90f8e257.png)
