### PR TITLE
docs(dashboards): Revert Releases widget docs

### DIFF
--- a/src/docs/product/dashboards/widget-builder/index.mdx
+++ b/src/docs/product/dashboards/widget-builder/index.mdx
@@ -76,19 +76,6 @@ Choose this dataset if you want to customize a list of issues on your dashboard.
 - Most frequently occurring issues
 - The "Issues" dataset is only available in table visualization widgets and its disabled if you have other visualizations selected.
 
-### Releases
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
-Choosing "Releases (sessions, crash rates)" allows you to query properties specific to a release of your application, primarily session data. Choose this dataset if you want to display healthy, errored, and crashed sessions and crash rates for your releases or projects on your dashboard. This dataset isn't available in for [world map](#world-map) visualizations. Some example widgets using this dataset include:
-- Crash rates for your latest release
-- Session count across releases
-
 ## Choose Your Columns
 
 The option to set columns is only available for [table visualizations](/product/dashboards/widget-builder/#table).

--- a/src/docs/product/dashboards/widget-library/index.mdx
+++ b/src/docs/product/dashboards/widget-library/index.mdx
@@ -22,15 +22,6 @@ The library includes the following widgets:
 - **Issues For Review**: A table of unresolved issues for review, ordered by the most recently seen issues
 - **Top Unhandled Error Types**: The most frequently encountered unhandled errors
 - **Users Affected by Errors**: A comparison of the total number of errors and the number of unique users affected by the errors
-- **Crash Rates for Recent Releases**: Percentage of crashed sessions for your recent releases
-- **Session Health**: The total number of abnormal, crashed, errored, and healthy sessions
-
-<Note>
-
-The Crash Rates for Recent Releases and Session Health widgets are available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
 
 You can change the title, queries, fields, visualization types, sort order, and other fields of these prebuilt widgets to suit your use case by clicking the context menu on the widget and selecting "Edit Widget".
 
@@ -99,21 +90,3 @@ Update "Columns" to add `links` so you can see seen any external links related t
 
 - Columns: `issue, assignee, events, title, links`
 - Sort by: `Priority`
-
-
-### Release health
-
-<Note>
-
-This feature is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
-To monitor the health of your releases over time, you can modify the "Session Health" widget as follows:
-
-- Visualization Display: `Area Chart`
-
-Add search filters to narrow the data down to a particular release:
-
-- Search condition 1: `release:{version}`


### PR DESCRIPTION
We've completely rolled back Release widgets in dashboards
for the time being so rolling back the docs too.

