### PR TITLE
feat(apple): Add troubleshooting page

### DIFF
--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -4,12 +4,6 @@ sidebar_order: 10
 description: "Learn how to turn off Out Of Memory"
 ---
 
-<Alert level="info" title="Important">
-
-We recommend updating to at least [7.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.11.0), because the SDK might falsely report out-of-memory crashes when an app hangs, and the user kills it manually.
-
-</Alert>
-
 This integration tracks out-of-memory (OOM) crashes based on heuristics. This feature is available for iOS, tvOS, and Mac Catalyst, works only if the application was in the foreground, and doesn't track OOMs for unit tests.
 
 When a typical unhandled error occurs, the Apple SDK writes a report to disk with the current state of your application, with details like the stack trace, tags, breadcrumbs, and so on, before the app terminates. With OOM crashes, the operating system can kill your app without further notice, which means the SDK can't write a report to disk.

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -50,12 +50,6 @@ This feature is available for iOS, tvOS, and Mac Catalyst.
 The App Start Instrumentation provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
 To enable this feature, enable `AutoUIPerformanceTracking`.
 
-<Alert level="info" title="Important">
-
-Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we can't reliably measure the app start, so we drop it as of [sentry-cocoa 7.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.0). We are working on a fix for this. Follow the [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/1897) for more details.
-
-</Alert>
-
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
 * __Cold start__: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
@@ -71,12 +65,6 @@ The SDK uses the process start time as the beginning of the app start and the [`
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
 ## Slow and Frozen Frames
-
-<Alert level="info" title="Important">
-
-We recommend updating to at least [7.18.1](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.1), or else the SDK might report too high a percentage of slow frames.
-
-</Alert>
 
 This feature is available for iOS, tvOS, and Mac Catalyst.
 

--- a/src/platforms/apple/troubleshooting.mdx
+++ b/src/platforms/apple/troubleshooting.mdx
@@ -14,7 +14,7 @@ We recommend updating to at least [7.18.1](https://github.com/getsentry/sentry-c
 
 ## Falsely Reported Out Of Memory Crashes
 
-We recommend updating to at least [7.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.11.0), because the SDK might falsely report out-of-memory crashes when an app hangs, and the user kills it manually.
+We recommend updating to at least [7.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.11.0), because before this version the SDK might falsely report out-of-memory crashes when an app hangs, and the user kills it manually.
 
 ## Crashes with HTTP Auto Performance Instrumentation
 

--- a/src/platforms/apple/troubleshooting.mdx
+++ b/src/platforms/apple/troubleshooting.mdx
@@ -1,0 +1,21 @@
+---
+title: Troubleshooting
+description: "Troubleshoot and resolve common issues with the Cocoa SDK."
+sidebar_order: 2000
+---
+
+## Wrong App Start Data
+
+Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we can't reliably measure the app start, so we drop it as of [sentry-cocoa 7.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.0). We are working on a fix for this. Follow the [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/1897) for more details.
+
+## High Slow and Frozen Frames Rate
+
+We recommend updating to at least [7.18.1](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.1), or else the SDK might report too high a percentage of slow frames.
+
+## Falsely Reported Out Of Memory Crashes
+
+We recommend updating to at least [7.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.11.0), because the SDK might falsely report out-of-memory crashes when an app hangs, and the user kills it manually.
+
+## Crashes with HTTP Auto Performance Instrumentation
+
+We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3), because the HTTP instrumentation can lead to crashes. Alternatively, you can also <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#http-instrumentation">disable the feature</PlatformLink>.


### PR DESCRIPTION
Move notes on upgrading to an SDK version to fix critical bugs
to a newly added troubleshooting page.

