### PR TITLE
Remove space to enable link

### DIFF
--- a/src/docs/product/cli/send-event.mdx
+++ b/src/docs/product/cli/send-event.mdx
@@ -102,4 +102,4 @@ eval "$(sentry-cli bash-hook)"
 # rest of the script goes here
 ```
 
-Alternatively you can use other mechanisms like [a `.sentryclirc` file] (https://docs.sentry.io/product/cli/configuration/#configuration-file) to configure the DSN.
+Alternatively you can use other mechanisms like [a `.sentryclirc` file](https://docs.sentry.io/product/cli/configuration/#configuration-file) to configure the DSN.


### PR DESCRIPTION
There's currently an empty space breaking the link.