### PR TITLE
[JS v7] **do not merge** Add React Router v6 instrumentation docs.

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -42,7 +42,7 @@ import {
     matchRoutes,
 } from "react-router-dom";
 import * as Sentry from "@sentry/react";
-import { BrowserTracing } "@sentry/tracing";
+import { BrowserTracing } from "@sentry/tracing";
 
 Sentry.init({
     integrations: [

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -70,7 +70,7 @@ ReactDOM.render(
 );
 ```
 
-Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (ex. /teams/:teamid/user/:userid), where applicable.
+Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (for example, /teams/:teamid/user/:userid), where applicable.
 
 
 ## React Router v4/v5

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,7 +15,67 @@ The React Router integration is designed to work with our Tracing SDK, `@sentry/
 
 </Alert>
 
-We support integrations for React Router 3, 4 and 5.
+We support integrations for React Router 3, 4, 5 and 6.
+
+## React Router v6
+_(Available in version 7 and above)_
+
+To use React Router v6 with Sentry, you need to:
+
+1. Initialize `Sentry.reactRouterV6Instrumentation` as your routing instrumentation, and provide functions it needs to enable performance tracing.
+
+  You need to provide:
+
+    - `useEffect` hook from `react`
+    - `useLocation` and `useNavigationType` hooks from `react-router-dom`
+    - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages.
+    
+2. Wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing` to create a higher order component, which will enable Sentry to reach your router context.
+ 
+Example usage: 
+
+```javascript
+import React from 'react';
+import ReactDOM from "react-dom";
+import {
+    Routes,
+    BrowserRouter,
+    useLocation,
+    useNavigationType,
+    createRoutesFromChildren,
+    matchRoutes,
+} from "react-router-dom";
+import * as Sentry from "@sentry/react";
+import { BrowserTracing } "@sentry/tracing";
+
+Sentry.init({
+    integrations: [
+        new BrowserTracing({
+            routingInstrumentation: Sentry.reactRouterV6Instrumentation(
+                React.useEffect,
+                useLocation,
+                useNavigationType,
+                createRoutesFromChildren,
+                matchRoutes,
+            ),
+        }),
+    ],
+    tracesSampleRate: 1.0,
+});
+
+const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes)
+
+ReactDOM.render(
+    <BrowserRouter>
+        <SentryRoutes>
+            <Route path="/" element={<div>Home</div>} />
+        </SentryRoutes>
+    </BrowserRouter>,
+);
+```
+
+Now, Sentry should be generating `pageload`/`navigation` transactions, with parameterized transaction names (ex. /teams/:teamid/user/:userid), where applicable.
+
 
 ## React Router v4/v5
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,24 +15,20 @@ The React Router integration is designed to work with our Tracing SDK, `@sentry/
 
 </Alert>
 
-We support integrations for React Router 3, 4, 5 and 6.
+We support integrations for React Router 3, 4, 5, and 6.
 
 ## React Router v6
 _(Available in version 7 and above)_
 
-To use React Router v6 with Sentry, you need to:
+To use React Router v6 with Sentry:
 
-1. Initialize `Sentry.reactRouterV6Instrumentation` as your routing instrumentation, and provide functions it needs to enable performance tracing.
-
-  You need to provide:
+1. Initialize `Sentry.reactRouterV6Instrumentation` as your routing instrumentation and provide the functions it needs to enable performance tracing:
 
     - `useEffect` hook from `react`
     - `useLocation` and `useNavigationType` hooks from `react-router-dom`
     - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages.
     
-2. Wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing` to create a higher order component, which will enable Sentry to reach your router context.
- 
-Example usage: 
+2. Wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing` to create a higher order component, which will enable Sentry to reach your router context, as in the example below:
 
 ```javascript
 import React from 'react';
@@ -74,7 +70,7 @@ ReactDOM.render(
 );
 ```
 
-Now, Sentry should be generating `pageload`/`navigation` transactions, with parameterized transaction names (ex. /teams/:teamid/user/:userid), where applicable.
+Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (ex. /teams/:teamid/user/:userid), where applicable.
 
 
 ## React Router v4/v5


### PR DESCRIPTION
Adds a summary and usage example for the new React Router v6 instrumentation.

https://github.com/getsentry/sentry-javascript/pull/5042