### PR TITLE
fix(integrations): Add redirect from product page

### DIFF
--- a/src/docs/product/integrations/issue-tracking/height/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/height/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Height
 sidebar_order: 1
+redirect_from:
+  - /product/integrations/height/
 description: "Learn more about Sentry's Height integration and how you can effortlessly create new Height tasks from Sentry and link Sentry issues to existing Height tasks."
 ---
 

--- a/src/docs/product/integrations/notification-incidents/threads/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/threads/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Threads
 sidebar_order: 1
+redirect_from:
+  - /product/integrations/threads/
 description: "Learn more about Sentry's Threads integration and how you can effortlessly send alerts from Sentry to Threads."
 ---
 


### PR DESCRIPTION
Add a redirect so that when users click "View Documentation" in the integration overview page, it actually goes to the page ☠️ 