### PR TITLE
[JS v7] **do not merge** Remove `ignoreSentryErrors` section in JS docs

### DIFF
--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -100,21 +100,6 @@ exports.handler = Sentry.AWSLambda.wrapHandler(() => {
 // `first` and `second` errors are captured
 ```
 
-## Ignore Sentry Errors
-_(New in version 6.18.0)_
-
-By default, Sentry fails Lambda invocation if it is unable to send events to Sentry.
-In this case, even if all reported errors were handled and your handler executed successfully, Sentry will fail the whole Lambda invocation.
-
-The `ignoreSentryErrors` (default: `false`) option ignores all the errors raised by Sentry
-
-```javascript {tabTitle:ignoreSentryErrors}
-exports.handler = Sentry.AWSLambda.wrapHandler(yourHandler, {
-  // Ignore any errors raised by the Sentry SDK on attempts to send events to Sentry
-  ignoreSentryErrors: true,
-});
-```
-
 ## Behavior
 
 With the AWS Lambda integration enabled, the Node SDK will:


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/5090 we removed the `ignoreSentryErrors` from the AWS Lambda JS SDK. In this PR we're removing references to it.

Ref: https://getsentry.atlassian.net/browse/WEB-918