### PR TITLE
feat(perf): Add span details histogram note for EA

### DIFF
--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -103,7 +103,13 @@ The "Spans" tab displays a list of suspect spans that correspond to where most o
 
 Choose from one of several [metrics](#metrics) to sort spans and identify different types of problems. Filter spans to only see the span operation type you're interested in.
 
-Clicking on a span will give you more details about the specific span [group](#grouping). You can see the performance of the span over time and see a list of transaction events that contain the span.
+Clicking on a span will take you to its summary page that should give you more details about this specific span [group](#grouping). On the page you can see the performance of the span over time and see a list of transaction events that contain the span.
+
+<Note>
+
+If you're in the Early Adopter program, you can also see the distribution of the span self time. The self time histogram can help you identify systemic performance issues accross the entire dataset by illustrating how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max self time bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the specified bounds. Adding self time filters allows you to narrow down your focus on the best/worse performing spans so you can troubleshoot performance issues easier.
+
+</Note>
 
 ### Self Time
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -107,7 +107,7 @@ Clicking on a span will take you to its summary page that should give you more d
 
 <Note>
 
-If you're in the Early Adopter program, you can also see the distribution of the span self time. The self time histogram can help you identify systemic performance issues accross the entire dataset by illustrating how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max self time bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the specified bounds. Adding self time filters allows you to narrow down your focus on the best/worse performing spans so you can troubleshoot performance issues easier.
+If you're in the Early Adopter program, you can also see the distribution of the span self time. The histogram can help you identify systemic performance issues across the entire dataset by illustrating how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the specified bounds. Adding filters allows you to narrow down your focus on the best/worse performing spans so you can troubleshoot performance issues easier.
 
 </Note>
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -118,7 +118,6 @@ If you're in the Early Adopter program, you can also see the distribution of the
 You can also select a subset of the dataset by zooming into the distribution histogram. The stats and transaction events table will reflect that change and will only include spans with self time that are within the bounds of your subset. This allows you to focus on the best or worse performing spans so you can troubleshoot performance issues more easily.
 
 
-</Note>
 
 ### Self Time
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -103,7 +103,7 @@ The "Spans" tab displays a list of suspect spans that correspond to where most o
 
 Choose from one of several [metrics](#metrics) to sort spans and identify different types of problems. Filter spans to only see the span operation type you're interested in.
 
-Clicking on a span will take you to its summary page that should give you more details about this specific span [group](#grouping). On the page you can see the performance of the span over time and see a list of transaction events that contain the span.
+Clicking on a span will take you to its summary page that will give you more details about this specific span [group](#grouping). On the page you can see the performance of the span over time and see a list of transaction events that contain the span.
 
 <Note>
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -103,11 +103,20 @@ The "Spans" tab displays a list of suspect spans that correspond to where most o
 
 Choose from one of several [metrics](#metrics) to sort spans and identify different types of problems. Filter spans to only see the span operation type you're interested in.
 
-Clicking on a span will take you to its summary page that will give you more details about this specific span [group](#grouping). On the page you can see the performance of the span over time and see a list of transaction events that contain the span.
+### Span Summary
+
+Clicking on a span will take you to its summary page which will give you more details about this specific span [group](#grouping). On the page, you can see the performance of the span over time and see a list of transaction events that contain the span.
 
 <Note>
 
-If you're in the Early Adopter program, you can also see the distribution of the span self time. This histogram can help you identify systemic performance issues across the entire dataset by showing how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the set bounds. Adding filters allows you to focus on the best or worse performing spans so you can troubleshoot performance issues more easily.
+This span distribution feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+If you're in the Early Adopter program, you can also see the distribution of the span self time using the (added) "Display" dropdown. This histogram can help you identify systemic performance issues across the entire dataset by showing how self time for every span instance is distributed. 
+
+You can also select a subset of the dataset by zooming into the distribution histogram. The stats and transaction events table will reflect that change and will only include spans with self time that are within the bounds of your subset. This allows you to focus on the best or worse performing spans so you can troubleshoot performance issues more easily.
+
 
 </Note>
 

--- a/src/docs/product/performance/transaction-summary.mdx
+++ b/src/docs/product/performance/transaction-summary.mdx
@@ -107,7 +107,7 @@ Clicking on a span will take you to its summary page that will give you more det
 
 <Note>
 
-If you're in the Early Adopter program, you can also see the distribution of the span self time. The histogram can help you identify systemic performance issues across the entire dataset by illustrating how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the specified bounds. Adding filters allows you to narrow down your focus on the best/worse performing spans so you can troubleshoot performance issues easier.
+If you're in the Early Adopter program, you can also see the distribution of the span self time. This histogram can help you identify systemic performance issues across the entire dataset by showing how self time for every span instance is distributed. You can also select a subset of the dataset by zooming into the distribution histogram which will effectively set min and max bounds. The stats and transaction events table will reflect that change and will only include spans with self time that are within the set bounds. Adding filters allows you to focus on the best or worse performing spans so you can troubleshoot performance issues more easily.
 
 </Note>
 


### PR DESCRIPTION
I've added a note for EAs describing changes to the span details page. I've mentioned a new histogram and new data filters (min and max self time) that will enable users to narrow down the population.

Fixes PERF-1419

