### PR TITLE
chore: bump api sha with events doc

### DIFF
--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "fs";
 
 // SENTRY_API_SCHEMA_SHA is used in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
 // DO NOT change variable name unless you change it in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
-const SENTRY_API_SCHEMA_SHA = "d5ed0052c0935311db62a0f2bbf0728e0f503964"
+const SENTRY_API_SCHEMA_SHA = "55581ea676af95f8ab43080b3dd929c93f4184f8"
 
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "fs";
 
 // SENTRY_API_SCHEMA_SHA is used in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
 // DO NOT change variable name unless you change it in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
-const SENTRY_API_SCHEMA_SHA = "55581ea676af95f8ab43080b3dd929c93f4184f8"
+const SENTRY_API_SCHEMA_SHA = "803203504cbdf1881229c35024580d34f60d813f"
 
 const activeEnv =
   process.env.GATSBY_ENV || process.env.NODE_ENV || "development";


### PR DESCRIPTION
- Bump the SENTRY_API_SCHEMA_SHA with latest changes
- https://github.com/getsentry/sentry/pull/34768