### PR TITLE
Add performance to Go code snippets

### DIFF
--- a/src/includes/configuration/before-send-hint/go.mdx
+++ b/src/includes/configuration/before-send-hint/go.mdx
@@ -1,5 +1,6 @@
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 		if ex, ok := hint.OriginalException.(DatabaseConnectionError); ok {
 			event.Fingerprint = []string{"database-connection-error"}

--- a/src/includes/configuration/before-send/go.mdx
+++ b/src/includes/configuration/before-send/go.mdx
@@ -2,6 +2,7 @@ In Go, a function can be used to modify the event or return a completely new one
 
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 		// Modify the event here
 		event.User.Email = "" // Don't send user's email address

--- a/src/includes/configuration/sample-rate/go.mdx
+++ b/src/includes/configuration/sample-rate/go.mdx
@@ -1,5 +1,6 @@
 ```go
 sentry.Init(sentry.ClientOptions{
+  // ...
   SampleRate: 0.25,
 })
 ```

--- a/src/includes/enriching-events/breadcrumbs/before-breadcrumb/go.mdx
+++ b/src/includes/enriching-events/breadcrumbs/before-breadcrumb/go.mdx
@@ -1,5 +1,6 @@
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	BeforeBreadcrumb: func(breadcrumb *sentry.Breadcrumb, hint *sentry.BreadcrumbHint) *sentry.Breadcrumb {
 		if breadcrumb.Category == "auth" {
 			return nil

--- a/src/includes/getting-started-config/go.mdx
+++ b/src/includes/getting-started-config/go.mdx
@@ -19,6 +19,10 @@ func main() {
 		// Enable printing of SDK debug messages.
 		// Useful when getting started or trying to figure something out.
 		Debug: true,
+		// Set traces_sample_rate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production,
+		TracesSampleRate: 1.0,
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)

--- a/src/includes/getting-started-config/go.mdx
+++ b/src/includes/getting-started-config/go.mdx
@@ -19,7 +19,7 @@ func main() {
 		// Enable printing of SDK debug messages.
 		// Useful when getting started or trying to figure something out.
 		Debug: true,
-		// Set traces_sample_rate to 1.0 to capture 100%
+		// Set TracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,

--- a/src/includes/performance/always-inherit-sampling-decision/go.mdx
+++ b/src/includes/performance/always-inherit-sampling-decision/go.mdx
@@ -1,5 +1,6 @@
 ```go
 err := sentry.Init(sentry.ClientOptions{
+	// ...
 	TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
 		// Inherit decision from parent.
 		if ctx.Parent != nil && ctx.Parent.Sampled != sentry.SampledUndefined {

--- a/src/includes/performance/configure-sample-rate/go.mdx
+++ b/src/includes/performance/configure-sample-rate/go.mdx
@@ -7,8 +7,8 @@ func main() {
 
 		// Specify a fixed sample rate:
 		// We recommend adjusting this value in production
-        TracesSampleRate: 1.0,
-        // Or provide a custom sampler:
+		TracesSampleRate: 1.0,
+		// Or provide a custom sampler:
 		TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
 			return sentry.SampledTrue
 		}),

--- a/src/includes/performance/configure-sample-rate/go.mdx
+++ b/src/includes/performance/configure-sample-rate/go.mdx
@@ -3,8 +3,11 @@ Performance Monitoring is available for the Sentry's Go SDK version ≥ 0.9.0.
 ```go
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
+		// ...
+
 		// Specify a fixed sample rate:
-        TracesSampleRate: 0.2,
+		// We recommend adjusting this value in production
+        TracesSampleRate: 1.0,
         // Or provide a custom sampler:
 		TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
 			return sentry.SampledTrue

--- a/src/includes/performance/custom-sampling-context/go.mdx
+++ b/src/includes/performance/custom-sampling-context/go.mdx
@@ -7,6 +7,8 @@ type myContextData struct {
 }
 
 err := sentry.Init(sentry.ClientOptions{
+	// ...
+
 	// A custom TracesSampler can access data from the span's context:
 	TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
 		data, ok := ctx.Span.Context().Value(myContextKey{}).(*myContextData)

--- a/src/includes/performance/traces-sample-rate/go.mdx
+++ b/src/includes/performance/traces-sample-rate/go.mdx
@@ -1,5 +1,6 @@
 ```go
 err := sentry.Init(sentry.ClientOptions{
+	// ...
 	TracesSampleRate: 0.2,
 })
 ```

--- a/src/includes/set-environment/go.mdx
+++ b/src/includes/set-environment/go.mdx
@@ -1,5 +1,6 @@
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	Environment: "production",
 })
 ```

--- a/src/includes/set-release/go.mdx
+++ b/src/includes/set-release/go.mdx
@@ -1,5 +1,6 @@
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	Release: "my-project-name@1.0.0",
 })
 ```

--- a/src/platforms/go/common/configuration/options.mdx
+++ b/src/platforms/go/common/configuration/options.mdx
@@ -23,6 +23,9 @@ type ClientOptions struct {
 	AttachStacktrace bool
 	// The sample rate for event submission (0.0 - 1.0, defaults to 1.0)
 	SampleRate float64
+	// The sample rate for performance data submission (0.0 - 1.0)
+	// (defaults to 0.0 (meaning performance monitoring disabled))
+	TracesSampleRate float64
 	// List of regexp strings that will be used to match against event's message
 	// and if applicable, caught errors type and value.
 	// If the match is found, then a whole event will be dropped.
@@ -107,6 +110,7 @@ However, there are some cases where you may want to disable some of them. To do 
 
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 		var filteredIntegrations []sentry.Integration
 		for _, integration := range integrations {

--- a/src/platforms/go/common/migration.mdx
+++ b/src/platforms/go/common/migration.mdx
@@ -206,6 +206,7 @@ sentry-go
 
 ```go
 sentry.Init(sentry.ClientOptions{
+	// ...
 	SampleRate: 0.25,
 })
 ```

--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -37,7 +37,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -37,6 +37,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -36,6 +36,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -36,7 +36,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -36,6 +36,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -36,7 +36,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -37,7 +37,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -37,6 +37,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -35,7 +35,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -35,6 +35,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -35,7 +35,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -35,6 +35,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -36,6 +36,10 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
+	// Set traces_sample_rate to 1.0 to capture 100%
+	// of transactions for performance monitoring.
+	// We recommend adjusting this value in production,
+	TracesSampleRate: 1.0,
 }); err != nil {
 	fmt.Printf("Sentry initialization failed: %v\n", err)
 }

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -36,7 +36,7 @@ import (
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
-	// Set traces_sample_rate to 1.0 to capture 100%
+	// Set TracesSampleRate to 1.0 to capture 100%
 	// of transactions for performance monitoring.
 	// We recommend adjusting this value in production,
 	TracesSampleRate: 1.0,

--- a/src/wizard/go/index.md
+++ b/src/wizard/go/index.md
@@ -25,7 +25,7 @@ import (
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
-		// Set traces_sample_rate to 1.0 to capture 100%
+		// Set TracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,
@@ -51,7 +51,7 @@ import (
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
-		// Set traces_sample_rate to 1.0 to capture 100%
+		// Set TracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,

--- a/src/wizard/go/index.md
+++ b/src/wizard/go/index.md
@@ -25,6 +25,10 @@ import (
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
+		// Set traces_sample_rate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production,
+		TracesSampleRate: 1.0,
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
@@ -47,6 +51,10 @@ import (
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
+		// Set traces_sample_rate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production,
+		TracesSampleRate: 1.0,
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)


### PR DESCRIPTION
Added `TracesSampleRate` to Go code snippets to enable performance by default.