### PR TITLE
fix(python): Update snippet for setting transaction name

### DIFF
--- a/src/includes/enriching-events/set-transaction-name/python.mdx
+++ b/src/includes/enriching-events/set-transaction-name/python.mdx
@@ -2,5 +2,5 @@
 from sentry_sdk import configure_scope
 
 with configure_scope() as scope:
-    scope.transaction = "UserListView"
+    scope.transaction.name = "UserListView"
 ```


### PR DESCRIPTION
For reasons of backwards compatibility, we still support changing the active transaction's name by assigning to `scope.transaction`, even though `scope.transaction` is actually the `Transaction` object whose name you're changing. Eventually we won't support it, though, and in the meantime it's very confusing. This PR therefore updates the code to do it the right way, which is to first retrieve the transaction and then set its name directly.

Fixes https://github.com/getsentry/sentry-python/issues/1155.