### PR TITLE
fix(python): Clarify which Celery signals work and explain Celery + Django setup

### DIFF
--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -37,8 +37,8 @@ Generally, make sure that the **call to `init` is loaded on worker startup**, an
 
 If you're using Celery standalone, there are a two ways to set this up:
 
-* initializing the SDK in the configuration file loaded with Celery's `--config` parameter
-* initializing the SDK by hooking it to either the [`celeryd_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init) or [`worker_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init) signals
+* Initializing the SDK in the configuration file loaded with Celery's `--config` parameter
+* Initializing the SDK by hooking it to either the [`celeryd_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init) or [`worker_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init) signals
 
     ```python
     import sentry_sdk

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -33,7 +33,7 @@ The integration will automatically report errors from all celery jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-## Standalone setup
+## Standalone Setup
 
 If you are using Celery standalone, there are a couple of ways to do this:
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -35,7 +35,7 @@ Generally, make sure that the **call to `init` is loaded on worker startup**, an
 
 ## Standalone Setup
 
-If you are using Celery standalone, there are a couple of ways to do this:
+If you're using Celery standalone, there are a two ways to set this up:
 
 * initializing the SDK in the configuration file loaded with Celery's `--config` parameter
 * initializing the SDK by hooking it to either the [`celeryd_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init) or [`worker_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init) signals

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -33,7 +33,30 @@ The integration will automatically report errors from all celery jobs.
 
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
-There are many valid ways to do this like, for example, using a signal like [`worker_process_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html#worker-process-init), or by initializing the SDK in the configuration file loaded with Celery's `--config` parameter.
+## Standalone setup
+
+If you are using Celery standalone, there are a couple of ways to do this:
+
+* initializing the SDK in the configuration file loaded with Celery's `--config` parameter
+* initializing the SDK by hooking it to either the [`celeryd_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init) or [`worker_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init) signals
+
+    ```python
+    import sentry_sdk
+    from celery import Celery, signals
+
+    app = Celery("myapp")
+
+    #@signals.worker_init.connect
+    @signals.celeryd_init.connect
+    def init_sentry(**_kwargs):
+        sentry_sdk.init(dsn="...")
+    ```
+
+## Setup with Django
+
+If you are using Celery with Django in a conventional setup and have already initialized the SDK in [your `settings.py` file](/platforms/python/guides/django/#configure), and have Celery using the same settings with [`config_from_object`](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html), you don't need to initialize the SDK separately for Celery.
+
+## Verify
 
 To verify if your SDK is initialized on worker start, you can pass `debug=True` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -54,7 +54,7 @@ If you're using Celery standalone, there are a two ways to set this up:
 
 ## Setup With Django
 
-If you are using Celery with Django in a conventional setup and have already initialized the SDK in [your `settings.py` file](/platforms/python/guides/django/#configure), and have Celery using the same settings with [`config_from_object`](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html), you don't need to initialize the SDK separately for Celery.
+If you're using Celery with Django in a conventional setup, have already initialized the SDK in [your `settings.py` file](/platforms/python/guides/django/#configure), and have Celery using the same settings with [`config_from_object`](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html), you don't need to initialize the SDK separately for Celery.
 
 ## Verify
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -52,7 +52,7 @@ If you're using Celery standalone, there are a two ways to set this up:
         sentry_sdk.init(dsn="...")
     ```
 
-## Setup with Django
+## Setup With Django
 
 If you are using Celery with Django in a conventional setup and have already initialized the SDK in [your `settings.py` file](/platforms/python/guides/django/#configure), and have Celery using the same settings with [`config_from_object`](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html), you don't need to initialize the SDK separately for Celery.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -35,7 +35,7 @@ Generally, make sure that the **call to `init` is loaded on worker startup**, an
 
 ## Standalone Setup
 
-If you're using Celery standalone, there are a two ways to set this up:
+If you're using Celery standalone, there are two ways to set this up:
 
 * Initializing the SDK in the configuration file loaded with Celery's `--config` parameter
 * Initializing the SDK by hooking it to either the [`celeryd_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init) or [`worker_init`](https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init) signals


### PR DESCRIPTION
* `worker_process_init` doesn't work because it's called after our [patches need to run](https://github.com/getsentry/sentry-python/issues/1512#issuecomment-1195511889) 
* fixes https://github.com/getsentry/sentry-python/issues/1512