### PR TITLE
add height link from issue tracking page

### DIFF
--- a/src/docs/product/integrations/issue-tracking/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/index.mdx
@@ -14,6 +14,7 @@ Learn more about Sentry’s issue tracking integrations:
 - [ClickUp](/product/integrations/issue-tracking/clickup/)
 - [GitHub (Issues)](/product/integrations/source-code-mgmt/github/)
 - [GitLab (Issues)](/product/integrations/source-code-mgmt/gitlab/)
+- [Height](/product/integrations/issue-tracking/height/)
 - [Jira/Jira Server](/product/integrations/issue-tracking/jira/)
 - [Linear](/product/integrations/issue-tracking/linear/)
 - Phabricator


### PR DESCRIPTION
Adds link to Height integration page from Issue Tracking index page
