### PR TITLE
fix markdown rendering issue

### DIFF
--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
   - /performance-monitoring/discover/
   - /performance-monitoring/discover-queries/
   - /performance/discover/
-description: "Discover provides visibility into your data across environments by building upon and enriching your error data. You can query and unlock insights into the health of your entire system and get answers to critical business questions --- all in one place."
+description: "Discover provides visibility into your data across environments by building upon and enriching your error data. You can query and unlock insights into the health of your entire system and get answers to critical business questions — all in one place."
 ---
 
 <Note>
@@ -17,7 +17,9 @@ This feature is available only if your organization is on either a Business or T
 
 </Note>
 
-<SandboxLink scenario="discover" projectSlug="react">Discover</SandboxLink> provides visibility into your data across environments by building upon and enriching your error data. You can <SandboxLink scenario="oneDiscoverQuery" projectSlug="react">query</SandboxLink> and unlock insights into the health of your entire system and get answers to critical business questions --- all in one place. Use **Discover** to view comprehensive information sent to Sentry.
+<SandboxLink scenario="discover" projectSlug="react">Discover</SandboxLink> provides visibility into your data across environments by building upon and enriching your error data.
+
+You can <SandboxLink scenario="oneDiscoverQuery" projectSlug="react">query</SandboxLink> and unlock insights into the health of your entire system and get answers to critical business questions — all in one place. Use **Discover** to view comprehensive information sent to Sentry.
 
 ![Full view of the Discover Homepage with query cards and button to build new queries.](./discover-homepage.png)
 

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -17,9 +17,7 @@ This feature is available only if your organization is on either a Business or T
 
 </Note>
 
-<SandboxLink scenario="discover" projectSlug="react">Discover</SandboxLink> provides visibility into your data across environments by building upon and enriching your error data.
-
-You can <SandboxLink scenario="oneDiscoverQuery" projectSlug="react">query</SandboxLink> and unlock insights into the health of your entire system and get answers to critical business questions — all in one place. Use **Discover** to view comprehensive information sent to Sentry.
+<SandboxLink scenario="discover" projectSlug="react">Discover</SandboxLink> provides visibility into your data across environments by building upon and enriching your error data. You can <SandboxLink scenario="oneDiscoverQuery" projectSlug="react">query</SandboxLink> and unlock insights into the health of your entire system and get answers to critical business questions — all in one place. Use <b>Discover</b> to view comprehensive information sent to Sentry.
 
 ![Full view of the Discover Homepage with query cards and button to build new queries.](./discover-homepage.png)
 


### PR DESCRIPTION
Replaced markdown with html tags in first paragraph of the page because it seems like having two Sandbox Link components on one line causes the rest of the markdown in the paragraph to not render properly.