### PR TITLE
Document SDK usage of Flutter `PlatformDispatcher.onError` callback

### DIFF
--- a/src/platform-includes/capture-error/flutter.mdx
+++ b/src/platform-includes/capture-error/flutter.mdx
@@ -1,4 +1,5 @@
 <PlatformContent includePath="capture-error/dart.mdx" />
 
 - Flutter-specific errors, such as using `FlutterError.onError`, are captured automatically
-- Errors not cuaght by Flutter will be automatically recorded by the SDK using the [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) callback. For Flutter versions lower than 3.3, the `AppRunner` you provide on init will be run inside a custom zone using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to records errors.
+- For Flutter <3.3, the SDK runs your init `appRunner` callback in a custom error zone, using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to automatically record errors not caught by flutter.
+- Starting with Flutter 3.3, the SDK uses [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) to automatically record errors not caught by flutter.

--- a/src/platform-includes/capture-error/flutter.mdx
+++ b/src/platform-includes/capture-error/flutter.mdx
@@ -1,5 +1,4 @@
 <PlatformContent includePath="capture-error/dart.mdx" />
 
 - Flutter-specific errors, such as using `FlutterError.onError`, are captured automatically
-- For Flutter <3.3, the SDK runs your init `appRunner` callback in a custom error zone, using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to automatically record errors not caught by flutter.
-- Starting with Flutter 3.3, the SDK uses [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) to automatically record errors not caught by flutter.
+- The SDK already runs your init `callback` on an error handler, such as [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) on Flutter versions prior to `3.3`, or [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) on Flutter versions 3.3 and higher, so that errors are automatically captured.

--- a/src/platform-includes/capture-error/flutter.mdx
+++ b/src/platform-includes/capture-error/flutter.mdx
@@ -1,4 +1,4 @@
 <PlatformContent includePath="capture-error/dart.mdx" />
 
 - Flutter-specific errors, such as using `FlutterError.onError`, are captured automatically
-- The SDK already runs your init `callback` on an error handler, such as using `runZonedGuarded`, are captured automatically
+- Errors not cuaght by Flutter will be automatically recorded by the SDK using the [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) callback. For Flutter versions lower than 3.3, the `AppRunner` you provide on init will be run inside a custom zone using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to records errors.

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -5,7 +5,7 @@ sidebar_order: 1000
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 
-On Flutter < 3.3 we keep running your `appRunner` callback in a custom error zone ([`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html)). Starting with Flutter `3.3`, we are using [`PlatFormdispatcher.onError`](https://docs.flutter.dev/testing/errors#errors-not-caught-by-flutter) to automatically record errors not caught by flutter. No code changes are needed for this behaviour.
+The SDK already runs your init `callback` on an error handler, such as [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) on Flutter versions prior to `3.3`, or [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) on Flutter versions 3.3 and higher, so that errors are automatically captured. No code changes are needed on your part.
 
 ## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
 

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -3,6 +3,10 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
+## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
+
+Errors that are not caught by Flutter are recorded using [`PlatFormdispatcher.onError`](https://docs.flutter.dev/testing/errors#errors-not-caught-by-flutter). The SDK will install it's own callback and record errors automatically for Flutter versions 3.3 and above. Please consider this, if you yourself want to use the callback. For Flutter versions lower than 3.3, the `AppRunner` you provide on init will be run inside a custom zone using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to records errors.
+
 ## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
 
 There are no Flutter-specific breaking changes. However, there are some in [sentry](/platforms/dart/migration/) for Dart.

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -5,7 +5,7 @@ sidebar_order: 1000
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 
-Errors that are not caught by Flutter are recorded using [`PlatFormdispatcher.onError`](https://docs.flutter.dev/testing/errors#errors-not-caught-by-flutter). The SDK will install it's own callback and record errors automatically for Flutter versions 3.3 and above. Please consider this, if you yourself want to use the callback. For Flutter versions lower than 3.3, the `AppRunner` you provide on init will be run inside a custom zone using [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) to records errors.
+On Flutter < 3.3 we keep running your `appRunner` callback in a custom error zone ([`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html)). Starting with Flutter `3.3`, we are using [`PlatFormdispatcher.onError`](https://docs.flutter.dev/testing/errors#errors-not-caught-by-flutter) to automatically record errors not caught by flutter. No code changes are needed for this behaviour.
 
 ## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
 


### PR DESCRIPTION


<!-- Describe your PR here. -->

Mention usage of `PlatformDispatcher.onError` of SDK.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
