### PR TITLE
fix(electron): Uploading of debug symbols no longer required

### DIFF
--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -117,13 +117,11 @@ This script exposes IPC to the isolated renderer via Electrons `contextBridge` A
 
 Check out the [example apps](https://github.com/getsentry/sentry-electron/tree/master/examples) for how to do this.
 
-## Uploading Debug Information
+## Debug Information
 
-To get symbolicated stack traces for native crashes, you have to upload debug symbols to Sentry. Sentry Wizard creates a convenient `sentry-symbols.js` script that will upload the Electron symbols for you. After installing the SDK and every time you upgrade the Electron version, run this script:
-
-```shell
-node sentry-symbols.js
-```
+To get symbolicated stack traces for native crashes, you should enable fetching
+debug symbols from the Electron symbol server. Go to **Project Settings > Debug
+Files** and add Electron to the list of built-in repositories.
 
 If your app uses a custom Electron fork, contains modules with native extensions or spawns subprocesses, you have to upload those symbols manually using Sentry CLI. For more information, see [_Native Usage_](/platforms/electron/).
 


### PR DESCRIPTION
Related to:
https://github.com/getsentry/sentry-electron/issues/524
https://github.com/getsentry/sentry-wizard/pull/183

Full native stack decoding is now supported by simply enabling the Electron symbol server in Sentry.