### PR TITLE
Correct method name

### DIFF
--- a/src/platforms/javascript/common/configuration/webworkers/index.mdx
+++ b/src/platforms/javascript/common/configuration/webworkers/index.mdx
@@ -47,7 +47,7 @@ worker.postMessage("Hello!");
 
 <Alert level="warning" title="Manual Capturing">
 
-To capture errors or messages manually, such as to use `captureMessage` or `captureError` inside Web Workers, Sentry should be initialized inside each Web Workers' own scope. Only unhandled errors will be captured and sent to Sentry without worker-level initialization.
+To capture errors or messages manually, such as to use `captureMessage` or `captureException` inside Web Workers, Sentry should be initialized inside each Web Workers' own scope. Only unhandled errors will be captured and sent to Sentry without worker-level initialization.
 
 </Alert>
 


### PR DESCRIPTION
According to https://docs.sentry.io/platforms/javascript/usage/ it should be `captureException`.