### PR TITLE
fix(apple): Note on pre warmed app starts

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -52,7 +52,7 @@ To enable this feature enable `AutoUIPerformanceTracking`. The SDK differentiate
 * __Cold start__: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
 * __Warm start__: App launched at least once, is partially in memory, and no process exists.
 
-The SDK uses the process start time as the beginning of the app start and the [`UIWindowDidBecomeVisibleNotification`][UIWindow] as the end. It creates the following spans:
+The SDK uses the process start time as the beginning of the app start and the [`UIWindowDidBecomeVisibleNotification`][UIWindow] as the end. Since iOS 15, the system might decide to pre-warm your app by already creating the process before the user opens it. In such cases, we can't reliably measure the app start, and we drop it. The SDK creates the following spans:
 * __Pre Main__: From the process start time to the runtime init.
 * __UIKit and Application Init__: From the runtime init to the [`didFinishLaunchingNotification`][didFinishLaunching].
 * __Initial Frame Render__: From the [`didFinishLaunchingNotification`][didFinishLaunching] to [`UIWindowDidBecomeVisibleNotification`][UIWindow].


### PR DESCRIPTION
With https://github.com/getsentry/sentry-cocoa/issues/1849,
we stop reporting pre-warm app starts. Add a note to the docs
to avoid confusion.

Only merge after https://github.com/getsentry/sentry-cocoa/issues/1849 is released.
