### PR TITLE
Clarify attachments upload limits, taking compression into account

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -124,7 +124,7 @@ Unity features a global <PlatformLink to="/enriching-events/scopes/">scope</Plat
 
 <Note>
 
-Sentry allows at most 100MB of attachments per event, including the crash report file (if applicable) Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
+Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
 <PlatformSection supported={["native"]}>
 


### PR DESCRIPTION
This clarifies limits for upload-like endpoints that are already in place (20 MB compressed, 100 MB uncompressed), similar to ones already described in:
https://develop.sentry.dev/sdk/envelopes/#size-limits
https://docs.sentry.io/platforms/native/guides/minidumps/#size-limits