### PR TITLE
Add correct value for max_request_body_size option on PHP SDK

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -314,7 +314,7 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
-- `never`: Request bodies are never sent.
+- `never`: Request bodies are never sent. ***(PHP SDK: `none`)*** 
 - `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
 - `medium`: Medium and small requests will be captured (typically 10KB).
 - `always`: The SDK will always capture the request body as long as Sentry can make sense of it.


### PR DESCRIPTION
max-request-body-size does not accept never as an argument on PHP SDK. 

`"max_request_body_size" with value "never" is invalid. Accepted values are: "none", "small", "medium", "always"`

Maybe, the other libraries accept never instead of none but I think it should be mentioned that for PHP the correct argument is `none` and not `never`




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
