### PR TITLE
Add trace-propagation-targets to unified API options

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -437,7 +437,7 @@ If the callback is not set, or it returns `undefined`, the default naming scheme
 
 <ConfigKey name="enabled" supported={["javascript", "node"]}>
 
-Specifies whether this SDK should send events to Sentry. Defaults to `true`.  Setting this to `enabled: false` doesn't prevent all overhead from Sentry instrumentation. To disable Sentry completely, depending on environment, call `Sentry.init` conditionally.
+Specifies whether this SDK should send events to Sentry. Defaults to `true`. Setting this to `enabled: false` doesn't prevent all overhead from Sentry instrumentation. To disable Sentry completely, depending on environment, call `Sentry.init` conditionally.
 
 </ConfigKey>
 
@@ -595,6 +595,14 @@ An optional property that configures which downstream services receive the `sent
 
 </ConfigKey>
 
+<ConfigKey name="trace-propagation-targets" supported={["node"]}>
+
+An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and `baggage` headers attached to any outgoing HTTP requests.
+It contains a list of URLs or regex against which URLs are matched.
+If this option is not provided, trace data is attached to every outgoing request from the instrumented client.
+
+</ConfigKey>
+
 </PlatformSection>
 
 <PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor", "flutter"]}>
@@ -604,7 +612,6 @@ An optional property that configures which downstream services receive the `sent
 <ConfigKey name="experimental" supported={[]}>
 
 An optional property that configures which features are in experimental mode. This property is either an `Object Type` with properties or a key/value `TypedDict`, depending the language. Experimental features are still in-progress and may have bugs. We recognize the irony.
-
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -597,9 +597,13 @@ An optional property that configures which downstream services receive the `sent
 
 <ConfigKey name="trace-propagation-targets" supported={["node"]}>
 
-An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and `baggage` headers attached to any outgoing HTTP requests.
-It contains a list of URLs or regex against which URLs are matched.
-If this option is not provided, trace data is attached to every outgoing request from the instrumented client.
+An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
+
+The option may contain a list of strings or regex against which the URLs of outgoing requests are matched.
+If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
+String entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
+
+If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the instrumented client.
 
 </ConfigKey>
 


### PR DESCRIPTION
Adds documentation for the discussed `tracePropagationTargets` option. More context: [DACI](https://www.notion.so/sentry/DACI-Control-Sending-Trace-Data-63fd04ea885443ee99514c15a1e91499) (internal)

Related to changes in the JavaScript SDK: https://github.com/getsentry/sentry-javascript/pull/5521