### PR TITLE
fix(sentry apps): Fix url -> uri typo

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/alert-rule-action.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/alert-rule-action.mdx
@@ -60,7 +60,7 @@ The alert rule action component gives you to access to parameters to define rout
             "type": "select",
             "label": "Assignee",
             "name": "assignee",
-            "url": "/sentry/alert-rule/options/users/"
+            "uri": "/sentry/alert-rule/options/users/"
           }
         ]
       }


### PR DESCRIPTION
Fix the example where it says "url" instead of "uri". Double checked this on the [source of truth](https://github.com/getsentry/integration-platform-example/blob/main/integration-schema.json#L79-L82) 😉. 