### PR TITLE
fix(mep): Update metric fields

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -89,17 +89,16 @@ Release properties overlap with event and issue search properties, so they don't
 | Key/Token | Description | E | I | M | Type |
 |---|---|---|---|---|---|
 | age | Returns issues created since the time defined by the value. The syntax is similar to the Unix find command. Supported suffixes: `m - minutes`, `h - hours`, `d - days`, `w - weeks`. For example, `age:-24h` returns isssues that are new in the last 24 hours, while `age:+12h` returns ones that are older than 12 hours. Entering `age:+12h age:-24h` would return issues created between 12 and 24 hours ago. |  | x |  | relative time |
-| apdex(threshold) | Returns results with the [Apdex score](/product/performance/metrics/#apdex) that you entered. Values must be between `0` and `1`. Higher apdex values indicate higher user satisfaction. | x |  |  | number |
+| apdex(threshold) | Returns results with the [Apdex score](/product/performance/metrics/#apdex) that you entered. Values must be between `0` and `1`. Higher apdex values indicate higher user satisfaction. | x |  | x | number |
 | assigned | Returns issues assigned to the defined user. Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee, or # followed by the team name, that is `#team-name`. |  | x |  | team or org user |
 | assigned_<br></br>or_suggested | Returns issues assigned to or suggested to be assigned to the defined user. Suggested assignees are determined by matching [ownership rules](/product/error-monitoring/issue-owners/) and [suspect commits](/product/releases/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee/suggestions, or # followed by the team name, that is `#team-name`. |  | x |  | team or org user |
-| avg(field) | Returns results with matching averages for the field selected. The field can be either a number or a duration. Typically used with a comparison operator. | x |  |  | matches field |
+| avg(field) | Returns results with matching averages for the field selected. The field can be either a number or a duration. Typically used with a comparison operator. | x |  | x | matches field |
 | bookmarks | Returns issues bookmarked by the defined user. Values can be your user ID (your email address) or `me` for yourself. |  | x |  | team or org user |
-| browser.name | TBA |  |  | x | TBA |
-| count() | Returns results with a matching count. (Same as `timesSeen` in issue search.) Doesn't take a parameter. | x |  |  | number |
+| count() | Returns results with a matching count. (Same as `timesSeen` in issue search.) Doesn't take a parameter. | x |  | x | number |
 | count_if<br></br>(column,operator,value) | Returns results with a matching count that satisfy the condition passed to the parameters of the function. | x |  |  | number |
 | count_miserable<br></br>(field,threshold) | Returns results with a matching count of unique instances of the field that fall above the miserable threshold. | x |  |  | number |
-| count_unique(field) | Returns results with a matching count of the unique instances of the field entered. | x |  |  | number |
-| count_web_vitals(vital,threshold) | Returns results with a matching count that meet a web vitals quality threshold (`poor`, `meh`, `good`, or `any`). | x |  |  | number |
+| count_unique(field) | Returns results with a matching count of the unique instances of the field entered. | x |  | x | number |
+| count_web_vitals(vital,threshold) | Returns results with a matching count that meet a web vitals quality threshold (`poor`, `meh`, `good`, or `any`). | x |  | x | number |
 | culprit | Deprecated | x |  |  | string |
 | device.arch | CPU architecture | x | x |  | string |
 | device.battery_level | If the device has a battery, this can be a floating point value defining the battery level (in the range 0-100). | x |  |  | string |
@@ -113,10 +112,10 @@ Release properties overlap with event and issue search properties, so they don't
 | device.orientation | Describes the orientation of the device and can be either `portrait` or `landscape`. | x | x |  | string |
 | device.simulator | Indicates whether this device is a simulator or a real device. A string that is either `True` or `False`. | x |  |  | string |
 | device.uuid | Deprecated | x | x |  | uuid |
-| dist | Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build. | x | x | x | string |
+| dist | Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build. | x | x |  | string |
 | environment | Refers to your code deployment naming convention. For example, *development*, *testing*, *staging* and so on. [Learn more](/product/sentry-basics/environments/).<br></br><br></br>In some pages of [sentry.io](https://sentry.io), you filter on environment using a dropdown. | x |  | x | string |
-| epm() | Returns results with a matching events-per-minute count. Doesn't take a parameter. | x |  |  | number |
-| eps() | Returns results with a matching events-per-second count. Doesn't take a parameter. | x |  |  | number |
+| epm() | Returns results with a matching events-per-minute count. Doesn't take a parameter. | x |  | x | number |
+| eps() | Returns results with a matching events-per-second count. Doesn't take a parameter. | x |  | x | number |
 | error.handled | Indicates whether the user has handled the exception — for example, using try...catch. An error is considered handled if all stack traces handle the error. Values are `1/0` or `true/false` | x | x |  | boolean |
 | error.mechanism | An object describing the mechanism that created this exception. | x | x |  | array |
 | error.type | The type of exception. For example, `ValueError`. | x | x |  | array |
@@ -124,15 +123,15 @@ Release properties overlap with event and issue search properties, so they don't
 | error.value | Original value of a field that causes or exhibits the error. | x | x |  | array |
 | event.timestamp | Returns issues with matching datetime. |  | x |  | datetime |
 | event.type | Type of the event (transaction, error, default, csp, and so on). The transaction type is unavailable in **Issues**. | x | x |  | string |
-| failure_count() | Returns results with a matching count of events with a `transaction.status` value that's in the list of failing ones. Values can be: `ok`, `cancelled`, `unknown`. Doesn't take a parameter. | x |  |  | number |
-| failure_rate() | Returns results with a matching rate of failing transactions — that is, `failure_count()` divided by the `count()` (total count). Doesn't take a parameter. | x |  |  | number |
+| failure_count() | Returns results with a matching count of events with a `transaction.status` value that's in the list of failing ones. Values can be: `ok`, `cancelled`, `unknown`. Doesn't take a parameter. | x |  | x | number |
+| failure_rate() | Returns results with a matching rate of failing transactions — that is, `failure_count()` divided by the `count()` (total count). Doesn't take a parameter. | x |  | x | number |
 | firstRelease | Returns issues first seen within the given release. Can be an exact match on the version of a release, or `first-release:latest` to pick the most recent release. |  | x |  | datetime |
 | firstSeen | Returns issues with a matching first time seen. Syntax is the same as `age`. |  | x |  | datetime |
 | geo.city | Full name of the city | x | x |  | string |
 | geo.country_code | ISO 3166-1 country code | x | x |  | string |
 | geo.region | Full name of the country | x | x |  | string |
 | handled | The same as `error.handled`, but values are `yes/no`. |  | x |  | error |
-| has | Returns results with the defined tag or field, but not the value of that tag or field. For example, entering `has:user` would find events with the `user` tag. | x | x |  | error |
+| has | Returns results with the defined tag or field, but not the value of that tag or field. For example, entering `has:user` would find events with the `user` tag. | x | x | x | error |
 | http.method | HTTP method of the [request](https://develop.sentry.dev/sdk/event-payloads/request/) that created the event. | x | x | x | string |
 | http.referer | Identifies the web page from which the resource was requested. | x | x |  | string |
 | http.status_code | HTTP status code, which indicates whether a response was successful. For example, `200` or `404`. | x | x |  | string |
@@ -144,34 +143,33 @@ Release properties overlap with event and issue search properties, so they don't
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x |  | datetime |
 | location | Location where the error happened. | x | x |  | string |
 | max(numeric field) | Returns results with a matching maximum value for the field entered. | x |  |  | matches field |
-| measurements.<br></br>app_start_cold | A [cold start](/product/performance/mobile-vitals/#app-start) refers to when the app launches for the first time after a reboot or update. The app is not in memory and no process exists. | x |  | x | duration |
-| measurements.<br></br>app_start_warm | A [warm start](/product/performance/mobile-vitals/#app-start) refers to when the app has already launched at least once and is partially in memory. For instance, the user backs out of your app, but then re-launches it. The process may have continued to run, but the app must recreate the activity from scratch. | x |  | x | duration |
-| measurements.cls | [Cumulative Layout Shift (CLS)](/product/performance/web-vitals/#cumulative-layout-shift-cls) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. | x |  | x | number |
-| measurements.fcp | [First Contentful Paint (FCP)](/product/performance/web-vitals/#first-contentful-paint-fcp) measures the time for the first content to render in the viewport. | x |  | x | duration |
-| measurements.fid | [First Input Delay (FID)](/product/performance/web-vitals/#first-input-delay-fid) measures the response time when the user tries to interact with the viewport. | x |  | x | duration |
-| measurements.fp | [First Paint (FP)](/product/performance/web-vitals/#first-paint-fp) measures the amount of time the first pixel takes to appear in the viewport, rendering any visual change from what was previously displayed. | x |  | x | duration |
-| measurements.<br></br>frames_frozen | [Slow and frozen frames](/product/performance/mobile-vitals/#slow-and-frozen-frames) measure the responsiveness of your app. | x |  | x | number |
-| measurements.<br></br>frames_frozen_rate | Returns results with a matching rate of frozen frames. That is, `measurements.frames_frozen` divided by the `measurements.frames_total`. | x |  | x | number |
-| measurements.<br></br>frames_slow | [Slow and frozen frames](/product/performance/mobile-vitals/#slow-and-frozen-frames) measure the responsiveness of your app. | x |  | x | number |
-| measurements.<br></br>frames_slow_rate | Returns results with a matching rate of slow frames. That is, `measurements.frames_slow` divided by the `measurements.frames_total`. | x |  | x | number |
-| measurements.<br></br>frames_total | Returns results with a matching total number of frames. | x |  | x | number |
-| measurements.lcp | [Largest Contentful Paint (LCP)](/product/performance/web-vitals/#largest-contentful-paint-lcp) measures the render time for the largest content to appear in the viewport. | x |  | x | duration |
-| measurements.<br></br>stall_count | A [stall](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is when the JavaScript event loop takes longer than expected to complete. Only applies to React Native. | x |  | x | number |
-| measurements.<br></br>stall_longest_time | The [longest stall time](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is the time, in milliseconds, of the longest event loop stall. Only applies to React Native. | x |  | x | duration |
-| measurements.<br></br>stall_percentage | Stall percentage is equal to the `stall_total_time` divided by the `transaction.duration`. Only applies to React Native. | x |  | x | number |
-| measurements.<br></br>stall_total_time | The [total stall time](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is the total combined time, in milliseconds, of all stalls. Only applies to React Native. | x |  | x | duration |
-| measurements.ttfb | [Time To First Byte (TTFB)](/product/performance/web-vitals/#time-to-first-byte-ttfb) measures the time that it takes for a user's browser to receive the first byte of page content. | x |  | x | duration |
-| measurements.<br></br>ttfb.requesttime | The time between start of the request and start of the response (see [diagram](https://web.dev/ttfb/#what-is-ttfb)). | x |  | x | duration |
+| measurements.<br></br>app_start_cold | A [cold start](/product/performance/mobile-vitals/#app-start) refers to when the app launches for the first time after a reboot or update. The app is not in memory and no process exists. | x |  |  | duration |
+| measurements.<br></br>app_start_warm | A [warm start](/product/performance/mobile-vitals/#app-start) refers to when the app has already launched at least once and is partially in memory. For instance, the user backs out of your app, but then re-launches it. The process may have continued to run, but the app must recreate the activity from scratch. | x |  |  | duration |
+| measurements.cls | [Cumulative Layout Shift (CLS)](/product/performance/web-vitals/#cumulative-layout-shift-cls) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. | x |  |  | number |
+| measurements.fcp | [First Contentful Paint (FCP)](/product/performance/web-vitals/#first-contentful-paint-fcp) measures the time for the first content to render in the viewport. | x |  |  | duration |
+| measurements.fid | [First Input Delay (FID)](/product/performance/web-vitals/#first-input-delay-fid) measures the response time when the user tries to interact with the viewport. | x |  |  | duration |
+| measurements.fp | [First Paint (FP)](/product/performance/web-vitals/#first-paint-fp) measures the amount of time the first pixel takes to appear in the viewport, rendering any visual change from what was previously displayed. | x |  |  | duration |
+| measurements.<br></br>frames_frozen | [Slow and frozen frames](/product/performance/mobile-vitals/#slow-and-frozen-frames) measure the responsiveness of your app. | x |  |  | number |
+| measurements.<br></br>frames_frozen_rate | Returns results with a matching rate of frozen frames. That is, `measurements.frames_frozen` divided by the `measurements.frames_total`. | x |  |  | number |
+| measurements.<br></br>frames_slow | [Slow and frozen frames](/product/performance/mobile-vitals/#slow-and-frozen-frames) measure the responsiveness of your app. | x |  |  | number |
+| measurements.<br></br>frames_slow_rate | Returns results with a matching rate of slow frames. That is, `measurements.frames_slow` divided by the `measurements.frames_total`. | x |  |  | number |
+| measurements.<br></br>frames_total | Returns results with a matching total number of frames. | x |  |  | number |
+| measurements.lcp | [Largest Contentful Paint (LCP)](/product/performance/web-vitals/#largest-contentful-paint-lcp) measures the render time for the largest content to appear in the viewport. | x |  |  | duration |
+| measurements.<br></br>stall_count | A [stall](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is when the JavaScript event loop takes longer than expected to complete. Only applies to React Native. | x |  |  | number |
+| measurements.<br></br>stall_longest_time | The [longest stall time](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is the time, in milliseconds, of the longest event loop stall. Only applies to React Native. | x |  |  | duration |
+| measurements.<br></br>stall_percentage | Stall percentage is equal to the `stall_total_time` divided by the `transaction.duration`. Only applies to React Native. | x |  |  | number |
+| measurements.<br></br>stall_total_time | The [total stall time](/platforms/react-native/performance/instrumentation/automatic-instrumentation/#stall-tracking) is the total combined time, in milliseconds, of all stalls. Only applies to React Native. | x |  |  | duration |
+| measurements.ttfb | [Time To First Byte (TTFB)](/product/performance/web-vitals/#time-to-first-byte-ttfb) measures the time that it takes for a user's browser to receive the first byte of page content. | x |  |  | duration |
+| measurements.<br></br>ttfb.requesttime | The time between start of the request and start of the response (see [diagram](https://web.dev/ttfb/#what-is-ttfb)). | x |  |  | duration |
 | message | Returns errors with the matching message or transactions with matching transaction name. Also matches on any message containing the supplied value.<br></br><br></br>Searching `message:undefined` will match an event with a message of `undefined is not an object`.<br></br><br></br>Raw text searches (searches without the `message` key) are also checked against this field. For errors, the message can be a concatenatenation of elements, so searches might include unexpected results. | x | x |  | string |
-| min(numeric field) | Returns results with a matching minimum value for the field entered. | x |  |  | matches field |
+| min(numeric field) | Returns results with a matching minimum value for the field entered. | x |  | x | matches field |
 | os.build | The internal build revision of the operating system. | x | x |  | string |
-| os.name | TBA |  |  | x | TBA |
 | os.kernel_version | The independent kernel version string. This is typically the entire output of the `uname` syscall. | x | x |  | string |
-| percentile(field,level) | Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`. | x |  |  | number |
-| platform | Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`. | x |  | x | string |
+| percentile(field, level) | Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`. | x |  | x | number |
+| platform | Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`. | x |  |  | string |
 | platform.name | Name of the platform |  | x |  | string |
 | project | The name of the project. In **Issues** you can only search by project ID.<br></br><br></br>In some pages of [sentry.io](https://sentry.io), you filter on project using a dropdown. | x | x |  | string |
-| pXY(duration field) | Returns results with an approximate percentile of the field. Replace "XY" with 50, 75, 95, 99, or 100. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `p50(transaction.duration)`. | x |  |  | number |
+| pXY(duration field) | Returns results with an approximate percentile of the field. Replace "XY" with 50, 75, 95, 99, or 100. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `p50(transaction.duration)`. | x |  | x | number |
 | release | A release is a version of your code deployed to an environment. You can create a token with an exact match on the version of a release, or `release:latest` to pick the most recent release. | x | x | x | string |
 | release.build | The number that identifies an iteration of your app. For example, `CFBundleVersion` on iOS or `versionCode` on Android. [Learn more](/product/releases/usage/sorting-filtering/). | x | x |  | number |
 | release.package | The unique identifier of the project/app. For example, `CFBundleIdentifier` on iOS or `packageName` on Android. [Learn more](/product/releases/usage/sorting-filtering/). | x | x |  | string |
@@ -191,25 +189,25 @@ Release properties overlap with event and issue search properties, so they don't
 | stack.lineno | Line number of the call, starting at 1. | x |  |  | array |
 | stack.module | Platform-specific module path. For example, `sentry.interfaces.Stacktrace`. In events, this is an array. In issues, this is a single value. | x | x |  | array, single value |
 | stack.package | The "package" the frame was contained in. Depending on the platform, this can be different things. For C#, it can be the name of the assembly. For native code, it can be the path of the dynamic library or something else. In events, this is an array. In issues, this is a single value. | x | x |  | array, single value |
-| sum(numeric field) | Returns results with a matching total value for the the field entered. | x |  |  | matches field |
+| sum(numeric field) | Returns results with a matching total value for the the field entered. | x |  | x | matches field |
 | timesSeen | Returns results with a matching count. (Same as `count()` in events.) |  | x |  | number |
 | timestamp | The finish timestamp of the transaction. Returns events with matching datetime. | x | x |  | datetime |
 | timestamp.to_day | Timestamp rounded down to the nearest day. | x |  |  | datetime |
 | timestamp.to_hour | Timestamp rounded down to the nearest hour. | x |  |  | datetime |
-| title | Title of the error or the transaction name. | x | x |  | string |
+| title | Title of the error or the transaction name. | x | x | x | string |
 | trace | A trace represents the record of the entire operation you want to measure or track — like page load, searched using the uuid generated by Sentry’s SDK. | x | x |  | uuid |
 | trace.parent_span | Span ID of the parent to the current transaction. This is null if the transaction is root. | x |  |  | uuid |
 | trace.span | Span ID of the root span of the root transaction in the event. | x |  |  | uuid |
 | transaction | For [transactions](/product/performance/transaction-summary/#what-is-a-transaction), the name of the transaction. For errors, the name of the associated transaction. | x | x | x | string |
-| transaction.duration | Duration, in milliseconds, of the transaction. | x |  | x | duration |
+| transaction.duration | Duration, in milliseconds, of the transaction. | x |  |  | duration |
 | transaction.op | Short code identifying the [type of operation](https://develop.sentry.dev/sdk/performance/span-operations/) the span is measuring. | x |  | x | string |
 | transaction.status | Describes the status of the span/transaction. Check out our [Transaction Payloads documentation](https://develop.sentry.dev/sdk/event-payloads/transaction/) for all possible statuses. | x |  | x | string |
-| user.display | In order, the first available user field available: email, then username, ID, and then IP address. | x |  | x | string |
-| user.email | An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities. | x | x | x | string |
-| user.id | Application-specific internal identifier for the user. | x | x | x | string |
-| user.ip | User's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. | x | x | x | string |
-| user.username | Username, which is typically a better label than the `user.id`. | x | x | x | string |
-| user_misery(number) | Returns transactions with the defined user misery value. [User Misery](/product/performance/metrics/#user-misery) is a user-weighted performance metric that counts the number of unique users who were frustrated; "frustration" is measured as a response time four times the satisfactory response time threshold (in milliseconds). It highlights transactions that have the highest impact on users. | x |  |  | number |
+| user.display | In order, the first available user field available: email, then username, ID, and then IP address. | x |  |  | string |
+| user.email | An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities. | x | x |  | string |
+| user.id | Application-specific internal identifier for the user. | x | x |  | string |
+| user.ip | User's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. | x | x |  | string |
+| user.username | Username, which is typically a better label than the `user.id`. | x | x |  | string |
+| user_misery(number) | Returns transactions with the defined user misery value. [User Misery](/product/performance/metrics/#user-misery) is a user-weighted performance metric that counts the number of unique users who were frustrated; "frustration" is measured as a response time four times the satisfactory response time threshold (in milliseconds). It highlights transactions that have the highest impact on users. | x |  | x | number |
 
 <!-- prettier-ignore-end -->
 

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -165,7 +165,7 @@ Release properties overlap with event and issue search properties, so they don't
 | min(numeric field) | Returns results with a matching minimum value for the field entered. | x |  | x | matches field |
 | os.build | The internal build revision of the operating system. | x | x |  | string |
 | os.kernel_version | The independent kernel version string. This is typically the entire output of the `uname` syscall. | x | x |  | string |
-| percentile(field, level) | Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`. | x |  | x | number |
+| percentile(field,level) | Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`. | x |  | x | number |
 | platform | Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`. | x |  |  | string |
 | platform.name | Name of the platform |  | x |  | string |
 | project | The name of the project. In **Issues** you can only search by project ID.<br></br><br></br>In some pages of [sentry.io](https://sentry.io), you filter on project using a dropdown. | x | x |  | string |


### PR DESCRIPTION
- Some fields & functions were marked incorrectly for metrics.
- Removing os.name & browser.name for now instead of having a TBA
  definition