### PR TITLE
Document that issue-link hook `actor.id` is a number

### DIFF
--- a/src/docs/product/integrations/integration-platform/ui-components/issue-link.mdx
+++ b/src/docs/product/integrations/integration-platform/ui-components/issue-link.mdx
@@ -96,7 +96,7 @@ When a user attempts to create or link an issue, we will send a request to your 
   "issueId": <String>,
   "webUrl": <String>,
   "project": {"slug": <String>, "id": <String>},
-  "actor": {"type": "user", "name": <String>, "id": <String>},
+  "actor": {"type": "user", "name": <String>, "id": <Number>},
 }
 ```
 


### PR DESCRIPTION
I had a dictionary of `[String: User]` and was trying to look up additional user information (like email address), but for some reason that the ID was never found in my list.

Eventually I realized that, while the APIs return IDs as strings (of numbers), the field here seems to be a number directly. Code in question is at:

https://github.com/getsentry/sentry/blob/da7e0f5c3deffa6987059744a1d9df6cd9ea2443/src/sentry/mediators/external_requests/issue_link_requester.py#L116

I guess since the hook contract can't be modified easily, this means the documentation needs to be updated?

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
