### PR TITLE
feat(native): Provide documentation for on_crash

### DIFF
--- a/src/includes/configuration/before-send/native.mdx
+++ b/src/includes/configuration/before-send/native.mdx
@@ -17,8 +17,60 @@ int main(void) {
 
 The callback is executed in the same thread as the call to `sentry_capture_event`. Work performed by the function may thus block the executing thread. For this reason, consider avoiding heavy work in `before_send`.
 
+
+#### Using `on_crash` (starting with version 0.4.19)
+
+The `before_send` callback implementation in `sentry-native` makes it hard to distinguish between normal events
+and crashes. For this reason, we introduced another callback, `on_crash`, which - at this point - only exists 
+in `sentry_native`:
+
+```c
+#include <sentry.h>
+
+static sentry_value_t
+crash_cleanup(
+    const sentry_ucontext_t *uctx, // provides the user-space context of the crash
+    sentry_value_t event,          // used the same way as in `before_send` 
+    void *closure                  // user-data that you can provide at configuration time
+)
+{
+    // Do contextual clean-up before the crash is sent to sentry's backend infrastructure
+    
+    /* ... */
+    
+    // tell the backend to retain the event (+ dump)
+    // or to discard it, you could free the event and return a `null`:
+    //       sentry_value_decref(event);
+    //       return sentry_value_new_null();
+    return event;
+}
+
+int main(void) {
+  sentry_options_t *options = sentry_options_new();
+  sentry_options_set_on_crash(options, crash_cleanup, NULL);
+  sentry_init(options);
+
+  /* ... */
+}
+```
+
+The `on_crash` callback replaces `before_send` as a callback for crash events only. They can
+be defined simultaneously, where the SDK prevents `before_send` from being invoked for crash 
+events. This allows for better differentiation between crashes and other events and 
+gradual migration from existing `before_send` implementations:
+
+- If you have a `before_send` implementation and do not define an `on_crash`
+  callback `before_send` will receive both normal and crash events as before
+- If you only want to pre-process normal events with `before_send`, then 
+  you can define an "empty" `on_crash` callback that returns the 
+  passed-in event and does nothing else.
+- If you are not interested in pre-processing normal events but only want 
+  to act on crashes, then only define an `on_crash` callback with the option 
+  to filter (available for all backends) or enrich (only for `inproc`) the 
+  crash event.
+  
 <Alert level="warning" title="Not Supported in Crashpad on macOS">
 
-The Crashpad backend on macOS doesn't currently support notifying the crashing process and thus can't correctly terminate sessions or call the registered `before_send` hook. It will also lose any events queued for sending at the time of the crash.
+The Crashpad backend on macOS doesn't currently support notifying the crashing process and thus can't correctly terminate sessions or call the registered `before_send` or `on_crash` hooks. It will also lose any events queued for sending at the time of the crash.
 
 </Alert>


### PR DESCRIPTION
After merging https://github.com/getsentry/sentry-native/pull/734 we are ready to release version 0.4.19 of `sentry-native`. The last required step is to add documentation for this new feature.

@Swatinem please review. Thx!