### PR TITLE
fix(rn): Heading on getting started

### DIFF
--- a/src/includes/getting-started-install/react-native.mdx
+++ b/src/includes/getting-started-install/react-native.mdx
@@ -32,7 +32,7 @@ Link the SDK to your native projects to enable native crash reporting.
 react-native link @sentry/react-native
 ```
 
-### Run the Sentry Wizard.
+### Run the Sentry Wizard
 
 ```bash
 npx @sentry/wizard -i reactNative -p ios android


### PR DESCRIPTION
Remove the period at the end of the heading. Having a period only for one heading looks weird.
<img width="182" alt="Screen Shot 2022-06-17 at 08 42 37" src="https://user-images.githubusercontent.com/2443292/174240792-7fda1f0b-ebd4-4fbf-97d0-ad5114b48aa4.png">

