### PR TITLE
ref(rate limits): Add rate limit to documentation

### DIFF
--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -7,7 +7,7 @@ Sentry rate limits every API request made to prevent abuse and resource overuse.
 
 The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected.
 
-While there is a default value, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
+While there is a default value of 40 requests per second, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
 
 ## Headers
 


### PR DESCRIPTION
Mention the 40 RPS target rate limit in the rate limiting docs.