### PR TITLE
fix(apple): Core data instrumentation typo

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -144,7 +144,7 @@ This is an experimental feature and requires an opt-in. Experimental features ar
 </Alert>
 
 The Sentry SDK adds spans for Core Data operations to ongoing transactions bound to the scope. Currently, the SDK supports fetch and save operations with [NSManagedObjectContext](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext).
-To enable file I/O instrumentation:
+To enable core data instrumentation:
 
 ```swift {tabTitle:Swift}
 import Sentry


### PR DESCRIPTION
The core data section stated to enable file IO instrumentation,
which is wrong. This is fixed now.