### PR TITLE
fix: replace git.io links with redirect targets

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/getsentry/self-hosted/issues/new
     about: Please use the `self-hosted` repo for questions about self-hosted Sentry.
   - name: An issue with one of the SDKs
-    url: https://git.io/JtlVm
+    url: https://github.com/search?q=topic%3Acrash-reporting+org%3Agetsentry+fork%3Atrue
     about: Please use the relevant SDK repository to report any issues.


### PR DESCRIPTION
see: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Committed via https://github.com/asottile/all-repos