### PR TITLE
restructure releases page

### DIFF
--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -8,9 +8,9 @@ redirect_from:
 description: "Learn how to provide information to Sentry about your releases to determine regressions and resolve issues quickly."
 ---
 
-A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, determine whether an issue is resolved in the next release, and apply source maps or other mapping files. The **Releases** page presents adoption of releases from the past 24 hours and provides a high-level view of:
+A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, determine whether an issue is resolved in the next release, and apply source maps or other mapping files. The **Releases** page provides a visualization of your releases. It presents adoption of releases from the past 24 hours and provides a high-level view of:
 
-- Each release version
+- Each release version (a short version of the release name without the hash)
 - The associated project
 - The adoption stage of each release
 - The authors of each commit
@@ -19,6 +19,7 @@ A _release_ is a version of your code deployed to an environment. When you notif
 
 ![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
 
+Notifying Sentry of a release enables auto discovery of which commits to associate with a release and identifies what we consider "the most recent release" when searching in [sentry.io](https://sentry.io).
 Each release links to one or more projects. If a release has multiple projects, Sentry will duplicate the release data in relation to each one. From this page, you can also click any release to go to [Release Details](/product/releases/release-details/) for more information.
 
 Releases offer significant additional features when [fully configured](/product/releases/setup/):

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -38,9 +38,9 @@ We recommend notifying Sentry about a new release before deploying it. But if yo
 
 You don't need a repository integration for any of these features, though we recommend [installing one as part of an automated release option](/product/releases/setup/release-automation/) for efficiency.
 
-## Apply Source Maps or Mapping Files {#apply-source-maps}
+## Apply Source Maps or Other Debug Files {#apply-source-maps}
 
-Releases are required to apply code mapping files, such as [source maps](/platforms/javascript/sourcemaps/) for our JavaScript SDK, so that you can view source code context obtained from stack traces in their original untransformed form. This is particularly useful for debugging minified code (for example, UglifyJS), or transpiled code from a higher-level language (such as TypeScript and ES6).
+Releases are required to apply [source maps](/platforms/javascript/sourcemaps/) (for our JavaScript SDK) or other debug files, so that you can view source code context obtained from stack traces in their original untransformed form. This is useful for debugging files that are processed — that is bundled, minified, transpiled, compiled, or otherwise obfuscated by tools like Webpack, Terser, or the C++ compiler — from a higher-level language.
 
 ## Enable Suspect Commits
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -20,6 +20,7 @@ A _release_ is a version of your code deployed to an environment. When you notif
 ![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
 
 Notifying Sentry of a release enables auto discovery of which commits to associate with a release and identifies what we consider "the most recent release" when searching in [sentry.io](https://sentry.io).
+
 Each release links to one or more projects. If a release has multiple projects, Sentry will duplicate the release data in relation to each one. From this page, you can also click any release to go to [Release Details](/product/releases/release-details/) for more information.
 
 Releases offer significant additional features when [fully configured](/product/releases/setup/):
@@ -34,6 +35,8 @@ Releases offer significant additional features when [fully configured](/product/
 We recommend notifying Sentry about a new release before deploying it. But if you don’t, Sentry will automatically create a release entity in the system the first time it sees an event with that release identifier.
 
 </Note>
+
+You don't need a repository integration for any of these features, though we recommend [installing one as part of an automated release option](/product/releases/setup/release-automation/) for efficiency.
 
 ## Apply Source Maps or Mapping Files {#apply-source-maps}
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -8,9 +8,20 @@ redirect_from:
 description: "Learn how to provide information to Sentry about your releases to determine regressions and resolve issues quickly."
 ---
 
-A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, whether an issue is resolved in the next release, and apply source maps.
+A _release_ is a version of your code deployed to an environment. When you notify Sentry about a <SandboxLink scenario="oneRelease" projectSlug="react">release</SandboxLink>, you can easily identify new issues and regressions, determine whether an issue is resolved in the next release, and apply source maps or other mapping files. The **Releases** page presents adoption of releases from the past 24 hours and provides a high-level view of:
 
-Releases also offer significant additional features when you fully [configure your SDK](/platform-redirect/?next=/configuration/releases/):
+- Each release version
+- The associated project
+- The adoption stage of each release
+- The authors of each commit
+- The percentage of crash-free users
+- The percentage of crash-free sessions
+
+![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
+
+Each release links to one or more projects. If a release has multiple projects, Sentry will duplicate the release data in relation to each one. From this page, you can also click any release to go to [Release Details](/product/releases/release-details/) for more information.
+
+Releases offer significant additional features when [fully configured](/product/releases/setup/):
 
 - Determine the issues and regressions introduced in a new release
 - Predict which commit caused an issue and who is likely responsible
@@ -23,37 +34,22 @@ We recommend notifying Sentry about a new release before deploying it. But if yo
 
 </Note>
 
-## Releases Index
+## Apply Source Maps or Mapping Files {#apply-source-maps}
 
-The <SandboxLink scenario="releases" projectSlug="react">Releases</SandboxLink> page provides a high-level view of:
-
-- Each release version
-- The associated project
-- The adoption stage of each release
-- The authors of each commit
-- The percentage of crash-free users
-- The percentage of crash-free sessions
-
-Each release links to one project. If a release has multiple projects, Sentry will duplicate the release data in relation to each project.
-
-The page presents adoption of the release from the past 24 hours.
-
-![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
-
-## Track Release Health
-
-_Release health_ provides insight into the impact of crashes and bugs as it relates to your user's experience and reveals trends with each new issue. Monitor [release health](/product/releases/health/) by observing user adoption, usage of the application, percentage of crashes, and session data.
-
-You can view release health data either from the <SandboxLink scenario="oneIssue" projectSlug="react">Issue Details</SandboxLink> page by selecting the commit ID listed under **Last Seen**, or from the **Releases** page.
-
-## Apply Source Maps
-
-Releases are required to apply [source maps](/platforms/javascript/sourcemaps/) for our JavaScript SDK, which lets you view source code context obtained from stack traces in their original untransformed form. This is particularly useful for debugging minified code (for example, UglifyJS), or transpiled code from a higher-level language (such as TypeScript and ES6).
+Releases are required to apply code mapping files, such as [source maps](/platforms/javascript/sourcemaps/) for our JavaScript SDK, so that you can view source code context obtained from stack traces in their original untransformed form. This is particularly useful for debugging minified code (for example, UglifyJS), or transpiled code from a higher-level language (such as TypeScript and ES6).
 
 ## Enable Suspect Commits
 
-_Suspect commits_ predict which commit caused an issue and who is likely responsible. Sentry uses commit metadata from your source code repositories to identify the suspect commit.
+With releases, you can identify _suspect commits_, which help predict which commit caused an issue and who is likely responsible. Sentry uses commit metadata from your source code repositories to identify the suspect commits.
 
 You can resolve issues quickly using the **Issue Details** page to view suspect commits as well as the list of authors of those commits. In addition, we can automatically assign or alert the issue owner, based on your organization's [ownership rules](/product/error-monitoring/issue-owners/).
+
+## Track Release Health
+
+_Release health_ provides insight into the impact of crashes and bugs as it relates to your user's experience and reveals trends with each new issue. Monitor [release health](/product/releases/health/) by observing user adoption, usage of the application, percentage of crashes, and session data. You can explore the health of a release more closely in the [Release Details](/product/releases/release-details/) page.
+
+You can view release health data either from the <SandboxLink scenario="oneIssue" projectSlug="react">Issue Details</SandboxLink> page by selecting the commit ID listed under Last Seen", or from the **Releases** page.
+
+## Learn More
 
 <PageGrid />


### PR DESCRIPTION
- Moves hero image further up the page
- Rearranges headings below the image
- Adds generic wording for code mapping files
- Adds Learn More heading
- Points to Set Up page instead of SDK pages for setup content

**Merge after [PR 5108](https://github.com/getsentry/sentry-docs/pull/5108)**