### PR TITLE
chore(dev): Update VSCode mdx extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "silvenon.mdx"
+    "unifiedjs.vscode-mdx",
   ]
 }


### PR DESCRIPTION
The mdx VSCode extension we currently recommend [has been deprecated](https://marketplace.visualstudio.com/items?itemName=silvenon.mdx). This updates the recommendation to point to [its replacement](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx).