### PR TITLE
feat(apple): Add apple to trace-propagation-targets

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -595,7 +595,7 @@ An optional property that configures which downstream services receive the `sent
 
 </ConfigKey>
 
-<ConfigKey name="trace-propagation-targets" supported={["node"]}>
+<ConfigKey name="trace-propagation-targets" supported={["node", "apple"]}>
 
 An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
 


### PR DESCRIPTION
We've added support for `tracePropagationTargets` to the cocoa SDK in this PR: https://github.com/getsentry/sentry-cocoa/pull/2217

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
