### PR TITLE
Add docs for Next.js SDK option `autoInstrumentServerFunctions`

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -245,7 +245,7 @@ In that case you can also skip the `sentry-cli` configuration step below.
 
 ### Automatically Instrument API Routes and Data Fetching Methods
 
-_(New in version TODO)_
+_(New in version 7.14.0)_
 
 The SDK provides an option to automatically instrument API routes and server-side [Next.js data fetching methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`:
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -247,7 +247,7 @@ In that case you can also skip the `sentry-cli` configuration step below.
 
 _(New in version TODO)_
 
-The SDK provides an option to automatcally instrument API routes and serverside [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
+The SDK provides an option to automatically instrument API routes and serverside [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
 
 ```javascript {filename:next.config.js}
 const moduleExports = {
@@ -259,7 +259,7 @@ const moduleExports = {
 
 Under the hood, the SDK is using a Webpack loader to wrap all your API route handlers and data fetching methods.
 
-In case the automatic instrumentation does not work for your use-case, API routes can also be wrapped manually using the `withSentry` function.
+In case the automatic instrumentation does not work for your use case, API routes can also be wrapped manually using the `withSentry` function.
 
 ```javascript {filename:pages/api/*}
 import { withSentry } from "@sentry/nextjs";

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -184,6 +184,7 @@ const moduleExports = {
     // sections below for information on the following options:
     //   - disableServerWebpackPlugin
     //   - disableClientWebpackPlugin
+    //   - autoInstrumentServerFunctions
     //   - hideSourceMaps
     //   - widenClientFileUpload
     //   - transpileClientSDK
@@ -241,6 +242,20 @@ module.exports = withSentryConfig(moduleExports);
 ```
 
 In that case you can also skip the `sentry-cli` configuration step below.
+
+### Automatically Instrument API Routes And Data Fetching Methods
+
+_(New in version TODO)_
+
+The SDK provides an option to automatcally instrument API routes and [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
+
+```javascript {filename:next.config.js}
+const moduleExports = {
+  sentry: {
+    autoInstrumentServerFunctions: true,
+  },
+};
+```
 
 ### Use `hidden-source-map`
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -247,7 +247,7 @@ In that case you can also skip the `sentry-cli` configuration step below.
 
 _(New in version TODO)_
 
-The SDK provides an option to automatcally instrument API routes and [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
+The SDK provides an option to automatcally instrument API routes and serverside [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
 
 ```javascript {filename:next.config.js}
 const moduleExports = {
@@ -258,6 +258,38 @@ const moduleExports = {
 ```
 
 Under the hood, the SDK is using a Webpack loader to wrap all your API route handlers and data fetching methods.
+
+In case the automatic instrumentation does not work for your use-case, API routes can also be wrapped manually using the `withSentry` function.
+
+```javascript {filename:pages/api/*}
+import { withSentry } from "@sentry/nextjs";
+
+const handler = (req, res) => {
+  res.status(200).json({ name: "John Doe" });
+};
+
+export default withSentry(handler);
+```
+
+```typescript {filename:pages/api/*}
+import type { NextApiRequest, NextApiResponse } from "next"
+import { withSentry } from "@sentry/nextjs";
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json({ name: "John Doe" });
+};
+
+export default withSentry(handler);
+```
+
+Data Fetching Methods can also be manually wrapped using the following functions:
+
+- `withSentryServerSideGetInitialProps` for `getInitialProps`
+- `withSentryGetServerSideProps` for `getServerSideProps`
+- `withSentryGetStaticProps` for `getStaticProps`
+- `withSentryServerSideErrorGetInitialProps` for `getInitialProps` in [custom Error pages](https://nextjs.org/docs/advanced-features/custom-error-page)
+- `withSentryServerSideAppGetInitialProps` for `getInitialProps` in [custom `App` components](https://nextjs.org/docs/advanced-features/custom-app)
+- `withSentryServerSideDocumentGetInitialProps` for `getInitialProps` in [custom `Document` components](https://nextjs.org/docs/advanced-features/custom-document)
 
 ### Use `hidden-source-map`
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -243,11 +243,11 @@ module.exports = withSentryConfig(moduleExports);
 
 In that case you can also skip the `sentry-cli` configuration step below.
 
-### Automatically Instrument API Routes And Data Fetching Methods
+### Automatically Instrument API Routes and Data Fetching Methods
 
 _(New in version TODO)_
 
-The SDK provides an option to automatically instrument API routes and serverside [Next.js Data Fetching Methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`.
+The SDK provides an option to automatically instrument API routes and server-side [Next.js data fetching methods](https://nextjs.org/docs/basic-features/data-fetching/overview) with error and performance monitoring, removing the need to manually wrap API routes in `withSentry`:
 
 ```javascript {filename:next.config.js}
 const moduleExports = {
@@ -259,7 +259,7 @@ const moduleExports = {
 
 Under the hood, the SDK is using a Webpack loader to wrap all your API route handlers and data fetching methods.
 
-In case the automatic instrumentation does not work for your use case, API routes can also be wrapped manually using the `withSentry` function.
+If the automatic instrumentation doesn't work for your use case, API routes can also be wrapped manually using the `withSentry` function:
 
 ```javascript {filename:pages/api/*}
 import { withSentry } from "@sentry/nextjs";
@@ -282,7 +282,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
 export default withSentry(handler);
 ```
 
-Data Fetching Methods can also be manually wrapped using the following functions:
+Data fetching methods can also be manually wrapped using the following functions:
 
 - `withSentryServerSideGetInitialProps` for `getInitialProps`
 - `withSentryGetServerSideProps` for `getServerSideProps`

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -257,6 +257,8 @@ const moduleExports = {
 };
 ```
 
+Under the hood, the SDK is using a Webpack loader to wrap all your API route handlers and data fetching methods.
+
 ### Use `hidden-source-map`
 
 _(New in version 6.17.1, will default to `true` in 8.0.0 and beyond.)_


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5505

Adds a description for the `autoInstrumentServerFunctions` Next.js SDK option which automatically wraps user's API routes and data fetching methods.

