### PR TITLE
Describe team roles alongside org member roles

### DIFF
--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -15,50 +15,65 @@ which can then join one or more organizations. Each user should have
 their own account, where they can manage their personal preferences,
 including notification and security settings.
 
-| Action                                                       | Billing | Member | Admin | Manager | Owner |
-| ------------------------------------------------------------ | ------- | ------ | ----- | ------- | ----- |
-| Can see/edit billing information and subscription details    | X       |        |       |         | X     |
-| Can see/edit legal and compliance details                    | X       |        |       |         | X     |
-| Can view and act on issues, such as assigning/resolving/etc. |         | X      | X     | X       | X     |
-| Can join and leave teams                                     |         | X      | X     | X       | X     |
-| Can change Project Settings                                  |         |        | X     | X       | X     |
-| Can add/remove projects                                      |         |        | X     | X       | X     |
-| Can edit Global Integrations                                 |         |        | X     | X       | X     |
-| Can add/remove/change members                                |         |        |       | X       | X     |
-| Can add/remove teams                                         |         |        | X     | X       | X     |
-| Can add/remove Repositories                                  |         | X      | X     | X       | X     |
-| Can change Organization Settings                             |         |        |       | X       | X     |
-| Can remove an Organization                                   |         |        |       |         | X     |
-
-## Roles
+### Organization Member Roles
 
 Member roles dictate access within an organization.
 
-### Owner
+| Action                                                       | Billing | Member | Manager | Owner |
+| ------------------------------------------------------------ | ------- | ------ | ------- | ----- |
+| Can see/edit billing information and subscription details    | X       |        |         | X     |
+| Can see/edit legal and compliance details                    | X       |        |         | X     |
+| Can view and act on issues, such as assigning/resolving/etc. |         | X      | X       | X     |
+| Can join and leave teams                                     |         | X      | X       | X     |
+| Is automatically a Team Admin                                |         |        | X       | X     |
+| Can add/remove teams                                         |         |        | X       | X     |
+| Can change Organization Settings                             |         |        | X       | X     |
+| Can remove an Organization                                   |         |        |         | X     |
+
+#### Owner
 
 - Unrestricted access to the organization, its data, and settings.
 - Can add, modify, and delete projects and members, as well as manage subscription and billing details.
 - Can manage legal and compliance details.
 - Can delete an organization.
 
-### Manager
+#### Manager
 
 - Gains admin access on all teams.
 - Can add and remove members from the organization.
-
-### Admin
-
-- Admin access only on teams they're a member of.
 - Can create new teams and projects, as well as remove teams and projects they're a member of.
 
-### Member
+#### Member
 
 - Can view and act on events, as well as view most other data within the organization.
 
-### Billing
+#### Billing
 
 - Can manage subscription and billing details.
 - Can manage legal and compliance details.
+
+### Team Member Roles
+
+Team roles dictate access within projects owned by the team.
+
+A project may belong to multiple teams. To have administrative access to a
+project, you only need to be an admin of one of those teams, not all.
+
+| Action                       | Team Contributor | Team Admin |
+| ---------------------------- | ---------------- | ---------- |
+| Can change Project Settings  |                  | X          |
+| Can add/remove projects      |                  | X          |
+| Can edit Global Integrations |                  | X          |
+| Can add/remove Repositories  | X                | X          |
+
+#### Team Admin
+
+- Can create new projects and remove projects they're a member of.
+
+#### Team Contributor
+
+- Can view and act on events, as well as view most other data within the team's
+  projects.
 
 ## Open Membership
 

--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -66,15 +66,6 @@ project, you only need to be an admin of one of those teams, not all.
 | Can edit Global Integrations |                  | X          |
 | Can add/remove Repositories  | X                | X          |
 
-#### Team Admin
-
-- Can create new projects and remove projects they're a member of.
-
-#### Team Contributor
-
-- Can view and act on events, as well as view most other data within the team's
-  projects.
-
 ## Open Membership
 
 Open membership is enabled by default, which allows members to join, leave, and add other members to teams.


### PR DESCRIPTION
Add description of team roles. Split table of organization membership in two, deleting the "admin" column and moving affected rows to a new "Team Member Roles" subsection. Demoted the "Organization Member Roles" section to an `h3` so that "Team Member Roles" can sit next to it.