### PR TITLE
adding version info

### DIFF
--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -53,6 +53,17 @@ Releases are global per organization; prefix them with something project-specifi
 
 </Note>
 
+The behavior of a few features depends on whether a project is using semantic or time-based versioning.
+
+- Regression detection
+- `release:latest`
+
+We automatically detect whether a project is using semantic or time-based versioning based on:
+
+- If ≤ 2 releases total: we look at most recent release.
+- If 3-10 releases total: if any of the most recent 3 releases is semver, project is semver.
+- If 10+ releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+
 ## Setting a Release
 
 <PlatformContent includePath="set-release" notateUnsupported />

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -62,7 +62,7 @@ We automatically detect whether a project is using semantic or time-based versio
 
 - If ≤ 2 releases total: we look at most recent release.
 - If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10+ releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
 
 ## Setting a Release
 

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -61,7 +61,7 @@ The behavior of a few features depends on whether a project is using semantic or
 We automatically detect whether a project is using semantic or time-based versioning based on:
 
 - If ≤ 2 releases total: we look at most recent release.
-- If 3-10 releases total: if any of the most recent 3 releases is semver, project is semver.
+- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
 - If 10+ releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
 
 ## Setting a Release


### PR DESCRIPTION
Removed this version information from the Releases Set Up page in product and moved it here since this is when you need to know about version naming behavior (during the actual SDK configuration)