### PR TITLE
Dotnet tunnel docs

### DIFF
--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -287,7 +287,7 @@ Opt-in to capture values from [System.Diagnostic.Activity](https://github.com/do
 
 If events are being logged to sentry from the client-side then a [Tunnel](/platforms/javascript/troubleshooting/#using-the-tunnel-option) should be used.
 
-> A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked.
+A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked.
 
 ### Usage
 

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -285,7 +285,7 @@ Opt-in to capture values from [System.Diagnostic.Activity](https://github.com/do
 
 ## Tunnel
 
-If events are being logged to sentry from the client-side then a [Tunnel](/platforms/javascript/troubleshooting/#using-the-tunnel-option) should be used.
+If events are being logged to Sentry from the client-side, then you should use a [tunnel](/platforms/javascript/troubleshooting/#using-the-tunnel-option).
 
 A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked.
 

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -282,3 +282,12 @@ Opt-in to capture values from [System.Diagnostic.Activity](https://github.com/do
 - An [example](https://github.com/getsentry/sentry-dotnet/tree/main/samples/Sentry.Samples.AspNetCore.Mvc) using MVC and most of the SDK features. (**C#**)
 - An [example](https://github.com/sentry-demos/giraffe) using Giraffe on top of ASP.NET Core with a basic overview of available features. (**F#**)
 - For [more samples](https://github.com/getsentry/sentry-dotnet-samples) of the .NET SDKs.
+
+
+## Tunnel
+
+If events are being logged to sentry from the client-side then a [Tunnel](/platforms/javascript/troubleshooting/#using-the-tunnel-option) should be used.
+
+> A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked.
+
+

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -302,5 +302,5 @@ Sentry.init({
 });
 ```
 
-The [AspNetCore.Mvc Sample](https://github.com/getsentry/sentry-dotnet/tree/main/samples/Sentry.Samples.AspNetCore.Mvc) uses this approach.
+The [AspNetCore.Mvc sample](https://github.com/getsentry/sentry-dotnet/tree/main/samples/Sentry.Samples.AspNetCore.Mvc) uses this approach.
 

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -293,7 +293,7 @@ If events are being logged to sentry from the client-side then a [Tunnel](/platf
 
  * Add to the container by calling `AddSentryTunneling();` on `IServiceCollection`.
  * Add the web app by calling `UseSentryTunneling();` on `IApplicationBuilder`.
- * In the client side JavaScript configuration ensure the tunnel option is sued:
+ * In the client-side JavaScript configuration, ensure the tunnel option is used:
 
 ```javascript
 Sentry.init({

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -283,11 +283,24 @@ Opt-in to capture values from [System.Diagnostic.Activity](https://github.com/do
 - An [example](https://github.com/sentry-demos/giraffe) using Giraffe on top of ASP.NET Core with a basic overview of available features. (**F#**)
 - For [more samples](https://github.com/getsentry/sentry-dotnet-samples) of the .NET SDKs.
 
-
 ## Tunnel
 
 If events are being logged to sentry from the client-side then a [Tunnel](/platforms/javascript/troubleshooting/#using-the-tunnel-option) should be used.
 
 > A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked.
 
+### Usage
+
+ * Add to the container by calling `AddSentryTunneling();` on `IServiceCollection`.
+ * Add the web app by calling `UseSentryTunneling();` on `IApplicationBuilder`.
+ * In the client side JavaScript configuration ensure the tunnel option is sued:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tunnel: "/tunnel",
+});
+```
+
+The [AspNetCore.Mvc Sample](https://github.com/getsentry/sentry-dotnet/tree/main/samples/Sentry.Samples.AspNetCore.Mvc) uses this approach.
 


### PR DESCRIPTION
Add docs on how to use tunneling from the sentry aspnetcore package

related to https://github.com/getsentry/sentry-dotnet/pull/1645

Merge after the sentry-dotnet PR