### PR TITLE
ref: Update `BrowserTracing` options description

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -52,7 +52,7 @@ Supported options:
 
 ### tracingOrigins
 
-A list of strings and regular expressions. The JavaScript SDK will attach the `sentry-trace` and `baggage` headers to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you'll need to add it there to propagate the `sentry-trace` and `baggage` headers to the backend services, which is required to link transactions together as part of a single trace. 
+A list of strings and regular expressions. The JavaScript SDK will attach the `sentry-trace` and `baggage` headers to all outgoing XHR/fetch requests whose destination contains a string in the list or matches a regex in the list. If your frontend is making requests to a different domain, you'll need to add it there to propagate the `sentry-trace` and `baggage` headers to the backend services, which is required to link transactions together as part of a single trace.
 
 **The `tracingOrigins` option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests do not unnecessarily have the additional headers attached.**
 
@@ -76,9 +76,15 @@ This function can be used to filter out unwanted spans such as XHR's running hea
 
 ### idleTimeout
 
-The idle time, measured in ms, to wait until the transaction will be finished. The transaction will use the end timestamp of the last finished span as the endtime for the transaction.
+The idle time, measured in ms, to wait until the transaction will be finished, if there are no unfinished spans. The transaction will use the end timestamp of the last finished span as the endtime for the transaction.
 
 The default is `1000`.
+
+### finalTimeout
+
+The maximum duration of the transaction, measured in ms. If the transaction duration hits the `finalTimeout` value, it will be finished.
+
+The default is `30000`.
 
 ### startTransactionOnLocationChange
 
@@ -91,12 +97,6 @@ The default is `true`.
 This flag enables or disables creation of `pageload` transaction on first pageload.
 
 The default is `true`.
-
-### maxTransactionDuration
-
-The maximum duration of a transaction, measured in seconds, before it will be marked as "deadline_exceeded". If you never want transactions marked that way, set `maxTransactionDuration` to 0.
-
-The default is `600`.
 
 ### markBackgroundTransactions
 


### PR DESCRIPTION
Noticed a few inconsistencies between docs and SDK code while working on #5606: This PR brings the JS SDK `BrowserTracing` integration options up to date with the currently available options:

* add `finalTimeout` option introduced in v7
* remove `maxTransactionDuration` option dropped in v7
* improve `idleTimeout` description