### PR TITLE
Improve EF Core details

### DIFF
--- a/src/platforms/dotnet/guides/entityframework/index.mdx
+++ b/src/platforms/dotnet/guides/entityframework/index.mdx
@@ -7,7 +7,7 @@ redirect_from:
 
 Sentry provides an integration with `EntityFramework` through the of the [Sentry.EntityFramework NuGet package](https://www.nuget.org/packages/Sentry.EntityFramework).
 
-> Looking for `EntityFramework Core`? That integration is achieved through the [Sentry.Extensions.Logging](/platforms/dotnet/microsoft-extensions-logging/) package.
+> Looking for `EntityFramework Core`? If you're targeting .NET Core 3.1 or newer, that's already built in to the main Sentry .NET SDK.  It's also enabled by default for our ASP.NET or ASP.NET Core integrations, even for older targets.  For other scenarios, you may need to add the `Sentry.DiagnosticSource` package and call `AddDiagnosticSourceIntegration`, [as described here](/platforms/dotnet/performance/instrumentation/automatic-instrumentation/#diagnosticsource-integration).  (The rest of this page describes our EF6 integration, not EFCore.)
 
 ## Installation
 


### PR DESCRIPTION
EFCore is integrated through `Sentry` or `Sentry.DiagnosticSource`, not `Sentry.Extensions.Logging`.