### PR TITLE
[JS v7] **do not merge**: Adust docs after renaming `UserAgent` integration to `HttpContext`

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks/errors.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks/errors.mdx
@@ -182,7 +182,7 @@ If you've set up user identification you can find the user attributes under `dat
           "Breadcrumbs",
           "GlobalHandlers",
           "LinkedErrors",
-          "UserAgent"
+          "HttpContext"
         ],
         "name": "sentry.javascript.browser",
         "packages": [

--- a/src/docs/product/integrations/integration-platform/webhooks/issue-alerts.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks/issue-alerts.mdx
@@ -239,7 +239,7 @@ The following two fields are for [alert rule action UI components](/product/inte
           "Breadcrumbs",
           "GlobalHandlers",
           "LinkedErrors",
-          "UserAgent"
+          "HttpContext"
         ],
         "name": "sentry.javascript.browser",
         "packages": [

--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -1,7 +1,7 @@
 ---
 title: Default Integrations
 excerpt: ""
-description: "Learn more about system integrations Dedupe, InboundFilters, FunctionToString, Breadcrumbs, GlobalHandlers, LinkedErrors, and UserAgent, that are enabled by default to integrate into the standard library or the interpreter itself."
+description: "Learn more about system integrations Dedupe, InboundFilters, FunctionToString, Breadcrumbs, GlobalHandlers, LinkedErrors, and HttpContext, that are enabled by default to integrate into the standard library or the interpreter itself."
 redirect_from:
   - /platforms/javascript/integrations/default/
   - /platforms/javascript/default-integrations/
@@ -122,11 +122,12 @@ document
   });
 ```
 
-### UserAgent
+### HttpContext
 
-_Import name: `Sentry.Integrations.UserAgent`_
+_Import name: `Sentry.Integrations.HttpContext`_
 
-This integration attaches user-agent information to the event, which allows us to correctly catalog and tag them with specific OS, browser, and version information.
+This integration attaches HTTP request information, such as URL, user-agent, referrer and other headers to the event.
+It allows us to correctly catalog and tag events with specific OS, browser, and version information.
 
 ### Dedupe
 


### PR DESCRIPTION
This PR adjusts docs after renaming the `UserAgent` integration in the Sentry JS SDK to `HttpContext`.  

ref: https://getsentry.atlassian.net/browse/WEB-270