### PR TITLE
docs(sdk): Add long tasks experiment to docs

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -99,3 +99,21 @@ The default is `600`.
 This option flags transactions when tabs are moved to the background with "cancelled". Because browser background tab timing is not suited for precise measurements of operations and can affect your statistics in nondeterministic ways, we recommend that this option be enabled.
 
 The default is `true`.
+
+
+### _experiments
+
+This is an object containing experimental flags for features that may involve breaking changes that haven't yet landed in a new major version. 
+
+The default is
+```
+{
+  enableLongTasks: true
+}
+```
+
+#### _experiments.enableLongTasks
+
+This experimental option determines whether spans for long tasks automatically get created.
+
+The default is `true`.


### PR DESCRIPTION
### Summary 
This adds the new 'experiments' option for `BrowserTracing` with the on-by-default `enableLongTasks` flag.

Refs: https://github.com/getsentry/sentry-javascript/pull/5529