### PR TITLE
feat(docs): Document flutter autoInitializeNativeSdk

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -565,11 +565,23 @@ Set this boolean to `false` to disable the native SDK. This will disable all nat
 
 </ConfigKey>
 
-<ConfigKey name="autoInitializeNativeSdk" supported={["react-native"]}>
+<ConfigKey name="autoInitializeNativeSdk" supported={["react-native", "flutter"]}>
 
-Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer, but instead use [enableNative](#enableNative).
+Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer.
+
+<PlatformSection supported={["react-native"]}>
+
+To disable the native layer, use [enableNative](#enableNative).
 
 You should follow the [guide to native initialization](/platforms/react-native/manual-setup/native-init/) if you chose to use this option.
+
+</PlatformSection>
+
+<PlatformSection supported={["flutter"]}>
+
+You should follow the [guide to native initialization](/platforms/flutter/native-init/) if you chose to use this option.
+
+</PlatformSection>
 
 </ConfigKey>
 
@@ -623,20 +635,6 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 <ConfigKey name="onReady" supported={["react-native"]}>
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).
-
-</ConfigKey>
-
-</PlatformSection>
-
-<PlatformSection supported={["flutter"]}>
-
-## Hybrid SDK Options
-
-<ConfigKey name="autoInitializeNativeSdk">
-
-Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer.
-
-You should follow the [guide to native initialization](/platforms/flutter/native-init/) if you chose to use this option.
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -555,21 +555,21 @@ An optional property that configures which downstream services receive the `sent
 
 </PlatformSection>
 
-<PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor"]}>
+<PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor", "flutter"]}>
 
 ## Hybrid SDK Options
 
-<ConfigKey name="enableNative">
+<ConfigKey name="enableNative" supported={["react-native", "javascript.cordova", "javascript.capacitor"]}>
 
 Set this boolean to `false` to disable the native SDK. This will disable all native crash and error handling and, instead, the SDK will only capture errors on the upper layer.
 
 </ConfigKey>
 
-<ConfigKey name="autoInitializeNativeSdk" supported={["react-native", "flutter"]}>
+<ConfigKey name="autoInitializeNativeSdk">
 
 Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer.
 
-<PlatformSection supported={["react-native"]}>
+<PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor"]}>
 
 To disable the native layer, use [enableNative](#enableNative).
 
@@ -585,7 +585,7 @@ You should follow the [guide to native initialization](/platforms/flutter/native
 
 </ConfigKey>
 
-<ConfigKey name="enableNativeCrashHandling" supported={["react-native", "javascript.capacitor"]}>
+<ConfigKey name="enableNativeCrashHandling" supported={["react-native", "javascript.capacitor", "flutter"]}>
 
 Set this boolean to `false` to disable hard crash handling from the native layer. Doing so means that the SDK won't capture events for hard crashes on Android and iOS if the error was caused by native code.
 
@@ -626,7 +626,7 @@ Set this boolean to `false` to disable auto [performance monitoring](/product/pe
 
 </ConfigKey>
 
-<ConfigKey name="enableOutOfMemoryTracking" supported={["react-native"]}>
+<ConfigKey name="enableOutOfMemoryTracking" supported={["react-native", "flutter"]}>
 
 Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/ios/configuration/out-of-memory/) tracking on iOS.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -606,7 +606,6 @@ Set this boolean to `false` to disable the scope sync from Java to NDK on Androi
 <ConfigKey name="attachThreads">
 
 Set this boolean to `true` to automatically attach all threads to all logged events on Android.
-
 </ConfigKey>
 
 <ConfigKey name="enableAutoPerformanceTracking" supported={["react-native"]}>
@@ -624,6 +623,20 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 <ConfigKey name="onReady" supported={["react-native"]}>
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).
+
+</ConfigKey>
+
+</PlatformSection>
+
+<PlatformSection supported={["flutter"]}>
+
+## Hybrid SDK Options
+
+<ConfigKey name="autoInitializeNativeSdk">
+
+Set this boolean to `false` to disable the auto initialization of the native layer SDK. Doing so means you will need to initialize the native SDK manually. Do not use this to disable the native layer.
+
+You should follow the [guide to native initialization](/platforms/flutter/native-init/) if you chose to use this option.
 
 </ConfigKey>
 

--- a/src/platforms/flutter/native-init.mdx
+++ b/src/platforms/flutter/native-init.mdx
@@ -1,0 +1,33 @@
+---
+title: Native Initialization
+sidebar_order: 900
+description: "Learn how to manually initialize the native SDKs."
+---
+
+By default, the Flutter SDK initializes the native SDK underneath the `init` method called on the Flutter layer. As a result, the SDK has a current limitation of not capturing native crashes that occur prior to the `init` method being called on the Flutter layer. You can initialize the native SDKs yourself to overcome this limitation or if you want to provide custom options above what the Flutter SDK currently provides.
+
+To do this, set [autoInitializeNativeSdk](/platforms/flutter/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
+
+```dart
+import 'package:sentry/sentry.dart';
+
+Future<void> main() async {
+  await Sentry.init((options) => options
+    ..dsn = '___PUBLIC_DSN___'
+    ..autoInitializeNativeSdk = false);
+}
+```
+
+This will prevent the Flutter SDK from initializing the native SDK automatically.
+
+Next, initialize the native SDKs for Android, which is documented below, or for iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.
+
+## Android Configuration
+
+To use auto-init, add the following to your `AndroidManifest.xml`:
+
+```xml
+<meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
+```
+
+Then follow [the guide on initializing Android](/platforms/android/#configure).

--- a/src/platforms/flutter/native-init.mdx
+++ b/src/platforms/flutter/native-init.mdx
@@ -22,6 +22,6 @@ Future<void> main() async {
 }
 ```
 
-This will prevent the Flutter SDK from initializing the native SDK automatically.
+This will prevent the Flutter SDK from initializing the native SDKs automatically.
 
-Next, [initialize the native SDKs for Android](/platforms/android/configuration/manual-init/), or iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.
+Next, [initialize the native SDKs for Android](/platforms/android/configuration/manual-init/) and iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.

--- a/src/platforms/flutter/native-init.mdx
+++ b/src/platforms/flutter/native-init.mdx
@@ -9,25 +9,19 @@ By default, the Flutter SDK initializes the native SDK underneath the `init` met
 To do this, set [autoInitializeNativeSdk](/platforms/flutter/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
 ```dart
-import 'package:sentry/sentry.dart';
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 Future<void> main() async {
-  await Sentry.init((options) => options
-    ..dsn = '___PUBLIC_DSN___'
-    ..autoInitializeNativeSdk = false);
+  await SentryFlutter.init(
+    (options) => options
+      ..dsn = '___PUBLIC_DSN___'
+      ..autoInitializeNativeSdk = false,
+    appRunner: () => runApp(MyApp()),
+  );
 }
 ```
 
 This will prevent the Flutter SDK from initializing the native SDK automatically.
 
-Next, initialize the native SDKs for Android, which is documented below, or for iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.
-
-## Android Configuration
-
-To use auto-init, add the following to your `AndroidManifest.xml`:
-
-```xml
-<meta-data android:name="io.sentry.auto-init" tools:replace="android:value" android:value="true" />
-```
-
-Then follow [the guide on initializing Android](/platforms/android/#configure).
+Next, [initialize the native SDKs for Android](/platforms/android/configuration/manual-init/), or iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.

--- a/src/platforms/flutter/native-init.mdx
+++ b/src/platforms/flutter/native-init.mdx
@@ -4,7 +4,7 @@ sidebar_order: 900
 description: "Learn how to manually initialize the native SDKs."
 ---
 
-By default, the Flutter SDK initializes the native SDK underneath the `init` method called on the Flutter layer. As a result, the SDK has a current limitation of not capturing native crashes that occur prior to the `init` method being called on the Flutter layer. You can initialize the native SDKs yourself to overcome this limitation or if you want to provide custom options above what the Flutter SDK currently provides.
+By default, the Flutter SDK initializes the native SDK underneath the `init` method called on the Flutter layer. As a result, the SDK currenty has a limitation of not capturing native crashes that occur prior to the `init` method being called on the Flutter layer. You can initialize the native SDKs yourself to overcome this limitation or if you want to provide custom options above what the Flutter SDK currently provides.
 
 To do this, set [autoInitializeNativeSdk](/platforms/flutter/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
@@ -24,4 +24,4 @@ Future<void> main() async {
 
 This will prevent the Flutter SDK from initializing the native SDKs automatically.
 
-Next, [initialize the native SDKs for Android](/platforms/android/configuration/manual-init/) and iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.
+Next, initialize the [Android](/platforms/android/configuration/manual-init/) and [iOS (using the configuration guide to initialize the Sentry Cocoa SDK)](/platforms/apple/guides/ios/#configure) native SDKs. Note that you do not need to install the native SDKs as they are already packaged with the Flutter SDK.


### PR DESCRIPTION
Add documentation for option `autoInitializeNativeSdk` for flutter/dart sdk.

Merge after `6.6.0-alpha.3` gets released.