### PR TITLE
Sync wizard pages with current docs

### DIFF
--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -12,7 +12,6 @@ Laravel is supported using a native package: [sentry-laravel](https://github.com
 
 This guide is for Laravel 8+. We also provide instructions for [other versions](/platforms/php/guides/laravel/other-versions/) as well as [Lumen-specific instructions](/platforms/php/guides/laravel/other-versions/lumen/).
 
-
 ## Install
 
 Install the `sentry/sentry-laravel` package:
@@ -54,7 +53,6 @@ It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.en
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
 ```
 
-
 ## Verify
 
 ### Verify With Artisan
@@ -77,7 +75,6 @@ Route::get('/debug-sentry', function () {
 
 Visiting this route will trigger an exception that will be captured by Sentry.
 
-
 ## Performance Monitoring
 
 Set `traces_sample_rate` in `config/sentry.php` or `SENTRY_TRACES_SAMPLE_RATE` in your `.env` to a value greater than `0.0`. Setting a value greater than `0.0` will enable Performance Monitoring, `0` (the default) will disable Performance Monitoring.
@@ -92,7 +89,6 @@ The example configuration above will transmit 100% of captured traces. Be sure t
 You can also be more granular with the sample rate by using the `traces_sampler` option. Learn more in [Using Sampling to Filter Transaction Events](configuration/filtering/#using-sampling-to-filter-transaction-events).
 
 Performance data is transmitted using a new event type called "transactions", which you can learn about in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans).
-
 
 ## Local Development and Testing
 

--- a/src/wizard/php/index.md
+++ b/src/wizard/php/index.md
@@ -5,11 +5,15 @@ support_level: production
 type: language
 ---
 
-To install the SDK, you will need to be using `composer` in your project. If you are not already using Composer, check out the [Composer documentation](https://getcomposer.org/download/).
+## Install
+
+To install the PHP SDK, you need to be using Composer in your project. For more details about Composer, see the [Composer documentation](https://getcomposer.org/doc/).
 
 ```bash
 composer require sentry/sdk
 ```
+
+## Configure
 
 To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.
 
@@ -17,10 +21,18 @@ To capture all errors, even the one during the startup of your application, you 
 \Sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
 ```
 
-One way to verify your setup is by intentionally causing an error that breaks your application.
+## Usage
 
-You can throw an exception in your PHP application:
+In PHP you can either capture a caught exception or capture the last error with captureLastError.
 
 ```php
-throw new Exception("My first Sentry error!");
+try {
+    $this->functionFailsForSure();
+} catch (\Throwable $exception) {
+    \Sentry\captureException($exception);
+}
+
+// OR
+
+\Sentry\captureLastError();
 ```

--- a/src/wizard/php/laravel.md
+++ b/src/wizard/php/laravel.md
@@ -5,53 +5,60 @@ support_level: production
 type: framework
 ---
 
+This guide is for Laravel 8+. We also provide instructions for [other versions](https://docs.sentry.io/platforms/php/guides/laravel/other-versions/) as well as [Lumen-specific instructions](https://docs.sentry.io/platforms/php/guides/laravel/other-versions/lumen/).
+
+## Install
+
 Install the `sentry/sentry-laravel` package:
 
 ```bash
 composer require sentry/sentry-laravel
 ```
 
-If you're on Laravel 5.5 or higher, the package will be auto-discovered. Otherwise you will need to manually configure it in your `config/app.php`.
+Enable capturing unhandled exception to report to Sentry by making the following change to your `App/Exceptions/Handler.php`:
 
-Add Sentry reporting to `App/Exceptions/Handler.php`.
-
-**For Laravel 7.x and later:**
-
-```php
-public function report(Throwable $exception)
+```php {filename:App/Exceptions/Handler.php}
+public function register()
 {
-    if (app()->bound('sentry') && $this->shouldReport($exception)) {
-        app('sentry')->captureException($exception);
-    }
-
-    parent::report($exception);
+    $this->reportable(function (Throwable $e) {
+        if (app()->bound('sentry')) {
+            app('sentry')->captureException($e);
+        }
+    });
 }
 ```
 
-**For Laravel 5.x and 6.x:**
+Alternatively, you can configure Sentry in your [Laravel Log Channel](https://docs.sentry.io/platforms/php/guides/laravel/usage/#log-channels), allowing you to log `info` and `debug` as well.
 
-```php
-public function report(Exception $exception)
-{
-    if (app()->bound('sentry') && $this->shouldReport($exception)) {
-        app('sentry')->captureException($exception);
-    }
+## Configure
 
-    parent::report($exception);
-}
-```
-
-Setup Sentry with this command:
+Configure the Sentry DSN with this command:
 
 ```shell
 php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
-It creates (`config/sentry.php`) and adds the `DSN` to your `.env` file.
+It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
 
-You can easily verify that Sentry is capturing errors in your Laravel application by creating a debug route that will throw an exception:
+```shell {filename:.env}
+SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
+```
 
-```php
+## Verify
+
+### Verify With Artisan
+
+You can test your configuration using the provided `sentry:test` artisan command:
+
+```shell
+php artisan sentry:test
+```
+
+### Verify With Code
+
+You can verify that Sentry is capturing errors in your Laravel application by creating a route that will throw an exception:
+
+```php {filename:routes/web.php}
 Route::get('/debug-sentry', function () {
     throw new Exception('My first Sentry error!');
 });
@@ -59,16 +66,27 @@ Route::get('/debug-sentry', function () {
 
 Visiting this route will trigger an exception that will be captured by Sentry.
 
-**Monitor Performance**
+## Performance Monitoring
 
-Set `traces_sample_rate` to a value greater than `0.0` (`config/sentry.php`) after that, Performance Monitoring will be enabled.
+Set `traces_sample_rate` in `config/sentry.php` or `SENTRY_TRACES_SAMPLE_RATE` in your `.env` to a value greater than `0.0`. Setting a value greater than `0.0` will enable Performance Monitoring, `0` (the default) will disable Performance Monitoring.
 
-```php
-'traces_sample_rate' => 1.0 # be sure to lower this in production to prevent quota issues
+```shell {filename:.env}
+# Be sure to lower this value in production otherwise you could burn through your quota quickly.
+SENTRY_TRACES_SAMPLE_RATE=1.0
 ```
 
-or in the `.env` file:
+The example configuration above will transmit 100% of captured traces. Be sure to lower this value in production or you could use up your quota quickly.
 
-```shell
-SENTRY_TRACES_SAMPLE_RATE=1
-```
+You can also be more granular with the sample rate by using the `traces_sampler` option. Learn more in [Using Sampling to Filter Transaction Events](https://docs.sentry.io/platforms/php/guides/laravel/configuration/filtering/#using-sampling-to-filter-transaction-events).
+
+Performance data is transmitted using a new event type called "transactions", which you can learn about in [Distributed Tracing](https://docs.sentry.io/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans).
+
+## Local Development and Testing
+
+When Sentry is installed in your application, it will also be active when you are developing or running tests.
+
+You most likely don't want errors to be sent to Sentry when you are developing or running tests. To avoid this, set the DSN value to `null` to disable sending errors to Sentry.
+
+You can also do this by not defining `SENTRY_LARAVEL_DSN` in your `.env` or by defining it as `SENTRY_LARAVEL_DSN=null`.
+
+If you do leave Sentry enabled when developing or running tests, it's possible for it to have a negative effect on the performance of your application or test suite.


### PR DESCRIPTION
The current PHP wizard pages got a little out of sync, this brings them up to speed to have more similar information tot he current getting started guides on docs.sentry.io.
