### PR TITLE
Use latest version in serverless GCP docs

### DIFF
--- a/src/platforms/node/guides/gcp-functions/index.mdx
+++ b/src/platforms/node/guides/gcp-functions/index.mdx
@@ -10,7 +10,7 @@ _(New in version 5.26.0)_
 Add `@sentry/serverless` as a dependency to `package.json`:
 
 ```bash
-  "@sentry/serverless": "^5.26.0"
+  "@sentry/serverless": "^{{ packages.version('sentry.javascript.node') }}"
 ```
 
 To set up Sentry for a Google Cloud Function:


### PR DESCRIPTION
https://sentry-docs-git-abhi-version-serverless.sentry.dev/platforms/node/guides/gcp-functions/