### PR TITLE
Document mismatched line numbers on react native ram bundles

### DIFF
--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -165,6 +165,6 @@ In this case, type `ln -s $(which node) /usr/local/bin/node`, which tells your e
 
 If you're using `React Navigation 5` and you're not receiving transactions anymore, it might be because of [this bug](https://github.com/react-navigation/react-navigation/issues/9213). Upgrading to `React Navigation 6` should solve the issue, but if not, file an issue in our [repo](https://github.com/getsentry/sentry-react-native).
 
-## RAM Bundles Mismatched line numbers
+## RAM Bundles Mismatched Line Numbers
 
 If you experience mismatched line numbers on sentry.io when using RAM Bundles, this is due to a [bug](https://github.com/facebook/metro/issues/399) on the Metro tooling.

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -167,4 +167,4 @@ If you're using `React Navigation 5` and you're not receiving transactions anymo
 
 ## RAM Bundles Mismatched Line Numbers
 
-If you experience mismatched line numbers on sentry.io when using RAM Bundles, this is due to a [bug](https://github.com/facebook/metro/issues/399) on the Metro tooling.
+If you experience mismatched line numbers on [sentry.io](https://sentry.io) when using RAM Bundles, this is due to a [bug](https://github.com/facebook/metro/issues/399) on the Metro tooling.

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -165,3 +165,6 @@ In this case, type `ln -s $(which node) /usr/local/bin/node`, which tells your e
 
 If you're using `React Navigation 5` and you're not receiving transactions anymore, it might be because of [this bug](https://github.com/react-navigation/react-navigation/issues/9213). Upgrading to `React Navigation 6` should solve the issue, but if not, file an issue in our [repo](https://github.com/getsentry/sentry-react-native).
 
+## RAM Bundles Mismatched line numbers
+
+If you experience mismatched line numbers on sentry.io when using RAM Bundles, this is due to a [bug](https://github.com/facebook/metro/issues/399) on the Metro tooling.


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry-react-native/issues/1937