### PR TITLE
Update Apollo version from 5.2.0 to 6.5.0

### DIFF
--- a/src/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/src/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -31,7 +31,7 @@ implementation 'io.sentry:sentry-apollo-3:{{ packages.version('sentry.java.apoll
 ```
 
 ```scala {tabTitle: SBT}
-libraryDependencies += "io.sentry" % "sentry-apollo-3" % "{{ packages.version('sentry.java.apollo3', '6.5.0') }}"
+libraryDependencies += "io.sentry" % "sentry-apollo-3" % "{{ packages.version('sentry.java.apollo-3', '5.2.0') }}"
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-apollo-3).

--- a/src/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/src/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -22,7 +22,7 @@ Sentry Apollo3 integration provides the `SentryApollo3Interceptor` and the `Sent
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-apollo-3</artifactId>
-    <version>{{ packages.version('sentry.java.apollo3', '6.5.0') }}</version>
+    <version>{{ packages.version('sentry.java.apollo-3', '5.2.0') }}</version>
 </dependency>
 ```
 

--- a/src/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/src/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -27,7 +27,7 @@ Sentry Apollo3 integration provides the `SentryApollo3Interceptor` and the `Sent
 ```
 
 ```groovy {tabTitle:Gradle}
-implementation 'io.sentry:sentry-apollo-3:{{ packages.version('sentry.java.apollo3', '6.5.0') }}'
+implementation 'io.sentry:sentry-apollo-3:{{ packages.version('sentry.java.apollo-3', '5.2.0') }}'
 ```
 
 ```scala {tabTitle: SBT}

--- a/src/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/src/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -22,16 +22,16 @@ Sentry Apollo3 integration provides the `SentryApollo3Interceptor` and the `Sent
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-apollo-3</artifactId>
-    <version>{{ packages.version('sentry.java.apollo3', '5.2.0') }}</version>
+    <version>{{ packages.version('sentry.java.apollo3', '6.5.0') }}</version>
 </dependency>
 ```
 
 ```groovy {tabTitle:Gradle}
-implementation 'io.sentry:sentry-apollo-3:{{ packages.version('sentry.java.apollo3', '5.2.0') }}'
+implementation 'io.sentry:sentry-apollo-3:{{ packages.version('sentry.java.apollo3', '6.5.0') }}'
 ```
 
 ```scala {tabTitle: SBT}
-libraryDependencies += "io.sentry" % "sentry-apollo-3" % "{{ packages.version('sentry.java.apollo3', '5.2.0') }}"
+libraryDependencies += "io.sentry" % "sentry-apollo-3" % "{{ packages.version('sentry.java.apollo3', '6.5.0') }}"
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-apollo-3).


### PR DESCRIPTION
I tested the "5.2.0" version multiple times, but it seems this version doesn't include Apollo 3 kotlin integration! Finally, I found [another page](https://docs.sentry.io/platforms/android/configuration/integrations/apollo/) and saw the correct version there. So I think it's better to update this page to the newer version too.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
