### PR TITLE
Change min supported DS SDK version for Java

### DIFF
--- a/src/includes/sampling-supported-sdks.mdx
+++ b/src/includes/sampling-supported-sdks.mdx
@@ -6,5 +6,5 @@
 - Dart and Flutter: 6.11.0 or later
 - PHP: 3.9.0 or later
 - Ruby: 5.5.0 or later
-- Java: 6.5.0-beta.2 or later
+- Java: 6.5.0 or later
 - .NET: 3.22.0 or later


### PR DESCRIPTION
Remove `beta` as `6.5.0` has been released.
