### PR TITLE
ref(integrations): Remove indirect reference to plugin behavior

### DIFF
--- a/src/docs/product/integrations/debugging/rookout/index.mdx
+++ b/src/docs/product/integrations/debugging/rookout/index.mdx
@@ -10,7 +10,7 @@ description: "Learn more about Sentry's Rookout integration and how it adds a la
 
 Rookout adds a layer of depth to Sentry issues by allowing you to jump right from an Issue to a non-breaking breakpoint on the line that caused the error.
 
-The Rookout integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/debugging/rookout/index.mdx
+++ b/src/docs/product/integrations/debugging/rookout/index.mdx
@@ -10,7 +10,7 @@ description: "Learn more about Sentry's Rookout integration and how it adds a la
 
 Rookout adds a layer of depth to Sentry issues by allowing you to jump right from an Issue to a non-breaking breakpoint on the line that caused the error.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+The Rookout integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/deployment/vercel/index.mdx
+++ b/src/docs/product/integrations/deployment/vercel/index.mdx
@@ -10,8 +10,6 @@ description: "Learn more about Sentry's Vercel integration and how you can conne
 
 Vercel is an all-in-one platform with Global CDN supporting static and JAMstack deployment and Serverless Functions. Connect your Sentry and Vercel projects to automatically upload source maps and notify Sentry of release deployment. To learn more about using Sentry in your Next.js app, check out the [Next.js SDK](/platforms/javascript/guides/nextjs/).
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/feature-flag/split/index.mdx
+++ b/src/docs/product/integrations/feature-flag/split/index.mdx
@@ -10,7 +10,7 @@ description: "Learn more about Sentry's Split integration and how it quickly pro
 
 The Split integration quickly processes and displays Sentry exception data in the Split platform as track events for analysis. You can control what environments and traffic types you're capturing exceptions for in the Split dashboard without having to touch any code.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+The Split integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/feature-flag/split/index.mdx
+++ b/src/docs/product/integrations/feature-flag/split/index.mdx
@@ -10,7 +10,7 @@ description: "Learn more about Sentry's Split integration and how it quickly pro
 
 The Split integration quickly processes and displays Sentry exception data in the Split platform as track events for analysis. You can control what environments and traffic types you're capturing exceptions for in the Split dashboard without having to touch any code.
 
-The Split integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/issue-tracking/clickup/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/clickup/index.mdx
@@ -11,7 +11,7 @@ description: "Learn more about Sentry's ClickUp integration and how you can crea
 
 ClickUp’s core focus is about removing frustrations, inefficiencies, and disconnect caused by current project management solutions. You can create an issue in ClickUp from a Sentry issue or link it to an existing issue.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -14,8 +14,6 @@ description: "Learn more about Sentry's Jira integration and how it can help tra
 
 Track and resolve bugs faster by connecting errors from Sentry with Jira issues.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/issue-tracking/shortcut/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/shortcut/index.mdx
@@ -14,7 +14,7 @@ description: "Learn more about Sentry's Shortcut integration and how it can crea
 
 Create a more efficient workflow by linking your Sentry Issues with your Shortcut Stories. Errors, features, and anything else you track in Shortcut can now live side by side. The new Shortcut integration has feature parity with the Shortcut plugin. If you're choosing between the two, we recommend installing the Shortcut integration.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/notification-incidents/amixr/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/amixr/index.mdx
@@ -10,7 +10,7 @@ description: "Learn about Sentry's Amixr integration and how it synchronizes iss
 
 In Amixr, issues from Sentry get stored as well as alerts from other sources like Grafana or Alertmanager. The Amixr integration synchronizes issue statuses between Amixr and Sentry. Issues get posted to your Slack, and users can change the statuses of those issues by clicking on buttons within the message.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
@@ -11,8 +11,6 @@ description: "Learn more about Sentry's PagerDuty integration and how it allows 
 
 The PagerDuty integration allows you to connect your Sentry organization with one or more PagerDuty accounts, and start getting incidents triggered by Sentry alerts.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/notification-incidents/slack/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/slack/index.mdx
@@ -12,8 +12,6 @@ description: "Learn more about Sentry's Slack integration and how you can triage
 
 Triage, resolve, and ignore Sentry issues directly from Slack.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/notification-incidents/spikesh/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/spikesh/index.mdx
@@ -8,7 +8,7 @@ description: "Learn about Sentry's Spike.sh integration and how it creates incid
 
 Convert exceptions into Phone, SMS, Email and Slack alerts with Spike.sh.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects. It is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
+This integration is maintained and supported by the company that created it. For more details, see [Integration Platform](/product/integrations/integration-platform/).
 
 ## Install and Configure
 

--- a/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -11,8 +11,6 @@ description: "Learn more about Sentry's Azure DevOps integration and how it can 
 
 Track and resolve bugs faster by using data from your Azure DevOps (formerly known as Visual Studio Team Services, VSTS) commits.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/source-code-mgmt/bitbucket/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/bitbucket/index.mdx
@@ -11,8 +11,6 @@ description: "Learn more about Sentry's Bitbucket integration and how it can tra
 
 Track and resolve bugs faster by using data from your Bitbucket commits.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -11,8 +11,6 @@ description: "Learn more about Sentry's GitHub integration and how it can track 
 
 Track and resolve bugs faster by using data from your GitHub commits, and streamline your triaging process by creating a GitHub issue directly from Sentry.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -10,8 +10,6 @@ description: "Learn more about Sentry’s GitLab integration and how it helps yo
 
 Sentry’s GitLab integration helps you track and resolve bugs faster by using data from your GitLab commits. Additionally, you can streamline your triaging process by creating a GitLab issue directly from Sentry.
 
-This integration needs to set up only once per organization, then it is available for _all_ projects.
-
 ## Install
 
 <Note>


### PR DESCRIPTION
Remove the sentence "This integration needs to set up only once per organization, then it is available for _all_ projects." from our first party integration docs. This is an artifact of differentiating between plugins and first party integrations, but since first party integrations (and partner integrations) are the majority and the path forward, this sentence doesn't need to be here. 