### PR TITLE
chore(billing): GA on-demand budget for all performance plans

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -46,9 +46,8 @@ You can set a maximum monthly on-demand invoice amount by setting an on-demand b
 
 <Note>
 
-Per-category on-demand budgets are rolling out for general availability (GA) to paying customers on plans with [performance monitoring](/product/performance/) features.
+Per-category on-demand budgets are available to paying customers on plans with [performance monitoring](/product/performance/) features.
 
-Until the GA rollout is complete, the feature is still available for organizations on paid performance plans in the Early Adopter program. If you opt out of the Early Adopter program while on the per-category on-demand budget strategy, you'll retain the per-category budgets you've set and the ability to update them. However, if you switch to the shared on-demand budget strategy, you won't be able to switch back unless you opt in to the Early Adopter program again.
 Customers on plans without performance monitoring can only use the shared on-demand budget strategy.
 
 </Note>


### PR DESCRIPTION
This PR syncs with https://github.com/getsentry/getsentry/pull/7548

This updates the note on the availability of the split on-demand budget on performance plans.

