### PR TITLE
Add discontinuation of AngularJS 1.x

### DIFF
--- a/src/platforms/javascript/guides/angular/angular1.mdx
+++ b/src/platforms/javascript/guides/angular/angular1.mdx
@@ -7,16 +7,22 @@ redirect_from:
 
 If you're using `AngularJS 1.x`, you can use Sentry's AngularJS integration.
 
+<Alert level="warning" title="Discontinued support for AngularJS 1.x">
+
+From version 7 onwards, the Sentry JavaScript SDK will not support AngularJS 1.x. Please use version 6.x of the SDK if you want to use Sentry in combination with AngularJs 1.x.
+
+</Alert>
+
 ### Install
 
 Install `@sentry/browser` and `@sentry/integrations` using `yarn` or `npm`:
 
 ```bash
 # Using yarn
-yarn add @sentry/browser @sentry/integrations
+yarn add @sentry/browser@6 @sentry/integrations@6
 
 # Using npm
-npm install --save @sentry/browser @sentry/integrations
+npm install --save @sentry/browser@6 @sentry/integrations@6
 ```
 
 and afterwards using it like this:
@@ -41,14 +47,14 @@ If you're using the CDN version of the SDK, Sentry provides a standalone file fo
 
 ```html
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/6.19.7/bundle.min.js"
+  integrity="sha384-KXjn4K+AYjp1cparCXazrB+5HKdi69IUYz8glD3ySH3fnDgMX3Wg6VTMvXUGr4KB"
   crossorigin="anonymous"
 ></script>
 
 <!-- If you include the integration it will be available under Sentry.Integrations.Angular -->
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/angular.min.js"
+  src="https://browser.sentry-cdn.com/6.19.7/angular.min.js"
   crossorigin="anonymous"
 ></script>
 


### PR DESCRIPTION
Adjusts AngularJS 1.x SDK documentation because we dropped support for it in version 7 of the JS SDK.

Fixes https://github.com/getsentry/sentry-javascript/issues/5216