### PR TITLE
docs: document the log levels in a convenient place

### DIFF
--- a/src/platforms/common/usage/set-level.mdx
+++ b/src/platforms/common/usage/set-level.mdx
@@ -9,3 +9,5 @@ notSupported:
 The level - similar to logging levels - is generally added by default based on the integration. You can also override it within an event.
 
 <PlatformContent includePath="set-level" />
+
+Available levels are `:fatal`, `:critical`, `:error`, `:warning`, `:log`, `:info`, and `:debug`. The default if not specified is `:error`.


### PR DESCRIPTION
## What

Put the log level options under the code telling us how to set the log level.

## Why

So that I don't have to guess or search the docs for the level options and I can speedily implement my change.

## How

Copy paste the log level from [the JS docs](https://docs.sentry.io/platforms/javascript/usage/set-level/).

## Future suggestions

It'd be better to have one page with all the levels then each language can just reference that place.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
