### PR TITLE
feat(unity): Added migration path from 0.3.0

### DIFF
--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -6,7 +6,7 @@ redirect_from:
   - /platforms/unity/unity-lite/
 ---
 
-## Migrating from 0.3.0 or earlier
+## Migrating From 0.3.0 or earlier
 
 The Sentry SDK deprecated the use of a Json file to store the options in favor of Scriptable Objects. If you're migrating from version 0.3.0 or older make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as Json. When you're opening the Sentry Configuration Editor Window that file will be automatically converted into a Scriptable Object. This support is being dropped in version 0.16.0 going forward.
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -8,7 +8,7 @@ redirect_from:
 
 ## Migrating From 0.3.0 or earlier
 
-The Sentry SDK deprecated the use of a Json file to store the options in favor of Scriptable Objects. If you're migrating from version 0.3.0 or older make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as Json. When you're opening the Sentry Configuration Editor Window that file will be automatically converted into a Scriptable Object. This support is being dropped in version 0.16.0 going forward.
+The Sentry SDK deprecated the use of a JSON file to store the options in favor of scriptable objects. If you're migrating from version 0.3.0 or older, make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as JSON. When you're opening the Sentry configuration editor window, that file will be automatically converted into a scriptable object. This support will be dropped in version 0.16.0 and going forward.
 
 ## Migrating to 0.11.0
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -6,6 +6,10 @@ redirect_from:
   - /platforms/unity/unity-lite/
 ---
 
+## Migrating from 0.3.0 or earlier
+
+The Sentry SDK deprecated the use of a Json file to store the options in favor of Scriptable Objects. If you're migrating from version 0.3.0 or older make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as Json. When you're opening the Sentry Configuration Editor Window that file will be automatically converted into a Scriptable Object. This support is being dropped in version 0.16.0 going forward.
+
 ## Migrating to 0.11.0
 
 ### Programmatic Configuration Changes


### PR DESCRIPTION
Documentation for dropping the support saving the options as Json in https://github.com/getsentry/sentry-unity/pull/709