### PR TITLE
add Serverless Cloud base guide

### DIFF
--- a/src/platforms/node/guides/serverless-cloud/index.mdx
+++ b/src/platforms/node/guides/serverless-cloud/index.mdx
@@ -1,0 +1,164 @@
+---
+title: Serverless Cloud
+redirect_from:
+  - /clients/node/integrations/serverless-cloud/
+  - /platforms/node/serverless-cloud/
+description: "Learn about using Sentry with Serverless Cloud."
+---
+
+Add `@sentry/node` as a dependency:
+
+```bash {tabTitle:npm}
+cloud install @sentry/node
+```
+
+Sentry should be initialized as early in your app as possible:
+
+```javascript
+import api from "@serverless/cloud";
+import * as Sentry from "@sentry/node";
+
+// or using CommonJS
+// const api = require("@serverless/cloud");
+// const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // or pull from params
+  // dsn: params.SENTRY_DSN,
+  environment: params.INSTANCE_NAME,
+});
+
+// The request handler must be the first middleware on the app
+api.use(Sentry.Handlers.requestHandler());
+
+// All controllers should live here
+api.get("/", function rootHandler(req, res) {
+  res.end("Hello world!");
+});
+
+// The error handler must be before any other error middleware and after all controllers
+api.use(Sentry.Handlers.errorHandler());
+
+// Optional fallthrough error handler
+api.use(function onError(err, req, res, next) {
+  // The error id is attached to `res.sentry` to be returned
+  // and optionally displayed to the user for support.
+  res.statusCode = 500;
+  res.end(res.sentry + "\n");
+});
+```
+
+You can verify the Sentry integration by creating a route that will throw an error:
+
+```javascript
+api.get("/debug-sentry", function mainHandler(req, res) {
+  throw new Error("My first Sentry error!");
+});
+```
+
+`requestHandler` accepts some options that let you decide what data should be included in the event sent to Sentry.
+
+Possible options are:
+
+```javascript
+// keys to be extracted from req
+request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
+
+// server name
+serverName?: boolean; // default: true
+
+// generate transaction name
+//   path == request.path (eg. "/foo")
+//   methodPath == request.method + request.path (eg. "GET|/foo")
+//   handler == function name (eg. "fooHandler")
+transaction?: boolean | 'path' | 'methodPath' | 'handler'; // default: true = 'methodPath'
+
+// keys to be extracted from req.user
+user?: boolean | string[]; // default: true = ['id', 'username', 'email']
+
+// client ip address
+ip?: boolean; // default: false
+
+// node version
+version?: boolean; // default: true
+
+// timeout for fatal route errors to be delivered
+flushTimeout?: number; // default: undefined
+```
+
+For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:
+
+```javascript
+api.use(
+  Sentry.Handlers.requestHandler({
+    serverName: false,
+    user: ["email"],
+  })
+);
+```
+
+By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts middleware errors as its argument and decides, whether an error should be sent or not, by returning an appropriate boolean value.
+
+```javascript
+api.use(
+  Sentry.Handlers.errorHandler({
+    shouldHandleError(error) {
+      // Capture all 404 and 500 errors
+      if (error.status === 404 || error.status === 500) {
+        return true;
+      }
+      return false;
+    },
+  })
+);
+```
+
+## Monitor Performance
+
+```bash {tabTitle:npm}
+cloud install --save @sentry/node @sentry/tracing
+```
+
+```javascript
+const Sentry = require("@sentry/node");
+const Tracing = require("@sentry/tracing");
+const api = require("@serverless/cloud");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // or pull from params
+  // dsn: params.SENTRY_DSN,
+  integrations: [
+    // enable HTTP calls tracing
+    new Sentry.Integrations.Http({ tracing: true }),
+    // enable Express.js middleware tracing
+    new Tracing.Integrations.Express({
+      // to trace all requests to the default router
+      api,
+      // alternatively, you can specify the routes you want to trace:
+      // router: someRouter,
+    }),
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  // or pull from params
+  // tracesSampleRate: parseFloat(params.SENTRY_TRACES_SAMPLE_RATE),
+});
+
+// RequestHandler creates a separate execution context using domains, so that every
+// transaction/span/breadcrumb is attached to its own Hub instance
+api.use(Sentry.Handlers.requestHandler());
+// TracingHandler creates a trace for every incoming request
+api.use(Sentry.Handlers.tracingHandler());
+// the rest of your app
+api.use(Sentry.Handlers.errorHandler());
+```
+
+Spans are instrumented for the following operations within a transaction:
+
+- HTTP requests made with `request`
+- `get` calls using native `http` and `https` modules
+- Middleware (Express.js only)

--- a/src/platforms/node/guides/serverless-cloud/index.mdx
+++ b/src/platforms/node/guides/serverless-cloud/index.mdx
@@ -1,8 +1,5 @@
 ---
 title: Serverless Cloud
