### PR TITLE
ios screenshots for crashes

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -373,7 +373,7 @@ This is the maximum number of properties or entries that will be included in any
 <ConfigKey name="attach-screenshot" supported={["android", "apple.ios", "unity", "dotnet.xamarin"]}>
 
 Takes a screenshot of the application when an error happens and includes it as an attachment.
-Screenshots for hard crashes are not supported on iOS.
+Learn more on <PlatformLink to="/enriching-events/screenshots/">`Enriching Events with Screenshots</PlatformLink>.
 
 <PlatformSection supported={["android"]}>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -373,7 +373,7 @@ This is the maximum number of properties or entries that will be included in any
 <ConfigKey name="attach-screenshot" supported={["android", "apple.ios", "unity", "dotnet.xamarin"]}>
 
 Takes a screenshot of the application when an error happens and includes it as an attachment.
-Learn more on <PlatformLink to="/enriching-events/screenshots/">`Enriching Events with Screenshots</PlatformLink>.
+Learn more in <PlatformLink to="/enriching-events/screenshots/">Enriching Events with Screenshots</PlatformLink>.
 
 <PlatformSection supported={["android"]}>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -373,7 +373,7 @@ This is the maximum number of properties or entries that will be included in any
 <ConfigKey name="attach-screenshot" supported={["android", "apple.ios", "unity", "dotnet.xamarin"]}>
 
 Takes a screenshot of the application when an error happens and includes it as an attachment.
-Learn more in <PlatformLink to="/enriching-events/screenshots/">Enriching Events with Screenshots</PlatformLink>.
+Learn more about enriching events with screenshots in our <PlatformLink to="/enriching-events/screenshots/">Screenshots documentation</PlatformLink> .
 
 <PlatformSection supported={["android"]}>
 


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
