### PR TITLE
feat(js): Document new bundle varieties

### DIFF
--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -6,7 +6,7 @@ description: "Learn how Sentry supports loading its JavaScript SDK via a CDN."
 
 import JsBundleList from "~src/components/jsBundleList";
 
-Sentry supports loading its JavaScript SDK via a CDN. Generally we suggest using our npm package (`@sentry/browser`) as utilizing a CDN create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/).
+Sentry supports loading the JavaScript SDK via a CDN. Generally we suggest using our npm package (`@sentry/browser`) instead, as using the CDN can create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/), which provides a deferred version of our minified ES5 browser bundle. To see what other bundles are available, see [Available Bundles](#available-bundles) below.
 
 ```html {tabTitle: CDN}
 <script
@@ -18,7 +18,7 @@ Sentry supports loading its JavaScript SDK via a CDN. Generally we suggest using
 
 ## Performance Bundle
 
-To use Sentry's performance tracing an alternative bundle is needed. This allows us to keep the filesize down for users who only need error monitoring.
+To use Sentry's performance tracing, an alternative bundle is needed. This allows us to keep the filesize down for users who only need error monitoring.
 
 ```html {tabTitle: CDN}
 <script
@@ -34,12 +34,12 @@ You only need to load `bundle.tracing.min.js`, which provides both error and per
 
 </Note>
 
-The most important thing to note here is that `Sentry.Integrations` has been made available, and can be referenced in your call to `Sentry.init`:
+Once you've included the Sentry SDK bundle in your page, you can use Sentry in your own bundle:
 
 ```javascript {tabTitle: CDN}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // this assumes your build process sets "npm_package_version" in the env
+  // this assumes your build process replaces `process.env.npm_package_version` with a value
   release: "my-project-name@" + process.env.npm_package_version,
   integrations: [new Sentry.BrowserTracing()],
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -51,7 +51,15 @@ Sentry.init({
 
 ## Available Bundles
 
-A variety of bundles are provided which are optimized for Sentry's various integrations.
+Our CDN hosts a variety of bundles:
+
+- `@sentry/browser` (named `bundle.<modifiers>.js`)
+- `@sentry/browser` and `@sentry/tracing` together (named `bundle.tracing.<modifiers>.js`)
+- each of the integrations in `@sentry/integrations` (named `<integration-name>.<modifiers>.js`)
+
+Each bundle is offered in both ES5 and ES6 versions, and for each version there are three bundle varieties: unminified, minified, and minified with debug logging. (That last version can be helpful for times when you need to debug an issue which only occurs in prod. In dev, it makes most sense to use the unminified bundle, which always includes logging.)
+
+So, for example, `bundle.tracing.es6.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES6, and minified (but with debug logging included). On the simpler end of the naming spectrum, `bundle.js` is `@sentry/browser`, compiled to ES5 but not minified (with debug logging included, as it is for all unminified bundles).
 
 <JsBundleList />
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -6,7 +6,7 @@ description: "Learn how Sentry supports loading its JavaScript SDK via a CDN."
 
 import JsBundleList from "~src/components/jsBundleList";
 
-Sentry supports loading the JavaScript SDK via a CDN. Generally we suggest using our npm package (`@sentry/browser`) instead, as using the CDN can create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/), which provides a deferred version of our minified ES5 browser bundle. To see what other bundles are available, see [Available Bundles](#available-bundles) below.
+Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest using our npm package (`@sentry/browser`) instead, as using the CDN can create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/), which provides a deferred version of our minified ES5 browser bundle. To see what other bundles are available, see [Available Bundles](#available-bundles) below.
 
 ```html {tabTitle: CDN}
 <script
@@ -57,9 +57,13 @@ Our CDN hosts a variety of bundles:
 - `@sentry/browser` and `@sentry/tracing` together (named `bundle.tracing.<modifiers>.js`)
 - each of the integrations in `@sentry/integrations` (named `<integration-name>.<modifiers>.js`)
 
-Each bundle is offered in both ES5 and ES6 versions, and for each version there are three bundle varieties: unminified, minified, and minified with debug logging. (That last version can be helpful for times when you need to debug an issue which only occurs in prod. In dev, it makes most sense to use the unminified bundle, which always includes logging.)
+Each bundle is offered in both ES5 and ES6 versions, and for each version there are three bundle varieties: unminified, minified, and minified with debug logging. (That last version can be helpful for times when you need to debug an issue which only occurs in production. In a development environment, it makes most sense to use the unminified bundle, which always includes logging.)
 
-So, for example, `bundle.tracing.es6.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES6, and minified (but with debug logging included). On the simpler end of the naming spectrum, `bundle.js` is `@sentry/browser`, compiled to ES5 but not minified (with debug logging included, as it is for all unminified bundles).
+For example:
+
+- `bundle.js` is `@sentry/browser`, compiled to ES5 but not minified, with debug logging included (as it is for all unminified bundles)
+- `rewriteframes.es6.min.js` is the `RewriteFrames` integration, compiled to ES6 and minified, with no debug logging
+- `bundle.tracing.es6.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES6 and minified, with debug logging included
 
 <JsBundleList />
 


### PR DESCRIPTION
A number of PRs ([#4674](https://github.com/getsentry/sentry-javascript/pull/4674), [#4699](https://github.com/getsentry/sentry-javascript/pull/4699), [#4718](https://github.com/getsentry/sentry-javascript/pull/4718)) have recently added to the bundles available for use on the CDN. This documents the new options, and does some general wordsmithing on the page.