### PR TITLE
Docs for HTTP Client errors OkHttp

### DIFF
--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -293,7 +293,7 @@ By default, error events won't contain any PII data such as `Headers` and `Cooki
 
 Those events can be searchable and alertable with the `http.url` and `http.status_code` properties, learn more about it in the [Searchable Properties](/product/sentry-basics/search/searchable-properties/) docs.
 
-### Customize or drop the error event
+### Customize or Drop the Error Event
 
 For that, you need to do a [Manual Initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -269,7 +269,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. In the case of a plain string, it must contain at least one of the items from the list. Plain strings do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
 
 ```kotlin
 import okhttp3.OkHttpClient

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -269,7 +269,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-HTTP Client errors from every target (`.*` Regular expression) will be automatically captured, but you can change this behavior by setting the `failedRequestTargets` option either with a Regular expression or a plain `String`, in the case of a plain string, contains at least one of the items from the list. Plain strings do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. In the case of a plain string, it must contain at least one of the items from the list. Plain strings do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
 
 ```kotlin
 import okhttp3.OkHttpClient

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -337,4 +337,4 @@ try {
 }
 ```
 
-The recommendation is to identify those errors and to __not__ capture them manually with the `Sentry.captureException` method.
+We recommend you identify those errors and  __not__ capture them manually with the `Sentry.captureException` method.

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -283,7 +283,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-By default, error events won't contain any PII data such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`.
+By default, error events won't contain any PII data such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`:
 
 ```xml {filename:AndroidManifest.xml}
 <application>

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -242,7 +242,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
 
 ## HTTP Client Errors
 
-HTTP client errors, like bad response code, are captured as error events and reported to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
+This feature, once enabled, automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
 
 This feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -295,7 +295,7 @@ Those events are searchable and you can set alerts on them if you use the `http.
 
 ### Customize or Drop the Error Event
 
-For that, you need to do a [Manual Initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
+For that, you need to do a [manual initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
 
 The captured error event can be customized or dropped with a `BeforeSendCallback`:
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -255,7 +255,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-Only HTTP Client errors with the response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option.
+Only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option:
 
 ```kotlin
 import okhttp3.OkHttpClient

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -291,7 +291,7 @@ By default, error events won't contain any PII data such as `Headers` and `Cooki
 </application>
 ```
 
-Those events can be searchable and alertable with the `http.url` and `http.status_code` properties, learn more about it in the [Searchable Properties](/product/sentry-basics/search/searchable-properties/) docs.
+Those events are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
 
 ### Customize or Drop the Error Event
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -240,7 +240,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
   .build();
 ```
 
-## HTTP Client errors
+## HTTP Client Errors
 
 HTTP Client errors such as bad response code are captured as error events and reported to Sentry. The error event will contain the `request` and `response` data such as `url`, `status_code`, and so on.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -239,3 +239,89 @@ private final OkHttpClient client = new OkHttpClient.Builder()
   .addInterceptor(new SentryOkHttpInterceptor(new CustomBeforeSpanCallback()))
   .build();
 ```
+
+## HTTP Client errors
+
+HTTP Client errors such as bad response code are captured as error events and reported to Sentry. The error event will contain the `request` and `response` data such as `url`, `status_code`, and so on.
+
+This feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.android.okhttp.SentryOkHttpInterceptor
+
+private val client = OkHttpClient.Builder()
+  .addInterceptor(SentryOkHttpInterceptor(captureFailedRequests = true))
+  .build()
+```
+
+Only HTTP Client errors with the response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.HttpStatusCodeRange
+
+private val client = OkHttpClient.Builder()
+  .addInterceptor(SentryOkHttpInterceptor(
+    captureFailedRequests = true,
+    failedRequestStatusCodes = listOf(HttpStatusCodeRange(400, 599))))
+  .build()
+```
+
+HTTP Client errors from every target (`.*` Regular expression) will be automatically captured, but you can change this behavior by setting the `failedRequestTargets` option either with a `String.contains` value or a Regular expression.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.HttpStatusCodeRange
+
+private val client = OkHttpClient.Builder()
+  .addInterceptor(SentryOkHttpInterceptor(
+    captureFailedRequests = true,
+    failedRequestTargets = listOf("myapi.com")))
+  .build()
+```
+
+By default, error events won't contain any PII data such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`.
+
+```xml {filename:AndroidManifest.xml}
+<application>
+  <meta-data android:name="io.sentry.send-default-pii" android:value="true" />
+</application>
+```
+
+Those events can be searchable and alertable with the `http.url` and `http.status_code` properties, learn more about it in the [Searchable Properties](/product/sentry-basics/search/searchable-properties/) docs.
+
+### Customize or drop the error event
+
+For that, you need to do a [Manual Initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
+
+The captured error event can be customized or dropped with a `BeforeSendCallback`:
+
+```kotlin
+import io.sentry.android.core.SentryAndroid
+import io.sentry.SentryOptions.BeforeSendCallback
+import okhttp3.Request
+import okhttp3.Response
+import io.sentry.TypeCheckHint.OKHTTP_REQUEST
+import io.sentry.TypeCheckHint.OKHTTP_RESPONSE
+
+SentryAndroid.init(this) { options ->
+  // Add a callback that will be used before the event is sent to Sentry.
+  // With this callback, you can modify the event or, when returning null, also discard the event.
+  options.beforeSend = BeforeSendCallback { event, hint ->
+    val request = hint.getAs(OKHTTP_REQUEST, Request::class.java)
+    val response = hint.getAs(OKHTTP_RESPONSE, Response::class.java)
+
+    // customize or drop the event
+    event
+  }
+}
+```
+
+### Automatically captured HTTP Client errors and manually captured errors
+
+When `captureFailedRequests` is enabled, be aware that some HTTP Client libraries throw Unchecked exceptions such as `retrofit2.HttpException`, in this case, the error event will be captured twice, once by the HTTP Client library and once by the Sentry Android SDK.
+
+The recommendation is to identify those errors and to __not__ capture them manually with the `Sentry.captureException` method.

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -242,7 +242,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
 
 ## HTTP Client Errors
 
-HTTP Client errors such as bad response code are captured as error events and reported to Sentry. The error event will contain the `request` and `response` data such as `url`, `status_code`, and so on.
+HTTP client errors, like bad response code, are captured as error events and reported to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
 
 This feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -283,7 +283,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-By default, error events won't contain any PII data such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`:
+By default, error events won't contain any PII data, such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`:
 
 ```xml {filename:AndroidManifest.xml}
 <application>

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -320,7 +320,7 @@ SentryAndroid.init(this) { options ->
 }
 ```
 
-### Automatically captured HTTP Client errors and manually captured errors
+### Automatically Captured HTTP Client Errors and Manually Captured Errors
 
 When `captureFailedRequests` is enabled, be aware that some HTTP Client libraries throw Unchecked exceptions such as `retrofit2.HttpException`, in this case, the error event will be captured twice, once by the HTTP Client library and once by the Sentry Android SDK.
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -324,4 +324,17 @@ SentryAndroid.init(this) { options ->
 
 When `captureFailedRequests` is enabled, be aware that some HTTP Client libraries throw Unchecked exceptions such as `retrofit2.HttpException`, in this case, the error event will be captured twice, once by the HTTP Client library and once by the Sentry Android SDK.
 
+```kotlin
+import io.sentry.Sentry
+import retrofit2.HttpException
+
+try {
+  // If this API call returns 500, it will be captured as an error event by the `SentryOkHttpInterceptor`.
+  return GithubAPI.service.listReposAsync("getsentry")
+} catch (e: HttpException) {
+  // Do not manually capture this exception to avoid duplicated error events.
+  // Sentry.captureException(e)
+}
+```
+
 The recommendation is to identify those errors and to __not__ capture them manually with the `Sentry.captureException` method.

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -269,7 +269,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-HTTP Client errors from every target (`.*` Regular expression) will be automatically captured, but you can change this behavior by setting the `failedRequestTargets` option either with a `String.contains` value or a Regular expression.
+HTTP Client errors from every target (`.*` Regular expression) will be automatically captured, but you can change this behavior by setting the `failedRequestTargets` option either with a Regular expression or a plain `String`, in the case of a plain string, contains at least one of the items from the list. Plain strings do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
 
 ```kotlin
 import okhttp3.OkHttpClient

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -322,7 +322,7 @@ SentryAndroid.init(this) { options ->
 
 ### Automatically Captured HTTP Client Errors and Manually Captured Errors
 
-When `captureFailedRequests` is enabled, be aware that some HTTP Client libraries throw Unchecked exceptions such as `retrofit2.HttpException`, in this case, the error event will be captured twice, once by the HTTP Client library and once by the Sentry Android SDK.
+When `captureFailedRequests` is enabled, some HTTP client libraries throw unchecked exceptions like `retrofit2.HttpException`. In this case, the error event is captured twice; once by the HTTP client library and once by the Sentry Android SDK:
 
 ```kotlin
 import io.sentry.Sentry

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -295,7 +295,7 @@ Those events are searchable and you can set alerts on them if you use the `http.
 
 ### Customize or Drop the Error Event
 
-For that, you need to do a [manual initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
+To customize or drop the error event, you need to do a [manual initialization](/platforms/android/configuration/manual-init/) of the Sentry Android SDK.
 
 The captured error event can be customized or dropped with a `BeforeSendCallback`:
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -255,7 +255,7 @@ private val client = OkHttpClient.Builder()
   .build()
 ```
 
-Only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option:
+By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option:
 
 ```kotlin
 import okhttp3.OkHttpClient


### PR DESCRIPTION
Blocked by https://github.com/getsentry/sentry-java/pull/2287 till it gets released.