### PR TITLE
Fix imported user on java samples

### DIFF
--- a/src/platforms/java/guides/spring-boot/record-user.mdx
+++ b/src/platforms/java/guides/spring-boot/record-user.mdx
@@ -29,7 +29,7 @@ To record custom user information, you can register a bean that implements `Sent
 
 ```java
 import org.springframework.stereotype.Component;
-import io.sentry.core.protocol.User;
+import io.sentry.protocol.User;
 import io.sentry.spring.SentryUserProvider;
 
 @Component
@@ -44,7 +44,7 @@ class CustomSentryUserProvider implements SentryUserProvider {
 
 ```kotlin
 import org.springframework.stereotype.Component
-import io.sentry.core.protocol.User
+import io.sentry.protocol.User
 import io.sentry.spring.SentryUserProvider
 
 @Component

--- a/src/platforms/java/guides/spring/advanced-usage.mdx
+++ b/src/platforms/java/guides/spring/advanced-usage.mdx
@@ -165,7 +165,7 @@ To record custom user information, you can register a bean that implements `Sent
 
 ```java {tabTitle:Java}
 import org.springframework.stereotype.Component;
-import io.sentry.core.protocol.User;
+import io.sentry.protocol.User;
 import io.sentry.spring.SentryUserProvider;
 
 @Component
@@ -180,7 +180,7 @@ class CustomSentryUserProvider implements SentryUserProvider {
 
 ```kotlin {tabTitle:Kotlin}
 import org.springframework.stereotype.Component
-import io.sentry.core.protocol.User
+import io.sentry.protocol.User
 import io.sentry.spring.SentryUserProvider
 
 @Component


### PR DESCRIPTION
`io.sentry.core.protocol` was a long time ago renamed to `io.sentry.protocol`