### PR TITLE
Capacitor: Add troubleshooting for Sibling SDKs

### DIFF
--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -5,6 +5,38 @@ keywords: ["minimum version", "deployment target"]
 sidebar_order: 1000
 ---
 
+### Different versions for Sibling SDKs 
+
+Sentry Capacitor requires your app to use the same versions of @Sentry/Angular (or another Sibling SDK) that is refered by the peer dependency of Sentry Capacitor, to avoid any issues when installing packages or using the code on another machine, it's recommended to use the exact version of both sentry/capacitor and the sibling SDK. 
+
+Correct
+
+```xml
+    "@sentry/angular": "7.13.0",
+    "@sentry/capacitor": "0.10.1"
+```
+
+Incorrect
+
+```xml
+    "@sentry/angular": "^7.13.0",
+    "@sentry/capacitor": "^0.10.1"
+```
+
+One side effect of mismatching the SDKs is the follwing error during build time:
+
+```js
+node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
+```
+
+To solve this you must use the exact version of the Sibling SDK.
+
+<Note>
+
+You can verify the correct version of the sibling SDK using the following command: `npm info @sentry/capacitor peerDependencies`
+
+</Note>
+
 ## Capacitor 2 on iOS
 
 Capacitor 3 has a minimum requirement of iOS 12.0. As a result, the Sentry SDK needs to match this requirement to support Capacitor 3. Users on older versions may run into an error similar to:

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -7,6 +7,12 @@ sidebar_order: 1000
 
 ## Different Versions for Sibling SDKs 
 
+If you see the following error during build time, the sibling SDKs installed in your app have mismatched versions:
+
+```js
+  node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
+```
+
 To avoid any issues when installing packages or using the code on another machine, you must use the same version of Sentry Capacitor and @Sentry/Angular (or any other sibling SDK) that is referred by the peer dependency of Sentry Capacitor in your app.  
 
 Correct:
@@ -22,15 +28,8 @@ Incorrect:
     "@sentry/angular": "^7.13.0",
     "@sentry/capacitor": "^0.10.1"
 ```
-
-If you see the following error during build time, the sibling SDKs installed in your app have mismatched versions:
-
-```js
-  node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
-```
-
-
 You can check which version of the sibling SDK is installed using the following command: `npm info @sentry/capacitor peerDependencies`
+
 ## Capacitor 2 on iOS
 
 Capacitor 3 has a minimum requirement of iOS 12.0. As a result, the Sentry SDK needs to match this requirement to support Capacitor 3. Users on older versions may run into an error similar to:

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -5,38 +5,32 @@ keywords: ["minimum version", "deployment target"]
 sidebar_order: 1000
 ---
 
-### Different versions for Sibling SDKs 
+## Different Versions for Sibling SDKs 
 
-Sentry Capacitor requires your app to use the same versions of @Sentry/Angular (or another Sibling SDK) that is refered by the peer dependency of Sentry Capacitor, to avoid any issues when installing packages or using the code on another machine, it's recommended to use the exact version of both sentry/capacitor and the sibling SDK. 
+To avoid any issues when installing packages or using the code on another machine, you must use the same version of Sentry Capacitor and @Sentry/Angular (or any other sibling SDK) that is referred by the peer dependency of Sentry Capacitor in your app.  
 
-Correct
+Correct:
 
 ```xml
     "@sentry/angular": "7.13.0",
     "@sentry/capacitor": "0.10.1"
 ```
 
-Incorrect
+Incorrect:
 
 ```xml
     "@sentry/angular": "^7.13.0",
     "@sentry/capacitor": "^0.10.1"
 ```
 
-One side effect of mismatching the SDKs is the follwing error during build time:
+If you see the following error during build time, the sibling SDKs installed in your app have mismatched versions:
 
 ```js
   node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
 ```
 
-To solve this you must use the exact version of the Sibling SDK.
-
-<Note>
 
 You can verify the correct version of the sibling SDK using the following command: `npm info @sentry/capacitor peerDependencies`
-
-</Note>
-
 ## Capacitor 2 on iOS
 
 Capacitor 3 has a minimum requirement of iOS 12.0. As a result, the Sentry SDK needs to match this requirement to support Capacitor 3. Users on older versions may run into an error similar to:

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -28,7 +28,7 @@ Incorrect:
     "@sentry/angular": "^7.13.0",
     "@sentry/capacitor": "^0.10.1"
 ```
