### PR TITLE
ref(native): capture-error using high-level API.

### DIFF
--- a/src/includes/capture-error/native.mdx
+++ b/src/includes/capture-error/native.mdx
@@ -1,23 +1,30 @@
 To capture an error or exception condition, create events containing an
-exception object. It needs to contain at least a value and type:
+exception object:
 
 ```cpp
 #include <sentry.h>
 
-sentry_value_t exc = sentry_value_new_object();
-sentry_value_set_by_key(exc, "type", sentry_value_new_string("Exception"));
-sentry_value_set_by_key(exc, "value", sentry_value_new_string("Error message."));
-
-sentry_value_t exceptions = sentry_value_new_object();
-sentry_value_t values = sentry_value_new_list();
-
-sentry_value_set_by_key(exceptions, "values", values);
-sentry_value_append(values, exc);
-
 sentry_value_t event = sentry_value_new_event();
-sentry_value_set_by_key(event, "exception", exceptions);
+
+sentry_value_t exc = sentry_value_new_exception("Exception", "Error message.");
+sentry_event_add_exception(event, exc);
 
 sentry_capture_event(event);
 ```
 
-This exception does not contain a stack trace, which must be added separately.
+The above exception does not contain a stack trace, which must be added separately:
+
+```cpp
+#include <sentry.h>
+
+sentry_value_t event = sentry_value_new_event();
+
+sentry_value_t exc = sentry_value_new_exception("Exception", "Error message.");
+
+sentry_value_t stacktrace = sentry_value_new_stacktrace(NULL, 0);
+sentry_value_set_by_key(exc, "stacktrace", stacktrace);
+
+sentry_event_add_exception(event, exc);
+
+sentry_capture_event(event);
+```


### PR DESCRIPTION
@Swatinem and @jan-auer: this is my suggested change to the documentation after our conversation on Tuesday. It replaces the low-level calls with all currently available high-level APIs. It also shows how to add a stack trace to the exception instead of only referring to it.

Instead of having two, we can provide only one example with the stack trace (and comment on its optionality).