### PR TITLE
clarify how sentry-cli associates commits

### DIFF
--- a/src/docs/product/releases/suspect-commits/index.mdx
+++ b/src/docs/product/releases/suspect-commits/index.mdx
@@ -76,7 +76,10 @@ sentry-cli releases new -p project1 -p project2 $VERSION
 sentry-cli releases set-commits --auto $VERSION
 ```
 
-If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. The `--auto` flag gets the identity of the remote <what?> locally, but pulls the identity of the current `head` and the contents of the commit from the remote. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag.
+If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag. 
+
+Alternatively, you can use the `--local` flag to enable this behavior by default.
+
 
 For more control over which commits to associate, or if you're unable to execute the command inside the repository, you can manually specify a repository and range.
 

--- a/src/docs/product/releases/suspect-commits/index.mdx
+++ b/src/docs/product/releases/suspect-commits/index.mdx
@@ -76,23 +76,20 @@ sentry-cli releases new -p project1 -p project2 $VERSION
 sentry-cli releases set-commits --auto $VERSION
 ```
 
-If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag. 
+If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag.
 
-Alternatively, you can use the `--local` flag to enable this behavior by default.
-
-
-For more control over which commits to associate, or if you're unable to execute the command inside the repository, you can manually specify a repository and range.
-
-The following example associates commits (or refs) between `from` and `to` with the current release, where `from` is the previous release’s commit. The repository name `my-repo` should match the name you entered when linking the repo using the form `owner-name/repo-name`. The `from` commit is optional; we’ll use the previous release’s commit as the baseline if it is excluded.
-
-```bash
-sentry-cli releases set-commits --commit "my-repo@from..to" $VERSION
-```
-
-Alternatively, you can use the `--local` flag to automatically associate commits between the previous release's head commit and the current head commit with the release, but only based on your local history.
+Alternatively, you can use the `--local` flag to enable this behavior by default:
 
 ```bash
 sentry-cli releases set-commits --local $VERSION
+```
+
+For more control over which commits to associate, or if you're unable to execute the command inside the repository, you can manually specify a repository and range.
+
+The following example associates commits (or refs) between `from` and `to` with the current release, where `from` is the previous release’s commit. The repository name `my-repo` should match the name you entered when linking the repo using the form `owner-name/repo-name`. The `from` commit is optional; we’ll use the previous release’s commit as the baseline if it is excluded:
+
+```bash
+sentry-cli releases set-commits --commit "my-repo@from..to" $VERSION
 ```
 
 ### Using the API

--- a/src/docs/product/releases/suspect-commits/index.mdx
+++ b/src/docs/product/releases/suspect-commits/index.mdx
@@ -76,7 +76,7 @@ sentry-cli releases new -p project1 -p project2 $VERSION
 sentry-cli releases set-commits --auto $VERSION
 ```
 
-If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag.
+If you don't have a repo-based integration associated with your Sentry organization, then the `--auto` flag will automatically use the git tree of your local repo, and associate commits between the previous release's head commit and the current head commit with the release. The `--auto` flag gets the identity of the remote <what?> locally, but pulls the identity of the current `head` and the contents of the commit from the remote. If this is the first release, Sentry will use the latest 10 - 20 commits, depending on the integration. This behavior is configurable with the `--initial-depth` flag.
 
 For more control over which commits to associate, or if you're unable to execute the command inside the repository, you can manually specify a repository and range.
 
@@ -86,7 +86,7 @@ The following example associates commits (or refs) between `from` and `to` with 
 sentry-cli releases set-commits --commit "my-repo@from..to" $VERSION
 ```
 
-Alternatively, you can use the `--local` flag to enable this behavior by default.
+Alternatively, you can use the `--local` flag to automatically associate commits between the previous release's head commit and the current head commit with the release, but only based on your local history.
 
 ```bash
 sentry-cli releases set-commits --local $VERSION


### PR DESCRIPTION
Updates language around how sentry-CLI associates commits when you don't have a repo-based integration

I've started with edits based on the conversation that happened on PR 5108, but I'm not sure if I've got this at all right.

Original conversation on PR 5108:
https://github.com/getsentry/sentry-docs/pull/5108/files#r893972887 
https://github.com/getsentry/sentry-docs/pull/5108/files#r896895816