### PR TITLE
Minor Ruby error in fingerprint example

### DIFF
--- a/src/includes/set-fingerprint/rpc/ruby.mdx
+++ b/src/includes/set-fingerprint/rpc/ruby.mdx
@@ -10,9 +10,11 @@ class RPCError < StandardError
 end
 
 Sentry.init do |config|
-  #...
+  # ...
   config.before_send = lambda do |event, hint|
-    if hint[:exception].is_a?(RPCError)
+    exception = hint[:exception]
+
+    if exception.is_a?(RPCError)
       event.fingerprint = ["{{default}}", exception.code, exception.function_name]
     end
 


### PR DESCRIPTION
Minor documentation fix in order for the Ruby code to be able to parse by default.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
