### PR TITLE
enable screenshot doc for Unity

### DIFF
--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -5,6 +5,7 @@ description: "Learn more about taking screenshots when an error occurs. Sentry p
 supported:
   - android
   - apple.ios
+  - unity
 notSupported:
   - apple.macos
   - apple.tvos
@@ -14,12 +15,6 @@ notSupported:
 When a user experiences an error, Sentry provides the ability to take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink>.
 
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, taking a screenshot requires the UI thread and in the event of a crash, that might not be available. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature will be a best effort solution.
-
-<PlatformSection supported={["apple.ios"]}>
-
-On iOS, only manually captured errors or exceptions will contain a screenshot.
-
-</PlatformSection>
 
 ## Enabling Screenshots
 

--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -6,6 +6,7 @@ supported:
   - android
   - apple.ios
   - unity
+  - dotnet.xamarin
 notSupported:
   - apple.macos
   - apple.tvos


### PR DESCRIPTION
Enable the screenshot doc for Unity

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
