### PR TITLE
Remove extra import from Prisma example.

### DIFF
--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -16,7 +16,6 @@ For example:
 import { PrismaClient } from '@prisma/client';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
-import { randomBytes } from 'crypto';
 
 const client = new PrismaClient();
 


### PR DESCRIPTION
That import is unnecessary and is a leftover from the Prisma demo app.