### PR TITLE
Make express wrapper usage clearer by extracting into seperate variable

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -55,8 +55,12 @@ If you use a custom Express server in your Remix application, you should wrap yo
 import { wrapExpressCreateRequestHandler } from "@sentry/remix";
 import { createRequestHandler } from '@remix-run/express';
 
-//...
-app.all('*', wrapExpressCreateRequestHandler(createRequestHandler)(/* ... */));
+// ...
+
+const createSentryRequestHandler = wrapExpressCreateRequestHandler(createRequestHandler);
+
+// Use createSentryRequestHandler like you would with createRequestHandler
+app.all('*', createSentryRequestHandler(/* ... */));
 ```
 
 Also, wrap your Remix root with `withSentry` to catch React component errors and to get parameterized router transactions.


### PR DESCRIPTION
Based on https://github.com/getsentry/blues-stack/pull/1

Make it clearer to users that they are wrapping the a factory function, not the request handler itself.