### PR TITLE
fix(native): add database-path to intro examples

### DIFF
--- a/src/platform-includes/getting-started-config/native.mdx
+++ b/src/platform-includes/getting-started-config/native.mdx
@@ -4,6 +4,9 @@
 int main(void) {
   sentry_options_t *options = sentry_options_new();
   sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+  // This is also the default-path. For further information and recommendations:
+  // https://docs.sentry.io/platforms/native/configuration/options/#database-path
+  sentry_options_set_database_path(options, ".sentry-native");
   sentry_options_set_release(options, "my-project-name@2.3.12");
   sentry_options_set_debug(options, 1);
   sentry_init(options);

--- a/src/platform-includes/getting-started-config/native.qt.mdx
+++ b/src/platform-includes/getting-started-config/native.qt.mdx
@@ -6,6 +6,9 @@ int main(int argc, char *argv[])
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+    // This is also the default-path. For further information and recommendations:
+    // https://docs.sentry.io/platforms/native/configuration/options/#database-path
+    sentry_options_set_database_path(options, ".sentry-native");
     sentry_options_set_release(options, "my-project-name@2.3.12");
     sentry_options_set_debug(options, 1);
     sentry_init(options);

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -43,7 +43,7 @@ Changing this value will affect issue grouping. Since the frame significantly ch
 
 <ConfigKey name="database-path" supported={["native"]}>
 
-Allows you to specify a path to the local event- and crash-database of the Native SDK. This path will default to `.sentry-native` relative to the executable. While this is a convenient setting for development, we strongly urge you to provide an explicit database path for your production deployments. In most deployment scenarios, the path relative to the executable will not be writable. For this reason, you should store the database in your application's user-specific data/cache directory (e.g., under `%AppData%\Local` on Windows, `~/Library/Application Support` on macOS, or `XDG_CACHE_HOME` on Linux).
+Allows you to specify a path to the local event- and crash-database of the Native SDK. This path will default to `.sentry-native` relative to the current working directory (`CWD`). While this is a convenient setting for development, we strongly urge you to provide an explicit database path for our production deployments. In many deployment scenarios, the path relative to the `CWD` will not be writable. For this reason, you should store the database in your application's user-specific data/cache directory (e.g., under `%AppData%\Local` on Windows, `~/Library/Application Support` on macOS, or `XDG_CACHE_HOME` on Linux).
 
 </ConfigKey>
 

--- a/src/wizard/native/index.md
+++ b/src/wizard/native/index.md
@@ -17,6 +17,9 @@ Import and initialize the Sentry SDK early in your application setup:
 int main(void) {
   sentry_options_t *options = sentry_options_new();
   sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+  // This is also the default-path. For further information and recommendations:
+  // https://docs.sentry.io/platforms/native/configuration/options/#database-path
+  sentry_options_set_database_path(options, ".sentry-native");
   sentry_options_set_release(options, "my-project-name@2.3.12");
   sentry_options_set_debug(options, 1);
   sentry_init(options);

--- a/src/wizard/native/qt.md
+++ b/src/wizard/native/qt.md
@@ -18,6 +18,9 @@ int main(int argc, char *argv[])
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "___PUBLIC_DSN___");
+    // This is also the default-path. For further information and recommendations:
+    // https://docs.sentry.io/platforms/native/configuration/options/#database-path
+    sentry_options_set_database_path(options, ".sentry-native");  
     sentry_options_set_release(options, "my-project-name@2.3.12");
     sentry_options_set_debug(options, 1);
     sentry_init(options);


### PR DESCRIPTION
As discussed with @Swatinem.