### PR TITLE
Added missing parameter

### DIFF
--- a/src/includes/configuration/before-send-hint/php.laravel.mdx
+++ b/src/includes/configuration/before-send-hint/php.laravel.mdx
@@ -1,5 +1,5 @@
 ```php {filename:config/sentry.php}
-'before_send' => function (\Sentry\Event $event): ?\Sentry\Event {
+'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
     // Ignore the event if the original exception is an instance of MyException
     if ($hint !== null && $hint->exception instanceof MyException) {
       return null;

--- a/src/includes/configuration/before-send-hint/php.symfony.mdx
+++ b/src/includes/configuration/before-send-hint/php.symfony.mdx
@@ -20,7 +20,7 @@ class Sentry
 {
     public function getBeforeSend(): callable
     {
-        return function (\Sentry\Event $event): ?\Sentry\Event {
+        return function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
             // Ignore the event if the original exception is an instance of MyException
             if ($hint !== null && $hint->exception instanceof MyException) {
               return null;


### PR DESCRIPTION
Added the parameter `hint` because in the prose before the code snippet it is stated that a parameter `hint` is present and then in the code snippet there was none.

fixes #5149
