### PR TITLE
SDKs typo fix

### DIFF
--- a/src/platforms/common/enriching-events/context.mdx
+++ b/src/platforms/common/enriching-events/context.mdx
@@ -63,7 +63,7 @@ Learn more about conventions for common contexts in the [contexts interface deve
 
 When sending context, _consider payload size limits_. Sentry does not recommend sending the entire application state and large data blobs in contexts. If you exceed the maximum payload size, Sentry will respond with HTTP error `413 Payload Too Large` and reject the event. <PlatformSection supported={["javascript", "node"]}>When `keepalive: true` is used, the request may additionally stay pending forever.</PlatformSection>
 
-The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKS can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/data-handling/).
+The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKs can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/data-handling/).
 
 <PlatformSection supported={["javascript", "node"]}>
 


### PR DESCRIPTION


<!-- Describe your PR here. -->
I only have a one character fix to suggest.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
