### PR TITLE
feat(svelte): Add documentation for component tracking

### DIFF
--- a/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
+++ b/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
@@ -52,7 +52,8 @@ If you don't want to use our preprocessor to automatically insert the function c
     trackUpdates: false,
     // Specify a custom name to be shown in the span description
     // (defaults to the automatically detected component name)
-    componentName: string})
+    componentName: string
+  })
   // rest of your code
 </script>
 ```

--- a/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
+++ b/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
@@ -2,7 +2,7 @@
 title: Track Svelte Components
 ---
 
-Sentry's Svelte SDK offers a feature to monitor the performance of your Svelte components: **Component Tracking**. By enabling this feature, you will get spans in your transactions showing the initialization and update cycles of your Svelte components. This feature allows you to get a drilled down view into how your components are behaving, to e.g. identify slow component initializations or frequent component updates which might have an impact on your app's performance.
+Sentry's Svelte SDK offers a feature to monitor the performance of your Svelte components: **Component Tracking**. By enabling this feature, you will get spans in your transactions showing the initialization and update cycles of your Svelte components. This feature allows you to get a drilled down view into how your components are behaving, to e.g. identify slow initializations or frequent updates which might have an impact on your app's performance.
 
 ## Usage
 
@@ -34,11 +34,11 @@ const config = {
 export default config;
 ```
 
-This preprocessor is called at application build time. It inserts a function call to a function in the Sentry SDK into the `<script>` tag of your components before this component is compiled by the Svelte compiler. The called function takes care of recording the spans by leveraging the Svelte component's lifecycle hooks.
+This preprocessor is called at application build time. It inserts a function call to a function in the Sentry SDK into the `<script>` tag of your components before it is compiled and bundled. The called function takes care of recording the spans by using the Svelte component's lifecycle hooks.
 
 ## Alternative Usage
 
-If you don't want to use our preprocessor to automatically insert the function call to track all components, you can call the tracking function manually in every component you would like to see tracked yourself:
+If you don't want to use our preprocessor to automatically insert the function call at build time, you can call the tracking function manually in every component you would like to see tracked:
 
 ```javascript {tabTitle: MyComponent.svelte}
 <script>

--- a/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
+++ b/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
@@ -2,11 +2,11 @@
 title: Track Svelte Components
 ---
 
-Sentry's Svelte SDK offers a feature to monitor the performance of your Svelte components: **Component Tracking**. By enabling this feature, you will get spans in your transactions showing the initialization and update cycles of your Svelte components. This feature allows you to get a drilled down view into how your components are behaving, to e.g. identify slow initializations or frequent updates which might have an impact on your app's performance.
+Sentry's Svelte SDK offers a feature to monitor the performance of your Svelte components: component tracking. Enabling this feature provides you with spans in your transactions that show the initialization and update cycles of your Svelte components. This allows you to get a drilled-down view into how your components are behaving so you can do things like identify slow initializations or frequent updates, which might have an impact on your app's performance.
 
 ## Usage
 
-To get started, simply add the Sentry `componentTrackingPreprocessor` to your `svelte.config.js` file:
+To get started, add the Sentry `componentTrackingPreprocessor` to your `svelte.config.js` file:
 
 ```javascript {tabTitle: svelte.config.js}
 import * as Sentry from "@sentry/svelte";
