### PR TITLE
Add information about missing java stack trace on rn new arch

### DIFF
--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -238,3 +238,7 @@ shellScript = "set -e\nexport SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_
 ## React Native 0.60.3 Failing Build
 
 React Native 0.60.3 tooling was unexpectedly moving source maps files, which caused the Sentry Gradle plugin to fail. This was fixed in version 0.60.4. For more detailed information, follow the [issue](https://github.com/getsentry/sentry-react-native/issues/2442).
+
+## Missing Java stacktrace on the New Architecture
+
+If you're using the new architecture on React Native, you might be missing the Java stacktrace. Follow the [issue](https://github.com/facebook/react-native/issues/34923) for more information.


### PR DESCRIPTION
Inform users of the new arch that we are aware of the issues with the jave stack trace.