### PR TITLE
add canadian, VAT, and b2b/b2c sections to taxes

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -158,7 +158,7 @@ If you're currently on a paid plan, you can sign up for a 30-day trial; if you'r
 
 The following sections cover taxation for various jurisdictions, business-to-business and business-to-customer taxation differences, and exemptions.
 
-Currently, prices displayed on Sentry.io do not include sales tax since tax rates and applicability varies across country, state/province, and locality.
+Currently, prices displayed on our [pricing page](http://sentry.io/pricing) don't include sales tax since tax rates and applicability varies across country, state/province, and locality.
 
 ### US Taxes
 
@@ -177,8 +177,6 @@ As of December 1, 2020, customers with a US-based billing address may be subject
 - Texas
 - Utah
 - Washington
-
-Currently, prices displayed on our [pricing page](http://sentry.io/pricing) don't include sales tax since tax rates and applicability varies across country, state, and locality.
 
 ### Canadian Taxes
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -156,7 +156,7 @@ If you're currently on a paid plan, you can sign up for a 30-day trial; if you'r
 
 ## Taxes
 
-The following sections cover taxation for various areas, business-to-business and business-to-customer taxation differences, and exemptions.
+The following sections cover taxation for various jurisdictions, business-to-business and business-to-customer taxation differences, and exemptions.
 
 Currently, prices displayed on Sentry.io do not include sales tax since tax rates and applicability varies across country, state/province, and locality.
 

--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -10,7 +10,7 @@ description: "Learn about pricing variables, managing volume, and different Sent
 
 This page clarifies concepts around pricing and billing like:
 
-- [Reserved (prepaid)](#prepaid-reserved-capacity) and [on-demand](#on-demand-capacity)  volume
+- [Reserved (prepaid)](#prepaid-reserved-capacity) and [on-demand](#on-demand-capacity) volume
 - [How our pricing works](#pricing-how-it-works), including [pricing tables](#pricing-tables)
 - [Billing periods](#billing-cycles)
 - [Taxes](#taxes) and [exemptions](#tax-exemptions)
@@ -53,7 +53,7 @@ You have two choices for setting your on-demand budget strategy:
 
 If you raise your on-demand budget mid-month, your organization will start accepting additional data as soon as your new budget is applied. If you lower your on-demand budget mid-month to below the current month's usage, your on-demand budget will be reduced to match your usage. On your next bill date, your on-demand budget will be lowered to the requested amount.
 
-After a new budget is in effect, all additional data will be rejected and no additional on-demand volume will be added. At the end of the billing month, you will be charged for any on-demand volume consumed. 
+After a new budget is in effect, all additional data will be rejected and no additional on-demand volume will be added. At the end of the billing month, you will be charged for any on-demand volume consumed.
 
 We guarantee new budgets will be applied and effective within 24 hours. However, in most cases the new budget will be applied within minutes.
 
@@ -156,6 +156,12 @@ If you're currently on a paid plan, you can sign up for a 30-day trial; if you'r
 
 ## Taxes
 
+The following sections cover taxation for various areas, business-to-business and business-to-customer taxation differences, and exemptions.
+
+Currently, prices displayed on Sentry.io do not include sales tax since tax rates and applicability varies across country, state/province, and locality.
+
+### US Taxes
+
 As of December 1, 2020, customers with a US-based billing address may be subject to state and local sales tax. Sales tax will apply to billing addresses located in the following states/localities:
 
 - Connecticut
@@ -173,6 +179,36 @@ As of December 1, 2020, customers with a US-based billing address may be subject
 - Washington
 
 Currently, prices displayed on our [pricing page](http://sentry.io/pricing) don't include sales tax since tax rates and applicability varies across country, state, and locality.
+
+### Canadian Taxes
+
+As of October 1, 2022, customers with a Canadian-based billing address may be subject to provincial and local sales tax, varying according to province. Canadian customers may be subject to one or more of the following taxes depending on their location:
+
+<!-- prettier-ignore-start -->
+
+| Province(s) | Tax Type(s) | Total Tax Rate |
+|---|---|---|
+| Alberta, Northwest Territories,<br></br> Nunavut, Yukon | Goods & Service Tax (5%) | 5% |
+| British Columbia, Manitoba | Goods & Service Tax (5%) <br></br> Provincial Sales Tax (7%) | 12% |
+| New Brunswick,<br></br> Newfoundland and Labrador,<br></br> Nova Scotia, Prince Edward Island | Harmonized Sales Tax | 15% for all provinces<br></br> except Ontario (13%) |
+| Quebec | Goods & Service Tax (5%) <br></br> Quebec Sales Tax (9.975%) | 14.975% |
+| Saskatchewan | Goods & Service Tax (5%) <br></br> Provincial Sales Tax (6%) | 11% |
+
+<!-- prettier-ignore-end -->
+
+All Canadian federal and provincial taxes will be calculated based on billing address. Canadian business-to-business (B2B) customers with a valid Business Number ID can input their ID in their billing address settings to avoid sales tax being added to their invoices.
+
+### VAT
+
+In the European Union (EU) and in accordance with EU VAT legislation, VAT will be applied only to orders where exemption documentation or a valid VAT ID has not been supplied prior to or at the time of payment.
+
+The VAT in other countries such as Switzerland, South Africa, and Russia is applicable on all taxable sales where valid exemption documentation has not been provided to Sentry prior to payment.
+
+### B2B and B2C Taxation - Differences
+
+Internationally, sales tax rules differ based on whether the customer is business-to-business (B2B) or business-to-consumer (B2C). In most countries, B2C sales are taxable, while B2B customers are not charged sales tax at the point of sale, but self-assess when they file their returns.
+
+However, in some countries, both B2C and B2B customers need to be charged sales tax at the point of sale. Sentry will levy tax on your purchase based on your local tax legislation and rate according to your billing address.
 
 ### Tax Exemptions
 


### PR DESCRIPTION
Adds the following to the Pricing & Billing page under Taxes:
Canadian Taxes
VAT
B2B/B2C taxes 