### PR TITLE
ref(android): Simplify UI transaction code sample

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -285,15 +285,8 @@ void loadUserDataOnClick() {
   ISpan span = Sentry.getSpan();
   if (span != null) {
     ISpan innerSpan = span.startChild("loadUserData");
-    try {
-      // omitted code
-    } catch (Exception e) {
-      innerSpan.setThrowable(e);
-      innerSpan.setStatus(SpanStatus.NOT_FOUND);
-      throw e;
-    } finally {
-      innerSpan.finish();
-    }
+    // omitted code
+    innerSpan.finish();
   }
 }
 ```
@@ -308,16 +301,8 @@ fun loadUserDataOnClick() {
   val span = Sentry.getSpan()
   span?.let {
     val innerSpan = it.startChild("displayUloadUserDataserData")
-
-    try {
-      // omitted code
-    } catch (e: Exception) {
-      innerSpan.throwable = e
-      innerSpan.status = SpanStatus.NOT_FOUND
-      throw e
-    } finally {
-      innerSpan.finish()
-    }
+    // omitted code
+    innerSpan.finish()
   }
 }
 ```


### PR DESCRIPTION
Reduce the complexity of the code sample for manually adding spans
to user interaction transactions.
