### PR TITLE
Add snippet for Xamarin Screenshot

### DIFF
--- a/src/includes/enriching-events/attach-screenshots/dotnet.xamarin.mdx
+++ b/src/includes/enriching-events/attach-screenshots/dotnet.xamarin.mdx
@@ -1,0 +1,7 @@
+```csharp
+SentryXamarin.Init(options =>
+{
+    options.Dsn = "___PUBLIC_DSN___";
+    options.AttachScreenshots = true;
+});
+```


### PR DESCRIPTION
This adds the missing configuration Sample for screenshots on Sentry Xamarin.

