### PR TITLE
feat(apiDocs): Add api type to params too

### DIFF
--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -21,7 +21,7 @@ const Params = ({ params }) => (
         <dt>
           <div>
             <code data-index>{param.name}</code>
-            {!!param.schema?.type && <em> ({param.schema.type})</em>}
+            {!!param.schema?.type && <em> ({param.schema.type}{param.schema.items && `(${param.schema.items.type})`})</em>}
           </div>
           {!!param.required && <div className="required">REQUIRED</div>}
         </dt>


### PR DESCRIPTION
- This changes `array` to also include its subtype
   - eg. instead of just `array` it'll now say `array(string)`