### PR TITLE
feat(discover): Include count_web_vitals in query builder and query equations

### DIFF
--- a/src/docs/product/discover-queries/query-builder.mdx
+++ b/src/docs/product/discover-queries/query-builder.mdx
@@ -106,6 +106,7 @@ You can also add any of the following functions as columns to stack events:
 - `count_if(...)`
 - `count_miserable(...)`
 - `count_unique(...)`
+- `count_web_vitals(...)`
 - `epm()`
 - `eps()`
 - `failure_count()`

--- a/src/docs/product/discover-queries/query-builder/query-equations.mdx
+++ b/src/docs/product/discover-queries/query-builder/query-equations.mdx
@@ -65,6 +65,7 @@ Equations can only operate on numeric columns and functions, which includes:
   - count
   - count_unique
   - count_if
+  - count_web_vitals
   - failure_count
   - avg
   - sum

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -76,6 +76,7 @@ Release properties overlap with event and issue search properties, so they don't
 | count_if<br></br>(column,operator,value) | Returns results with a matching count that satisfy the condition passed to the parameters of the function. | x |  | number |
 | count_miserable<br></br>(field,threshold) | Returns results with a matching count of unique instances of the field that fall above the miserable threshold. | x |  | number |
 | count_unique(field) | Returns results with a matching count of the unique instances of the field entered. | x |  | number |
+| count_web_vitals(vital,threshold) | Returns results with a matching count of web vitals which meet the given quality threshold (`poor`, `meh`, `good`, or `any`). | x |  | number |
 | culprit | Deprecated | x |  | string |
 | device.arch | CPU architecture | x | x | string |
 | device.battery_level | If the device has a battery, this can be a floating point value defining the battery level (in the range 0-100). | x |  | string |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -76,7 +76,7 @@ Release properties overlap with event and issue search properties, so they don't
 | count_if<br></br>(column,operator,value) | Returns results with a matching count that satisfy the condition passed to the parameters of the function. | x |  | number |
 | count_miserable<br></br>(field,threshold) | Returns results with a matching count of unique instances of the field that fall above the miserable threshold. | x |  | number |
 | count_unique(field) | Returns results with a matching count of the unique instances of the field entered. | x |  | number |
-| count_web_vitals(vital,threshold) | Returns results with a matching count of web vitals which meet the given quality threshold (`poor`, `meh`, `good`, or `any`). | x |  | number |
+| count_web_vitals(vital,threshold) | Returns results with a matching count that meet a web vitals quality threshold (`poor`, `meh`, `good`, or `any`). | x |  | number |
 | culprit | Deprecated | x |  | string |
 | device.arch | CPU architecture | x | x | string |
 | device.battery_level | If the device has a battery, this can be a floating point value defining the battery level (in the range 0-100). | x |  | string |


### PR DESCRIPTION
Includes the `count_web_vitals` function within the Query Builder and Query Equations pages in the docs

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/16740047/174679036-a343baf4-6494-4f8c-83a2-f626eda5ea22.png">


<img width="1671" alt="image" src="https://user-images.githubusercontent.com/16740047/174679406-51d92d94-6d5f-40a6-8901-094e3e3d5132.png">
