### PR TITLE
Add installation troubleshooting note for MAUI

### DIFF
--- a/src/platforms/dotnet/guides/maui/index.mdx
+++ b/src/platforms/dotnet/guides/maui/index.mdx
@@ -9,7 +9,7 @@ Sentry has an integration for the [.NET Multi-platform App UI (MAUI)](https://do
 
 ## Installation
 
-Add the Sentry dependency:
+Add the Sentry dependency to your .NET MAUI application:
 
 ```powershell {tabTitle:Package Manager}
 Install-Package Sentry.Maui -Version 3.18.0-preview.1
@@ -20,6 +20,23 @@ dotnet add package Sentry.Maui -v 3.18.0-preview.1
 ```
 
 This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extensions-logging/). This means that besides the MAUI related features, through this package you'll also get access to all the framework's logging integration and also the features available in the main [Sentry](/platforms/dotnet/) SDK.
+
+<Note>
+
+#### Troubleshooting
+
+The MAUI workloads are updated by Microsoft periodically. When trying to install or update `Sentry.Maui`, you may get errors such as the following:
+
+```
+error: NU1605: Detected package downgrade: Microsoft.Maui.Dependencies from 6.0.400 to 6.0.312. Reference the package directly from the project to select a different version.
+error:  test -> Sentry.Maui 3.18.0-preview.1 -> Microsoft.Maui.Dependencies (>= 6.0.400)
+error:  test -> Microsoft.Maui.Dependencies (>= 6.0.312)
+```
+
+This happens when you have an older version of the `maui` workload than the one that was current when we built the package.
+We are investigating how to avoid this issue in a future release.  For now, you can update your workloads by using the `dotnet workload update` command.  See [this issue](https://github.com/getsentry/sentry-dotnet/issues/1724) for further details.
+
+</Note>
 
 ### Configure
 


### PR DESCRIPTION
Add a note about a common error users may get when installing the new .NET MAUI package.