### PR TITLE
celeryproject.org compromised; use celeryq.dev

### DIFF
--- a/src/docs/clients/python/integrations.mdx
+++ b/src/docs/clients/python/integrations.mdx
@@ -76,7 +76,7 @@ request.app.sentry.captureMessage('Hello, world!')
 
 ## Celery
 
-[Celery](https://www.celeryproject.org/) is a distributed task queue system for Python built on AMQP principles. For Celery built-in support by Raven is provided but it requires some manual configuration.
+[Celery](https://docs.celeryq.dev/) is a distributed task queue system for Python built on AMQP principles. For Celery built-in support by Raven is provided but it requires some manual configuration.
 
 ### Installation
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -6,7 +6,7 @@ redirect_from:
 description: "Learn about using Sentry with Celery."
 ---
 
-The Celery integration adds support for the [Celery Task Queue System](http://www.celeryproject.org/).
+The Celery integration adds support for the [Celery Task Queue System](https://docs.celeryq.dev/).
 
 Just add `CeleryIntegration()` to your `integrations` list:
 
@@ -26,13 +26,13 @@ The integration will automatically report errors from all celery jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-There are many valid ways to do this like, for example, using a signal like [`worker_process_init`](https://docs.celeryproject.org/en/stable/userguide/signals.html#worker-process-init), or by initializing the SDK in the configuration file loaded with Celery's `--config` parameter.
+There are many valid ways to do this like, for example, using a signal like [`worker_process_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html#worker-process-init), or by initializing the SDK in the configuration file loaded with Celery's `--config` parameter.
 
 To verify if your SDK is initialized on worker start, you can pass `debug=True` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly.
 
 <Alert level="info" title="Note on distributed tracing">
 
-Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [message protocol of version 1](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-1), this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
+Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [message protocol of version 1](https://docs.celeryq.dev/en/stable/internals/protocol.html#version-1), this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
 
 The fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
 

--- a/src/wizard/python/celery.md
+++ b/src/wizard/python/celery.md
@@ -5,7 +5,7 @@ support_level: production
 type: library
 ---
 
-The celery integration adds support for the [Celery Task Queue System](https://www.celeryproject.org/).
+The celery integration adds support for the [Celery Task Queue System](https://docs.celeryq.dev/).
 
 Just add `CeleryIntegration()` to your `integrations` list:
 


### PR DESCRIPTION
The Celery team [has not had full control][1] of their celeryproject.org domain for well over a year. The domain is now [compromised][2] and redirects requests to a third party.

The Celery team has [acquired a new domain][3], [docs.celeryq.dev][4]. Usage of the old domain should be discontinued.

[1]: https://github.com/celery/celeryproject/issues/44#issuecomment-781323756
[2]: https://github.com/celery/celeryproject/issues/52
[3]: https://github.com/celery/celeryproject/issues/52#issuecomment-1072945869
[4]: https://docs.celeryq.dev