### PR TITLE
(.NET) Remove redundant using

### DIFF
--- a/src/includes/performance/traces-sampler-as-sampler/dotnet.aspnetcore.mdx
+++ b/src/includes/performance/traces-sampler-as-sampler/dotnet.aspnetcore.mdx
@@ -1,5 +1,4 @@
 ```csharp
-using Sentry;
 
 // Add this to the SDK initialization callback
 // To set a uniform sample rate


### PR DESCRIPTION
The using on the ASP.NET Core doc is not used so I just removed it.