### PR TITLE
add guidance for SDKs not supporting user feedback

### DIFF
--- a/src/docs/product/user-feedback/index.mdx
+++ b/src/docs/product/user-feedback/index.mdx
@@ -4,18 +4,24 @@ sidebar_order: 70
 description: "Learn how you can view user feedback submissions which, paired with the original event, give you additional insight into issues."
 ---
 
-While event data allows you to collect information about errors in your application, getting any extra helpful feedback can be crucial in determining the root cause of an issue. Sentry provides the ability to collect additional information with User Feedback. 
+While event data allows you to collect information about errors in your application, getting any extra helpful feedback can be crucial in determining the root cause of an issue. Sentry provides the ability to collect additional information with User Feedback.
 
 The **User Feedback** page in [sentry.io](https://sentry.io) displays feedback submissions from users who experienced an error while using your application. Each submission includes the name and email address entered by the user, as well as their description of what happened to produce the error.
 
 ![User Feedback page with submissions.](user-feedback.png)
-<!--placeholder image to be updated-->
 
 In each submission, you can click the “View Event” link, which takes you to the **Issue Details** page for that event (or instance of the issue). From there, you can dig into what caused the issue and start working to resolve it.
 
 ![The event that generated the user feedback on the Issue Details page.](user-feedback-event.png)
-<!--placeholder image to be updated-->
 
 ## Set Up
 
-Sentry provides two ways to collect user feedback, an API or an embeddable widget, which you can [configure](/platform-redirect/?next=/enriching-events/user-feedback/) to collect feedback when a user experiences an error. 
+Sentry provides two ways to collect user feedback, an API or an embeddable widget, which you can [configure](/platform-redirect/?next=/enriching-events/user-feedback/) to collect feedback when a user experiences an error.
+
+This feature is not currently supported for the following SDKs:
+
+- Native
+- Perl
+- React Native
+
+Clicking the "configure" link above for these SDKs may result in a "Page Not Found" error. For JVM-related use of Kotlin, check out our [Java](/platforms/java/enriching-events/user-feedback/) or [Android](/platforms/android/enriching-events/user-feedback/) SDKs.

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -4,12 +4,21 @@ sidebar_order: 105
 redirect_from:
   - /learn/user-feedback/
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
-notSupported:
-  - native
-  - react-native
 ---
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. You can collect feedback according to the method supported by the SDK.
+
+<PlatformSection supported={["ruby"]} notSupported={["ruby.rails"]}>
+
+While this feature isn't currently supported for Ruby or most of its frameworks, it is supported for [Rails](/platforms/ruby/guides/rails/enriching-events/user-feedback/).
+
+</PlatformSection>
+
+<PlatformSection supported={["native", "react-native"]} >
+
+**The user feedback feature is not currently supported for this SDK.**
+
+</PlatformSection>
 
 <PlatformSection supported={["java", "apple", "android", "dart", "flutter", "unreal"]} >
 


### PR DESCRIPTION
- Adds a note at the end of the main [User Feedback](https://docs.sentry.io/product/user-feedback/) indicating which SDKs don't support the feature with a warning that clicking the link may result in a 404
- Adds PlatformSection for Native and React Native indicating the feature is not supported
- Adds PlatformSection for Ruby indicating the feature is only supported for Rails