### PR TITLE
Move API SHA bump to its own script

### DIFF
--- a/scripts/bump-api-schema-sha.sh
+++ b/scripts/bump-api-schema-sha.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script is part of the API docs build process:
+#
+#  https://develop.sentry.dev/api/public/#build-process
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+SENTRY_API_SCHEMA_SHA="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
+sed -i -e 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "'$SENTRY_API_SCHEMA_SHA'"|g' src/gatsby/utils/resolveOpenAPI.ts

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+
+# This script is part of the monthly CalVer release:
+#
+#   https://github.com/getsentry/sentry-docs/blob/master/.github/workflows/release.yml#L24
+#   https://github.com/getsentry/action-prepare-release/blob/main/action.yml
+#   https://github.com/getsentry/craft#pre-release-command
+
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
-SENTRY_API_SCHEMA_SHA="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
 
-# These commands won't work on our machines since they're running macosx
-if [ "${1:-prod}" == "prod" ]; then
-	sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
-	sed -i -e 's|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = "'$SENTRY_API_SCHEMA_SHA'"|g' src/gatsby/utils/resolveOpenAPI.ts
-fi
+sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE


### PR DESCRIPTION
Overloading the `bump-version.sh` Craft [hook](https://github.com/getsentry/craft#pre-release-command) to also be used from localhost during [more-frequent API doc updates](https://develop.sentry.dev/api/public/#build-process) added some [inter-environment friction](https://github.com/getsentry/sentry-docs/pull/5115) that resulted in [a CalVer release failure](https://github.com/getsentry/self-hosted/issues/1515#issuecomment-1156787127).

Seems great to update the API docs more frequently than once a month, and that means it would be redundant to also do this during monthly CalVer release, so let's move that to a separate script.