### PR TITLE
feat(alerts): Remove EA label from duplicate alerts

### DIFF
--- a/src/docs/product/alerts/create-alerts/index.mdx
+++ b/src/docs/product/alerts/create-alerts/index.mdx
@@ -23,14 +23,6 @@ To create alerts:
 
 ## Duplicate Alerts
 
-<Note>
-
-  This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-  If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
 You can also create an alert by duplicating an existing issue or metric alert rule. To do so, navigate to **Alerts** and click "Duplicate" in the context menu (under "Actions") on the row with the alert rule you want to copy:
 
 ![Expanded alert list row context menu](alert-list-row-menu.png)


### PR DESCRIPTION
This removes the EA label from duplicate alerts for GA.