### PR TITLE
Remove Gson dependency note

### DIFF
--- a/src/includes/getting-started-install/android.mdx
+++ b/src/includes/getting-started-install/android.mdx
@@ -24,8 +24,6 @@ dependencies {
 
 [NDK integration](/platforms/android/using-ndk/) is packed with the SDK and requires API level 16, though other levels are supported.
 
-Sentry's Android SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.jul.mdx
+++ b/src/includes/getting-started-install/java.jul.mdx
@@ -18,8 +18,6 @@ For other dependency managers, see the [central Maven repository](https://search
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.log4j2.mdx
+++ b/src/includes/getting-started-install/java.log4j2.mdx
@@ -18,8 +18,6 @@ For other dependency managers see the [central Maven repository](https://search.
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.logback.mdx
+++ b/src/includes/getting-started-install/java.logback.mdx
@@ -18,8 +18,6 @@ For other dependency managers, see the [central Maven repository](https://search
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.mdx
+++ b/src/includes/getting-started-install/java.mdx
@@ -24,8 +24,6 @@ libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.jav
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.servlet.mdx
+++ b/src/includes/getting-started-install/java.servlet.mdx
@@ -20,8 +20,6 @@ For other dependency managers, see the [central Maven repository](https://search
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.spring-boot.mdx
+++ b/src/includes/getting-started-install/java.spring-boot.mdx
@@ -12,8 +12,6 @@ implementation 'io.sentry:sentry-spring-boot-starter:{{ packages.version('sentry
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>

--- a/src/includes/getting-started-install/java.spring.mdx
+++ b/src/includes/getting-started-install/java.spring.mdx
@@ -18,8 +18,6 @@ For other dependency managers see the [central Maven repository](https://search.
 
 <Note>
 
-Sentry's Java SDK depends on [Gson](https://github.com/google/gson) as a transitive dependency; the minimum required version is 2.7.
-
 If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/java/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>


### PR DESCRIPTION
Gson dependency has been vendored in `6.0.0` so we no longer need the note.