### PR TITLE
Docs for Starlette and FastAPI integration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "4.4.0",
+    "platformicons": "5.2.0",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "5.2.0",
+    "platformicons": "5.2.1",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -76,7 +76,7 @@ Visiting `"/sentry-debug"` will trigger an error that will be captured by Sentry
 
 - Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
-- If a `traces_sample_rate` is set, then also performance information is reported than can be seen in the "Performance" section of the Sentry UI.
+- If a `traces_sample_rate` is set, then performance information is also reported, which you can see on the **Performance** page of [sentry.io](https://sentry.io).
 
 ## Options
 

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -84,7 +84,7 @@ You can pass the following keyword arguments to `FastApiIntegration()`:
 
 - `transaction_style`:
 
-With this option you can influence how the transactions are named in Sentry. Here is an example:
+With this option, you can influence how the transactions are named in Sentry. For example:
 
 ```python
 from fastapi import FastAPI

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -1,0 +1,101 @@
+---
+title: FastAPI
+redirect_from:
+  - /clients/python/integrations/fastapi/
+  - /platforms/python/fastapi/
+description: "Learn about using Sentry with FastAPI."
+---
+
+The FastAPI integration adds support for the [FastAPI Framework](https://fastapi.tiangolo.com/).
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `fastapi` extra:
+
+```bash
+pip install --upgrade 'sentry-sdk[fastapi]'
+```
+
+## Configure
+
+To configure the SDK, initialize it with the integration before your app has been initialized:
+
+```python
+from fastapi import FastAPI
+
+import sentry_sdk
+from sentry_sdk.integrations.starlette import StarletteIntegration
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        StarletteIntegration(),
+        FastApiIntegration(),
+    ],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production,
+    traces_sample_rate=1.0,
+)
+
+app = FastAPI()
+```
+
+Because FastAPI is based on the Starlette framework, you need to enable both integrations `StarletteIntegration` and `FastApiIntegration`.
+
+**Note:** In the future we will make this auto enabling, so you do not need to add the `StarletteIntegration` to your `sentry_sdk.init()` call but the Sentry SDK will detect the presence of Starlette and will setup the integration automatically.
+
+## Verify
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+
+```python
+from fastapi import FastAPI
+
+
+app = FastAPI()
+
+@app.get("/sentry-debug")
+async def trigger_error():
+    division_by_zero = 1 / 0
+
+```
+
+Visiting `"/sentry-debug"` will trigger an error that will be captured by Sentry.
+
+## Behavior
+
+- All exceptions leading to an Internal Server Error are reported.
+
+- Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+
+- If a `traces_sample_rate` is set, then also performance information is reported than can be seen in the "Performance" section of the Sentry UI.
+
+## Options
+
+You can pass the following keyword arguments to `FastApiIntegration()`:
+
+- `transaction_style`:
+
+With this option you can influence how the transactions are named in Sentry. Here is an example:
+
+```python
+from fastapi import FastAPI
+
+
+app = FastAPI()
+
+@app.get("/catalog/product/{product_id}")
+async def product_detail(product_id):
+    return {...}
+```
+
+In the above code, the transaction name will be:
+
+- `"/catalog/product/{product_id}"` if you set `transaction_style="url"`
+- `"product_detail"` if you set `transaction_style="endpoint"`
+
+The default is `"url"`.

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -46,7 +46,11 @@ app = FastAPI()
 
 Because FastAPI is based on the Starlette framework, you need to enable both `StarletteIntegration` and `FastApiIntegration`.
 
-**Note:** In the future we will make this auto enabling, so you do not need to add the `StarletteIntegration` to your `sentry_sdk.init()` call but the Sentry SDK will detect the presence of Starlette and will setup the integration automatically.
+<Note>
+
+In the future, we will make this auto-enabling, so you won't need to add the `StarletteIntegration` to your `sentry_sdk.init()` call. Instead, the Sentry SDK will detect the presence of Starlette and will set up the integration automatically.
+
+</Note>
 
 ## Verify
 

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -44,7 +44,7 @@ sentry_sdk.init(
 app = FastAPI()
 ```
 
-Because FastAPI is based on the Starlette framework, you need to enable both integrations `StarletteIntegration` and `FastApiIntegration`.
+Because FastAPI is based on the Starlette framework, you need to enable both `StarletteIntegration` and `FastApiIntegration`.
 
 **Note:** In the future we will make this auto enabling, so you do not need to add the `StarletteIntegration` to your `sentry_sdk.init()` call but the Sentry SDK will detect the presence of Starlette and will setup the integration automatically.
 

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -87,8 +87,13 @@ You can pass the following keyword arguments to `FastApiIntegration()`:
 With this option, you can influence how the transactions are named in Sentry. For example:
 
 ```python
-from fastapi import FastAPI
-
+sentry_sdk.init(
+    # ...
+    integrations=[
+        StarletteIntegration(transaction_style="endpoint"),
+        FastApiIntegration(transaction_style="endpoint"),
+    ],
+)
 
 app = FastAPI()
 

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -42,7 +42,11 @@ sentry_sdk.init(
 app = Starlette(routes=[...])
 ```
 
-**Note:** In the future we will make this auto enabling, so you do not need to add the `StarletteIntegration` to your `sentry_sdk.init()` call but the Sentry SDK will detect the presence of Starlette and will setup the integration automatically.
+<Note>
+
+In the future, we will make this auto-enabling, so you won't need to add the `StarletteIntegration` to your `sentry_sdk.init()` call. Instead, the Sentry SDK will detect the presence of Starlette and will set up the integration automatically.
+
+</Note>
 
 ## Verify
 

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -1,0 +1,100 @@
+---
+title: Starlette
+redirect_from:
+  - /clients/python/integrations/starlette/
+  - /platforms/python/starlette/
+description: "Learn about using Sentry with Starlette."
+---
+
+The Starlette integration adds support for the [Starlette Framework](https://www.starlette.io/).
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `starlette` extra:
+
+```bash
+pip install --upgrade 'sentry-sdk[starlette]'
+```
+
+## Configure
+
+To configure the SDK, initialize it with the integration before your app has been initialized:
+
+```python
+from starlette.applications import Starlette
+
+import sentry_sdk
+from sentry_sdk.integrations.starlette import StarletteIntegration
+
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        StarletteIntegration(),
+    ],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production,
+    traces_sample_rate=1.0,
+)
+
+app = Starlette(routes=[...])
+```
+
+**Note:** In the future we will make this auto enabling, so you do not need to add the `StarletteIntegration` to your `sentry_sdk.init()` call but the Sentry SDK will detect the presence of Starlette and will setup the integration automatically.
+
+## Verify
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+
+async def trigger_error(request):
+    division_by_zero = 1 / 0
+
+app = Starlette(routes=[
+    Route("/sentry-debug", trigger_error),
+])
+```
+
+Visiting `"/sentry-debug"` will trigger an error that will be captured by Sentry.
+
+## Behavior
+
+- All exceptions leading to an Internal Server Error are reported.
+
+- Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+
+- If a `traces_sample_rate` is set, then also performance information is reported than can be seen in the "Performance" section of the Sentry UI.
+
+## Options
+
+You can pass the following keyword arguments to `StarletteIntegration()`:
+
+- `transaction_style`:
+
+With this option you can influence how the transactions are named in Sentry. Here is an example:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+
+async def product_detail(request):
+    return JSONResponse({...})
+
+app = Starlette(routes=[
+    Route('/catalog/product/{product_id}', product_detail),
+])
+```
+
+In the above code, the transaction name will be:
+
+- `"/catalog/product/{product_id}"` if you set `transaction_style="url"`.
+- `"product_detail"` if you set `transaction_style="endpoint"`
+
+The default is `"url"`.

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -81,7 +81,7 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
 - `transaction_style`:
 
-With this option you can influence how the transactions are named in Sentry. Here is an example:
+With this option, you can influence how the transactions are named in Sentry. For example:
 
 ```python
 from starlette.applications import Starlette

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -84,9 +84,12 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 With this option, you can influence how the transactions are named in Sentry. For example:
 
 ```python
-from starlette.applications import Starlette
-from starlette.routing import Route
-
+sentry_sdk.init(
+    # ...
+    integrations=[
+        StarletteIntegration(transaction_style="endpoint"),
+    ],
+)
 
 async def product_detail(request):
     return JSONResponse({...})

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -73,7 +73,7 @@ Visiting `"/sentry-debug"` will trigger an error that will be captured by Sentry
 
 - Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
-- If a `traces_sample_rate` is set, then also performance information is reported than can be seen in the "Performance" section of the Sentry UI.
+- If a `traces_sample_rate` is set, then performance information is also reported, which you can see on the **Performance** page of [sentry.io](https://sentry.io).
 
 ## Options
 

--- a/src/wizard/python/fastapi.md
+++ b/src/wizard/python/fastapi.md
@@ -1,0 +1,58 @@
+---
+name: FastAPI
+doc_link: https://docs.sentry.io/platforms/python/guides/fastapi/
+support_level: production
+type: framework
+---
+
+The FastAPI integration adds support for the [FastAPI Framework](https://fastapi.tiangolo.com/).
+
+1. Install `sentry-sdk` from PyPI with the `fastapi` extra:
+
+```bash
+pip install --upgrade 'sentry-sdk[fastapi]'
+```
+
+2. To configure the SDK, initialize it with the integration before your app has been initialized:
+
+```python
+from fastapi import FastAPI
+
+import sentry_sdk
+from sentry_sdk.integrations.starlette import StarletteIntegration
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        StarletteIntegration(),
+        FastApiIntegration(),
+    ],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production,
+    traces_sample_rate=1.0,
+)
+
+app = FastAPI()
+```
+
+The above configuration captures both error and performance data. To reduce the volume of performance data captured, change `traces_sample_rate` to a value between 0 and 1.
+
+3. You can easily verify your Sentry installation by creating a route that triggers an error:
+
+```python
+from fastapi import FastAPI
+
+
+app = FastAPI()
+
+@app.get("/sentry-debug")
+async def trigger_error():
+    division_by_zero = 1 / 0
+
+```
+
+Visiting this route will trigger an error that will be captured by Sentry.

--- a/src/wizard/python/starlette.md
+++ b/src/wizard/python/starlette.md
@@ -1,0 +1,57 @@
+---
+name: Starlette
+doc_link: https://docs.sentry.io/platforms/python/guides/starlette/
+support_level: production
+type: framework
+---
+
+The Starlette integration adds support for the [Starlette Framework](https://www.starlette.io/).
+
+1. Install `sentry-sdk` from PyPI with the `starlette` extra:
+
+```bash
+pip install --upgrade 'sentry-sdk[starlette]'
+```
+
+2. To configure the SDK, initialize it with the integration before your app has been initialized:
+
+```python
+from starlette.applications import Starlette
+
+import sentry_sdk
+from sentry_sdk.integrations.starlette import StarletteIntegration
+
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        StarletteIntegration(),
+    ],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production,
+    traces_sample_rate=1.0,
+)
+
+app = Starlette(routes=[...])
+```
+
+The above configuration captures both error and performance data. To reduce the volume of performance data captured, change `traces_sample_rate` to a value between 0 and 1.
+
+3. You can easily verify your Sentry installation by creating a route that triggers an error:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+
+async def trigger_error(request):
+    division_by_zero = 1 / 0
+
+app = Starlette(routes=[
+    Route("/sentry-debug", trigger_error),
+])
+```
+
+Visiting this route will trigger an error that will be captured by Sentry.

--- a/yarn.lock
+++ b/yarn.lock
@@ -13878,10 +13878,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.0.tgz#822854b965514840b7c3effe27a9f824d834dc0a"
-  integrity sha512-VlWDzwo2naHGRSK3sAMDv9lv+A82K5SXFObio647TyqXDfot5cSPckYvG9B27kUTPYYtzuZjKPoaiL6UwUvZnQ==
+platformicons@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.1.tgz#4edbb1db58bf84c3f2fd3ed65afb90110253929e"
+  integrity sha512-56S/1RHaSYeeYCpumg+jWGAnL2iCd3i3xVLqwN9F26LzGz2SMZA8LBkEEbFWf2DbBv3N5GnsgUDtJrnN1f0SqA==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13878,10 +13878,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.4.0.tgz#4188696c73fcc40afff212aa3ed0d0559cb25607"
-  integrity sha512-aC1akUKsIh9WJe7uRpfbuiMz/Xp4WzsxIx1z07OXahFOf2+QNlnNcN/D1Lpt2ymdJ8y86KCkjunl4WbPn3BArw==
+platformicons@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.0.tgz#822854b965514840b7c3effe27a9f824d834dc0a"
+  integrity sha512-VlWDzwo2naHGRSK3sAMDv9lv+A82K5SXFObio647TyqXDfot5cSPckYvG9B27kUTPYYtzuZjKPoaiL6UwUvZnQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Starlette and FastAPI are two new Python frameworks we support. They are both heavily depending on each other, so it makes sense to add documentation for both at the same time. 

Refs getsentry/sentry-python#1409