### PR TITLE
unity config heading

### DIFF
--- a/src/includes/configuration/config-intro/unity.mdx
+++ b/src/includes/configuration/config-intro/unity.mdx
@@ -1,4 +1,6 @@
-In order to provide native crash support, the Sentry SDK for Unity includes platform-specific (that is, Native) SDKs, such as [Android](/platforms/android/), [Apple](/platforms/apple/guides/ios/), and [Native](/platforms/native/).
+## Programatic Configuration
+
+In order to provide native crash support, the Sentry SDK for Unity includes [platform-specific (that is, Native)](/platforms/unity/native-support/) SDKs, such as [Android](/platforms/android/), [Apple](/platforms/apple/guides/ios/), and [Native](/platforms/native/).
 
 By default, we initialize the native SDKs before the Unity engine itself. That means it also runs before the C# layer that relies on [BeforeSceneLoad RuntimeInitializeOnLoadMethodAttribute](https://docs.unity3d.com/ScriptReference/RuntimeInitializeLoadType.BeforeSceneLoad.html) to get initialized. This allows us to capture bugs/crashes of the engine itself, any native plugin, and anything written in C#. The setup for the native SDKs happens during build time, which is why we rely on the options being set in the Sentry editor configuration window and saved to `Assets/Resources/Sentry/SentryOptions.asset`. To provide a way to modify options programmatically, we've added `ScriptableOptionsConfiguration` to the `Options Config` tab in the Sentry editor window.
 


### PR DESCRIPTION
So we can link to, from https://github.com/getsentry/sentry-docs/pull/5337/files