### PR TITLE
chore(android): Switch to SAGP stable version in integrations docs

### DIFF
--- a/src/platforms/android/configuration/integrations/fragment.mdx
+++ b/src/platforms/android/configuration/integrations/fragment.mdx
@@ -28,7 +28,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.android.gradle" version "3.1.0-beta.1"
+  id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
@@ -40,7 +40,7 @@ buildscript {
 }
 
 plugins {
-  id("io.sentry.android.gradle") version "3.1.0-beta.1"
+  id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -36,7 +36,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.android.gradle" version "3.1.0-beta.1"
+  id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
@@ -48,7 +48,7 @@ buildscript {
 }
 
 plugins {
-  id("io.sentry.android.gradle") version "3.1.0-beta.1"
+  id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id "io.sentry.android.gradle" version "3.1.0-beta.1"
+  id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
@@ -42,7 +42,7 @@ buildscript {
 }
 
 plugins {
-  id("io.sentry.android.gradle") version "3.1.0-beta.1"
+  id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 


### PR DESCRIPTION
Was an oversight when bumping it on the Gradle docs