### PR TITLE
Add legacy warning to integrations page

### DIFF
--- a/src/docs/clients/javascript/integrations.mdx
+++ b/src/docs/clients/javascript/integrations.mdx
@@ -7,6 +7,12 @@ noindex: true
 tags: []
 ---
 
+<Alert level="warning" title="Note">
+
+A new JavaScript SDK has superseded this deprecated version. Sentry preserves this documentation for customers using the old client. We recommend using the [updated JavaScript SDK](/platforms/javascript/) for new projects.
+
+</Alert>
+
 Integrations extend the functionality of Raven.js to cover common libraries and environments automatically using simple plugins.
 
 ## What are plugins? {#what-are-plugins}


### PR DESCRIPTION
Add legacy warning to integrations page, similar to the one here: https://docs.sentry.io/clients/javascript/