### PR TITLE
ref(native): update capture-error with a new higher level stacktrace API

### DIFF
--- a/src/includes/capture-error/native.mdx
+++ b/src/includes/capture-error/native.mdx
@@ -20,10 +20,7 @@ The above exception does not contain a stack trace, which must be added separate
 sentry_value_t event = sentry_value_new_event();
 
 sentry_value_t exc = sentry_value_new_exception("Exception", "Error message.");
-
-sentry_value_t stacktrace = sentry_value_new_stacktrace(NULL, 0);
-sentry_value_set_by_key(exc, "stacktrace", stacktrace);
-
+sentry_value_set_stacktrace(exc, NULL, 0);
 sentry_event_add_exception(event, exc);
 
 sentry_capture_event(event);


### PR DESCRIPTION
Since `sentry_value_set_stacktrace()` (https://github.com/getsentry/sentry-native/pull/723) was [released](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0418) with version [0.4.18 of sentry-native](https://github.com/getsentry/sentry-native/commit/ff5bfcf0eb2c47d03eb57a51bdf2e6ad4b8ece10), we now can also update the docs accordingly.

@Swatinem can you please give this a quick check. Thx!