### PR TITLE
feat(android): Add autoinstallation sections for okhttp, fragment and timber

### DIFF
--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -44,7 +44,7 @@ plugins {
 }
 ```
 
-Then, initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/#configure).
 
 The Android SDK automatically adds the `FragmentLifecycleIntegration` if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -48,7 +48,7 @@ Then, initialize the [Android SDK](/platforms/android/).
 
 The Android SDK automatically adds the `FragmentLifecycleIntegration` if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
 
-However, you can still override the default behaviour by adding your own instance of the `FragmetnLifecycleIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/fragment/#configure) section below.
+However, you can still override the default behaviour by adding your own instance of the `FragmentLifecycleIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/fragment/#configure) section below.
 
 ## Manual Installation
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -16,7 +16,7 @@ On this page, we get you up and running with Sentry's Fragment Integration, so t
 
 ### Install
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-fragment` dependency. The plugin will only add the `sentry-android-fragment` dependency in case a `androidx.fragment` dependency was discovered on the classpath.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-fragment` dependency. The plugin will only add the `sentry-android-fragment` dependency if a `androidx.fragment` dependency was discovered on the classpath.
 
 Add the Sentry Android Gradle plugin in `build.gradle`:
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -46,7 +46,7 @@ plugins {
 
 Then, initialize the [Android SDK](/platforms/android/).
 
-The Android SDK automatically adds the `FragmentLifecycleIntegration`, if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
+The Android SDK automatically adds the `FragmentLifecycleIntegration` if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
 
 However, you can still override the default behaviour by adding your own instance of the `FragmetnLifecycleIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/fragment/#configure) section below.
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -50,7 +50,7 @@ The Android SDK automatically adds the `FragmentLifecycleIntegration` if the `se
 
 However, you can still override the default behaviour by adding your own instance of the `FragmetnLifecycleIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/fragment/#configure) section below.
 
-## Manually
+## Manual Installation
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -12,7 +12,47 @@ The `sentry-android-fragment` library provides [Fragment](https://developer.andr
 
 On this page, we get you up and running with Sentry's Fragment Integration, so that it will automatically add a breadcrumb for each fragment's lifecycle and start a span out of the active transaction bound to the scope for each launch of a fragment.
 
-## Install
+## Automatically with the Sentry Android Gradle plugin
+
+### Install
+
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-fragment` dependency.
+
+Add the Sentry Android Gradle plugin in `build.gradle`:
+
+```groovy
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id "io.sentry.android.gradle" version "3.1.0-alpha.1"
+}
+```
+
+```kotlin
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("io.sentry.android.gradle") version "3.1.0-alpha.1"
+}
+```
+
+and initialize the [Android SDK](/platforms/android/).
+
+The Android SDK automatically adds the `FragmentLifecycleIntegration`, if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
+
+However, you can still override the default behaviour by adding your own instance of the `FragmetnLifecycleIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/fragment/#configure) section below.
+
+## Manually
+
+### Install
 
 To add the Fragment integration, [manually initialize](/platforms/android/configuration/manual-init/) the Android SDK, then add the `sentry-android-fragment` dependency. Using Gradle:
 
@@ -21,7 +61,7 @@ implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.androi
 implementation 'io.sentry:sentry-android-fragment:{{ packages.version('sentry.java.android.fragment', '5.1.0') }}'
 ```
 
-## Configure
+### Configure
 
 Configuration should happen as early as possible in your application's lifecycle.
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -12,7 +12,7 @@ The `sentry-android-fragment` library provides [Fragment](https://developer.andr
 
 On this page, we get you up and running with Sentry's Fragment Integration, so that it will automatically add a breadcrumb for each fragment's lifecycle and start a span out of the active transaction bound to the scope for each launch of a fragment.
 
-## Automatically with the Sentry Android Gradle plugin
+## Auto-Installation With the Sentry Android Gradle Plugin
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -16,7 +16,7 @@ On this page, we get you up and running with Sentry's Fragment Integration, so t
 
 ### Install
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-fragment` dependency.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-fragment` dependency. The plugin will only add the `sentry-android-fragment` dependency in case a `androidx.fragment` dependency was discovered on the classpath.
 
 Add the Sentry Android Gradle plugin in `build.gradle`:
 

--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -44,7 +44,7 @@ plugins {
 }
 ```
 
