### PR TITLE
SF Install : Missing extends AbstractController

### DIFF
--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -118,9 +118,10 @@ To test that both logger error and exception are correctly sent to sentry.io, yo
 namespace App\Controller;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
-class SentryTestController
+class SentryTestController extends AbstractController
 {
     /**
      * @var LoggerInterface


### PR DESCRIPTION
Just a little missing typo that I find will integrating the SentryTestController myself :)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
