### PR TITLE
update platformicons to 5.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "^5.3.1",
+    "platformicons": "^5.2.3",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13875,10 +13875,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.3.1.tgz#778c9bc4899e9f668cad5bb49efbcfeacbb890c3"
-  integrity sha512-P25aSE/3tup5fxLJHK7yhQEs1QOQny+sqw4o2SU2xLgSMo0zRPr9wkxZ3EEHDqCYOBsYqQtstTECFLUmk9yUFA==
+platformicons@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.3.tgz#180f85a0a973cad36dd9a8abe30b5f38461f3a6e"
+  integrity sha512-8bQtN1qWQJ0wI2p9+xpCOtjCupuJ9HeNzbabRVO5fmivjyvwRxQPDbOS3G5GmKZH1PvZaMyFxWG1mLawgWDGxQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Bumping platformicons to 5.2.3 – adds wasm icons to the docs.

<img width="232" alt="CleanShot 2022-09-19 at 16 04 58@2x" src="https://user-images.githubusercontent.com/1900676/191134668-f7f97798-d151-4981-9933-ce1e9ec0c791.png">
