### PR TITLE
fix(electron): Re-enable attachment docs

### DIFF
--- a/src/platforms/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/common/enriching-events/attachments/index.mdx
@@ -16,8 +16,6 @@ supported:
 
 ---
 
-<PlatformSection notSupported={["javascript.electron"]}>
-
 <PlatformSection supported={["apple", "android", "java"]}>
 
 Please note that attachments don't work yet with crashes.
@@ -140,7 +138,6 @@ Attachments persist for 30 days; if your total storage included in your quota is
 
 Learn more about how attachments impact your [quota](/product/accounts/quotas/).
 
-</PlatformSection>
 
 <PlatformSection supported={["native", "javascript.electron"]}>
 


### PR DESCRIPTION
Essentially reverts #5261 since the SDK now supports attachments.