### PR TITLE
fix(native): clean up install/build instructions

### DIFF
--- a/src/includes/getting-started-install/native.mdx
+++ b/src/includes/getting-started-install/native.mdx
@@ -6,9 +6,9 @@ For example, `CMake` can be used like this (on macOS):
 
 ```shell
 # configure the cmake build into the `build` directory, with crashpad (on macOS)
-cmake -B build -D SENTRY_BACKEND=crashpad --config RelWithDebInfo -S .
+cmake -B build -D SENTRY_BACKEND=crashpad
 # build the project
-cmake --build build --config RelWithDebInfo --parallel
+cmake --build build --parallel
 # install the resulting artifacts into a specific prefix
 cmake --install build --prefix install
 # which will result in the following (on macOS):

--- a/src/includes/getting-started-install/native.mdx
+++ b/src/includes/getting-started-install/native.mdx
@@ -5,8 +5,11 @@ To build the SDK, download the latest sources from the [Releases page](https://g
 For example, `CMake` can be used like this (on macOS):
 
 ```shell
-# configure the cmake build into the `build` directory, with crashpad (on macOS)
-cmake -B build -D SENTRY_BACKEND=crashpad
+# Configure the CMake build into the `build` directory with crashpad (the default
+# backend on macOS, thus optional to specify). Specifying `RelWithDebInfo` as the 
+# `CMAKE_BUILD_TYPE` is also optional because it is the default in sentry-native
+# for all generators supporting it.
+cmake -B build -D SENTRY_BACKEND=crashpad -D CMAKE_BUILD_TYPE=RelWithDebInfo
 # build the project
 cmake --build build --parallel
 # install the resulting artifacts into a specific prefix
@@ -23,6 +26,35 @@ install
    ├── libsentry.dylib
    └── libsentry.dylib.dSYM
 ```
+
+contrast the above with the build-steps for a typical msbuild project on Windows:
+
+```shell
+# The msbuild generator ignores the CMAKE_BUILD_TYPE because it contains all 
+# build-types. Here we leave out the backend specification and rely on CMake
+# selecting crashpad as Windows' default backend.
+cmake -B build 
+# The actual build step then requires we specify which build-type we want 
+# to apply via the `--config` parameter. Please be aware that in msbuild 
+# projects, the `--parallel` option has no effect. 
+cmake --build build --config RelWithDebInfo
+# install the resulting artifacts (again requiring build-type!)
+cmake --install build --prefix install --config RelWithDebInfo
+# which will result in the following output (ignoring non-essential lines):
+tree /f install
+├───bin
+│       crashpad_handler.exe
+│       crashpad_handler.pdb
+│       sentry.dll
+│       sentry.pdb
+│
+├───include
+│       sentry.h
+│
+└───lib
+    │   sentry.lib
+```
+
 
 [cmake]: https://cmake.org/cmake/help/latest/
 

--- a/src/includes/getting-started-install/native.qt.mdx
+++ b/src/includes/getting-started-install/native.qt.mdx
@@ -18,12 +18,10 @@ For example (on macOS):
 # with crashpad, and Qt integration (on macOS).
 cmake -B build \
     -D SENTRY_BACKEND=crashpad \
-    -D SENTRY_INTEGRATION_QT=YES \
-    --config RelWithDebInfo \
-    -S .
+    -D SENTRY_INTEGRATION_QT=YES
 
 # Build the project
-cmake --build build --config RelWithDebInfo --parallel
+cmake --build build --parallel
 
 # Install the resulting artifacts into a specific prefix
 cmake --install build --prefix install

--- a/src/includes/getting-started-install/native.qt.mdx
+++ b/src/includes/getting-started-install/native.qt.mdx
@@ -39,6 +39,8 @@ install
    └── libsentry.dylib.dSYM
 ```
 
+You can configure the Qt build for Windows analogous to the [regular build instructions](/platforms/native/#install).
+
 [cmake]: https://cmake.org/cmake/help/latest/
 
 <Alert level="warning" title="Bundling crashpad_handler">


### PR DESCRIPTION
This fixes https://github.com/getsentry/sentry-docs/issues/5274. It seems the docs got a bit out of sync with the repository documentation. I took the liberty of cleaning up the required build steps as follows:

We can remove the CMAKE_BUILD_TYPE entirely for the purpose of this documentation because it uses our default build type. In addition to that, it would have to be passed as `-DCMAKE_BUILD_TYPE=RelWithDebInfo` and not via `--config` at the build-generator stage. This leads to an error in CMake [starting with version 3.20](https://cmake.org/cmake/help/latest/release/3.20.html#other-changes).

In the actual compile/build stage it could be passed via `--config` for build-generators that provide all build-types under a single hierarchy (like Visual Studio solutions). This is also not applicable for a
macOS example, but was silently ignored. I removed it too.

Last but not least, I got rid of the explicit `-S .` (=source) argument, because the [default value when not specifying the source directory is also the cwd](https://cmake.org/cmake/help/latest/manual/cmake.1.html#generate-a-project-buildsystem).

@Swatinem as always, welcome your input.