### PR TITLE
feat(JS): Add `normalizeMaxBreadth` option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -352,13 +352,13 @@ Maximum number of characters a single value can have before it will be truncated
 
 <ConfigKey name="normalize-depth" supported={["javascript", "node"]}>
 
-Sentry SDKs normalize any contextual data to a given depth. Any data beyond this depth will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed `3` levels deep.
+Sentry SDKs normalize any contextual data to a given depth. Any data beyond this depth will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed three levels deep.
 
 </ConfigKey>
 
-<ConfigKey name="normalize-max-depth" supported={["javascript", "node"]}>
+<ConfigKey name="normalize-max-breadth" supported={["javascript", "node"]}>
 
-This is the maximum number of properties or entries which will be included in any given object or array when the SDK is normalizing contextual data. Any data beyond this depth will be dropped. (defaults to 1000)
+This is the maximum number of properties or entries that will be included in any given object or array when the SDK is normalizing contextual data. Any data beyond this depth will be dropped. (defaults to 1000)
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -352,7 +352,13 @@ Maximum number of characters a single value can have before it will be truncated
 
 <ConfigKey name="normalize-depth" supported={["javascript", "node"]}>
 
-Sentry SDKs normalize any contextual data to a given depth. Any keys containing data with a structure deeper than this will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed `3` levels deep.
+Sentry SDKs normalize any contextual data to a given depth. Any data beyond this depth will be trimmed and marked using its type instead (`[Object]` or `[Array]`), without walking the tree any further. By default, walking is performed `3` levels deep.
+
+</ConfigKey>
+
+<ConfigKey name="normalize-max-depth" supported={["javascript", "node"]}>
+
+This is the maximum number of properties or entries which will be included in any given object or array when the SDK is normalizing contextual data. Any data beyond this depth will be dropped. (defaults to 1000)
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -356,7 +356,9 @@ Sentry SDKs normalize any contextual data to a given depth. Any data beyond this
 
 </ConfigKey>
 
-<ConfigKey name="normalize-max-breadth" supported={["javascript", "node"]}>
+<ConfigKey name="normalize-max-breadth" supported={["javascript", "node"]} notSupported={["react-native", "electron"]}>
+
+_(New in version 6.19.1)_
 
 This is the maximum number of properties or entries that will be included in any given object or array when the SDK is normalizing contextual data. Any data beyond this depth will be dropped. (defaults to 1000)
 


### PR DESCRIPTION
This documents the new `normalizeMaxBreadth` option added to JS-based SDKs in https://github.com/getsentry/sentry-javascript/pull/4689, which controls how many properties or entries any given object or array will contain after normalization.

Ref: https://getsentry.atlassian.net/browse/WEB-712