### PR TITLE
fix(apple): release option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -67,6 +67,12 @@ For app models that don't have a console to print to, you can <PlatformLink to="
 
 <ConfigKey name="release">
 
+<PlatformSection supported={["apple"]}>
+
+`releaseName` for the Cocoa SDK because `release` is a [reserved keyword](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571957-release).
+
+</PlatformSection>
+
 Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/) or the <SandboxLink scenario="releases">sandbox</SandboxLink>.
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -65,13 +65,13 @@ For app models that don't have a console to print to, you can <PlatformLink to="
 
 </PlatformSection>
 
-<ConfigKey name="release">
+<ConfigKey name="releaseName" supported={["apple"]}>
 
-<PlatformSection supported={["apple"]}>
+Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/) or the <SandboxLink scenario="releases">sandbox</SandboxLink>.
 
-`releaseName` for the Cocoa SDK because `release` is a [reserved keyword](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571957-release).
+</ConfigKey>
 
-</PlatformSection>
+<ConfigKey name="release" notSupported={["apple"]}>
 
 Sets the release. Some SDKs will try to automatically configure a release out of the box but it's a better idea to manually set it to guarantee that the release is in sync with your deploy integrations or source map uploads. Release names are strings, but some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/) or the <SandboxLink scenario="releases">sandbox</SandboxLink>.
 


### PR DESCRIPTION
Release is a reserved keyword on
Cocoa and instead, the option
is called releaseName.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
