### PR TITLE
Mention sentry-servlet-jakarta

### DIFF
--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -16,6 +16,10 @@ libraryDependencies += "io.sentry" % "sentry-servlet" % "{{ packages.version('se
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-servlet).
 
+<Note>
+As of Sentry Java SDK `6.0.0-alpha.6` we also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+</Note>
+
 `sentry-servlet` module comes with a `ServletContainerInitializer` that registers a `ServletRequestListener` which enhances each Sentry event triggered within the scope of HTTP request with a request information like HTTP method, query string, url and HTTP headers.
 
 <Note>

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -16,10 +16,6 @@ libraryDependencies += "io.sentry" % "sentry-servlet" % "{{ packages.version('se
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-servlet).
 
-<Note>
-As of Sentry Java SDK `6.0.0-alpha.6` we also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
-</Note>
-
 `sentry-servlet` module comes with a `ServletContainerInitializer` that registers a `ServletRequestListener` which enhances each Sentry event triggered within the scope of HTTP request with a request information like HTTP method, query string, url and HTTP headers.
 
 <Note>
@@ -29,3 +25,13 @@ Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transit
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>
+
+## Jakarta support
+
+<Note>
+
+This feature is available on Sentry Java SDK `6.0.0-alpha.6` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+
+</Note>
+
+We also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`.

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -26,7 +26,7 @@ If you are using multiple Sentry dependencies, you can add a [bill of materials]
 
 </Note>
 
-## Jakarta support
+### Jakarta support
 
 <Note>
 

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -25,13 +25,3 @@ Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transit
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>
-
-## Jakarta support
-
-<Note>
-
-This feature is available on Sentry Java SDK `6.0.0-alpha.6` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
-
-</Note>
-
-We also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`.

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -25,3 +25,13 @@ Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transit
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>
+
+## Jakarta support
+
+<Note>
+
+This feature is available on Sentry Java SDK `6.0.0-alpha.6` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+
+</Note>
+
+We also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`.

--- a/src/includes/getting-started-next-steps/java.servlet.mdx
+++ b/src/includes/getting-started-next-steps/java.servlet.mdx
@@ -1,9 +1,0 @@
-## Jakarta support
-
-<Note>
-
-This feature is available on Sentry Java SDK `6.0.0-alpha.6` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
-
-</Note>
-
-We also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`.

--- a/src/includes/getting-started-next-steps/java.servlet.mdx
+++ b/src/includes/getting-started-next-steps/java.servlet.mdx
@@ -1,0 +1,9 @@
+## Jakarta support
+
+<Note>
+
+This feature is available on Sentry Java SDK `6.0.0-alpha.6` and above. Features available in Beta are still in-progress and may have bugs. We recognize the irony.
+
+</Note>
+
+We also provide a module called `sentry-servlet-jakarta` if you want to use `jakarta.servlet-api` instead of `javax.servlet-api`.


### PR DESCRIPTION
Document that `sentry-servlet-jakarta` exists as of `6.0.0-alpha.6` (https://github.com/getsentry/sentry-java/pull/1987)

