### PR TITLE
docs(gatsby): add Render git commit environment variable

### DIFF
--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -116,3 +116,4 @@ With this approach, the SDK sets some options automatically based on environment
 - GitHub Actions: `process.env.GITHUB_SHA`
 - Netlify: `process.env.COMMIT_REF`
 - Vercel: `process.env.VERCEL_GIT_COMMIT_SHA`
+- Render: `process.env.RENDER_GIT_COMMIT`


### PR DESCRIPTION
This adds Render's [`RENDER_GIT_COMMIT` variable](https://render.com/docs/environment-variables) to the list of platform-specific environment variables in the Gatsby integration docs.

Disclaimer: I'm a Render employee.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
