### PR TITLE
ref(rate limits): Add concurrent headers

### DIFF
--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -5,9 +5,15 @@ sidebar_order: 3
 
 Sentry rate limits every API request made to prevent abuse and resource overuse. The limit is applied to each unique combination of caller and endpoint.
 
-We restrict both how frequently a request is made (requests per second rate limit) and how many concurrent requests a caller can make (concurrent rate limit). The requests per second rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected.  Meanwhile, the concurrent rate limiter will reject requests if the caller has too many requests in progress at the same time.
 
-While there is a default rate limit of **40 requests per second** for the requests per second rate limit, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
+We restrict both how frequently a request is made (requests per second rate limit) and how many concurrent requests a caller can make (concurrent rate limit).
+
+The requests per second rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected. While there is a default rate limit of **40 requests per second**, each endpoint can have their own maximum number of requests and window size.
+
+Meanwhile, the concurrent rate limiter will reject requests if the caller has too many requests in progress at the same time.
+
+You can track your rate limit usage by looking at special headers in the response.
+
 
 ## Headers
 

--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -5,7 +5,7 @@ sidebar_order: 3
 
 Sentry rate limits every API request made to prevent abuse and resource overuse. The limit is applied to each unique combination of caller and endpoint.
 
-The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected. We restrict both how frequently a request is made and how many requests are occurring within same time period.
+We restrict both how frequently a request is made (requests per second rate limit) and how many concurrent requests a caller can make (concurrent rate limit). The requests per second rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected.  Meanwhile, the concurrent rate limiter will reject requests if the caller has too many requests in progress at the same time.
 
 While there is a default rate limit of **40 requests per second**, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
 

--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -7,7 +7,7 @@ Sentry rate limits every API request made to prevent abuse and resource overuse.
 
 We restrict both how frequently a request is made (requests per second rate limit) and how many concurrent requests a caller can make (concurrent rate limit). The requests per second rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected.  Meanwhile, the concurrent rate limiter will reject requests if the caller has too many requests in progress at the same time.
 
-While there is a default rate limit of **40 requests per second**, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
+While there is a default rate limit of **40 requests per second** for the requests per second rate limit, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
 
 ## Headers
 

--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -19,6 +19,10 @@ Every API request response includes the following headers:
   - The number of requests this caller has left on this endpoint within the current window
 - `X-Sentry-Rate-Limit-Reset`
   - The time when the next rate limit window begins and the count resets, measured in UTC seconds from epoch
+- `X-Sentry-Rate-Limit-ConcurrentLimit`
+  - The maximum number of concurrent requests allowed within the window
+- `X-Sentry-Rate-Limit-ConcurrentRemaining`
+  - The number of concurrent requests this caller has left on this endpoint within the current window
 
 ## Additional Information
 

--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -5,7 +5,8 @@ sidebar_order: 3
 
 Sentry rate limits every API request made to prevent abuse and resource overuse. The limit is applied to each unique combination of caller and endpoint.
 
-The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected.
+The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. The concurrent rate limit limits the number of requests happening at the same time to a given endpoint grouping. If the number of requests from a caller exceeds the number of allowed requests or concurrent requests within a window, then that request will be rejected.
+
 
 While there is a default rate limit of **40 requests per second**, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
 

--- a/src/api/ratelimits.mdx
+++ b/src/api/ratelimits.mdx
@@ -5,8 +5,7 @@ sidebar_order: 3
 
 Sentry rate limits every API request made to prevent abuse and resource overuse. The limit is applied to each unique combination of caller and endpoint.
 
-The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. The concurrent rate limit limits the number of requests happening at the same time to a given endpoint grouping. If the number of requests from a caller exceeds the number of allowed requests or concurrent requests within a window, then that request will be rejected.
-
+The rate limit follows a fixed window approach. Requests are counted into time buckets, determined by the window size. If the number of requests from a caller exceeds the number of allowed requests within a window, then that request will be rejected. We restrict both how frequently a request is made and how many requests are occurring within same time period.
 
 While there is a default rate limit of **40 requests per second**, each endpoint can have their own maximum number of requests and window size. You can track your rate limit usage by looking at special headers in the response.
 


### PR DESCRIPTION
Update the rate limit documentation to include the concurrent rate limiter headers. 