### PR TITLE
fix: remove duplicate info in relay metrics

### DIFF
--- a/src/docs/product/relay/monitoring/index.mdx
+++ b/src/docs/product/relay/monitoring/index.mdx
@@ -52,7 +52,6 @@ Both endpoints return a _200 OK_ response when successful:
 ## Metrics
 
 You can submit stats to a StatsD server by configuring the `metrics.statsd` key to an `ip:port` tuple.
-can be set to an `ip:port` tuple.
 
 ### Example Configuration
 


### PR DESCRIPTION
Remove a duplicate line from the relay monitoring docs. This line is a partial sentence and repeats info from the sentence before it.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
