### PR TITLE
fix(native): recommend setting database_path...

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -41,6 +41,12 @@ Changing this value will affect issue grouping. Since the frame significantly ch
 
 </ConfigKey>
 
+<ConfigKey name="database-path" supported={["native"]}>
+
+Allows you to specify a path to the local event- and crash-database of the Native SDK. This path will default to `.sentry-native` relative to the executable. While this is a convenient setting for development, we strongly urge you to provide an explicit database path for your production deployments. In most deployment scenarios, the path relative to the executable will not be writable. For this reason, you should store the database in your application's user-specific data/cache directory (e.g., under `AppData/Local` on Windows, `~/Library/Caches` on macOS, or `XDG_CACHE_HOME` on Linux).
+
+</ConfigKey>
+
 <ConfigKey name="debug" notSupported={["php"]}>
 
 Turns debug mode on or off. If debug is enabled SDK will attempt to print out useful debugging information if something goes wrong with sending the event. The default is always `false`. It's generally not recommended to turn it on in production, though turning `debug` mode on will not cause any safety concerns.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -43,7 +43,7 @@ Changing this value will affect issue grouping. Since the frame significantly ch
 
 <ConfigKey name="database-path" supported={["native"]}>
 
-Allows you to specify a path to the local event- and crash-database of the Native SDK. This path will default to `.sentry-native` relative to the executable. While this is a convenient setting for development, we strongly urge you to provide an explicit database path for your production deployments. In most deployment scenarios, the path relative to the executable will not be writable. For this reason, you should store the database in your application's user-specific data/cache directory (e.g., under `AppData/Local` on Windows, `~/Library/Caches` on macOS, or `XDG_CACHE_HOME` on Linux).
+Allows you to specify a path to the local event- and crash-database of the Native SDK. This path will default to `.sentry-native` relative to the executable. While this is a convenient setting for development, we strongly urge you to provide an explicit database path for your production deployments. In most deployment scenarios, the path relative to the executable will not be writable. For this reason, you should store the database in your application's user-specific data/cache directory (e.g., under `%AppData%\Local` on Windows, `~/Library/Application Support` on macOS, or `XDG_CACHE_HOME` on Linux).
 
 </ConfigKey>
 


### PR DESCRIPTION
...in the common configuration. Using the default path when deploying an application will often lead to access errors (e.g. https://github.com/getsentry/sentry-native/issues/754). There should be a native-only entry to provide an explanation and recommendation for proper deployment configuration in the __Common Options__.