### PR TITLE
Minor fixes to Sentry Docs

### DIFF
--- a/src/includes/enriching-events/set-transaction-name/android.mdx
+++ b/src/includes/enriching-events/set-transaction-name/android.mdx
@@ -2,7 +2,7 @@
 import io.sentry.Sentry
 
 Sentry.configureScope { scope ->
-    scope.setTransaction("UserListView"))
+    scope.setTransaction("UserListView")
 }
 ```
 

--- a/src/includes/enriching-events/set-transaction-name/ruby.mdx
+++ b/src/includes/enriching-events/set-transaction-name/ruby.mdx
@@ -1,4 +1,6 @@
 ```ruby
+require "sentry-ruby"
+
 Sentry.configure_scope do |scope|
   scope.set_transaction_name("transaction")
 end

--- a/src/includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/includes/getting-started-config/javascript.capacitor.mdx
@@ -60,5 +60,5 @@ Learn more about uploading [source maps](/platforms/javascript/guides/capacitor/
 
 To make stack-trace information for native crashes on iOS easier to understand, you need to provide debug information to Sentry. Debug information is provided by uploading dSYM files using one of two methods, depending on your setup:
 
-- [With Bitcode](dsym/#dsym-with-bitcode)
-- [Without Bitcode](dsym/#dsym-without-bitcode)
+- [With Bitcode](/platforms/javascript/guides/capacitor/dsym/#dsym-with-bitcode)
+- [Without Bitcode](/platforms/javascript/guides/capacitor/dsym/#dsym-without-bitcode)

--- a/src/platforms/javascript/guides/capacitor/ionic.mdx
+++ b/src/platforms/javascript/guides/capacitor/ionic.mdx
@@ -4,4 +4,8 @@ sidebar_order: 201
 description: "Learn how to use Sentry with Ionic."
 ---
 
-Sentry Capacitor supports [Ionic](https://ionicframework.com/), check the [Getting Started documentation](/platforms/javascript/guides/capacitor/) to setup your Ionic project with Sentry Capacitor SDK.
+Sentry Capacitor supports [Ionic](https://ionicframework.com/) out of the box, the documentation below is similar to the one at [Getting Started documentation](/platforms/javascript/guides/capacitor/) since the setup of both Capacitor and Ionic are the same without the need of any additional change.
+
+<PlatformContent includePath="getting-started-install" />
+
+<PlatformContent includePath="getting-started-config" />

--- a/src/platforms/javascript/guides/capacitor/ionic.mdx
+++ b/src/platforms/javascript/guides/capacitor/ionic.mdx
@@ -6,6 +6,6 @@ description: "Learn how to use Sentry with Ionic."
 
 Sentry Capacitor supports [Ionic](https://ionicframework.com/) out of the box, the documentation below is similar to the one at [Getting Started documentation](/platforms/javascript/guides/capacitor/) since the setup of both Capacitor and Ionic are the same without the need of any additional change.
 
-<PlatformContent includePath="getting-started-install" />
+<PlatformContent includePath="../getting-started-install" />
 
-<PlatformContent includePath="getting-started-config" />
+<PlatformContent includePath="../getting-started-config" />

--- a/src/platforms/javascript/guides/capacitor/ionic.mdx
+++ b/src/platforms/javascript/guides/capacitor/ionic.mdx
@@ -6,6 +6,6 @@ description: "Learn how to use Sentry with Ionic."
 
 Sentry Capacitor supports [Ionic](https://ionicframework.com/) out of the box. The documentation below is similar to our [Capacitor Getting Started documentation](/platforms/javascript/guides/capacitor/) since the setup of Capacitor and Ionic are the same.
 
-<PlatformContent includePath="../getting-started-install" />
+<PlatformContent includePath="getting-started-install" />
 
-<PlatformContent includePath="../getting-started-config" />
+<PlatformContent includePath="getting-started-config" />

--- a/src/wizard/unity/index.md
+++ b/src/wizard/unity/index.md
@@ -5,8 +5,6 @@ support_level: production
 type: framework
 ---
 
-> The Unity SDK now supports line numbers for IL2CPP. The feature is currently in beta, but you can enable it at `Tools -> Sentry -> Advanced -> IL2CPP line numbers`. To learn more check out our [docs](https://docs.sentry.io/platforms/unity/configuration/il2cpp/).
-
 ## Installation
 
 Install the package via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
@@ -16,6 +14,8 @@ https://github.com/getsentry/unity.git#{{ packages.version('sentry.dotnet.unity'
 ```
 
 ## Configuration
+
+> The Unity SDK now supports line numbers for IL2CPP. The feature is currently in beta, but you can enable it at `Tools -> Sentry -> Advanced -> IL2CPP line numbers`. To learn more check out our [docs](https://docs.sentry.io/platforms/unity/configuration/il2cpp/).
 
 Access the Sentry configuration window by going to Unity's top menu: `Tools` > `Sentry` and enter the following DSN:
 


### PR DESCRIPTION
- Fix Kotlin Sample for transaction name.
- Add include to Ruby sample for transaction name.
- Populate the Ionic page so it's not too empty