### PR TITLE
fix(docs): Typo missing third underscore around DSN

### DIFF
--- a/src/docs/clients/node/integrations.mdx
+++ b/src/docs/clients/node/integrations.mdx
@@ -50,7 +50,7 @@ var app = require("express")();
 var Raven = require("raven");
 
 // Must configure Raven before doing anything else with it
-Raven.config("__DSN__").install();
+Raven.config("___DSN___").install();
 
 // The request handler must be the first middleware on the app
 app.use(Raven.requestHandler());
@@ -101,7 +101,7 @@ Configure `raven-node` as early as possible:
 // server/server.js
 
 const Raven = require("raven");
-Raven.config("__DSN__").install();
+Raven.config("___DSN___").install();
 ```
 
 Add `Raven.errorHandler` as a Loopback middleware:
@@ -124,7 +124,7 @@ Add `Raven.errorHandler` as a Loopback middleware:
 // config/http.js
 
 var Raven = require("raven");
-Raven.config("__DSN__").install();
+Raven.config("___DSN___").install();
 
 module.exports.http = {
   middleware: {

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -6,7 +6,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___DSN___",
   tracesSampleRate: 1,
   integrations: [
     new Sentry.BrowserTracing({
@@ -29,14 +29,14 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___DSN___",
   tracesSampleRate: 1,
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
   // ...
 });
 ```
 
-<Note>    
+<Note>
 
 Learn more about <Link to="/platforms/node/performance/database/opt-in/#prisma-orm-integration">Sentry's Prisma integration </Link>.
 
@@ -45,12 +45,12 @@ Learn more about <Link to="/platforms/node/performance/database/opt-in/#prisma-o
 If you use a custom Express server in your Remix application, you should wrap your [`createRequestHandler` function](https://remix.run/docs/en/v1/other-api/adapter#createrequesthandler) manually with `wrapExpressCreateRequestHandler`. This is not required if you use the built-in Remix App Server.
 
 <Alert level="info">
-  
+
 `wrapExpressCreateRequestHandler` is available starting with version 7.11.0.
 
 </Alert>
 
-  
+
 ```typescript {filename: server/index.ts}
 import { wrapExpressCreateRequestHandler } from "@sentry/remix";
 import { createRequestHandler } from '@remix-run/express';
@@ -111,7 +111,7 @@ withSentry(App, {
 
 Once you've done this set up, the SDK will automatically capture unhandled errors and promise rejections, and monitor performance in the client. You can also [manually capture errors](/platforms/javascript/guides/remix/usage).
 
-  
+
 <Note>
 
 You can refer to [Remix Docs](https://remix.run/docs/en/v1/guides/envvars#browser-environment-variables) to learn how to use your Sentry DSN from environment variables.

--- a/src/platform-includes/performance/custom-performance-metrics/python.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/python.mdx
@@ -4,7 +4,7 @@ To enable the capturing of custom metrics, you'll need to enable the `custom_mea
 
 ```python
 sentry_sdk.init(
-    dsn="__DSN__",
+    dsn="___DSN___",
     _experiments={
         "custom_measurements": True,
     },

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -27,7 +27,7 @@ Initialize `Sentry.reactRouterV6Instrumentation` as your routing instrumentation
     - `useEffect` hook from `react`
     - `useLocation` and `useNavigationType` hooks from `react-router-dom`
     - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages.
-    
+
 <Alert level="warning">
 
 Make sure `Sentry.reactRouterV6Instrumentation` is initialized by your `Sentry.init` call, before you wrap `<Routes />` component  or `useRoutes` hook. Otherwise, the routing instrumentation may not work properly.
@@ -35,7 +35,7 @@ Make sure `Sentry.reactRouterV6Instrumentation` is initialized by your `Sentry.i
 </Alert>
 
 ### Usage With `<Routes />` Component
-  
+
 If you use the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context, as in the example below:
 
 ```javascript
@@ -101,7 +101,7 @@ import { wrapUseRoutes } from "@sentry/react";
 import { useEffect } from "react";
 
 Sentry.init({
-    dsn: "__DSN__",
+    dsn: "___DSN___",
     integrations: [
         new BrowserTracing({
             routingInstrumentation: Sentry.reactRouterV6Instrumentation(

--- a/src/wizard/javascript/remix.md
+++ b/src/wizard/javascript/remix.md
@@ -23,7 +23,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___DSN___",
   tracesSampleRate: 1,
   integrations: [
     new Sentry.BrowserTracing({
@@ -45,7 +45,7 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___DSN___",
   tracesSampleRate: 1,
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
 });


### PR DESCRIPTION
Unsure what the distinction between `___DSN___` and `___PUBLIC_DSN___` is but all `__DSN__` (2 underscores) should all be `___DSN___` (3 underscores).