### PR TITLE
docs: add alternative snippet that blocks on sentry-cli errors

### DIFF
--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -169,7 +169,7 @@ You need to have an Auth Token for this to work. You can [create an Auth Token h
 
 <Alert level="" title="Warnings vs. Errors">
 
-Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it, like in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols woudn't be able to be symbolicated until after release.
+Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it. For example, in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols couldn't be symbolicated until after release, it might be better to fail the build.
 
 Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` to `YES` in build settings for configurations you use to deploy to production.
 

--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -167,7 +167,8 @@ You need to have an Auth Token for this to work. You can [create an Auth Token h
 1.  Download and install [sentry-cli](/product/cli/installation/)
 2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
 
-<Alert level="" title="Warnings vs. errors">
+<Alert level="" title="Warnings vs. Errors">
+
 Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it, like in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols woudn't be able to be symbolicated until after release.
 
 Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` to `YES` in build settings for configurations you use to deploy to production.

--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -165,9 +165,9 @@ Your project’s dSYM can be upload during the build phase as a “Run Script”
 You need to have an Auth Token for this to work. You can [create an Auth Token here](https://sentry.io/api/).
 
 1.  Download and install [sentry-cli](/product/cli/installation/)
-2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
+2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_ (depending on your needs, you may want to emit warnings or errors to the Xcode build log to either let the build pass, or to fail it, like in a CI deployment)
 
-```bash
+```bash {tabTitle:Warn on failures - nonblocking}
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
@@ -178,6 +178,20 @@ echo "warning: sentry-cli - $ERROR"
 fi
 else
 echo "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
+fi
+```
+
+```bash {tabTitle:Error on failures - blocking}
+if which sentry-cli >/dev/null; then
+export SENTRY_ORG=___ORG_SLUG___
+export SENTRY_PROJECT=___PROJECT_SLUG___
+export SENTRY_AUTH_TOKEN=YOUR_AUTH_TOKEN
+ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
+if [ ! $? -eq 0 ]; then
+echo "error: sentry-cli - $ERROR"
+fi
+else
+echo "error: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
 fi
 ```
 

--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -170,7 +170,8 @@ You need to have an Auth Token for this to work. You can [create an Auth Token h
 <Alert level="" title="Warnings vs. errors">
 Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it, like in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols woudn't be able to be symbolicated until after release.
 
-Another option is to use warnings, and then set GCC_TREAT_WARNINGS_AS_ERRORS to YES in build settings for configurations you use to deploy to production.
+Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` to `YES` in build settings for configurations you use to deploy to production.
+
 </Alert>
 
 ```bash {tabTitle:Warn on failures - nonblocking}

--- a/src/includes/debug-symbols-apple/_default.mdx
+++ b/src/includes/debug-symbols-apple/_default.mdx
@@ -165,7 +165,13 @@ Your project’s dSYM can be upload during the build phase as a “Run Script”
 You need to have an Auth Token for this to work. You can [create an Auth Token here](https://sentry.io/api/).
 
 1.  Download and install [sentry-cli](/product/cli/installation/)
-2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_ (depending on your needs, you may want to emit warnings or errors to the Xcode build log to either let the build pass, or to fail it, like in a CI deployment)
+2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
+
+<Alert level="" title="Warnings vs. errors">
+Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it, like in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols woudn't be able to be symbolicated until after release.
+
+Another option is to use warnings, and then set GCC_TREAT_WARNINGS_AS_ERRORS to YES in build settings for configurations you use to deploy to production.
+</Alert>
 
 ```bash {tabTitle:Warn on failures - nonblocking}
 if which sentry-cli >/dev/null; then


### PR DESCRIPTION
Some developers may want errors from `sentry-cli` to break their builds, like if it's part of a CI deployment that shouldn't succeed, lest they encounter sentry issues with unsymbolicated symbols. This gives an example of each as copyable snippets, with a quick explainer on the difference.

<img width="746" alt="Screen Shot 2022-06-15 at 6 10 27 PM" src="https://user-images.githubusercontent.com/3241469/173941044-3172cbbe-9a30-4889-bd01-dd2ef1d5496e.png">
<img width="768" alt="Screen Shot 2022-06-15 at 6 10 57 PM" src="https://user-images.githubusercontent.com/3241469/173941047-7b9c98dd-8247-43d6-b84d-ed19cc98899e.png">

