### PR TITLE
Denote that the Sentry plugin doesn't generate SM

### DIFF
--- a/src/includes/sourcemaps/generate/javascript.mdx
+++ b/src/includes/sourcemaps/generate/javascript.mdx
@@ -3,7 +3,8 @@ Most modern JavaScript transpilers support source maps. Below are instructions f
 <Note>
 
 We recommend using Sentry's [Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) to configure source maps and upload them automatically during the build.
-* Sentry Webpack plugin does not generate sourcemaps, it does the upload. 
+Sentry's Webpack plugin does not generate source maps, but it does the upload them. 
+
 </Note>
 
 <Alert level="warning" title="source-map-support">

--- a/src/includes/sourcemaps/generate/javascript.mdx
+++ b/src/includes/sourcemaps/generate/javascript.mdx
@@ -1,4 +1,4 @@
-Most modern JavaScript transpilers support source maps. Below are instructions for some common tools. Note that the directions below ensure that your source maps can be uploaded to Sentry, but you must generate them.
+Most modern JavaScript transpilers support source maps. Below are instructions for some common tools. 
 
 <Note>
 

--- a/src/includes/sourcemaps/generate/javascript.mdx
+++ b/src/includes/sourcemaps/generate/javascript.mdx
@@ -3,7 +3,7 @@ Most modern JavaScript transpilers support source maps. Below are instructions f
 <Note>
 
 We recommend using Sentry's [Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) to configure source maps and upload them automatically during the build.
-
+* Sentry Webpack plugin does not generate sourcemaps, it does the upload. 
 </Note>
 
 <Alert level="warning" title="source-map-support">

--- a/src/includes/sourcemaps/generate/javascript.mdx
+++ b/src/includes/sourcemaps/generate/javascript.mdx
@@ -1,4 +1,4 @@
-Most modern JavaScript transpilers support source maps. Below are instructions for some common tools.
+Most modern JavaScript transpilers support source maps. Below are instructions for some common tools. Note that the directions below ensure that your source maps can be uploaded to Sentry, but you must generate them.
 
 <Note>
 
@@ -33,7 +33,7 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 module.exports = {
   // other webpack configuration
-  devtool: 'source-map',
+  devtool: "source-map",
   plugins: [
     new SentryWebpackPlugin({
       // sentry-cli configuration - can also be done directly through sentry-cli
@@ -73,7 +73,6 @@ If you prefer to upload source maps manually, configure Webpack to output source
 
 If you use [SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin) for more fine-grained control of source map generation, turn off `noSources` so Sentry can display proper source code context in event stack traces.
 
-
 ## Rollup
 
 You can configure [Rollup](https://rollupjs.org/) to generate source maps, which you can then [upload using `sentry-cli`](/product/cli/releases/#sentry-cli-sourcemaps):
@@ -109,7 +108,7 @@ This example configuration will inline your original, un-transformed source code
 
 ## TypeScript
 
-The [TypeScript](https://www.typescriptlang.org/) compiler can output source maps, which you can then [upload using `sentry-cli`](/product/cli/releases/#sentry-cli-sourcemaps). 
+The [TypeScript](https://www.typescriptlang.org/) compiler can output source maps, which you can then [upload using `sentry-cli`](/product/cli/releases/#sentry-cli-sourcemaps).
 
 Configure the `sourceRoot` property as `/` to strip the build path prefix from generated source code references. This allows Sentry to match source files relative to your source root folder:
 

--- a/src/includes/sourcemaps/generate/javascript.mdx
+++ b/src/includes/sourcemaps/generate/javascript.mdx
@@ -14,7 +14,7 @@ To rely on Sentry's source map resolution, your code cannot use the [source-map-
 
 ## Webpack
 
-Sentry provides a convenient [Webpack](https://webpack.js.org/) plugin that [configures source maps and automatically uploads them to Sentry](https://github.com/getsentry/sentry-webpack-plugin).
+Use webpack's `devtool` option to enable the generation of source maps. Sentry provides a convenient [Webpack](https://webpack.js.org/) plugin to [automatically upload the generated source maps to Sentry](https://github.com/getsentry/sentry-webpack-plugin).
 
 To use the plugin, you first need to install it:
 

--- a/src/platforms/javascript/common/sourcemaps/generating.mdx
+++ b/src/platforms/javascript/common/sourcemaps/generating.mdx
@@ -7,3 +7,8 @@ notSupported:
 ---
 
 <PlatformContent includePath="sourcemaps/generate" />
+---
+  This page implies that the Sentry plugin generates the sourcemaps and upload them as well
+  and right now this is not the case.
+  We need to denote that it is up to the user to generate the sourcemaps and then Sentry will just take care of uploading it.
+---

--- a/src/platforms/javascript/common/sourcemaps/generating.mdx
+++ b/src/platforms/javascript/common/sourcemaps/generating.mdx
@@ -7,8 +7,3 @@ notSupported:
 ---
 
 <PlatformContent includePath="sourcemaps/generate" />
----
-  This page implies that the Sentry plugin generates the sourcemaps and upload them as well
-  and right now this is not the case.
-  We need to denote that it is up to the user to generate the sourcemaps and then Sentry will just take care of uploading it.
----


### PR DESCRIPTION
This page implies that the Sentry plugin generates the sourcemaps and upload them as well
and right now this is not the case.
We need to denote that it is up to the user to generate the sourcemaps and then Sentry will just take care of uploading it.