### PR TITLE
fix(apple): UIViewController wording

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -14,7 +14,8 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 This feature is available for iOS, tvOS, and Mac Catalyst, and only works for UIViewControllers.
 
-The UIViewController Instrumentation, once enabled, captures transactions whenever your app loads an in-app UIViewController, meaning it doesn't capture transactions of UIKits UIViewControllers, other third-party libraries, or SwiftUI. The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
+The UIViewController Instrumentation, once enabled, captures transactions when your app loads an [UIViewController][UIViewController], which is in-app and a subclass of UIViewController. Nevertheless, the SDK doesn't capture transactions for UIViewControllers of third-party libraries or SwiftUI.
+The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
 The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 
@@ -39,6 +40,8 @@ SentrySDK.start { options in
     options.enableUIViewControllerTracking = NO;
 }];
 ```
+
+[UIViewController]: https://developer.apple.com/documentation/uikit/uiviewcontroller
 
 ## App Start Instrumentation
 


### PR DESCRIPTION
Improve the wording for UIViewControllers a bit, because the wording
was a bit confusing for some people.