### PR TITLE
Use elevated token to trigger CI from automated PR

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -16,7 +16,10 @@ jobs:
       - name: "Bump API Schema SHA"
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # An elevated token is necessary because with plain github.token
+          # GitHub does not recursively call workflows, which means CI does not
+          # kick off for the PR we're about to create.
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: |
           git config user.email "bot@getsentry.com"
           git config user.name "openapi-getsentry-bot"


### PR DESCRIPTION
Could've caught this [the other day](https://github.com/getsentry/develop/pull/607), but had to hear it from Support. ¯\\\_(ツ)\_/¯

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow