### PR TITLE
docs(js): Add decompress flag to sourcemaps troubleshooting

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -203,7 +203,9 @@ Often users hit this limit because they are transmitting source files at an inte
 
 The Sentry API currently only works with source maps and source files that are uploaded as plain text (UTF-8 encoded). If the files are uploaded in a compressed format (for example, gzip), they will be not be interpreted correctly.
 
-This sometimes occurs with build scripts and plugins that produce pre-compressed minified files. For example, Webpack’s [compression plugin](https://github.com/webpack/compression-webpack-plugin). You’ll need to disable such plugins and perform the compression _after_ the generated source maps/source files have been uploaded to Sentry.
+If you are using `sentry-cli` to upload your artifacts, starting version `2.4.0` you can add `--decompress` flag to your `sourcemaps upload` or `files upload` commands.
+
+However, this sometimes also occurs with build scripts and plugins that produce pre-compressed minified files. For example, Webpack’s [compression plugin](https://github.com/webpack/compression-webpack-plugin). Otherwise, you’ll need to disable such plugins and perform the compression _after_ the generated source maps/source files have been uploaded to Sentry.
 
 ## Verify workers are sharing the same volume as web (if running self-hosted Sentry via Docker)
 


### PR DESCRIPTION
NOTE: Merge only once `2.4.0` is actually released.