@@ -34,7 +34,7 @@ const config = {
 export default config;
 ```
 
-This preprocessor is called at application build time. It inserts a function call to a function in the Sentry SDK into the `<script>` tag of your components before it is compiled and bundled. The called function takes care of recording the spans by using the Svelte component's lifecycle hooks.
+This preprocessor is called at application build time. It inserts a function call to a function in the Sentry SDK into the `<script>` tag of your components before your app is compiled and bundled. The called function takes care of recording the spans by using the Svelte component's lifecycle hooks.
 
 ## Alternative Usage
 

--- a/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
+++ b/src/platforms/javascript/guides/svelte/features/componenttracking.mdx
@@ -1,0 +1,58 @@
+---
+title: Track Svelte Components
+---
+
+Sentry's Svelte SDK offers a feature to monitor the performance of your Svelte components: **Component Tracking**. By enabling this feature, you will get spans in your transactions showing the initialization and update cycles of your Svelte components. This feature allows you to get a drilled down view into how your components are behaving, to e.g. identify slow component initializations or frequent component updates which might have an impact on your app's performance.
+
+## Usage
+
+To get started, simply add the Sentry `componentTrackingPreprocessor` to your `svelte.config.js` file:
+
+```javascript {tabTitle: svelte.config.js}
+import * as Sentry from "@sentry/svelte";
+
+const config = {
+  preprocess: [
+    Sentry.componentTrackingPreprocessor({
+      // Add the components you want to be tracked to this array.
+      // Specificy `true` to track all components or `false` to disable
+      // tracking entirely
+      // (defaults to `true`)
+      trackComponents: ["Navbar", "PrimaryButton", "LoginForm"],
+      // To disable component initialization spans, set this to `false`.
+      // (defaults to `true`)
+      trackInit: true,
+      // To disable component update spans, set this to `false`
+      // (defaults to `true`)
+      trackUpdates: false,
+    }),
+    // ...
+  ],
+  // ...
+};
+
+export default config;
+```
+
+This preprocessor is called at application build time. It inserts a function call to a function in the Sentry SDK into the `<script>` tag of your components before this component is compiled by the Svelte compiler. The called function takes care of recording the spans by leveraging the Svelte component's lifecycle hooks.
+
+## Alternative Usage
+
+If you don't want to use our preprocessor to automatically insert the function call to track all components, you can call the tracking function manually in every component you would like to see tracked yourself:
+
+```javascript {tabTitle: MyComponent.svelte}
+<script>
+  import * as Sentry from "@sentry/svelte";
+  Sentry.trackComponent({
+    // To disable component initialization spans, set this to `false`.
+    // (defaults to `true`)
+    trackInit: true,
+    // To disable component update spans, set this to `false`
+    // (defaults to `true`)
+    trackUpdates: false,
+    // Specify a custom name to be shown in the span description
+    // (defaults to the automatically detected component name)
+    componentName: string})
+  // rest of your code
+</script>
+```

--- a/src/platforms/javascript/guides/svelte/features/index.mdx
+++ b/src/platforms/javascript/guides/svelte/features/index.mdx
@@ -4,8 +4,8 @@ description: "Learn how Sentry's Svelte SDK exposes features for first class int
 excerpt: ""
 ---
 
-The Sentry Svelte SDK offers Svelte specific features for first class integration with the framework.
+The Sentry Svelte SDK offers Svelte-specific features for first class integration with the framework.
 
 - **[Component Tracking](./componenttracking/)**
 
-  If you are using Performance monitoring, you can track the individual components of you Svelte application.
+  If you're using Performance monitoring, you can track the individual components of your Svelte application.

--- a/src/platforms/javascript/guides/svelte/features/index.mdx
+++ b/src/platforms/javascript/guides/svelte/features/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Svelte Features
+description: "Learn how Sentry's Svelte SDK exposes features for first class integration with Svelte."
+excerpt: ""
+---
+
+The Sentry Svelte SDK offers Svelte specific features for first class integration with the framework.
+
+- **[Component Tracking](./componenttracking/)**
+
+  If you are using Performance monitoring, you can track the individual components of you Svelte application.


### PR DESCRIPTION
This PR adds a page in the Svelte SDK documentation about a new feature in the SDK, component tracking. It includes a brief description of what this feature does and how to use it (two ways). 

I'm not particularly happy with the placement of the documentation but I took what we have in Angular and React as an example. In the future I'd vote to rename the navigation item on the left for Angular and React from "Components" to "[Framwork] Features". This title is IMO more general and better represents what's in there than "Components". In Angular for instance, none of the trace helpers are actual components. If we do this, we should also consider to adapt the Vue documentation which doesn't have such a section but scatters its component tracking documentation in the performance monitorin setup and router instrumentation pages.

ref: https://github.com/getsentry/sentry-javascript/issues/5573