### PR TITLE
Add a reminder on the supported languages for Stack Trace Linking

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -221,6 +221,12 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 ### Stack Trace Linking
 
+<Note>
+
+Only JavaScript and Python are supported at this moment.
+
+</Note>
+
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
 1. Navigate to **Settings > Integrations > GitHub > Configurations**.

--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -223,7 +223,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 <Note>
 
-Only JavaScript and Python are supported at this moment.
+This feature is currently only supported for JavaScript and Python.
 
 </Note>
 

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -124,6 +124,12 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
 ### Stack Trace Linking
 
+<Note>
+
+Only JavaScript and Python are supported at this moment.
+
+</Note>
+
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
 1. Navigate to **Settings > Integrations > GitLab > Configurations**.

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -126,7 +126,7 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
 <Note>
 
-Only JavaScript and Python are supported at this moment.
+This feature is currently only supported for JavaScript and Python.
 
 </Note>
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/issues/35608

Since Stack Trace Linking is not supported in languages except JS and Python? Adding a reminder so that others won't spent days to find out why it is not working

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
