### PR TITLE
chore(platformicons): update to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "5.2.1",
+    "platformicons": "^5.3.1",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13875,10 +13875,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.1.tgz#4edbb1db58bf84c3f2fd3ed65afb90110253929e"
-  integrity sha512-56S/1RHaSYeeYCpumg+jWGAnL2iCd3i3xVLqwN9F26LzGz2SMZA8LBkEEbFWf2DbBv3N5GnsgUDtJrnN1f0SqA==
+platformicons@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.3.1.tgz#778c9bc4899e9f668cad5bb49efbcfeacbb890c3"
+  integrity sha512-P25aSE/3tup5fxLJHK7yhQEs1QOQny+sqw4o2SU2xLgSMo0zRPr9wkxZ3EEHDqCYOBsYqQtstTECFLUmk9yUFA==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Includes Svelte logo - linked to https://github.com/getsentry/sentry/pull/38118 