### PR TITLE
clarify team plan behaviour for app-store-connect

### DIFF
--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -34,7 +34,7 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
-<Alert level="info">
+<Alert level="Note">
 
 Developer and Team subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
 

--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -34,9 +34,9 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
-<Alert level="Note">
+<Alert level="info">
 
-Free subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+Developer and Team subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
 
 </Alert>
 


### PR DESCRIPTION


<!-- Describe your PR here. -->

- Change Alert level from Note to info to make the content more apparent. Customers may miss this content when being redirected from the app like so:

![example of app store connect up-sell modal](https://user-images.githubusercontent.com/76002357/168144658-c4c82467-b7cd-42f4-94e4-1ac578cf11d4.png)

- Clarify App Store Connect behaviour for Team subscription plans

