### PR TITLE
Top page nav disappears on mobile 

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import { Nav } from "react-bootstrap";
 
 import Breadcrumbs from "./breadcrumbs";
 import Header from "./header";
 import Sidebar from "./sidebar";
 import Navbar from "./navbar";
+import SmartLink from "./smartLink";
+import NavbarPlatformDropdown from "./navbarPlatformDropdown";
+import { getSandboxURL, SandboxOnly } from "./sandboxLink";
 
 import "~src/css/screen.scss";
 
@@ -46,6 +50,45 @@ export default ({
               {sidebar ? sidebar : <Sidebar />}
             </div>
           </div>
+        </div>
+        <div className="d-sm-none d-block" id="navbar-menu">
+          <Nav className="justify-content-center" style={{ flex: 1 }}>
+            <NavbarPlatformDropdown />
+            <Nav.Item>
+              <SmartLink className="nav-link" to="/api/">
+                API
+              </SmartLink>
+            </Nav.Item>
+            <SandboxOnly>
+              <Nav.Item>
+                <Nav.Link
+                  className="text-primary"
+                  href={getSandboxURL().toString()}
+                  target="_blank"
+                >
+                  Demo
+                </Nav.Link>
+              </Nav.Item>
+            </SandboxOnly>
+            <Nav.Item>
+              <Nav.Link href="https://sentry.io/">
+                Sign In
+                <svg
+                  width="1em"
+                  height="1em"
+                  viewBox="0 0 16 16"
+                  className="bi bi-arrow-right-short"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+                  />
+                </svg>
+              </Nav.Link>
+            </Nav.Item>
+          </Nav>
         </div>
       </div>
 


### PR DESCRIPTION
Added nav bar to the layout to show in case of mobile view, hide otherwise

Related to this <a href="https://github.com/getsentry/sentry-docs/issues/4593">issue</a>

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
