### PR TITLE
Update .NET MAUI

### DIFF
--- a/src/platforms/dotnet/guides/maui/index.mdx
+++ b/src/platforms/dotnet/guides/maui/index.mdx
@@ -31,12 +31,12 @@ This documentation will be updated as we get closer to general availability rele
 
 Add the Sentry dependency to your .NET MAUI application:
 
-```powershell {tabTitle:Package Manager}
-Install-Package Sentry.Maui -Version 3.19.0-preview.2
+```shell {tabTitle:.NET Core CLI}
+dotnet add package Sentry.Maui --prerelease
 ```
 
-```shell {tabTitle:.NET Core CLI}
-dotnet add package Sentry.Maui -v 3.19.0-preview.2
+```powershell {tabTitle:Package Manager}
+Install-Package Sentry.Maui -AllowPrereleaseVersions
 ```
 
 This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extensions-logging/). This means that besides the MAUI related features, through this package you'll also get access to all the framework's logging integration and also the features available in the main [Sentry](/platforms/dotnet/) SDK.

--- a/src/wizard/dotnet/maui.md
+++ b/src/wizard/dotnet/maui.md
@@ -9,14 +9,12 @@ Install the **NuGet** package:
 
 .NET Core CLI:
 
-```shell
-dotnet add package Sentry.Maui -v 3.19.0-preview.2
+```shell {tabTitle:.NET Core CLI}
+dotnet add package Sentry.Maui --prerelease
 ```
 
-Or, with the Visual Studio Package Manager:
-
-```powershell
-Install-Package Sentry.Maui -Version 3.19.0-preview.2
+```powershell {tabTitle:Package Manager}
+Install-Package Sentry.Maui -AllowPrereleaseVersions
 ```
 
 Then add Sentry to `MauiProgram.cs` through the `MauiAppBuilder`:

--- a/src/wizard/dotnet/maui.md
+++ b/src/wizard/dotnet/maui.md
@@ -7,8 +7,6 @@ type: framework
 
 Install the **NuGet** package:
 
-.NET Core CLI:
-
 ```shell {tabTitle:.NET Core CLI}
 dotnet add package Sentry.Maui --prerelease
 ```


### PR DESCRIPTION
Update the .NET MAUI package install to remove the version string and just use the latest pre-release.

We'll go back to using the version string when we are out of preview.