### PR TITLE
Add a warning about the React Router v6 init order.

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -28,6 +28,12 @@ Initialize `Sentry.reactRouterV6Instrumentation` as your routing instrumentation
     - `useLocation` and `useNavigationType` hooks from `react-router-dom`
     - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages.
     
+<Alert level="warning">
+
+Make sure `Sentry.reactRouterV6Instrumentation` is initialized by your `Sentry.init` call, before you wrap `<Routes />` component  or `useRoutes` hook. Otherwise, the routing instrumentation may not work properly.
+
+</Alert>
+
 ### Usage With `<Routes />` Component
   
 If you use the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context, as in the example below:


### PR DESCRIPTION
Adds a warning about the React Router 6 Instrumentation's expected init order.

Related: 
https://github.com/getsentry/sentry-javascript/issues/5555
https://github.com/getsentry/sentry-javascript/issues/5309