### PR TITLE
docs: add explanation regarding appcenter token

### DIFF
--- a/src/platforms/react-native/manual-setup/codepush.mdx
+++ b/src/platforms/react-native/manual-setup/codepush.mdx
@@ -83,14 +83,13 @@ sentry-cli react-native appcenter {APP} ios ./build/CodePush --deployment {DEPLO
 
 <Alert level="info">
 
-Make sure to export the `APPCENTER_ACCESS_TOKEN` in your environment in order to run the `appcenter` commands above. Ohterwise you might get an empty error:
+Make sure to export the `APPCENTER_ACCESS_TOKEN` in your environment in order to run the `appcenter` commands above. Otherwise you will get the following error:
 
 ```bash
-error: Failed to load AppCenter deployment history
-  caused by:
+Command 'appcenter codepush deployment history' requires a logged in user. Use the 'appcenter login' command to log in.
 ```
 
-You can find more information about this in the [AppCenter CLI](https://docs.microsoft.com/en-us/appcenter/cli/#logging-in).
+You can find more information about this in the [AppCenter CLI](https://docs.microsoft.com/en-us/appcenter/cli/#logging-in) documentation.
 
 </Alert>
 


### PR DESCRIPTION
- Make it more clear on how to use the AppCenter CLI commands.

Note 1:
- I tried running the documentation following the readme, using `make` but got an error with `node-sass`, tried with both python@2, python@3, after quickly googling, it seemed to be an issue with node@16 but it didn't solve it. I, unfortunately, don't have enough time to go into the rabbit hole of debugging this. Here is the command error https://app.warp.dev/block/YhGQTsuUjgzLDxARexqrHj

Note 2:
- I created another ticket in the `@sentry/cli` repository: https://github.com/getsentry/sentry-cli/issues/1241

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
