### PR TITLE
fix(apple): Clarify UI interaction operations

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -206,11 +206,11 @@ SentrySDK.start { options in
 }];
 ```
 
-The SDK composes the transaction name out of the host `UIViewController` and the method that the `UIView` is calling; for example, `YourApp_LoginUIViewController.loginButton`. The transaction operation is set to `ui.action` plus the interaction type `click`. The transaction finishes automatically after it reaches the specified [idleTimeout](/platforms/android/configuration/options/#idle-timeout) and all of its child spans are finished. The `idleTimeoout` defaults to `3000` milliseconds (three seconds).
+The SDK composes the transaction name out of the host `UIViewController` and the method that the `UIView` is calling; for example, `YourApp_LoginUIViewController.loginButton`. The SDK sets the transaction operation to `ui.action`. If the SDK detects the interaction's origin was a click, it adds `click` as a suffix to the operation. The transaction finishes automatically after it reaches the specified [idleTimeout](/platforms/android/configuration/options/#idle-timeout) and all of its child spans are finished. The `idleTimeoout` defaults to `3000` milliseconds (three seconds).
 
 <Note>
 
-If the UI transaction has idled, but didn't have any child spans added, it will be dropped.
+If the UI transaction has idled but didn't have any child spans added, the SDK will drop it.
 
 </Note>
 


### PR DESCRIPTION
Clarify when the Cocoa SDK adds the click suffix
to UI interactions transactions and when not.
