### PR TITLE
Fix wrong schema for FormField - Select component

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/formfield.mdx
@@ -61,7 +61,7 @@ The [issue linking](/product/integrations/integration-platform/ui-components/iss
   "async": <Bool>,
   "options": <Array<Array<String, String>>>,
   "depends_on": <Array<String>>,
-  "skip_load_on_open": <Array<String>>
+  "skip_load_on_open": <Bool>
 }
 ```
 


### PR DESCRIPTION
Looks like a copy/paste typo.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
