### PR TITLE
feat(apple): Transaction bound to scope

### DIFF
--- a/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
+++ b/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
@@ -1,0 +1,57 @@
+## Create Transaction Bound to The Current Scope
+
+
+Our SDK can bind a transaction to the scope making it accessible to every method running within this scope by calling `Sentry#startTransaction` method with `bindToScope` parameter to `true`.
+
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.span`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
+
+
+```swift {tabTitle:Swift}
+import Sentry
+
+let transaction = SentrySDK.startTransaction(
+    name: "processOrderBatch",
+    operation: "task",
+    bindToScope: true
+)
+processOrderBatch()
+transaction.finish()
+
+func processOrderBatch() {
+    var span = SentrySDK.span
+
+    if span == nil {
+        span = SentrySDK.startTransaction(name: "processOrderBatch", operation: "task")
+    }
+
+    var innerSpan = span.startChild(operation: "subtask")
+    // omitted code
+    innerSpan.finish()
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+id<SentrySpan> transaction =
+    [SentrySDK startTransactionWithName:@"processOrderBatch"
+                              operation:@"task"
+                            bindToScope:YES];
+
+
+[self processOrderBatch];
+[transaction finish];
+
+- (void)processOrderBatch {
+    id<SentrySpan> span = SentrySDK.span;
+
+    if (span == nil) {
+        span = [SentrySDK startTransactionWithName:@"processOrderBatch"
+                                         operation:@"task"];
+    }
+
+    id<SentrySpan> innerSpan = [span startChildWithOperation:@"subtask"];
+    // omitted code
+    [innerSpan finish];
+}
+```

--- a/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
+++ b/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
@@ -3,7 +3,7 @@
 
 Our SDK can bind a transaction to the scope making it accessible to every method running within this scope by calling `Sentry#startTransaction` method with `bindToScope` parameter to `true`.
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.span`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `SentrySDK.span`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
 
 
 ```swift {tabTitle:Swift}

--- a/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
+++ b/src/includes/performance/create-transaction-bound-to-scope/apple.mdx
@@ -1,7 +1,7 @@
 ## Create Transaction Bound to The Current Scope
 
 
-Our SDK can bind a transaction to the scope making it accessible to every method running within this scope by calling `Sentry#startTransaction` method with `bindToScope` parameter to `true`.
+Our SDK can bind a transaction to the scope making it accessible to every method running within this scope by calling `SentrySDK#startTransaction` method with `bindToScope` parameter to `true`.
 
 In cases where you want to attach Spans to an already ongoing Transaction you can use `SentrySDK.span`. This method will return a `SpanProtocol` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `nil`.
 

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -52,13 +52,13 @@ To instrument certain regions of your code, you can create transactions to captu
 
 <PlatformContent includePath="performance/add-spans-example" />
 
-<PlatformSection supported={["java"]}>
+<PlatformSection supported={["java", "apple"]}>
 
 <PlatformContent includePath="performance/create-transaction-bound-to-scope" />
 
 </PlatformSection>
 
-<PlatformSection notSupported={["java", "native"]}>
+<PlatformSection notSupported={["java", "native", "apple"]}>
 
 <PlatformContent includePath="performance/retrieve-transaction" />
 


### PR DESCRIPTION
Add Create transaction bound to scope as Java already has it because the Apple SDK
supports the bound to scope feature.