-and initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/).
 
 The Android SDK automatically adds the `FragmentLifecycleIntegration`, if the `sentry-android-fragment` dependency was found on the classpath. The integration is added with both `enableFragmentLifecycleBreadcrumbs` and `enableAutoFragmentLifecycleTracing` enabled. 
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -22,7 +22,7 @@ The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilit
 
 ## Auto-Installation With Sentry Android Gradle Plugin
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency in case a `okhttp` dependency was discovered on the classpath.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency if an `okhttp` dependency was discovered on the classpath.
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -52,7 +52,7 @@ plugins {
 }
 ```
 
-Then, initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/#configure).
 
 ### Disable
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -20,7 +20,7 @@ The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilit
 
 </Note>
 
-## Auto-Installation With Sentry Android Gradle Plugin
+## Auto-Installation With the Sentry Android Gradle Plugin
 
 Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency if an `okhttp` dependency was discovered on the classpath.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -52,7 +52,7 @@ plugins {
 }
 ```
 
-and initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/).
 
 ### Disable
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -22,7 +22,7 @@ The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilit
 
 ## Automatically with Sentry Android Gradle plugin
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency in case a `okhttp` dependency was discovered on the classpath.
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -87,7 +87,7 @@ Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/and
 
 </Note>
 
-## Manually
+## Manual Installation
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -20,7 +20,7 @@ The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilit
 
 </Note>
 
-## Automatically with Sentry Android Gradle plugin
+## Auto-Installation With Sentry Android Gradle Plugin
 
 Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency in case a `okhttp` dependency was discovered on the classpath.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -20,7 +20,76 @@ The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilit
 
 </Note>
 
-## Install
+## Automatically with Sentry Android Gradle plugin
+
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation.
+
+### Install
+
+Add the Sentry Android Gradle plugin in `build.gradle`:
+
+```groovy
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id "io.sentry.android.gradle" version "3.1.0-alpha.1"
+}
+```
+
+```kotlin
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("io.sentry.android.gradle") version "3.1.0-alpha.1"
+}
+```
+
+and initialize the [Android SDK](/platforms/android/).
+
+### Disable
+
+If you would like to disable the OkHttp instrumentation feature, we expose a configuration option for that:
+
+```groovy
+import io.sentry.android.gradle.InstrumentationFeature
+
+sentry {
+  tracingInstrumentation {
+    enabled = true
+    features = EnumSet.allOf(InstrumentationFeature) - InstrumentationFeature.OKHTTP
+  }
+}
+```
+
+```kotlin
+import java.util.EnumSet
+import io.sentry.android.gradle.InstrumentationFeature
+
+sentry {
+  tracingInstrumentation {
+    enabled.set(true)
+    features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.OKHTTP)
+  }
+}
+```
+
+<Note>
+
+Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/common/gradle/) documentation.
+
+</Note>
+
+## Manually
+
+### Install
 
 Sentry captures data by adding an `OkHttp Interceptor`. To add the OkHttp integration, initialize the [Android SDK](/platforms/android/), then add the `sentry-android-okhttp` dependency. Using Gradle:
 
