### PR TITLE
Mention HTTPX in automatic instrumentation

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -29,7 +29,7 @@ Many integrations for popular frameworks automatically capture transactions. If 
 Spans are instrumented for the following operations within a transaction:
 
 - Database queries that use SQLAlchemy or the Django ORM
-- HTTP requests made with requests or the stdlib
+- HTTP requests made with HTTPX, requests or the stdlib
 - Spawned subprocesses
 - Redis operations
 


### PR DESCRIPTION
Mention HTTPX in automatic instrumentation page. HTTPX supported since version 1.2.0:
https://docs.sentry.io/platforms/python/configuration/integrations/httpx/

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
