### PR TITLE
Update options.mdx

### DIFF
--- a/src/docs/clients/ruby/configuration/options.mdx
+++ b/src/docs/clients/ruby/configuration/options.mdx
@@ -246,14 +246,6 @@ config.silence_ready = true
 config.ssl_verification = false
 ```
 
-`tags`
-
-: Default tags to send with each event.
-
-```ruby
-config.tags = { foo: :bar }
-```
-
 `transport_failure_callback`
 
 : If the transport fails to send an event to Sentry for any reason (either the Sentry server has returned a 4XX or 5XX response), this Proc or lambda will be called.


### PR DESCRIPTION
I think that feature doesn't exist anymore. I tried using this in an example app, and checked https://github.com/getsentry/sentry-ruby/blob/master/sentry-ruby/lib/sentry/configuration.rb.