### PR TITLE
feat(apple): Add auto generated breadcrumbs

### DIFF
--- a/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
@@ -1,0 +1,5 @@
+The Cocoa SDK captures [breadcrumbs automatically](/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs) for
+  - Application lifecycle events (`didBecomeActive`, `didEnterBackground`, `viewDidAppear`)
+  - Touch events
+  - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
+  - Outgoing HTTP requests

--- a/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
@@ -1,4 +1,4 @@
-The Cocoa SDK captures [breadcrumbs automatically](/platforms/apple/enriching-events/breadcrumbs/#automatic-breadcrumbs) for
+The Cocoa SDK captures breadcrumbs automatically for:
   - Application lifecycle events (`didBecomeActive`, `didEnterBackground`, `viewDidAppear`)
   - Touch events
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)

--- a/src/platform-includes/getting-started-primer/apple.macos.mdx
+++ b/src/platform-includes/getting-started-primer/apple.macos.mdx
@@ -16,7 +16,7 @@
   - Touch events
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
-  // When adding an auto breadcrumb item here please also update /platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
+<!-- When adding an auto breadcrumb item here please also update /platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx -->
 - [Release health](/product/releases/health/) tracks crash free users and sessions
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/platform-includes/getting-started-primer/apple.macos.mdx
+++ b/src/platform-includes/getting-started-primer/apple.macos.mdx
@@ -16,6 +16,7 @@
   - Touch events
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests
+  // When adding an auto breadcrumb item here please also update /platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
 - [Release health](/product/releases/health/) tracks crash free users and sessions
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs


### PR DESCRIPTION
The auto-generated breadcrumbs page for Apple was missing. This is fixed now.

Came up in https://github.com/getsentry/sentry-docs/issues/5509.
