### PR TITLE
fix manual login command

### DIFF
--- a/src/docs/product/cli/configuration.mdx
+++ b/src/docs/product/cli/configuration.mdx
@@ -41,7 +41,7 @@ Visit your [auth token user settings page](https://sentry.io/settings/account/ap
   ```
 - pass it as a parameter when you invoke `sentry-cli`:
   ```bash
-  $ sentry-cli --auth-token your-auth-token
+  $ sentry-cli login --auth-token your-auth-token
   ```
 
 ## Configuration File


### PR DESCRIPTION
Documentation was missing login command for manual cli login.



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
