### PR TITLE
Document implications of tree shaking `__SENTRY_TRACING__`

### DIFF
--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -24,7 +24,7 @@ To make optional code eligible for tree shaking, you can replace various flags i
 `__SENTRY_TRACING__`
 
 : Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
-**Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're directly using the `@sentry/trace` package, or when you're using any performance monitoring related SDK features (e.g. `Sentry.startTransaction()`).
+**Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're directly using the `@sentry/tracing` package, or when you're using any performance monitoring related SDK features (e.g. `Sentry.startTransaction()`).
 This flag is intended to be used in combination with packages like `@sentry/next` where the `@sentry/trace` package is used implicitly.
 
 <PlatformSection notSupported={["javascript.nextjs"]}>

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -23,7 +23,9 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 `__SENTRY_TRACING__`
 
-: Replacing this flag with `false` will tree shake all code in the SDK that is related to automatic instrumentation performance monitoring.
+: Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
+**Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're directly using the `@sentry/trace` package, or when you're using any performance monitoring related SDK features (e.g. `Sentry.startTransaction()`).
+This flag is intended to be used in combination with packages like `@sentry/next` where the `@sentry/trace` package is used implicitly.
 
 <PlatformSection notSupported={["javascript.nextjs"]}>
 


### PR DESCRIPTION
The `__SENTRY_TRACING__` tree-shaking flag in the JS SDK is supposed to be used in combination with packages like the Next.js SDK where `@sentry/tracing` usage. It shouldn't be used when directly using methods from the `@sentry/tracing` package, like for example `Sentry.startTransaction()`.

To make this a little bit more explicit and to avoid confusion (like reported in https://github.com/getsentry/sentry-javascript/issues/5320) we're documenting this with this PR.