### PR TITLE
fix(apple): Explain why no duration for app hangs

### DIFF
--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -10,7 +10,7 @@ There are many reasons an app can become unresponsive, from long running code to
 With app hang tracking, you can detect and fix this problem.
 
 The app hang detection integration has a default timeout of two (2) seconds, which means if the app becomes unresponsive for two seconds, an error event is created.
-The event has the stack trace of all running threads so you can easily detect where the problem occurred.
+The event has the stack trace of all running threads so you can easily detect where the problem occurred. The SDK reports an app hang immediately and doesn't report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app any time when blocking the main thread.
 
 The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
 

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -10,7 +10,7 @@ There are many reasons an app can become unresponsive, from long running code to
 With app hang tracking, you can detect and fix this problem.
 
 The app hang detection integration has a default timeout of two (2) seconds, which means if the app becomes unresponsive for two seconds, an error event is created.
-The event has the stack trace of all running threads so you can easily detect where the problem occurred. The SDK reports an app hang immediately and doesn't report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app any time when blocking the main thread.
+The event has the stack trace of all running threads so you can easily detect where the problem occurred. The SDK reports an app hang immediately but doesn't report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app any time when blocking the main thread.
 
 The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
 


### PR DESCRIPTION
Explain why the Cocoa SDK can't report the exact duration of app hangs.

