### PR TITLE
Fix wrong URL in link for sampling.mdx

### DIFF
--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -106,7 +106,7 @@ When using custom instrumentation to create a transaction, you can add data to t
 
 <!-- TODO: the link in the paragraph below is intentionally hard-coded to point at JS, since for now that's where the information lives -->
 
-Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See [Connecting Services](/platforms/python/performance/) for more about how that propagation is done.)
+Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See <PlatformLink to="/performance/connect-services">Connecting Services</PlatformLink> for more about how that propagation is done.)
 
 If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid partial traces.)
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -104,9 +104,19 @@ When using custom instrumentation to create a transaction, you can add data to t
 
 ## Inheritance
 
-<!-- TODO: the link in the paragraph below is intentionally hard-coded to point at JS, since for now that's where the information lives -->
+Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services.
 
-Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See <PlatformLink to="/performance/connect-services/">Connecting Services</PlatformLink> for more about how that propagation is done.)
+<PlatformSection notSupported={["javascript.cordova", "php"]}>
+
+(See <PlatformLink to="/performance/connect-services/">Connecting Services</PlatformLink> for more about how that propagation is done.)
+
+</PlatformSection>
+
+<PlatformSection supported={["php.laravel"]}>
+
+(See [Connecting Services](/platforms/php/guides/laravel/performance/connect-services/) for more about how that propagation is done.)
+
+</PlatformSection>
 
 If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid partial traces.)
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -106,7 +106,7 @@ When using custom instrumentation to create a transaction, you can add data to t
 
 <!-- TODO: the link in the paragraph below is intentionally hard-coded to point at JS, since for now that's where the information lives -->
 
-Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See [Connecting Services](/platforms/javascript/performance/) for more about how that propagation is done.)
+Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See [Connecting Services](/platforms/python/performance/) for more about how that propagation is done.)
 
 If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid partial traces.)
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -106,7 +106,7 @@ When using custom instrumentation to create a transaction, you can add data to t
 
 <!-- TODO: the link in the paragraph below is intentionally hard-coded to point at JS, since for now that's where the information lives -->
 
-Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See <PlatformLink to="/performance/connect-services">Connecting Services</PlatformLink> for more about how that propagation is done.)
+Whatever a transaction's sampling decision, that decision will be passed to its child spans and from there to any transactions they subsequently cause in other services. (See <PlatformLink to="/performance/connect-services/">Connecting Services</PlatformLink> for more about how that propagation is done.)
 
 If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid partial traces.)
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

The link to the "Connecting Services" page was for the JavaScript docs, not the Python docs.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
