### PR TITLE
Modify user setup snippet as current snippet represent deprecated method

### DIFF
--- a/src/includes/enriching-events/set-user/dart.mdx
+++ b/src/includes/enriching-events/set-user/dart.mdx
@@ -2,6 +2,6 @@
 import 'package:sentry/sentry.dart';
 
 Sentry.configureScope(
-  (scope) => scope.user = SentryUser(id: '1234', email: 'jane.doe@example.com'),
+  (scope) => scope.setUser(SentryUser(id: '1234', email: 'jane.doe@example.com')),
 );
 ```

--- a/src/includes/enriching-events/unset-user/dart.mdx
+++ b/src/includes/enriching-events/unset-user/dart.mdx
@@ -1,5 +1,5 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-Sentry.configureScope((scope) => scope.user = null);
+Sentry.configureScope((scope) => scope.setUser(null));
 ```


### PR DESCRIPTION
<!-- Describe your PR here. -->

Current dart snippet for setting user in Sentry scope is deprecated with the latest version of Sentry. Snippet has been updated to follow the latest version of Sentry


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