-You can check which version of the sibling SDK is installed using the following command: `npm info @sentry/capacitor peerDependencies`
+You can check which version of the sibling SDK is installed using the following command: `npm info @sentry/capacitor peerDependencies`.
 
 ## Capacitor 2 on iOS
 

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -13,7 +13,7 @@ If you see the following error during build time, the sibling SDKs installed in 
   node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
 ```
 
-To avoid any issues when installing packages or using the code on another machine, you must use the same version of Sentry Capacitor and @Sentry/Angular (or any other sibling SDK) that is referred by the peer dependency of Sentry Capacitor in your app.  
+To avoid any issues when installing packages or using the code on another machine, you must use the same version of Sentry Capacitor and @Sentry/Angular (or any other sibling SDK) that is referenced by the peer dependency of Sentry Capacitor in your app.  
 
 Correct:
 

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -30,7 +30,7 @@ If you see the following error during build time, the sibling SDKs installed in 
 ```
 
 
-You can verify the correct version of the sibling SDK using the following command: `npm info @sentry/capacitor peerDependencies`
+You can check which version of the sibling SDK is installed using the following command: `npm info @sentry/capacitor peerDependencies`
 ## Capacitor 2 on iOS
 
 Capacitor 3 has a minimum requirement of iOS 12.0. As a result, the Sentry SDK needs to match this requirement to support Capacitor 3. Users on older versions may run into an error similar to:

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -26,7 +26,7 @@ Incorrect
 One side effect of mismatching the SDKs is the follwing error during build time:
 
 ```js
-node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
+  node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
 ```
 
 To solve this you must use the exact version of the Sibling SDK.

--- a/src/wizard/capacitor/index.md
+++ b/src/wizard/capacitor/index.md
@@ -31,8 +31,6 @@ The version of the sibling SDK must match with the version refered by Sentry Cap
 
 </Note>
 
-
-
 ## Capacitor 2 - Android Installation
 
 <Note>

--- a/src/wizard/capacitor/index.md
+++ b/src/wizard/capacitor/index.md
@@ -27,7 +27,7 @@ yarn add @sentry/capacitor
 
 <Note>
 
-The version of the sibling SDK must match with the version refered by Sentry Capacitor. To verify the correct version of the sibling SDK using the following command: `npm info @sentry/capacitor peerDependencies`
+The version of the sibling SDK must match with the version referred by Sentry Capacitor. To check which version of the sibling SDK is installed, use the following command: `npm info @sentry/capacitor peerDependencies`
 
 </Note>
 

--- a/src/wizard/capacitor/index.md
+++ b/src/wizard/capacitor/index.md
@@ -12,7 +12,7 @@ Install the Sentry Capacitor SDK alongside the sibling Sentry Angular SDK:
 npm install --save @sentry/capacitor @sentry/angular
 
 # yarn
-yarn add @sentry/capacitor @sentry/angular @sentry/tracing
+yarn add @sentry/capacitor @sentry/angular @sentry/tracing --exact
 ```
 
 Or install the standalone Sentry Capacitor SDK if you don't use Ionic/Angular:
@@ -24,6 +24,14 @@ npm install --save @sentry/capacitor @sentry/tracing
 # yarn
 yarn add @sentry/capacitor
 ```
+
+<Note>
+
+The version of the sibling SDK must match with the version refered by Sentry Capacitor. To verify the correct version of the sibling SDK using the following command: `npm info @sentry/capacitor peerDependencies`
+
+</Note>
+
+
 
 ## Capacitor 2 - Android Installation
 


### PR DESCRIPTION
The PR explains the importance of using the exact version of the Sibling SDK for Capacitor and a side effect of not doing so.

Wizard was also updated in order to avoid mismatched versions when installing Sentry Capacitor with a sibling SDK.