### PR TITLE
Change migration guide for hints

### DIFF
--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -27,7 +27,7 @@ description: "Migrating between versions of Sentry's SDK for Android."
   * `IHandler` is now `MainLooperHandler` only.
 * `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
 
-* Hints changed its type from `Object` to `Map<String, Object>`
+* Hints changed its type from `Object` to `io.sentry.Hint`
 
 _Old_:
 

--- a/src/platforms/java/migration.mdx
+++ b/src/platforms/java/migration.mdx
@@ -28,7 +28,7 @@ description: "Learn about migrating from io.sentry:sentry 1.x to io.sentry:sentr
 * `ISpan` now has higher precision using the `System#nanoTime` instead of milliseconds.
 * `TransactionNameProvider` is now an interface and `SpringMvcTransactionNameProvider` is the default implementation.
 
-* Hints changed its type from `Object` to `Map<String, Object>`
+* Hints changed its type from `Object` to `io.sentry.Hint`
 
 _Old_:
 


### PR DESCRIPTION
Update migration guide for https://github.com/getsentry/sentry-java/pull/2045
