### PR TITLE
feat(electron): Add details of JavaScript framework specific init

### DIFF
--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -70,9 +70,9 @@ In the renderer processes:
 import * as Sentry from "@sentry/electron/renderer";
 ```
 
-## Framework Specific SDKs
+## Framework-Specific SDKs
 
-If you are using a framework specific Sentry SDK in the Electron renderers, you
+If you're using a framework-specific Sentry SDK in the Electron renderers, you
 can pass that `init` function as the second parameter and the two SDKs functionalities will be combined:
 ```javascript
 import { init } from '@sentry/electron/renderer';

--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -70,6 +70,18 @@ In the renderer processes:
 import * as Sentry from "@sentry/electron/renderer";
 ```
 
+## Framework Specific SDKs
+
+If you are using a framework specific Sentry SDK in the Electron renderers, you
+can pass that `init` function as the second parameter and the two SDKs functionalities will be combined:
+```javascript
+import { init } from '@sentry/electron/renderer';
+import { init as reactInit } from '@sentry/react';
+
+init({ /* config */ }, reactInit);
+
+```
+
 ## Inter-Process Communication
 
 To give detailed information for all events including native crashes, the SDK merges context, scope and breadcrumbs from all processes in the Electron `main` process.


### PR DESCRIPTION
Adds details of how to configure the Electron SDK combined with a JavaScript framework specific SDK.