### PR TITLE
Hide warning for Ruby

### DIFF
--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -120,12 +120,14 @@ made will stay isolated within the `with-scope` callback function. This allows y
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
+<PlatformSection notSupported={["ruby"]}>
 <Alert level="info" title="Important">
 
 Any exceptions that occur within the callback function for `with-scope` will not be
 caught, and all errors that occur will be silently ignored and **not** reported.
 
 </Alert>
+</PlatformSection>
 
 </PlatformSection>
 


### PR DESCRIPTION
I might not be understanding this part of the docs, but I don't think this section applies to the way the Ruby library works?

(I also might not understand how this documentation format works. Can you nest a "PlatformSection" inside a "PlatformSection"?)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
