### PR TITLE
fix(electron): Remove attachment docs

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -16,6 +16,8 @@ supported:
 
 ---
 
+<PlatformSection notSupported={["javascript.electron"]}>
+
 <PlatformSection supported={["apple", "android", "java"]}>
 
 Please note that attachments don't work yet with crashes.
@@ -137,6 +139,8 @@ Usually, native crash reports range from a few kilobytes to a few megabytes. Thi
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 
 Learn more about how attachments impact your [quota](/product/accounts/quotas/).
+
+</PlatformSection>
 
 <PlatformSection supported={["native", "javascript.electron"]}>
 


### PR DESCRIPTION
For now the Electron SDK does not support the new JS attachments API. This will change soon