### PR TITLE
Unify Ruby code snippets.

### DIFF
--- a/src/includes/configuration/auto-session-tracking/ruby.mdx
+++ b/src/includes/configuration/auto-session-tracking/ruby.mdx
@@ -9,6 +9,7 @@ By default, the Ruby SDK sends sessions. To disable sending sessions, set the `a
 
 ```ruby
 Sentry.init do |config|
+  # ...
   config.auto_session_tracking = false
 end
 ```

--- a/src/includes/configuration/before-send-fingerprint/ruby.mdx
+++ b/src/includes/configuration/before-send-fingerprint/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  # ...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
       event.fingerprint = ["database-unavailable"]

--- a/src/includes/configuration/before-send-hint/ruby.mdx
+++ b/src/includes/configuration/before-send-hint/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  # ...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
       event.fingerprint = ["database-unavailable"]

--- a/src/includes/configuration/before-send/ruby.mdx
+++ b/src/includes/configuration/before-send/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  # ...
   config.before_send = lambda do |event, hint|
     # skip ZeroDivisionError exceptions
     # note: hint[:exception] would be a String if you use async callback

--- a/src/includes/configuration/before-send/ruby.rails.mdx
+++ b/src/includes/configuration/before-send/ruby.rails.mdx
@@ -1,5 +1,7 @@
 ```ruby
 Sentry.init do |config|
+  #...
+
   # this example uses Rails' parameter filter to sanitize the event payload
   # for Rails 6+
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)

--- a/src/includes/enriching-events/breadcrumbs/before-breadcrumb/ruby.mdx
+++ b/src/includes/enriching-events/breadcrumbs/before-breadcrumb/ruby.mdx
@@ -1,5 +1,7 @@
 ```ruby
 Sentry.init do |config|
+  # ...
+
   # this will be called before every breadcrumb is added to the breadcrumb buffer
   # you can use it to
   # - remove the data you don't want to send

--- a/src/includes/getting-started-config/ruby.mdx
+++ b/src/includes/getting-started-config/ruby.mdx
@@ -5,7 +5,7 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     0.5

--- a/src/includes/getting-started-config/ruby.rack.mdx
+++ b/src/includes/getting-started-config/ruby.rack.mdx
@@ -9,7 +9,7 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/includes/getting-started-config/ruby.rails.mdx
+++ b/src/includes/getting-started-config/ruby.rails.mdx
@@ -7,7 +7,7 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|
     true

--- a/src/includes/performance/configure-sample-rate/ruby.mdx
+++ b/src/includes/performance/configure-sample-rate/ruby.mdx
@@ -2,8 +2,11 @@ Performance Monitoring is available for our updated Ruby SDK (`sentry-ruby`, not
 
 ```ruby
 Sentry.init do |config|
-  # set a uniform sample rate between 0.0 and 1.0
-  config.traces_sample_rate = 0.2
+  #...
+
+  # Set a uniform sample rate between 0.0 and 1.0
+  # We recommend adjusting the value in production:
+  config.traces_sample_rate = 1.0
 
   # or control sampling dynamically
   config.traces_sampler = lambda do |sampling_context|

--- a/src/includes/performance/traces-sample-rate/ruby.mdx
+++ b/src/includes/performance/traces-sample-rate/ruby.mdx
@@ -1,6 +1,6 @@
 ```ruby
 Sentry.init do |config|
   # ...
-  config.traces_sample_rate = 0.25
+  config.traces_sample_rate = 0.2
 end
 ```

--- a/src/includes/performance/traces-sampler-as-filter/ruby.mdx
+++ b/src/includes/performance/traces-sampler-as-filter/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  #...
   config.traces_sampler = lambda do |sampling_context|
     # transaction_context is the transaction object in hash form
     # keep in mind that sampling happens right after the transaction is initialized

--- a/src/includes/performance/traces-sampler-as-sampler/ruby.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  #...
   config.traces_sampler = lambda do |sampling_context|
     # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
     unless sampling_context[:parent_sampled].nil?

--- a/src/includes/set-environment/ruby.mdx
+++ b/src/includes/set-environment/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  #...
   config.environment = 'production'
 end
 ```

--- a/src/includes/set-fingerprint/database-connection/ruby.mdx
+++ b/src/includes/set-fingerprint/database-connection/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  #...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionTimeoutError)
       event.fingerprint = ["database-connection-error"]

--- a/src/includes/set-fingerprint/rpc/ruby.mdx
+++ b/src/includes/set-fingerprint/rpc/ruby.mdx
@@ -10,6 +10,7 @@ class RPCError < StandardError
 end
 
 Sentry.init do |config|
+  #...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(RPCError)
       event.fingerprint = ["{{default}}", exception.code, exception.function_name]

--- a/src/includes/set-release/ruby.mdx
+++ b/src/includes/set-release/ruby.mdx
@@ -1,5 +1,6 @@
 ```ruby
 Sentry.init do |config|
+  #...
   config.release = 'my-project-name@2.3.12'
 end
 ```

--- a/src/wizard/ruby/rails.md
+++ b/src/wizard/ruby/rails.md
@@ -27,9 +27,9 @@ Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-  # Set tracesSampleRate to 1.0 to capture 100%
+  # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
+  # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
   # or
   config.traces_sampler = lambda do |context|


### PR DESCRIPTION
Unify the use of Ruby code snippets. Basically just adding the ellipsis to show that other parameters need to be added.