### PR TITLE
feat(unity): add thread-safety note to Hooks

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -423,7 +423,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 <PlatformSection supported={["unity"]}>
 
 The callbacks you specify as hooks will be called on the thread where the event happened. Therefore, you may only use
-thread-safe APIs and only use UI-specific APIs after you've checked that you're on the UI thread.
+thread-safe APIs and only use Unity-specific APIs after you've checked that you're on the UI thread.
 
 </PlatformSection>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -420,6 +420,13 @@ This can be used to disable integrations that are added by default. When set to 
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
 
+<PlatformSection supported={["unity"]}>
+
+The callbacks you specify as hooks will be called on the thread where the event happened. Therefore, you may only use
+thread-safe APIs and only use UI-specific APIs after you've checked that you're on the UI thread.
+
+</PlatformSection>
+
 <ConfigKey name="before-send">
 
 This function is called with an SDK-specific event object, and can return a modified event object or nothing to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -422,7 +422,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <PlatformSection supported={["unity"]}>
 
-The callbacks you specify as hooks will be called on the thread where the event happened. Therefore, you may only use
+The callbacks you set as hooks will be called on the thread where the event happened. So you can only use
 thread-safe APIs and only use Unity-specific APIs after you've checked that you're on the UI thread.
 
 </PlatformSection>


### PR DESCRIPTION
Clarifies that BeforeSend hook (and others in general) are run on the same thread where the event (error) happens. https://github.com/getsentry/sentry-unity/issues/471#issuecomment-1087598702

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
