### PR TITLE
ref(alerts): Mention issue owner alert types

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -90,13 +90,7 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Issue Owners
 
-[Issue owners](/product/issues/issue-owners/) can receive notifications (emails only) when an alert is triggered.
-
-<Note>
-
-For early adopters, these notifications are received by email or Slack depending on the [notification settings](/product/alerts/notifications/notification-settings/) of the issue owner.
-
-</Note>
+[Issue owners](/product/issues/issue-owners/) can receive notifications by email or Slack depending on the [notification settings](/product/alerts/notifications/notification-settings/) of the issue owner when an alert is triggered.
 
 If an issue owner is not configured or not found, either the notification won’t be sent or it’ll be sent to all project members, depending on the following setting in **[Project] > Settings > Issue Owners**.
 


### PR DESCRIPTION
Remove the EA mention of issue owner Slack alerts and make it a normal GA thing. This has been out for a while but it was missed when we GA'd the feature 😬 