### PR TITLE
Spelling of bootStrapSpan corrected

### DIFF
--- a/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
+++ b/src/platforms/javascript/guides/angular/components/tracehelpers.mdx
@@ -97,7 +97,7 @@ platformBrowserDynamic()
   .catch(err => console.error(err))
   .finally(() => {
     if (bootstrapSpan) {
-      boostrapSpan.finish();
+      bootstrapSpan.finish();
     }
   });
 ```


### PR DESCRIPTION


<!-- Describe your PR here. -->
On the Line 100, spelling of bootstrapSpan was wrong.
Current Implementation :- boostrapSpan.finish()
Should be:- bootstrapSpan.finish()


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
