### PR TITLE
feat(java): Add automatic and custom performance metrics doc

### DIFF
--- a/src/platform-includes/performance/automatic-performance-metrics/android.mdx
+++ b/src/platform-includes/performance/automatic-performance-metrics/android.mdx
@@ -1,0 +1,4 @@
+If configured, the Android SDK can automatically collect the following performance metrics:
+
+* Cold and Warm app start time, see [App Start instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
+* Frozen and slow frame rendering, details can be found on the [Slow and Frozen Frames page](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).

--- a/src/platform-includes/performance/automatic-performance-metrics/android.mdx
+++ b/src/platform-includes/performance/automatic-performance-metrics/android.mdx
@@ -1,4 +1,4 @@
 If configured, the Android SDK can automatically collect the following performance metrics:
 
-* Cold and Warm app start time, see [App Start instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
-* Frozen and slow frame rendering, details can be found on the [Slow and Frozen Frames page](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).
+* Cold and Warm app start time - learn more in [App Start Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
+* Frozen and slow frame rendering - learn more in [Slow and Frozen Frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).

--- a/src/platform-includes/performance/automatic-performance-metrics/android.mdx
+++ b/src/platform-includes/performance/automatic-performance-metrics/android.mdx
@@ -1,4 +1,4 @@
 If configured, the Android SDK automatically collects the following performance metrics:
 
-* Cold and Warm app start time - learn more in [App Start Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
+* Cold and warm app start time - learn more in [App Start Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
 * Frozen and slow frame rendering - learn more in [Slow and Frozen Frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).

--- a/src/platform-includes/performance/automatic-performance-metrics/android.mdx
+++ b/src/platform-includes/performance/automatic-performance-metrics/android.mdx
@@ -1,4 +1,4 @@
-If configured, the Android SDK can automatically collect the following performance metrics:
+If configured, the Android SDK automatically collects the following performance metrics:
 
 * Cold and Warm app start time - learn more in [App Start Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
 * Frozen and slow frame rendering - learn more in [Slow and Frozen Frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).

--- a/src/platform-includes/performance/custom-performance-metrics/java.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/java.mdx
@@ -1,0 +1,36 @@
+Adding custom metrics is supported in Sentry's Java SDK version `6.5.0` and above.
+
+```java {tabTitle:Java}
+import io.sentry.ISpan;
+import io.sentry.MeasurementUnit;
+import io.sentry.Sentry;
+
+final ISpan span = Sentry.getSpan();
+if (span != null) {
+    // Record amount of memory used
+    span.setMeasurement("memory_used", 64, MeasurementUnit.Information.MEGABYTE);
+
+    // Record time it took to load user profile
+    span.setMeasurement("user_profile_loading_time", 1.3, MeasurementUnit.Duration.SECOND);
+
+    // Record number of times the screen was loaded
+    span.setMeasurement("screen_load_count", 4);
+}
+```
+
+
+```kotlin {tabTitle:Kotlin}
+import io.sentry.MeasurementUnit
+import io.sentry.Sentry
+
+val span = Sentry.getSpan()
+
+// Record amount of memory used
+span?.setMeasurement("memory_used", 64, MeasurementUnit.Information.MEGABYTE)
+
+// Record time it took to load user profile
+span?.setMeasurement("user_profile_loading_time", 1.3, MeasurementUnit.Duration.SECOND)
+
+// Record number of times the screen was loaded
+span?.setMeasurement("screen_load_count", 4)
+```

--- a/src/platforms/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/common/performance/instrumentation/performance-metrics.mdx
@@ -7,15 +7,15 @@ supported:
   - dart
   - flutter
   - react-native
+  - java
+  - java.spring-boot
+  - android
 notSupported:
   - javascript.cordova
   - javascript.electron
   - dotnet
   - go
-  - java
-  - android
   - ruby
-  - java.spring-boot
   - apple
   - unity
   - rust

--- a/src/platforms/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/common/performance/instrumentation/performance-metrics.mdx
@@ -31,7 +31,7 @@ description: "Learn how to attach performance metrics to your transactions."
 
 Sentry's SDKs support sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
 
-<PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
+<PlatformSection supported={["javascript", "android"]} notSupported={["react-native"]}>
 
 <PlatformContent includePath="performance/automatic-performance-metrics" />
 


### PR DESCRIPTION
Add missing API doc for custom performance metrics, including java and kotlin example code.

See https://github.com/getsentry/sentry-java/pull/2260 for the relevant SDK implementation.


@romtsn who else should be reviewing this PR?