### PR TITLE
Docs change to make it easier for new users to find their DSN

### DIFF
--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -26,7 +26,7 @@ If your application is shipped to client devices, if possible, we recommend havi
 
 If you're in the process of setting up a project, you can find your DSN in the installation or configuration code snippets provided in [sentry.io](https://sentry.io/) during setup:
 
-![DSN in code snippet](../../create-new-project-04.png)
+![DSN in code snippet](integrate-frontend/create-new-project-04.png)
 
 You can also find the DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -18,15 +18,13 @@ If an SDK is not initialized or if it is initialized with an empty DSN, the SDK 
 
 DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 
-While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to _Settings > Projects > Client Keys (DSN)_.
-
-> Note: If you're new to sentry, the DSN can be found within the setup code after scrolling to `Installation Instructions` at the bottom of your project page
+While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to **[Project] > Settings > Client Keys (DSN)**.
 
 If your application is shipped to client devices, if possible, we recommend having a way to configure the DSN dynamically. In an ideal scenario, you can "ship" a new DSN to your application without the customer downloading the latest version. We recognize that this may not always be practical, but we cannot offer further advice as this scenario is implementation specific.
 
 ### Where to Find Your DSN
 
-If you forget your DSN, view _Settings -> Projects -> Client Keys (DSN)_ in [sentry.io](https://sentry.io/).
+You can find your DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 
 ### The Parts of the DSN
 

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -20,6 +20,8 @@ DSNs are safe to keep public because they only allow submission of new events an
 
 While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to _Settings > Projects > Client Keys (DSN)_.
 
+> Note: If you're new to sentry, the DSN can be found within the setup code after scrolling to `Installation Instructions` at the bottom of your project page
+
 If your application is shipped to client devices, if possible, we recommend having a way to configure the DSN dynamically. In an ideal scenario, you can "ship" a new DSN to your application without the customer downloading the latest version. We recognize that this may not always be practical, but we cannot offer further advice as this scenario is implementation specific.
 
 ### Where to Find Your DSN

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -26,7 +26,7 @@ If your application is shipped to client devices, if possible, we recommend havi
 
 If you're in the process of setting up a project, you can find your DSN in the installation or configuration code snippets provided in [sentry.io](https://sentry.io/) during setup:
 
-![DSN in code snippet](../integrate-frontend/create-new-project-04.png)
+![DSN in code snippet](../create-new-project-04.png)
 
 You can also find the DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -26,7 +26,7 @@ If your application is shipped to client devices, if possible, we recommend havi
 
 If you're in the process of setting up a project, you can find your DSN in the installation or configuration code snippets provided in [sentry.io](https://sentry.io/) during setup:
 
-![DSN in code snippet](../create-new-project-04.png)
+![DSN in code snippet](../../create-new-project-04.png)
 
 You can also find the DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 

--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -24,7 +24,11 @@ If your application is shipped to client devices, if possible, we recommend havi
 
 ### Where to Find Your DSN
 
-You can find your DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
+If you're in the process of setting up a project, you can find your DSN in the installation or configuration code snippets provided in [sentry.io](https://sentry.io/) during setup:
+
+![DSN in code snippet](../integrate-frontend/create-new-project-04.png)
+
+You can also find the DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 
 ### The Parts of the DSN
 


### PR DESCRIPTION
I'm new to Sentry and these docs didn't help me find the DSN for my app (`Settings > Projects > Client Keys (DSN)` had nothing for me - see screenshot below).

I'm sure this could be worded better (and/or link to the appropriate spot), but I at least wanted to start the discussion.

<img width="1439" alt="Screen Shot 2022-04-11 at 9 25 36 AM" src="https://user-images.githubusercontent.com/6445731/162761224-1a8a94b0-1ea9-42fa-93a1-f9ff410ee667.png">