### PR TITLE
Update send_attempts option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -547,7 +547,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 <ConfigKey name="send-attempts" supported={["php"]}>
 
-Controls how many times the SDK will attempt to resend an event to Sentry. The default is `3`.
+_Deprecated._ Controls how many times the SDK will attempt to resend an event to Sentry. The default is `0`.
 
 </ConfigKey>
 


### PR DESCRIPTION
The send_attempts option was deprecated and default changed to 0 in https://github.com/getsentry/sentry-php/pull/1312

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
