### PR TITLE
Document sendClientReport option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -372,7 +372,7 @@ This is the maximum number of properties or entries that will be included in any
 
 <ConfigKey name="attach-screenshot" supported={["android", "apple.ios"]}>
 
-Takes a screenshot of the application when an error happens and includes it as an attachment. 
+Takes a screenshot of the application when an error happens and includes it as an attachment.
 Screenshots for hard crashes are not supported on iOS.
 
 <PlatformSection supported={["android"]}>
@@ -410,6 +410,18 @@ Callback function that allows custom naming of renderer processes.
 If the callback is not set, or it returns `undefined`, the default naming scheme is used.
 
 </PlatformSection>
+
+<ConfigKey name="send-client-reports" supported={["java", "javascript", "dotnet", "python", "dart", "apple"]}>
+
+Set this boolean to `false` to disable sending of client reports.
+
+<PlatformSection supported={["java", "dotnet", "dart", "apple"]}>
+
+_(New in version 6.0.0)_
+
+</PlatformSection>
+
+</ConfigKey>
 
 <PlatformSection supported={["javascript", "python", "node", "dart", "java", "apple"]}>
 


### PR DESCRIPTION
As discussed here https://github.com/getsentry/sentry-docs/pull/4971 we want to document how to disable sending of client reports so we can link to the docs from the migration guide.

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
