### PR TITLE
ref(nextjs): Add note about upcoming default `hideSourceMaps` value

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -244,9 +244,9 @@ In that case you can also skip the `sentry-cli` configuration step below.
 
 ### Use `hidden-source-map`
 
-_(New in version 6.17.1)_
+_(New in version 6.17.1, will default to `true` in 8.0.0 and beyond.)_
 
-If you would like to use `hidden-source-map` rather than `source-map` as your webpack `devtool`, so that your built files do not contain a `sourceMappingURL` comment, add a `sentry` object to `moduleExports` above, and set the `hideSourceMaps` option to `true`:
+Depending on your deployment setup, adding `sentry/nextjs` to your app may cause your source code to be visible in browser devtools when it wasn't before. (This happens because of the default behavior of [Webpack's `source-map` built-in `devtool`](https://webpack.js.org/configuration/devtool/).) To prevent this, you can use `hidden-source-map` rather than `source-map`, which will prevent your built files from containing a `sourceMappingURL` comment, thus making sourcemaps invisible to the browser. To use `hidden-source-map`, add a `sentry` object to `moduleExports` above, and set the `hideSourceMaps` option to `true`:
 
 ```javascript {filename:next.config.js}
 const moduleExports = {
@@ -256,7 +256,7 @@ const moduleExports = {
 };
 ```
 
-Note that this only applies to client-side builds, and requires the `SentryWebpackPlugin` to be enabled.
+Note that this only applies to client-side builds, and requires the `SentryWebpackPlugin` to be enabled. This option will default to `true` starting in version 8.0.0. See https://webpack.js.org/configuration/devtool/ for more information.
 
 ### Widen the Upload Scope
 


### PR DESCRIPTION
This expands the explanation of the `hideSourceMaps` option in `next.config.js`, and notes that it will default to `true` starting in version 8 of the SDK.

In conjunction with https://github.com/getsentry/sentry-javascript/pull/5649, https://github.com/getsentry/sentry-wizard/pull/188, and https://github.com/vercel/next.js/pull/40079, this is the first step in addressing the concerns raised in https://github.com/getsentry/sentry-javascript/issues/4489. See [here](https://github.com/getsentry/sentry-javascript/issues/4489#issuecomment-1231137629) for more details.