### PR TITLE
chore(unity): Fixed typo

### DIFF
--- a/src/platforms/unity/troubleshooting.mdx
+++ b/src/platforms/unity/troubleshooting.mdx
@@ -90,9 +90,9 @@ You can resolve this issue by installing the SDK with UPM.
 
 ## Events
 
-### Unhandled Excpetions - Debug.LogException
+### Unhandled Exception - Debug.LogException
 
-Currenty, it is not possible for the SDK to distiguish between the user calling `Debug.LogException` and the SDK capturing an unhandled excpetion through the Unity logging integration. To capture an exception and mark it as handled you can call `SentrySDK.CaptureException` instead.
+Currenty, it is not possible for the SDK to distiguish between the user calling `Debug.LogException` and the SDK capturing an unhandled excpetion. To capture an exception and mark it as handled you can call `SentrySDK.CaptureException` instead.
 
 ### Universal Windows Platform - Events Not Sent
 


### PR DESCRIPTION
Fixed typo and removed direct reference as to which integration captures unhandled references.