### PR TITLE
Fix sidebar reconciliation issue

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 export default ({
   children,
-  sidebar,
+  sidebar = <Sidebar />,
   pageContext = {},
 }: Props): JSX.Element => {
   const searchPlatforms = [
@@ -42,9 +42,7 @@ export default ({
           id="sidebar"
         >
           <div className="toc">
-            <div className="text-white p-3">
-              {sidebar ? sidebar : <Sidebar />}
-            </div>
+            <div className="text-white p-3">{sidebar}</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#4915

My guess is that the `<Sidebar />` subtree is incorrectly reused during reconciliation on client-side (perhaps because JSX composition is same). I don't know exactly why.

[src/components/layout.tsx](https://github.com/getsentry/sentry-docs/blob/ad0cd9a3d12cbcee1faffe83c730bfc030abe9ae/src/components/layout.tsx#L46):
```jsx
<div className="text-white p-3">
  {sidebar ? sidebar : <Sidebar />}
</div>
```

Most likely my fix is not optimal. As far as I know it will be lazily evaluated when used as default function parameter value.