### PR TITLE
Update Chrome docs broken link + feature name

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -70,7 +70,7 @@ To fix this, change the `tracingOrigins` option during SDK initialization. For m
 
 ## `instrument.js` Line Numbers for Console Log statements
 
-If `instrument.js` displays in your console while debugging, add Sentry to your framework [blackboxing](https://developer.chrome.com/devtools/docs/blackboxing) settings like: `/@sentry/` so Chrome ignores the SDK stackframes when debugging.
+If `instrument.js` displays in your console while debugging, add Sentry to your Framework [Ignore List](https://developer.chrome.com/docs/devtools/javascript/ignore-chrome-extension-scripts/) by adding this pattern: `/@sentry/` so Chrome ignores the SDK stackframes when debugging.
 
 ## Dealing with Ad-Blockers
 


### PR DESCRIPTION
The docs used the old term for a Chrome DevTools feature: `framework blackboxing` which was changed to `Framework Ignore List`.

The URL to the `blackboxing` docs was broken and led to the main page of the Chrome Developers Docs. I searched for a Docs article about `Framework Ignore List` and only found a stub that seemed to focus more on ignoring Chrome extension scripts. I used this URL as it's the closest to the original `blackboxing` URL. I tried this fix and it worked.

I hope this makes sense. I wish there was a more thorough article about this Chrome feature. If any changes are needed, please let me know!

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
