### PR TITLE
feat(components): Add `additionalPages` prop to `PageGrid` component

### DIFF
--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -20,12 +20,25 @@ const query = graphql`
   }
 `;
 
+type PageLink = {
+  title: string;
+  path: string;
+  description?: string;
+};
+
 type Props = {
   nextPages: boolean;
   header?: string;
+
+  /** Adds list items of page links that are not automatically found by the PageGrid component */
+  additionalPages?: PageLink[];
 };
 
-export default ({ nextPages = false, header }: Props): JSX.Element => {
+export default ({
+  nextPages = false,
+  header,
+  additionalPages,
+}: Props): JSX.Element => {
   const data = useStaticQuery(query);
   const location = useLocation();
 
@@ -53,11 +66,21 @@ export default ({ nextPages = false, header }: Props): JSX.Element => {
 
   if (!matches.length) return null;
 
+  const addedPages =
+    (additionalPages &&
+      additionalPages.map(p => ({
+        path: p.path,
+        context: { title: p.title, description: p.description },
+      }))) ||
+    [];
+
+  const items = [...matches, ...addedPages];
+
   return (
     <nav>
       {header && <h2>{header}</h2>}
       <ul>
-        {matches.map(n => (
+        {items.map(n => (
           <li key={n.path} style={{ marginBottom: "1rem" }}>
             <h4 style={{ marginBottom: 0 }}>
               <SmartLink to={n.path}>{n.context.title}</SmartLink>

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -37,7 +37,7 @@ type Props = {
 export default ({
   nextPages = false,
   header,
-  additionalPages,
+  additionalPages = [],
 }: Props): JSX.Element => {
   const data = useStaticQuery(query);
   const location = useLocation();
@@ -66,13 +66,10 @@ export default ({
 
   if (!matches.length) return null;
 
-  const addedPages =
-    (additionalPages &&
-      additionalPages.map(p => ({
-        path: p.path,
-        context: { title: p.title, description: p.description },
-      }))) ||
-    [];
+  const addedPages = additionalPages.map(p => ({
+    path: p.path,
+    context: { title: p.title, description: p.description },
+  }));
 
   const items = [...matches, ...addedPages];
 

--- a/src/platforms/javascript/common/performance/instrumentation/index.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Instrumentation
+sidebar_order: 20
+description: "Learn how to instrument performance in your app."
+supported:
+  - javascript.angular
+  - javascript.react
+  - javascript.svelte
+  - javascript.vue
+---
+
+Instrumenting performance monitoring is specific to your SDK.
+
+<PageGrid header="testheader" additionalPages={ [{title: 'Track Components', path:'../../features/component-tracking', description: 'Learn how to monitor the rendering performance of your application and its components'},] }/>

--- a/src/platforms/javascript/common/performance/instrumentation/index.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/index.mdx
@@ -11,4 +11,4 @@ supported:
 
 Instrumenting performance monitoring is specific to your SDK.
 
-<PageGrid header="testheader" additionalPages={ [{title: 'Track Components', path:'../../features/component-tracking', description: 'Learn how to monitor the rendering performance of your application and its components'},] }/>
+<PageGrid additionalPages={ [{title: 'Track Components', path:'../../features/component-tracking', description: 'Learn how to monitor the rendering performance of your application and its components'},] }/>


### PR DESCRIPTION
## ⚠️ Only merge this after #5619 was merged!

(This might cause build errors until #5619 is merged. Opening as a draft for now)

This PR adds a new optional prop to the `PageGrid` component (`additionalPages`) that allows us to pass a list of additional page links that should be added to the list of pages generated by the component. This is useful when we want to link to a page that is not a sub-page of the MDX file where `PageGrid` was placed. 

Furthermore, this PR adds an index page to JS SDK's performance instrumentation section that makes use of the new prop. 

ref: #5582 