### PR TITLE
fix source maps references and time range change example

### DIFF
--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 description: "Learn how to provide information to Sentry about your releases to determine regressions and resolve issues quickly."
 ---
 
-A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, whether an issue is resolved in the next release, and apply [source maps](/platforms/javascript/sourcemaps/).
+A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, whether an issue is resolved in the next release, and apply source maps.
 
 Releases also offer significant additional features when you fully [configure your SDK](/platform-redirect/?next=/configuration/releases/):
 

--- a/src/docs/product/releases/setup/release-automation/circleci/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/circleci/index.mdx
@@ -70,6 +70,6 @@ For more details about the release management concepts in the snippet above, see
 
 **Notes**:
 
-- If you’re not deploying a JavaScript project or have sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
 - If you can’t install a repository integration, send commit metadata via the [create release endpoint](/product/releases/setup/manual-setup-releases/) or omit the `set-commits` line.
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/src/docs/product/releases/setup/release-automation/github-actions/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/github-actions/index.mdx
@@ -5,6 +5,6 @@ redirect_from:
 description: "Learn how Sentry and GitHub Actions automate release management and help identify suspect commits."
 ---
 
-The [Sentry Release GitHub Action](https://github.com/marketplace/actions/sentry-release) automates Sentry release management in GitHub with just one step. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
+The [Sentry Release GitHub Action](https://github.com/marketplace/actions/sentry-release) automates Sentry release management in GitHub with just one step. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. Additionally, releases are used for applying source maps to view original, untransformed source code.
 
 For more details about Sentry release management concepts, see the full documentation on [releases](/product/releases/).

--- a/src/docs/product/releases/setup/release-automation/jenkins/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/jenkins/index.mdx
@@ -81,7 +81,7 @@ pipeline {
 
 **Notes**:
 
-- If you’re not deploying a JavaScript project or have sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
 - If you can’t install a repository integration, send commit metadata via the [create release endpoint](/product/releases/setup/manual-setup-releases/) or omit the `set-commits` line.
 - `credentials('sentry-auth-token')` refers to the ID of the credentials just added to Jenkins.
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.
@@ -115,6 +115,6 @@ If you're using Freestyle projects, you need to add another build step after dep
 
    **Notes**:
 
-   - If you’re not deploying a JavaScript project or have sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+   - If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
    - If you can’t install a repository integration, send commit metadata via the [create release endpoint](/product/releases/setup/manual-setup-releases/) or omit the `set-commits` line.
    - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/src/docs/product/releases/setup/release-automation/travis-ci/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/travis-ci/index.mdx
@@ -63,6 +63,6 @@ For more details about the release management concepts in the snippet above, see
 
 **Notes**:
 
-- If you’re not deploying a JavaScript project or have sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
 - If you can’t install a repository integration, send commit metadata via the [create release endpoint](/product/releases/setup/manual-setup-releases/) or omit the `set-commits` line (`set-commits` is required for suspect commits).
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed (recommended). To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/src/docs/product/releases/usage/time-range.mdx
+++ b/src/docs/product/releases/usage/time-range.mdx
@@ -8,4 +8,4 @@ When you change the date range in **Releases**, Sentry recalculates the values. 
 
 For example, you have seven users that are using your application for seven days and each day one of them experiences a crash. If you select the 24-hour time range, the **Releases** page will show you that every day there were 85.7% crash-free users on the release.
 
-By contrast, let's say you have seven users and each day a different user experiences a crash. If you select the seven-day time range, by the end of the week, the **Releases** page will show you the release had 0% crash-free users.
+By contrast, if you have the same conditions but you select the seven-day time range, by the end of the week, the **Releases** page will show you that there were 0% crash-free users on the release.


### PR DESCRIPTION
Fixes references to source maps to remove JavaScript-specific text and links
Fixes time range change example to improve clarity