### PR TITLE
ref(integration-platform): Add URI formatting guidelines to docs

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/alert-rule-action.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/alert-rule-action.mdx
@@ -33,7 +33,7 @@ The alert rule action component gives you to access to parameters to define rout
 ## Attributes
 
 - `title` - (Required) The title shown in the UI component.
-- `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form. If the services fails to process the request (status code >= 400), this component will bubble up the error to the User with the provided response text.
+- `uri` - (Required) Sentry will make a POST request to the URI when the User submits the form. If the services fails to process the request (status code >= 400), this component will bubble up the error to the User with the provided response text. See [URI Guidelines](/product/integrations/integration-platform/ui-components/#uri-guidelines) for formatting help.
 - `required_fields` - (Required) List of [FormField](/product/integrations/integration-platform/ui-components/formfield) components the User is required to complete.
 - `optional_fields` - (Optional) List of [FormField](/product/integrations/integration-platform/ui-components/formfield) components the User may complete.
 - `description` - (Optional) Text that will be displayed above the form. Limited to 140 characters.
@@ -68,7 +68,6 @@ The alert rule action component gives you to access to parameters to define rout
   ]
 }
 ```
-
 
 ## Issue Alert Request Format
 
@@ -141,7 +140,7 @@ When a metric alert fires, your service will need to read the settings from the 
 If a user setting up an alert rule action with your app tries to save an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io) by responding to the POST request with a JSON response in this shape:
 
 ```json
-{"message": "Channel no longer exists!"}
+{ "message": "Channel no longer exists!" }
 ```
 
 Alternately, if an error code (40x, 50x) is returned, we will show a generic error message. If an error occurs, the user will not be able to save the alert rule.

--- a/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
@@ -69,7 +69,7 @@ The [issue linking](/product/integrations/integration-platform/ui-components/iss
 
 - `label` - (Required) Label text to be rendered for the form field
 - `name` - (Required) Value to use in `name` attribute of the field
-- `uri` - (Required if developer doesn't provide `options`) URI to retrieve values from.
+- `uri` - (Required if developer doesn't provide `options`) URI to retrieve values from. See [URI Guidelines](/product/integrations/integration-platform/ui-components/#uri-guidelines) for formatting help.
 - `async` - (Optional) Used only if `uri` is present. If true (default), will query the URI as the user types, for autocomplete suggestions (see response format below). If false, will query the URI once initially to retrieve all possible options. This request _must_ succeed, and the response _must_ return data in the format Sentry expects, otherwise the entire component won't render.
 - `options` - (Required if developer doesn't provide `uri`) Static list of options in the format of [value, label]
 - `depends_on` - (Optional) If a field value depends on the value of another field, a request will be made to load those options when the dependent field is set.

--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -27,6 +27,11 @@ The UI components are specified in the schema section of the integration details
 }
 ```
 
+### URI Guidelines
+
+The `uri` keys in your schema elements describe the URI path that will receive a request from that UI Component. Sentry will append the path in the `uri` field onto the host of your integration's **Webhook URL**.
+For example, if the Webhook URL is `https://example.com/webhook/`, and your schema's `uri` attribute is `/alerts/`, then the integration will receive requests to `https://example.com/alerts/`.
+
 ## Error Handling
 
 Component rendering either 100% works or shows nothing. To protect the integration from looking chaotic due to errors we have no control over, if any part of the third-party component rendering fails, nothing will render.

--- a/src/docs/product/integrations/integration-platform/ui-components/issue-link.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/issue-link.mdx
@@ -39,10 +39,9 @@ When an external issue is created or linked in [sentry.io](https://sentry.io), a
 
 ## Attributes
 
-- `uri` - (Required) The URI to request when the User submits the Link/Create Issue form.
+- `uri` - (Required) The URI to request when the User submits the Link/Create Issue form. See [URI Guidelines](/product/integrations/integration-platform/ui-components/#uri-guidelines) for formatting help.
 - `required_fields` - (Required) List of [FormField](/product/integrations/integration-platform/ui-components/formfield) components the User is required to complete.
 - `optional_fields` - (Optional) List of [FormField](/product/integrations/integration-platform/ui-components/formfield) components the User may complete.
-
 
 ## Example
 
@@ -85,9 +84,6 @@ When an external issue is created or linked in [sentry.io](https://sentry.io), a
   ]
 }
 ```
-
-
-
 
 ## Request Format
 

--- a/src/docs/product/integrations/integration-platform/ui-components/stacktrace-link.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/stacktrace-link.mdx
@@ -23,11 +23,11 @@ This feature allows you to insert a link within a stack trace frame. The link co
 
 ## Attributes
 
-- `uri` - (Required) The link destination. Sentry will automatically add the following query params to the link.
-    - `installationId` - Your integration's installation ID (helps you determine the requesting Sentry org)
-    - `projectSlug` - slug of the project the issue belongs to
-    - `filename` - full path of the stack frame file
-    - `lineNo` - line number of the stack trace in the file
+- `uri` - (Required) The link destination. Sentry will automatically add the following query params to the link. See [URI Guidelines](/product/integrations/integration-platform/ui-components/#uri-guidelines) for formatting help.
+  - `installationId` - Your integration's installation ID (helps you determine the requesting Sentry org)
+  - `projectSlug` - slug of the project the issue belongs to
+  - `filename` - full path of the stack frame file
+  - `lineNo` - line number of the stack trace in the file
 
 ## Example
 
@@ -36,7 +36,7 @@ This feature allows you to insert a link within a stack trace frame. The link co
   "elements": [
     {
       "type": "stacktrace-link",
-      "uri": "/stacktrace-redirect",
+      "uri": "/stacktrace-redirect"
     }
   ]
 }


### PR DESCRIPTION


<!-- Describe your PR here. -->

This PR adds a blurb explaining the URI formatting guidelines for the schema they provide when specifying UI Components. Each instance of a URI attribute links back to these guidlines.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->