### PR TITLE
Add typescript support

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -142,6 +142,72 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
 export default MyError;
 ```
 
+```typescript {filename:pages/_error.js}
+import * as Sentry from '@sentry/nextjs';
+import type { NextPageContext } from 'next';
+import NextErrorComponent, { ErrorProps as ErrorBaseProps } from 'next/error';
+
+interface ErrorProps extends ErrorBaseProps {
+  err?: Error;
+  hasGetInitialPropsRun?: boolean;
+}
+
+const MyError = ({ statusCode, hasGetInitialPropsRun, err }: ErrorProps) => {
+  if (!hasGetInitialPropsRun && err) {
+    // getInitialProps is not called in case of
+    // https://github.com/vercel/next.js/issues/8592. As a workaround, we pass
+    // err via _app.js so it can be captured
+    Sentry.captureException(err);
+    // Flushing is not required in this case as it only happens on the client
+  }
+
+  return <NextErrorComponent statusCode={statusCode} />;
+};
+
+MyError.getInitialProps = async (context: NextPageContext) => {
+  const errorInitialProps: ErrorProps = await NextErrorComponent.getInitialProps(context);
+
+  const { err, asPath } = context;
+
+  // Workaround for https://github.com/vercel/next.js/issues/8592, mark when
+  // getInitialProps has run
+  errorInitialProps.hasGetInitialPropsRun = true;
+
+  // Running on the server, the response object (`res`) is available.
+  //
+  // Next.js will pass an err on the server if a page's data fetching methods
+  // threw or returned a Promise that rejected
+  //
+  // Running on the client (browser), Next.js will provide an err if:
+  //
+  //  - a page's `getInitialProps` threw or returned a Promise that rejected
+  //  - an exception was thrown somewhere in the React lifecycle (render,
+  //    componentDidMount, etc) that was caught by Next.js's React Error
+  //    Boundary. Read more about what types of exceptions are caught by Error
+  //    Boundaries: https://reactjs.org/docs/error-boundaries.html
+
+  if (err) {
+    Sentry.captureException(err);
+
+    // Flushing before returning is necessary if deploying to Vercel, see
+    // https://vercel.com/docs/platform/limits#streaming-responses
+    await Sentry.flush(2000);
+
+    return errorInitialProps;
+  }
+
+  // If this point is reached, getInitialProps was called without any
+  // information about what the error might be. This is unexpected and may
+  // indicate a bug introduced in Next.js, so record it in Sentry
+  Sentry.captureException(new Error(`_error.js getInitialProps missing data at path: ${asPath}`));
+  await Sentry.flush(2000);
+
+  return errorInitialProps;
+};
+
+export default MyError;
+```
+
 ## Extend Next.js Configuration
 
 Use `withSentryConfig` to extend the default Next.js usage of Webpack. This will do two things:


### PR DESCRIPTION
Add typescript support on topic "Create a Custom `_error` Page"

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
