### PR TITLE
fix(search): Mention wildcards are not allowed with multi value search

### DIFF
--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -80,7 +80,7 @@ An example of searching on the same key with a list of values:
 release:[12.0, 13.0]
 ```
 
-Currently, you can't use this type of search on the keyword `is`.
+Currently, you can't use this type of search on the keyword `is` and you can't use wildcards with this type of search.
 
 ### Explicit Tag Syntax
 


### PR DESCRIPTION
The docs currently do not mention that wildcards are not allowed when you use
the multi value search. As is, it implies that wildcards do work, which is not
the case.