### PR TITLE
feat(javascript): Link to Github `MIGRATION.md` file from docs

### DIFF
--- a/src/includes/getting-started-install/javascript.mdx
+++ b/src/includes/getting-started-install/javascript.mdx
@@ -11,8 +11,5 @@ We also support alternate [installation methods](/platforms/javascript/install/)
 
 </Note>
 
-<Note>
+ If you're updating your Sentry SDK to the latest version, check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn more about breaking changes.
 
-Are you updating your Sentry SDK to the latest version? Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn more about breaking changes!
-
-</Note>

--- a/src/includes/getting-started-install/javascript.mdx
+++ b/src/includes/getting-started-install/javascript.mdx
@@ -10,3 +10,9 @@ npm install --save @sentry/browser @sentry/tracing
 We also support alternate [installation methods](/platforms/javascript/install/).
 
 </Note>
+
+<Note>
+
+Are you updating your Sentry SDK to the latest version? Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn more about breaking changes!
+
+</Note>

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -9,6 +9,12 @@ sidebar_order: 1000
 
 If you need help solving issues with your Sentry JavaScript SDK integration, you can read the edge cases documented here. If you need additional help, you can view our forums, and customers on a paid plan may also contact support.
 
+## Updating to a new Sentry SDK Version
+
+If you update your Sentry SDK to a new major version, you might encounter breaking changes that need some adaption on your end.
+Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn everything you need
+to know to get up and running again with the latest Sentry features.
+
 ## Debugging Additional Data
 
 You can view the JSON payload of an event to see how Sentry stores additional data in the event. The shape of the data may not exactly match the description.

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -9,7 +9,7 @@ sidebar_order: 1000
 
 If you need help solving issues with your Sentry JavaScript SDK integration, you can read the edge cases documented here. If you need additional help, you can view our forums, and customers on a paid plan may also contact support.
 
-## Updating to a new Sentry SDK Version
+## Updating to a New Sentry SDK Version
 
 If you update your Sentry SDK to a new major version, you might encounter breaking changes that need some adaption on your end.
 Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn everything you need


### PR DESCRIPTION
This PR adds two links to the JS SDK repo's `MIGRATION.md` file which contains information on breaking changes and instructions how to update to the latest version of Sentry. 
Currently, the URLs link to the `7.x` version of the migration guide to include v7 migration instructions for early adopters of v7 beta versions. This means we'll have to adjust the URLs as soon as v7 is released.

Currently, there are two links, one in the "Getting Started" (which arguably many people won't look up when updating but IMO it doesn't hurt to have it there either) and one in the "Troubleshooting" section.

ref: https://getsentry.atlassian.net/browse/WEB-807
