### PR TITLE
Remove git output from diff view in Vite troubleshooting section

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -438,12 +438,8 @@ Error: Could not resolve './{}.js' from node_modules/@sentry/utils/esm/index.js
 
 This might be because the [`define`](https://vitejs.dev/config/shared-options.html#define) option in your Vite config is string-replacing some variable used by the Sentry SDK, like `global`, which causes build errors. Vite recommends using `define` for CONSTANTS only, and not putting `process` or `global` into the options. To fix this build error, remove or update your `define` option, as shown below:
 
-```diff
-diff --git a/vite.config.ts b/vite.config.ts
-index 8614337..005915c 100644
---- a/vite.config.ts
-+++ b/vite.config.ts
-@@ -6,8 +6,5 @@ export default defineConfig({
+```diff {filename:vite.config.ts}
+export default defineConfig({
    build: {
      sourcemap: true
    },
@@ -451,5 +447,5 @@ index 8614337..005915c 100644
 -    global: {}
 -  },
    plugins: [react()]
- })
+})
 ```


### PR DESCRIPTION
Removes git output in code block, that might be confusing at times.