### PR TITLE
ref(svelte): Bump SDK status from alpha to beta

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.svelte.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.svelte.mdx
@@ -4,9 +4,9 @@ Sentry's Svelte SDK enables automatic reporting of errors and exceptions, as wel
 
 </Note>
 
-<Alert level="info" title="Important">
+<Alert level="info" title="SDK Status">
 
-This SDK is considered **experimental and in alpha state**. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. The SDK currently only supports [Svelte](https://svelte.dev/) and is not yet compatible with with [SvelteKit](https://kit.svelte.dev/).
+This SDK currently in beta state. It might still be unstable or exhibit bugs. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. The SDK currently only supports [Svelte](https://svelte.dev/) and is not fully compatible with with [SvelteKit](https://kit.svelte.dev/).
 
 </Alert>
 

--- a/src/platform-includes/getting-started-primer/javascript.svelte.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.svelte.mdx
@@ -4,9 +4,9 @@ Sentry's Svelte SDK enables automatic reporting of errors and exceptions, as wel
 
 </Note>
 
-<Alert level="info" title="SDK Status">
+<Alert level="info">
 
-This SDK currently in beta state. It might still be unstable or exhibit bugs. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. The SDK currently only supports [Svelte](https://svelte.dev/) and is not fully compatible with with [SvelteKit](https://kit.svelte.dev/).
+This SDK is currently in beta state and might still be unstable or exhibit bugs. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. The SDK currently only supports [Svelte](https://svelte.dev/) and is not fully compatible with with [SvelteKit](https://kit.svelte.dev/).
 
 </Alert>
 


### PR DESCRIPTION
This tiny PR bumps our Svelte SDK's status from alpha to beta. 

Only merge this, when we go live with the beta

ref: https://github.com/getsentry/sentry-javascript/issues/5671