### PR TITLE
restructure quota mgmt docs v3

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -29,19 +29,19 @@ Sentry completes a thorough evaluation of each event to determine if it counts t
 
 | Strategy                                                            | Yes, this event counts                  | No, this event does not count |
 | ------------------------------------------------------------------- | --------------------------------------- | ----------------------------- |
-| [SDK filtering](#1-sdk-filtering-beforesend)                        |                                         |                               |
-| [SDK configuration](#2-sdk-configuration)                           | Not set                                 | Set to filter this event      |
-| [SDK sample rate](#3-sdk-sample-rate)                               | Not set                                 | Set                           |
-| [Event grouping](#4-event-grouping)                                 |                                         |                               |
-| [Quota availability](#5-quota-availability)                         | Not reached                             | Exceeded                      |
-| [Has spike protection (errors only) been triggered?](#6-spike-protection) | No                                | Yes                           |
-| [Are future error events that repeat set to Delete & Discard?](#delete--discard)    | No                      |                               |
-| [Is this a repeated error event for a previously resolved issue?](#resolve) | Yes, this may be a regression in your code |                    |
+| [Has spike protection (errors only) been triggered?](#1-spike-protection) | No                                | Yes                           |
+| [Something about event usage](#common-workflows-for-managing-your-event-stream) |                             |                               |
+| [Quota availability](#3-quota-availability)                         | Not reached                             | Exceeded                      |
+| [Rate limit for error events for the project](#4-rate-limits)       | Not set or not reached                  | Set and exceeded              |
+| [Are future error events that repeat set to Delete & Discard?](#5-delete--discard)    | No                    |                               |
+| [Is this a repeated error event for a previously resolved issue?](#event-repetition) | Yes, this may be a regression in your code  |          |
 | [Is this repeated error event set to Ignore Alert?](#event-repetition) | Yes, it is still occurring           |                               |
-| [Rate limit for error events for the project](#8-rate-limits)          | Not set or not reached               | Set and exceeded              |
-| [Inbound filters (errors only)](#9-inbound-filters)                 | Not set                                 | Set for this error event      |
-| [Something about event usage](#common-workflows-for-managing-your-event-stream) |                            |       |
-| [Something about size limits](#size-limits) |                            |       |
+| [Inbound filters (errors only)](#6-inbound-filters)                 | Not set                                 | Set for this error event      |
+| [Event grouping](#7-event-grouping)                                 |                                         |                               |
+| [SDK sample rate](#8-sdk-sample-rate)                               | Not set                                 | Set                           |
+| [SDK filtering](#9-sdk-filtering-beforesend)                        | Not set                                 | Set to filter this event      |
+| [SDK configuration](#10-sdk-configuration)                          | Not set                                 | Set to filter this event      |
+| [Exceeds size limit](#size-limits)                                  | No                                      | Yes                           |
 
 <!-- prettier-ignore-end -->
 
@@ -51,110 +51,7 @@ Delete and discard and per-project rate limits are available only for Business p
 
 </Alert>
 
-## 1. SDK Filtering: beforeSend
-
-All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
-
-## 2. SDK Configuration
-
-The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
-
-### JavaScript
-
-The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
-
-#### InboundFilters
-
-The integration is enabled by default and adds the following configuration options to the SDK:
-
-- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
-- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
-- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
-
-To learn more and see code samples, check out:
-
-- [Filtering](/platforms/javascript/configuration/filtering/)
-- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
-
-#### GlobalHandlers
-
-The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
-
-Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
-
-### Other SDKs
-
-**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
-
-**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
-
-**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
-
-## 3. SDK Sample Rate
-
-If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
-
-## 4. Event Grouping
-
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
-
-With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
-
-![JavaScript stack trace without source maps](manage-event-stream-04.png)
-
-![JavaScript stack trace with source maps](manage-event-stream-05.png)
-
-For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
-
-## 5. Quota Availability
-
-Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
-
-### Increasing Quotas
-
-Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
-
-If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
-
-If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
-
-#### On-Demand Capacity
-
-If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
-
-#### Reserved Capacity
-
-If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
-
-You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
-
-#### Plan Upgrade
-
-If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
-
-### Decreasing Quotas
-
-Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
-
-<Alert level="warning">
-
-If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
-
-</Alert>
-
-Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
-
-To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
-
-![The Review & Confirm step of a subscription update.](review-subscription.png)
-
-<Note>
-
-We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
-
-</Note>
-
-## 6. Spike Protection
+## 1. Spike Protection
 
 Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
 
@@ -225,45 +122,93 @@ If, instead of a single big spike (or an overall, permanent, increase in traffic
 
 Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
-## 7. Resolve, Delete, or Ignore Issues
+## 2. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
-Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 
-- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
-- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+- What's the breakdowndown of my incoming events?
+- Which projects are consuming my quota?
+- Which issues are consuming my quota?
 
-### Resolve
+The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
 
-You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
+### How can I see a breakdown of incoming events? {#-how-can-i-see-a-breakdown-of-incoming-events}
 
-### Delete & Discard
+The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events (by project) into three categories:
+
+- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
+- **Dropped**: Events that were discarded due to a limit being hit.
+- **Filtered**: Events that were blocked based on your inbound filter rules.
+
+![Overview of Usage Stats page](../../stats/usage-stats.png)
+
+You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
+
+### What are my busiest projects? {#-what-are-my-busiest-projects}
+
+The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project, so you can see which ones are consuming your quota.Clicking on the settings icon next to a project name in the table will open the project's settings page where you can manage its inbound filters and rate limits
+
+You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
+
+### Which issues are consuming my quota? {#-what-issues-are-consuming-my-quota}
+
+The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolving your busiest issues, you can set up a query in **Discover**. When you're building the query, search for `event.type:error` and then set the columns `issue`, `title`, `project`, and `count()`, as shown below:
+
+![Busiest Projects](manage-event-stream-02.png)
+
+Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest issues:
+
+![Busiest Issues](manage-event-stream-10.png)
+
+## 3. Quota Availability
+
+Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
+
+### Increasing Quotas
+
+Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
+
+If you exceed your quota threshold, the server will respond with a 429 HTTP status code, which communicates to SDKs and clients to stop sending events. This status code comes with a `Retry-After` header that indicates the time for which this rate limit is active. However, clients are not supposed to retry events, but instead drop events until the rate limit has expired, to prevent queue backlogs. Note, that since event ingestion and rate limiting happen asynchronously, the 429 HTTP status code is always slightly delayed.
+
+If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
+
+#### On-Demand Capacity
+
+If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
+
+#### Reserved Capacity
+
+If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
+
+You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
+
+#### Plan Upgrade
+
+If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
+
+### Decreasing Quotas
+
+Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
+
+<Alert level="warning">
+
+If you have an annual billing cycle, plan downgrades and decreases in reserved capacity go into effect at the beginning of your **next billing year.**
+
+</Alert>
+
+Changes to on-demand capacity typically go into effect immediately and are guaranteed to go into effect within 24 hours.
+
+To decrease your quota, go to **Settings > Subscription** and click "Manage Subscriptions". When you reach the "Review & Confirm" step, the date that these changes go into effect will be displayed:
+
+![The Review & Confirm step of a subscription update.](review-subscription.png)
 
 <Note>
 
-This feature is available only on a Business plan or higher.
+We strongly recommend that you make subscription changes before the last day of your billing cycle. Depending on your time zone, in some cases, changes made on the last day of the billing cycle will not go into effect until the next billing cycle.
 
 </Note>
 
-If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
-
-![Delete and Discard](manage-event-stream-06.png)
-
-You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
-
-![List of Discarded Issues](manage-event-stream-07.png)
-
-<Note>
-
-Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
-
-</Note>
-
-### Ignore Issues
-
-blah blah blah
-
-## 8. Rate Limits
+## 4. Rate Limits
 
 If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
 
@@ -308,7 +253,37 @@ This feature is available only if your organization is on a Business plan.
 
 If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
-## 9. Inbound Filters
+## 5. Delete, & Discard Issues
+
+<Note>
+
+This feature is available only on a Business plan or higher.
+
+</Note>
+
+If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
+
+![Delete and Discard](manage-event-stream-06.png)
+
+You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
+
+![List of Discarded Issues](manage-event-stream-07.png)
+
+<Note>
+
+Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
+
+</Note>
+
+### Event Repetition
+
+Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+
+## 6. Inbound Filters
 
 If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
 
@@ -366,43 +341,60 @@ When you are unable to take immediate action on an issue, but it continues to oc
 
 You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
-## 10. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
+## 7. Event Grouping
 
-Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
 
-- What's the breakdowndown of my incoming events?
-- Which projects are consuming my quota?
-- Which issues are consuming my quota?
+With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
 
-The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
+![JavaScript stack trace without source maps](manage-event-stream-04.png)
 
-### How can I see a breakdown of incoming events? {#-how-can-i-see-a-breakdown-of-incoming-events}
+![JavaScript stack trace with source maps](manage-event-stream-05.png)
 
-The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events (by project) into three categories:
+For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
 
-- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
-- **Dropped**: Events that were discarded due to a limit being hit.
-- **Filtered**: Events that were blocked based on your inbound filter rules.
+## 8. SDK Sample Rate
 
-![Overview of Usage Stats page](../../stats/usage-stats.png)
+If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
 
-You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
+## 9. SDK Filtering: beforeSend
 
-### What are my busiest projects? {#-what-are-my-busiest-projects}
+All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
 
-The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project, so you can see which ones are consuming your quota.Clicking on the settings icon next to a project name in the table will open the project's settings page where you can manage its inbound filters and rate limits
+## 10. SDK Configuration
 
-You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
+The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
 
-### Which issues are consuming my quota? {#-what-issues-are-consuming-my-quota}
+### JavaScript
 
-The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolving your busiest issues, you can set up a query in **Discover**. When you're building the query, search for `event.type:error` and then set the columns `issue`, `title`, `project`, and `count()`, as shown below:
+The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
 
-![Busiest Projects](manage-event-stream-02.png)
+#### InboundFilters
 
-Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest issues:
+The integration is enabled by default and adds the following configuration options to the SDK:
 
-![Busiest Issues](manage-event-stream-10.png)
+- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
+- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
+- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
+
+To learn more and see code samples, check out:
+
+- [Filtering](/platforms/javascript/configuration/filtering/)
+- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
+
+#### GlobalHandlers
+
+The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
+
+Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
+
+### Other SDKs
+
+**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
+
+**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
+
+**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
 
 ## A Note About Size Limits
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -74,7 +74,6 @@ Also, consider doing the following:
 
 To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
 
-Learn more about [how spike protection works](/product/accounts/quotas/#1-spike-protection).
 
 <!-- new stuff -->
 
@@ -253,7 +252,7 @@ This feature is available only if your organization is on a Business plan.
 
 If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
-## 5. Delete, & Discard Issues
+## 5. Delete & Discard Issues
 
 <Note>
 
@@ -281,11 +280,11 @@ Event repetition only applies to error events, not transactions or attachments. 
 
 - If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
 - If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#6-inbound-filters).
 
 ## 6. Inbound Filters
 
-If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
+If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. 
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
@@ -396,7 +395,7 @@ Check out additional configuration options with the [tryCatch](/platforms/javasc
 
 **Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
 
-## A Note About Size Limits
+## Size Limits
 
 Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -25,47 +25,13 @@ Let’s clarify a few terms to start:
 
 Sentry completes a thorough evaluation of each event to determine if it counts toward your quota, as outlined in this overview. Detailed documentation for each evaluation is linked throughout. Before completing any of these evaluations, Sentry confirms that each event includes a valid DSN and project as well as whether the event can be parsed. In addition, for error events, Sentry validates that the event contains valid fingerprint information. If any of these items are missing or incorrect, the event is rejected.
 
-1. **SDK configuration**
+- SDK configuration
+- SDK sample rate
+- other things
+- ...
+  <!-- to do - add links to list above -->
 
-   The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
-
-2. **SDK sample rate**
-
-   If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
-
-3. **Quota availability**
-
-   Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
-
-4. **Event repetition**
-
-   Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
-
-   - If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
-   - If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-   - If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
-
-5. **Spike protection**
-
-   Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
-
-In addition, depending on your project’s configuration and the plan you subscribe to, Sentry may also check:
-
-6. **Rate limit for the project**
-
-   If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
-
-7. **Inbound filters**
-
-   If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
-
-After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
-
-<Alert>
-  If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
-  compressed or 100MB decompressed for minidump uploads (all files combined),
-  the event will be rejected.
-</Alert>
+<!-- to do - add missing options to the table, make this table markdown -->
 
 ## What Counts Toward my Quota, Table View
 
@@ -140,7 +106,50 @@ After these checks are processed, the event counts toward your quota. It is acce
   plans.
 </Alert>
 
-## Increasing Quotas
+## SDK configuration\*\*
+
+The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
+
+### JavaScript
+
+The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
+
+#### InboundFilters
+
+The integration is enabled by default and adds the following configuration options to the SDK:
+
+- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
+- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
+- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
+
+To learn more and see code samples, check out:
+
+- [Filtering](/platforms/javascript/configuration/filtering/)
+- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
+
+#### GlobalHandlers
+
+The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
+
+Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
+
+### Other SDKs
+
+**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
+
+**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
+
+**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
+
+## SDK sample rate
+
+If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
+
+## Quota availability\*\*
+
+Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
+
+### Increasing Quotas
 
 Add to your quota at any time during your billing period by either upgrading to a higher plan or tier, increasing your reserved capacity, or increasing your on-demand capacity. To increase your quota, go to **Settings > Subscription** and click the "Manage Subscription" button to access your subscription options. When you increase your quota, the change goes into effect immediately.
 
@@ -148,21 +157,21 @@ If you exceed your quota threshold, the server will respond with a 429 HTTP stat
 
 If this is your first time exceeding quota, however, you'll be entered into a one-time grace period. Learn more about the grace period in this [Help article](https://help.sentry.io/account/billing/what-happens-when-i-run-out-of-event-capacity-and-a-grace-period-is-triggered/).
 
-### On-Demand Capacity
+#### On-Demand Capacity
 
 If you need to increase your event quota temporarily, we recommend that you add or increase on-demand capacity. This is ideal for situations like rolling out a new version of your application where you anticipate more events for the month. To add on-demand capacity, you enter a monthly maximum budget on either a shared or per-category (errors, transactions, and attachments) basis. Learn more about [on-demand capacity](/product/accounts/pricing/#on-demand-capacity) in our pricing documentation.
 
-### Reserved Capacity
+#### Reserved Capacity
 
 If the number of events you need is steadily increasing, you may want to increase your reserved capacity. Reserved capacity is less expensive than on-demand capacity since you prepay for it. It also allows you to choose the number of events that you want to have available beforehand rather than just setting an arbitrary on-demand budget. Learn more about [reserved capacity](/product/accounts/pricing/#prepaid-reserved-capacity) in our pricing documentation.
 
 You shouldn't increase your reserved capacity if you think your need for more events is temporary, since [reducing your reserved capacity is tied to your billing cycle](#decreasing-quotas).
 
-### Plan Upgrade
+#### Plan Upgrade
 
 If you're on a Developer plan and want to increase your quota, you'll need to upgrade to a Team or Business plan. On these plans you can prepay for more event capacity and purchase on-demand capacity, as needed. Learn about Sentry's plans on our [pricing page](https://sentry.io/pricing/).
 
-## Decreasing Quotas
+### Decreasing Quotas
 
 Plan downgrades and decreases in reserved capacity are processed at the end of your billing cycle, and remaining capacity cannot be refunded. For example, if you have a monthly billing cycle that starts on the 5th of the month, and you decrease your reserved capacity on June 20th, then this change will be processed on July 4th. Your billing cycle beginning on July 5th will reflect your new reserved capacity.
 
@@ -184,7 +193,149 @@ We strongly recommend that you make subscription changes before the last day of 
 
 </Note>
 
-## Limiting Events
+## Event Grouping
+
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+
+With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
+
+![JavaScript stack trace without source maps](manage-event-stream-04.png)
+
+![JavaScript stack trace with source maps](manage-event-stream-05.png)
+
+For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
+
+## Resolve or Delete Issues
+
+### Resolve
+
+You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
+
+### Delete & Discard
+
+<Note>
+
+This feature is available only on a Business plan or higher.
+
+</Note>
+
+If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
+
+![Delete and Discard](manage-event-stream-06.png)
+
+You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
+
+![List of Discarded Issues](manage-event-stream-07.png)
+
+<Note>
+
+Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
+
+</Note>
+
+## Event repetition
+
+Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+
+## Spike protection
+
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
+
+### Managing a Spike {#-spike-protection-was-activated----what-should-i-do}
+
+You might receive an email notifying you that spike protection was triggered and applied to your account.
+
+![Spike Protection Email](spike-email.jpg)
+
+Many times, an unexpected spike is caused by a new error (or errors) introduced into your code with a new release version. We understand that errors can come in spikes and service interruptions can be challenging, so we include a one-time grace period for all paid accounts.
+
+If an account depletes its event capacity and has never previously triggered a grace period, we continue to accept events for the next three days at a maximum rate of 10,000 events per hour. If you choose not to increase your capacity, Sentry will stop accepting events for the remainder of the current billing month. However, if you increase your capacity, events accepted during the grace period will be counted as consumed capacity.
+
+Once you've used your grace period, we recommend setting up an on-demand budget to ensure you have time to adjust your capacity in the event of a future spike in errors.
+
+Also, consider doing the following:
+
+- Set better rate limits on the DSN keys for the projects related to the spike.
+- If it's a specific release version that has caused the spike, add the version identifier to the project's inbound filters to avoid accepting events from that release.
+
+To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
+
+Learn more about [how spike protection works](/product/accounts/quotas/#spike-protection).
+
+<!-- new stuff -->
+
+<Alert level="info">
+
+Spike protection is not currently available for transactions nor attachments.
+
+</Alert>
+
+A spike is both a **large** and **temporary** increase in error event volume. Because Sentry bills based on monthly event volume, spikes can easily consume your capacity for the rest of the month. Sentry's spike protection prevents these types of overages from consuming your error event capacity by dropping error events during the spike.
+
+Spike protection is an organization-level setting, so once it's triggered, it affects all the projects in the organization, regardless of which project triggered the spike.
+
+Spike protection is enabled for your organization by default, and when it's enabled, Sentry continually monitors for spikes. If you want to disable it, you can do so in **Settings > Subscription**.
+
+### How Does Spike Protection Work?
+
+We use your historical error event volume to implement a dynamic rate limit, and then discard error events when you hit its threshold. When spike protection is activated, we limit the number of error events accepted in any minute to:
+
+```
+maximum(20, 6 x average error events per minute over the last 24 hours)
+```
+
+<Note>
+
+The 24-hour window ends at the beginning of the current hour, not at the current minute.
+
+</Note>
+
+This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
+
+For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
+
+1. Spike protection becomes "active".
+
+1. If your organization has used more than 25% of your monthly quota, Sentry sends the organization owner a [notification](/product/alerts/notifications/#quota-notifications) including which project the 61st event came from. This is likely, but not guaranteed to be, the project in which something broke.
+
+1. Events 61-100 are dropped.
+
+When the next minute begins, we again record up to 60 events, dropping the rest until the minute is up. It continues like this for the remainder of the hour. After an hour, we re-calculate your per-minute limit, and for the next hour use that limit to decide whether events get dropped each minute. We repeat this process every hour until Sentry eventually accepts all events.
+
+If, instead of a single big spike (or an overall, permanent, increase in traffic), you experience many small spikes, there may be many days in a row when at least a few events are dropped. In that scenario, spike protection remains active the entire time.
+
+### When Does Spike Protection Become "Inactive?"
+
+Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
+
+## Rate Limits
+
+If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
+
+In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
+
+![Per DSN Key rate limits](manage-event-stream-11.png)
+
+### Setting Useful Rate Limits {#-how-to-set-proper-rate-limits}
+
+A good way to set a project rate limit is by figuring out the expected event volume based on your average traffic. Let's look at an example:
+
+![Calculating rate limits](manage-event-stream-14.png)
+
+- Open the project DSN key configuration under **[Project] > Settings > Client Keys (DSN)** by clicking "Configure".
+- In the `KEY USAGE IN THE LAST 30 DAYS` graph and look for the highest point, or the maximum daily rate. In this example, the maximum daily rate in the last month is less than 326K.
+- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or about 230 events a **minute**.
+- You can set a daily, hourly, or minute-based rate limit. We'd recommend using a minute-based rate to avoid situations where a random event spike might exhaust your daily or hourly quota and leave you blind for a long period.
+
+You should periodically go back and check the graph to see the number of events dropped due to rate limiting and, if needed, revisit your settings.
+
+![Revisit rate limits](manage-event-stream-15.png)
+
+<!-- new stuff -->
 
 You can add limits for error events and attachments in [sentry.io](https://sentry.io). This does not apply to transaction events.
 
@@ -206,7 +357,11 @@ This feature is available only if your organization is on a Business plan.
 
 If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
-## Inbound Filters {#inbound-data-filters}
+## Inbound filters\*\*
+
+If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
+
+After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 
 In some cases, the data you’re receiving in Sentry is hard to filter, or you don’t have the ability to update the SDK’s configuration to apply the filters. Sentry provides several methods to filter all events and attachments server-side, which are applied before checking for potential rate limits.
 
@@ -260,51 +415,43 @@ When you are unable to take immediate action on an issue, but it continues to oc
 
 You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
-## Spike Protection
+## Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
-<Alert level="info">
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 
-Spike protection is not currently available for transactions nor attachments.
+- What's the breakdowndown of my incoming events?
+- Which projects are consuming my quota?
+- Which issues are consuming my quota?
 
-</Alert>
+The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
 
-A spike is both a **large** and **temporary** increase in error event volume. Because Sentry bills based on monthly event volume, spikes can easily consume your capacity for the rest of the month. Sentry's spike protection prevents these types of overages from consuming your error event capacity by dropping error events during the spike.
+### How can I see a breakdown of incoming events? {#-how-can-i-see-a-breakdown-of-incoming-events}
 
-Spike protection is an organization-level setting, so once it's triggered, it affects all the projects in the organization, regardless of which project triggered the spike.
+The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events (by project) into three categories:
 
-Spike protection is enabled for your organization by default, and when it's enabled, Sentry continually monitors for spikes. If you want to disable it, you can do so in **Settings > Subscription**.
+- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
+- **Dropped**: Events that were discarded due to a limit being hit.
+- **Filtered**: Events that were blocked based on your inbound filter rules.
 
-### How Does Spike Protection Work?
+![Overview of Usage Stats page](../../stats/usage-stats.png)
 
-We use your historical error event volume to implement a dynamic rate limit, and then discard error events when you hit its threshold. When spike protection is activated, we limit the number of error events accepted in any minute to:
+You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
 
-```
-maximum(20, 6 x average error events per minute over the last 24 hours)
-```
+### What are my busiest projects? {#-what-are-my-busiest-projects}
 
-<Note>
+The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project, so you can see which ones are consuming your quota.Clicking on the settings icon next to a project name in the table will open the project's settings page where you can manage its inbound filters and rate limits
 
-The 24-hour window ends at the beginning of the current hour, not at the current minute.
+You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
 
-</Note>
+### Which issues are consuming my quota? {#-what-issues-are-consuming-my-quota}
 
-This means if you experience a spike, we'll temporarily protect you, but if the increase in volume is sustained, the spike protection limit will gradually **increase until Sentry accepts all events**.
+The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolving your busiest issues, you can set up a query in **Discover**. When you're building the query, search for `event.type:error` and then set the columns `issue`, `title`, `project`, and `count()`, as shown below:
 
-For example, in the last 24 hours, your organization has been receiving, on average, 10 events per minute (after any inbound filters have been applied). That means your current per-minute limit is 6 \* 10 or 60 events. There have been no spikes in that time, so spike control is "inactive". Something breaks, and in the next minute, your organization sends Sentry 100 events. When we see the 61st event, three things happen:
+![Busiest Projects](manage-event-stream-02.png)
 
-1. Spike protection becomes "active".
+Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest issues:
 
-1. If your organization has used more than 25% of your monthly quota, Sentry sends the organization owner a [notification](/product/alerts/notifications/#quota-notifications) including which project the 61st event came from. This is likely, but not guaranteed to be, the project in which something broke.
-
-1. Events 61-100 are dropped.
-
-When the next minute begins, we again record up to 60 events, dropping the rest until the minute is up. It continues like this for the remainder of the hour. After an hour, we re-calculate your per-minute limit, and for the next hour use that limit to decide whether events get dropped each minute. We repeat this process every hour until Sentry eventually accepts all events.
-
-If, instead of a single big spike (or an overall, permanent, increase in traffic), you experience many small spikes, there may be many days in a row when at least a few events are dropped. In that scenario, spike protection remains active the entire time.
-
-### When Does Spike Protection Become "Inactive?"
-
-Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
+![Busiest Issues](manage-event-stream-10.png)
 
 ## Size Limits
 
@@ -321,3 +468,8 @@ The precise limits may change over time. For more information, please refer to t
 - [Store Endpoint Size Limits](https://develop.sentry.dev/sdk/store/#size-limits)
 - [Minidump Size Limits](/platforms/native/guides/minidumps/#size-limits)
 - [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)
+
+<Alert>
+  If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
+  compressed or 100MB decompressed for minidump uploads (all files combined),
+  the event will be rejected.

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -40,7 +40,8 @@ Sentry completes a thorough evaluation of each event to determine if it counts t
 | [Is this repeated error event set to Ignore Alert?](#event-repetition) | Yes, it is still occurring           |                               |
 | [Rate limit for error events for the project](#8-rate-limits)          | Not set or not reached               | Set and exceeded              |
 | [Inbound filters (errors only)](#9-inbound-filters)                 | Not set                                 | Set for this error event      |
-| [Something about event usage](##common-workflows-for-managing-your-event-stream) |                            |       |
+| [Something about event usage](#common-workflows-for-managing-your-event-stream) |                            |       |
+| [Something about size limits](#size-limits) |                            |       |
 
 <!-- prettier-ignore-end -->
 
@@ -224,7 +225,13 @@ If, instead of a single big spike (or an overall, permanent, increase in traffic
 
 Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
-## 7. Resolve or Delete Issues
+## 7. Resolve, Delete, or Ignore Issues
+
+Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
 
 ### Resolve
 
@@ -251,6 +258,10 @@ You can find a list of these issues in the "Discarded Issues" tab in **[Project]
 Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
 
 </Note>
+
+### Ignore Issues
+
+blah blah blah
 
 ## 8. Rate Limits
 
@@ -393,19 +404,7 @@ Once the changes are applied, sort the "Results" table by the "COUNT" column to 
 
 ![Busiest Issues](manage-event-stream-10.png)
 
-## Other Factors
-
-### Event Repetition
-
-<!-- rethink this section -->
-
-Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
-
-- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
-- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
-
-### Size Limits
+## A Note About Size Limits
 
 Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -21,92 +21,26 @@ Let’s clarify a few terms to start:
 - **Transaction** - A [transaction](/product/performance/transaction-summary/#what-is-a-transaction) represents a single instance of a service being called to support an operation you want to measure or track, like a page load. Transaction events are grouped by the transaction name.
 - **Quota** - Your quota is the monthly number of events — errors, attachments, and transactions — that you pay Sentry to track.
 
-## What Counts Toward My Quota, an Overview
+## What Counts Toward My Quota
 
 Sentry completes a thorough evaluation of each event to determine if it counts toward your quota, as outlined in this overview. Detailed documentation for each evaluation is linked throughout. Before completing any of these evaluations, Sentry confirms that each event includes a valid DSN and project as well as whether the event can be parsed. In addition, for error events, Sentry validates that the event contains valid fingerprint information. If any of these items are missing or incorrect, the event is rejected.
 
-- SDK configuration
-- SDK sample rate
-- other things
-- ...
-  <!-- to do - add links to list above -->
+- [SDK filtering]()
+- [SDK configuration]()
+- [SDK sample rate]()
+- [Event grouping]()
+- [Quota availability]()
+- [Spike protection]()
+- [Resolve or delete issues]()
+- [Rate limits]()
+- [Inbound filters]()
+- [Event usage stats]()
 
-<!-- to do - add missing options to the table, make this table markdown -->
+## 1. SDK Filtering: beforeSend
 
-## What Counts Toward my Quota, Table View
+All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <strong> </strong>
-      </td>
-      <td>
-        <strong>Yes, this event counts</strong>
-      </td>
-      <td>
-        <strong>No, this event does not count</strong>
-      </td>
-    </tr>
-    <tr>
-      <td>SDK configuration</td>
-      <td>Not set</td>
-      <td>Set to filter this event</td>
-    </tr>
-    <tr>
-      <td>SDK sample rate</td>
-      <td>Not set</td>
-      <td>Set</td>
-    </tr>
-    <tr>
-      <td>Quota</td>
-      <td>Not reached</td>
-      <td>Exceeded</td>
-    </tr>
-    <tr>
-      <td>
-        Are <i>future</i> error events that repeat set to Delete & Discard?
-      </td>
-      <td>No</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Is this a repeated error event for a previously resolved issue?</td>
-      <td>Yes, this may be a regression in your code</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Is this repeated error event set to Ignore Alert?</td>
-      <td>Yes, it is still occurring</td>
-      <td> </td>
-    </tr>
-    <tr>
-      <td>Has spike protection (errors only) been triggered?</td>
-      <td>No</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Rate limit for error events for the project</td>
-      <td>
-        Not set <i>or</i> not reached
-      </td>
-      <td>
-        Set <i>and</i> exceeded
-      </td>
-    </tr>
-    <tr>
-      <td>Inbound filters (errors only)</td>
-      <td>Not set</td>
-      <td>Set for this error event</td>
-    </tr>
-  </tbody>
-</table>
-<Alert>
-  Delete and discard and per-project rate limits are available only for Business
-  plans.
-</Alert>
-
-## SDK configuration\*\*
+## 2. SDK Configuration
 
 The SDK configuration either allows the event or filters the event out. Learn more in [errors](/product/accounts/quotas/manage-event-stream-guide/) and [transactions](/product/accounts/quotas/manage-transaction-quota/) quota management docs or in the [filtering docs for your specific SDK](/platform-redirect/?next=/configuration/filtering/).
 
@@ -141,11 +75,23 @@ Check out additional configuration options with the [tryCatch](/platforms/javasc
 
 **Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
 
-## SDK sample rate
+## 3. SDK Sample Rate
 
 If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is documented for each SDK. The SDK sample rate is not dynamic; changing it requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
 
-## Quota availability\*\*
+## 4. Event Grouping
+
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+
+With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
+
+![JavaScript stack trace without source maps](manage-event-stream-04.png)
+
+![JavaScript stack trace with source maps](manage-event-stream-05.png)
+
+For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
+
+## 5. Quota Availability
 
 Events that exceed your quota are not accepted. Once your event volume is approaching or has exceeded the quota, teammates with the "owner" organization permission level will receive [notification](/product/alerts/notifications/#quota-notifications) emails. Learn about adding to your quota and what happens when you exceed it in [Increasing Quotas](#increasing-quotas).
 
@@ -193,55 +139,7 @@ We strongly recommend that you make subscription changes before the last day of 
 
 </Note>
 
-## Event Grouping
-
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
-
-With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
-
-![JavaScript stack trace without source maps](manage-event-stream-04.png)
-
-![JavaScript stack trace with source maps](manage-event-stream-05.png)
-
-For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
-
-## Resolve or Delete Issues
-
-### Resolve
-
-You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
-
-### Delete & Discard
-
-<Note>
-
-This feature is available only on a Business plan or higher.
-
-</Note>
-
-If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
-
-![Delete and Discard](manage-event-stream-06.png)
-
-You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
-
-![List of Discarded Issues](manage-event-stream-07.png)
-
-<Note>
-
-Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
-
-</Note>
-
-## Event repetition
-
-Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
-
-- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
-- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
-- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
-
-## Spike protection
+## 6. Spike Protection
 
 Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
 
@@ -312,7 +210,35 @@ If, instead of a single big spike (or an overall, permanent, increase in traffic
 
 Events will not be dropped during any minute in which you don't send more than the hourly limit that Sentry has calculated for you. After 24 hours without any dropped events, spike protection becomes "inactive" again. This means that it is no longer dropping events, but _it does not mean the system has stopped paying attention._ It does however mean that the next time events are dropped, with respect to alerts it will count as a "reactivation" of spike protection.
 
-## Rate Limits
+## 7. Resolve or Delete Issues
+
+### Resolve
+
+You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
+
+### Delete & Discard
+
+<Note>
+
+This feature is available only on a Business plan or higher.
+
+</Note>
+
+If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
+
+![Delete and Discard](manage-event-stream-06.png)
+
+You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
+
+![List of Discarded Issues](manage-event-stream-07.png)
+
+<Note>
+
+Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
+
+</Note>
+
+## 8. Rate Limits
 
 If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
 
@@ -357,7 +283,7 @@ This feature is available only if your organization is on a Business plan.
 
 If you have enabled the storage of crash reports, you may set limits for the maximum number of crash reports that will be stored per issue. To set up these limits, use the slider in the "Store Native Crash Reports" option in your organization's "Security & Privacy" settings.
 
-## Inbound filters\*\*
+## 9. Inbound Filters
 
 If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. Learn more in [Inbound Data Filters](#inbound-data-filters).
 
@@ -415,7 +341,7 @@ When you are unable to take immediate action on an issue, but it continues to oc
 
 You can view and restore previously discarded issues by navigating to the "Discarded Issues" tab of **[Project] > Settings > Inbound Filters**.
 
-## Event Usage Stats {#common-workflows-for-managing-your-event-stream}
+## 10. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
 Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 
@@ -453,7 +379,17 @@ Once the changes are applied, sort the "Results" table by the "COUNT" column to 
 
 ![Busiest Issues](manage-event-stream-10.png)
 
-## Size Limits
+## Other Factors
+
+### Event Repetition
+
+Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
+
+- If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
+- If you previously resolved an issue, a new error event counts toward your quota because it may represent a regression in your code.
+- If you have chosen to ignore alerts about error events with the same fingerprint, a new event counts toward your quota because the event is still occurring. Learn more in [Inbound Filters](#inbound-data-filters).
+
+### Size Limits
 
 Sentry imposes limits on various fields within an event, as well as the size of full events and the requests they are sent in:
 
@@ -470,6 +406,33 @@ The precise limits may change over time. For more information, please refer to t
 - [Variable Size Limits](https://develop.sentry.dev/sdk/data-handling/#variable-size)
 
 <Alert>
-  If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
-  compressed or 100MB decompressed for minidump uploads (all files combined),
-  the event will be rejected.
+
+If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
+compressed or 100MB decompressed for minidump uploads (all files combined),
+the event will be rejected.
+
+</Alert>
+
+<!-- ignore prettier start -->
+
+## What Counts Toward my Quota Table
+
+| Strategy                                                        | Yes, this event counts                     | No, this event does not count |
+| --------------------------------------------------------------- | ------------------------------------------ | ----------------------------- |
+| SDK configuration                                               | Not set                                    | Set to filter this event      |
+| SDK sample rate                                                 | Not set                                    | Set                           |
+| Quota                                                           | Not reached                                | Exceeded                      |
+| Are future error events that repeat set to Delete & Discard?    | No                                         |                               |
+| Is this a repeated error event for a previously resolved issue? | Yes, this may be a regression in your code |                               |
+| Is this repeated error event set to Ignore Alert?               | Yes, it is still occurring                 |                               |
+| Has spike protection (errors only) been triggered?              | No                                         | Yes                           |
+| Rate limit for error events for the project                     | Not set or not reached                     | Set and exceeded              |
+| Inbound filters (errors only)                                   | Not set                                    | Set for this error event      |
+
+<!-- ignore prettier end -->
+
+<Alert>
+
+Delete and discard and per-project rate limits are available only for Business plans.
+
+</Alert>

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -36,7 +36,7 @@ Sentry completes a thorough evaluation of each event to determine if it counts t
 | [Are future error events that repeat set to Delete & Discard?](#5-delete--discard)    | No                    |                               |
 | [Is this a repeated error event for a previously resolved issue?](#event-repetition) | Yes, this may be a regression in your code  |          |
 | [Is this repeated error event set to Ignore Alert?](#event-repetition) | Yes, it is still occurring           |                               |
-| [Inbound filters (errors only)](#6-inbound-filters)                 | Not set                                 | Set for this error event      |
+| [Inbound filters](#6-inbound-filters)                 | Not set                                 | Set for this error event      |
 | [Event grouping](#7-event-grouping)                                 |                                         |                               |
 | [SDK sample rate](#8-sdk-sample-rate)                               | Not set                                 | Set                           |
 | [SDK filtering](#9-sdk-filtering-beforesend)                        | Not set                                 | Set to filter this event      |
@@ -53,7 +53,7 @@ Delete and discard and per-project rate limits are available only for Business p
 
 ## 1. Spike Protection
 
-Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. 
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions.
 
 ### Managing a Spike {#-spike-protection-was-activated----what-should-i-do}
 
@@ -73,7 +73,6 @@ Also, consider doing the following:
 - If it's a specific release version that has caused the spike, add the version identifier to the project's inbound filters to avoid accepting events from that release.
 
 To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
-
 
 <!-- new stuff -->
 
@@ -240,7 +239,7 @@ Per-key rate limits allow you to set the maximum volume of error events a key wi
 
 For example, you may have a project in production that generates a lot of noise. A rate limit allows you to set the maximum amount of data to “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
 
-To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key. For additional information and examples, see [Rate Limiting in our guide to managing your error quota](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting).
+To set up rate limits, navigate to **[Project] > Settings > Client Keys** and click "Configure"\*\*". Select an individual key or create a new one, then you’ll be able to define a rate limit as well as view a breakdown of events received by that key.
 
 <Note>
 
@@ -284,7 +283,7 @@ Event repetition only applies to error events, not transactions or attachments. 
 
 ## 6. Inbound Filters
 
-If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted. 
+If any inbound filter is set for a type of event or attachment, and your subscription allows, the event or attachment won't be counted.
 
 After these checks are processed, the event counts toward your quota. It is accepted into Sentry, where it persists and is stored.
 

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -25,16 +25,30 @@ Let’s clarify a few terms to start:
 
 Sentry completes a thorough evaluation of each event to determine if it counts toward your quota, as outlined in this overview. Detailed documentation for each evaluation is linked throughout. Before completing any of these evaluations, Sentry confirms that each event includes a valid DSN and project as well as whether the event can be parsed. In addition, for error events, Sentry validates that the event contains valid fingerprint information. If any of these items are missing or incorrect, the event is rejected.
 
-- [SDK filtering]()
-- [SDK configuration]()
-- [SDK sample rate]()
-- [Event grouping]()
-- [Quota availability]()
-- [Spike protection]()
-- [Resolve or delete issues]()
-- [Rate limits]()
-- [Inbound filters]()
-- [Event usage stats]()
+<!-- prettier-ignore-start -->
+
+| Strategy                                                            | Yes, this event counts                  | No, this event does not count |
+| ------------------------------------------------------------------- | --------------------------------------- | ----------------------------- |
+| [SDK filtering](#1-sdk-filtering-beforesend)                        |                                         |                               |
+| [SDK configuration](#2-sdk-configuration)                           | Not set                                 | Set to filter this event      |
+| [SDK sample rate](#3-sdk-sample-rate)                               | Not set                                 | Set                           |
+| [Event grouping](#4-event-grouping)                                 |                                         |                               |
+| [Quota availability](#5-quota-availability)                         | Not reached                             | Exceeded                      |
+| [Has spike protection (errors only) been triggered?](#6-spike-protection) | No                                | Yes                           |
+| [Are future error events that repeat set to Delete & Discard?](#delete--discard)    | No                      |                               |
+| [Is this a repeated error event for a previously resolved issue?](#resolve) | Yes, this may be a regression in your code |                    |
+| [Is this repeated error event set to Ignore Alert?](#event-repetition) | Yes, it is still occurring           |                               |
+| [Rate limit for error events for the project](#8-rate-limits)          | Not set or not reached               | Set and exceeded              |
+| [Inbound filters (errors only)](#9-inbound-filters)                 | Not set                                 | Set for this error event      |
+| [Something about event usage](##common-workflows-for-managing-your-event-stream) |                            |       |
+
+<!-- prettier-ignore-end -->
+
+<Alert>
+
+Delete and discard and per-project rate limits are available only for Business plans.
+
+</Alert>
 
 ## 1. SDK Filtering: beforeSend
 
@@ -383,6 +397,8 @@ Once the changes are applied, sort the "Results" table by the "COUNT" column to 
 
 ### Event Repetition
 
+<!-- rethink this section -->
+
 Event repetition only applies to error events, not transactions or attachments. The following rules apply for event repetition and your quota:
 
 - If you have chosen to "Delete & Discard" an issue, then _future_ error events with the same fingerprint do not count toward your quota.
@@ -410,29 +426,5 @@ The precise limits may change over time. For more information, please refer to t
 If the event exceeds 200KB compressed or 1MB decompressed for events and 20MB
 compressed or 100MB decompressed for minidump uploads (all files combined),
 the event will be rejected.
-
-</Alert>
-
-<!-- ignore prettier start -->
-
-## What Counts Toward my Quota Table
-
-| Strategy                                                        | Yes, this event counts                     | No, this event does not count |
-| --------------------------------------------------------------- | ------------------------------------------ | ----------------------------- |
-| SDK configuration                                               | Not set                                    | Set to filter this event      |
-| SDK sample rate                                                 | Not set                                    | Set                           |
-| Quota                                                           | Not reached                                | Exceeded                      |
-| Are future error events that repeat set to Delete & Discard?    | No                                         |                               |
-| Is this a repeated error event for a previously resolved issue? | Yes, this may be a regression in your code |                               |
-| Is this repeated error event set to Ignore Alert?               | Yes, it is still occurring                 |                               |
-| Has spike protection (errors only) been triggered?              | No                                         | Yes                           |
-| Rate limit for error events for the project                     | Not set or not reached                     | Set and exceeded              |
-| Inbound filters (errors only)                                   | Not set                                    | Set for this error event      |
-
-<!-- ignore prettier end -->
-
-<Alert>
-
-Delete and discard and per-project rate limits are available only for Business plans.
 
 </Alert>

--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -53,7 +53,7 @@ Delete and discard and per-project rate limits are available only for Business p
 
 ## 1. Spike Protection
 
-Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. Learn more in [Spike Protection](#spike-protection).
+Sentry’s spike protection prevents huge overages in error events from consuming your event capacity. Spike protection is not currently available for transactions. 
 
 ### Managing a Spike {#-spike-protection-was-activated----what-should-i-do}
 
@@ -74,7 +74,7 @@ Also, consider doing the following:
 
 To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page.
 
-Learn more about [how spike protection works](/product/accounts/quotas/#spike-protection).
+Learn more about [how spike protection works](/product/accounts/quotas/#1-spike-protection).
 
 <!-- new stuff -->
 
@@ -210,7 +210,7 @@ We strongly recommend that you make subscription changes before the last day of 
 
 ## 4. Rate Limits
 
-If the error event rate limit for a project has been exceeded, and your subscription allows, the event will not be counted. Learn more in [Rate Limiting](/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) or in [Error Event Limits](/product/accounts/quotas/#error-event-limits). This does not apply to transactions or attachments.
+If the error event rate limit for a project has been exceeded, and your subscription allows, the error event or attachment will not be counted. This does not apply to transactions.
 
 In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -17,7 +17,7 @@ Applying the proper filters, SDK configuration, and rate limits is an iterative 
 
 ## 1. Spike Protection
 
-Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
+Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the other quota management methods that make sense for your use case.** Learn more in [Spike Protection](/product/accounts/quotas/#1-spike-protection).
 
 ## 2. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
@@ -27,23 +27,25 @@ Once you've completed the steps above, you can look at your events in aggregate 
 - Which projects are consuming my quota?
 - Which issues are consuming my quota?
 
-The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
+The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration. Learn more in [Event Usage Stats](/product/accounts/quotas/#common-workflows-for-managing-your-event-stream).
 
 ## 3. Quota Availability
 
 blah blah
 
+Learn more in [Quota Availability](/product/accounts/quotas/#3-quota-availability).
+
 ## 4. Rate Limiting
 
-Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
+Rate limiting allows you to limit the amount of events Sentry accepts per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes. Learn more in [Rate Limits](/product/accounts/quotas/#4-rate-limits). 
 
 ## 5. Delete & Discard Issues {#5-applying-workflows}
 
-Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
+Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it. Learn more in [Delete & Discard Issues](/product/accounts/quotas/#5-delete--discard-issues).
 
 ## 6. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#6-inbound-filters).
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 
@@ -51,11 +53,13 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 ## 7. Event Grouping
 
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_. Learn more in [Event Grouping](/product/accounts/quotas/#7-event-grouping).
 
 ## 8. SDK Sample Rate
 
 blah blah
+
+Learn more in [SDK Sample Rate](/product/accounts/quotas/#8-sdk-sample-rate).
 
 ## 9. SDK Filtering: beforeSend
 
@@ -63,4 +67,4 @@ All Sentry SDKs support the `beforeSend` callback method. Once implemented, the 
 
 ## 10. SDK Configuration
 
-The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
+The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Learn more in [SDK Configuration](/product/accounts/quotas/#10-sdk-configuration).

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -15,47 +15,11 @@ Sending all your application errors to Sentry ensures you'll be notified in real
 
 Applying the proper filters, SDK configuration, and rate limits is an iterative and on-going process, but these tips will show you how to get the most out of your error events.
 
-## 1. SDK Filtering: beforeSend
-
-All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
-
-## 2. SDK Configuration
-
-The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
-
-## 3. SDK Sample Rate
-
-blah blah
-
-## 4. Event Grouping
-
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
-
-## 5. Quota Availability
-
-blah blah
-
-## 6. Spike Protection
+## 1. Spike Protection
 
 Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
 
-## 7. Resolve or Delete Issues {#5-applying-workflows}
-
-Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
-
-## 8. Rate Limiting
-
-Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
-
-## 9. Inbound Data Filters
-
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
-
-Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
-
-![Built-in Inbound Filters](manage-event-stream-03.png)
-
-## 10. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
+## 2. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
 Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 
@@ -64,3 +28,39 @@ Once you've completed the steps above, you can look at your events in aggregate 
 - Which issues are consuming my quota?
 
 The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
+
+## 3. Quota Availability
+
+blah blah
+
+## 4. Rate Limiting
+
+Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
+
+## 5. Delete & Discard Issues {#5-applying-workflows}
+
+Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
+
+## 6. Inbound Data Filters
+
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+
+Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
+
+![Built-in Inbound Filters](manage-event-stream-03.png)
+
+## 7. Event Grouping
+
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+
+## 8. SDK Sample Rate
+
+blah blah
+
+## 9. SDK Filtering: beforeSend
+
+All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
+
+## 10. SDK Configuration
+
+The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -23,37 +23,6 @@ All Sentry SDKs support the `beforeSend` callback method. Once implemented, the 
 
 The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
 
-### JavaScript
-
-The JavaScript SDK includes multiple integrations: functional plugins that you can configure, enable, or disable. Learn more in [JavaScript SDK Integrations](/platforms/javascript/configuration/integrations/). Several integrations allow you to configure the types of events you want Sentry to monitor:
-
-#### InboundFilters
-
-The integration is enabled by default and adds the following configuration options to the SDK:
-
-- `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
-- `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
-- `ignoreErrors`: Instruct the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
-
-To learn more and see code samples, check out:
-
-- [Filtering](/platforms/javascript/configuration/filtering/)
-- [Enriching Events: Add Context](/platforms/javascript/enriching-events/context/)
-
-#### GlobalHandlers
-
-The integration attaches global handlers to capture uncaught exceptions (`onerror`) and unhandled rejections (`onunhandledrejection`). Both handlers are enabled by default, but can be disabled through configuration. Learn more in [GlobalHandlers Integration](/platforms/javascript/configuration/integrations/default/#globalhandlers).
-
-Check out additional configuration options with the [tryCatch](/platforms/javascript/configuration/integrations/default/#trycatch) and [ReportingObserver](/platforms/javascript/configuration/integrations/plugin/#reportingobserver) integrations.
-
-### Other SDKs
-
-**Java** - Sentry's [Java SDK](/platforms/java/) provides integrations with common Java logging libraries. The configuration allows you to set a logging threshold determining the minimum level to capture a log message as breadcrumb. It also provides a setting to configure the minimum log level to capture an event.
-
-**PHP** - The `error_types` configuration option allows you to set the error types you want Sentry to monitor. Learn more in PHP [Basic Options](/platforms/php/configuration/options/#common-options).
-
-**Ruby** - The `excluded_exceptions` configuration option allows you to set the exception types you wish to suppress. Learn more in the [Ruby configuration docs](/platforms/ruby/configuration/options/#optional-settings)
-
 ## 3. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
@@ -66,91 +35,17 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
 
-With JavaScript errors, minified source code might result in a nondeterministic stack trace that could negatively affect associated event grouping. To improve grouping, make sure Sentry has access to your source maps and minified artifacts. Learn more in [Source Maps](/platforms/javascript/sourcemaps/).
-
-![JavaScript stack trace without source maps](manage-event-stream-04.png)
-
-![JavaScript stack trace with source maps](manage-event-stream-05.png)
-
-For more information on the fingerprint algorithm and customizing event grouping, check out our [Issue Grouping docs](/product/data-management-settings/event-grouping/).
-
 ## 5. Resolve or Delete Issues {#5-applying-workflows}
 
 Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
-
-### Resolve
-
-You've been alerted on a new error in your code? Go to the **[Issue Details](/product/issues/issue-details/)** page to get all the data you need to know about the error. If it's a real issue in your code, assign a team member to resolve it. Don't forget to let Sentry know once it's resolved. Learn more about workflows for handling issues in [Issue States and Triage](/product/issues/states-triage/).
-
-### Delete & Discard
-
-<Note>
-
-  This feature is available only on a Business plan or higher.
-
-</Note>
-
-If there is an irrelevant, reoccurring issue that you are unable or unwilling to resolve, you can delete and discard it from the **Issue Details** page by clicking "Delete and discard future events". This will remove the issue and event data from Sentry and filter out future matching events.
-
-![Delete and Discard](manage-event-stream-06.png)
-
-You can find a list of these issues in the "Discarded Issues" tab in **[Project] > Settings > Inbound Filters**. From here, you can un-discarded any of these issues to receive future events.
-
-![List of Discarded Issues](manage-event-stream-07.png)
-
-<Note>
-
-Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
-
-</Note>
 
 ## 6. Rate Limiting
 
 Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
 
-In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
-
-![Per DSN Key rate limits](manage-event-stream-11.png)
-
-### Setting Useful Rate Limits {#-how-to-set-proper-rate-limits}
-
-A good way to set a project rate limit is by figuring out the expected event volume based on your average traffic. Let's look at an example:
-
-![Calculating rate limits](manage-event-stream-14.png)
-
-- Open the project DSN key configuration under **[Project] > Settings > Client Keys (DSN)** by clicking "Configure".
-- In the `KEY USAGE IN THE LAST 30 DAYS` graph and look for the highest point, or the maximum daily rate. In this example, the maximum daily rate in the last month is less than 326K.
-- Based on that, we can define a ceiling **daily** maximum value of approximantely 330K, which is around 13,750 events an **hour**, or  about 230 events a **minute**.
-- You can set a daily, hourly, or minute-based rate limit. We'd recommend using a minute-based rate to avoid situations where a random event spike might exhaust your daily or hourly quota and leave you blind for a long period.
-
-You should periodically go back and check the graph to see the number of events dropped due to rate limiting and, if needed, revisit your settings.
-
-![Revisit rate limits](manage-event-stream-15.png)
-
 ## 7. Spike Protection
 
 Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
-
-### Managing a Spike {#-spike-protection-was-activated----what-should-i-do}
-
-You might receive an email notifying you that spike protection was triggered and applied to your account.
-
-![Spike Protection Email](spike-email.jpg)
-
-Many times, an unexpected spike is caused by a new error (or errors) introduced into your code with a new release version. We understand that errors can come in spikes and service interruptions can be challenging, so we include a one-time grace period for all paid accounts.
-
-If an account depletes its event capacity and has never previously triggered a grace period, we continue to accept events for the next three days at a maximum rate of 10,000 events per hour. If you choose not to increase your capacity, Sentry will stop accepting events for the remainder of the current billing month. However, if you increase your capacity, events accepted during the grace period will be counted as consumed capacity.
-
-Once you've used your grace period, we recommend setting up an on-demand budget to ensure you have time to adjust your capacity in the event of a future spike in errors.
-
-Also, consider doing the following:
-
-- Set better rate limits on the DSN keys for the projects related to the spike. 
-- If it's a specific release version that has caused the spike, add the version identifier to the project's inbound filters to avoid accepting events from that release.
-
-To review the error events dropped because of spike protection, go to **Settings > Subscription** for your Sentry org and scroll to the "Error Usage" section of the page. 
-
-Learn more about [how spike protection works](/product/accounts/quotas/#spike-protection).
 
 ## 8. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
@@ -161,31 +56,3 @@ Once you've completed the steps above, you can look at your events in aggregate 
 - Which issues are consuming my quota?
 
 The answers to these questions can help you figure out where you need to do further fine-tuning of your filters, limits, or SDK configuration.
-
-### How can I see a breakdown of incoming events? {#-how-can-i-see-a-breakdown-of-incoming-events}
-
-The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events (by project) into three categories:
-
-- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
-- **Dropped**: Events that were discarded due to a limit being hit.
-- **Filtered**: Events that were blocked based on your inbound filter rules.
-
-![Overview of Usage Stats page](../../stats/usage-stats.png)
-
-You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
-
-### What are my busiest projects? {#-what-are-my-busiest-projects}
-
-The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project, so you can see which ones are consuming your quota.Clicking on the settings icon next to a project name in the table will open the project's settings page where you can manage its inbound filters and rate limits
-
-You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
-
-### Which issues are consuming my quota? {#-what-issues-are-consuming-my-quota}
-
-The Sentry workflow starts with a real-time alert notifying you about an error in your code. If you want to take a more proactive approach to resolving your busiest issues, you can set up a query in **Discover**. When you're building the query, search for `event.type:error` and then set the columns `issue`, `title`, `project`, and `count()`, as shown below:
-
-![Busiest Projects](manage-event-stream-02.png)
-
-Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest issues:
-
-![Busiest Issues](manage-event-stream-10.png)

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -23,7 +23,31 @@ All Sentry SDKs support the `beforeSend` callback method. Once implemented, the 
 
 The Sentry SDKs have several configuration options that can be used to filter unwanted errors from leaving your application's runtime. A lot of these options are platform-specific, so make sure you look for yours in our docs under [Platforms](/platforms/) and [Configuration](/platform-redirect/?next=/configuration/). Following are some examples.
 
-## 3. Inbound Data Filters
+## 3. SDK Sample Rate
+
+blah blah
+
+## 4. Event Grouping
+
+Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
+
+## 5. Quota Availability
+
+blah blah
+
+## 6. Spike Protection
+
+Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
+
+## 7. Resolve or Delete Issues {#5-applying-workflows}
+
+Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
+
+## 8. Rate Limiting
+
+Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
+
+## 9. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
 
@@ -31,23 +55,7 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 ![Built-in Inbound Filters](manage-event-stream-03.png)
 
-## 4. Event Grouping
-
-Proper event grouping is essential to maintaining a meaningful set of issues and reducing redundant notifications. Sentry groups similar error events into unique _[issues](/product/issues/)_ based on their _fingerprint_. An event's fingerprint relies firstly on its _stack trace_.
-
-## 5. Resolve or Delete Issues {#5-applying-workflows}
-
-Now that your error events have been fine-tuned to reflect real problems in your code, it's an excellent practice to react to errors as they happen. If an issue reflects a real problem in your code, resolve it; otherwise, delete and discard it.
-
-## 6. Rate Limiting
-
-Rate limiting allows you to [limit the amount of events Sentry accepts](/product/accounts/quotas/#what-counts-toward-my-quota-table-view) per project for a defined time span. While this is quite useful for managing your monthly event quota, keep in mind that once a defined threshold is crossed, **subsequent events will be dropped**. Therefore, you shouldn't constantly be hitting your rate limit; rather, it should act as a ceiling intended to protect you from unexpected spikes.
-
-## 7. Spike Protection
-
-Sentry also applies a dynamic rate limit to your account designed to protect you from short-term spikes. **However, we still recommend applying all of the previously mentioned methods.**
-
-## 8. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
+## 10. Event Usage Stats {#common-workflows-for-managing-your-event-stream}
 
 Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer some key questions like:
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -11,7 +11,11 @@ In most cases, sending all [transaction](/product/performance/transaction-summar
 
 When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.
 
-## 2. Inbound Data Filters
+## 2. Quota Availability
+
+blah blah
+
+## 3. Inbound Data Filters
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
 
@@ -19,6 +23,6 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 ![Built-in Inbound Filters](manage-event-stream-03.png)
 
-## 3. Event Usage Stats
+## 4. Event Usage Stats
 
 Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration.

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -21,32 +21,4 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 ## 3. Event Usage Stats
 
-Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK filters and configuration.
-
-### How can I see a breakdown of incoming events?
-
-The [Usage Stats](/product/stats/#usage-stats) tab displays details about the total number of events Sentry has received across your entire organization for up to 90 days. The page breaks down the events, by project, into three categories:
-
-- **Accepted**: Events processed and displayed in the issues or transactions views in [sentry.io](https://sentry.io).
-- **Dropped**: Events that were discarded due to a limit being hit.
-- **Filtered**: Events that were blocked based on your inbound filter rules.
-
-![Overview of Usage Stats page](../../stats/usage-stats.png)
-
-You can also download monthly reports with a similar breakdown of all your previous billing periods under **Settings > Subscription** in the "Usage History" tab.
-
-### What are my busiest projects?
-
-The "Project" table in the "Usage Stats" tab of **Stats** breaks down your events by project so you can see which ones are consuming your quota. Clicking on the settings icon next to a project name in the table will open the project's settings, where you can manage its inbound filters and rate limits
-
-You can also download monthly reports that provide a breakdown of events by project under **Settings > Subscription** in the "Usage History" tab.
-
-### Which transactions are consuming my quota?
-
-You can set up a query in **Discover** to see which transactions you're receiving the most and if you want to adjust that. When you're building the query, search for `event.type:transaction` and then set the columns to `title`, `project`, and `count`, as shown below:
-
-![Busiest Projects](manage-trans-quota-01.png)
-
-Once the changes are applied, sort the "Results" table by the "COUNT" column to display your busiest transactions:
-
-![Busiest Issues](manage-trans-quota-02.png)
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration.

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -9,15 +9,17 @@ In most cases, sending all [transaction](/product/performance/transaction-summar
 
 ## 1. Event Usage Stats
 
-Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration.
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration. Learn more in [Event Usage Stats](/product/accounts/quotas/#common-workflows-for-managing-your-event-stream).
 
 ## 2. Quota Availability
 
 blah blah
 
+Learn more in [Quota Availability](/product/accounts/quotas/#3-quota-availability).
+
 ## 3. Inbound Data Filters
 
-While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#inbound-data-filters).
+While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**. Learn more in [Inbound Filters](/product/accounts/quotas/#6-inbound-filters).
 
 Once applied, you can track the filtered events (numbers and cause) using the graph provided at the top of the "Inbound Filters" page.
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -7,9 +7,9 @@ description: "Learn how to use the tools Sentry provides to control the type and
 
 In most cases, sending all [transaction](/product/performance/transaction-summary/#what-is-a-transaction) events to Sentry would generate more performance data than you might find useful and might use up your transactions quota too quickly. Sentry provides tools to control the _type_ and _amount_ of transactions that are monitored. This allows you to have transaction data that's actionable and meaningful, and to manage your quota. Applying the proper SDK configuration is an iterative and on-going process, but these tips will show you how to best use Sentry's tools to get the most out of your transaction events.
 
-## 1. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
+## 1. Event Usage Stats
 
-When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.
+Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration.
 
 ## 2. Quota Availability
 
@@ -23,6 +23,6 @@ Once applied, you can track the filtered events (numbers and cause) using the gr
 
 ![Built-in Inbound Filters](manage-event-stream-03.png)
 
-## 4. Event Usage Stats
+## 4. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
 
-Once you've completed the steps above, you can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK configuration.
+When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.


### PR DESCRIPTION
- Restructures Quota Management index page with more content from guides
- Adds missing content from guides
- Converts existing table to markdown and revamps it
- Makes guides much shorter, referencing content on index page