### PR TITLE
[JS v7] **do not merge** ref(javascript): Replace deprecated severity enums with string literals

### DIFF
--- a/src/includes/enriching-events/breadcrumbs/breadcrumbs-example/javascript.mdx
+++ b/src/includes/enriching-events/breadcrumbs/breadcrumbs-example/javascript.mdx
@@ -2,6 +2,6 @@
 Sentry.addBreadcrumb({
   category: "auth",
   message: "Authenticated user " + user.email,
-  level: Sentry.Severity.Info,
+  level: "info",
 });
 ```

--- a/src/includes/set-level/javascript.mdx
+++ b/src/includes/set-level/javascript.mdx
@@ -4,6 +4,8 @@ To set the level out of scope, you can call `captureMessage()` per event:
 Sentry.captureMessage("this is a debug message", "debug");
 ```
 
+Available levels are `"fatal"`, `"critical"`, `"error"`, `"warning"`, `"log"`, `"info"`, and `"debug"`.
+
 To set the level within scope, you can call `setLevel()`:
 
 ```javascript

--- a/src/includes/set-level/javascript.mdx
+++ b/src/includes/set-level/javascript.mdx
@@ -8,7 +8,7 @@ To set the level within scope, you can call `setLevel()`:
 
 ```javascript
 Sentry.configureScope(function(scope) {
-  scope.setLevel(Sentry.Severity.Warning);
+  scope.setLevel("warning");
 });
 ```
 
@@ -20,8 +20,8 @@ Sentry.withScope(function(scope) {
 
   // The exception has the event level set by the scope (info).
   Sentry.captureException(new Error("custom error"));
-
 });
+
 // Outside of withScope, the Event level will have their previous value restored.
 // The exception has the event level set (error).
 Sentry.captureException(new Error("custom error 2"));

--- a/src/platforms/common/enriching-events/breadcrumbs.mdx
+++ b/src/platforms/common/enriching-events/breadcrumbs.mdx
@@ -41,6 +41,12 @@ The available breadcrumb keys are `type`, `category`, `message`, `level`, `times
 
 </PlatformSection>
 
+<PlatformSection supported={["javascript", "node"]}>
+
+You can choose from the following breadcrumb log levels: `"fatal"`, `"critical"`, `"error"`, `"warning"`, `"log"`, `"info"`, and `"debug"`.
+
+</PlatformSection>
+
 <PlatformSection notSupported={["native", "unreal"]}>
 
 ## Automatic Breadcrumbs

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -395,12 +395,12 @@ document.body.addEventListener(
     if (event.target.tagName === "IMG") {
       Sentry.captureMessage(
         `Failed to load image: ${event.target.src}`,
-        Sentry.Severity.Warning
+        "warning" // message severiity level
       );
     } else if (event.target.tagName === "LINK") {
       Sentry.captureMessage(
         `Failed to load css: ${event.target.href}`,
-        Sentry.Severity.Warning
+        "warning" // message severiity level
       );
     }
   },

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -395,12 +395,12 @@ document.body.addEventListener(
     if (event.target.tagName === "IMG") {
       Sentry.captureMessage(
         `Failed to load image: ${event.target.src}`,
-        "warning" // message severiity level
+        "warning" // message severity level
       );
     } else if (event.target.tagName === "LINK") {
       Sentry.captureMessage(
         `Failed to load css: ${event.target.href}`,
-        "warning" // message severiity level
+        "warning" // message severity level
       );
     }
   },

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -395,12 +395,12 @@ document.body.addEventListener(
     if (event.target.tagName === "IMG") {
       Sentry.captureMessage(
         `Failed to load image: ${event.target.src}`,
-        "warning" // message severity level
+        "warning"
       );
     } else if (event.target.tagName === "LINK") {
       Sentry.captureMessage(
         `Failed to load css: ${event.target.href}`,
-        "warning" // message severity level
+        "warning"
       );
     }
   },


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4926, we deprecated the `Severity`. This PR replaces all occurrences of that enum with their now recommended string value counterpart.

Ref: https://getsentry.atlassian.net/browse/WEB-849

**DO NOT MERGE: Only merge this branch after the Sentry JavaScript SDK version 7 has been published.**