### PR TITLE
Fix Java migration from 5.x to 6.0

### DIFF
--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -22,7 +22,7 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
   * `SentryOptions#setEnableSessionTracking`
   * `sentry.enable-tracing` property
   * `SentrySpringRequestListener`, `SentrySpringFilter` is used instead.
-  * `SentryUserProviderEventProcessor` and `SentryUserProvider`, `SentryUserFilter` is used instead.
+  * `SentryUserProviderEventProcessor`, please use `SentryUserProvider` instead.
 * `SentryOptions#enableScopeSync` is now enabled by default.
 * `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
 * `TransactionNameProvider` is now an interface and `SpringMvcTransactionNameProvider` is the default implementation.


### PR DESCRIPTION
`SentryUserProvider` has not been removed. Migration guide did say so.

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
