### PR TITLE
enriching events: set transaction name

### DIFF
--- a/src/includes/enriching-events/set-transaction-name/android.mdx
+++ b/src/includes/enriching-events/set-transaction-name/android.mdx
@@ -1,9 +1,13 @@
 ```kotlin
+import io.sentry.Sentry
+
 Sentry.configureScope { scope ->
     scope.setTransaction("UserListView"))
 }
 ```
 
 ```java
+import io.sentry.Sentry;
+
 Sentry.configureScope(scope -> scope.setTransaction("UserListView"));
 ```

--- a/src/includes/enriching-events/set-transaction-name/android.mdx
+++ b/src/includes/enriching-events/set-transaction-name/android.mdx
@@ -1,0 +1,9 @@
+```kotlin
+Sentry.configureScope { scope ->
+    scope.setTransaction("UserListView"))
+}
+```
+
+```java
+Sentry.configureScope(scope -> scope.setTransaction("UserListView"));
+```

--- a/src/includes/enriching-events/set-transaction-name/dart.mdx
+++ b/src/includes/enriching-events/set-transaction-name/dart.mdx
@@ -1,3 +1,5 @@
 ```dart
-Sentry.configureScope((scope) { scope.transaction = "UserListView"; });
+import 'package:sentry/sentry.dart';
+
+Sentry.configureScope((scope) { scope.transaction = 'UserListView'; });
 ```

--- a/src/includes/enriching-events/set-transaction-name/dart.mdx
+++ b/src/includes/enriching-events/set-transaction-name/dart.mdx
@@ -1,0 +1,3 @@
+```dart
+Sentry.configureScope((scope) { scope.transaction = "UserListView"; });
+```

--- a/src/includes/enriching-events/set-transaction-name/dotnet.mdx
+++ b/src/includes/enriching-events/set-transaction-name/dotnet.mdx
@@ -1,0 +1,3 @@
+```csharp
+SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
+```

--- a/src/includes/enriching-events/set-transaction-name/dotnet.mdx
+++ b/src/includes/enriching-events/set-transaction-name/dotnet.mdx
@@ -1,3 +1,5 @@
 ```csharp
+using Sentry;
+
 SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
 ```

--- a/src/includes/enriching-events/set-transaction-name/flutter.mdx
+++ b/src/includes/enriching-events/set-transaction-name/flutter.mdx
@@ -1,0 +1,3 @@
+```dart
+Sentry.configureScope((scope) { scope.transaction = "UserListView"; });
+```

--- a/src/includes/enriching-events/set-transaction-name/flutter.mdx
+++ b/src/includes/enriching-events/set-transaction-name/flutter.mdx
@@ -1,3 +1,0 @@
-```dart
-Sentry.configureScope((scope) { scope.transaction = "UserListView"; });
-```

--- a/src/includes/enriching-events/set-transaction-name/java.mdx
+++ b/src/includes/enriching-events/set-transaction-name/java.mdx
@@ -1,8 +1,12 @@
 ```java
+import io.sentry.Sentry;
+
 Sentry.configureScope(scope -> scope.setTransaction("UserListView"));
 ```
 
 ```kotlin
+import io.sentry.Sentry
+
 Sentry.configureScope { scope ->
     scope.setTransaction("UserListView"))
 }

--- a/src/includes/enriching-events/set-transaction-name/java.mdx
+++ b/src/includes/enriching-events/set-transaction-name/java.mdx
@@ -1,0 +1,9 @@
+```java
+Sentry.configureScope(scope -> scope.setTransaction("UserListView"));
+```
+
+```kotlin
+Sentry.configureScope { scope ->
+    scope.setTransaction("UserListView"))
+}
+```

--- a/src/includes/enriching-events/set-transaction-name/native.mdx
+++ b/src/includes/enriching-events/set-transaction-name/native.mdx
@@ -1,3 +1,5 @@
 ```c
+#include <sentry.h>
+
 sentry_set_transaction("UserListView");
 ```

--- a/src/includes/enriching-events/set-transaction-name/react-native.mdx
+++ b/src/includes/enriching-events/set-transaction-name/react-native.mdx
@@ -1,0 +1,3 @@
+```javascript
+Sentry.configureScope(scope => scope.setTransactionName("UserListView"));
+```

--- a/src/includes/enriching-events/set-transaction-name/unity.mdx
+++ b/src/includes/enriching-events/set-transaction-name/unity.mdx
@@ -1,0 +1,3 @@
+```csharp
+SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
+```

--- a/src/includes/enriching-events/set-transaction-name/unity.mdx
+++ b/src/includes/enriching-events/set-transaction-name/unity.mdx
@@ -1,3 +1,5 @@
 ```csharp
+using Sentry;
+
 SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
 ```

--- a/src/platforms/common/enriching-events/transaction-name.mdx
+++ b/src/platforms/common/enriching-events/transaction-name.mdx
@@ -7,6 +7,14 @@ supported:
   - python
   - ruby
   - native
+  - react-native
+  - dotnet
+  - unity
+  - flutter
+  - dart
+  - java
+  - android
+  - apple
 notSupported:
   - javascript.cordova
   - javascript.nextjs

--- a/src/platforms/common/enriching-events/transaction-name.mdx
+++ b/src/platforms/common/enriching-events/transaction-name.mdx
@@ -14,7 +14,6 @@ supported:
   - dart
   - java
   - android
-  - apple
 notSupported:
   - javascript.cordova
   - javascript.nextjs


### PR DESCRIPTION
We'll need to add the code snippets for each new platform.

Apple might need to be dropped though