### PR TITLE
fix(unity): Duplicate Environment

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -119,7 +119,7 @@ By default, the SDK reports `editor` when running inside the Unity Editor. Other
 
 </PlatformSection>
 
-<PlatformSection supported={["dotnet"]}>
+<PlatformSection supported={["dotnet"]} notSupported={["unity"]}>
 
 Sets the environment. This string is freeform and set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 


### PR DESCRIPTION
Since Unity "inherits" from the .NET it has to be specifically excluded here to avoid duplication.