### PR TITLE
fix(native): set debug option in introductory examples

### DIFF
--- a/src/platform-includes/getting-started-config/native.mdx
+++ b/src/platform-includes/getting-started-config/native.mdx
@@ -5,6 +5,7 @@ int main(void) {
   sentry_options_t *options = sentry_options_new();
   sentry_options_set_dsn(options, "___PUBLIC_DSN___");
   sentry_options_set_release(options, "my-project-name@2.3.12");
+  sentry_options_set_debug(options, 1);
   sentry_init(options);
 
   /* ... */

--- a/src/platform-includes/getting-started-config/native.qt.mdx
+++ b/src/platform-includes/getting-started-config/native.qt.mdx
@@ -7,6 +7,7 @@ int main(int argc, char *argv[])
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "___PUBLIC_DSN___");
     sentry_options_set_release(options, "my-project-name@2.3.12");
+    sentry_options_set_debug(options, 1);
     sentry_init(options);
 
     // Make sure everything flushes

--- a/src/wizard/native/index.md
+++ b/src/wizard/native/index.md
@@ -17,6 +17,7 @@ Import and initialize the Sentry SDK early in your application setup:
 int main(void) {
   sentry_options_t *options = sentry_options_new();
   sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+  sentry_options_set_debug(options, 1);
   sentry_init(options);
 
   /* ... */

--- a/src/wizard/native/index.md
+++ b/src/wizard/native/index.md
@@ -17,6 +17,7 @@ Import and initialize the Sentry SDK early in your application setup:
 int main(void) {
   sentry_options_t *options = sentry_options_new();
   sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+  sentry_options_set_release(options, "my-project-name@2.3.12");
   sentry_options_set_debug(options, 1);
   sentry_init(options);
 

--- a/src/wizard/native/qt.md
+++ b/src/wizard/native/qt.md
@@ -18,6 +18,7 @@ int main(int argc, char *argv[])
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+    sentry_options_set_debug(options, 1);
     sentry_init(options);
 
     // Make sure everything flushes

--- a/src/wizard/native/qt.md
+++ b/src/wizard/native/qt.md
@@ -18,6 +18,7 @@ int main(int argc, char *argv[])
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+    sentry_options_set_release(options, "my-project-name@2.3.12");
     sentry_options_set_debug(options, 1);
     sentry_init(options);
 


### PR DESCRIPTION
As discussed with @Swatinem and raised in https://github.com/getsentry/sentry-native/issues/754, we should enable the debug option in all introductory examples because many new users are unaware of that option. I left out examples that discuss only one specific option.