### PR TITLE
Fixed incorrect variable assignment

### DIFF
--- a/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
+++ b/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
@@ -2,10 +2,10 @@
 using Sentry;
 
 // will be tagged with my-tag="my value"
-SentrySdk.CaptureException(new Exception("my error"), configureScope =>
+SentrySdk.CaptureException(new Exception("my error"), scope =>
 {
-    configureScope.SetTag("my-tag", "my value");
-    configureScope.Level = SentryLevel.Warning;
+    scope.SetTag("my-tag", "my value");
+    scope.Level = SentryLevel.Warning;
 });
 
 // will not be tagged with my-tag
@@ -19,7 +19,7 @@ open Sentry
 SentrySdk.CaptureException (exn "my error",
   fun scope ->
     scope.SetTag("my-tag", "my value")
-    scope.Level <- SentryLevel.Warning
+    .Level <- SentryLevel.Warning
   )
 
 // will not be tagged with my-tag

--- a/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
+++ b/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
@@ -19,7 +19,7 @@ open Sentry
 SentrySdk.CaptureException (exn "my error",
   fun scope ->
     scope.SetTag("my-tag", "my value")
-    .Level <- SentryLevel.Warning
+    scope.Level <- SentryLevel.Warning
   )
 
 // will not be tagged with my-tag

--- a/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
+++ b/src/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
@@ -4,8 +4,8 @@ using Sentry;
 // will be tagged with my-tag="my value"
 SentrySdk.CaptureException(new Exception("my error"), configureScope =>
 {
-    scope.SetTag("my-tag", "my value");
-    scope.Level = SentryLevel.Warning;
+    configureScope.SetTag("my-tag", "my value");
+    configureScope.Level = SentryLevel.Warning;
 });
 
 // will not be tagged with my-tag


### PR DESCRIPTION
Fixed incorrect variable assignment in CaptureException call back  function.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
