### PR TITLE
fix broken redirect link from relay docs

### DIFF
--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -46,7 +46,7 @@ To choose the right place for data scrubbing, consider:
   configure data scrubbing in a centralized place, configure your SDK to send events to Relay. Relay uses the privacy settings configured in Sentry, and scrubs PII before forwarding data to Sentry.
 
 - If you must enforce strict data privacy requirements, you can configure SDKs to
-  scrub PII using the [`before-send` hooks](/platform-redirect/?next=configuration/options/%23hooks), which prevents data from being
+  scrub PII using the [`before-send` hooks](/platform-redirect/?next=/configuration/options/%23hooks), which prevents data from being
   collected on the device. This may require you to replicate the same logic across
   your applications, and may impact performance.
 


### PR DESCRIPTION
Fixes broken platform redirect from Relay docs to platform before-send hooks docs
