### PR TITLE
ref: Remove mentions of "Global Header"

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -14,7 +14,7 @@ Sentry provides several configuration options to create an issue alert based on 
 
 Specify which <PlatformLink to="/configuration/environments/">environment(s)</PlatformLink> will use this particular alert rule. This control filters on the `environment` tag in your events. This filter is helpful because the urgency and workflows you apply to production alerts might differ from those you apply to alerts originating from your QA environment, for example.
 
-The “Environment” dropdown list here has the same environments that are available for the selected project in the global “Environment” dropdown (this does not include hidden environments). Selecting "All Environments" is equivalent to having no environment filter.
+The “Environment” dropdown list here has the same environments that are available for the selected project in the common “Environment” filter dropdown (this does not include hidden environments). Selecting "All Environments" is equivalent to having no environment filter.
 
 ## Team
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -16,7 +16,7 @@ The following set of filters translates into a [Discover query](/product/discove
 
 Specify which <PlatformLink to="/configuration/environments/">environment(s)</PlatformLink> will use this particular alert rule. This control filters on the `environment` tag in your events. This filter is helpful because the urgency and workflows you apply to production alerts might differ from those you apply to alerts originating from your QA environment, for example.
 
-The “Env:” dropdown list here has the same environments that are available for the selected project in the global “Environment” dropdown (this does not include hidden environments). Selecting "All" is equivalent to having no environment filter.
+The “Env:” dropdown list here has the same environments that are available for the selected project in the common “Environment” filter dropdown (this does not include hidden environments). Selecting "All" is equivalent to having no environment filter.
 
 ### Event Type
 

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -18,7 +18,7 @@ Sentry's <SandboxLink scenario="dashboards" projectSlug="react">Dashboards</Sand
 
 ![Widgets visualizing events, errors by country, affected users, and handled vs unhandled issues.](dashboard-default.png)
 
-All widgets in the same view reflect the date range indicated in the Global Selection Header and update synchronously if you update that date range. You can also zoom in on any time series visualizations you may want to investigate, and all of the widgets reflect the time period that you’ve zoomed in on.
+All widgets in the same view reflect the date range indicated in date time range filter and update synchronously if you update that date range. You can also zoom in on any time series visualizations you may want to investigate, and all of the widgets reflect the time period that you’ve zoomed in on.
 
 ## Customization
 

--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -24,14 +24,14 @@ From the **Discover** page, you can build a query in three ways.
 
 There are four main building blocks that impact the results of your saved query. You can use a combination of these to narrow down your search.
 
-1. Global Selection Header
+1. Proejct, environment, and date range filters
 2. Search Conditions
 3. Interactive Graph
 4. Table Columns
 
-## Filter by Global Selection Header
+## Filter by project, enviornment, and date range
 
-Specify which projects, environments, and date range you want to zoom in on at the top of the page. This can also be found in other parts of Sentry as a top level filter.
+These common filters allow you to filter on your projects and environments as well as specify the date range you want to zoom in on.
 
 ## Filter by Search Conditions
 

--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -29,9 +29,9 @@ There are four main building blocks that impact the results of your saved query.
 3. Interactive Graph
 4. Table Columns
 
-## Filter by project, enviornment, and date range
+## Filter by Project, Environment, and Date Range {#filter-by-global-selection-header}
 
-These common filters allow you to filter on your projects and environments as well as specify the date range you want to zoom in on.
+These common filters allow you to filter on your projects and environments, as well as specify the date range you want to zoom in on.
 
 ## Filter by Search Conditions
 

--- a/src/docs/product/discover-queries/uncover-trends.mdx
+++ b/src/docs/product/discover-queries/uncover-trends.mdx
@@ -29,7 +29,7 @@ Sentry notifies you in real-time when your application breaks, and then provides
 
 1. Navigate to **Discover** and click on "Build a new query".
 
-2. Select the projects, environments, and date time range of errors you'd like to query.
+2. Select the projects, environments, and date range of errors you'd like to query.
 
 3. Sentry monitors different types of events for errors and performance. To query issues, filter by `event.type:error` in the search bar.
 

--- a/src/docs/product/discover-queries/uncover-trends.mdx
+++ b/src/docs/product/discover-queries/uncover-trends.mdx
@@ -29,7 +29,7 @@ Sentry notifies you in real-time when your application breaks, and then provides
 
 1. Navigate to **Discover** and click on "Build a new query".
 
-2. In the Global Header, select the projects, environments, and time range of errors you'd like to query.
+2. Select the projects, environments, and date time range of errors you'd like to query.
 
 3. Sentry monitors different types of events for errors and performance. To query issues, filter by `event.type:error` in the search bar.
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -49,7 +49,7 @@ On initial load, the table displays slow occurrences of the transaction along wi
 - Outlier Transactions (p100)
 - Recent Transactions
 
-The table also updates dynamically if you change any of the selections in the global header or when you drill in on a latency segment (applicable when viewing the Latency Histogram).
+The table also updates dynamically if you change any of the project, environment, or date-range filters or when you drill in on a latency segment (applicable when viewing the Latency Histogram).
 
 When viewing transactions, you may want to create more curated views. Click "Open in Discover" above the table to create a custom query to investigate further. For more details, see the full documentation for the Discover [Query Builder](/product/discover-queries/query-builder/).
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -49,7 +49,7 @@ On initial load, the table displays slow occurrences of the transaction along wi
 - Outlier Transactions (p100)
 - Recent Transactions
 
-The table also updates dynamically if you change any of the project, environment, or date-range filters or when you drill in on a latency segment (applicable when viewing the Latency Histogram).
+The table also updates dynamically if you change any of the project, environment, or date range filters or when you drill in on a latency segment (applicable when viewing the Latency Histogram).
 
 When viewing transactions, you may want to create more curated views. Click "Open in Discover" above the table to create a custom query to investigate further. For more details, see the full documentation for the Discover [Query Builder](/product/discover-queries/query-builder/).
 

--- a/src/docs/product/sentry-basics/environments/index.mdx
+++ b/src/docs/product/sentry-basics/environments/index.mdx
@@ -11,7 +11,7 @@ description: "Learn more about how environments can help you better filter issue
 
 Environments help you better filter issues, releases, and user feedback in the **Issue Details** page of [sentry.io](https://sentry.io). On that page, you can view information about a specific environment, focusing on the most recent release. If you’re using a multi-staged release process, you can also select a different default environment and set conditions that match the `environment` attribute to restrict alerts to only specific release stages.
 
-Use projects to separate different services or applications, and environments to separate different environments or release stages within each. If you've selected one or more projects in the global header of Sentry's web UI, the environment selector shows only environments associated with events from the selected projects.
+Use projects to separate different services or applications, and environments to separate different environments or release stages within each. If you've selected one or more projects in the filters of Sentry's web UI, the environment selector shows only environments associated with events from the selected projects.
 
 ![A project's All Environments dropdown expanded to show production and staging as options.](env_dropdown.png)
 


### PR DESCRIPTION
We're phasing out the 'Global Selection Header' (GSH, sometimes also called Global Header Selection).

This PR changes all mentions of the "Global Header" to a bit more generically refer to the specific filters themselves.