### PR TITLE
Add note explaining that minimumEventLevel and minimumBreadcrumbLevel…

### DIFF
--- a/src/includes/getting-started-config/java.jul.mdx
+++ b/src/includes/getting-started-config/java.jul.mdx
@@ -42,7 +42,7 @@ Two log levels are used to configure this integration:
 
 <Note>
 
-Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logging.properties` only affects events logged via JUL. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logging.properties` only affects events logged by way of JUL. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
 
 </Note>
 

--- a/src/includes/getting-started-config/java.jul.mdx
+++ b/src/includes/getting-started-config/java.jul.mdx
@@ -40,6 +40,12 @@ Two log levels are used to configure this integration:
 1. Configure the lowest level required for a log message to become an event (`minimumEventLevel`) sent to Sentry.
 2. Configure the lowest level a message has to be to become a breadcrumb (`minimumBreadcrumbLevel`).
 
+<Note>
+
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logging.properties` only affects events logged via JUL. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+
+</Note>
+
 Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.config` or `logger.warn`, no event is sent to Sentry. If you then log with `logger.error`, an event is sent to Sentry which includes those 100 `config` or `warning` messages. For this to work, `SentryHandler` needs to receive **all** log entries to decide what to keep as breadcrumb or send as event. Set the `SentryHandler` log level configuration to a value lower than what is set for the `minimumBreadcrumbLevel` and `minimumEventLevel` so that `SentryHandler` receives these log messages.
 
 ```properties {tabTitle:logging.properties}

--- a/src/includes/getting-started-config/java.log4j2.mdx
+++ b/src/includes/getting-started-config/java.log4j2.mdx
@@ -47,7 +47,7 @@ Two log levels are used to configure this integration, as illustrated below in t
 
 <Note>
 
-Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `log4j2.xml` only affects events logged via Log4j2. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `log4j2.xml` only affects events logged by way of Log4j2. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
 
 </Note>
 

--- a/src/includes/getting-started-config/java.log4j2.mdx
+++ b/src/includes/getting-started-config/java.log4j2.mdx
@@ -45,6 +45,12 @@ Two log levels are used to configure this integration, as illustrated below in t
 1. Configure the lowest level required for a log message to become an event (`minimumEventLevel`) sent to Sentry.
 2. Configure the lowest level a message has to be to become a breadcrumb (`minimumBreadcrumbLevel`)
 
+<Note>
+
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `log4j2.xml` only affects events logged via Log4j2. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+
+</Note>
+
 Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.info` or `logger.warn`, no event is sent to Sentry. If you then log with `logger.error`, an event is sent to Sentry that includes those 100 `info` or `warn` messages. For this to work, `SentryAppender` needs to receive **all** log entries to decide what to keep as breadcrumb or send as event. Set the `SentryAppender` log level configuration to a value lower than what is set for the `minimumBreadcrumbLevel` and `minimumEventLevel` so that `SentryAppender` receives these log messages.
 
 ```xml

--- a/src/includes/getting-started-config/java.logback.mdx
+++ b/src/includes/getting-started-config/java.logback.mdx
@@ -54,6 +54,12 @@ Two log levels are used to configure this integration:
 1. Configure the lowest level required for a log message to become an event (`minimumEventLevel`) sent to Sentry.
 2. Configure the lowest level a message has to be to become a breadcrumb (`minimumBreadcrumbLevel`).
 
+<Note>
+
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logback.xml` only affects events logged via Logback. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+
+</Note>
+
 Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.info` or `logger.warn`, no event is sent to Sentry. If you then log with `logger.error`, an event is sent to Sentry which includes those 100 `info` or `warn` messages. For this to work, `SentryAppender` needs to receive **all** log entries to decide what to keep as breadcrumb or sent as event. Set the `SentryAppender` log level configuration to a value lower than what is set for the `minimumBreadcrumbLevel` and `minimumEventLevel` so that `SentryAppender` receives these log messages.
 
 ```xml

--- a/src/includes/getting-started-config/java.logback.mdx
+++ b/src/includes/getting-started-config/java.logback.mdx
@@ -56,7 +56,7 @@ Two log levels are used to configure this integration:
 
 <Note>
 
-Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logback.xml` only affects events logged via Logback. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
+Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logback.xml` only affects events logged by way of Logback. The settings will have no effect when calling `Sentry.captureMessage` or similar directly.
 
 </Note>
 


### PR DESCRIPTION
Add note explaining that `minimumEventLevel` and `minimumBreadcrumbLevel` only affect log messages, not direct calls to `Sentry.capture`.



As requested here https://github.com/getsentry/sentry-java/issues/2091 