### PR TITLE
Update docs for Remix alpha -> beta

### DIFF
--- a/src/includes/getting-started-primer/javascript.remix.mdx
+++ b/src/includes/getting-started-primer/javascript.remix.mdx
@@ -4,15 +4,7 @@ Sentry's Remix SDK enables automatic reporting of errors and exceptions, as well
 
 </Note>
 
-<Alert level="info" title="Important">
-
-This SDK is still in experimental phase and is not yet ready for production use.
-
-</Alert>
-
-Sentry's Remix SDK is introduced in version `7.7.0`.
-
-Features:
+## Features Overview
 
 - [Error Tracking](/product/issues/) with source maps for both JavaScript and TypeScript
 - Events [enriched](/platforms/javascript/guides/remix/enriching-events/context/) with device data
@@ -21,3 +13,12 @@ Features:
 - [Performance Monitoring](/product/performance/) for both the client and server
 
 Under the hood, Remix SDK relies on our [React SDK](/platforms/javascript/guides/react/) on the frontend and [Node SDK](/platforms/node) on the backend, which makes all features available in those SDKs also available in this SDK.
+
+## SDK Status
+
+The Remix SDK is currently in beta. We appreciate your feedback:
+
+- [Open Issues (GitHub)](https://github.com/getsentry/sentry-javascript/issues?q=is%3Aopen+is%3Aissue+label%3A%22Package%3A+remix%22)
+- [New Issues or Feature Requests (GitHub)](https://github.com/getsentry/sentry-javascript/issues/new/choose)
+
+This documentation will be updated as we get closer to general availability release.


### PR DESCRIPTION
Since https://github.com/getsentry/sentry-javascript/issues/4894 has been closed, let's move this into beta.