### PR TITLE
fix servers spelling error

### DIFF
--- a/src/platforms/go/common/serverless.mdx
+++ b/src/platforms/go/common/serverless.mdx
@@ -44,6 +44,6 @@ The only requirement is that you locate the source code on the deployed machine.
 ### Events Delivery
 
 Most (if not all) serverless solutions won't wait for network responses before closing the process.
-Because of that, we need to make sure that the event is delivered to Sentry's severs.
+Because of that, we need to make sure that the event is delivered to Sentry's servers.
 
 It can be achieved twofold, using the [`sentry.Flush` method](../configuration/draining/) or by swapping the transport to [`HTTPSyncTransport`](../configuration/transports/#httpsynctransport).


### PR DESCRIPTION


<!-- Describe your PR here. -->
Fixing a spelling error in go serverless document.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
