### PR TITLE
docs(perf): Clarify widget overall number values

### DIFF
--- a/src/docs/product/performance/filters-display/widgets.mdx
+++ b/src/docs/product/performance/filters-display/widgets.mdx
@@ -7,6 +7,12 @@ description: "Learn more about Sentry's Performance widgets such as, Most Relate
 Performance widgets offer visualizations that you can change to best match your workflow. They provide performance-specific views that allow you see and act on transaction data across your organization.
 Depending on which **Performance** tab you've selected, different curated performance widgets will be available.
 
+<Note>
+
+The value displayed in the top right of some widgets is the overall value for the selected time period, rather than the mean of the data displayed in the chart. For data sets with low event volume the overall value may be higher or lower than expected due to the non-linear nature of metrics like [Apdex](/product/performance/metrics/#apdex) and [User Misery](/product/performance/metrics/#user-misery).
+
+</Note>
+
 ## Most Improved
 
 Shows the most improved transactions and visualizes the improvement for the selected transaction in the list. Only trends of a specific significance and throughput are shown. Learn more in [Trends](/product/performance/trends).

--- a/src/docs/product/performance/filters-display/widgets.mdx
+++ b/src/docs/product/performance/filters-display/widgets.mdx
@@ -9,7 +9,7 @@ Depending on which **Performance** tab you've selected, different curated perfor
 
 <Note>
 
-The value displayed in the top right of some widgets is the overall value for the selected time period, rather than the mean of the data displayed in the chart. For data sets with low event volume the overall value may be higher or lower than expected due to the non-linear nature of metrics like [Apdex](/product/performance/metrics/#apdex) and [User Misery](/product/performance/metrics/#user-misery).
+The value displayed in the top right of some widgets is the overall value for the selected time period, rather than the average of the data displayed in the chart. For data sets with low event volume the overall value may be higher or lower than expected due to the non-linear nature of metrics like [Apdex](/product/performance/metrics/#apdex) and [User Misery](/product/performance/metrics/#user-misery).
 
 </Note>
 

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -81,6 +81,12 @@ User Misery is a user-weighted performance metric to assess the relative magnitu
 
 You can set satisfactory thresholds for each project with [custom thresholds](#custom-thresholds).
 
+<Note>
+
+User Misery is calculated using a probability distribution. This prevents false positives and ensures reasonable values for data sets with low event volume.
+
+</Note>
+
 ## Custom Thresholds
 
 For each project, you can configure how [Apdex](#apdex) and [User Misery](#user-misery) are calculated in **[Project] > Settings > Performance**. You can override project-level settings at the transaction level in **Transaction Summary > Settings**.

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -14,11 +14,11 @@ Apdex is an industry-standard metric used to track and measure user satisfaction
 
 Below are the components of Apdex and its formula:
 
-* **T**: Threshold for the target response time.
-* **Satisfactory**: Users are satisfied using the app when their page load times are less than or equal to T.
-* **Tolerable**: Users consider the app tolerable to use when their page load times are greater than T and less than or equal to 4T.
-* **Frustrated**: Users are frustrated with the app when their page load times are greater than 4T.
-* **Apdex**: (Number of Satisfactory Requests + (Number of Tolerable Requests/2)) / (Number of Total Requests)
+- **T**: Threshold for the target response time.
+- **Satisfactory**: Users are satisfied using the app when their page load times are less than or equal to T.
+- **Tolerable**: Users consider the app tolerable to use when their page load times are greater than T and less than or equal to 4T.
+- **Frustrated**: Users are frustrated with the app when their page load times are greater than 4T.
+- **Apdex**: (Number of Satisfactory Requests + (Number of Tolerable Requests/2)) / (Number of Total Requests)
 
 Configure what a satisfactory response time threshold (ms) is for Apdex in **Settings > Performance**. You can set this for each project with [custom thresholds](#custom-thresholds).
 

--- a/src/docs/product/performance/metrics.mdx
+++ b/src/docs/product/performance/metrics.mdx
@@ -83,7 +83,7 @@ You can set satisfactory thresholds for each project with [custom thresholds](#c
 
 <Note>
 
-User Misery is calculated using a probability distribution. This prevents false positives and ensures reasonable values for data sets with low event volume.
+User Misery is calculated using a probability distribution. This prevents false positives and ensures reasonable values for data sets with low event volume. You can view the underlying data by querying for the [`count_miserable()` function](/product/discover-queries/query-builder/#stacking-functions).
 
 </Note>
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/37470. Explains why the values in the top right of the widgets might be surprising for sparse data sets. Related to PERF-1383