### PR TITLE
fix(react): Update React Router v4/v5 to make paramaterization more clear

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -79,9 +79,9 @@ The React router instrumentation uses the React router library to create `pagelo
 
 ### Parameterized Transaction Names
 
-To get parameterized transaction names (ex. `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`), you must explicitly set the routes you want paramaterized. This is as there is no static route config that the SDK can use in React Router v4/v5.
+To get parameterized transaction names (for example, `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`), you must explicitly set the routes you want paramaterized. That's because there is no static route config that the SDK can use in React Router v4/v5.
 
-Use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render. This is the method we recommend to paramaterize transaction names.
+We recommend you use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render.
 
 ```javascript
 import {Route, Router, Switch } from 'react-router-dom';
@@ -120,7 +120,7 @@ render() {
 }
 ```
 
-If you would not like to wrap individual routes, you can still specify parameterized routes manually by passing an array of route config objects as per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config) to the instrumentation function call. You will also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
+If you don't want to wrap individual routes, you can still specify parameterized routes manually by passing an array of route config objects, per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config), to the instrumentation function call. You'll also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
 
 ```javascript
 import { Route, Router, Switch, matchPath } from 'react-router-dom';

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -77,7 +77,7 @@ Now, Sentry should generate `pageload`/`navigation` transactions with parameteri
 
 The React router instrumentation uses the React router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
-### Parameterized transaction names
+### Parameterized Transaction Names
 
 To get parameterized transaction names (ex. `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`), you must explicitly set the routes you want paramaterized. This is as there is no static route config that the SDK can use in React Router v4/v5.
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -79,11 +79,48 @@ The React router instrumentation uses the React router library to create `pagelo
 
 ### Parameterized transaction names
 
-To get parameterized transaction names (ex. `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`), you must give the SDK access to the match path of the route render. This is as there is no static route config that the SDK can use in React Router v4/v5. There are two ways to accomplish this:
+To get parameterized transaction names (ex. `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`), you must explicitly set the routes you want paramaterized. This is as there is no static route config that the SDK can use in React Router v4/v5.
 
-1. Pass a Route Config Object
+Use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render. This is the method we recommend to paramaterize transaction names.
 
-You can pass an array of route config objects as per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config). to the instrumentation function call. You will also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
+```javascript
+import {Route, Router, Switch } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
+
+import * as Sentry from '@sentry/react';
+import { BrowserTracing } from '@sentry/tracing';
+
+// Create Custom Sentry Route component
+const SentryRoute = Sentry.withSentryRouting(Route);
+
+const history = createBrowserHistory();
+
+Sentry.init({
+  integrations: [
+    new BrowserTracing({
+      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
+    }),
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+
+render() {
+  return (
+    <Router history={history}>
+      <Switch>
+        <SentryRoute path="/users/:userid" component={() => <div>UserId</div>} />
+        <SentryRoute path="/users" component={() => <div>Users</div>} />
+        <SentryRoute path="/" component={() => <div>Home</div>} />
+      </Switch>
+    </Router>
+  );
+}
+```
+
+If you would not like to wrap individual routes, you can still specify parameterized routes manually by passing an array of route config objects as per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config) to the instrumentation function call. You will also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
 
 ```javascript
 import { Route, Router, Switch, matchPath } from 'react-router-dom';
@@ -118,47 +155,6 @@ render() {
          <Route path="/users/:userid" component={() => <div>UserId</div>} />
          <Route path="/users" component={() => <div>Users</div>} />
          <Route path="/" component={() => <div>Home</div>} />
-      </Switch>
-    </Router>
-  );
-}
-```
-
-2. Use Sentry Route component
-
-Use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render.
-
-```javascript
-import {Route, Router, Switch } from 'react-router-dom';
-import { createBrowserHistory } from 'history';
-
-import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
-
-// Create Custom Sentry Route component
-const SentryRoute = Sentry.withSentryRouting(Route);
-
-const history = createBrowserHistory();
-
-Sentry.init({
-  integrations: [
-    new BrowserTracing({
-      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
-    }),
-  ],
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 1.0,
-});
-
-render() {
-  return (
-    <Router history={history}>
-      <Switch>
-        <SentryRoute path="/users/:userid" component={() => <div>UserId</div>} />
-        <SentryRoute path="/users" component={() => <div>Users</div>} />
-        <SentryRoute path="/" component={() => <div>Home</div>} />
       </Switch>
     </Router>
   );


### PR DESCRIPTION
To make sure we prevent possible mis-configurations with the React Router v4/v5 integration, this PR updates our docs around it. We first move the usage of `withSentryRouting` higher up, and encourage it as the default approach to use for paramaterization. We then move down the route config option below that, and offer it as a way for users to define paths outside of the usage of `withSentryRouting`.