### PR TITLE
add log levels for ruby

### DIFF
--- a/src/platform-includes/set-level/ruby.mdx
+++ b/src/platform-includes/set-level/ruby.mdx
@@ -1,3 +1,5 @@
 ```ruby
 Sentry.capture_message("this is not important", level: :info)
 ```
+
+Available levels are `:fatal`, `:critical`, `:error`, `:warning`, `:log`, `:info`, and `:debug`. The default, if not specified, is `:error`.


### PR DESCRIPTION
Added list of log levels for Ruby
Replaces PR #5401 - had to close that one because we changed the structure of our includes since it was opened