### PR TITLE
Added missing comma to webhook issue alert example

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -441,7 +441,7 @@ The following two fields are for [Alert Rule Action UI Components](/product/inte
       "version": "7",
       "web_url": "https://sentry.io/organizations/test-org/issues/1117540176/events/e4874d664c3540c1a32eab185f12c5ab/"
     },
-    "triggered_rule": "Very Important Alert Rule!"
+    "triggered_rule": "Very Important Alert Rule!",
     "issue_alert": {
       "title": "Very Important Alert Rule!",
       "settings": [


### PR DESCRIPTION
This example was missing a comma, this missing comma caused the JSON to be invalid