### PR TITLE
feat(perf): Update onPostBuild step to generate performance on-boarding docs

### DIFF
--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -74,11 +74,7 @@ const parsePathSlug = (slug: string) => {
     );
     const { platform, sub_platform } = pathMatch.groups;
     const step = String(pathMatch.groups.step).replace(/\./g, "-");
-    let sub = `performance-onboarding-${sub_platform}-${step}`;
-
-    if (platform === pathMatch.groups.sub_platform) {
-      sub = `performance-onboarding-${step}`;
-    }
+    const sub = platform === sub_platform ? `performance-onboarding-${step}` : `performance-onboarding-${sub_platform}-${step}`;
 
     return {
       platform,

--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -72,6 +72,11 @@ const parsePathSlug = (slug: string) => {
     const pathMatch = slug.match(
       /^\/(?<platform>[^/]+)\/performance-onboarding\/(?<sub_platform>[^/]+)\/(?<step>[^/]+)\/$/
     );
+    
+    if(!pathMatch) {
+      throw new Error(`Unable to parse performance onboarding from slug: ${slug}`);
+    }
+    
     const { platform, sub_platform } = pathMatch.groups;
     const step = String(pathMatch.groups.step).replace(/\./g, "-");
     const sub = platform === sub_platform ? `performance-onboarding-${step}` : `performance-onboarding-${sub_platform}-${step}`;

--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -79,7 +79,7 @@ const parsePathSlug = (slug: string) => {
     
     const { platform, sub_platform } = pathMatch.groups;
     const step = String(pathMatch.groups.step).replace(/\./g, "-");
-    const sub = platform === sub_platform ? `performance-onboarding-${step}` : `performance-onboarding-${sub_platform}-${step}`;
+    const sub = platform === sub_platform ? `performance-onboarding-${step}` : `${sub_platform}-performance-onboarding-${step}`;
 
     return {
       platform,

--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -73,8 +73,7 @@ const parsePathSlug = (slug: string) => {
       /^\/(?<platform>[^/]+)\/performance-onboarding\/(?<sub_platform>[^/]+)\/(?<step>[^/]+)\/$/
     );
     const { platform, sub_platform } = pathMatch.groups;
-    let step = pathMatch.groups.step;
-    step = String(step).replace(/\./g, "-");
+    const step = String(pathMatch.groups.step).replace(/\./g, "-");
     let sub = `performance-onboarding-${sub_platform}-${step}`;
 
     if (platform === pathMatch.groups.sub_platform) {

--- a/src/wizard/javascript/performance-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/1.install.md
@@ -9,11 +9,10 @@ type: language
 
 Install our JavaScript browser SDK using either `yarn` or `npm`:
 
-```bash {tabTitle: ESM}
+```bash
 # Using yarn
 yarn add @sentry/browser @sentry/tracing
+
 # Using npm
 npm install --save @sentry/browser @sentry/tracing
 ```
-
-We also support alternate [installation methods](/platforms/javascript/install/).

--- a/src/wizard/javascript/performance-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/1.install.md
@@ -1,0 +1,19 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/performance/
+support_level: production
+type: language
+---
+
+#### Install
+
+Install our JavaScript browser SDK using either `yarn` or `npm`:
+
+```bash {tabTitle: ESM}
+# Using yarn
+yarn add @sentry/browser @sentry/tracing
+# Using npm
+npm install --save @sentry/browser @sentry/tracing
+```
+
+We also support alternate [installation methods](/platforms/javascript/install/).

--- a/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
@@ -27,7 +27,3 @@ Sentry.init({
 ```
 
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](/platforms/javascript/configuration/sampling/).
-
-Learn more about manually capturing an error or message in our [Usage documentation](/usage/).
-
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
@@ -1,0 +1,33 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/performance/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Configuration should happen as early as possible in your application's lifecycle.
+
+Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions and transactions.
+
+```javascript
+import * as Sentry from "@sentry/browser";
+import { BrowserTracing } from "@sentry/tracing";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new BrowserTracing()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+```
+
+We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](/platforms/javascript/configuration/sampling/).
+
+Learn more about manually capturing an error or message in our [Usage documentation](/usage/).
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
@@ -7,12 +7,14 @@ type: language
 
 #### Verify
 
-This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+Verify that performance monitoring is working correctly by using our [automatic instrumentation](/javascript/performance/instrumentation/automatic-instrumentation/) by simply using your JavaScript application.
+
+You have the option to manually construct a transaction using [custom instrumentation](/platforms/javascript/performance/instrumentation/custom-instrumentation/):
 
 ```javascript
-myUndefinedFunction();
+const transaction = Sentry.startTransaction({ name: "test-transaction" });
+const span = transaction.startChild({ op: "functionX" }); // This function returns a Span
+// functionCallX
+span.finish(); // Remember that only finished spans will be sent with the transaction
+transaction.finish(); // Finishing the transaction will send it to Sentry
 ```
-
-If you're new to Sentry, use the email alert to access your account and complete a product tour.
-
-If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
@@ -7,7 +7,7 @@ type: language
 
 #### Verify
 
-Verify that performance monitoring is working correctly by using our [automatic instrumentation](/javascript/performance/instrumentation/automatic-instrumentation/) by simply using your JavaScript application.
+Verify that performance monitoring is working correctly by using our [automatic instrumentation](/platforms/javascript/performance/instrumentation/automatic-instrumentation/) by simply using your JavaScript application.
 
 You have the option to manually construct a transaction using [custom instrumentation](/platforms/javascript/performance/instrumentation/custom-instrumentation/):
 

--- a/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/performance/
+support_level: production
+type: language
+---
+
+#### Verify
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+
+```javascript
+myUndefinedFunction();
+```
+
+If you're new to Sentry, use the email alert to access your account and complete a product tour.
+
+If you're an existing user and have disabled alerts, you won't receive this email.

--- a/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
@@ -14,7 +14,7 @@ You have the option to manually construct a transaction using [custom instrument
 ```javascript
 const transaction = Sentry.startTransaction({ name: "test-transaction" });
 const span = transaction.startChild({ op: "functionX" }); // This function returns a Span
-// functionCallX
+// exampleFunctionCall();
 span.finish(); // Remember that only finished spans will be sent with the transaction
 transaction.finish(); // Finishing the transaction will send it to Sentry
 ```

--- a/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/3.verify.md
@@ -7,7 +7,7 @@ type: language
 
 #### Verify
 
-Verify that performance monitoring is working correctly by using our [automatic instrumentation](/platforms/javascript/performance/instrumentation/automatic-instrumentation/) by simply using your JavaScript application.
+Verify that performance monitoring is working correctly with our [automatic instrumentation](/platforms/javascript/performance/instrumentation/automatic-instrumentation/) by simply using your JavaScript application.
 
 You have the option to manually construct a transaction using [custom instrumentation](/platforms/javascript/performance/instrumentation/custom-instrumentation/):
 

--- a/src/wizard/javascript/performance-onboarding/react/1.install.md
+++ b/src/wizard/javascript/performance-onboarding/react/1.install.md
@@ -11,8 +11,8 @@ Install our JavaScript browser SDK using either `yarn` or `npm`:
 
 ```bash
 # Using yarn
-yarn add @sentry/tracing
+yarn add @sentry/react @sentry/tracing
 
 # Using npm
-npm install --save @sentry/tracing
+npm install --save @sentry/react @sentry/tracing
 ```

--- a/src/wizard/javascript/performance-onboarding/react/1.install.md
+++ b/src/wizard/javascript/performance-onboarding/react/1.install.md
@@ -1,0 +1,18 @@
+---
+name: React
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/performance/
+support_level: production
+type: framework
+---
+
+#### Install
+
+Install our JavaScript browser SDK using either `yarn` or `npm`:
+
+```bash
+# Using yarn
+yarn add @sentry/tracing
+
+# Using npm
+npm install --save @sentry/tracing
+```

--- a/src/wizard/javascript/performance-onboarding/react/2.configure.md
+++ b/src/wizard/javascript/performance-onboarding/react/2.configure.md
@@ -1,0 +1,35 @@
+---
+name: React
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/performance/
+support_level: production
+type: framework
+---
+
+#### Configure
+
+Next, import and initialize the Sentry module as early as possible, before initializing React:
+
+```javascript
+import React from "react";
+import ReactDOM from "react-dom";
+import * as Sentry from "@sentry/react";
+import { BrowserTracing } from "@sentry/tracing";
+import App from "./App";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new BrowserTracing()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+
+ReactDOM.render(<App />, document.getElementById("root"));
+
+// Can also use with React Concurrent Mode
+// ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+```
+
+We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](/platforms/javascript/guides/react/configuration/sampling/).

--- a/src/wizard/javascript/performance-onboarding/react/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/react/3.verify.md
@@ -7,7 +7,7 @@ type: framework
 
 #### Verify
 
-Verify that performance monitoring is working correctly by using our [automatic instrumentation](/platforms/javascript/guides/react/performance/instrumentation/automatic-instrumentation/) by simply using your React application.
+Verify that performance monitoring is working correctly with our [automatic instrumentation](/platforms/javascript/guides/react/performance/instrumentation/automatic-instrumentation/) by simply using your React application.
 
 You have the option to manually construct a transaction using [custom instrumentation](/platforms/javascript/guides/react/performance/instrumentation/custom-instrumentation/):
 

--- a/src/wizard/javascript/performance-onboarding/react/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/react/3.verify.md
@@ -19,7 +19,7 @@ span.finish(); // Remember that only finished spans will be sent with the transa
 transaction.finish(); // Finishing the transaction will send it to Sentry
 ```
 
-In addition, `@sentry/react` exports a `withProfiler` higher order component that can be used to capture React related spans for specific React components:
+In addition, `@sentry/react` exports a `withProfiler` higher order component that can be used to capture React-related spans for specific React components:
 
 ```javascript
 import * as Sentry from "@sentry/react";

--- a/src/wizard/javascript/performance-onboarding/react/3.verify.md
+++ b/src/wizard/javascript/performance-onboarding/react/3.verify.md
@@ -1,0 +1,34 @@
+---
+name: React
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/performance/
+support_level: production
+type: framework
+---
+
+#### Verify
+
+Verify that performance monitoring is working correctly by using our [automatic instrumentation](/platforms/javascript/guides/react/performance/instrumentation/automatic-instrumentation/) by simply using your React application.
+
+You have the option to manually construct a transaction using [custom instrumentation](/platforms/javascript/guides/react/performance/instrumentation/custom-instrumentation/):
+
+```javascript
+const transaction = Sentry.startTransaction({ name: "test-transaction" });
+const span = transaction.startChild({ op: "functionX" }); // This function returns a Span
+// functionCallX
+span.finish(); // Remember that only finished spans will be sent with the transaction
+transaction.finish(); // Finishing the transaction will send it to Sentry
+```
+
+In addition, `@sentry/react` exports a `withProfiler` higher order component that can be used to capture React related spans for specific React components:
+
+```javascript
+import * as Sentry from "@sentry/react";
+
+function App(props) {
+  // ...
+
+  return <div />;
+}
+
+export default Sentry.withProfiler(App);
+```


### PR DESCRIPTION
This pull request extends the wizard onboarding documentation generation such that we generate Performance onboarding documentation content as sub-steps.

We aim to provide Performance onboarding content for JavaScript and React projects. They'll be shown in the product like this:

![Screen Shot 2022-05-13 at 3 10 10 PM](https://user-images.githubusercontent.com/139499/168374107-b8f6c675-0075-47a1-857c-8af4574d9574.png)

-----

Related to https://github.com/getsentry/sentry-docs/issues/3226

I intentionally did not provide any meta-documentation for how to write and contribute content to the Performance onboarding checklist at @imatwawana 's wishes; since we're only providing content for JavaScript and React platforms in the short-term to validate this feature.