### PR TITLE
fix(native): title casing in filtering fast-fail alert box

### DIFF
--- a/src/platform-includes/configuration/before-send/native.mdx
+++ b/src/platform-includes/configuration/before-send/native.mdx
@@ -75,7 +75,7 @@ The Crashpad backend on macOS doesn't currently support notifying the crashing p
 
 </Alert>
 
-<Alert level="warning" title="Bypassed in Crashpad on Windows when capturing fast-fail crashes">
+<Alert level="warning" title="Bypassed in Crashpad on Windows When Capturing Fast-fail Crashes">
 
 The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error Reporting) module, which signals the `crashpad_handler` to send a minidump when a fast-fail crash occurs. But since this process bypasses SEH, the application local exception handler is no longer invoked, which also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before sending the minidump and thus have no effect.
 


### PR DESCRIPTION
... and find a better phrasing for the title introduced here: #5524