### PR TITLE
Migration docs for Android and Java v6

### DIFF
--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -29,6 +29,8 @@ description: "Migrating between versions of Sentry's SDK for Android."
   * `IHandler` is now `MainLooperHandler` only.
 * Spans now have higher precision using the `System#nanoTime` instead of milliseconds.
 
+There are more changes and refactors, but they are not user breaking changes.
+
 ## Migrating to `io.sentry:sentry-android-timber 5.6.2`
 
 Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK (the tag will not be captured and reflected on Sentry). Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -23,7 +23,7 @@ description: "Migrating between versions of Sentry's SDK for Android."
   * `SentryOptions#isEnableSessionTracking`
   * `SentryOptions#setEnableSessionTracking`
 * Hints changed its type from `Object` to `Map<String, Object>`
-* `enableScopeSync` is now enabled by default.
+* `SentryOptions#enableScopeSync` is now enabled by default.
 * Removed unnecessary abstractions
   * `IBuildInfoProvider` is now `BuildInfoProvider` only.
   * `IHandler` is now `MainLooperHandler` only.

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -27,7 +27,7 @@ description: "Migrating between versions of Sentry's SDK for Android."
 * Removed unnecessary abstractions
   * `IBuildInfoProvider` is now `BuildInfoProvider` only.
   * `IHandler` is now `MainLooperHandler` only.
-* Spans now have higher precision using the `System#nanoTime` instead of milliseconds.
+* `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -22,12 +22,31 @@ description: "Migrating between versions of Sentry's SDK for Android."
   * `SentryOptions#setCacheDirSize`
   * `SentryOptions#isEnableSessionTracking`
   * `SentryOptions#setEnableSessionTracking`
-* Hints changed its type from `Object` to `Map<String, Object>`
-* `SentryOptions#enableScopeSync` is now enabled by default.
 * Removed unnecessary abstractions
   * `IBuildInfoProvider` is now `BuildInfoProvider` only.
   * `IHandler` is now `MainLooperHandler` only.
 * `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
+
+* Hints changed its type from `Object` to `Map<String, Object>`
+
+_Old_:
+
+```kotlin
+Sentry.captureException(RuntimeException("exception"), "myStringHint")
+```
+
+_New_:
+
+```kotlin
+val hints = mutableMapOf<String, Any>("myHint" to "myStringHint")
+Sentry.captureException(RuntimeException("exception"), hints)
+```
+
+* `SentryOptions#enableScopeSync` is now enabled by default, to disable it, see the code snippet bellow.
+
+```xml {filename:AndroidManifest.xml}
+<meta-data android:name="io.sentry.ndk.scope-sync.enable" android:value="false" />
+```
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -49,7 +49,7 @@ The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0
 
 The `autoUpload` flag has been deprecated in favor of two new options:
 
-* `includeProguardMapping` - Disables/enables Proguard mapping functionality. When enabled, generates a UUID and attempts to upload a Proguard mapping associated with that UUID to Sentry.  When `autoUploadProguardMapping` is disabled, the plugin will only generate a `sentry-debug-meta.properties` file containg UUID, which later can be used to manually upload the mapping, for example, using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
+* `includeProguardMapping` - Disables/enables Proguard mapping functionality. When enabled, generates a UUID and attempts to upload a Proguard mapping associated with that UUID to Sentry.  When `autoUploadProguardMapping` is disabled, the plugin will only generate a `sentry-debug-meta.properties` file containg UUID, which can later be used to manually upload the mapping using, for example [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 * `autoUploadProguardMapping` - Defines whether the gradle plugin should attempt to auto-upload the mapping file to Sentry.
 When `includeProguardMapping` is disabled, this flag has no effect.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -6,6 +6,29 @@ redirect_from:
 description: "Migrating between versions of Sentry's SDK for Android."
 ---
 
+## Migrating from `io.sentry:sentry-android 5.x` to `io.sentry:sentry-android 6.0.0`
+
+* Kotlin plugin is upgraded to `1.5`.
+* Kotlin `languageVersion` is upgraded to `1.4`.
+* `Gson` is removed as a transitive dependency and vendored in the SDK.
+  * Protocol classes now implement the `JsonSerializable` and `JsonDeserializer` interfaces.
+* `SentryOptions#shutdownTimeout` is renamed to `shutdownTimeoutMillis`.
+* Removed `@Deprecated` and `@ApiStatus.ScheduledForRemoval` methods
+  * `ITransaction#setRequest`
+  * `ITransaction#getRequest`
+  * `ITransaction#getContexts`
+  * `SentryBaseEvent#getOriginThrowable`
+  * `SentryOptions#getCacheDirSize`
+  * `SentryOptions#setCacheDirSize`
+  * `SentryOptions#isEnableSessionTracking`
+  * `SentryOptions#setEnableSessionTracking`
+* Hints changed its type from `Object` to `Map<String, Object>`
+* `enableScopeSync` is now enabled by default.
+* Removed unnecessary abstractions
+  * `IBuildInfoProvider` is now `BuildInfoProvider` only.
+  * `IHandler` is now `MainLooperHandler` only.
+* Spans now have higher precision using the `System#nanoTime` instead of milliseconds.
+
 ## Migrating to `io.sentry:sentry-android-timber 5.6.2`
 
 Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK (the tag will not be captured and reflected on Sentry). Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.
@@ -24,7 +47,7 @@ The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0
 
 The `autoUpload` flag has been deprecated in favor of two new options:
 
-* `includeProguardMapping` - Disables/enables Proguard mapping functionality. When enabled, generates a UUID and attempts to upload a Proguard mapping associated with that UUID to Sentry.  When `autoUploadProguardMapping` is disabled, the plugin will only generate a `sentry-debug-meta.properties` file containg UUID, which later can be used to manually upload the mapping, for example, using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).  
+* `includeProguardMapping` - Disables/enables Proguard mapping functionality. When enabled, generates a UUID and attempts to upload a Proguard mapping associated with that UUID to Sentry.  When `autoUploadProguardMapping` is disabled, the plugin will only generate a `sentry-debug-meta.properties` file containg UUID, which later can be used to manually upload the mapping, for example, using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 * `autoUploadProguardMapping` - Defines whether the gradle plugin should attempt to auto-upload the mapping file to Sentry.
 When `includeProguardMapping` is disabled, this flag has no effect.
 
@@ -57,7 +80,7 @@ sentry {
   autoUploadProguardMapping.set(false)
 }
 ```
- 
+
 
 ### tracingInstrumentation
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -23,10 +23,24 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
   * `sentry.enable-tracing` property
   * `SentrySpringRequestListener`, `SentrySpringFilter` is used instead.
   * `SentryUserProviderEventProcessor` and `SentryUserProvider`, `SentryUserFilter` is used instead.
-* Hints changed its type from `Object` to `Map<String, Object>`
 * `SentryOptions#enableScopeSync` is now enabled by default.
 * `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
 * `TransactionNameProvider` is now an interface and `SpringMvcTransactionNameProvider` is the default implementation.
+
+* Hints changed its type from `Object` to `Map<String, Object>`
+
+_Old_:
+
+```kotlin
+Sentry.captureException(RuntimeException("exception"), "myStringHint")
+```
+
+_New_:
+
+```kotlin
+val hints = mutableMapOf<String, Any>("myHint" to "myStringHint")
+Sentry.captureException(RuntimeException("exception"), hints)
+```
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -20,9 +20,13 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
   * `SentryOptions#setCacheDirSize`
   * `SentryOptions#isEnableSessionTracking`
   * `SentryOptions#setEnableSessionTracking`
+  * `sentry.enable-tracing` property
+  * `SentrySpringRequestListener`, `SentrySpringFilter` is used instead.
+  * `SentryUserProviderEventProcessor` and `SentryUserProvider`, `SentryUserFilter` is used instead.
 * Hints changed its type from `Object` to `Map<String, Object>`
 * `SentryOptions#enableScopeSync` is now enabled by default.
-* Spans now have higher precision using the `System#nanoTime` instead of milliseconds.
+* `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
+* `TransactionNameProvider` is now an interface and `SpringMvcTransactionNameProvider` is the default implementation.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -4,6 +4,28 @@ sidebar_order: 1000
 description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentry 3.x."
 ---
 
+## Migrating from `io.sentry:sentry` `5.x` to `io.sentry:sentry` `6.0.0`
+
+* Kotlin plugin is upgraded to `1.5`.
+* Kotlin `languageVersion` is upgraded to `1.4`.
+* `Gson` is removed as a transitive dependency and vendored in the SDK.
+  * Protocol classes now implement the `JsonSerializable` and `JsonDeserializer` interfaces.
+* `SentryOptions#shutdownTimeout` is renamed to `shutdownTimeoutMillis`.
+* Removed `@Deprecated` and `@ApiStatus.ScheduledForRemoval` methods
+  * `ITransaction#setRequest`
+  * `ITransaction#getRequest`
+  * `ITransaction#getContexts`
+  * `SentryBaseEvent#getOriginThrowable`
+  * `SentryOptions#getCacheDirSize`
+  * `SentryOptions#setCacheDirSize`
+  * `SentryOptions#isEnableSessionTracking`
+  * `SentryOptions#setEnableSessionTracking`
+* Hints changed its type from `Object` to `Map<String, Object>`
+* `SentryOptions#enableScopeSync` is now enabled by default.
+* Spans now have higher precision using the `System#nanoTime` instead of milliseconds.
+
+There are more changes and refactors, but they are not user breaking changes.
+
 ## Migrating from `io.sentry:sentry` `4.3.0` to `io.sentry:sentry` `5.0.0`
 
 `Sentry#startTransaction` by default does not bind created transaction to the scope. To start transaction with binding to the scope, use one of the new overloaded `startTransaction` methods taking `bindToScope` parameter and set it to `true`. Bound transaction can be retrieved with `Sentry#getSpan`.


### PR DESCRIPTION
https://github.com/getsentry/sentry-java/releases

TODO:
* Remove notes about min. version Gson and deprecated features from docs once this is GA.