### PR TITLE
feat(perf-issues): General documentation updates for Performance Issues

### DIFF
--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -13,8 +13,8 @@ description: "Learn about the two types of alerts Sentry provides: issue alerts 
 
 You can create two types of alerts:
 
-1. **Issue alerts**: Trigger when an issue (a grouped set of error events) matches a specific criteria.
-2. **Metric alerts**: Trigger when macro-level metrics for error or transaction events cross specific thresholds.
+1. **Issue alerts**: Trigger when an issue matches a specific criteria.
+2. **Metric alerts**: Trigger when macro-level metrics cross specific thresholds.
 
 ## Issue Alerts
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -16,7 +16,7 @@ From the **Alerts** page in [sentry.io](https://sentry.io), you can create new a
 
 The **Alerts** page also displays a “History” tab where you can find a list of metric alerts with information like when it was triggered and how long it was active.
 
-## Issue Alerts for Errors
+## Issue Alerts
 
 [Issue alerts](/product/alerts/alert-types/#issue-alerts) trigger whenever any issue in a project matches specified criteria. You can create alerts for issue-level changes, such as:
 

--- a/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
@@ -6,6 +6,8 @@ redirect_from:
 description: "Learn about fingerprint rules, matchers for fingerprinting, how to combine matchers, and using variables for fingerprinting."
 ---
 
+<Include name="only-error-issues-note.mdx" />
+
 Fingerprint rules (previously known as _server-side fingerprinting_) are also configured with a config similar to [stack trace rules](../stack-trace-rules/), but the syntax is slightly different. The matchers are the same, but instead of flipping flags, a fingerprint is assigned and it overrides the default grouping entirely.
 
 These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Fingerprint Rules**. This setting has input fields where you can write custom fingerprinting rules. To update a rule:

--- a/src/docs/product/data-management-settings/event-grouping/grouping-breakdown/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/grouping-breakdown/index.mdx
@@ -6,6 +6,8 @@ description: "Learn more about the grouping algorithm and using the Grouping tab
 
 <Include name="early-adopter-note.mdx" />
 
+<Include name="only-error-issues-note.mdx" />
+
 Sentry's current grouping algorithm puts two error events into the same issue if they have the same stack trace. This approach sometimes creates multiple distinct issues for errors with the same root cause.
 
 If two distinct issues are created occasionally, you may be able to reduce the noise by manually [merging](/product/data-management-settings/event-grouping/merging-issues/) those issues. Alternatively, if you want coarser issue groups (thus fewer issues) by default, follow the process outlined here.

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -12,7 +12,7 @@ A fingerprint is a way to uniquely identify an event, and all events have one. E
 
 By default, Sentry will run one of our built-in grouping algorithms to generate an event fingerprint based on information available within the event. The available information and the grouping algorithms vary by event type. Sentry fingerprints error events based on information like `stacktrace`, `exception`, and `message`. Transaction events are fingerprinted by their `spans`.
 
-If the way that Sentry is grouping issues for your organization is already ideal, you don't need to make any changes. However, you may find that Sentry is either creating too many similar groups, or is grouping disparate events into groups that should be separate. If this is the case, you can extend and change the default grouping behaviour. Error grouping can be extended, and changed completely according to your needs. Transaction grouping currently cannot be customized.
+If the way that Sentry is grouping issues for your organization is already ideal, you don't need to make any changes. However, you may find that Sentry is either creating too many similar groups, or is grouping disparate events into groups that should be separate. If this is the case, for **error issues**, you can extend and change the default grouping behavior. Error grouping can be extended and changed completely according to your needs. (Transaction grouping currently cannot be customized.)
 
 You can customize error grouping using a combination of the following options, listed from least to most complex:
 

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -72,7 +72,7 @@ Grouping falls back to messages if the stack trace, `type`, and `value` are not 
 
 ## Transaction Grouping Algorithms
 
-Sentry groups transactions with performance problems into [performance issues](/product/issues/performance-issues/) using the transaction's `spans`. Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. This algorithm is not customizable or extendable at this time.
+Sentry groups transactions with performance problems into [performance issues](/product/issues/performance-issues/) using the transaction's `spans`. Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. This algorithm isn't currently customizable or extendable.
 
 ## Learn More
 

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -15,13 +15,13 @@ By default, Sentry will run one of our built-in grouping algorithms to generate 
 If the way that Sentry is grouping issues for your organization is already ideal, you don't need to make any changes. However, if a set of issues looks similar but they aren't being automatically grouped, or you have other grouping needs, you can extend the default grouping behavior or change it completely. You can do this using a combination of the following options, listed from least to most complex:
 
 1. In your project, by [Merging Issues](/product/data-management-settings/event-grouping/merging-issues/)
-> Merges together similar issues that have already been created. No settings or configuration changes are required for this.
+   > Merges together similar issues that have already been created. No settings or configuration changes are required for this.
 1. In your project, using [Fingerprint Rules](./fingerprint-rules/)
-> Sets a new fingerprint for incoming events based on matchers. This doesn't affect already existing issues.
+   > Sets a new fingerprint for incoming events based on matchers. This doesn't affect already existing issues.
 1. In your project, using [Stack Trace Rules](./stack-trace-rules/)
-> Sets rules for how incoming events should be treated based on matchers. This doesn't affect already existing issues.
+   > Sets rules for how incoming events should be treated based on matchers. This doesn't affect already existing issues.
 1. In your SDK, using [SDK Fingerprinting](/platform-redirect/?next=/usage/sdk-fingerprinting/)
-> Sets a new fingerprint for incoming events based on matchers in the SDK. This doesn't affect already existing issues. Note that is not supported in WebAssembly.
+   > Sets a new fingerprint for incoming events based on matchers in the SDK. This doesn't affect already existing issues. Note that is not supported in WebAssembly.
 
 <Note>
 

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -64,6 +64,10 @@ You can also see what events would group together if a larger or smaller amount 
 
 If the stack trace is not available, but exception information is, then the grouping will consider the `type` and `value` of the exception if both pieces of data are present on the event. This grouping is a lot less reliable because of changing error messages.
 
+### Grouping by Span Evidence
+
+If the event is a transaction and it causes a [performance issue](/product/issues/performance-issue), Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. Note that this algorithm does not support versioning.
+
 ### Fallback Grouping
 
 Grouping falls back to messages if the stack trace, `type`, and `value` are not available. When this happens, the grouping algorithm will try to use the message without any parameters. If that is not available, the grouping algorithm will use the full message attribute.

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -66,7 +66,7 @@ If the stack trace is not available, but exception information is, then the grou
 
 ### Grouping by Span Evidence
 
-If the event is a transaction and it causes a [performance issue](/product/issues/performance-issue), Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. Note that this algorithm does not support versioning.
+If the event is a transaction and it causes a [performance issue](/product/issues/performance-issues/), Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. Note that this algorithm does not support versioning.
 
 ### Fallback Grouping
 

--- a/src/docs/product/data-management-settings/event-grouping/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/index.mdx
@@ -8,11 +8,13 @@ redirect_from:
 description: "Learn about fingerprints, the grouping algorithm, grouping by stack trace, grouping by exceptions, and fallback grouping. Learn more about how Sentry groups issues together as well as different approaches for updating how events group into issues"
 ---
 
-A fingerprint is a way to uniquely identify an error, and all events have one. Events with the same fingerprint are grouped together into an issue.
+A fingerprint is a way to uniquely identify an event, and all events have one. Events with the same fingerprint are grouped together into an issue.
 
-By default, Sentry will run one of our built-in grouping algorithms to generate an event fingerprint based on information available within the event, such as `stacktrace`, `exception`, and `message`.
+By default, Sentry will run one of our built-in grouping algorithms to generate an event fingerprint based on information available within the event. The available information and the grouping algorithms vary by event type. Sentry fingerprints error events based on information like `stacktrace`, `exception`, and `message`. Transaction events are fingerprinted by their `spans`.
 
-If the way that Sentry is grouping issues for your organization is already ideal, you don't need to make any changes. However, if a set of issues looks similar but they aren't being automatically grouped, or you have other grouping needs, you can extend the default grouping behavior or change it completely. You can do this using a combination of the following options, listed from least to most complex:
+If the way that Sentry is grouping issues for your organization is already ideal, you don't need to make any changes. However, you may find that Sentry is either creating too many similar groups, or is grouping disparate events into groups that should be separate. If this is the case, you can extend and change the default grouping behaviour. Error grouping can be extended, and changed completely according to your needs. Transaction grouping currently cannot be customized.
+
+You can customize error grouping using a combination of the following options, listed from least to most complex:
 
 1. In your project, by [Merging Issues](/product/data-management-settings/event-grouping/merging-issues/)
    > Merges together similar issues that have already been created. No settings or configuration changes are required for this.
@@ -31,13 +33,13 @@ Stack trace rules can work as a combination of both SDK and project settings. As
 
 You can see a fingerprint by opening an issue, clicking the JSON link, and finding the _fingerprint_ property in that file. If the default grouping was used, you'll see "default" written there. If a different grouping was used, you'll see the actual fingerprint value itself.
 
-## Grouping Algorithms
+## Error Grouping Algorithms
 
-Each time default grouping behavior is modified, Sentry releases it as a new version. As a result, modifications to the default behavior do not affect the grouping of existing issues.
+Each time default error grouping behavior is modified, Sentry releases it as a new version. As a result, modifications to the default behavior do not affect the grouping of existing issues.
 
-When you create a Sentry project, the most recent version of the grouping algorithm is automatically selected. This ensures that grouping behavior is consistent within a project.
+When you create a Sentry project, the most recent version of the error grouping algorithm is automatically selected. This ensures that grouping behavior is consistent within a project.
 
-To upgrade an existing project to a new grouping algorithm version, navigate to **Settings > Projects > [project] > Issue Grouping > Upgrade Grouping**. After upgrading to a new grouping algorithm, you will very likely see new groups being created.
+To upgrade an existing project to a new error grouping algorithm version, navigate to **Settings > Projects > [project] > Issue Grouping > Upgrade Grouping**. After upgrading to a new error grouping algorithm, you will very likely see new groups being created.
 
 All versions consider the `stack trace` first, the `exception` next, and then finally the `message`.
 
@@ -64,13 +66,13 @@ You can also see what events would group together if a larger or smaller amount 
 
 If the stack trace is not available, but exception information is, then the grouping will consider the `type` and `value` of the exception if both pieces of data are present on the event. This grouping is a lot less reliable because of changing error messages.
 
-### Grouping by Span Evidence
-
-If the event is a transaction and it causes a [performance issue](/product/issues/performance-issues/), Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. Note that this algorithm does not support versioning.
-
 ### Fallback Grouping
 
 Grouping falls back to messages if the stack trace, `type`, and `value` are not available. When this happens, the grouping algorithm will try to use the message without any parameters. If that is not available, the grouping algorithm will use the full message attribute.
+
+## Transaction Grouping Algorithms
+
+Sentry groups transactions with performance problems into [performance issues](/product/issues/performance-issues/) using the transaction's `spans`. Sentry fingerprints by the span evidence related to the performance problem found in the event. This includes the spans directly involved in the problem, as well as spans that might have caused the problem or are closely related to it. This algorithm is not customizable or extendable at this time.
 
 ## Learn More
 

--- a/src/docs/product/data-management-settings/event-grouping/merging-issues/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/merging-issues/index.mdx
@@ -4,6 +4,8 @@ sidebar_order: 10
 description: "Learn about merging similar issues that aren't automatically grouped."
 ---
 
+<Include name="only-error-issues-note.mdx" />
+
 If you have similar-looking issues that have not been grouped together automatically and you want to reduce noise, you can do so by merging them.
 
 In this example, before merge, there are two issues that are very similiar, but have not been grouped together. One issue has 39 events in the past 24 hours, and the other has 76:

--- a/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/stack-trace-rules.mdx
@@ -6,6 +6,8 @@ redirect_from:
 description: "Learn about ways to enhance your custom grouping."
 ---
 
+<Include name="only-error-issues-note.mdx" />
+
 If you use stack traces for grouping, the stack trace rules (previously known as _grouping enhancements_) influence the data that's fed into the grouping algorithm. These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Stack Trace Rules**.
 
 Each line is a single rule; one or multiple match expressions are followed by one or multiple actions to be executed when all expressions match. All rules are executed from top to bottom on all frames in the stack trace.

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -71,7 +71,7 @@ You can set your own <PlatformLink to="/enriching-events/breadcrumbs/">breadcrum
 
 ## Event Grouping Information
 
-The Event Grouping Information section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the stack trace contributed to the fingerprint as well as all values that were available. You can also use the "Grouping Config" dropdown to experiment with other grouping algorithms.
+The "Event Grouping Information" section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the stack trace contributed to the fingerprint as well as all values that were available. You can also use the "Grouping Config" dropdown to experiment with other grouping algorithms.
 
 ## Tabs
 

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -69,6 +69,10 @@ You can set your own <PlatformLink to="/enriching-events/breadcrumbs/">breadcrum
 
 [Tracing](/product/sentry-basics/tracing/distributed-tracing/) augments your existing error data by capturing interactions between your software systems. In the "Trace Details" section, you can click the "Search by Trace" button to see all the events that share the same trace ID.
 
+## Event Grouping Information
+
+The Event Grouping Information section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the stack trace contributed to the fingerprint as well as all values that were available. You can also use the "Grouping Config" dropdown to experiment with other grouping algorithms.
+
 ## Tabs
 
 This page displays the Details tab when it first opens, but several other tabs are available:

--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -11,6 +11,8 @@ redirect_from:
 description: "Learn how to automatically assign issues to their respective owners, or alert the owners about an issue, allowing you to find the developer with the most context about a fix."
 ---
 
+<Include name="only-error-issues-note.mdx" />
+
 Sentry offers multiple ways to define the "ownership" of an issue. With ownership defined, we can automatically assign issues and send alerts to the owner. Sentry defines ownership with _code owners_ and _ownership rules_. Code owners functionality lets you import your [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) or [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) CODEOWNERS file, and then we assign issues according to those file paths. Ownership rules allow you to override the assignments based on code owners and provide advanced matcher types (for example, urls and tags). These rules can also match on the file paths of files in the stack trace, URL of the request, or event tags.
 
 ## How It Works
@@ -38,7 +40,7 @@ The general format of a rule is: `type:pattern owners`
 
 : The pattern you're matching on. For example, `src/javascript/*` for `path`, `[https://www.example.io/checkout](https://www.example.io/checkout)` for `url`, or `Chrome 81.0.*` for `tags.browser`.
 
-: `pattern` matching supports unix-style [glob syntax](<https://en.wikipedia.org/wiki/Glob_(programming)>). For example, add `*` to match anything and `?` to match a single character. *This is not a regex.*
+: `pattern` matching supports unix-style [glob syntax](<https://en.wikipedia.org/wiki/Glob_(programming)>). For example, add `*` to match anything and `?` to match a single character. _This is not a regex._
 
 `owners`
 

--- a/src/docs/product/issues/performance-issues/index.mdx
+++ b/src/docs/product/issues/performance-issues/index.mdx
@@ -32,7 +32,7 @@ Span evidence is information that explains the performance problem in the contex
 
 ## Event Grouping Information
 
-The Event Grouping Information section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the span evidence contributed to the fingerprint.
+The "Event Grouping Information" section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the span evidence contributed to the fingerprint.
 
 ## Performance Issue Limitations
 

--- a/src/docs/product/issues/performance-issues/index.mdx
+++ b/src/docs/product/issues/performance-issues/index.mdx
@@ -30,6 +30,10 @@ The tags displayed in the main section of this page are specific to the event th
 
 Span evidence is information that explains the performance problem in the context of the current event. It may include details like the specific database queries that cause the problem, the spans that contain the problem, and the slow spans that have an impact on performance. This section also has a span tree which shows how the problematic spans relate to the rest of the event. Different performance problems will have slightly different kinds of evidence.
 
+## Event Grouping Information
+
+The Event Grouping Information section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the span evidence contributed to the fingerprint.
+
 ## Performance Issue Limitations
 
 Performance issues currently have the following limitations:

--- a/src/docs/product/issues/performance-issues/n-one-queries.mdx
+++ b/src/docs/product/issues/performance-issues/n-one-queries.mdx
@@ -12,9 +12,9 @@ _N+1 queries_ are a performance problem in which the application makes database 
 
 The detector for performance issues looks for a set of sequential, non-overlapping database spans with similar descriptions. It also uses the following criteria:
 
-- the total duration of involved spans must exceed a threshold (usually 100ms)
-- the total count of involved spans must exceed a threshold (usually 5 spans)
-- the involved spans cannot be truncated
+- Total duration of involved spans must exceed a threshold (usually 100ms)
+- Total count of involved spans must exceed a threshold (usually 5 spans)
+- Involved spans cannot be truncated
 
 If Sentry is not detecting an N+1 issue where you expect one, it's probably because the transaction did not meet one of the above criteria.
 

--- a/src/docs/product/issues/performance-issues/n-one-queries.mdx
+++ b/src/docs/product/issues/performance-issues/n-one-queries.mdx
@@ -10,7 +10,7 @@ _N+1 queries_ are a performance problem in which the application makes database 
 
 ## Detection Criteria
 
-This detector looks for a set of sequential, non-overlapping database spans with similar descriptions. It also uses a few extra criteria:
+The detector for performance issues looks for a set of sequential, non-overlapping database spans with similar descriptions. It also uses the following criteria:
 
 - the total duration of involved spans must exceed a threshold (usually 100ms)
 - the total count of involved spans must exceed a threshold (usually 5 spans)

--- a/src/docs/product/issues/performance-issues/n-one-queries.mdx
+++ b/src/docs/product/issues/performance-issues/n-one-queries.mdx
@@ -24,7 +24,7 @@ The evidence for an N+1 queries problem has four main aspects:
 
 - Transaction name
 - Parent span - This can be a view, a serializer, or another span that logically groups the queries.
-- Source span - This is the query that caused the N+1 queries.
+- Source span - This is the query that most likely caused the N+1 queries.
 - Repeating span - This is the "N" of N+1 queries. This is the looped query that should have been part of the source.
 
 ![N+1 Query span evidence](n-plus-one-span-evidence.png)

--- a/src/docs/product/issues/performance-issues/n-one-queries.mdx
+++ b/src/docs/product/issues/performance-issues/n-one-queries.mdx
@@ -8,6 +8,16 @@ description: "Learn more about N+1 queries and how to diagnose and fix them."
 
 _N+1 queries_ are a performance problem in which the application makes database queries in a loop, instead of making a single query that returns all the information at once. Each database connection takes some amount of time, so querying the database in a loop can be many times slower than doing it just once. This problem often occurs when you use an object-relational mapping (ORM) tool in web frameworks like Django or Ruby on Rails.
 
+## Detection Criteria
+
+This detector looks for a set of sequential, non-overlapping database spans with similar descriptions. It also uses a few extra criteria:
+
+- the total duration of involved spans must exceed a threshold (usually 100ms)
+- the total count of involved spans must exceed a threshold (usually 5 spans)
+- the involved spans cannot be truncated
+
+If Sentry is not detecting an N+1 issue where you expect one, it's probably because the transaction did not meet one of the above criteria.
+
 ## Span Evidence
 
 The evidence for an N+1 queries problem has four main aspects:

--- a/src/docs/product/sentry-basics/enrich-data/index.mdx
+++ b/src/docs/product/sentry-basics/enrich-data/index.mdx
@@ -7,8 +7,8 @@ redirect_from:
 description: "Learn about event data and how to configure Sentry workflows and tools to fine-tune the data sent to Sentry."
 ---
 
-The Sentry SDK captures errors, exceptions, crashes, and generally anything that goes wrong in your application in real-time.
-Once captured, the SDK enriches the error data with contextual information that it gets from the application's runtime and sends all this data as an _event_ to your Sentry account.
+The Sentry SDK captures errors, exceptions, crashes, transactions, and generally anything that goes wrong in your application in real-time.
+Once captured, the SDK enriches the data with contextual information that it gets from the application's runtime and sends all this data as an _event_ to your Sentry account.
 
 While Sentry adds a lot of this contextual data by default, we highly encourage you to add your custom data through the SDK. Multiple Sentry workflows and tools can be configured and fine-tuned based on this data, so adapting those to the way you work is very helpful in getting even more value out of Sentry.
 
@@ -26,11 +26,11 @@ The SDK allows you to set various types of data that are then attached to every 
 
 ## Using Your Data {#utilizing-your-data}
 
-Adding custom **structured data** that is unique to your applications, users, and business logic enriches your error data and provides valuable context to every error. You can also use that same data to customize Sentry workflows and adapt them to your precise needs. Let's look at those major workflows:
+Adding custom **structured data** that is unique to your applications, users, and business logic enriches your data and provides valuable context to every event. You can also use that same data to customize Sentry workflows and adapt them to your precise needs. Let's look at those major workflows:
 
 ### Alert Rules
 
-Targeted alerts are key to focusing attention when your app breaks and notifying exactly the people who can fix it. The more data you add to your errors, the more flexibility you gain to create pinpointed alerts. The following data types can be incorporated in your alert rules by adding the relevant conditions to trigger the alert:
+Targeted alerts are key to focusing attention when your app breaks and notifying exactly the people who can fix it. The more data you add to your events, the more flexibility you gain to create pinpointed alerts. The following data types can be incorporated in your alert rules by adding the relevant conditions to trigger the alert:
 
 - **User Context**: Once a certain issue has impacted a defined threshold of unique users.
 - **Custom Tags**: When events contain custom tag values that match your defined values.
@@ -61,7 +61,7 @@ Learn more in [Search](/product/sentry-basics/search/).
 
 ### Discover
 
-Discover is a powerful query engine that builds upon your error data, allowing you to reveal patterns, anomalies, and deeper insights in the health of your entire system. With this in mind, the more (custom) data you add to your errors, the more flexibility you'll gain in building queries that address your environments, releases, custom development, and business characteristics through _tags_, and the end-users impacted by those errors.
+Discover is a powerful query engine that builds upon your data, allowing you to reveal patterns, anomalies, and deeper insights in the health of your entire system. With this in mind, the more (custom) data you add to your events, the more flexibility you'll gain in building queries that address your environments, releases, custom development, and business characteristics through _tags_, and the end-users impacted by those events.
 
 For instance, the Discover query below displays all the errors (total of 143 events) that occurred in the _production environment_, distributed by the _customer-type custom tag_, and ordered by the _uniquely impacted end users_.
 

--- a/src/docs/product/sentry-basics/enrich-data/index.mdx
+++ b/src/docs/product/sentry-basics/enrich-data/index.mdx
@@ -18,7 +18,7 @@ The SDK allows you to set various types of data that are then attached to every 
 
 1. **Unstructured Data** - Includes additional data like `Breadcrumbs`, `Extra data`, and `Custom Contexts`. While these fields are **unsearchable**, they enrich your events with information that will help you debug and resolve the associated issues.
 
-2. **Structured Data** - Key/value pairs that are **indexed and searchable**, allowing you to search, filter, and query **through all your errors** across projects, in addition to helping you debug specific issues. These include:
+2. **Structured Data** - Key/value pairs that are **indexed and searchable**, allowing you to search, filter, and query **through all your events** across projects, in addition to helping you debug specific issues. These include:
 
    - `Custom Tags` - A way to reflect key characteristics that apply to your applications, dev process, or business in your error data. These might include variants and flavors of your app, a user type, tenant ID, payment plan, and so on.
    - `Release` and `Environment` - Predefined data fields available as SDK configuration options.

--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -11,7 +11,7 @@ description: "Learn more about how Sentry groups issues together as well as diff
 Have you ever had a set of similar-looking issues like this?
 ![Issues Dashboard](issues-dashboard.png)
 
-Let's first understand how events group into an issue. The issue `testTypeIssue16` has 18 events that Sentry grouped into an issue because they share the same _fingerprint_.
+Let's first understand how errors and transactions group into an issue. For example, the issue `testTypeIssue16` has 18 events that Sentry grouped into an issue because they share the same _fingerprint_.
 
 **What is a fingerprint?**
 A fingerprint is a way to uniquely identify an event. Sentry sets a fingerprint by default for you. Sentry uses its own built-in grouping algorithms to generate a fingerprint based on information available within the event such as a stack trace, exception, and message. Events with the same fingerprint are grouped together.
@@ -22,10 +22,10 @@ A fingerprint is a way to uniquely identify an event. Sentry sets a fingerprint 
 
 ## Why are similar looking Issues not grouping together?
 
-If a set of issues in the Issues Stream looks similar, there is something that still differs: the stack trace, and therefore the fingerprint. Let's compare two similar looking issues side-by-side:
+If a set of issues in the Issues Stream looks similar, there is something that still differs: in this case it is the stack trace, and therefore the fingerprint. Let's compare two similar looking error issues side-by-side:
 ![Issues Dashboard](issue-stacktraces-comparison.png)
 
-Notice the only difference is one had function testTypeIssue15 and the other had testTypeIssue14. This means the stack traces are not identical.
+Notice the only difference is one had function `testTypeIssue15` and the other had `testTypeIssue14`. This means the stack traces are not identical.
 Sometimes two stack traces are the same function execution path but differ by one frame. This can be due to several things like middleware you've configured, node_modules, the framework itself, or library imports. To have greater control over which stack frames are included or excluded, see [Stack Trace Rules](/product/data-management-settings/event-grouping/stack-trace-rules/).
 
 <Note>
@@ -35,6 +35,8 @@ Fortunately you can change the default grouping behavior to make certain issue t
 </Note>
 
 ## Solutions
+
+<Include name="only-error-issues-note.mdx" />
 
 There are three different approaches for updating how events group into issues. The first approach is for merging together historical issues already created. We'll call this **Merging Similar Issues**. The second is for setting rules so next incoming issues will get grouped together. We'll call this **Fingerprint Rules**. The third is **SDK Side Fingerprinting**. The difference between SDK side and Server side is the data elements on the exception and stack traces which you can use for matching issues.
 

--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -36,7 +36,11 @@ Fortunately you can change the default grouping behavior to make certain issue t
 
 ## Solutions
 
-<Include name="only-error-issues-note.mdx" />
+<Note>
+
+The solutions described in this section are only applicable for [error issues](/product/issues/#error-issues). Other categories of issues (such as, [performance issues](/product/issues/#performance-issues)) do not support this feature.
+
+</Note>
 
 There are three different approaches for updating how events group into issues. The first approach is for merging together historical issues already created. We'll call this **Merging Similar Issues**. The second is for setting rules so next incoming issues will get grouped together. We'll call this **Fingerprint Rules**. The third is **SDK Side Fingerprinting**. The difference between SDK side and Server side is the data elements on the exception and stack traces which you can use for matching issues.
 

--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -18,7 +18,7 @@ A fingerprint is a way to uniquely identify an event. Sentry sets a fingerprint 
 
 **Do I need to do anything?** No. Sentry automatically generates a fingerprint based on the event type and all available information. If events have the same root cause, they will group into one issue. If you have separate issues that you'd like to group together, then this guide will show you how.
 
-**How do I see the fingerprint?** Open an issue, click the JSON link, and find the _fingerprint_ property. If the default grouping was used, you'll see default written there. If a different grouping was used, you'll see the actual fingerprint value itself.
+**How do I see the fingerprint?** Open an issue, scroll down to the "Event Grouping Information" section, and click "Show Details". You'll see detailed information about how the fingerprint was generated, the algorithm that was used, and the final result.
 
 ## Why are similar looking Issues not grouping together?
 

--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -16,7 +16,7 @@ Let's first understand how events group into an issue. The issue `testTypeIssue1
 **What is a fingerprint?**
 A fingerprint is a way to uniquely identify an event. Sentry sets a fingerprint by default for you. Sentry uses its own built-in grouping algorithms to generate a fingerprint based on information available within the event such as a stack trace, exception, and message. Events with the same fingerprint are grouped together.
 
-**Do I need to do anything?** No. A stack trace is used by default if it's available. So if two events have the same stack trace, then they will group into one issue. If you have separate issues that you'd like to group together, then this guide will show you how.
+**Do I need to do anything?** No. Sentry automatically generates a fingerprint based on the event type and all available information. If events have the same root cause, they will group into one issue. If you have separate issues that you'd like to group together, then this guide will show you how.
 
 **How do I see the fingerprint?** Open an issue, click the JSON link, and find the _fingerprint_ property. If the default grouping was used, you'll see default written there. If a different grouping was used, you'll see the actual fingerprint value itself.
 

--- a/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
+++ b/src/docs/product/sentry-basics/grouping-and-fingerprints/index.mdx
@@ -18,7 +18,7 @@ A fingerprint is a way to uniquely identify an event. Sentry sets a fingerprint 
 
 **Do I need to do anything?** No. Sentry automatically generates a fingerprint based on the event type and all available information. If events have the same root cause, they will group into one issue. If you have separate issues that you'd like to group together, then this guide will show you how.
 
-**How do I see the fingerprint?** Open an issue, scroll down to the "Event Grouping Information" section, and click "Show Details". You'll see detailed information about how the fingerprint was generated, the algorithm that was used, and the final result.
+**How do I see the fingerprint?** Open an issue, click the JSON link, and find the _fingerprint_ property. If the default grouping was used, you'll see default written there. If a different grouping was used, you'll see the actual fingerprint value itself.
 
 ## Why are similar looking Issues not grouping together?
 

--- a/src/docs/product/sentry-basics/key-terms.mdx
+++ b/src/docs/product/sentry-basics/key-terms.mdx
@@ -22,7 +22,7 @@ Some of the following key concepts have corresponding features with the same nam
 
 - **attachments** - Stored additional files, such as config or log files that are attached to an error event.
 
-- **issues** - An issue is a grouping of similar error events. Every error event has a set of characteristics called its fingerprint, which is what Sentry uses to group them. For example, Sentry groups events together when they are triggered by the same part of your code. This grouping of events into issues allows you to see how frequently a problem is happening and how many users it's affecting.
+- **issues** - An issue is a grouping of similar errors or performance problems. Every event has a set of characteristics called its fingerprint, which is what Sentry uses to group them. For example, Sentry groups error events together when they are triggered by the same part of your code. This grouping of events into issues allows you to see how frequently a problem is happening and how many users it's affecting.
 
 - **transaction** - A transaction represents a single instance of a service being called to support an operation you want to measure or track, like a page load, page navigation, or asynchronous task. Transaction events are grouped by the transaction name.
 
@@ -50,7 +50,7 @@ Each of these key features in [sentry.io](https://sentry.io) is represented by a
 
 - **Projects** - Lists the projects of which you're a member, by team, and provides you with a high-level overview of your projects. From here, you can go to the **Project Details** page of each project for a more granular view. Learn more in the full [Projects documentation](/product/projects/).
 
-- **Issues** - Displays information about grouped errors in your application. From here, you can go to the **Issue Details** page for a more granular view of any issue. Learn more in the full [Issues documentation](/product/issues/).
+- **Issues** - Displays information about grouped problems in your application. From here, you can go to the **Issue Details** page for a more granular view of any issue. Learn more in the full [Issues documentation](/product/issues/).
 
 - **Performance** - The main view in [sentry.io](http://sentry.io) where you can search or browse for transaction data. The page displays graphs that visualize transactions or trends, as well as a table where you can view relevant transactions and drill down to more information about them. Learn more in the full [Performance documentation](/product/performance/).
 

--- a/src/docs/product/sentry-basics/key-terms.mdx
+++ b/src/docs/product/sentry-basics/key-terms.mdx
@@ -20,7 +20,7 @@ Some of the following key concepts have corresponding features with the same nam
 
 - **error** - What counts as an error varies by platform, but in general, if there's something that looks like an exception, it can be captured as an error in Sentry. Sentry automatically captures errors, uncaught exceptions, and unhandled rejections, as well as other types of errors, depending on platform.
 
-- **attachments** - Stored additional files, such as config or log files that are attached to an error event.
+- **attachments** - Stored additional files, such as config or log files that are related to an error event.
 
 - **issues** - An issue is a grouping of similar errors or performance problems. Every event has a set of characteristics called its fingerprint, which is what Sentry uses to group them. For example, Sentry groups error events together when they are triggered by the same part of your code. This grouping of events into issues allows you to see how frequently a problem is happening and how many users it's affecting.
 

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -34,7 +34,7 @@ In the case of transaction events, we also refer to these properties as _indexed
 
 <Include name="early-adopter-note.mdx" />
 
-Processed events only apply to transactions and they comprise all the transaction events that you send to Sentry. These events represent aggregate data and underly metrics in the **Performance**, **Discover**, and **Dashboards** features. In **Dashboards**, for the ["Errors & Transactions"](/product/dashboards/widget-builder/#errors--transactions) dataset, we use this aggreate data to generate results if all search conditions and/or columns are processed event properties.
+Processed events only apply to transactions and they comprise all the transaction events that you send to Sentry. These events represent aggregate data and underly metrics in the **Performance**, **Discover**, and **Dashboards** features. In **Dashboards**, for the ["Errors & Transactions"](/product/dashboards/widget-builder/#errors--transactions) dataset, we use this aggregate data to generate results if all search conditions and/or columns are processed event properties.
 
 ### Release Properties
 

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -136,6 +136,7 @@ Release properties overlap with event and issue search properties, so they don't
 | id | The event id. In **Issues**, use only the ID value without the `id` key. | x | x |  | uuid |
 | is | The properties of an issue. Values can be: `unresolved`, `resolved`, `ignored`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not. |  | x |  | status |
 | issue | The short issue code, for example `SENTRY-ABC`. | x |  |  | string |
+| issue.category | Returns issues of a given category (either `error` or `performance`). | | x | | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x |  | datetime |
 | location | Location where the error happened. | x | x |  | string |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -136,7 +136,7 @@ Release properties overlap with event and issue search properties, so they don't
 | id | The event id. In **Issues**, use only the ID value without the `id` key. | x | x |  | uuid |
 | is | The properties of an issue. Values can be: `unresolved`, `resolved`, `ignored`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not. |  | x |  | status |
 | issue | The short issue code, for example `SENTRY-ABC`. | x |  |  | string |
-| issue.category | Returns issues of a given category (either `error` or `performance`). | | x | | string |
+| issue.category | The category of the issue (either `error` or `performance`). | | x | | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x |  | datetime |
 | location | Location where the error happened. | x | x |  | string |

--- a/src/includes/only-error-issues-note.mdx
+++ b/src/includes/only-error-issues-note.mdx
@@ -1,5 +1,5 @@
 <Note>
 
-This feature is only applicable to error issues. Other categories of issues (e.g., Performance Issues) do not support this feature.
+This feature is only applicable for [error issues](/product/issues/#error-issues). Other categories of issues (such as, [performance issues](/product/issues/#performance-issues)) do not support this feature.
 
 </Note>

--- a/src/includes/only-error-issues-note.mdx
+++ b/src/includes/only-error-issues-note.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+This feature is only applicable to error issues. Other categories of issues (e.g., Performance Issues) do not support this feature.
+
+</Note>


### PR DESCRIPTION
Various small changes. Partially addresses PERF-1733. Mostly makes documentation that relates to issues a little more generic by removing references to errors, since issues can now be groups of problematic transactions. In general:

- removes specific references to errors when talking about issues
- add disclaimers above features that only apply to error issues
- add more clarifications about how N+1 Queries work

Using the word "problem" as a substitute for "error", since it's a more generic term seems to work!

Related: #5633 
