### PR TITLE
Add sentry wizard setup instructions to sentry docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "react-instantsearch-dom": "^6.4.0",
     "react-popper": "^2.2.4",
     "react-select": "^3.1.0",
+    "remark": "^10.0.1",
     "remark-deflist": "^0.2.1",
+    "remark-html": "^8.0.0",
     "ts-node": "^9.0.0",
     "typescript": "^3.9.7"
   },

--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -1,5 +1,7 @@
 import fs from "fs";
 import jsdom from "jsdom";
+import remark from "remark";
+import remarkHtml from "remark-html";
 
 import PlatformRegistry from "../shared/platformRegistry";
 
@@ -37,6 +39,7 @@ export default async ({ graphql }) => {
                 frontmatter {
                   name
                   doc_link
+                  wizard_setup
                   support_level
                   type
                 }
@@ -120,6 +123,7 @@ const writeJson = async (
       type: node.frontmatter.type,
       details: sub ? `${main}/${sub}.json` : `${main}.json`,
       doc_link: node.frontmatter.doc_link,
+      wizard_setup: node.frontmatter.wizard_setup ? remark().use(remarkHtml).processSync(node.frontmatter.wizard_setup).toString() : null,
       name: node.frontmatter.name,
       aliases: [],
       categories: [],

--- a/src/wizard/javascript/nextjs.md
+++ b/src/wizard/javascript/nextjs.md
@@ -3,6 +3,12 @@ name: Next.js
 doc_link: https://docs.sentry.io/platforms/javascript/guides/nextjs/
 support_level: production
 type: framework
+wizard_setup: >-
+  Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+
+  ```bash
+  npx @sentry/wizard -i nextjs
+  ```
 ---
 
 Install Sentry’s Next.js SDK using either `yarn` or `npm`:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9425,7 +9425,14 @@ hast-util-raw@^4.0.0:
     xtend "^4.0.1"
     zwitch "^1.0.0"
 
-hast-util-to-html@^4.0.1:
+hast-util-sanitize@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz#4e60d66336bd67e52354d581967467029a933f2e"
+  integrity sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==
+  dependencies:
+    xtend "^4.0.1"
+
+hast-util-to-html@^4.0.0, hast-util-to-html@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz#3666b05afb62bd69f8f5e6c94db04dea19438e2a"
   integrity sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==
@@ -12125,7 +12132,7 @@ mdast-util-to-hast@9.1.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
-mdast-util-to-hast@^3.0.4:
+mdast-util-to-hast@^3.0.0, mdast-util-to-hast@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"
   integrity sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==
@@ -15227,6 +15234,16 @@ remark-footnotes@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-2.0.0.tgz#9001c4c2ffebba55695d2dd80ffb8b82f7e6303f"
   integrity sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==
+
+remark-html@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/remark-html/-/remark-html-8.0.0.tgz#9fcb859a6f3cb40f3ef15402950f1a62ec301b3a"
+  integrity sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==
+  dependencies:
+    hast-util-sanitize "^1.0.0"
+    hast-util-to-html "^4.0.0"
+    mdast-util-to-hast "^3.0.0"
+    xtend "^4.0.1"
 
 remark-mdx@1.6.18, remark-mdx@^1.6.16:
   version "1.6.18"


### PR DESCRIPTION
This adds a new frontmatter field, `wizard_setup`, that allows the author to specify simplified setup instructions. This will be used on the onboarding view to give simplified setup instructions.