### PR TITLE
updated incorrect links to data forwarding page

### DIFF
--- a/src/docs/product/integrations/data-visualization/amazon-sqs/index.mdx
+++ b/src/docs/product/integrations/data-visualization/amazon-sqs/index.mdx
@@ -26,6 +26,6 @@ Navigate to **Settings > Integrations > Amazon SQS**
 
 ### Data Forwarding
 
-Configure [Data Forwarding](/platform-redirect/?next=/data-management/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
+Configure [Data Forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
 
 The payload for Amazon is identical to our standard API event payload and will evolve over time. For more details on the format of this data, see our [API documentation](/api/events/retrieve-an-event-for-a-project/).

--- a/src/docs/product/integrations/data-visualization/amazon-sqs/index.mdx
+++ b/src/docs/product/integrations/data-visualization/amazon-sqs/index.mdx
@@ -26,6 +26,6 @@ Navigate to **Settings > Integrations > Amazon SQS**
 
 ### Data Forwarding
 
-Configure [Data Forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
+Configure [data forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
 
 The payload for Amazon is identical to our standard API event payload and will evolve over time. For more details on the format of this data, see our [API documentation](/api/events/retrieve-an-event-for-a-project/).

--- a/src/docs/product/integrations/data-visualization/segment/index.mdx
+++ b/src/docs/product/integrations/data-visualization/segment/index.mdx
@@ -30,4 +30,4 @@ Navigate to **Settings > Integrations > Segment**
 
 ### Data Forwarding
 
-Configure [data forwarding](/platform-redirect/?next=/data-management/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
+Configure [data forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.

--- a/src/docs/product/integrations/data-visualization/splunk/index.mdx
+++ b/src/docs/product/integrations/data-visualization/splunk/index.mdx
@@ -89,7 +89,7 @@ In Sentry, navigate to the project you want to forward events from, and click "P
 
 ### Data Forwarding
 
-Configure [Data Forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
+Configure [data forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
 
 After navigating to **Data Forwarding**, enable the Splunk integration:
 

--- a/src/docs/product/integrations/data-visualization/splunk/index.mdx
+++ b/src/docs/product/integrations/data-visualization/splunk/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 description: "Learn more about Sentry's Splunk integration and how you can connect Splunk to Sentry with Data Forwarding."
 ---
 
-Connect Splunk to Sentry with the [Data Forwarding](/platform-redirect/?next=/data-management/data-forwarding/) feature.
+Connect Splunk to Sentry with the [Data Forwarding](/product/data-management-settings/data-forwarding/) feature.
 
 <Note>
 
@@ -89,7 +89,7 @@ In Sentry, navigate to the project you want to forward events from, and click "P
 
 ### Data Forwarding
 
-Configure [Data Forwarding](/platform-redirect/?next=/data-management/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
+Configure [Data Forwarding](/product/data-management-settings/data-forwarding/) in **[Project] > Settings > Data Forwarding**, and provide the required information for the given integration.
 
 After navigating to **Data Forwarding**, enable the Splunk integration:
 


### PR DESCRIPTION
Updated data forwarding link. Previously it took you to https://docs.sentry.io/platform-redirect/?next=/data-management/data-forwarding/ which further redirected to “Page Not Found” because the content had been moved to a product page.
