### PR TITLE
docs(cli): Include version number in sentry-cli checksums table

### DIFF
--- a/src/components/cliChecksumTable.tsx
+++ b/src/components/cliChecksumTable.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 const query = graphql`
   query CliExecutableChecksums {
     app(id: { eq: "sentry-cli" }) {
+      version,
       files {
         name
         checksums {
@@ -23,14 +24,14 @@ const ChecksumValue = styled.code`
 
 export default (): JSX.Element => {
   const {
-    app: { files },
+    app: { files, version },
   } = useStaticQuery(query);
 
   return (
     <table style={{ display: "block", overflow: "scroll" }}>
       <thead>
         <tr>
-          <th>File</th>
+          <th>Filename (v{version})</th>
           <th>Integrity Checksum</th>
         </tr>
       </thead>

--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -139,3 +139,6 @@ When downloading an executable from a remote server, it's often a good practice 
 Below is the table of SHA256 checksums for all available build targets that our CLI supports. To calculate the hash of a downloaded file, you can use `sha256sum` utility, which is preinstalled in OSX and most Linux distributions.
 
 <CliChecksumTable />
+
+If you would like to verify checksums for historic versions of the `sentry-cli`, please refer to our release registry directly, which can be found under [https://release-registry.services.sentry.io/apps/sentry-cli/{version}](https://release-registry.services.sentry.io/apps/sentry-cli/latest) address.
+For example [https://release-registry.services.sentry.io/apps/sentry-cli/1.74.4](https://release-registry.services.sentry.io/apps/sentry-cli/1.74.4).


### PR DESCRIPTION
Document for which version the checksums apply.