### PR TITLE
CodePush: do not upload manually source maps

### DIFF
--- a/src/platforms/react-native/manual-setup/codepush.mdx
+++ b/src/platforms/react-native/manual-setup/codepush.mdx
@@ -93,4 +93,3 @@ You can find more information about this in the [AppCenter CLI](https://docs.mic
 
 </Alert>
 
-If you still have issues with CodePush source maps, you can refer to [Source Maps for Other Platforms](/platforms/react-native/sourcemaps/) to manually bundle and upload source maps to Sentry.


### PR DESCRIPTION
Solution given by @marandaneto https://github.com/getsentry/sentry-react-native/issues/2372#issuecomment-1191103821

We tested it and it gives wrong sourcemaps for both iOS and Android, see https://github.com/getsentry/sentry-react-native/issues/2372 for more details




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
