### PR TITLE
dotnet performance clarify GetSpan

### DIFF
--- a/src/includes/performance/retrieve-transaction/dotnet.mdx
+++ b/src/includes/performance/retrieve-transaction/dotnet.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`, otherwise it returns `null`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
 
 ```csharp
 using Sentry;

--- a/src/includes/performance/retrieve-transaction/dotnet.mdx
+++ b/src/includes/performance/retrieve-transaction/dotnet.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. This method will return a `SentryTransaction` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `null`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`, otherwise it returns `null`.
 
 ```csharp
 using Sentry;

--- a/src/includes/performance/retrieve-transaction/dotnet.mdx
+++ b/src/includes/performance/retrieve-transaction/dotnet.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `SentrySdk.GetSpan()`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
 
 ```csharp
 using Sentry;

--- a/src/includes/performance/retrieve-transaction/dotnet.mdx
+++ b/src/includes/performance/retrieve-transaction/dotnet.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.GetSpan`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
 
 ```csharp
 using Sentry;


### PR DESCRIPTION
Clarify the behaviour of the GetSpan method.

GetSpan will return an ongoing Transaction or Span that is on the Scope. This is not clear from the .NET docs.

Related to ZenDesk ticket #65770