### PR TITLE
Update docs to explain metric performance alerts

### DIFF
--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -67,7 +67,7 @@ Crash rate alerts tell you when the crash free percentage for either [sessions o
 - Crash Free User Rate
 
 ### Performance
-
+For performance alerts, [metrics-based](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use event-based data and a message saying this will be displayed.
 - Throughput
 - Transaction Duration
 - Apdex

--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -44,6 +44,12 @@ Metric alerts tell you when a [metric](/product/performance/metrics/) crosses a 
 
 Metric alerts monitor macro-level metrics for both error and transaction events. A metric takes a set of events and computes an aggregate value using a function, such as `count()` or `avg()`, applied to the event properties over a period of time. When you create a metric alert, you can filter events by attributes and <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, which is particularly useful for aggregating across events that aren't grouped into single issues.
 
+<Note>
+
+Metric alerts aren’t affected by [ignored issues](/product/issues/states-triage/#ignore), so events from those issues are counted if they match the filters of your metric alert rule.
+
+</Note>
+
 These alerts use _Critical_ and _Warning_ triggers to measure severity. An alert’s current status is the highest severity trigger that is active, which can be one of three values: Warning, Critical, or Resolved. Sentry notifies you whenever an alert's status changes.
 
 When you create an alert, all the displayed alert types (except “Issues”) may be used to create a metric alert. You can create metric alerts for Errors, Sessions (Crash Rate Alerts), and Performance:
@@ -67,7 +73,9 @@ Crash rate alerts tell you when the crash free percentage for either [sessions o
 - Crash Free User Rate
 
 ### Performance
+
 For performance alerts, [metric-backed](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use indexed events, or event-based data, and a message saying this will be displayed.
+
 - Throughput
 - Transaction Duration
 - Apdex
@@ -79,7 +87,7 @@ For performance alerts, [metric-backed](/product/sentry-basics/search/searchable
 
 <Note>
 
-Metric alerts aren’t affected by [ignored issues](/product/issues/states-triage/#ignore), so events from those issues are counted if they match the filters of your metric alert rule.
+Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in joining this limited release, please reach out at abc@sentry.io.
 
 </Note>
 

--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -67,7 +67,7 @@ Crash rate alerts tell you when the crash free percentage for either [sessions o
 - Crash Free User Rate
 
 ### Performance
-For performance alerts, [metrics-based](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use event-based data and a message saying this will be displayed.
+For performance alerts, [metric-backed](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use indexed events, or event-based data, and a message saying this will be displayed.
 - Throughput
 - Transaction Duration
 - Apdex

--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -87,7 +87,7 @@ For performance alerts, [metric-backed](/product/sentry-basics/search/searchable
 
 <Note>
 
-Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in joining this limited release, please reach out at abc@sentry.io.
+Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in participating, [join the waitlist](https://sentry.io/for/performance/#updates-signup).
 
 </Note>
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -38,7 +38,7 @@ For performance alerts, [metric-backed](/product/sentry-basics/search/searchable
 
 <Note>
 
-Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in joining this limited release, please reach out at abc@sentry.io.
+Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in participating, [join the waitlist](https://sentry.io/for/performance/#updates-signup).
 
 </Note>
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -13,14 +13,21 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 ### Metrics Types for Alerting
+
 #### Errors
+
 - Number of Errors
 - Users Experiencing Errors
+
 #### Sessions
+
 - Crash Free Session Rate
 - Crash Free User Rate
+
 #### Performance
+
 For performance alerts, [metric-backed](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use indexed events, or event-based data, and a message saying this will be displayed.
+
 - Throughput
 - Transaction Duration
 - Apdex
@@ -28,6 +35,12 @@ For performance alerts, [metric-backed](/product/sentry-basics/search/searchable
 - Largest Contentful Paint
 - First Input Delay
 - Cumulative Layout Shift
+
+<Note>
+
+Metric-backed data is in beta and is only available if your organization is participating in its limited release. Features in beta are still in-progress and may have bugs. We recognize the irony. If you’re interested in joining this limited release, please reach out at abc@sentry.io.
+
+</Note>
 
 ### Functions for Metric Types
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -13,11 +13,14 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 ### Metrics Types for Alerting
-
+#### Errors
 - Number of Errors
 - Users Experiencing Errors
+#### Sessions
 - Crash Free Session Rate
 - Crash Free User Rate
+#### Performance
+For performance alerts, [metrics-based](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use event-based data and a message saying this will be displayed.
 - Throughput
 - Transaction Duration
 - Apdex

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -20,7 +20,7 @@ To create a metric alert you first need to choose a metric type. For some alert 
 - Crash Free Session Rate
 - Crash Free User Rate
 #### Performance
-For performance alerts, [metrics-based](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use event-based data and a message saying this will be displayed.
+For performance alerts, [metric-backed](/product/sentry-basics/search/searchable-properties/#metrics-properties) data is the default. If you make a selection in configuring your alert that's not metrics-compatible, then your alert will use indexed events, or event-based data, and a message saying this will be displayed.
 - Throughput
 - Transaction Duration
 - Apdex


### PR DESCRIPTION
Based heavily on the wording from https://github.com/getsentry/sentry-docs/pull/5224

Update metric alert docs to explain how we switch between transaction vs metric based performance alerts.

**Do not merge** until [PR 5224](https://github.com/getsentry/sentry-docs/pull/5224) is merged).