### PR TITLE
feat(native): clarify filtering hook behavior in the context of fast-fail crashes...

### DIFF
--- a/src/platform-includes/configuration/before-send/native.mdx
+++ b/src/platform-includes/configuration/before-send/native.mdx
@@ -76,7 +76,7 @@ The Crashpad backend on macOS doesn't currently support notifying the crashing p
 </Alert>
 
 <Alert level="warning" title="Bypassed in Crashpad on Windows when capturing fast-fail crashes">
-  
-The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error Reporting) module and signals the `crashpad_handler` to send a minidump to sentry. But since this process bypasses SEH, the application local exception handler is no longer invoked, which also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before sending the minidump and thus have no effect.
+
+The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error Reporting) module, which signals the `crashpad_handler` to send a minidump when a fast-fail crash occurs. But since this process bypasses SEH, the application local exception handler is no longer invoked, which also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before sending the minidump and thus have no effect.
 
 </Alert>

--- a/src/platform-includes/configuration/before-send/native.mdx
+++ b/src/platform-includes/configuration/before-send/native.mdx
@@ -74,3 +74,9 @@ gradual migration from existing `before_send` implementations:
 The Crashpad backend on macOS doesn't currently support notifying the crashing process and thus can't correctly terminate sessions or call the registered `before_send` or `on_crash` hooks. It will also lose any events queued for sending at the time of the crash.
 
 </Alert>
+
+<Alert level="warning" title="Bypassed in Crashpad on Windows when capturing fast-fail crashes">
+  
+The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error Reporting) module and signals the `crashpad_handler` to send a minidump to sentry. But since this process bypasses SEH, the application local exception handler is no longer invoked, which also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before sending the minidump and thus have no effect.
+
+</Alert>


### PR DESCRIPTION
... when using crashpad on Windows together with the WER (Windows Error Reporting) module.