### PR TITLE
[JS v7] **do not merge** Adjust JS CDN bundle page to reflect ES5/ES6 naming changes

### DIFF
--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -16,6 +16,13 @@ Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest usin
 ></script>
 ```
 
+<Alert level="info" title="Updates to naming scheme in SDK Version 7">
+
+Version 7 of the Sentry JavaScript SDKs changed the bundles to be ES6 by default.
+Previously the default bundles were compiled to ES5. If you need to support ES5 see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](TODO).
+
+</Alert>
+
 ## Performance Bundle
 
 To use Sentry's performance tracing, an alternative bundle is needed. This allows us to keep the filesize down for users who only need error monitoring.
@@ -30,7 +37,7 @@ To use Sentry's performance tracing, an alternative bundle is needed. This allow
 
 <Note>
 
-You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring. There is also an ES6 version of the tracing bundle, `bundle.tracing.es6.min.js`.
+You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring. There is also an ES5 version of the tracing bundle, `bundle.tracing.es5.min.js`.
 
 </Note>
 
@@ -57,13 +64,13 @@ Our CDN hosts a variety of bundles:
 - `@sentry/browser` and `@sentry/tracing` together (named `bundle.tracing.<modifiers>.js`)
 - each of the integrations in `@sentry/integrations` (named `<integration-name>.<modifiers>.js`)
 
-Each bundle is offered in both ES5 and ES6 versions, and for each version there are three bundle varieties: unminified, minified, and minified with debug logging. (That last version can be helpful for times when you need to debug an issue which only occurs in production. In a development environment, it makes most sense to use the unminified bundle, which always includes logging.)
+Each bundle is offered in both ES6 and ES5 versions, and for each version there are three bundle varieties: unminified, minified, and minified with debug logging. (That last version can be helpful for times when you need to debug an issue which only occurs in production. In a development environment, it makes most sense to use the unminified bundle, which always includes logging.)
 
 For example:
 
-- `bundle.js` is `@sentry/browser`, compiled to ES5 but not minified, with debug logging included (as it is for all unminified bundles)
-- `rewriteframes.es6.min.js` is the `RewriteFrames` integration, compiled to ES6 and minified, with no debug logging
-- `bundle.tracing.es6.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES6 and minified, with debug logging included
+- `bundle.js` is `@sentry/browser`, compiled to ES6 but not minified, with debug logging included (as it is for all unminified bundles)
+- `rewriteframes.es5.min.js` is the `RewriteFrames` integration, compiled to ES5 and minified, with no debug logging
+- `bundle.tracing.es5.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES5 and minified, with debug logging included
 
 <JsBundleList />
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -16,10 +16,10 @@ Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest usin
 ></script>
 ```
 
-<Alert level="info" title="Updates to naming scheme in SDK Version 7">
+<Alert level="info" title="Updates to naming scheme in SDK version 7">
 
 Version 7 of the Sentry JavaScript SDKs changed the bundles to be ES6 by default.
-Previously the default bundles were compiled to ES5. If you need to support ES5 see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](TODO).
+Previously, the default bundles were compiled to ES5. If you need to support ES5, see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](TODO).
 
 </Alert>
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -19,7 +19,7 @@ Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest usin
 <Alert level="info" title="Updates to naming scheme in SDK version 7">
 
 Version 7 of the Sentry JavaScript SDKs changed the bundles to be ES6 by default.
-Previously, the default bundles were compiled to ES5. If you need to support ES5, see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](TODO).
+Previously, the default bundles were compiled to ES5. If you need to support ES5, see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#upgrading-from-6x-to-7x).
 
 </Alert>
 


### PR DESCRIPTION
This PR documents updates to our CDN bundle naming scheme - making ES6 the new default. Updates were made here: https://github.com/getsentry/sentry-javascript/pull/4958

Ref: https://getsentry.atlassian.net/browse/WEB-862

TODO before merging:
- [ ] Add Link to migration docs [here](https://github.com/getsentry/sentry-docs/pull/4962/files#diff-978a14688bb2800b7f756bd0480fa4bf18f42db7c2feacd475c7ed9844dbfc9aR22).

**DO NOT MERGE: Only merge this branch after the Sentry JavaScript SDK version 7 has been published.**