### PR TITLE
fix(android): Use correct imports for InstrumentationFeature

### DIFF
--- a/src/platforms/android/common/gradle.mdx
+++ b/src/platforms/android/common/gradle.mdx
@@ -48,7 +48,7 @@ The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0
 We expose the following configuration values directly in your `app/build.gradle`:
 
 ```groovy
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
     // Disables or enables the handling of Proguard mapping for Sentry.
@@ -91,16 +91,16 @@ sentry {
       // Defaults to all available values of InstrumentationFeature enum class.
       features = [InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP]
     }
-    
+
     // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
     // Default is enabled.
     // Only available v3.1.0 and above.
     autoInstallation {
       enabled = true
-      
+
       // Specifies a version of the sentry-android SDK and fragment, timber and okhttp integrations.
-      // 
-      // This is also useful, when you have the sentry-android SDK already included into a transitive dependency/module and want to 
+      //
+      // This is also useful, when you have the sentry-android SDK already included into a transitive dependency/module and want to
       // align integration versions with it (if it's a direct dependency, the version will be inferred).
       //
       // NOTE: if you have a higher version of the sentry-android SDK or integrations on the classpath, this setting will have no effect
@@ -113,7 +113,7 @@ sentry {
 ```
 
 ```kotlin
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
     // Disables or enables the handling of Proguard mapping for Sentry.
@@ -156,16 +156,16 @@ sentry {
       // Defaults to all available values of InstrumentationFeature enum class.
       features.set(setOf(InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP))
     }
-    
+
     // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
     // Default is enabled.
     // Only available v3.1.0 and above.
     autoInstallation {
       enabled.set(true)
-      
+
       // Specifies a version of the sentry-android SDK and fragment, timber and okhttp integrations.
-      // 
-      // This is also useful, when you have the sentry-android SDK already included into a transitive dependency/module and want to 
+      //
+      // This is also useful, when you have the sentry-android SDK already included into a transitive dependency/module and want to
       // align integration versions with it (if it's a direct dependency, the version will be inferred).
       //
       // NOTE: if you have a higher version of the sentry-android SDK or integrations on the classpath, this setting will have no effect
@@ -282,7 +282,7 @@ enum class InstrumentationFeature {
      * Requires sentry-android SDK version 5.5.0 and above
      */
     FILE_IO,
-    
+
     /**
      * When enabled the SDK will create spans for outgoing network requests and attach
      * sentry-trace-header for distributed tracing.

--- a/src/platforms/android/configuration/integrations/file-io.mdx
+++ b/src/platforms/android/configuration/integrations/file-io.mdx
@@ -66,7 +66,7 @@ Make sure, that [performance monitoring](/platforms/android/performance/#configu
 In general, no further configuration is required as the auto-instrumentation is enabled by default. If you would like to disable the file I/O instrumentation feature, we expose a configuration option for that:
 
 ```groovy
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -78,7 +78,7 @@ sentry {
 
 ```kotlin
 import java.util.EnumSet
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -59,7 +59,7 @@ Then, initialize the [Android SDK](/platforms/android/#configure).
 If you would like to disable the OkHttp instrumentation feature, we expose a configuration option for that:
 
 ```groovy
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -71,7 +71,7 @@ sentry {
 
 ```kotlin
 import java.util.EnumSet
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {

--- a/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
+++ b/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
@@ -66,7 +66,7 @@ Make sure, that [performance monitoring](/platforms/android/performance/#configu
 In general, no further configuration is required as the auto-instrumentation is enabled by default. If you would like to disable the database instrumentation feature, we expose a configuration option for that:
 
 ```groovy
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -78,7 +78,7 @@ sentry {
 
 ```kotlin
 import java.util.EnumSet
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -157,7 +157,7 @@ At the moment, we only support standard `androidx.room` usage. That is, the SDK 
 
 <Note>
 
-If you are directly using [SupportSQLiteDatabase#query](https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#query(java.lang.String)) or [SupportSQLiteDatabase#execSQL](https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#execSQL(java.lang.String)) methods through the Room's SQLiteOpenHelper, consider switching to their alternatives that accept `bindArgs` as a second parameter. 
+If you are directly using [SupportSQLiteDatabase#query](https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#query(java.lang.String)) or [SupportSQLiteDatabase#execSQL](https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#execSQL(java.lang.String)) methods through the Room's SQLiteOpenHelper, consider switching to their alternatives that accept `bindArgs` as a second parameter.
 
 Because Sentry captures SQL queries as Span description, there is a risk of leaking sensitive data when not using an SQL string with placeholders.
 

--- a/src/platforms/android/troubleshooting.mdx
+++ b/src/platforms/android/troubleshooting.mdx
@@ -115,7 +115,7 @@ You can set the debug log flag as an environment variable, which is picked up by
 In addition, set the `--stacktrace` flag:
 
 ```
-export SENTRY_LOG_LEVEL=debug && ./gradlew app:uploadSentryProguardMappingsRelease --stacktrace 
+export SENTRY_LOG_LEVEL=debug && ./gradlew app:uploadSentryProguardMappingsRelease --stacktrace
 ```
 
 With this information, it might be more clear what's happening. If not, please consider reporting these issues on [GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/issues), so we can keep track of them.
@@ -127,7 +127,7 @@ The [Sentry Android Gradle plugin](/platforms/android/gradle/) uses bytecode man
 The culprit is usually our [File I/O instrumentation](/platforms/android/configuration/integrations/file-io/), which can be disabled as follows:
 
 ```groovy
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -139,7 +139,7 @@ sentry {
 
 ```kotlin
 import java.util.EnumSet
-import io.sentry.android.gradle.InstrumentationFeature
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 sentry {
   tracingInstrumentation {
@@ -189,7 +189,7 @@ Or update the Android Gradle Plugin to version `7.2.1`:
 
 ```groovy
 plugins {
-  id 'com.android.application' version '7.2.1' 
+  id 'com.android.application' version '7.2.1'
 }
 ```
 


### PR DESCRIPTION
It looks like the package for `InstrumentationFeature` changed,  but the docs weren't up to date.

There are some minor whitespace changes as well - those were automatically applied by the pre-commit hook 😉 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
