### PR TITLE
feat: Custom error description docs for sentry-cocoa

### DIFF
--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -26,3 +26,17 @@ By default, macOS applications do not crash whenever an uncaught exception occur
 1. Open the application's `Info.plist` file
 2. Search for `Principal class` (the entry is expected to be `NSApplication`)
 3. Replace `NSApplication` with `SentryCrashExceptionApplication`
+
+## Customising Error Descriptions
+
+By default, Sentry will display error code as the error description. For custom error types, you may want to provide a custom description that makes it easier to identify the error in the Issues list. You can provide a custom description for `NSError` values by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+
+This can be particularly useful for Swift enum error types that conform to `Error`, where the error code can be hard to match with an enum case. To customise the description for Swift `Error` types you should conform to the `CustomNSError` protocol and return a user info dictionary:
+
+```swift {tabTitle:Swift}
+extension MyCustomError: CustomNSError {
+    var errorUserInfo: [String : Any] {
+        [NSDebugDescriptionErrorKey: "Custom error description"]
+    }
+}
+```

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -27,11 +27,11 @@ By default, macOS applications do not crash whenever an uncaught exception occur
 2. Search for `Principal class` (the entry is expected to be `NSApplication`)
 3. Replace `NSApplication` with `SentryCrashExceptionApplication`
 
-## Customising Error Descriptions
+## Customizing Error Descriptions
 
-By default, Sentry will display error code as the error description. For custom error types, you may want to provide a custom description that makes it easier to identify the error in the Issues list. You can provide a custom description for `NSError` values by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+By default, Sentry will display the error code as the error description. For custom error types, you may want to provide a custom description that makes it easier to identify the error in the **Issues** page. You can provide a custom description for `NSError` values by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
-This can be particularly useful for Swift enum error types that conform to `Error`, where the error code can be hard to match with an enum case. To customise the description for Swift `Error` types you should conform to the `CustomNSError` protocol and return a user info dictionary:
+This can be particularly useful for Swift enum error types that conform to `Error`, where the error code can be hard to match with an enum case. To customize the description for Swift `Error` types, you should conform to the `CustomNSError` protocol and return a user info dictionary:
 
 ```swift {tabTitle:Swift}
 extension MyCustomError: CustomNSError {


### PR DESCRIPTION
Added documentation for the new custom error description feature.

Relates to https://github.com/getsentry/sentry-cocoa/pull/2120

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
