### PR TITLE
fix(apple): Why app hangs run when disabled

### DIFF
--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -12,6 +12,8 @@ With app hang tracking, you can detect and fix this problem.
 The app hang detection integration has a default timeout of two (2) seconds, which means if the app becomes unresponsive for two seconds, an error event is created.
 The event has the stack trace of all running threads so you can easily detect where the problem occurred.
 
+The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
+
 To use this feature, add this to your code:
 
 ```swift {tabTitle:Swift}


### PR DESCRIPTION
Explain why the app hangs code runs when disabled but keeping OOM enabled.

Came up in https://github.com/getsentry/sentry-cocoa/issues/2214.



