### PR TITLE
feat: Add limitation about data scrubbing in breadcrumbs

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
@@ -61,8 +61,6 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 - While you cannot delete a single event, you can delete the issue the event is in by clicking the trash icon on the **Issue Details** page.
 - If a large number of unique events - representing multiple issues - contain the data, you may need to delete and re-create the project to effectively cleanse the system.
 
-## Known Limitations of server-side data scrubbing
+## Known Limitations
 
-The following limitations generally apply to all server-side data scrubbing.
-
-- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) by adding the category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And if custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.
+It's not currently possible to avoid scrubbing data in [breadcrumbs](/product/issues/issue-details/breadcrumbs/) by adding the category name in "Safe Fields". Only the message and data in breadcrumbs are used for data scrubbing. Also, if custom JSON data is provided, the fields will be scrubbed according to the configured rules and the entries in "Safe Fields".

--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
@@ -60,3 +60,9 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 - If you send the data as a tagged value, removing the event is not enough. Visit your **Project Settings > Tags** to permanently remove any related data for a given tag.
 - While you cannot delete a single event, you can delete the issue the event is in by clicking the trash icon on the **Issue Details** page.
 - If a large number of unique events - representing multiple issues - contain the data, you may need to delete and re-create the project to effectively cleanse the system.
+
+## Known Limitations of server-side data scrubbing
+
+The following limitations generally apply to all server-side data scrubbing.
+
+- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) even when category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And is custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.

--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
@@ -65,4 +65,4 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 
 The following limitations generally apply to all server-side data scrubbing.
 
-- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) even when category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And is custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.
+- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) by adding the category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And is custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.

--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
@@ -65,4 +65,4 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 
 The following limitations generally apply to all server-side data scrubbing.
 
-- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) by adding the category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And is custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.
+- It is currently not possible to avoid scrubbing data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) by adding the category name added to Safe Fields. Only the message and data in [_breadcrumbs_](/product/issues/issue-details/breadcrumbs/) are used for data scrubbing. And if custom JSON data is provided the fields will be scrubbed according to the configured rules and Safe Fields.


### PR DESCRIPTION
This PR adds mentions about some limitations which data scrubbing  has in the breadcrumbs. 
Where the scrubbing only works for message and data. 