### PR TITLE
ref(native): Clarify before_send with Crashpad

### DIFF
--- a/src/includes/configuration/before-send/native.mdx
+++ b/src/includes/configuration/before-send/native.mdx
@@ -17,8 +17,8 @@ int main(void) {
 
 The callback is executed in the same thread as the call to `sentry_capture_event`. Work performed by the function may thus block the executing thread. For this reason, consider avoiding heavy work in `before_send`.
 
-<Alert level="warning" title="Not Supported in Crashpad">
+<Alert level="warning" title="Not Supported in Crashpad on macOS">
 
-The Crashpad Backend sends Minidumps with an additional event payload out-of-process. `before_send` hooks are not invoked when capturing crashes using Crashpad.
+The Crashpad backend on macOS currently has no support for notifying the crashing process and can thus not correctly terminate sessions or call the registered `before_send` hook. It will also lose any events queued for sending at the time of the crash.
 
 </Alert>


### PR DESCRIPTION
The docs are out of date regarding the support of the `before_send` hook when using the Crashpad backend (https://github.com/getsentry/sentry-native/issues/720).
