### PR TITLE
Page with index of all integrations of one SDK

### DIFF
--- a/src/components/guideLink.tsx
+++ b/src/components/guideLink.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { PlatformIcon } from "platformicons";
+
+import SmartLink from "./smartLink";
+import usePlatform, { Platform, Guide } from "./hooks/usePlatform";
+
+type Props = {
+  platform?: string;
+  guide?: string;
+  className?: string;
+};
+
+export default ({ platform, guide, className }: Props): JSX.Element => {
+  const [currentPlatform] = usePlatform(platform);
+  const currentGuide = (currentPlatform as Platform).guides.find(
+    (g: Guide) => g.name === guide
+  );
+  // platform might actually not be a platform, so lets handle that case gracefully
+  if (!(currentPlatform as Platform).guides) {
+    return null;
+  }
+
+  // If guide does not exist
+  if (!currentGuide) {
+    return null;
+  }
+
+  return (
+    <span className={className}>
+      <SmartLink to={currentGuide.url}>
+        <PlatformIcon
+          size={16}
+          platform={currentGuide.key}
+          style={{ marginRight: "0.5rem", border: 0, boxShadow: "none" }}
+          format="lg"
+        />
+        <h4 style={{ display: "inline-block" }}>{currentGuide.title}</h4>
+      </SmartLink>
+    </span>
+  );
+};

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -11,6 +11,7 @@ import CodeBlock from "./codeBlock";
 import CodeTabs from "./codeTabs";
 import ConfigKey from "./configKey";
 import GuideGrid from "./guideGrid";
+import GuideLink from "./guideLink";
 import Include from "./include";
 import JsCdnTag from "./jsCdnTag";
 import LambdaLayerDetail from "./lambdaLayerDetail";
@@ -34,6 +35,7 @@ const mdxComponents = {
   CodeTabs,
   ConfigKey,
   GuideGrid,
+  GuideLink,
   Include,
   JsCdnTag,
   Link: SmartLink,

--- a/src/platforms/python/common/integrations.mdx
+++ b/src/platforms/python/common/integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 description: "The Sentry Python SDK has integrations for popular projects in the Python world."
-sidebar_order: 5
+sidebar_order: 3
 redirect_from:
 ---
 

--- a/src/platforms/python/common/integrations.mdx
+++ b/src/platforms/python/common/integrations.mdx
@@ -1,0 +1,77 @@
+---
+title: Integrations
+description: "The Sentry Python SDK has integrations for popular projects in the Python world."
+sidebar_order: 5
+redirect_from:
+---
+
+The Sentry SDK for Python supports various projects from the Python world out of the box:
+
+## Web Frameworks
+
+- <GuideLink platform="python" guide="django" />
+- <GuideLink platform="python" guide="flask" />
+- <GuideLink platform="python" guide="fastapi" />
+- <GuideLink platform="python" guide="starlette" />
+- <GuideLink platform="python" guide="bottle" />
+- <GuideLink platform="python" guide="falcon" />
+- <GuideLink platform="python" guide="chalice" />
+- <GuideLink platform="python" guide="sanic" />
+- <GuideLink platform="python" guide="quart" />
+- <GuideLink platform="python" guide="pyramid" />
+- <GuideLink platform="python" guide="tornado" />
+- <GuideLink platform="python" guide="serverless" />
+- <GuideLink platform="python" guide="aiohttp" />
+
+## Databases
+
+- PostgreSQL <GuideLink platform="python" guide="postgres" />
+- SQLAlchemy <GuideLink platform="python" guide="sqlalchemy" />
+- Redis <GuideLink platform="python" guide="redis" />
+
+## Task Queues
+
+- <GuideLink platform="python" guide="celery" />
+- <GuideLink platform="python" guide="rq" />
+
+## Web Server Interfaces
+
+- <GuideLink platform="python" guide="wsgi" />
+- <GuideLink platform="python" guide="asgi" />
+
+## Cloud Services
+
+- Boto3 <GuideLink platform="python" guide="boto3" />
+
+## Data processing
+
+- <GuideLink platform="python" guide="beam" />
+- Apache Spark <GuideLink platform="python" guide="spark" />
+
+## Function as a service (Faas)
+
+- <GuideLink platform="python" guide="aws-lambda" />
+- <GuideLink platform="python" guide="gcp-functions" />
+
+## Logging
+
+- <GuideLink platform="python" guide="logging" />
+
+## Business Software
+
+- <GuideLink platform="python" guide="tryton" />
+
+## Low Level
+
+- argv
+- asyncio
+- atexit
+- dedupe
+- excepthook
+- executing
+- gnu_backtrace
+- httpx
+- modules
+- pure_eval
+- stdlib
+- threading


### PR DESCRIPTION
This is a proof of concept of a "Integrations" page for a Sentry SDK. 
This pages shows all the different projects our SDK supports grouped by "type of software" (like "Web Frameworks", "Databases", ...)