### PR TITLE
Add User Feedback section for Rails

### DIFF
--- a/src/includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
+++ b/src/includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
@@ -1,6 +1,6 @@
-In Rails, being able to serve dynamic (e.g. `.html.erb`) pages in response to errors is required in order to pass the needed `event_id` to the JavaScript SDK. Normally, this looks like overwriting the `config.exceptions_app` setting to point at your own router, and then calling your own controller to handle the error. Several tutorials or gems exist to allow for this.
+In Rails, being able to serve dynamic (for example, `.html.erb`) pages in response to errors is required to pass the needed `event_id` to the JavaScript SDK. Typically, this is done by overwriting the `config.exceptions_app` setting to point to your own router, and then calling your own controller to handle the error. You can find more detailed instructions for this configuration online or install a gem to handle this for you.
 
-Once you are able to serve dynamic exception pages, supporting user feedback is straightforward.
+Once you're able to serve dynamic exception pages, you can support user feedback.
 
 Make sure you've got the JavaScript SDK available:
 
@@ -12,7 +12,7 @@ Make sure you've got the JavaScript SDK available:
 ></script>
 ```
 
-And the template that brings up the dialog:
+Additionally, you need the template that brings up the dialog:
 
 ```ERB
 <% sentry_id = request.env["sentry.error_event_id"] %>

--- a/src/includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
+++ b/src/includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
@@ -1,0 +1,25 @@
+In Rails, being able to serve dynamic (e.g. `.html.erb`) pages in response to errors is required in order to pass the needed `event_id` to the JavaScript SDK. Normally, this looks like overwriting the `config.exceptions_app` setting to point at your own router, and then calling your own controller to handle the error. Several tutorials or gems exist to allow for this.
+
+Once you are able to serve dynamic exception pages, supporting user feedback is straightforward.
+
+Make sure you've got the JavaScript SDK available:
+
+```ERB
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+And the template that brings up the dialog:
+
+```ERB
+<% sentry_id = request.env["sentry.error_event_id"] %>
+<% if sentry_id.present? %>
+<script>
+  Sentry.init({ dsn: "___PUBLIC_DSN___" });
+  Sentry.showReportDialog({ eventId: "<%= sentry_id %>" });
+</script>
+<% end %>
+```

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -57,7 +57,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
 
 </PlatformSection>
 
-<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "ruby" "unity", "react-native", "unreal"]}>
+<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "ruby", "unity", "react-native", "unreal"]}>
 
 ## Embeddable JavaScript Widget
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -57,7 +57,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
 
 </PlatformSection>
 
-<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "ruby", "unity", "react-native", "unreal"]}>
+<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "unity", "react-native", "unreal"]}>
 
 ## Embeddable JavaScript Widget
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -57,7 +57,58 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
 
 </PlatformSection>
 
-<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "unity", "react-native", "unreal"]}>
+<PlatformSection notSupported={["android", "apple", "java", "native", "dart", "flutter", "ruby" "unity", "react-native", "unreal"]}>
+
+## Embeddable JavaScript Widget
+
+Our embeddable JavaScript widget is useful when you may typically render a plain error page (the classic `500.html`) on your website.
+
+To collect feedback, the widget requests and collects the user's name, email address, and a description of what occurred. When feedback is provided, Sentry pairs the feedback with the original event, giving you additional insights into issues.
+
+The screenshot below provides an example of the User Feedback widget, though yours may differ depending on your customization:
+
+![An example of a user feedback widget with text boxes for user name, email, and additional details about the break.](user_feedback_widget.png)
+
+### Integration
+
+To integrate the widget, you'll need to be running version 2.1 or newer of our JavaScript SDK. The widget authenticates with your public DSN, then passes in the Event ID that was generated on your backend.
+
+<PlatformContent includePath="enriching-events/user-feedback/example-widget" />
+
+## Customizing the Widget
+
+You can customize the widget to your organization's needs, especially for localization purposes. All options can be passed through the `showReportDialog` call.
+
+An override for Sentry’s automatic language detection (e.g. `lang=de`)
+
+| Param            | Default                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| `eventId`        | Manually set the id of the event.                                                                 |
+| `dsn`            | Manually set dsn to report to.                                                                    |
+| `user`           | Manually set user data _[an object with keys listed below]_.                                      |
+| `user.email`     | User's email address.                                                                             |
+| `user.name`      | User's name.                                                                                      |
+| `lang`           | _[automatic]_ – **override for Sentry’s language code**                                           |
+| `title`          | It looks like we’re having issues.                                                                |
+| `subtitle`       | Our team has been notified.                                                                       |
+| `subtitle2`      | If you’d like to help, tell us what happened below. – **not visible on small screen resolutions** |
+| `labelName`      | Name                                                                                              |
+| `labelEmail`     | Email                                                                                             |
+| `labelComments`  | What happened?                                                                                    |
+| `labelClose`     | Close                                                                                             |
+| `labelSubmit`    | Submit                                                                                            |
+| `errorGeneric`   | An unknown error occurred while submitting your report. Please try again.                         |
+| `errorFormEntry` | Some fields were invalid. Please correct the errors and try again.                                |
+| `successMessage` | Your feedback has been sent. Thank you!                                                           |
+| `onLoad`         | n/a                                                                                               |
+
+## User Feedback API
+
+If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use the [User Feedback API](/api/projects/submit-user-feedback/).
+
+</PlatformSection>
+
+<PlatformSection supported={["ruby.rails"]}>
 
 ## Embeddable JavaScript Widget
 


### PR DESCRIPTION
Adds information on integrating the JavaScript User Feedback SDK into a Rails app. It's modeled off the existing Python documentation.

It also serves as a way to document the env variable `sentry.error_event_id` which was added in https://github.com/getsentry/sentry-ruby/pull/1849 (CC: @st0012).

This has the unfortunate side-effect of populating the Ruby-only version of this page, when the Ruby SDK doesn't actually support user feedback. But there's no easy way to show this page for Rails and not Ruby. Python also has the same problem, so I don't think this should block merging.

I recently implemented the described behavior in our Rails app, so I thought I'd add a couple words to the documentation. Feedback is welcome.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
