### PR TITLE
restructure quota mgmt docs v2

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -16,9 +16,9 @@ Sentry’s flexibility means you can exercise fine-grained control over which ev
 Let’s clarify a few terms to start:
 
 - **Event** - An event is one instance of you sending data to Sentry. Generally, this data is an error or a transaction.
-- **Error** - An error is.... A grouping of similar errors makes [an issue]().
+- **Error** - An error is.... A grouping of similar errors makes [an issue](/product/issues/).
 - **Transaction** - A [transaction](/product/performance/transaction-summary/#what-is-a-transaction) represents a single instance of a service being called to support an operation you want to measure or track, like a page load. Transaction events are grouped by the transaction name.
-- **Attachment** - Attachments are files uploaded in the same request, such as log files. Unless the option to store crash reports is enabled, Sentry will use these files only to create an event, and then drop them.
+- **Attachment** - Attachments are uploaded files associated with an error event, such as log files. Unless the option to store crash reports is enabled, Sentry will use these files only to create an event, and then drop them.
 - **Quota** - Your quota is the monthly number of data units — errors, attachments, and transactions — that you pay Sentry to track.
 
 ## Manage Your Quota - Quick Guide
@@ -29,20 +29,22 @@ This list of things to do to manage your quota is arranged from the fastest and 
 
 | Action | Errors | Transactions | Attachments |
 | ------ | ------ | ------------ | ----------- |
-| 1. [Check your spike protection is enabled](#spike-protection) | Y | N | N |
-| 2. [Review your event usage to see which projects are using up your quota](#common-workflows-for-managing-your-event-stream) | Y | Y | Y |
-| 3. [Adjust your quota](#quota-availbility) | Y | Y | Y |
-| 4. [Limit your events](#rate-limits) | Y | N | Y |
-| 5. [Delete and discard issues](#delete--discard-issues) | Y | N | N* |
-| 6. [Filter your events](#inbound-filters) | Y | Y | Y |
-| 7. [Check your issue grouping (some of this is in the SDK)](#event-grouping) | Y | N | N|
-| 8. [Update your SDK sample rate](#sdk-sample-rate) | Y | Y | N |
-| 9. [SDK filtering](#sdk-filtering-beforesend) | Y | N | N |
-| 10. [SDK configuration](#sdk-configuration) | Y | Y | Y |
+| 1. [Check your spike protection is enabled](#1-spike-protection) | &check; |  |  |
+| 2. [Review your event usage to see which projects are using up your quota](#common-workflows-for-managing-your-event-stream) | &check; | &check; | &check; |
+| 3. [Adjust your quota](#3-quota-availbility) | &check; | &check; | &check; |
+| 4. [Limit your events](#4-rate-limits) | &check; |  | &check; |
+| 5. [Delete and discard issues](#6-event-repetition) | &check; |  | * |
+| 6. [Filter your events](#7-inbound-filters) | &check; | &check; | &check; |
+| 7. [Check your issue grouping (some of this is in the SDK)](#event-grouping) | &check; |  | |
+| 8. [Update your SDK sample rate](#8-sdk-sample-rate) | &check; | &check; |  |
+| 9. [SDK filtering](#9-sdk-filtering-beforesend) | &check; |  |  |
+| 10. [SDK configuration](#10-sdk-configuration) | &check; | &check; | &check; |
 
 <!-- prettier-ignore-end -->
 
- <!-- ## Managing My Quota, an Overview -->
+<!-- event grouping isn't in table above
+
+## Managing My Quota, an Overview -->
 
 ## Some Other Heading
 
@@ -122,21 +124,27 @@ the event will be rejected.
 
 </Alert>
 
-## What Counts Toward my Quota, Table View
+## What Counts Toward my Quota
 
 <!-- make this table binary, use checkmarks? -->
 
+<!-- prettier-ignore-start -->
+
 |                                                                 | Yes, this event counts                     | No, this event does not count |
 | --------------------------------------------------------------- | ------------------------------------------ | ----------------------------- |
-| SDK configuration                                               | Not set                                    | Set to filter this event      |
-| SDK sample rate                                                 | Not set                                    | Set                           |
+| Has spike protection (errors only) been triggered?              | No                                         | Yes                           |
+| Check projects                                                  | No                                         | Yes                           |
 | Quota                                                           | Not reached                                | Exceeded                      |
+| Rate limit for error events for the project                     | Not set or not reached                     | Set and exceeded              |
 | Are future error events that repeat set to Delete & Discard?    | No                                         |                               |
 | Is this a repeated error event for a previously resolved issue? | Yes, this may be a regression in your code |                               |
 | Is this repeated error event set to Ignore Alert?               | Yes, it is still occurring                 |                               |
-| Has spike protection (errors only) been triggered?              | No                                         | Yes                           |
-| Rate limit for error events for the project                     | Not set or not reached                     | Set and exceeded              |
-| Inbound filters (errors only)                                   | Not set                                    | Set for this error event      |
+| Inbound filters                                                 | Not set                                    | Set for this error event      |
+| Event grouping                                                  |                                    |       |
+| SDK sample rate                                                 | Not set                                    | Set                           |
+| SDK configuration                                               | Not set                                    | Set to filter this event      |
+
+<!-- prettier-ignore-end -->
 
 <Alert>
   Delete and discard and per-project rate limits are available only for Business
@@ -151,12 +159,12 @@ There are a few rules of thumb you can use to determine if an event will count o
 
 | Something here | Doesn't count | Counts |
 | -------------- | ------------ | --------|
-| Filtering of any kind applied including: <br></br> SDK filtering, SDK configuration, SDK sample rate setting, event/issue grouping, inbound filters, deleting and discarding issues | x | |
-| Rate limited | x | |
-| Exceeds size limits | x | |
-| Quota exceeded | x | until quota is reached |
-| Spike protection triggered (temporarily) | x | see Spike Protection for details |
-| New events on resolved issues | | x |
-| New events on ignored issues | | x |
+| Filtering of any kind applied including: <br></br> SDK filtering, SDK configuration, SDK sample rate setting, event/issue grouping, inbound filters, deleting and discarding issues | &check; | |
+| Rate limited | &check; | |
+| Exceeds size limits | &check; | |
+| Quota exceeded | &check; | until quota is reached |
+| Spike protection triggered (temporarily) | &check; | see Spike Protection for details |
+| New events on resolved issues | | &check; |
+| New events on ignored issues | | &check; |
 
 <!-- prettier-ignore-end -->

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -16,18 +16,41 @@ Sentry’s flexibility means you can exercise fine-grained control over which ev
 Let’s clarify a few terms to start:
 
 - **Event** - An event is one instance of you sending data to Sentry. Generally, this data is an error or a transaction.
-- **Issue** - An issue is a grouping of similar error events. Every error event has a set of characteristics called its fingerprint, which is what Sentry uses for grouping. For example, Sentry groups events together when they are triggered by the same part of your code. Learn more in our full [Issue Grouping documentation](/product/data-management-settings/event-grouping/).
-- **Attachment** - Attachments are files uploaded in the same request, such as log files. Unless the option to store crash reports is enabled, Sentry will use these files only to create an event, and then drop them.
+- **Error** - An error is.... A grouping of similar errors makes [an issue]().
 - **Transaction** - A [transaction](/product/performance/transaction-summary/#what-is-a-transaction) represents a single instance of a service being called to support an operation you want to measure or track, like a page load. Transaction events are grouped by the transaction name.
-- **Quota** - Your quota is the monthly number of events — errors, attachments, and transactions — that you pay Sentry to track.
+- **Attachment** - Attachments are files uploaded in the same request, such as log files. Unless the option to store crash reports is enabled, Sentry will use these files only to create an event, and then drop them.
+- **Quota** - Your quota is the monthly number of data units — errors, attachments, and transactions — that you pay Sentry to track.
 
-## Managing My Quota, an Overview
+## Manage Your Quota - Quick Guide
+
+This list of things to do to manage your quota is arranged from the fastest and least involved thing you can do to the most. Each of these items is linked to a longer explanation if you need it and the table indicates whether the action can affect, errors, transactions, or attachments or a combination of those.
+
+<!-- prettier-ignore-start -->
+
+| Action | Errors | Transactions | Attachments |
+| ------ | ------ | ------------ | ----------- |
+| 1. [Check your spike protection is enabled](#spike-protection) | Y | N | N |
+| 2. [Review your event usage to see which projects are using up your quota](#common-workflows-for-managing-your-event-stream) | Y | Y | Y |
+| 3. [Adjust your quota](#quota-availbility) | Y | Y | Y |
+| 4. [Limit your events](#rate-limits) | Y | N | Y |
+| 5. [Delete and discard issues](#delete--discard-issues) | Y | N | N* |
+| 6. [Filter your events](#inbound-filters) | Y | Y | Y |
+| 7. [Check your issue grouping (some of this is in the SDK)](#event-grouping) | Y | N | N|
+| 8. [Update your SDK sample rate](#sdk-sample-rate) | Y | Y | N |
+| 9. [SDK filtering](#sdk-filtering-beforesend) | Y | N | N |
+| 10. [SDK configuration](#sdk-configuration) | Y | Y | Y |
+
+<!-- prettier-ignore-end -->
+
+ <!-- ## Managing My Quota, an Overview -->
+
+## Some Other Heading
 
 Sentry completes a thorough evaluation of each event to determine if it counts toward your quota, as outlined in this overview. Detailed documentation for each evaluation is linked throughout. Before completing any of these evaluations, Sentry confirms that each event includes a valid DSN and project as well as whether the event can be parsed. In addition, for error events, Sentry validates that the event contains valid fingerprint information. If any of these items are missing or incorrect, the event is rejected.
 
 ### 1. Spike Protection
 
-Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in the Spike Protection section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#1-spike-protection). 
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in the Spike Protection section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#1-spike-protection).
 
 ### 2. Event Usage Stats
 
@@ -37,7 +60,7 @@ Learn more in the Event Usage Stats section of [Manage Your Error Quota](/produc
 
 ### 3. Quota Availability
 
-Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in the Increasing Quotas section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#3-increasing-quotas) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-increasing-quotas). 
+Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in the Increasing Quotas section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#3-increasing-quotas) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-increasing-quotas).
 
 ### 4. Rate Limits
 
@@ -53,7 +76,7 @@ Event repetition only applies to error events, not transactions or attachments. 
 
 - If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota. Learn more in the Delete & Discard section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#5-applying-workflows).
 - If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in the Inbound Filters section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-inbound-data-filters). 
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in the Inbound Filters section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-inbound-data-filters).
 
 ### 7. Inbound Filters
 
@@ -92,80 +115,48 @@ The precise limits may change over time. For more information, please refer to t
 - [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)
 
 <Alert>
-  If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
-  compressed or 100MB decompressed for minidump uploads (all files combined),
-  the event will be rejected.
+
+If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
+compressed or 100MB decompressed for minidump uploads (all files combined),
+the event will be rejected.
+
 </Alert>
 
 ## What Counts Toward my Quota, Table View
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <strong> </strong>
-      </td>
-      <td>
-        <strong>Yes, this event counts</strong>
-      </td>
-      <td>
-        <strong>No, this event does not count</strong>
-      </td>
-    </tr>
-    <tr>
-      <td>SDK configuration</td>
-      <td>Not set</td>
-      <td>Set to filter this event</td>
-    </tr>
-    <tr>
-      <td>SDK sample rate</td>
-      <td>Not set</td>
-      <td>Set</td>
-    </tr>
-    <tr>
-      <td>Quota</td>
-      <td>Not reached</td>
-      <td>Exceeded</td>
-    </tr>
-    <tr>
-      <td>
-        Are <i>future</i> error events that repeat set to Delete & Discard?
-      </td>
-      <td>No</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Is this a repeated error event for a previously resolved issue?</td>
-      <td>Yes, this may be a regression in your code</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Is this repeated error event set to Ignore Alert?</td>
-      <td>Yes, it is still occurring</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Has spike protection (errors only) been triggered?</td>
-      <td>No</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Rate limit for error events for the project</td>
-      <td>
-        Not set <i>or</i> not reached
-      </td>
-      <td>
-        Set <i>and</i> exceeded
-      </td>
-    </tr>
-    <tr>
-      <td>Inbound filters (errors only)</td>
-      <td>Not set</td>
-      <td>Set for this error event</td>
-    </tr>
-  </tbody>
-</table>
+<!-- make this table binary, use checkmarks? -->
+
+|                                                                 | Yes, this event counts                     | No, this event does not count |
+| --------------------------------------------------------------- | ------------------------------------------ | ----------------------------- |
+| SDK configuration                                               | Not set                                    | Set to filter this event      |
+| SDK sample rate                                                 | Not set                                    | Set                           |
+| Quota                                                           | Not reached                                | Exceeded                      |
+| Are future error events that repeat set to Delete & Discard?    | No                                         |                               |
+| Is this a repeated error event for a previously resolved issue? | Yes, this may be a regression in your code |                               |
+| Is this repeated error event set to Ignore Alert?               | Yes, it is still occurring                 |                               |
+| Has spike protection (errors only) been triggered?              | No                                         | Yes                           |
+| Rate limit for error events for the project                     | Not set or not reached                     | Set and exceeded              |
+| Inbound filters (errors only)                                   | Not set                                    | Set for this error event      |
+
 <Alert>
   Delete and discard and per-project rate limits are available only for Business
   plans.
 </Alert>
+
+Table v2
+
+There are a few rules of thumb you can use to determine if an event will count or not
+
+<!-- prettier-ignore-start -->
+
+| Something here | Doesn't count | Counts |
+| -------------- | ------------ | --------|
+| Filtering of any kind applied including: <br></br> SDK filtering, SDK configuration, SDK sample rate setting, event/issue grouping, inbound filters, deleting and discarding issues | x | |
+| Rate limited | x | |
+| Exceeds size limits | x | |
+| Quota exceeded | x | until quota is reached |
+| Spike protection triggered (temporarily) | x | see Spike Protection for details |
+| New events on resolved issues | | x |
+| New events on ignored issues | | x |
+
+<!-- prettier-ignore-end -->

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -27,19 +27,21 @@ Sentry completes a thorough evaluation of each event to determine if it counts t
 
 ### 1. Spike Protection
 
-Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in the Spike Protection section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#1-spike-protection). 
 
 ### 2. Event Usage Stats
 
 blah blah
 
+Learn more in the Event Usage Stats section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#common-workflows-for-managing-your-event-stream) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#1-event-usage-stats).
+
 ### 3. Quota Availability
 
-Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
+Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in the Increasing Quotas section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#3-increasing-quotas) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-increasing-quotas). 
 
 ### 4. Rate Limits
 
-If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments. You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
+If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events. Learn more in the Rate Limiting section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#4-rate-limiting) or
 
 #### Attachment Limits
 
@@ -49,27 +51,29 @@ If you have enabled the storage of crash reports, you may set limits for the max
 
 Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
 
-- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota. Learn more in the Delete & Discard section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#5-applying-workflows).
 - If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in the Inbound Filters section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-inbound-data-filters). 
 
 ### 7. Inbound Filters
 
-If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
+If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in the Inbound Data Filters section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-inbound-data-filters) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#3-inbound-data-filters).
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
 ### 8. SDK Sample Rate
 
-If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
+If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs. Learn more in the SDK Sample Rate section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#8-sdk-sample-rate) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#4-sdk-sample-rate).
 
 ### 9. SDK Filtering
 
 Blah blah
 
+Learn More in the SDK Filtering section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#9-sdk-filtering-beforesend).
+
 ### 10. SDK Configuration
 
-The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
+The SDK configuration either allows the event or filters the event out. Learn more in the SDK Configuration section of [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#10-sdk-configuration) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-sdk-configuration-tracing-options) or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
 
 ## A Note About Size Limits
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -59,7 +59,7 @@ If any inbound filter is set for a type of event or attachment, and your subscri
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
-## 8. SDK Sample Rate
+### 8. SDK Sample Rate
 
 If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -53,13 +53,33 @@ In addition, depending on your project’s configuration and the plan you subscr
 
 6. **Rate limit for the project**
 
-   If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
+   If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments. You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
+
+### Attachment Limits
+
+If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
 7. **Inbound filters**
 
    If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
+
+## Size Limits
+
+Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
+
+- Events, attachments, and requests exceeding payload size limits are immediately dropped with a `413 Payload Too Large` error. Sentry allows compressed content encoding, and applies separate limits before and after decompression.
+- Fields exceeding the individual size limits are afterwards trimmed and truncated at a best effort.
+
+To avoid unintentional data loss, consider limiting the size of values passed into Sentry's APIs. For example, if your application attaches application state or request bodies to Sentry events, truncate them first.
+
+The precise limits may change over time. For more information, please refer to the following resources:
+
+- [Envelope Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
+- [Store Endpoint Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
+- [Minidump Size Limits](/platforms/native/guides/minidumps/#size-limits)
+- [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)
 
 <Alert>
   If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
@@ -139,185 +159,3 @@ After these checks are processed, the event counts toward your quota. It is acce
   Delete and discard and per-project rate limits are available only for Business
   plans.
 </Alert>
-
-## Increasing Quotas
-
-Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
-
-If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
-
-If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
-
-### On-Demand Capacity
-
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
-
-### Reserved Capacity
-
-If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
-
-You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
-
-### Plan Upgrade
-
-If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
-
-## Decreasing Quotas
-
-Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
-
-<Alert level="warning">
-
-If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
-
-</Alert>
-
-Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
-
-To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
-
-![The Review & Confirm step of a subscription update.](review-subscription.png)
-
-<Note>
-
-We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
-
-</Note>
-
-## Limiting Events
-
-You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
-
-### Error Event Limits
-
-Per-key rate limits allow you to set the maximum volume of error events a key will accept during a period of time.
-
-For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
-
-To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-### Attachment Limits
-
-If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
-
-## Inbound Filters {#inbound-data-filters}
-
-In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
-
-Inbound filters include:
-
-- Common browser extension errors
-- Events coming from localhost
-- Known legacy browsers errors
-- Known web crawlers
-- By their error message
-- From specific release versions of your code
-- From certain IP addresses.
-
-Explore these by navigating to **[Project] > Settings > Inbound Filters**.
-
-### IP Filters
-
-If you have a rogue client, Sentry supports blocking an IP from sending data. Navigate to **[Project] > Settings > Inbound Filters** to add the IP addresses (or subnets) in the "IP Addresses" field.
-
-### Filter by Release
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-If you discover a problematic release causing excessive noise, Sentry supports ignoring all events from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the releases to the "Releases" field
-
-### Filter by Error Message
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] > Settings > Inbound Filters**, then add the error message to the "Error Message" field.
-
-To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
-
-### Filter by Issue
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-When you are unable to take immediate action on an issue, but it continues to occur, Sentry supports deleting and discarding that issue, which you can do from the **Issue Details** page. Navigate to the issue you would like to filter, click on the drop-down menu next to the bin icon, and select “Delete and discard future events”. This setting deletes most data associated with the issue and filters out new matching events before they count against your quota.
-
-You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
-
-## Spike Protection
-
-<Alert level="info">
-
-Spike protection is not currently available for transactions nor attachments.
-
-</Alert>
-
-A spike is both a **large** and **temporary** increase in error event volume. Because Sentry bills based on monthly event volume, spikes can easily consume your capacity for the rest of the month. Sentry's spike protection prevents these types of overages from consuming your error event capacity by dropping error events during the spike.
-
-Spike protection is an organization-level setting, so once it's triggered, it affects all the projects in the organization, regardless of which project triggered the spike.
-
-Spike protection is enabled for your organization by default, and when it's enabled, Sentry continually monitors for spikes. If you want to disable it, you can do so in **Settings > Subscription**.
-
-### How Does Spike Protection Work?
-
-We use your historical error event volume to implement a dynamic rate limit, and then discard error events when you hit its threshold. When spike protection is activated, we limit the number of error events accepted in any minute to:
-
-```
-maximum(20, 6 x average error events per minute over the last 24 hours)
-```
-
-<Note>
-
-The 24-hour window ends at the beginning of the current hour, not at the current minute.
-
-</Note>
-
-This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
-
-For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
-
-1. Spike protection becomes "active".
-
-1. If your organization has used more than 25% of your monthly quota, Sentry sends the organization owner a [notification](/product/alerts/notifications/#quota-notifications) including which project the 61st event came from. This is likely, but not guaranteed to be, the project in which something broke.
-
-1. Events 61-100 are dropped.
-
-When the next minute begins, we again record up to 60 events, dropping the rest until the minute is up. It continues like this for the remainder of the hour. After an hour, we re-calculate your per-minute limit, and for the next hour use that limit to decide whether events get dropped each minute. We repeat this process every hour until Sentry eventually accepts all events.
-
-If, instead of a single big spike (or an overall, permanent, increase in traffic), you experience many small spikes, there may be many days in a row when at least a few events are dropped. In that scenario, spike protection remains active the entire time.
-
-### When Does Spike Protection Become "Inactive?"
-
-Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
-
-## Size Limits
-
-Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
-
-- Events, attachments, and requests exceeding payload size limits are immediately dropped with a `413 Payload Too Large` error. Sentry allows compressed content encoding, and applies separate limits before and after decompression.
-- Fields exceeding the individual size limits are afterwards trimmed and truncated at a best effort.
-
-To avoid unintentional data loss, consider limiting the size of values passed into Sentry's APIs. For example, if your application attaches application state or request bodies to Sentry events, truncate them first.
-
-The precise limits may change over time. For more information, please refer to the following resources:
-
-- [Envelope Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
-- [Store Endpoint Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
-- [Minidump Size Limits](/platforms/native/guides/minidumps/#size-limits)
-- [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -21,51 +21,57 @@ Let’s clarify a few terms to start:
 - **Transaction** - A [transaction](/product/performance/transaction-summary/#what-is-a-transaction) represents a single instance of a service being called to support an operation you want to measure or track, like a page load. Transaction events are grouped by the transaction name.
 - **Quota** - Your quota is the monthly number of events — errors, attachments, and transactions — that you pay Sentry to track.
 
-## What Counts Toward My Quota, an Overview
+## Managing My Quota, an Overview
 
 Sentry completes a thorough evaluation of each event to determine if it counts toward your quota, as outlined in this overview. Detailed documentation for each evaluation is linked throughout. Before completing any of these evaluations, Sentry confirms that each event includes a valid DSN and project as well as whether the event can be parsed. In addition, for error events, Sentry validates that the event contains valid fingerprint information. If any of these items are missing or incorrect, the event is rejected.
 
-1. **SDK configuration**
+### 1. Spike Protection
 
-   The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
 
-2. **SDK sample rate**
+### 2. Event Usage Stats
 
-   If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
+blah blah
 
-3. **Quota availability**
+### 3. Quota Availability
 
-   Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
+Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
 
-4. **Event repetition**
+### 4. Rate Limits
 
-   Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments. You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
 
-   - If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
-   - If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-   - If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
-
-5. **Spike protection**
-
-   Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
-
-In addition, depending on your project’s configuration and the plan you subscribe to, Sentry may also check:
-
-6. **Rate limit for the project**
-
-   If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments. You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
-
-### Attachment Limits
+#### Attachment Limits
 
 If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
-7. **Inbound filters**
+### 6. Event Repetition
 
-   If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
+Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+
+### 7. Inbound Filters
+
+If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
-## Size Limits
+## 8. SDK Sample Rate
+
+If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
+
+### 9. SDK Filtering
+
+Blah blah
+
+### 10. SDK Configuration
+
+The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
+
+## A Note About Size Limits
 
 Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -15,233 +15,7 @@ Sending all your application errors to Sentry ensures you'll be notified in real
 
 Applying the proper filters, SDK configuration, and rate limits is an iterative and on-going process, but these tips will show you how to get the most out of your error events.
 
-## 1. SDK Filtering: beforeSend
-
-All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
-
-## 2. SDK Configuration
-
-The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
-
-### JavaScript
-
-The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
-
-#### InboundFilters
-
-The integration is enabled by default and adds the following configuration options to the SDK:
-
-- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
-- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
-- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
-
-To learn more and see code samples, check out:
-
-- [Filtering](/platforms/javascript/configuration/filtering/)
-- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
-
-#### GlobalHandlers
-
-The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
-
-Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
-
-### Other SDKs
-
-**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
-
-**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
-
-**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
-
-## 3. Increasing Quotas
-
-Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
-
-If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
-
-If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
-
-### On-Demand Capacity
-
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
-
-### Reserved Capacity
-
-If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
-
-You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
-
-### Plan Upgrade
-
-If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
-
-### Decreasing Quotas
-
-Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
-
-<Alert level="warning">
-
-If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
-
-</Alert>
-
-Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
-
-To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
-
-![The Review & Confirm step of a subscription update.](review-subscription.png)
-
-<Note>
-
-We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
-
-</Note>
-
-## 4. Inbound Data Filters
-
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
-
-Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
-
-![Built-in Inbound Filters](manage-event-stream-03.png)
-
-<!-- added stuff -->
-
-In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
-
-Inbound filters include:
-
-- Common browser extension errors
-- Events coming from localhost
-- Known legacy browsers errors
-- Known web crawlers
-- By their error message
-- From specific release versions of your code
-- From certain IP addresses.
-
-Explore these by navigating to **[Project] > Settings > Inbound Filters**.
-
-### IP Filters
-
-If you have a rogue client, Sentry supports blocking an IP from sending data. Navigate to **[Project] > Settings > Inbound Filters** to add the IP addresses (or subnets) in the "IP Addresses" field.
-
-### Filter by Release
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-If you discover a problematic release causing excessive noise, Sentry supports ignoring all events from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the releases to the "Releases" field
-
-### Filter by Error Message
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] > Settings > Inbound Filters**, then add the error message to the "Error Message" field.
-
-To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
-
-### Filter by Issue
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-When you are unable to take immediate action on an issue, but it continues to occur, Sentry supports deleting and discarding that issue, which you can do from the **Issue Details** page. Navigate to the issue you would like to filter, click on the drop-down menu next to the bin icon, and select “Delete and discard future events”. This setting deletes most data associated with the issue and filters out new matching events before they count against your quota.
-
-You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
-
-## 4. Event Grouping
-
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
-
-With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
-
-![JavaScript stack trace without source maps](manage-event-stream-04.png)
-
-![JavaScript stack trace with source maps](manage-event-stream-05.png)
-
-For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
-
-## 5. Resolve or Delete Issues {#5-applying-workflows}
-
-Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
-
-### Resolve
-
-You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
-
-### Delete & Discard
-
-<Note>
-
-This feature is available only on a Business plan or higher.
-
-</Note>
-
-If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
-
-![Delete and Discard](manage-event-stream-06.png)
-
-You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
-
-![List of Discarded Issues](manage-event-stream-07.png)
-
-<Note>
-
-Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
-
-</Note>
-
-## 6. Rate Limiting
-
-Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
-
-In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
-
-![Per DSN Key rate limits](manage-event-stream-11.png)
-
-### Setting Useful Rate Limits {#-how-to-set-proper-rate-limits}
-
-A good way to set a project rate limit is by figuring out the expected event volume based on your average traffic. Let's look at an example:
-
-![Calculating rate limits](manage-event-stream-14.png)
-
-- Open the project DSN key configuration under **[Project] > Settings > Client Keys (DSN)** by clicking "Configure".
-- In the `KEY USAGE IN THE LAST 30 DAYS` graph and look for the highest point, or the maximum daily rate. In this example, the maximum daily rate in the last month is less than 326K.
-- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or about 230 events a **minute**.
-- You can set a daily, hourly, or minute-based rate limit. We'd recommend using a minute-based rate to avoid situations where a random event spike might exhaust your daily or hourly quota and leave you blind for a long period.
-
-You should periodically go back and check the graph to see the number of events dropped due to rate limiting and, if needed, revisit your settings.
-
-![Revisit rate limits](manage-event-stream-15.png)
-
-<!-- added stuff -->
-
-### Error Event Limits
-
-Per-key rate limits allow you to set the maximum volume of error events a key will accept during a period of time.
-
-For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
-
-To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
-
-<Note>
-
-This feature is available only if your organization is on a Business plan.
-
-</Note>
-
-## 7. Spike Protection
+## 1. Spike Protection
 
 Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
 
@@ -312,7 +86,7 @@ If, instead of a single big spike (or an overall, permanent, increase in traffic
 
 Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
-## 8. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
+## 2. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
 Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 
@@ -349,3 +123,233 @@ The Sentry workflow starts with a real-time alert notifying you about an error i
 Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest issues:
 
 ![Busiest Issues](manage-event-stream-10.png)
+
+## 3. Increasing Quotas
+
+Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
+
+If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
+
+If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
+
+### On-Demand Capacity
+
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+
+### Reserved Capacity
+
+If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
+
+You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
+
+### Plan Upgrade
+
+If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
+
+### Decreasing Quotas
+
+Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
+
+<Alert level="warning">
+
+If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
+
+</Alert>
+
+Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
+
+To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
+
+![The Review & Confirm step of a subscription update.](review-subscription.png)
+
+<Note>
+
+We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
+
+</Note>
+
+## 4. Rate Limiting
+
+Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
+
+In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
+
+![Per DSN Key rate limits](manage-event-stream-11.png)
+
+### Setting Useful Rate Limits {#-how-to-set-proper-rate-limits}
+
+A good way to set a project rate limit is by figuring out the expected event volume based on your average traffic. Let's look at an example:
+
+![Calculating rate limits](manage-event-stream-14.png)
+
+- Open the project DSN key configuration under **[Project] > Settings > Client Keys (DSN)** by clicking "Configure".
+- In the `KEY USAGE IN THE LAST 30 DAYS` graph and look for the highest point, or the maximum daily rate. In this example, the maximum daily rate in the last month is less than 326K.
+- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or about 230 events a **minute**.
+- You can set a daily, hourly, or minute-based rate limit. We'd recommend using a minute-based rate to avoid situations where a random event spike might exhaust your daily or hourly quota and leave you blind for a long period.
+
+You should periodically go back and check the graph to see the number of events dropped due to rate limiting and, if needed, revisit your settings.
+
+![Revisit rate limits](manage-event-stream-15.png)
+
+<!-- added stuff -->
+
+### Error Event Limits
+
+Per-key rate limits allow you to set the maximum volume of error events a key will accept during a period of time.
+
+For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
+
+To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+## 5. Delete & Discard Issues {#5-applying-workflows}
+
+Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
+
+### Resolve
+
+You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
+
+### Delete & Discard
+
+<Note>
+
+This feature is available only on a Business plan or higher.
+
+</Note>
+
+If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
+
+![Delete and Discard](manage-event-stream-06.png)
+
+You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
+
+![List of Discarded Issues](manage-event-stream-07.png)
+
+<Note>
+
+Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
+
+</Note>
+
+## 6. Inbound Data Filters
+
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+
+Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
+
+![Built-in Inbound Filters](manage-event-stream-03.png)
+
+<!-- added stuff -->
+
+In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
+
+Inbound filters include:
+
+- Common browser extension errors
+- Events coming from localhost
+- Known legacy browsers errors
+- Known web crawlers
+- By their error message
+- From specific release versions of your code
+- From certain IP addresses.
+
+Explore these by navigating to **[Project] > Settings > Inbound Filters**.
+
+### IP Filters
+
+If you have a rogue client, Sentry supports blocking an IP from sending data. Navigate to **[Project] > Settings > Inbound Filters** to add the IP addresses (or subnets) in the "IP Addresses" field.
+
+### Filter by Release
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+If you discover a problematic release causing excessive noise, Sentry supports ignoring all events from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the releases to the "Releases" field
+
+### Filter by Error Message
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] > Settings > Inbound Filters**, then add the error message to the "Error Message" field.
+
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
+
+### Filter by Issue
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+When you are unable to take immediate action on an issue, but it continues to occur, Sentry supports deleting and discarding that issue, which you can do from the **Issue Details** page. Navigate to the issue you would like to filter, click on the drop-down menu next to the bin icon, and select “Delete and discard future events”. This setting deletes most data associated with the issue and filters out new matching events before they count against your quota.
+
+You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
+
+## 7. Event Grouping
+
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+
+With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
+
+![JavaScript stack trace without source maps](manage-event-stream-04.png)
+
+![JavaScript stack trace with source maps](manage-event-stream-05.png)
+
+For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
+
+## 8. SDK Sample Rate
+
+blah blah
+
+## 9. SDK Filtering: beforeSend
+
+All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
+
+## 10. SDK Configuration
+
+The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
+
+### JavaScript
+
+The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
+
+#### InboundFilters
+
+The integration is enabled by default and adds the following configuration options to the SDK:
+
+- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
+- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
+- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
+
+To learn more and see code samples, check out:
+
+- [Filtering](/platforms/javascript/configuration/filtering/)
+- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
+
+#### GlobalHandlers
+
+The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
+
+Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
+
+### Other SDKs
+
+**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
+
+**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
+
+**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -199,7 +199,7 @@ Per-key rate limits allow you to set the maximum volume of error events a key wi
 
 For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
 
-To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
+To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. 
 
 <Note>
 
@@ -236,7 +236,7 @@ Once you've identified a set of discarded issues, it might make sense to go back
 
 ## 6. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. 
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -54,13 +54,111 @@ Check out additional configuration options with the [tryCatch](/platforms/javasc
 
 **Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
 
-## 3. Inbound Data Filters
+## 3. Increasing Quotas
+
+Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
+
+If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
+
+If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
+
+### On-Demand Capacity
+
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+
+### Reserved Capacity
+
+If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
+
+You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
+
+### Plan Upgrade
+
+If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
+
+### Decreasing Quotas
+
+Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
+
+<Alert level="warning">
+
+If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
+
+</Alert>
+
+Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
+
+To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
+
+![The Review & Confirm step of a subscription update.](review-subscription.png)
+
+<Note>
+
+We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
+
+</Note>
+
+## 4. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 
 ![Built-in Inbound Filters](manage-event-stream-03.png)
+
+<!-- added stuff -->
+
+In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
+
+Inbound filters include:
+
+- Common browser extension errors
+- Events coming from localhost
+- Known legacy browsers errors
+- Known web crawlers
+- By their error message
+- From specific release versions of your code
+- From certain IP addresses.
+
+Explore these by navigating to **[Project] > Settings > Inbound Filters**.
+
+### IP Filters
+
+If you have a rogue client, Sentry supports blocking an IP from sending data. Navigate to **[Project] > Settings > Inbound Filters** to add the IP addresses (or subnets) in the "IP Addresses" field.
+
+### Filter by Release
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+If you discover a problematic release causing excessive noise, Sentry supports ignoring all events from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the releases to the "Releases" field
+
+### Filter by Error Message
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] > Settings > Inbound Filters**, then add the error message to the "Error Message" field.
+
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
+
+### Filter by Issue
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+When you are unable to take immediate action on an issue, but it continues to occur, Sentry supports deleting and discarding that issue, which you can do from the **Issue Details** page. Navigate to the issue you would like to filter, click on the drop-down menu next to the bin icon, and select “Delete and discard future events”. This setting deletes most data associated with the issue and filters out new matching events before they count against your quota.
+
+You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
 ## 4. Event Grouping
 
@@ -86,7 +184,7 @@ You've been alerted on a new error in your code? Go to the **[Issue Details](/pr
 
 <Note>
 
-  This feature is available only on a Business plan or higher.
+This feature is available only on a Business plan or higher.
 
 </Note>
 
@@ -120,12 +218,28 @@ A good way to set a project rate limit is by figuring out the expected event vol
 
 - Open the project DSN key configuration under **[Project] > Settings > Client Keys (DSN)** by clicking "Configure".
 - In the `KEY USAGE IN THE LAST 30 DAYS` graph and look for the highest point, or the maximum daily rate. In this example, the maximum daily rate in the last month is less than 326K.
-- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or  about 230 events a **minute**.
+- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or about 230 events a **minute**.
 - You can set a daily, hourly, or minute-based rate limit. We'd recommend using a minute-based rate to avoid situations where a random event spike might exhaust your daily or hourly quota and leave you blind for a long period.
 
 You should periodically go back and check the graph to see the number of events dropped due to rate limiting and, if needed, revisit your settings.
 
 ![Revisit rate limits](manage-event-stream-15.png)
+
+<!-- added stuff -->
+
+### Error Event Limits
+
+Per-key rate limits allow you to set the maximum volume of error events a key will accept during a period of time.
+
+For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
+
+To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
 
 ## 7. Spike Protection
 
@@ -145,12 +259,58 @@ Once you've used your grace period, we recommend setting up an on-demand budget 
 
 Also, consider doing the following:
 
-- Set better rate limits on the DSN keys for the projects related to the spike. 
+- Set better rate limits on the DSN keys for the projects related to the spike.
 - If it's a specific release version that has caused the spike, add the version identifier to the project's inbound filters to avoid accepting events from that release.
 
-To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page. 
+To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
 
 Learn more about [how spike protection works](/product/accounts/quotas/#spike-protection).
+
+<!-- added stuff -->
+
+<Alert level="info">
+
+Spike protection is not currently available for transactions nor attachments.
+
+</Alert>
+
+A spike is both a **large** and **temporary** increase in error event volume. Because Sentry bills based on monthly event volume, spikes can easily consume your capacity for the rest of the month. Sentry's spike protection prevents these types of overages from consuming your error event capacity by dropping error events during the spike.
+
+Spike protection is an organization-level setting, so once it's triggered, it affects all the projects in the organization, regardless of which project triggered the spike.
+
+Spike protection is enabled for your organization by default, and when it's enabled, Sentry continually monitors for spikes. If you want to disable it, you can do so in **Settings > Subscription**.
+
+### How Does Spike Protection Work?
+
+We use your historical error event volume to implement a dynamic rate limit, and then discard error events when you hit its threshold. When spike protection is activated, we limit the number of error events accepted in any minute to:
+
+```
+maximum(20, 6 x average error events per minute over the last 24 hours)
+```
+
+<Note>
+
+The 24-hour window ends at the beginning of the current hour, not at the current minute.
+
+</Note>
+
+This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
+
+For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
+
+1. Spike protection becomes "active".
+
+1. If your organization has used more than 25% of your monthly quota, Sentry sends the organization owner a [notification](/product/alerts/notifications/#quota-notifications) including which project the 61st event came from. This is likely, but not guaranteed to be, the project in which something broke.
+
+1. Events 61-100 are dropped.
+
+When the next minute begins, we again record up to 60 events, dropping the rest until the minute is up. It continues like this for the remainder of the hour. After an hour, we re-calculate your per-minute limit, and for the next hour use that limit to decide whether events get dropped each minute. We repeat this process every hour until Sentry eventually accepts all events.
+
+If, instead of a single big spike (or an overall, permanent, increase in traffic), you experience many small spikes, there may be many days in a row when at least a few events are dropped. In that scenario, spike protection remains active the entire time.
+
+### When Does Spike Protection Become "Inactive?"
+
+Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
 ## 8. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -38,7 +38,7 @@ Also, consider doing the following:
 
 To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
 
-Learn more about [how spike protection works](/product/accounts/quotas/#spike-protection).
+Learn more about [how spike protection works](#how-does-spike-protection-work).
 
 <!-- added stuff -->
 
@@ -211,11 +211,8 @@ This feature is available only if your organization is on a Business plan.
 
 Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
 
-### Resolve
 
-You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
 
-### Delete & Discard
 
 <Note>
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -11,6 +11,50 @@ In most cases, sending all [transaction](/product/performance/transaction-summar
 
 When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.
 
+## 2. Increasing Quotas
+
+Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
+
+If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
+
+If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
+
+### On-Demand Capacity
+
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+
+### Reserved Capacity
+
+If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
+
+You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
+
+### Plan Upgrade
+
+If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
+
+## Decreasing Quotas
+
+Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
+
+<Alert level="warning">
+
+If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
+
+</Alert>
+
+Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
+
+To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
+
+![The Review & Confirm step of a subscription update.](review-subscription.png)
+
+<Note>
+
+We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
+
+</Note>
+
 ## 2. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
@@ -18,6 +62,60 @@ While SDK configuration requires changes to your source code and depends on your
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 
 ![Built-in Inbound Filters](manage-event-stream-03.png)
+
+<!-- added stuff -->
+
+In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
+
+Inbound filters include:
+
+- Common browser extension errors
+- Events coming from localhost
+- Known legacy browsers errors
+- Known web crawlers
+- By their error message
+- From specific release versions of your code
+- From certain IP addresses.
+
+Explore these by navigating to **[Project] > Settings > Inbound Filters**.
+
+### IP Filters
+
+If you have a rogue client, Sentry supports blocking an IP from sending data. Navigate to **[Project] > Settings > Inbound Filters** to add the IP addresses (or subnets) in the "IP Addresses" field.
+
+### Filter by Release
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+If you discover a problematic release causing excessive noise, Sentry supports ignoring all events from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the releases to the "Releases" field
+
+### Filter by Error Message
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+Sentry supports filtering out a specific or certain kind of error as well. Navigate to **[Project] > Settings > Inbound Filters**, then add the error message to the "Error Message" field.
+
+To ensure you’re adding the correct message to the inbound filter setting, check the JSON for an event in the issue. The filter by error message setting matches the data found in the "title" field near the end of the file.
+
+### Filter by Issue
+
+<Note>
+
+This feature is available only if your organization is on a Business plan.
+
+</Note>
+
+When you are unable to take immediate action on an issue, but it continues to occur, Sentry supports deleting and discarding that issue, which you can do from the **Issue Details** page. Navigate to the issue you would like to filter, click on the drop-down menu next to the bin icon, and select “Delete and discard future events”. This setting deletes most data associated with the issue and filters out new matching events before they count against your quota.
+
+You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
 ## 3. Event Usage Stats
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -7,9 +7,37 @@ description: "Learn how to use the tools Sentry provides to control the type and
 
 In most cases, sending all [transaction](/product/performance/transaction-summary/#what-is-a-transaction) events to Sentry would generate more performance data than you might find useful and might use up your transactions quota too quickly. Sentry provides tools to control the _type_ and _amount_ of transactions that are monitored. This allows you to have transaction data that's actionable and meaningful, and to manage your quota. Applying the proper SDK configuration is an iterative and on-going process, but these tips will show you how to best use Sentry's tools to get the most out of your transaction events.
 
-## 1. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
+## 1. Event Usage Stats
 
-When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK filters and configuration.
+
+### How can I see a breakdown of incoming events?
+
+The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events, by project, into three categories:
+
+- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
+- **Dropped**: Events that were discarded due to a limit being hit.
+- **Filtered**: Events that were blocked based on your inbound filter rules.
+
+![Overview of Usage Stats page](../../stats/usage-stats.png)
+
+You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
+
+### What are my busiest projects?
+
+The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project so you can see which ones are consuming your quota. Clicking on the settings icon next to a project name in the table will open the project's settings, where you can manage its inbound filters and rate limits
+
+You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
+
+### Which transactions are consuming my quota?
+
+You can set up a query in **Discover** to see which transactions you're receiving the most and if you want to adjust that. When you're building the query, search for `event.type:transaction` and then set the columns to `title`, `project`, and `count`, as shown below:
+
+![Busiest Projects](manage-trans-quota-01.png)
+
+Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest transactions:
+
+![Busiest Issues](manage-trans-quota-02.png)
 
 ## 2. Increasing Quotas
 
@@ -55,7 +83,7 @@ We strongly recommend that you make subscription changes before the last day of 
 
 </Note>
 
-## 2. Inbound Data Filters
+## 3. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
 
@@ -117,34 +145,10 @@ When you are unable to take immediate action on an issue, but it continues to oc
 
 You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
-## 3. Event Usage Stats
+## 4. SDK Sample Rate
 
-Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK filters and configuration.
+blah blah
 
-### How can I see a breakdown of incoming events?
+## 5. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
 
-The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events, by project, into three categories:
-
-- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
-- **Dropped**: Events that were discarded due to a limit being hit.
-- **Filtered**: Events that were blocked based on your inbound filter rules.
-
-![Overview of Usage Stats page](../../stats/usage-stats.png)
-
-You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
-
-### What are my busiest projects?
-
-The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project so you can see which ones are consuming your quota. Clicking on the settings icon next to a project name in the table will open the project's settings, where you can manage its inbound filters and rate limits
-
-You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
-
-### Which transactions are consuming my quota?
-
-You can set up a query in **Discover** to see which transactions you're receiving the most and if you want to adjust that. When you're building the query, search for `event.type:transaction` and then set the columns to `title`, `project`, and `count`, as shown below:
-
-![Busiest Projects](manage-trans-quota-01.png)
-
-Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest transactions:
-
-![Busiest Issues](manage-trans-quota-02.png)
+When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -85,7 +85,7 @@ We strongly recommend that you make subscription changes before the last day of 
 
 ## 3. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. 
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 


### PR DESCRIPTION
Restructures Quota Management index page to be significantly shorter
Adds Quick Guide table
Moves content from index page to guides
Moves Does it Count table to end of page

