### PR TITLE
Document addExceptionFilterForType for Java and .NET

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -475,6 +475,30 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 </ConfigKey>
 
+<PlatformSection supported={["java", "dotnet"]}>
+
+## Ignoring Errors
+
+<ConfigKey name="add-exception-filter-for-type">
+
+You can ignore exceptions by their type when initializing the SDK.
+
+<PlatformSection supported={["dotnet"]}>
+
+This modifies the behavior of the [entire inheritance chain](https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/inheritance#background-what-is-inheritance). As a result, the example code will also filter out `TaskCanceledException` since it derives from `OperationCanceledException`.
+
+</PlatformSection>
+
+<PlatformSection supported={["java"]}>
+
+Exceptions derived from the class added to the filter will not automatically be filtered. You have to add them to the list too.
+
+</PlatformSection>
+
+</ConfigKey>
+
+</PlatformSection>
+
 <PlatformSection supported={["javascript", "java", "python", "node", "php", "dotnet", "flutter"]}>
 
 ## Transport Options


### PR DESCRIPTION
Document addExceptionFilterForType in common options for .NET and Java.

See also https://github.com/getsentry/sentry-java/pull/2014 and https://github.com/getsentry/sentry-java/issues/1532

