### PR TITLE
Remove explicit rewrite flags from sentry cli RN

### DIFF
--- a/src/docs/clients/react-native/sourcemaps.mdx
+++ b/src/docs/clients/react-native/sourcemaps.mdx
@@ -15,7 +15,7 @@ This SDK has been superseded by the new React Native SDK. Sentry preserves this 
 
 Currently automatic source map handling is only implemented for iOS with Xcode and Android with gradle. If you manually invoke the [react-native packager](https://github.com/facebook/metro) you can however get source maps anyways by passing _–sourcemap-output_ to it.
 
-If you do get source maps, you can upload them with `sentry-cli`. Before _v1.59.0_, please ensure passing `--rewrite` to the `upload-sourcemaps` command which will fix up the source maps before the upload (inlines sources etc.). As of _1.59.0_, this is done automatically.
+If you do get source maps, you can upload them with `sentry-cli`.
 
 Example:
 
@@ -39,6 +39,12 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
     --strip-prefix /path/to/project/root \
     /path/to/your/files
 ```
+
+<Note>
+
+If you're using `sentry-cli` prior to version 1.59.0, pass `--rewrite` to the `upload-sourcemaps` command to fix up the source maps before the upload (inlines sources and so forth). Version 1.59.0 does this automatically.
+
+</Note>
 
 The values for `RELEASE_NAME` and `DISTRIBUTION_NAME` are as follows:
 

--- a/src/platforms/react-native/sourcemaps.mdx
+++ b/src/platforms/react-native/sourcemaps.mdx
@@ -99,7 +99,7 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
     upload-sourcemaps \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
-    --rewrite index.android.bundle index.android.bundle.map
+    index.android.bundle index.android.bundle.map
 ```
 
 ```bash {tabTitle:iOS}
@@ -108,7 +108,7 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
     upload-sourcemaps \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
-    --rewrite main.jsbundle main.jsbundle.map
+    main.jsbundle main.jsbundle.map
 ```
 
 <Note>


### PR DESCRIPTION



<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
