### PR TITLE
(.NET): Update TracerSampling Key reference

### DIFF
--- a/src/includes/performance/traces-sampler-as-sampler/dotnet.aspnetcore.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/dotnet.aspnetcore.mdx
@@ -17,7 +17,7 @@ options.TracesSampler = context =>
     }
 
     // Otherwise, sample based on URL (exposed through custom sampling context)
-    return context.CustomSamplingContext.GetValueOrDefault("__HttpPath") switch
+    return context.CustomSamplingContext.GetValueOrDefault("url") switch
     {
         // These are important - take a big sample
         "/payment" => 0.5,


### PR DESCRIPTION
Aims to fix the following issue: https://github.com/getsentry/sentry-docs/issues/5124


Sampling context was retrieving the wrong key on the Documentation.

Also, only ASP.NET Core has `TryGetHttpPath` so for other platforms I only fixed the correct key where in ASP.NET Core I used the appropriate extension.