### PR TITLE
ref(JS): Add warning for potentially sensitive data in transaction names

### DIFF
--- a/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
+++ b/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
@@ -183,6 +183,12 @@ Transactions share most of their properties (start and end time, tags, and so fo
 
 Transactions also have one additional property not included in spans, called `transaction_name`, which is used in the UI to identify the transaction. Common examples of `transaction_name` values include endpoint paths (like `/store/checkout/` or `api/v2/users/<user_id>/`) for backend request transactions, task names (like `data.cleanup.delete_inactive_users`) for cron job transactions, and URLs (like `https://docs.sentry.io/performance-monitoring/distributed-tracing/`) for page-load transactions.
 
+<Note>
+
+Transaction names can potentially contain **sensitive information**. See [Scrubbing Sensitive Data](/platforms/javascript/data-management/sensitive-data/#scrubbing-data) for more information.
+
+</Note>
+
 _Note:_ Before the transaction is sent, the `tags` and `data` properties will get merged with data from the global scope. (Global scope data is set either in `Sentry.init()` - for things like `environment` and `release` - or by using `Sentry.configureScope()`, `Sentry.setTag()`, `Sentry.setUser()`, and `Sentry.setExtra()`.
 
 #### Spans

--- a/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
+++ b/src/docs/product/sentry-basics/tracing/distributed-tracing.mdx
@@ -185,7 +185,7 @@ Transactions also have one additional property not included in spans, called `tr
 
 <Note>
 
-Transaction names can potentially contain **sensitive information**. See [Scrubbing Sensitive Data](/platforms/javascript/data-management/sensitive-data/#scrubbing-data) for more information.
+Transaction names can potentially contain **sensitive data**. See [Scrubbing Sensitive Data](/platforms/javascript/data-management/sensitive-data/#scrubbing-data) for more information.
 
 </Note>
 

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -60,9 +60,9 @@ There's a few areas you should consider that sensitive data may appear:
 - User context → automated behavior is controlled via `send-default-pii`
 - HTTP context → query strings may be picked up in some frameworks as part of the HTTP request context
 - Transaction Names → In certain situations, transaction names might contain sensitive data.
-  For example, a browser's pageload transaction might have the raw URL as a name (e.g. `/users/1234/details`, where `1234` is the user id).
-  Our SDKs manage to parameterize URLs and routes in most cases successfully (i.e. turn `/users/1234/details` into `/users/:userid/details`).
-  However, depending on the framework you use, your routing configurations, timings and a few other factors, the SDKs might not be able to
+  For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII).
+In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`.
+  However, depending on the framework you use, your routing configurations, timings, and a few other factors, the SDKs might not be able to
   completely parameterize all your URLs.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -59,8 +59,13 @@ There's a few areas you should consider that sensitive data may appear:
 - Breadcrumbs → some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed
 - User context → automated behavior is controlled via `send-default-pii`
 - HTTP context → query strings may be picked up in some frameworks as part of the HTTP request context
+- Transaction Names → In certain situations, transaction names might contain sensitive data.
+  For example, a browser's pageload transaction might have the raw URL as a name (e.g. `/users/1234/details`, where `1234` is the user id).
+  Our SDKs manage to parameterize URLs and routes in most cases successfully (i.e. turn `/users/1234/details` into `/users/:userid/details`).
+  However, depending on the framework you use, your routing configurations, timings and a few other factors, the SDKs might not be able to
+  completely parameterize all your URLs.
 
-For more details, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
+For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 
 ### Examples
 


### PR DESCRIPTION
This PR adds a small warning in the product guide that transaction names can potentially contain sensitive data (i.e. unparameterized URLs). Furthermore, the PR adds a list item for transaction names in the "Scrubbing Sensitive Data" page).