### PR TITLE
chore(billing): Prepare on-demand budget for GA to all performance plans

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,7 +46,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are rolling out for general availability to paying customers on plans with [performance monitoring](/product/performance/) features.
+Per-category on-demand budgets are rolling out for general availability (GA) to paying customers on plans with [performance monitoring](/product/performance/) features.
 
 Until the GA rollout is complete, the feature is still available for organizations on paid performance plans in the Early Adopter program. If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,8 +46,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features and if you're in the Early Adopter program.
-If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
+Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -48,7 +48,7 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 Per-category on-demand budgets are rolling out for general availability to paying customers on plans with [performance monitoring](/product/performance/) features.
 
-In addition, it is available if you're opted into the Early Adopter program. If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
+Until the GA rollout is complete, the feature is still available for organizations on paid performance plans in the Early Adopter program. If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,7 +46,9 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are only available on plans with [performance monitoring](/product/performance/) features.
+Per-category on-demand budgets are rolling out for general availability to paying customers on plans with [performance monitoring](/product/performance/) features.
+
+In addition, it is available if you're opted into the Early Adopter program. If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>


### PR DESCRIPTION
This pull request prepares the documentation surrounding on-demand budgets for GA roll out.

This entails updating the note introduced in https://github.com/getsentry/sentry-docs/pull/4808

GA for on-demand budgets is expected to begin on Monday, April 18 2022. 