### PR TITLE
Dart: Document Scope Deprecations

### DIFF
--- a/src/includes/enriching-events/scopes/scope-synchronization/flutter.mdx
+++ b/src/includes/enriching-events/scopes/scope-synchronization/flutter.mdx
@@ -1,0 +1,12 @@
+### Scope Synchronization
+
+Starting with version '6.6.0' of the SDK, setting data on the Flutter `Scope` can be synced to the Android and iOS SDKs. This behaviour is enabled by default and can be disabled by setting `SentryOptions.enableScopeSync` to false. The following `Scope` methods will sync and can also be awaited upon:
+  - `setContexts`
+  - `removeContexts`
+  - `setUser`
+  - `addBreadcrumb`
+  - `clearBreadcrumbs`
+  - `setExtra`
+  - `removeExtra`
+  - `setTag`
+  - `removeTag`

--- a/src/includes/enriching-events/scopes/scope-synchronization/flutter.mdx
+++ b/src/includes/enriching-events/scopes/scope-synchronization/flutter.mdx
@@ -1,6 +1,6 @@
 ### Scope Synchronization
 
-Starting with version '6.6.0' of the SDK, setting data on the Flutter `Scope` can be synced to the Android and iOS SDKs. This behaviour is enabled by default and can be disabled by setting `SentryOptions.enableScopeSync` to false. The following `Scope` methods will sync and can also be awaited upon:
+Starting with version `6.6.0` of the SDK, setting data on the Flutter `Scope` can be synced to the Android and iOS SDKs. This behavior is enabled by default and can be disabled by setting `SentryOptions.enableScopeSync` to false. The following `Scope` methods will sync and can also be awaited upon:
   - `setContexts`
   - `removeContexts`
   - `setUser`

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -430,7 +430,7 @@ If the callback is not set, or it returns `undefined`, the default naming scheme
 <ConfigKey name="enabled" supported={["javascript", "node"]}>
 
 Specifies whether this SDK should send events to Sentry. Defaults to `true`.  Setting this to `enabled: false` doesn't prevent all overhead from Sentry instrumentation. To disable Sentry completely, depending on environment, call `Sentry.init` conditionally.
-  
+
 </ConfigKey>
 
 <ConfigKey name="send-client-reports" supported={["java", "javascript", "dotnet", "python", "dart", "apple"]} notSupported={["react-native"]}>
@@ -657,6 +657,12 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 <ConfigKey name="onReady" supported={["react-native"]}>
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).
+
+</ConfigKey>
+
+<ConfigKey name="enableScopeSync" supported={["flutter"]}>
+
+Set this boolean to `false` to disable sync of `Scope` data to Android and iOS SDKs.
 
 </ConfigKey>
 

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -84,7 +84,7 @@ You can also apply this configuration when unsetting a user at logout:
 
 </PlatformSection>
 
-<PlatformSection supported={["android"]}>
+<PlatformSection supported={["android", "flutter"]}>
 
 <PlatformContent includePath="enriching-events/scopes/scope-synchronization" />
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -18,7 +18,7 @@ Future<void> main() async {
 
 - The `Scope.user` setter was deprecated in favor of `Scope.setUser`, and it will be removed in a future update.
 
-- `Scope.attachements` getter was deprecated in favor of `attachments` and it will be removed in a future update.
+- The `Scope.attachements` getter was deprecated in favor of `attachments`, and it will be removed in a future update.
 
 ### Sentry Self-hosted Compatibility
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -16,7 +16,7 @@ Future<void> main() async {
 }
 ```
 
-- `Scope.user` setter was deprecated in favor of `Scope.setUser` and it will be removed in a future update.
+- The `Scope.user` setter was deprecated in favor of `Scope.setUser`, and it will be removed in a future update.
 
 - `Scope.attachements` getter was deprecated in favor of `attachments` and it will be removed in a future update.
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -20,7 +20,7 @@ Future<void> main() async {
 
 - The `Scope.attachements` getter was deprecated in favor of `attachments`, and it will be removed in a future update.
 
-- The following `Scope` methods now return `Future<void>` instead od `void`:
+- The following `Scope` methods now return `Future<void>` instead of `void`:
   - `setContexts`
   - `removeContexts`
   - `setUser`

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -18,7 +18,7 @@ Future<void> main() async {
 
 - `Scope.user` setter was deprecated in favor of `Scope.setUser` and it will be removed in a future update.
 
-- `Scope.attachements` getter was deprecated in favour of `attachments` and it will be removed in a future update.
+- `Scope.attachements` getter was deprecated in favor of `attachments` and it will be removed in a future update.
 
 ### Sentry Self-hosted Compatibility
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -16,6 +16,10 @@ Future<void> main() async {
 }
 ```
 
+- 'Scope.user' setter was deprecated in favour of `Scope.setUser` and it will be removed in a future update.
+
+- `Scope.attachements` getter was deprecated in favour of `attachments` and it will be removed in a future update.
+
 ### Sentry Self-hosted Compatibility
 
 - Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -20,6 +20,17 @@ Future<void> main() async {
 
 - The `Scope.attachements` getter was deprecated in favor of `attachments`, and it will be removed in a future update.
 
+- The following `Scope` methods now return `Future<void>` instead od `void`:
+  - `setContexts`
+  - `removeContexts`
+  - `setUser`
+  - `addBreadcrumb`
+  - `clearBreadcrumbs`
+  - `setExtra`
+  - `removeExtra`
+  - `setTag`
+  - `removeTag`
+
 ### Sentry Self-hosted Compatibility
 
 - Starting with version `6.6.0` of `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -16,7 +16,7 @@ Future<void> main() async {
 }
 ```
 
-- 'Scope.user' setter was deprecated in favour of `Scope.setUser` and it will be removed in a future update.
+- `Scope.user` setter was deprecated in favor of `Scope.setUser` and it will be removed in a future update.
 
 - `Scope.attachements` getter was deprecated in favour of `attachments` and it will be removed in a future update.
 


### PR DESCRIPTION
Document user and attachments deprecations of `Scope`.