### PR TITLE
Update Source Maps docs for Remix

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -8,6 +8,16 @@ Remix can be configured to output source maps using Remix CLI. Learn more about 
 
 Source maps can be uploaded to Sentry by creating a release. Learn more about [how to upload source maps](./uploading/).
 
+
+### 3: Remove Remix Source Maps 
+
+Remix validly discourages the user to have source maps in production. After uploading the maps to Sentry we suggest you delete the `.map` files, here's a simple example in bash:
+
+```bash
+rm ./public/**/*.map
+rm ./build/**/*.map 
+```
+
 <Note>
 
 By default, if Sentry can't find the uploaded files it needs, it will attempt to download them from the URLs in the stack trace. To disable this, turn off "Enable JavaScript source fetching" in either your organization's "Security & Privacy" settings or your project's general settings.


### PR DESCRIPTION
It's discouraged to upload your source maps to production. Some simple bash commands can be used to remove these after uploading the source maps to Sentry.

Fixes https://github.com/getsentry/sentry-javascript/issues/5740

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
