### PR TITLE
feat(node): Add Modules integration docs

### DIFF
--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -131,3 +131,11 @@ Available options:
   limit: number; // default: 5
 }
 ```
+
+### Modules
+
+_(New in version 7.13.0.)_
+
+_Import name: `Sentry.Integrations.Modules`_
+
+This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, Sentry will cache the list for later reuse.

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -77,12 +77,6 @@ For example `C:\\Program Files\\Apache\\www` won't work, however, `/Program File
 
 ## Node specific
 
-### Modules
-
-_Import name: `Sentry.Integrations.Modules`_
-
-This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, Sentry will cache the list for later reuse.
-
 ### Transaction
 
 _Import name: `Sentry.Integrations.Transaction`_


### PR DESCRIPTION
documents https://github.com/getsentry/sentry-javascript/pull/5706

Moves `Modules` integration from optional -> default

Blocked on new SDK release