### PR TITLE
chore(platformicons): update to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "4.3.2",
+    "platformicons": "4.4.0",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13852,10 +13852,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.3.2.tgz#a33b42a34bf1b4cdf9ff4d01879bf0575aa6e1d3"
-  integrity sha512-Xa/biMTxWfTKh8lKvy1BFnVhumcIawLX93Mq1PYWADE2nZJO7MRSrdUUqaNeeF0ZQj86UXKxlvX7pGApGFaRxw==
+platformicons@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.4.0.tgz#4188696c73fcc40afff212aa3ed0d0559cb25607"
+  integrity sha512-aC1akUKsIh9WJe7uRpfbuiMz/Xp4WzsxIx1z07OXahFOf2+QNlnNcN/D1Lpt2ymdJ8y86KCkjunl4WbPn3BArw==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Linked to https://github.com/getsentry/platformicons/pull/55