### PR TITLE
fix(native): Cut before_breadcrumb + add on_crash

### DIFF
--- a/src/platform-includes/configuration/before-send/native.mdx
+++ b/src/platform-includes/configuration/before-send/native.mdx
@@ -18,11 +18,9 @@ int main(void) {
 The callback is executed in the same thread as the call to `sentry_capture_event`. Work performed by the function may thus block the executing thread. For this reason, consider avoiding heavy work in `before_send`.
 
 
-#### Using `on_crash` (starting with version 0.4.19)
+#### Using `on_crash`
 
-The `before_send` callback implementation in `sentry-native` makes it hard to distinguish between normal events
-and crashes. For this reason, we introduced another callback, `on_crash`, which - at this point - only exists 
-in `sentry_native`:
+The `before_send` callback implementation in `sentry-native` makes it hard to distinguish between normal events and crashes. For this reason, we introduced another callback, `on_crash`, which - at this point - only exists in `sentry_native`:
 
 ```c
 #include <sentry.h>
@@ -54,10 +52,7 @@ int main(void) {
 }
 ```
 
-The `on_crash` callback replaces `before_send` as a callback for crash events only. They can
-be defined simultaneously, where the SDK prevents `before_send` from being invoked for crash 
-events. This allows for better differentiation between crashes and other events and 
-gradual migration from existing `before_send` implementations:
+The `on_crash` callback replaces `before_send` as a callback for crash events only. They can be defined simultaneously, where the SDK prevents `before_send` from being invoked for crash events. This allows for better differentiation between crashes and other events and gradual migration from existing `before_send` implementations:
 
 - If you have a `before_send` implementation and do not define an `on_crash`
   callback `before_send` will receive both normal and crash events as before

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -505,7 +505,13 @@ This function is called with an SDK-specific event object, and can return a modi
 
 </ConfigKey>
 
-<ConfigKey name="before-breadcrumb">
+<ConfigKey name="on-crash" supported={["native"]}>
+
+This function is called with a backend-specific event object, and can return a modified event object or nothing to skip reporting the event. In contrast to `before_send`, it is only called when a crash occured. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).
+
+</ConfigKey>
+
+<ConfigKey name="before-breadcrumb" notSupported={["native"]}>
 
 This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.


### PR DESCRIPTION
There is no support for the `before_breadcrumb`-hook in `sentry-native`, but there is an `on_crash`-hook which hasn't been mentioned yet in the __Basic Options__.