### PR TITLE
Remove `handled` property use `error.handled` instead

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -132,7 +132,6 @@ Release properties overlap with event and issue search properties, so they don't
 | geo.city | Full name of the city | x | x |  | string |
 | geo.country_code | ISO 3166-1 country code | x | x |  | string |
 | geo.region | Full name of the country | x | x |  | string |
-| handled | The same as `error.handled`, but values are `yes/no`. |  | x |  | error |
 | has | Returns results with the defined tag or field, but not the value of that tag or field. For example, entering `has:user` would find events with the `user` tag. | x | x | x | error |
 | http.method | HTTP method of the [request](https://develop.sentry.dev/sdk/event-payloads/request/) that created the event. | x | x | x | string |
 | http.referer | Identifies the web page from which the resource was requested. | x | x |  | string |


### PR DESCRIPTION
Fixes https://getsentry.atlassian.net/browse/ISSUE-1549

After some conversation we're going to be slowly removing "handled" from docs and product where possible.