### PR TITLE
fix(unity): Removed WebGL from migration page

### DIFF
--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -25,16 +25,12 @@ Learn more in our [options documentation](/platforms/unity/configuration/options
 
 <Note>
 
-The Sentry Unity Lite SDK is deprecated for mobile, desktop, and console players.
-Customers using Unity 5.x or WebGL can still use the Sentry Unity Lite as it continues to be compatible with sentry.io.
+The Sentry Unity Lite SDK is deprecated for mobile, desktop, WebGL, and console players.
+Customers using Unity 5.x can still use the Sentry Unity Lite as it continues to be compatible with sentry.io.
 
 The updated Sentry Unity SDK requires Unity version 2019.4 or higher with .NET Standard 2.0 scripting profile.
-Event submission happen on a background thread, which isn't currently available on WebGL players.
 
 </Note>
-
-Sentry is deprecating the Sentry Unity Lite SDK for Mobile, Desktop and Console players.
-Customers using Unity 5.x or WebGL can still use the Sentry Unity Lite as it continues to be compatible with sentry.io.
 
 1. Remove the old `Sentry.cs` and `SentrySdk.cs` files from your project.
 2. Remove the old initialization code `gameObject.AddComponent<SentrySdk>().Dsn = "___PUBLIC_DSN___";`.


### PR DESCRIPTION
https://github.com/getsentry/sentry-unity/pull/657 will bring WebGL support to the Unity SDK so we no longer need to refer users to the Sentry Lite SDK on the migration page.