### PR TITLE
Migration page for RN v4

### DIFF
--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -4,6 +4,12 @@ sidebar_order: 100
 description: "Learn about migrating from 1.x to 2.x to enable release health tracking and native stack traces by default."
 ---
 
+## From 3.x to 4.x
+
+By bumping Sentry JavaScript to v7, new breaking changes were introduced, to know more what was changed, check the [breaking changes changelog](https://github.com/getsentry/sentry-javascript/blob/7.0.0/CHANGELOG.md#breaking-changes) from Sentry Javascript.
+
+By bumping Sentry Android to v6, new breaking changes were introduced, to know more what was changed, check the [migration guide](/platforms/android/migration/#migrating-from-iosentrysentry-android-5x-to-iosentrysentry-android-600).
+
 ## From 3.0.x to 3.1.x
 
 `ReactNavigationV5Instrumentation` was renamed to `ReactNavigationInstrumentation` and supports every version of React Navigation from v5 onwards, including v6. You only need to change the name wherever you call the constructor for the instrumentation:


### PR DESCRIPTION
https://github.com/getsentry/sentry-react-native/releases/tag/4.0.0