### PR TITLE
Prevent confusion between environment and tag. 

### DIFF
--- a/src/platforms/common/configuration/environments.mdx
+++ b/src/platforms/common/configuration/environments.mdx
@@ -8,7 +8,7 @@ notSupported:
 
 Environments tell you where an error occurred, whether that's in your production system, your staging server, or elsewhere.
 
-Sentry automatically creates an environment when it receives an event with the `environment` tag set.
+Sentry automatically creates an environment when it receives an event with the `environment` parameter set.
 
 Environments are case sensitive. The environment name can't contain newlines, spaces or forward slashes, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](/product/sentry-basics/environments/#hidden-environments) them.
 


### PR DESCRIPTION
This text makes users confuse environments with tags. In this context it is the environment parameter that is given to the init() function.
