### PR TITLE
fix(apple): Delete experimental note GA features

### DIFF
--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -27,8 +27,8 @@
   - [Mobile Vitals](https://docs.sentry.io/product/performance/mobile-vitals/)
     - Cold and warm start
     - Slow and frozen frames
-  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">file I/O</PlatformLink> operations (experimental)
-  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Core Data</PlatformLink> queries (experimental)
+  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">file I/O</PlatformLink> operations
+  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Core Data</PlatformLink> queries
   - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User Interaction</PlatformLink> transactions for UI clicks (experimental)
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/platforms/apple/common/configuration/swizzling.mdx
+++ b/src/platforms/apple/common/configuration/swizzling.mdx
@@ -9,8 +9,8 @@ The Cocoa SDK uses [swizzling](https://nshipster.com/method-swizzling/) to provi
 __macOS__
 - <PlatformLink to="/enriching-events/breadcrumbs/">Breadcrumbs for touch events</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#network-tracking">Auto instrumentation for HTTP requests</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations (experimental)</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations (experimental)</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations</PlatformLink>
 - <PlatformLink to="/performance/connect-services/">Automatically added sentry-trace header to HTTP requests for distributed tracing</PlatformLink>
 
 
@@ -19,8 +19,8 @@ __iOS, tvOS and Catalyst__
 - <PlatformLink to="/enriching-events/breadcrumbs/">Breadcrumbs for touch events and navigation with UIViewControllers</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking">Auto instrumentation for UIViewControllers</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#network-tracking">Auto instrumentation for HTTP requests</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations (experimental)</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations (experimental)</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations</PlatformLink>
 - <PlatformLink to="/performance/connect-services/">Automatically added sentry-trace header to HTTP requests for distributed tracing</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User interaction transactions for UI clicks (experimental)</PlatformLink>
 


### PR DESCRIPTION
Remove experimental suffixes for file I/O and core data queries, which are GA already, see https://github.com/getsentry/sentry-docs/pull/5548.

