### PR TITLE
Document migration for sendclientreports

### DIFF
--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -56,7 +56,7 @@ Sentry.captureException(RuntimeException("exception"), hints)
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -48,6 +48,16 @@ Sentry.captureException(RuntimeException("exception"), hints)
 <meta-data android:name="io.sentry.ndk.scope-sync.enable" android:value="false" />
 ```
 
+* `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+
+```xml {filename:AndroidManifest.xml}
+<meta-data android:name="io.sentry.send-client-reports" android:value="false" />
+```
+
+### Sentry Self-hosted Compatibility
+
+- Starting with version `6.0.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+
 There are more changes and refactors, but they are not user breaking changes.
 
 ## Migrating to `io.sentry:sentry-android-timber 5.6.2`

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -56,7 +56,7 @@ Sentry.captureException(RuntimeException("exception"), hints)
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.0.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -48,7 +48,7 @@ Sentry.captureException(RuntimeException("exception"), hints)
 <meta-data android:name="io.sentry.ndk.scope-sync.enable" android:value="false" />
 ```
 
-* `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+* `SentryOptions#sendClientReports` is now enabled by default. To disable it, use the code snippet below:
 
 ```xml {filename:AndroidManifest.xml}
 <meta-data android:name="io.sentry.send-client-reports" android:value="false" />

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -4,6 +4,22 @@ sidebar_order: 1000
 description: "Migrate between versions of Sentry's SDK for Dart."
 ---
 
+## Migrating From `sentry` `6.5.x` to `sentry` `6.6.x`
+
+- `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+
+```dart
+import 'package:sentry/sentry.dart';
+
+Future<void> main() async {
+  await Sentry.init((options) => options.sendClientReports = false;
+}
+```
+
+### Sentry Self-hosted Compatibility
+
+- Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+
 ## Migrating From `sentry` `5.1.x` to `sentry` `6.0.0`
 
 - `Sentry.currentHub` was removed. Please use the static methods on `Sentry`

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -18,7 +18,7 @@ Future<void> main() async {
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 ## Migrating From `sentry` `5.1.x` to `sentry` `6.0.0`
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -18,7 +18,7 @@ Future<void> main() async {
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 ## Migrating From `sentry` `5.1.x` to `sentry` `6.0.0`
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -6,7 +6,7 @@ description: "Migrate between versions of Sentry's SDK for Dart."
 
 ## Migrating From `sentry` `6.5.x` to `sentry` `6.6.x`
 
-- `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+- `SentryOptions#sendClientReports` is now enabled by default. To disable it, use the code snippet below:
 
 ```dart
 import 'package:sentry/sentry.dart';

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -3,6 +3,26 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
+## Migrating From `sentry` `6.5.x` to `sentry` `6.6.x`
+
+- `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) => options.sendClientReports = false,
+    appRunner: () => runApp(MyApp()),
+  );
+}
+```
+
+### Sentry Self-hosted Compatibility
+
+- Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+
 ## Migrating From `sentry_flutter` `6.3.x` to `sentry_flutter` `6.4.x`
 
 To build a Flutter app for Android, Kotlin 1.5.31 or higher is required.

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -5,7 +5,7 @@ sidebar_order: 1000
 
 ## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
 
-There are no Flutter specific breaking changes. However there are some in [sentry](/platforms/dart/migration/) for Dart.
+There are no Flutter-specific breaking changes. However, there are some in [sentry](/platforms/dart/migration/) for Dart.
 
 ## Migrating From `sentry_flutter` `6.3.x` to `sentry_flutter` `6.4.x`
 

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -3,25 +3,9 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
-## Migrating From `sentry` `6.5.x` to `sentry` `6.6.x`
+## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
 
-- `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
-
-```dart
-import 'package:flutter/widgets.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
-
-Future<void> main() async {
-  await SentryFlutter.init(
-    (options) => options.sendClientReports = false,
-    appRunner: () => runApp(MyApp()),
-  );
-}
-```
-
-### Sentry Self-hosted Compatibility
-
-- Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+There are no Flutter specific breaking changes. However there are some in [sentry](/platforms/dart/migration/) for Dart.
 
 ## Migrating From `sentry_flutter` `6.3.x` to `sentry_flutter` `6.4.x`
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -50,7 +50,7 @@ send-client-reports=false
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -42,7 +42,7 @@ val hints = mutableMapOf<String, Any>("myHint" to "myStringHint")
 Sentry.captureException(RuntimeException("exception"), hints)
 ```
 
-* `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+* `SentryOptions#sendClientReports` is now enabled by default. To disable it, use the code snippet below:
 
 ```properties
 send.client.reports=false

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -50,7 +50,7 @@ send.client.reports=false
 
 ### Sentry Self-hosted Compatibility
 
-- Starting with version `6.0.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+- Starting with version `6.0.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 There are more changes and refactors, but they are not user breaking changes.
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -42,6 +42,16 @@ val hints = mutableMapOf<String, Any>("myHint" to "myStringHint")
 Sentry.captureException(RuntimeException("exception"), hints)
 ```
 
+* `SentryOptions#sendClientReports` is now enabled by default, to disable it, see the code snippet bellow.
+
+```properties
+send.client.reports=false
+```
+
+### Sentry Self-hosted Compatibility
+
+- Starting with version `6.0.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
+
 There are more changes and refactors, but they are not user breaking changes.
 
 ## Migrating from `io.sentry:sentry` `4.3.0` to `io.sentry:sentry` `5.0.0`

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -45,7 +45,7 @@ Sentry.captureException(RuntimeException("exception"), hints)
 * `SentryOptions#sendClientReports` is now enabled by default. To disable it, use the code snippet below:
 
 ```properties
-send.client.reports=false
+send-client-reports=false
 ```
 
 ### Sentry Self-hosted Compatibility


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry-java/issues/2005