### PR TITLE
clarify initial premise of issue alerts

### DIFF
--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -18,7 +18,7 @@ You can create two types of alerts:
 
 ## Issue Alerts
 
-Issue alerts trigger whenever a new event is received and any issue in a project matches the specified criteria. These criteria might be, for example, a resolved issue re-appearing or an issue affecting many users.
+Issue alerts trigger whenever a new event is received for any issue in a project matching the specified criteria. These criteria might be, for example, a resolved issue re-appearing or an issue affecting many users.
 
 In the “Alert Rules” tab, these alerts are identified by the issues icon, and by default, they are displayed at the bottom of your list of alerts. (If you have several metric alerts, this may push your issue alerts off the first page of the list.)
 

--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -18,7 +18,7 @@ You can create two types of alerts:
 
 ## Issue Alerts
 
-Issue alerts trigger whenever any issue in a project matches the specified criteria. These criteria might be, for example, a resolved issue re-appearing or an issue affecting many users.
+Issue alerts trigger whenever a new event is received and any issue in a project matches the specified criteria. These criteria might be, for example, a resolved issue re-appearing or an issue affecting many users.
 
 In the “Alert Rules” tab, these alerts are identified by the issues icon, and by default, they are displayed at the bottom of your list of alerts. (If you have several metric alerts, this may push your issue alerts off the first page of the list.)
 


### PR DESCRIPTION
Some users miss this point and expect issue alerts to be constantly scanning. It is reiterated further down after a screenshot though.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
