### PR TITLE
ref(codeowners): Add file limit

### DIFF
--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -100,6 +100,9 @@ Ownership rules take precedence over the information provided by your CODEOWNERS
 
 </Alert>
 
+#### Limitations
+We support CODEOWNERS files with a maximum of 100,000 characters. If your file exceeds this, we suggest using wildcard rules to consolidate multiple entries into a single entry.
+
 #### External Team/User Mappings
 
 <Note>


### PR DESCRIPTION
Add a mention of the maximum file size for codeowners with a suggestion on what to do if your file exceeds it. We get this question frequently.