### PR TITLE
chore(docs): More description for options details

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
@@ -59,7 +59,7 @@ The [issue linking](/product/integrations/integration-platform/ui-components/iss
   "name": <String>,
   "uri": <URI>,
   "async": <Bool>,
-  "options": <Array<String, String>>,
+  "options": <Array<Array<String, String>>>,
   "depends_on": <Array<String>>,
   "skip_load_on_open": <Array<String>>
 }
@@ -71,7 +71,7 @@ The [issue linking](/product/integrations/integration-platform/ui-components/iss
 - `name` - (Required) Value to use in `name` attribute of the field
 - `uri` - (Required if developer doesn't provide `options`) URI to retrieve values from. Check out our [URI Guidelines](/product/integrations/integration-platform/ui-components/#uri-guidelines) documentation for formatting help.
 - `async` - (Optional) Used only if `uri` is present. If true (default), will query the URI as the user types, for autocomplete suggestions (see response format below). If false, will query the URI once initially to retrieve all possible options. This request _must_ succeed, and the response _must_ return data in the format Sentry expects, otherwise the entire component won't render.
-- `options` - (Required if developer doesn't provide `uri`) Static list of options in the format of [value, label]
+- `options` - (Required if developer doesn't provide `uri`) Static list of options in the format of `[["value1", "label1"], ["value2", "label2"]]`
 - `depends_on` - (Optional) If a field value depends on the value of another field, a request will be made to load those options when the dependent field is set.
 - `skip_load_on_open` (Optional) If true, this field will not load options when the page loads. Instead, it will wait for the user to start typing before fetching options.
 


### PR DESCRIPTION
Adds a bit more description to the 'options' field requirements




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
