### PR TITLE
ref(js): Add note about old name of HttpContext integration

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -1,7 +1,7 @@
 ---
 title: Default Integrations
 excerpt: ""
-description: "Learn more about system integrations Dedupe, InboundFilters, FunctionToString, Breadcrumbs, GlobalHandlers, LinkedErrors, and HttpContext, that are enabled by default to integrate into the standard library or the interpreter itself."
+description: "Learn more about system integrations Dedupe, InboundFilters, FunctionToString, Breadcrumbs, GlobalHandlers, LinkedErrors, and HttpContext (UserAgent), that are enabled by default to integrate into the standard library or the interpreter itself."
 redirect_from:
   - /platforms/javascript/integrations/default/
   - /platforms/javascript/default-integrations/
@@ -122,9 +122,18 @@ document
   });
 ```
 
-### HttpContext
+### HttpContext (previously: UserAgent)
 
 _Import name: `Sentry.Integrations.HttpContext`_
+
+<Note>
+
+Before version 7.0.0 of the Sentry SDK, this integration was called `UserAgent`.
+It was renamed because the integration handles more than just user-agent data.
+
+_Import name: `Sentry.Integrations.UserAgent`_
+
+</Note>
 
 This integration attaches HTTP request information, such as URL, user-agent, referrer and other headers to the event.
 It allows us to correctly catalog and tag events with specific OS, browser, and version information.


### PR DESCRIPTION
This PR adds a note to the `HttpContext` integration of the JS SDK explaining that it was  called `UserAgent` before v7. This ensures that pre-v7 users can find correct information about their default integrations.