### PR TITLE
Remove beta warning from Svelte Docs

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.svelte.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.svelte.mdx
@@ -4,10 +4,4 @@ Sentry's Svelte SDK enables automatic reporting of errors and exceptions, as wel
 
 </Note>
 
-<Alert level="info">
-
-This SDK is currently in beta state and might still be unstable or exhibit bugs. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. The SDK currently only supports [Svelte](https://svelte.dev/) and is not fully compatible with with [SvelteKit](https://kit.svelte.dev/).
-
-</Alert>
-
 Sentry's Svelte SDK was introduced with version `7.10.0`.


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/5492

Svelte is now GA, so we can remove this warning from the docs.