-redirect_from:
-  - /clients/node/integrations/serverless-cloud/
-  - /platforms/node/serverless-cloud/
 description: "Learn about using Sentry with Serverless Cloud."
 ---
 

--- a/src/wizard/node/serverlesscloud.md
+++ b/src/wizard/node/serverlesscloud.md
@@ -1,0 +1,128 @@
+---
+name: Express
+doc_link: https://docs.sentry.io/platforms/node/guides/serverless-cloud/
+support_level: production
+type: framework
+---
+
+Add `@sentry/node` and `@sentry/tracing` as dependencies:
+
+```bash
+cloud install @sentry/node @sentry/tracing
+```
+
+Sentry should be initialized as early in your app as possible.
+
+```javascript
+import api from "@serverless/cloud";
+import * as Sentry from "@sentry/node";
+import * as Tracing from "@sentry/tracing";
+
+// or using CommonJS
+// const api = require("@serverless/cloud");
+// const Sentry = require('@sentry/node');
+// const Tracing = require("@sentry/tracing");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // or pull from params
+  // dsn: params.SENTRY_DSN,
+  environment: params.INSTANCE_NAME,
+  integrations: [
+    // enable HTTP calls tracing
+    new Sentry.Integrations.Http({ tracing: true }),
+    // enable Express.js middleware tracing
+    new Tracing.Integrations.Express({ app }),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+  // or pull from params
+  // tracesSampleRate: parseFloat(params.SENTRY_TRACES_SAMPLE_RATE),
+});
+
+// RequestHandler creates a separate execution context using domains, so that every
+// transaction/span/breadcrumb is attached to its own Hub instance
+api.use(Sentry.Handlers.requestHandler());
+// TracingHandler creates a trace for every incoming request
+api.use(Sentry.Handlers.tracingHandler());
+
+// All controllers should live here
+api.get("/", function rootHandler(req, res) {
+  res.end("Hello world!");
+});
+
+// The error handler must be before any other error middleware and after all controllers
+api.use(Sentry.Handlers.errorHandler());
+
+// Optional fallthrough error handler
+api.use(function onError(err, req, res, next) {
+  // The error id is attached to `res.sentry` to be returned
+  // and optionally displayed to the user for support.
+  res.statusCode = 500;
+  res.end(res.sentry + "\n");
+});
+```
+
+The above configuration captures both error and performance data. To reduce the volume of performance data captured, change `tracesSampleRate` to a value between 0 and 1.
+
+You can verify the Sentry integration is working by creating a route that will throw an error:
+
+```javascript
+api.get("/debug-sentry", function mainHandler(req, res) {
+  throw new Error("My first Sentry error!");
+});
+```
+
+`requestHandler` accepts some options that let you decide what data should be included in the event sent to Sentry.
+
+Possible options are:
+
+```javascript
+// keys to be extracted from req
+request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
+// server name
+serverName?: boolean; // default: true
+// generate transaction name
+//   path == request.path (eg. "/foo")
+//   methodPath == request.method + request.path (eg. "GET|/foo")
+//   handler == function name (eg. "fooHandler")
+transaction?: boolean | 'path' | 'methodPath' | 'handler'; // default: true = 'methodPath'
+// keys to be extracted from req.user
+user?: boolean | string[]; // default: true = ['id', 'username', 'email']
+// client ip address
+ip?: boolean; // default: false
+// node version
+version?: boolean; // default: true
+// timeout for fatal route errors to be delivered
+flushTimeout?: number; // default: undefined
+```
+
+For example, if you want to skip the server name and add just user, you would use `requestHandler` like this:
+
+```javascript
+api.use(
+  Sentry.Handlers.requestHandler({
+    serverName: false,
+    user: ["email"],
+  })
+);
+```
+
+By default, `errorHandler` will capture only errors with a status code of `500` or higher. If you want to change it, provide it with the `shouldHandleError` callback, which accepts middleware errors as its argument and decides, whether an error should be sent or not, by returning an appropriate boolean value.
+
+```javascript
+api.use(
+  Sentry.Handlers.errorHandler({
+    shouldHandleError(error) {
+      // Capture all 404 and 500 errors
+      if (error.status === 404 || error.status === 500) {
+        return true;
+      }
+      return false;
+    },
+  })
+);
+```


### PR DESCRIPTION
Adds a Sentry Guide for [Serverless Cloud](https://www.serverless.com/cloud) ([docs](https://www.serverless.com/cloud/docs)).

Serverless Cloud's API functionality is based on ExpressJS, and allows us to use many of the same concepts (with a few small tweaks).

I haven't tested out any of the advanced performance monitoring stuff yet, so I haven't touched that part of the guide yet.