### PR TITLE
Laravel 3.0.0

### DIFF
--- a/src/platforms/php/guides/laravel/configuration/laravel-options.mdx
+++ b/src/platforms/php/guides/laravel/configuration/laravel-options.mdx
@@ -89,6 +89,9 @@ You can also configure what is being monitored automatically. These settings hav
     // Indicates if the tracing integrations supplied by Sentry should be loaded
     // See all default integration: https://github.com/getsentry/sentry-laravel/tree/master/src/Sentry/Laravel/Tracing/Integrations
     'default_integrations' => true,
+
+    // Indicates that requests without a matching route should be traced
+    'missing_routes' => false,
 ],
 ```
 

--- a/src/platforms/php/guides/laravel/other-versions/index.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/index.mdx
@@ -1,8 +1,6 @@
 ---
 title: Other Versions
 description: "Learn about using Sentry with Laravel Lumen or Laravel 4.x/5.x/6.x/7.x."
-redirect_from:
-  - /platforms/php/guides/laravel/configuration/other-versions/
 ---
 
 <PageGrid />

--- a/src/platforms/php/guides/laravel/other-versions/laravel4.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel4.mdx
@@ -1,7 +1,7 @@
 ---
 title: Laravel 4.x
 description: "Learn about using Sentry with Laravel 4.x."
-sidebar_order: 800
+sidebar_order: 300
 redirect_from:
   - /platforms/php/guides/laravel/configuration/other-versions/laravel4/
 ---

--- a/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
@@ -23,7 +23,7 @@ Install the `sentry/sentry-laravel` package:
 composer require "sentry/sentry-laravel:^2.14"
 ```
 
-If you're on Laravel 5.5 or higher, the package will be auto-discovered. Otherwise you will need to manually configure it in your `config/app.php`.
+If you're on Laravel 5.5 or higher, the package will be auto-discovered. Otherwise, you will need to manually configure it in your `config/app.php`.
 
 ```php {filename:config/app.php}
 'providers' => array(

--- a/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
@@ -1,14 +1,18 @@
 ---
-title: Laravel Lumen
-description: "Learn about using Sentry with Laravel Lumen."
-sidebar_order: 400
-redirect_from:
-  - /platforms/php/guides/laravel/configuration/other-versions/lumen/
+title: Laravel 5.x
+description: "Learn about using Sentry with Laravel 5.x."
+sidebar_order: 200
 ---
+
+<Note>
+
+Laravel 5.x is supported until version 2.14.x of the `sentry/sentry-laravel` package.
+
+</Note>
 
 Laravel is supported using a native package: [sentry-laravel](https://github.com/getsentry/sentry-laravel).
 
-This guide is for Laravel Lumen 5+. We also provide instructions for [the latest Laravel](/platforms/php/guides/laravel/) as well as [other versions](/platforms/php/guides/laravel/other-versions/).
+This guide is for Laravel 5.x. We also provide instructions for [the latest Laravel](/platforms/php/guides/laravel/) as well as [Lumen-specific instructions](/platforms/php/guides/laravel/other-versions/lumen/).
 
 
 ## Install
@@ -19,24 +23,25 @@ Install the `sentry/sentry-laravel` package:
 composer require "sentry/sentry-laravel:^2.14"
 ```
 
-Register Sentry in `bootstrap/app.php`:
+If you're on Laravel 5.5 or higher, the package will be auto-discovered. Otherwise you will need to manually configure it in your `config/app.php`.
 
-```php {filename:bootstrap/app.php}
-$app->register('Sentry\Laravel\ServiceProvider');
-
-// To enable Sentry Performance Monitoring, the `TracingServiceProvider` has to be registered additionally:
-// $app->register('Sentry\Laravel\Tracing\ServiceProvider');
-
-// Sentry must be registered before routes are included
-require __DIR__ . '/../app/Http/routes.php';
+```php {filename:config/app.php}
+'providers' => array(
+    // ...
+    Sentry\Laravel\ServiceProvider::class,
+),
+'aliases' => array(
+    // ...
+    'Sentry' => Sentry\Laravel\Facade::class,
+),
 ```
 
-Add Sentry reporting to `app/Exceptions/Handler.php`:
+Add Sentry reporting to `App/Exceptions/Handler.php`.
 
-```php {filename:app/Exceptions/Handler.php}
+```php {filename:App/Exceptions/Handler.php}
 public function report(Exception $exception)
 {
-    if (app()->bound('sentry') && $this->shouldReport($exception)) {
+    if ($this->shouldReport($exception) && app()->bound('sentry')) {
         app('sentry')->captureException($exception);
     }
 
@@ -47,13 +52,13 @@ public function report(Exception $exception)
 
 ## Configure
 
-Copy the Sentry configuration file from the vendor directory:
+Configure the Sentry DSN with this command:
 
-```bash
-cp vendor/sentry/sentry-laravel/config/sentry.php config/sentry.php
+```shell
+php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
-Afterwards, add your DSN to `.env`:
+It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/src/platforms/php/guides/laravel/other-versions/laravel6-7.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel6-7.mdx
@@ -1,15 +1,12 @@
 ---
-title: Laravel 5.x, 6.x, and 7.x
-description: "Learn about using Sentry with Laravel 5.x, 6.x, and 7.x."
-sidebar_order: 600
-redirect_from:
-  - /platforms/php/guides/laravel/other-versions/laravel5-6/
-  - /platforms/php/guides/laravel/configuration/other-versions/laravel5-6/
+title: Laravel 6.x, and 7.x
+description: "Learn about using Sentry with Laravel 6.x, and 7.x."
+sidebar_order: 100
 ---
 
 Laravel is supported using a native package: [sentry-laravel](https://github.com/getsentry/sentry-laravel).
 
-This guide is for Laravel 5.x, 6.x, and 7.x. We also provide instructions for [the latest Laravel](/platforms/php/guides/laravel/) as well as [Lumen-specific instructions](/platforms/php/guides/laravel/other-versions/lumen/).
+This guide is for Laravel 6.x, and 7.x. We also provide instructions for [the latest Laravel](/platforms/php/guides/laravel/) as well as [Lumen-specific instructions](/platforms/php/guides/laravel/other-versions/lumen/).
 
 
 ## Install

--- a/src/platforms/php/guides/laravel/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/php/guides/laravel/performance/instrumentation/automatic-instrumentation.mdx
@@ -9,4 +9,5 @@ The Laravel integration automatically instruments your application to capture tr
 - Views
 - Queue jobs
 - Database queries
+- Laravel HTTP Client
 - GraphQL operations (when using [Lighthouse](https://lighthouse-php.com/))


### PR DESCRIPTION
Updates the Laravel docs to be in line with our new major [v3.0.0](https://github.com/getsentry/sentry-laravel/releases/tag/3.0.0).
As Laravel 5.x is now deprecated, I moved it to its own page.