### PR TITLE
Add SENTRY_ALLOW_FAILURE into react-native troubleshooting page

### DIFF
--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -245,7 +245,7 @@ If you're using the new architecture on React Native, you might be missing the J
 
 ## Failing Build Due to `sentry-cli`
 
-If your build fails due to Sentry CLI error, because you don't have internet connection or [sentry.io](https://sentry.io) is down, you can allow failure of the `sentry-cli` step by adding an environmental variable `SENTRY_ALLOW_FAILURE` equal to `true`. The CLI will still run, but won't cause the build to fail:
+If your build fails due to Sentry CLI error, because you don't have internet connection, or because [sentry.io](https://sentry.io) is down, you can allow failure of the `sentry-cli` step by adding an environmental variable `SENTRY_ALLOW_FAILURE` equal to `true`. The CLI will still run, but won't cause the build to fail:
 
 ```bash
 # iOS
@@ -255,6 +255,6 @@ SENTRY_ALLOW_FAILURE=true npx react-native run-ios
 SENTRY_ALLOW_FAILURE=true npx react-native run-android
 ```
 
-Note that if source-maps upload failed it will have to be done [manually](/platforms/react-native/sourcemaps) later when the connection is restored.
+Note that if the source maps upload fails, you'll have to do it [manually](/platforms/react-native/sourcemaps) later when the connection is restored.
 
-When you remove the environmental variable in front of your build command your build will work as before.
+When you remove the environmental variable in front of your build command, your build will work as before.


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-react-native/issues/2246