### PR TITLE
Fix java typo in record-user

### DIFF
--- a/src/platforms/java/guides/spring-boot/record-user.mdx
+++ b/src/platforms/java/guides/spring-boot/record-user.mdx
@@ -35,7 +35,7 @@ import io.sentry.spring.SentryUserProvider;
 @Component
 class CustomSentryUserProvider implements SentryUserProvider {
   public User provideUser() {
-    User user = User();
+    User user = new User();
     // ... set user information
     return user
   }


### PR DESCRIPTION
Java needs `new` to instantiate object. Small typo in docs.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
