### PR TITLE
[nextjs] remove duplicated withSentry docs

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -235,38 +235,6 @@ const moduleExports = {
 
 Under the hood, when using this option, the SDK is using a Webpack loader to wrap all your API route handlers and data fetching methods.
 
-If the automatic instrumentation doesn't work for your use-case, API routes can also be wrapped manually using the `withSentry` function:
-
-```javascript {filename:pages/api/*}
-import { withSentry } from "@sentry/nextjs";
-
-const handler = (req, res) => {
-  res.status(200).json({ name: "John Doe" });
-};
-
-export default withSentry(handler);
-```
-
-```typescript {filename:pages/api/*}
-import type { NextApiRequest, NextApiResponse } from "next"
-import { withSentry } from "@sentry/nextjs";
-
-const handler = (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json({ name: "John Doe" });
-};
-
-export default withSentry(handler);
-```
-
-Data fetching methods can also be manually wrapped using the following functions:
-
-- `withSentryServerSideGetInitialProps` for `getInitialProps`
-- `withSentryGetServerSideProps` for `getServerSideProps`
-- `withSentryGetStaticProps` for `getStaticProps`
-- `withSentryServerSideErrorGetInitialProps` for `getInitialProps` in [custom Error pages](https://nextjs.org/docs/advanced-features/custom-error-page)
-- `withSentryServerSideAppGetInitialProps` for `getInitialProps` in [custom `App` components](https://nextjs.org/docs/advanced-features/custom-app)
-- `withSentryServerSideDocumentGetInitialProps` for `getInitialProps` in [custom `Document` components](https://nextjs.org/docs/advanced-features/custom-document)
-
 If the automatic instrumentation doesn't work for your use case, API routes can also be wrapped manually using the `withSentry` function:
 
 ```javascript {filename:pages/api/*}


### PR DESCRIPTION
This section is repeated on the manual setup docs page for nextjs

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
