### PR TITLE
update include directions

### DIFF
--- a/src/docs/contributing/approach/product-docs/write-index.mdx
+++ b/src/docs/contributing/approach/product-docs/write-index.mdx
@@ -55,8 +55,13 @@ If you use this approach, you may want to include a very high-level, one- or two
 
 - Create a section called “Learn More”
 - Use a `<PageGrid />` element to link to child pages for this feature
+
   - This displays a bullet list of page links with their front matter page descriptions
   - This might require that you edit the front matter descriptions of the pages displayed in the page grid
+
+## Includes
+
+You might need to use an `include` file for small pieces of reusable content, such as Early Adopter notes, plan/feature notes, or short snippets of text. These are found in [`src/includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes).
 
 ## Other Guidelines
 

--- a/src/docs/contributing/approach/sdk-docs/common_content.mdx
+++ b/src/docs/contributing/approach/sdk-docs/common_content.mdx
@@ -3,7 +3,7 @@ title: Common Content
 noindex: true
 sidebar_order: 20
 redirect_from:
- - /contributing/approach/common_content/
+  - /contributing/approach/common_content/
 ---
 
 We provide common content to prevent duplication in our repository. It is provided for all platforms as well as frameworks that rely on a primary platform. In some circumstances, the common content is not valid, or the content varies enough that it must be written specifically to a particular platform or framework. However, if the content is technically correct for a new SDK or framework, there is no need to develop separate content that duplicates the information.
@@ -16,7 +16,11 @@ What displays for the user relies upon the hierarchy of content as detailed in o
 
 ## Tuning Common Content
 
-To ensure that common content can scale as we support more platforms and frameworks, we use `include` files. These files can range from, most typically, a code sample specific to a platform or framework to information that augments the core content for a specific platform or framework.
+To ensure that common content can scale as we support more platforms and frameworks, we use `include` files. These files can range from, most typically, a code sample specific to a platform or framework to information that augments the core content for a specific platform or framework. These platform-specific `include` files live in [`src/plaftorm-includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes) and the examples below demonstrate how to use them. We also have platform-agnostic `include` files which are discussed in our product docs.
+
+[`src/includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes).
+
+The examples below demonstrate how to use platform-specific `include` files.
 
 ### Simple Example
 

--- a/src/docs/contributing/approach/sdk-docs/common_content.mdx
+++ b/src/docs/contributing/approach/sdk-docs/common_content.mdx
@@ -16,9 +16,7 @@ What displays for the user relies upon the hierarchy of content as detailed in o
 
 ## Tuning Common Content
 
-To ensure that common content can scale as we support more platforms and frameworks, we use `include` files. These files can range from, most typically, a code sample specific to a platform or framework to information that augments the core content for a specific platform or framework. These platform-specific `include` files live in [`src/plaftorm-includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes) and the examples below demonstrate how to use them. We also have platform-agnostic `include` files which are discussed in our product docs.
-
-[`src/includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes).
+To ensure that common content can scale as we support more platforms and frameworks, we use `include` files. These files can range from, most typically, a code sample specific to a platform or framework to information that augments the core content for a specific platform or framework. These platform-specific `include` files live in [`src/plaftorm-includes/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes) and the examples below demonstrate how to use them. We also have [platform-agnostic `include` files](/contributing/approach/product-docs/write-index/#includes) which are discussed in our product docs.
 
 The examples below demonstrate how to use platform-specific `include` files.
 

--- a/src/docs/contributing/approach/sdk-docs/write-configuration.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-configuration.mdx
@@ -46,14 +46,12 @@ To develop content for this file:
 
 This file is `releases.mdx`. It explains how to configure the SDK to tell Sentry about releases. Provide a code sample for this SDK to set a release, then add the code sample to this directory:
 
-- `/src/includes/set-release/`
+- `/src/platform-includes/set-release/`
 
 A few nuances:
 
 - If adding an SDK related to JavaScript, update the source maps-related paragraph, as appropriate, in the `PlatformSection supported` statement.
-- For SDKs that support release health, we control the display of content with a `PlatformSection supported` statement. For these SDKs, provide the following code samples:
-  - Session tracking, stored in `/src/includes/configuration/session-tracking-interval`
-  - Opt out of auto session tracking, stored in `/src/includes/configuration/auto-session-tracking`
+- For SDKs that support release health, we control the display of content with a `PlatformSection supported` statement. For these SDKs, provide the following code sample: Opt out of auto session tracking, stored in `/src/platform-includes/configuration/auto-session-tracking`.
 
 ### Environments
 
@@ -61,23 +59,23 @@ This file is `environments.mdx`. It explains how to configure the SDK to set an 
 
 Add the code sample to this directory:
 
-- `/src/includes/set-environment/`
+- `/src/platform-includes/set-environment/`
 
 ### Filtering Events
 
 This file is `filtering.mdx`. It explains how to configure the SDK to filter events sent to Sentry. Add code samples to these directories:
 
-- `/src/includes/configuration/before-send/`
-- `/src/includes/configuration/before-send-hint/`
+- `/src/platform-includes/configuration/before-send/`
+- `/src/platform-includes/configuration/before-send-hint/`
 
 Enable or disable the content for "Using Hints", as appropriate to the SDK, by adding it to the list of either `supported` or `notSupported`, then add code sample to these directories:
 
-- `/src/includes/configuration/before-send-fingerprint/`
-- `/src/includes/configuration/decluttering/`
+- `/src/platform-includes/configuration/before-send-fingerprint/`
+- `/src/platform-includes/configuration/decluttering/`
 
 Enable or disable the content for "Using Sampling to Filter Transaction Events" by adding the SDK to the list of either `supported` or `notSupported`, then add code sample to this directory:
 
-- `/src/includes/performance/traces-sampler-as-filter/`
+- `/src/platform-includes/performance/traces-sampler-as-filter/`
 
 ### Sampling Events
 
@@ -85,19 +83,19 @@ This file is `sampling.mdx`. It explains how to set the sample rate for the SDK.
 
 Add code samples to these directories:
 
-- `/src/includes/configuration/sample-rate/`
-- `/src/includes/performance/uniform-sample-rate/`
-- `/src/includes/performance/sampling-function-intro/`
-- `/src/includes/performance/default-sampling-context`
-- `/src/includes/performance/custom-sampling-context`
-- `src/includes/performance/always-inherit-sampling-decision`
-- `src/includes/performance/force-sampling-decision`
+- `/src/platform-includes/configuration/sample-rate/`
+- `/src/platform-includes/performance/uniform-sample-rate/`
+- `/src/platform-includes/performance/sampling-function-intro/`
+- `/src/platform-includes/performance/default-sampling-context`
+- `/src/platform-includes/performance/custom-sampling-context`
+- `src/platform-includes/performance/always-inherit-sampling-decision`
+- `src/platform-includes/performance/force-sampling-decision`
 
 ### Shutdown and Draining
 
 This file is `draining.mdx`. Add the drain example content to this directory:
 
-- `/src/includes/configuration/drain-example/`
+- `/src/platform-includes/configuration/drain-example/`
 
 ### Integrations
 

--- a/src/docs/contributing/approach/sdk-docs/write-data-management.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-data-management.mdx
@@ -3,14 +3,14 @@ title: How to Write - Data Management
 noindex: true
 sidebar_order: 60
 redirect_from:
- - /contributing/approach/write-data-management/
+  - /contributing/approach/write-data-management/
 ---
 
 The Data Management section of the content covers how customers can manage the data sent to Sentry using the SDK. We provide a parallel section in product, which focuses on the settings in [sentry.io](http://sentry.io) a user can user to control data. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/data-management/` - feel free to peruse the files in that directory to answer any questions.
 
 <Alert >
 
-DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on  GitHub with questions/suggestions.
+DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on GitHub with questions/suggestions.
 
 </Alert >
 
@@ -20,9 +20,8 @@ Most of these pages are pretty self-evident, so only basic information is provid
 
 Determine if the page applies:
 
-- If the content *does not apply*, add the SDK to `notSupported` list in the frontmatter of the file. This will turn off the display of the content for this SDK.
-- If the content *does apply*, add the `include` file to the correct directory as noted for each page. If the code sample is not provided, the page will display a big gray box requesting customers open an issue for the missing sample.
-
+- If the content _does not apply_, add the SDK to `notSupported` list in the frontmatter of the file. This will turn off the display of the content for this SDK.
+- If the content _does apply_, add the `include` file to the correct directory as noted for each page. If the code sample is not provided, the page will display a big gray box requesting customers open an issue for the missing sample.
 
 ### Sensitive Data
 
@@ -34,9 +33,9 @@ For data scrubbing that the SDK DOES NOT support, add the name of the SDK to the
 
 Add the code sample to these directories:
 
-- `/src/includes/configuration/before-send`
-- `/src/includes/sensitive-data/set-tag`
-- `/src/includes/sensitive-data/set-user`
+- `/src/platform-includes/configuration/before-send`
+- `/src/platform-includes/sensitive-data/set-tag`
+- `/src/platform-includes/sensitive-data/set-user`
 
 ### Debug Files
 

--- a/src/docs/contributing/approach/sdk-docs/write-enriching-events.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-enriching-events.mdx
@@ -3,14 +3,14 @@ title: How to Write - Enriching Events
 noindex: true
 sidebar_order: 50
 redirect_from:
- - /contributing/approach/write-enriching-events/
+  - /contributing/approach/write-enriching-events/
 ---
 
 The Enriching Events section of the content covers how customers can add context to the data sent to Sentry. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/enriching-events/` - feel free to peruse the files in that directory to answer any questions.
 
 <Alert >
 
-DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on  GitHub with questions/suggestions.
+DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on GitHub with questions/suggestions.
 
 </Alert >
 
@@ -20,15 +20,15 @@ Most of these pages are pretty self-evident, so only basic information is provid
 
 Determine if the page applies:
 
-- If the content *does not apply*, add the SDK to `notSupported` list in the frontmatter of the file. This will turn off the display of the content for this SDK.
-- If the content *does apply*, add the `include` file to the correct directory as noted for each page. If the code sample is not provided, the page will display a big gray box requesting customers open an issue for the missing sample.
-- The JS family of content needs to import the SDK for the code samples to make sense on each page. Add the import statement to `/src/includes/enriching-events/enriching-events/import`.
+- If the content _does not apply_, add the SDK to `notSupported` list in the frontmatter of the file. This will turn off the display of the content for this SDK.
+- If the content _does apply_, add the `include` file to the correct directory as noted for each page. If the code sample is not provided, the page will display a big gray box requesting customers open an issue for the missing sample.
+- The JS family of content needs to import the SDK for the code samples to make sense on each page. Add the import statement to `/src/platform-includes/enriching-events/enriching-events/import`.
 
 ### Add Context
 
 This file is `context.mdx`. It explains how to enable custom contexts. Add the code sample to this directory:
 
-- `/src/includes/enriching-events/set-context/`
+- `/src/platform-includes/enriching-events/set-context/`
 
 If the SDK can pass context directly, add it to the list of supported SDKs immediately above "Passing Context Directly".
 
@@ -36,14 +36,14 @@ If the SDK can pass context directly, add it to the list of supported SDKs immed
 
 This file is `identify-user.mdx`. It explains how to capture the user. Add the code samples to these directories:
 
-- `/src/includes/enriching-events/set-user/`
-- `/src/includes/enriching-events/unset-user/`
+- `/src/platform-includes/enriching-events/set-user/`
+- `/src/platform-includes/enriching-events/unset-user/`
 
 ### Set Transaction Name
 
 This file is `transaction-name.mdx`. It explains how to override the transaction name. Add the code sample to this directory:
 
-- `/src/includes/enriching-events/set-transaction-name/`
+- `/src/platform-includes/enriching-events/set-transaction-name/`
 
 If the SDK can control the starting and stopping of transactions, add it to the list of supported SDKs that refers customers to our tracing docs.
 
@@ -51,7 +51,7 @@ If the SDK can control the starting and stopping of transactions, add it to the 
 
 This file is `tags.mdx`. It explains how to customize tags for an event. Add the code sample to this directory:
 
-- `/src/includes/enriching-events/set-tag/`
+- `/src/platform-includes/enriching-events/set-tag/`
 
 If the SDK doesn't bind tags to the current scope, add it to the list of SDKs that don't support this option.
 
@@ -59,7 +59,7 @@ If the SDK doesn't bind tags to the current scope, add it to the list of SDKs th
 
 This file is `/attachments/index.mdx`. It explains attaching files along with the event. Add the code sample to this directory:
 
-- `/src/includes/enriching-events/add-attachment/`
+- `/src/platform-includes/enriching-events/add-attachment/`
 
 If the SDK is part of the native family, add it to the list of SDKs that support the native content regarding:
 
@@ -72,8 +72,8 @@ If the SDK is part of the native family, add it to the list of SDKs that support
 
 This file is `breadcrumbs.mdx`. It explains manual breadcrumbs. Add the code sample to manually add record a breadcrumb to this directory:
 
-- `/src/includes/enriching-events/breadcrumbs/breadcrumbs-example/`
-- `/src/includes/enriching-events/breadcrumbs/before-breadcrumb/`
+- `/src/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/`
+- `/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/`
 
 One nuance:
 
@@ -84,15 +84,15 @@ One nuance:
 This file is `user-feedback.mdx`. It explains how to use the embeddable JS widget or the API.
 
 - Update, as appropriate, the supported SDK list in the `PlatformSection supported` that precedes "User Feedback API".
-Then add the code sample to the `src/includes/enriching-events/user-feedback/sdk-api-example` directory
+  Then add the code sample to the `src/platform-includes/enriching-events/user-feedback/sdk-api-example` directory
 - For the .NET family, if the User Feedback API has a specific integration, add it to the `PlatformSection supported` that precedes the "Use the .NET SDK", and add the appropriate link.
 - Update, as appropriate, the SDKs that don't support the JS widget in the listed `PlatformSection notSupported` that precedes "Embeddeable JavaScript Widget".
-- For the SDKs that use the JS widget, add the code sample to`/src/includes/enriching-events/user-feedback/user-feedback-example-widget/`
+- For the SDKs that use the JS widget, add the code sample to`/src/platform-includes/enriching-events/user-feedback/user-feedback-example-widget/`
 
 ### Scopes
 
 This file is `scopes.mdx`. It explains managing scopes. Add the code samples to these directories:
 
-- `/src/includes/enriching-events/scopes/configure-scope/`
-- `/src/includes/enriching-events/unset-user/`
-- `/src/includes/enriching-events/scopes/with-scope/`
+- `/src/platform-includes/enriching-events/scopes/configure-scope/`
+- `/src/platform-includes/enriching-events/unset-user/`
+- `/src/platform-includes/enriching-events/scopes/with-scope/`

--- a/src/docs/contributing/approach/sdk-docs/write-getting-started.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-getting-started.mdx
@@ -3,14 +3,14 @@ title: How to Write - Getting Started
 noindex: true
 sidebar_order: 30
 redirect_from:
- - /contributing/approach/write-getting-started/
+  - /contributing/approach/write-getting-started/
 ---
 
 In most cases, the platform/SDK will adopt the common index page, which is stored in [`src/platforms/common/`](https://github.com/getsentry/sentry-docs/tree/master/src/platforms/common), as the [`index.mdx`](https://github.com/getsentry/sentry-docs/blob/master/src/platforms/common/index.mdx) file - feel free to peruse that file to answer any questions.
 
 <Alert >
 
-DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on  GitHub with questions/suggestions.
+DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on GitHub with questions/suggestions.
 
 </Alert >
 
@@ -28,7 +28,7 @@ caseStyle: camelCase
 supportLevel: production
 sdk: "sentry.javascript.browser"
 categories:
-- browser
+  - browser
 ```
 
 ## Primer Content
@@ -38,15 +38,15 @@ Explain the SDK at a high level in these two parts:
 1. An italicized sentence that explains what the SDK enables (errors, or errors and transactions)
 2. A brief paragraph that provides technical insight and the versions supported
 
-    <Note>
+   <Note>
 
-    If the primer content isn't developed, this fallback will display "*Sentry's SDKs enable automatic reporting of errors and exceptions*."
+   If the primer content isn't developed, this fallback will display "_Sentry's SDKs enable automatic reporting of errors and exceptions_."
 
-    </Note>
+   </Note>
 
 Add the primer content to this directory:
 
-- [`/src/includes/getting-started-primer/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-primer)
+- [`/src/platform-includes/getting-started-primer/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes/getting-started-primer)
 
 ## Installation Method
 
@@ -54,7 +54,7 @@ Provide an example of the primary installation method for this SDK. While we doc
 
 Add the installation method to this directory:
 
-- [`/src/includes/getting-started-install/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-install)
+- [`/src/platform-includes/getting-started-install/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes/getting-started-install)
 
 ## Configuration Code Sample
 
@@ -62,7 +62,7 @@ Provide an example of the configuration of this SDK, commenting in the code samp
 
 Add the configuration code sample to this directory:
 
-- [`/src/includes/getting-started-config/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-config)
+- [`/src/platform-includes/getting-started-config/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes/getting-started-config)
 
 <Note >
 
@@ -76,7 +76,7 @@ Provide a verification code sample for this SDK. It can be as simple as one line
 
 Add the verification code sample to this directory:
 
-- [`/src/includes/getting-started-verify/`](https://github.com/getsentry/sentry-docs/tree/master/src/includes/getting-started-verify)
+- [`/src/platform-includes/getting-started-verify/`](https://github.com/getsentry/sentry-docs/tree/master/src/platform-includes/getting-started-verify)
 
 ## But, that's not all
 

--- a/src/docs/contributing/approach/sdk-docs/write-performance.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-performance.mdx
@@ -3,7 +3,7 @@ title: How to Write - Performance
 noindex: true
 sidebar_order: 70
 redirect_from:
- - /contributing/approach/write-performance/
+  - /contributing/approach/write-performance/
 ---
 
 The Performance section of the content covers performance instrumentation for our SDKs. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/performance/` - feel free to peruse the files in that directory to help answer any questions. **However,** each SDK will have its _own_ page devoted to what instrumentation is automatic. We do not develop common content for this page, just its structure.
@@ -33,18 +33,18 @@ To develop content for this file:
 
 1. If the SDK is still a work-in-progress and is exposed as an experimental or an early access feature, add the platform to the `<PlatformSection>` wrapping the appropriate alert located at the beginning of the content for the page.
 
-1. If the SDK is expected to be used in a high-throughput environment, add the platform to the following `<PlatformSection>` which advises testing before deploying to production. 
+1. If the SDK is expected to be used in a high-throughput environment, add the platform to the following `<PlatformSection>` which advises testing before deploying to production.
 
 1. If automatic instrumentation is still in preview/beta for the SDK, add your platform to the next `<PlatformSection>` that wraps around text that discusses this.
 
 1. If automatic instrumentation is supported, add your platform to the `<PlatformSection>` immediately following **Verify** which advises users to either use auto or custom (or manual) instrumentation to verify the feature. Either omit the platform from the `supported` list or add the platform to the `notSupported` list if auto instrumentation is not available.
 
-1. Add a code sample to `/src/includes/performance/configure-sample-rate/` that covers how to set sample rates. Make sure to update `/platforms/common/configuration/sampling.mdx` and **Tracing Options** in `/platforms/common/configuration/options.mdx`.
+1. Add a code sample to `/src/platform-includes/performance/configure-sample-rate/` that covers how to set sample rates. Make sure to update `/platforms/common/configuration/sampling.mdx` and **Tracing Options** in `/platforms/common/configuration/options.mdx`.
 
 1. Do one of the following based on whether automatic instrumentation is available for the SDK or not:
-    a. If automatic instrumentation is supported, add your platform to the `<PlatformSection>` immediately following **Verify** which advises users to either use auto or custom (a.k.a. manual) instrumentation to verify the feature. Either omit the platform from `supported` or the platform to `notSupported`.
+   a. If automatic instrumentation is supported, add your platform to the `<PlatformSection>` immediately following **Verify** which advises users to either use auto or custom (a.k.a. manual) instrumentation to verify the feature. Either omit the platform from `supported` or the platform to `notSupported`.
 
-    b. If automatic instrumentation is not supported, add your platform to the second `<PlatformSection>` after **Verify** which advises users to test out tracing using custom (manual) instrumentation. Omit the platform from the `supported` list or add it to the `notSupported` list if automatic instrumentation is available.
+   b. If automatic instrumentation is not supported, add your platform to the second `<PlatformSection>` after **Verify** which advises users to test out tracing using custom (manual) instrumentation. Omit the platform from the `supported` list or add it to the `notSupported` list if automatic instrumentation is available.
 
 1. Determine if the paragraph regarding pageload and navigation applies to the SDK. If so, add the SDK to the `Supported` list in the `<PlatformSection>`. If not, either omit the platform from the `supported` list or add the platform to the `notSupported` list, which will prevent the content from displaying for this SDK.
 
@@ -58,15 +58,15 @@ If custom instrumentation for the SDK is exposed as an experimental or an early 
 
 To develop content for this file, add code samples to these directories:
 
-- `/src/includes/enable-manual-instrumentation/`
-- `/src/includes/performance/add-spans-example/`
-- `/src/includes/performance/retrieve-transaction/`
+- `/src/platform-includes/performance/enable-manual-instrumentation/`
+- `/src/platform-includes/performance/add-spans-example/`
+- `/src/platform-includes/performance/retrieve-transaction/`
 
 If any of the above files are not applicable to your platform, find the `<PlatformSection>` wrapping the `<PlatformContent>` pointing to the unsupported file, and add your platform to its `notSupported` list. If such a `<PlatformSection>` doesn't already exist, create one and add your platform to its `notSupported` list.
 
-Then, determine whether to provide a code sample illustrating how to connect errors and spans. If so, add the SDK to the `Supported` list in the appropriate `<PlatformSection>`, then add a code sample `/src/includes/performance/connect-errors-spans/`.
+Then, determine whether to provide a code sample illustrating how to connect errors and spans. If so, add the SDK to the `Supported` list in the appropriate `<PlatformSection>`, then add a code sample `/src/platform-includes/performance/connect-errors-spans/`.
 
-If the platform supports distributed tracing using custom instrumentation, add the SDK to the appropriate `<PlatformSection>` and create an appropriate file at `src/includes/performance/distributed-tracing`.
+If the platform supports distributed tracing using custom instrumentation, add the SDK to the appropriate `<PlatformSection>` and create an appropriate file at `src/platform-includes/performance/distributed-tracing`.
 
 ### Automatic Instrumentation
 
@@ -80,7 +80,7 @@ This file is `troubleshooting-performance.mdx`. It explains corner cases and how
 
 1. Determine if the SDK needs an illustration of how to group transactions. If so, add the SDK to `Supported` list in the `<PlatformSection>`, then add a code sample to `performance/group-transaction-example/`. If not, add the SDK to `notSupported` list, which will prevent the **Group Transactions** heading from displaying for this SDK.
 
-2. Add an example to `src/includes/performance/control-data-truncation/`
+2. Add an example to `src/platform-includes/performance/control-data-truncation/`
 
 ### Connecting Services
 

--- a/src/docs/contributing/approach/sdk-docs/write-usage.mdx
+++ b/src/docs/contributing/approach/sdk-docs/write-usage.mdx
@@ -3,14 +3,14 @@ title: How to Write - Usage
 noindex: true
 sidebar_order: 80
 redirect_from:
- - /contributing/approach/write-usage/
+  - /contributing/approach/write-usage/
 ---
 
 The Usage section of the content covers how to manually capture events and message. In most cases, the SDK will adopt the common content, which is stored in `/platforms/common/usage/` - feel free to peruse the files in that directory to help answer questions.
 
 <Alert >
 
-DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on  GitHub with questions/suggestions.
+DO NOT change the common content. That change will ripple across all SDKs that rely on the common content. Instead, open an issue on GitHub with questions/suggestions.
 
 </Alert >
 
@@ -22,11 +22,11 @@ This file is `index.mdx`. It explains how to manually capture events.
 
 Add the code sample to these directories:
 
-- `/src/includes/capture-error/`
-- `/src/includes/capture-message/`
+- `/src/platform-includes/capture-error/`
+- `/src/platform-includes/capture-message/`
 
 ### Set the Level
 
 This file is `set-level.mdx`. It explains how to set the level of the event. Add the code sample to this directory:
 
-- `/src/includes/set-level/`
+- `/src/platform-includes/set-level/`


### PR DESCRIPTION
Update include directions for platform docs to indicate new platform-includes folder
Add include directions for product docs