### PR TITLE
Fixed wrong default value in documentation

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -103,7 +103,7 @@ By default the SDK will read from `Application.productName` and `Application.ver
 
 <ConfigKey name="environment">
 
-<PlatformSection notSupported={["unity", "dotnet", "javascript.electron", "native"]}>
+<PlatformSection notSupported={["native", "javascript.electron", "unity", "dotnet", "python"]}>
 
 Sets the environment. This string is freeform and not set by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `prod` or similar).
 
@@ -140,6 +140,14 @@ Sets the environment. This string is freeform and set by default. A release can 
 By default, the SDK reports `debug` when the debugger is attached. Otherwise, the default environment is `production`.
 
 Additionally, if you are running with the ASP.NET Core integration, you will also see the environment named as `staging`, if running in staging, or `development`, if running in development mode.
+
+</PlatformSection>
+
+<PlatformSection supported={["python"]}>
+
+Sets the environment. This string is freeform and set to `production` by default. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `production` or similar).
+
+By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` environment variable.
 
 </PlatformSection>
 
@@ -580,7 +588,7 @@ The default value is `Environment.GetFolderPath(Environment.SpecialFolder.LocalA
 
 <PlatformSection supported={["dotnet.maui"]}>
 
-The default value is `Path.Combine(FileSystem.CacheDirectory, "sentry")`.  See the [Microsoft docs](https://docs.microsoft.com/dotnet/maui/platform-integration/storage/file-system-helpers#platform-differences) for how `FileSystem.CacheDirectory` differs on each supported platform.
+The default value is `Path.Combine(FileSystem.CacheDirectory, "sentry")`. See the [Microsoft docs](https://docs.microsoft.com/dotnet/maui/platform-integration/storage/file-system-helpers#platform-differences) for how `FileSystem.CacheDirectory` differs on each supported platform.
 
 </PlatformSection>
 


### PR DESCRIPTION
The default of `environment` is `production` in the Python SDK.

Fixes https://github.com/getsentry/sentry-python/issues/1625


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
