### PR TITLE
apple: remove mention of experimental feature

### DIFF
--- a/src/includes/getting-started-primer/apple.macos.mdx
+++ b/src/includes/getting-started-primer/apple.macos.mdx
@@ -9,7 +9,6 @@
   - C++ exceptions
   - Objective-C exceptions
   - Error messages of fatalError, assert, and precondition
-  - Main thread deadlock (experimental)
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data
 - Offline caching when a device is unable to connect; we send a report once we receive another event
 - [Breadcrumbs automatically](/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for


### PR DESCRIPTION
See: https://github.com/getsentry/sentry-cocoa/issues/1052#issuecomment-1129736553

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
