### PR TITLE
fix(sentry apps): Update error handling docs

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/index.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/index.mdx
@@ -41,3 +41,5 @@ For example, if the webhook URL is `https://example.com/webhook/`, and your sche
 ## Error Handling
 
 Component rendering either 100% works or shows nothing. To protect the integration from looking chaotic due to errors we have no control over, if any part of the third-party component rendering fails, nothing will render.
+
+If there is an error in an issue linking component the link will be disabled.


### PR DESCRIPTION
Update the error handling docs for the integration platform to reflect a change made in https://github.com/getsentry/sentry/pull/37454 and https://github.com/getsentry/sentry/pull/37325 which shows an issue link as disabled rather than not showing it at all.