### PR TITLE
fix(saml2): Spelling error in anchor tag

### DIFF
--- a/src/docs/product/accounts/sso/index.mdx
+++ b/src/docs/product/accounts/sso/index.mdx
@@ -57,7 +57,7 @@ This feature is available only if your organization is on a Team or Trial plan.
 
 The GitHub integration will authenticate against all organizations, and once complete prompt you for the organization which you wish to restrict access by.
 
-### SAML2 Identity Providers {#smal2-identity-provider}
+### SAML2 Identity Providers {#saml2-identity-provider}
 
 <Note>
 


### PR DESCRIPTION
Noticed this while sending a link to a customer.