### PR TITLE
ref: Clarify JS tracingOrigins default values

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -52,7 +52,9 @@ Supported options:
 
 ### tracingOrigins
 
-The default value of `tracingOrigins` is `['localhost', /^\//]`. The JavaScript SDK will attach the `sentry-trace` and `baggage` headers to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you will need to add it there to propagate the `sentry-trace` and `baggage` headers to the backend services, which is required to link transactions together as part of a single trace. **The `tracingOrigins` option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests do not unnecessarily have the additional headers attached.**
+A list of strings and regular expressions. The JavaScript SDK will attach the `sentry-trace` and `baggage` headers to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you will need to add it there to propagate the `sentry-trace` and `baggage` headers to the backend services, which is required to link transactions together as part of a single trace. **The `tracingOrigins` option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests do not unnecessarily have the additional headers attached.**
+
+The default value of `tracingOrigins` is `['localhost', /^\//]`. This means that by default, tracing headers are only attached to requests that contain `localhost` in their URL or to requests whose URL starts with a `'/'` (for example `GET /api/v1/users`).
 
 <PlatformContent includePath="performance/tracingOrigins-example" />
 
@@ -100,19 +102,19 @@ This option flags transactions when tabs are moved to the background with "cance
 
 The default is `true`.
 
+### \_experiments
 
-### _experiments
-
-This is an object containing experimental flags for features that may involve breaking changes that haven't yet landed in a new major version. 
+This is an object containing experimental flags for features that may involve breaking changes that haven't yet landed in a new major version.
 
 The default is
+
 ```
 {
   enableLongTasks: true
 }
 ```
 
-#### _experiments.enableLongTasks
+#### \_experiments.enableLongTasks
 
 This experimental option determines whether spans for long tasks automatically get created.
 


### PR DESCRIPTION
This PR clarifies the meaning of the JS SDK's default values for the `tracingOrigins` option of the `BrowserTracing` integration. As pointed out in https://github.com/getsentry/sentry-javascript/issues/5868, it is not obvious on first glance, to which requests tracing headers are attached if the default values are used. This PR therefore adds an explanation and slightly changes the ordering of the `tracingOrigins` description. 