### PR TITLE
Add callout about pii rule precedence

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -15,6 +15,12 @@ In addition to <PlatformLink to="/data-management/sensitive-data/">using hooks i
 - Detailed tuning on which parts of an event to scrub
 - Partial removal or hashing of sensitive data instead of deletion
 
+<Alert level="info" title="Rule Precedence">
+
+Advanced Data Scrubbing rules take precedence over other Server-Side Data Scrubbing settings. Specifically, any advanced rule will apply regardless of whether the matched field is in Safe Fields or not.
+
+</Alert>
+
 ## A Basic Example
 
 Navigate to your project- or organization-settings, click _Security and Privacy_, then _Advanced Data Scrubbing_.


### PR DESCRIPTION
in Relay, data scrubbing with the new config format (i.e. Advanced Data Scrubbing) runs before applying data scrubbing settings in the old format (Safe Fields, etc.). This means that if an advanced rule scrubs a field, it is not recovered even if it is declared as a Safe Field.

https://github.com/getsentry/relay/blob/4894c1d3bab6111585c29c9ea3b55e1511faca60/relay-server/src/actors/processor.rs#L1830-L1843

Document this precedence.

![image](https://user-images.githubusercontent.com/1565449/192727023-6110df69-ba3b-43bd-b2b4-379e5dc14fc1.png)