### PR TITLE
ref(remix): Improve Remix SDK docs and wizard

### DIFF
--- a/src/includes/getting-started-verify/javascript.remix.mdx
+++ b/src/includes/getting-started-verify/javascript.remix.mdx
@@ -1,5 +1,3 @@
-Add a button to a frontend component that throws an error.
-
 ```typescript {filename:routes/error.tsx}
 <button
   type="button"
@@ -10,6 +8,8 @@ Add a button to a frontend component that throws an error.
   Throw error
 </button>
 ```
+
+This snippet adds a button that throws an error in a component or page.
 
 <Note>
 

--- a/src/includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/includes/sourcemaps/overview/javascript.remix.mdx
@@ -6,7 +6,7 @@ Remix can be configured to output source maps using Remix CLI. Learn more about 
 
 ### 2: Provide Source Maps to Sentry
 
-Source maps can be uploaded to Sentry by creating a release. Learn more about [how to upload source maps] (./uploading/).
+Source maps can be uploaded to Sentry by creating a release. Learn more about [how to upload source maps](./uploading/).
 
 <Note>
 

--- a/src/includes/sourcemaps/upload/primer/javascript.remix.mdx
+++ b/src/includes/sourcemaps/upload/primer/javascript.remix.mdx
@@ -1,7 +1,7 @@
-On release, call `yarn sentry-upload-sourcemaps` to upload source maps and create a release. 
+On release, call `yarn sentry-upload-sourcemaps` to upload source maps and create a release.
 
 <Alert level="warning">
-  
+
 `sentry-upload-sourcemaps` requires either [`env` variables](/product/cli/configuration/#configuration-values) or a valid `.sentryclirc` file to pick up your project ID, organization ID, and token. You can create the `.sentryclirc` file with necessary configuration, as documented on this [page](/product/cli/configuration/).
 
 </Alert>

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -13,6 +13,7 @@ notSupported:
   - javascript.react
   - javascript.vue
   - javascript.wasm
+  - javascript.remix
 ---
 
 <PageGrid />

--- a/src/wizard/javascript/remix.md
+++ b/src/wizard/javascript/remix.md
@@ -30,7 +30,7 @@ Sentry.init({
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,
-        useMatches,
+        useMatches
       ),
     }),
   ],
@@ -85,4 +85,14 @@ function App() {
 export default withSentry(App);
 ```
 
-Once you've verified the library is initialized properly and sent a test event, consider visiting our [complete Remix docs](https://docs.sentry.io/platforms/javascript/guides/remix/). There, you'll find additional instructions for configuring the Remix SDK.
+After this step, Sentry will report any uncaught exceptions triggered by your application.
+
+You can trigger your first event from your development environment by raising an exception somewhere within your application. An example of this would be rendering a button whose `onClick` handler attempts to invoke a method that does not exist:
+
+```javascript
+<button type="button" onClick={methodDoesNotExist}>
+  Throw error
+</button>
+```
+
+Once you've verified the SDK is initialized properly and sent a test event, check our our [complete Remix docs](https://docs.sentry.io/platforms/javascript/guides/remix/)for additional configuration instructions.

--- a/src/wizard/javascript/remix.md
+++ b/src/wizard/javascript/remix.md
@@ -95,4 +95,4 @@ You can trigger your first event from your development environment by raising an
 </button>
 ```
 
-Once you've verified the SDK is initialized properly and sent a test event, check our our [complete Remix docs](https://docs.sentry.io/platforms/javascript/guides/remix/)for additional configuration instructions.
+Once you've verified the SDK is initialized properly and sent a test event, check out our [complete Remix docs](https://docs.sentry.io/platforms/javascript/guides/remix/)for additional configuration instructions.


### PR DESCRIPTION
This PR makes a few small improvements to our Remix SDK documentation and the onboarding wizard. While working on #5413 and #5415 I came across some things that IMO could be slightly improved. Furthermore, during the review of the two PRs a few additional things came up that we should also address in the Remix docs.

Specifically, this PR 
* disables the "Installation Methods" section in the left nav menu. (Doesn't make sense for Remix b/c the only installation method is NPM)
* Fixes a few broken links (which didn't work b/c of some formatting problems)
* repositions and adjusts a sentence regarding the SDK functionality "verification" (i.e. the section to send your first event)
* Adds a basic SDK functionality "verification" step to the onboarding wizard (for consistency with our other SDKs).   