### PR TITLE
Document new timeout options

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -551,6 +551,18 @@ Controls how many times the SDK will attempt to resend an event to Sentry. The d
 
 </ConfigKey>
 
+<ConfigKey name="http-connect-timeout" supported={["php"]}>
+
+The maximum number of seconds to wait while trying to connect to a server. The default is `2`.
+
+</ConfigKey>
+
+<ConfigKey name="http-timeout" supported={["php"]}>
+
+The maximum execution time in seconds for the request+response as a whole. The value should also include the time for the connect phase, so it should be greater than the value set for the `http_connect_timeout` option. The default is `5`.
+
+</ConfigKey>
+  
 </PlatformSection>
 
 <PlatformSection supported={["node", "javascript", "python", "php", "dotnet", "java", "ruby", "go", "react-native", "android", "dotnet", "rust", "native"]}>


### PR DESCRIPTION
The http_connect_timeout and http_timeout options were added in https://github.com/getsentry/sentry-php/pull/1282

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
