### PR TITLE
ref(js): change migration guide URLs from v7 branch to master

### DIFF
--- a/src/includes/getting-started-install/javascript.mdx
+++ b/src/includes/getting-started-install/javascript.mdx
@@ -11,5 +11,4 @@ We also support alternate [installation methods](/platforms/javascript/install/)
 
 </Note>
 
- If you're updating your Sentry SDK to the latest version, check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn more about breaking changes.
-
+If you're updating your Sentry SDK to the latest version, check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md) to learn more about breaking changes.

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -12,7 +12,7 @@ If you need help solving issues with your Sentry JavaScript SDK integration, you
 ## Updating to a New Sentry SDK Version
 
 If you update your Sentry SDK to a new major version, you might encounter breaking changes that need some adaption on your end.
-Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md) to learn everything you need
+Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md) to learn everything you need
 to know to get up and running again with the latest Sentry features.
 
 ## Debugging Additional Data


### PR DESCRIPTION
This small PR changes the URLs of two links to the JS SDK migration guide which previously linked to the `7.x` branch version of the migration guide. It now links to master since we merged the `7.x` branch