### PR TITLE
[JS v7] **do not merge**: Update `ExtraErrorData` depth description

### DIFF
--- a/src/includes/configuration/extra-error-data/javascript.mdx
+++ b/src/includes/configuration/extra-error-data/javascript.mdx
@@ -4,16 +4,14 @@ import { ExtraErrorData as ExtraErrorDataIntegration } from "@sentry/integration
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new ExtraErrorDataIntegration(
-    {
+  integrations: [
+    new ExtraErrorDataIntegration({
       // Limit of how deep the object serializer should go. Anything deeper than limit will
       // be replaced with standard Node.js REPL notation of [Object], [Array], [Function] or
       // a primitive value. Defaults to 3.
-      // When changing this value, make sure to update `normalizeDepth` of the whole SDK
-      // to `depth + 1` in order to get it serialized properly - https://docs.sentry.io/platforms/javascript/configuration/options/#normalize-depth
-      depth: number;
-    }
-  )],
+      depth: number,
+    }),
+  ],
 });
 ```
 
@@ -32,15 +30,13 @@ Sentry.init({
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.Integrations.ExtraErrorData(
-    {
+  integrations: [
+    new Sentry.Integrations.ExtraErrorData({
       // Limit of how deep the object serializer should go. Anything deeper than limit will
       // be replaced with standard Node.js REPL notation of [Object], [Array], [Function] or
       // a primitive value. Defaults to 3.
-      // When changing this value, make sure to update `normalizeDepth` of the whole SDK
-      // to `depth + 1` in order to get it serialized properly - https://docs.sentry.io/platforms/javascript/configuration/options/#normalize-depth
-      depth: number;
-    }
-  )],
+      depth: number,
+    })
+  ],
 });
 ```


### PR DESCRIPTION
JavaScript SDK: Updates `ExtraErrorData` `depth` option description to not mention a workaround for the global `normalizeDepth` option.

Relates to https://github.com/getsentry/sentry-javascript/pull/5053 which gets rid of that workaround.

Ref: https://getsentry.atlassian.net/browse/WEB-600