### PR TITLE
docs(dashboards): Adds docs for Widget Viewer

### DIFF
--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -29,3 +29,12 @@ If you’d like to edit the default dashboard or build out multiple ones, each w
 ## Open Dashboard Widgets in Discover
 
 Each <SandboxLink scenario="dashboards" projectSlug="react">Dashboard</SandboxLink> widget has an ellipsis that opens a context menu. From here, you can open the widget in [Discover](/product/discover-queries/) for to get more information. If a widget contains more than one query, you'll be prompted to select which query to view in **Discover**.
+
+## Widget Viewer
+
+Dashboard widgets can be opened in an expanded widget viewer mode for further exploration. Click the expand icon on the top right of any widget card. The widget viewer allows enhanced filtering, sorting, and navigation features that are not available in the basic widget card view:
+
+- Widget tables display more rows per page, can be paginated, can be sorted, and allow column width adjustment
+- Widget charts can be zoomed in without affecting the rest of the dashboard
+- Chart visualizations display an additional table of results grouped by `title` for further insights
+- Widget Viewer URLs can be copied and shared for easy revisiting

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -32,9 +32,11 @@ Each <SandboxLink scenario="dashboards" projectSlug="react">Dashboard</SandboxLi
 
 ## Widget Viewer
 
-Dashboard widgets can be opened in an expanded widget viewer mode for further exploration. Click the expand icon on the top right of any widget card. The widget viewer allows enhanced filtering, sorting, and navigation features that are not available in the basic widget card view:
+Dashboard widgets can be opened in an expanded widget viewer mode for further exploration. The widget viewer allows enhanced filtering, sorting, and navigation features that are not available in the basic widget card view:
 
-- Widget tables display more rows per page, can be paginated, can be sorted, and allow column width adjustment
+- Widget tables display more rows per page, can be paginated and sorted, and allow column width adjustment
 - Widget charts can be zoomed in without affecting the rest of the dashboard
 - Chart visualizations display an additional table of results grouped by `title` for further insights
-- Widget Viewer URLs can be copied and shared for easy revisiting
+- Widget viewer URLs can be copied and shared for easy revisiting
+
+Click the expand icon on the top right of any widget card to open the viewer. 


### PR DESCRIPTION
Adds documentation for the Widget Viewer in the Dashboards page

![image](https://user-images.githubusercontent.com/83961295/159996927-c0a1c66c-71c4-4dce-a0b4-0d398eec1347.png)
