### PR TITLE
docs: clarifying Hermes artifacts

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -32,7 +32,7 @@ If you are manually bundling and building React Native apps, follow this three-s
 
 ### Compile Sourcemaps
 
-1. Bundle/minify with `metro` (`react-native`) to get the packager source map (`.packager.map`):
+1. Bundle/minify with `metro` (`react-native`) to get the bundle (`.bundle`) and packager source map (`.packager.map`):
 
 ```bash {tabTitle:Android}
 npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map
@@ -74,6 +74,6 @@ Upload your source maps following [Step 3 on the normal source maps guide](/plat
 
 <Note>
 
-You will upload the **original** bundle (output from Step 1) and the **composed** source map (output from Step 3)
+You will upload the **original** bundle (`.bundle`, output from Step 1) and the **composed** source map (`.map`, output from Step 3)
 
 </Note>


### PR DESCRIPTION


<!-- Describe your PR here. -->

This PR hopes to clarify the sentence 'You will upload the **original** bundle (output from Step 1) and the **composed** source map (output from Step 3)' from the docs. It took me a while to figure out what was meant here, because Step 1 has _two_ outputs, the bundle and the packager source map. 

So I clarified in step one that there's two outputs, and clarified which of those outputs need to be uploaded.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
