### PR TITLE
Mobile Vitals for Flutter

### DIFF
--- a/src/includes/getting-started-primer/android.mdx
+++ b/src/includes/getting-started-primer/android.mdx
@@ -27,8 +27,8 @@ The SDK builds a crash report that persists to disk and tries to send the report
 - [Performance Monitoring](/product/performance/) creates transactions for:
     - Android activity transactions
     - Android fragment spans with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
-    - Cold and warm app start spans and measurements with [Automatic Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
-    - Slow and frozen frames measurements with [Automatic Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
+    - [Cold and warm app start](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+    - [Slow and frozen frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
     - OkHttp request spans with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
     - SQLite and Room query spans with [Room and SQLite Integration](/platforms/android/configuration/integrations/room-and-sqlite/)
     - File I/O spans with [File I/O Integration](/platforms/android/configuration/integrations/file-io/)

--- a/src/includes/getting-started-primer/flutter.mdx
+++ b/src/includes/getting-started-primer/flutter.mdx
@@ -21,6 +21,8 @@ Features:
 - [Performance Monitoring](/product/performance/) creates transactions for:
     - [HTTP requests](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#httpclient-library-instrumentation)
     - [Routing Instumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation)
+    - Cold and warm app start spans and measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+    - Slow and frozen frames measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
 - [Logging Integration](/platforms/dart/configuration/integrations/logging)
 - Limited support for Flutter Web, Windows, and Linux
 - Under the hood the SDK relies on the [Dart SDK](/platforms/dart/); the minimum required version is `2.12.0` and Flutter SDK version is `1.17.0`.

--- a/src/includes/getting-started-primer/flutter.mdx
+++ b/src/includes/getting-started-primer/flutter.mdx
@@ -21,7 +21,7 @@ Features:
 - [Performance Monitoring](/product/performance/) creates transactions for:
     - [HTTP requests](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#httpclient-library-instrumentation)
     - [Routing Instumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation)
-    - Cold and warm app start spans and measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+    - Cold and warm app start measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
     - Slow and frozen frames measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
 - [Logging Integration](/platforms/dart/configuration/integrations/logging)
 - Limited support for Flutter Web, Windows, and Linux

--- a/src/includes/getting-started-primer/flutter.mdx
+++ b/src/includes/getting-started-primer/flutter.mdx
@@ -21,8 +21,8 @@ Features:
 - [Performance Monitoring](/product/performance/) creates transactions for:
     - [HTTP requests](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#httpclient-library-instrumentation)
     - [Routing Instumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation)
-    - Cold and warm app start measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
-    - Slow and frozen frames measurements with [Automatic Instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
+    - [Cold and warm app start](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+    - [Slow and frozen frames](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
 - [Logging Integration](/platforms/dart/configuration/integrations/logging)
 - Limited support for Flutter Web, Windows, and Linux
 - Under the hood the SDK relies on the [Dart SDK](/platforms/dart/); the minimum required version is `2.12.0` and Flutter SDK version is `1.17.0`.

--- a/src/includes/performance/configure-sample-rate/dart.mdx
+++ b/src/includes/performance/configure-sample-rate/dart.mdx
@@ -1,5 +1,3 @@
-Performance Monitoring is available for the Sentry Dart SDK version ≥ 6.1.0-alpha.1.
-
 ```dart
 import 'package:sentry/sentry.dart';
 

--- a/src/includes/performance/configure-sample-rate/flutter.mdx
+++ b/src/includes/performance/configure-sample-rate/flutter.mdx
@@ -1,5 +1,3 @@
-Performance Monitoring is available for the Sentry Dart SDK version ≥ 6.1.0-alpha.1.
-
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -160,9 +160,6 @@ Supported on Android OS version `7.0` and above.
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are *slow frames* and *frozen frames*. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the [Android's Activity](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation) transactions.
 
-- **Slow frames**: Slow frames are captured by the SDK when the app takes more than 16 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps). At 60 fps, every frame has 16 ms to render; slower than that, and the app has slow frames.
-- **Frozen frames**: Frozen frames are UI frames that take longer than 700 ms to render.
-
 Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
 #### AndroidX Support

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -44,9 +44,6 @@ This feature is available for iOS, tvOS, and Mac Catalyst.
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are *slow frames* and *frozen frames*. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-- **Slow frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders with 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
-- **Frozen frames**: Frozen frames are UI frames that take longer than 700 ms to render.
-
 The detail view of the transaction displays the slow, frozen, and total frames:
 
 ![Slow and Frozen Frames](slow-frozen-frames.png)
@@ -89,7 +86,7 @@ This is an experimental feature and requires an opt-in. Experimental features ar
 </Alert>
 
 The Sentry SDK adds spans for file I/O operations to ongoing transactions bound to the scope. Currently, the SDK supports operations with [NSData][NSData], but many other APIs like [NSFileManager][NSFileManager], [NSString][NSString] and [NSBundle][NSBundle] uses [NSData][NSData].
-This feature is experimental and is disabled by default. 
+This feature is experimental and is disabled by default.
 
 To enable file I/O instrumentation:
 

--- a/src/platforms/dart/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/dart/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -10,8 +10,6 @@ redirect_from:
 
 Capturing transactions requires that you first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink> if you haven't already.
 
-Supported in Sentry's Dart SDK version `6.1.0-alpha.2` and above.
-
 </Note>
 
 ### http.Client Library Instrumentation

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -140,7 +140,7 @@ This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Featur
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+To start getting the Mobile Vitals data, you have to set up the [routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
 In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
 

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -142,7 +142,7 @@ Unresponsive UI and animation hitches annoy users and degrade the user experienc
 
 To start getting the Mobile Vitals data, you have to set up the [routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
-In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
+If you want to opt out, you can flip the `enableAutoPerformanceTracking` flag:
 
 ```dart
 import 'package:flutter/widgets.dart';

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -95,7 +95,7 @@ The SDK differentiates between a cold and a warm start, but doesn't track hot st
 
 To start getting the Mobile Vitals data, you have to set up the [routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
-In case you do not initialize the SDK early in the App's lifecycle, you can also customize the ending of the App start, you have to disable the `autoAppStart` flag and call the `SentryFlutter.setAppStartEnd` function.
+If you don't initialize the SDK early in the app's lifecycle, you can also customize the ending of the app start by disabling the `autoAppStart` flag and calling the `SentryFlutter.setAppStartEnd` function.
 
 ```dart
 import 'package:flutter/widgets.dart';

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -10,8 +10,6 @@ redirect_from:
 
 Capturing transactions requires that you first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink> if you haven't already.
 
-Supported in Sentry's Dart SDK version `6.1.0-alpha.2` and above.
-
 </Note>
 
 ### http.Client Library Instrumentation
@@ -81,4 +79,53 @@ SentryNavigatorObserver(
   enableAutoTransactions: false,
   setRouteNameAsTransaction: true
 )
+```
+
+### App Start Instrumentation
+
+<Note>
+
+This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+
+</Note>
+
+The App Start Instrumentation provides insight into how long your application takes to launch. It tracks the length of time from the **earliest native process initialization** until the very first [PostFrameCallback](https://api.flutter.dev/flutter/scheduler/SchedulerBinding/addPostFrameCallback.html) is triggered.
+
+The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
+
+To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+
+In case you do not initialize the SDK early in the App's lifecycle, you can also customize the ending of the App start, you have to disable the `autoAppStart` flag and call the `SentryFlutter.setAppStartEnd` function.
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+// Run my App and do my things first
+
+// Initialize the Flutter SDK
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) => options.autoAppStart = false,
+  );
+}
+
+// End the App start
+SentryFlutter.setAppStartEnd(DateTime.now().toUtc());
+```
+
+In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) => options.enableAutoPerformanceTracking = false,
+    appRunner: () => runApp(MyApp()),
+  );
+}
+
+Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 ```

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -114,7 +114,7 @@ Future<void> main() async {
 SentryFlutter.setAppStartEnd(DateTime.now().toUtc());
 ```
 
-In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
+If you want to opt out, you can flip the `enableAutoPerformanceTracking` flag:
 
 ```dart
 import 'package:flutter/widgets.dart';

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -140,7 +140,7 @@ This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Featur
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
 In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
 

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -140,9 +140,6 @@ This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Featur
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-- **Slow Frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
-- **Frozen Frames**: Frozen frames are UI frames that take longer than 700 ms to render.
-
 To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
 In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -93,7 +93,7 @@ The App Start Instrumentation provides insight into how long your application ta
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
-To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
 In case you do not initialize the SDK early in the App's lifecycle, you can also customize the ending of the App start, you have to disable the `autoAppStart` flag and call the `SentryFlutter.setAppStartEnd` function.
 

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -126,6 +126,37 @@ Future<void> main() async {
     appRunner: () => runApp(MyApp()),
   );
 }
+```
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
+
+### Slow and Frozen Frames
+
+<Note>
+
+This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+
+</Note>
+
+Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
+
+- **Slow Frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
+- **Frozen Frames**: Frozen frames are UI frames that take longer than 700 ms to render.
+
+To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+
+In case you want to opt-out, you can flip the `enableAutoPerformanceTracking` flag:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) => options.enableAutoPerformanceTracking = false,
+    appRunner: () => runApp(MyApp()),
+  );
+}
 ```
+
+Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -93,7 +93,7 @@ The App Start Instrumentation provides insight into how long your application ta
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
-To start getting the Mobile Vitals data, you have to set up the [Routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
+To start getting the Mobile Vitals data, you have to set up the [routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
 
 In case you do not initialize the SDK early in the App's lifecycle, you can also customize the ending of the App start, you have to disable the `autoAppStart` flag and call the `SentryFlutter.setAppStartEnd` function.
 

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -93,8 +93,6 @@ The App Start Instrumentation provides insight into how long your application ta
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
-To start getting the Mobile Vitals data, you have to set up the [routing instrumentation](/platforms/flutter/performance/instrumentation/automatic-instrumentation/#routing-instumentation).
-
 If you don't initialize the SDK early in the app's lifecycle, you can also customize the ending of the app start by disabling the `autoAppStart` flag and calling the `SentryFlutter.setAppStartEnd` function.
 
 ```dart

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -85,7 +85,7 @@ SentryNavigatorObserver(
 
 <Note>
 
-This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+This feature is available on Sentry Flutter SDK `6.5.0-alpha.1` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
 
 </Note>
 
@@ -132,7 +132,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 <Note>
 
-This feature is available on Sentry Flutter SDK `6.4.0-beta.4` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+This feature is available on Sentry Flutter SDK `6.5.0-alpha.1` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
 
 </Note>
 

--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -300,9 +300,6 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are slow frames and frozen frames. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the transactions you capture.
 
-- **Slow Frames**: Slow frames are captured by the SDK when the app takes more than 16.67 ms to render a frame. Typically, a phone or tablet renders 60 frames per second (fps), though the frame rate can be higher, especially as 120 fps displays become popular. At 60 fps, every frame has 16.67 ms to render; slower than that, and the app has slow frames.
-- **Frozen Frames**: Frozen frames are UI frames that take longer than 700 ms to render.
-
 Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
 <Note>


### PR DESCRIPTION
cc @denrase 

* Removed the beta notes since they are GA already.
* Removed the duplicated slow/frozen explanations since they are explained under the Mobile vitals already, single source of truth is better.

https://github.com/getsentry/sentry-dart/pull/784

Merge after: https://github.com/getsentry/publish/issues/927