### PR TITLE
fix: Change casing of javascript webhook property

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -56,7 +56,7 @@ function verifySignature(request, secret = "") {
   const hmac = crypto.createHmac("sha256", secret);
   hmac.update(JSON.stringify(request.body), "utf8");
   const digest = hmac.digest("hex");
-  return digest === request.headers["Sentry-Hook-Signature"];
+  return digest === request.headers["sentry-hook-signature"];
 }
 ```
 


### PR DESCRIPTION
Updating the casing in the Javascript Verifying signature example. 

from `Sentry-Hook-Signature` to `sentry-hook-signature`

The header is received in my test webhook in all lowercase `sentry-hook-signature`, and it is also used like that in the python example. One customer reported getting errors when copying the code due to the wrong case.
