### PR TITLE
fix: sentry_transaction_start takes 2 arguments

### DIFF
--- a/src/platform-includes/performance/add-spans-example/native.mdx
+++ b/src/platform-includes/performance/add-spans-example/native.mdx
@@ -8,7 +8,7 @@ void perform_checkout() {
         "checkout",
         "perform-checkout",
     );
-    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     // Validate the cart
     sentry_span_t *validation_span = sentry_transaction_start_child(

--- a/src/platform-includes/performance/add-spans-example/native.mdx
+++ b/src/platform-includes/performance/add-spans-example/native.mdx
@@ -6,7 +6,7 @@ void perform_checkout() {
     // This will create a new Transaction for you
     sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
         "checkout",
-        "perform-checkout",
+        "perform-checkout"
     );
     sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 

--- a/src/platform-includes/performance/connect-errors-spans/native.mdx
+++ b/src/platform-includes/performance/connect-errors-spans/native.mdx
@@ -9,14 +9,14 @@ sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
     "checkout",
     "perform-checkout",
 );
-sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
 // Bind the transaction / span to the scope:
 sentry_set_span(tx);
 
 // Errors captured after the line above will be linked to the transaction
 sentry_value_t exc = sentry_value_new_exception(
-    "ParseIntError", 
+    "ParseIntError",
     "invalid digit found in string",
 );
 

--- a/src/platform-includes/performance/distributed-tracing/native.mdx
+++ b/src/platform-includes/performance/distributed-tracing/native.mdx
@@ -17,10 +17,10 @@ int main(int argc, char **argv) {
   ...
 	// Transaction to continue off of
 	sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
-        "honk", 
+        "honk",
         NULL,
     );
-    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
 	sentry_value_t *headers = sentry_value_new_object();
 	sentry_transaction_iter_headers(tx, copy_headers_to, (void *)headers);
@@ -31,12 +31,12 @@ To create a transaction as a continuation of a trace retrieved from an upstream 
 
 ```c
 	sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
-        "honk", 
+        "honk",
         NULL,
     );
     sentry_transaction_context_update_from_header(
-        tx_ctx, 
-        "sentry-trace", 
+        tx_ctx,
+        "sentry-trace",
         "atraceid-aspanid-issampled",
     );
 

--- a/src/platform-includes/performance/enable-manual-instrumentation/native.mdx
+++ b/src/platform-includes/performance/enable-manual-instrumentation/native.mdx
@@ -7,15 +7,15 @@ sentry_init(options);
 
 // Transactions can be started by providing the name and the operation
 sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
-    "transaction name", 
+    "transaction name",
     "transaction operation",
 );
-sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
 // Transactions can have child spans (and those spans can have child spans as well)
 sentry_span_t *span = sentry_transaction_start_child(
-    tx, 
-    "child operation", 
+    tx,
+    "child operation",
     "child description",
 );
 

--- a/src/platform-includes/performance/force-sampling-decision/native.mdx
+++ b/src/platform-includes/performance/force-sampling-decision/native.mdx
@@ -1,9 +1,9 @@
 ```c
 sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
-    "transaction", 
+    "transaction",
     "op",
 );
 sentry_transaction_context_set_sampled(tx_ctx, 1);
 
-sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 ```


### PR DESCRIPTION
As pointed out in https://github.com/getsentry/sentry-docs/issues/5568, `sentry_transaction_start` takes 2 arguments, but is called in multiple places in the docs with just one argument. The documentation of `sentry_transaction_start` says
```
The second parameter is a custom Sampling Context to be used with a Traces
Sampler to make a more informed sampling decision. The SDK does not currently
support a custom Traces Sampler and this parameter is ignored for the time
being but needs to be provided.
```
Therefore I think we should just add `sentry_value_new_null` as the second argument everywhere.

Fixes https://github.com/getsentry/sentry-docs/issues/5568.