### PR TITLE
Fix duplicate petabyte typo in Performance Metrics doc

### DIFF
--- a/src/platforms/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/common/performance/instrumentation/performance-metrics.mdx
@@ -86,7 +86,6 @@ Units augment metric values by giving meaning to what otherwise might be abstrac
 - `terabyte`
 - `tebibyte`
 - `petabyte`
-- `petabyte`
 - `pebibyte`
 - `exabyte`
 - `exbibyte`


### PR DESCRIPTION
fixes this typo in the performance metrics doc
![image](https://user-images.githubusercontent.com/83961295/185194250-047aec8c-e862-4d50-b951-f12b5dfedfdb.png)
https://docs.sentry.io/platforms/python/performance/instrumentation/performance-metrics/#information-units