@@ -29,7 +98,7 @@ implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.androi
 implementation 'io.sentry:sentry-android-okhttp:{{ packages.version('sentry.java.android.okhttp', '5.0.0') }}'
 ```
 
-## Configure
+### Configure
 
 Configuration should happen once you create your `OkHttpClient` instance.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -83,7 +83,7 @@ sentry {
 
 <Note>
 
-Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/common/gradle/) documentation.
+Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/gradle/) documentation.
 
 </Note>
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -20,7 +20,47 @@ Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by 
 
 </Note>
 
-## Install
+## Automatically with the Sentry Android Gradle plugin
+
+### Install
+
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-timber` dependency.
+
+Add the Sentry Android Gradle plugin in `build.gradle`:
+
+```groovy
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id "io.sentry.android.gradle" version "3.1.0-alpha.1"
+}
+```
+
+```kotlin
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("io.sentry.android.gradle") version "3.1.0-alpha.1"
+}
+```
+
+and initialize the [Android SDK](/platforms/android/).
+
+The Android SDK automatically adds the `SentryTimberIntegration`, if the `sentry-android-timber` dependency was found on the classpath. The integration is added with `minEventLevel` set to `ERROR` and `minBreadcrumbLevel` set to `INFO`. 
+
+However, you can still override the default behaviour by adding your own instance of the `SentryTimberIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/timber/#configure) section below.
+
+## Manually
+
+### Install
 
 To add the Timber integration, [manually initialize](/platforms/android/configuration/manual-init/) the Android SDK, then add the `sentry-android-timber` dependency. Using Gradle:
 
@@ -29,7 +69,7 @@ implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.androi
 implementation 'io.sentry:sentry-android-timber:{{ packages.version('sentry.java.android.timber', '4.2.0') }}'
 ```
 
-## Configure
+### Configure
 
 Configuration should happen as early as possible in your application's lifecycle.
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -52,7 +52,7 @@ plugins {
 }
 ```
 
-and initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/).
 
 The Android SDK automatically adds the `SentryTimberIntegration` if the `sentry-android-timber` dependency was found on the classpath. The integration is added with `minEventLevel` set to `ERROR` and `minBreadcrumbLevel` set to `INFO`. 
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -24,7 +24,7 @@ Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by 
 
 ### Install
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-timber` dependency.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-timber` dependency. The plugin will only add the `sentry-android-timber` dependency in case a `timber` dependency was discovered on the classpath.
 
 Add the Sentry Android Gradle plugin in `build.gradle`:
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -54,7 +54,7 @@ plugins {
 
 and initialize the [Android SDK](/platforms/android/).
 
-The Android SDK automatically adds the `SentryTimberIntegration`, if the `sentry-android-timber` dependency was found on the classpath. The integration is added with `minEventLevel` set to `ERROR` and `minBreadcrumbLevel` set to `INFO`. 
+The Android SDK automatically adds the `SentryTimberIntegration` if the `sentry-android-timber` dependency was found on the classpath. The integration is added with `minEventLevel` set to `ERROR` and `minBreadcrumbLevel` set to `INFO`. 
 
 However, you can still override the default behaviour by adding your own instance of the `SentryTimberIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/timber/#configure) section below.
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -58,7 +58,7 @@ The Android SDK automatically adds the `SentryTimberIntegration`, if the `sentry
 
 However, you can still override the default behaviour by adding your own instance of the `SentryTimberIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/timber/#configure) section below.
 
-## Manually
+## Manual Installation
 
 ### Install
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -24,7 +24,7 @@ Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by 
 
 ### Install
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-timber` dependency. The plugin will only add the `sentry-android-timber` dependency in case a `timber` dependency was discovered on the classpath.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-timber` dependency. The plugin will only add the `sentry-android-timber` dependency if a `timber` dependency was discovered on the classpath.
 
 Add the Sentry Android Gradle plugin in `build.gradle`:
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -52,7 +52,7 @@ plugins {
 }
 ```
 
-Then, initialize the [Android SDK](/platforms/android/).
+Then, initialize the [Android SDK](/platforms/android/#configure).
 
 The Android SDK automatically adds the `SentryTimberIntegration` if the `sentry-android-timber` dependency was found on the classpath. The integration is added with `minEventLevel` set to `ERROR` and `minBreadcrumbLevel` set to `INFO`. 
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -20,7 +20,7 @@ Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by 
 
 </Note>
 
-## Automatically with the Sentry Android Gradle plugin
+## Auto-Installation With the Sentry Android Gradle Plugin
 
 ### Install
 


### PR DESCRIPTION
Merge after 3.1.0 of SAGP is shipped