### PR TITLE
feat: Add `BrowserTracing` `heartbeatInterval` option description

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -86,6 +86,12 @@ The maximum duration of the transaction, measured in ms. If the transaction dura
 
 The default is `30000`.
 
+### heartbeatInterval
+
+The time, measured in ms, one heartbeat takes. If no new spans were started or no open spans finished within **three heartbeats**, the transaction will be finished. The heartbeat count restarts whenever a new span is created or an open span is finished.
+
+The default is `5000`.
+
 ### startTransactionOnLocationChange
 
 This flag enables or disables creation of `navigation` transaction on history changes.


### PR DESCRIPTION
This PR adds the JS SDK BrowserTracing integration's `heartbeatInterval` option that makes the previously hard-coded heartbeat interval configurable. 

ref: https://github.com/getsentry/sentry-javascript/issues/4925