### PR TITLE
fix(apple): Signal handlers for macOS

### DIFF
--- a/src/includes/getting-started-primer/note/apple.mdx
+++ b/src/includes/getting-started-primer/note/apple.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application causing the application to crash. Sentry's iOS and tvOS SDK hook into all signal and exception handlers, except for macOS.
+Sentry's SDKs report an error automatically whenever a thrown error or exception goes uncaught in your application, causing the application to crash. The SDK automatically hooks into all signal and exception handlers, except for macOS, where a simple [manual setup](https://docs.sentry.io/platforms/apple/guides/macos/usage/#capturing-uncaught-exceptions-in-macos) is required for uncaught exceptions.
 
 The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again.
 


### PR DESCRIPTION
Clarify that signal handlers work for macOS and manual setup
is required for uncaught exceptions.