### PR TITLE
[JS v7] Add Prisma ORM Integration Docs.

### DIFF
--- a/src/platforms/node/common/performance/database/auto-instrument.mdx
+++ b/src/platforms/node/common/performance/database/auto-instrument.mdx
@@ -1,5 +1,5 @@
 ---
-title: Database integrations
+title: Auto-instrumented
 ---
 
 Node.js integrations support tracking database queries as spans. Starting in version `6.4.0`, `@sentry/tracing` will auto-detect supported database drivers or ORMs being used in your project, and automatically enable the relevant integrations with default options - without needing additional code.

--- a/src/platforms/node/common/performance/database/index.mdx
+++ b/src/platforms/node/common/performance/database/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Database integrations
+title: Database Integrations
 ---
 
 Node.js integrations support tracking database queries as spans.
 
-## Supported platforms
+## Supported Platforms
 
 Auto-instrumented:
 

--- a/src/platforms/node/common/performance/database/index.mdx
+++ b/src/platforms/node/common/performance/database/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Database integrations
+---
+
+Node.js integrations support tracking database queries as spans.
+
+## Supported platforms
+
+Auto-instrumented:
+
+- `pg` (Postgres)
+- `pg-native` (Postgres) _Available from version 6.12.0_
+- `mongodb` (Mongo)
+- `mongoose` (Mongo)
+- `mysql` (MySQL)
+
+Opt-in:
+
+- [Prisma ORM](https://www.prisma.io/) _Available from version 7.0.0_
+
+## Next Steps
+
+<PageGrid />

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -4,7 +4,7 @@ title: Opt-in
 
 ## Prisma ORM Integration _(Available from `7.0.0`)_
 
-Sentry supports tracing [Prisma ORM](https://www.prisma.io/) fetchers with Prisma Integration. This integration is an opt-in feature and requires a `PrismaClient` instance provided.
+Sentry supports tracing [Prisma ORM](https://www.prisma.io/) fetchers with Prisma integration. This integration is an opt-in feature and requires that a `PrismaClient` instance is provided.
 
 For example:
 

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -6,6 +6,8 @@ title: Opt-in
 
 Sentry supports tracing [Prisma ORM](https://www.prisma.io/) fetchers with Prisma integration. This integration is an opt-in feature and requires that a `PrismaClient` instance is provided.
 
+Prisma integration creates a `db.prisma` span for each query and reports to Sentry with relevant details inside `description` if available.
+
 For example:
 
 ```javascript

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -2,7 +2,9 @@
 title: Opt-in
 ---
 
-## Prisma ORM Integration _(Available from `7.0.0`)_
+## Prisma ORM Integration
+
+_(Available from `7.0.0`)_
 
 Sentry supports tracing [Prisma ORM](https://www.prisma.io/) fetchers with Prisma integration. This integration is an opt-in feature and requires that a `PrismaClient` instance is provided.
 

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -1,0 +1,25 @@
+---
+title: Opt-in
+---
+
+## Prisma ORM Integration _(Available from `7.0.0`)_
+
+Sentry supports tracing [Prisma ORM](https://www.prisma.io/) fetchers with Prisma Integration. This integration is an opt-in feature and requires a `PrismaClient` instance provided.
+
+For example:
+
+```javascript
+import { PrismaClient } from '@prisma/client';
+import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
+import { randomBytes } from 'crypto';
+
+const client = new PrismaClient();
+
+Sentry.init({
+  dsn: ___PUBLIC_DSN___,
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  integrations: [new Tracing.Integrations.Prisma({ client })],
+});
+```


### PR DESCRIPTION
- Added a simple example about the use of new Prisma integration. (https://github.com/getsentry/sentry-javascript/pull/4931)