### PR TITLE
Update index.mdx

### DIFF
--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -23,13 +23,15 @@ composer require sentry/sentry-laravel
 Enable capturing unhandled exception to report to Sentry by making the following change to your `App/Exceptions/Handler.php`:
 
 ```php {filename:App/Exceptions/Handler.php}
-public function register()
+public function report(Throwable $e)
 {
-    $this->reportable(function (Throwable $e) {
-        if (app()->bound('sentry')) {
-            app('sentry')->captureException($e);
-        }
-    });
+   if (app()->environment(['local', 'development', 'staging', 'production'])) {
+       if (app()->bound("sentry") && $this->shouldReport($e)) {
+           app("sentry")->captureException($e);
+       }
+   }
+
+   parent::report($e);
 }
 ```
 


### PR DESCRIPTION
"laravel/framework": "^9.0", does not work in register() suggested by documentation, start working when I placed the code in report() instead




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
