### PR TITLE
Add Yarn as a dependency for development

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -12,7 +12,7 @@ if ! [ -x $(command -v homebrew) ]; then
 fi
 
 # Install system toolchain
-brew install volta pre-commit
+brew install volta pre-commit yarn
 
 # App dependencies
 make

--- a/src/docs/contributing/environment.mdx
+++ b/src/docs/contributing/environment.mdx
@@ -4,7 +4,7 @@ noindex: true
 sidebar_order: 1
 ---
 
-You will need [Volta][volta] and [pre-commit][pre-commit] installed. If you don't have opinions about the process, this will get you going:
+You will need [Yarn][yarn], [Volta][volta], and [pre-commit][pre-commit] installed. If you don't have opinions about the process, this will get you going:
 
 ```bash
 # Install Homebrew and everything mentioned above
@@ -24,9 +24,9 @@ Now run the development webserver:
 yarn start
 ```
 
-You will now be able to access docs via http://localhost:3000.
+You will now be able to access docs via [http://localhost:3000](http://localhost:3000).
 
-[gatsby]: https://gatsbyjs.org
+[yarn]: https://yarnpkg.com/
 [volta]: https://volta.sh/
 [pre-commit]: https://pre-commit.com/
 


### PR DESCRIPTION
I had to install yarn for this, and it would have saved me 2 seconds if it had been specified. If there's a reason to not list it explicitly, that's fine. But I figure while I have the project cloned I'll make a PR.

* Also, remove an unused Gatsby link
* Also, make the link to localhost clickable




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
