### PR TITLE
Add :z to volume mount in Relay example

### DIFF
--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -32,7 +32,8 @@ container and copying in the files.
 
 ```shell {tabTitle:Run in Docker}
 # Adjust permissions for the configuration directory
-# (the :z option is only necessary on selinux)
+# The :z option is only necessary on selinux.
+# See https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label.
 docker run --rm -it                  \
   -v $(pwd)/config/:/work/.relay/:z  \
   --entrypoint bash                  \

--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -32,8 +32,9 @@ container and copying in the files.
 
 ```shell {tabTitle:Run in Docker}
 # Adjust permissions for the configuration directory
+# (the :z option is only necessary on selinux)
 docker run --rm -it                  \
-  -v $(pwd)/config/:/work/.relay/:z  \ // ':z' is necessary only on selinux
+  -v $(pwd)/config/:/work/.relay/:z  \
   --entrypoint bash                  \
   getsentry/relay                    \
   -c 'chown -R relay:relay /work/.relay'

--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -32,16 +32,16 @@ container and copying in the files.
 
 ```shell {tabTitle:Run in Docker}
 # Adjust permissions for the configuration directory
-docker run --rm -it                \
-  -v $(pwd)/config/:/work/.relay/  \
-  --entrypoint bash                \
-  getsentry/relay                  \
+docker run --rm -it                  \
+  -v $(pwd)/config/:/work/.relay/:z  \ // ':z' is necessary only on selinux
+  --entrypoint bash                  \
+  getsentry/relay                    \
   -c 'chown -R relay:relay /work/.relay'
 
 # Generate the configuration
-docker run --rm -it                \
-  -v $(pwd)/config/:/work/.relay/  \
-  getsentry/relay                  \
+docker run --rm -it                  \
+  -v $(pwd)/config/:/work/.relay/:z  \
+  getsentry/relay                    \
   config init
 ```
 


### PR DESCRIPTION
Apparently the [`:z` option](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) is necessary for users of [SELinux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux).

Fixes https://github.com/getsentry/sentry-docs/issues/5422