### PR TITLE
fix(android): Typo for UI transactions

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -307,7 +307,7 @@ import io.sentry.SpanStatus
 fun loadUserDataOnClick() {
   val span = Sentry.getSpan()
   span?.let {
-    val innerSpan = it.startChild("displayUloadUserDataserData")
+    val innerSpan = it.startChild("loadUserData")
 
     try {
       // omitted code


### PR DESCRIPTION
The Kotlin code sample for user interaction transactions had a typo.
This is fixed now by aligning the code sample with Java.
