### PR TITLE
add `RequestData` integration

### DIFF
--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -139,3 +139,36 @@ _(New in version 7.13.0.)_
 _Import name: `Sentry.Integrations.Modules`_
 
 This integration fetches names of all currently installed Node modules and attaches the list to the event. Once fetched, Sentry will cache the list for later reuse.
+
+### RequestData
+
+_(New in version 7.17.1.)_
+
+_Import name: `Sentry.Integrations.RequestData`_
+
+This integration adds data from incoming requests to transaction and error events that occur during request handling.
+
+Available options:
+
+```javascript
+{
+  // Controls what types of data are added to the event
+  include: {
+    cookies: boolean  // default: true,
+    data: boolean  // default: true,
+    headers: boolean  // default: true,
+    ip: boolean  // default: false,
+    query_string: boolean  // default: true,
+    url: boolean  // default: true,
+    user: boolean | {
+      id: boolean  // default: true,
+      username: boolean  // default: true,
+      email: boolean  // default: true,
+    },
+  },
+  // Controls how the transaction will be reported. Options are 'path' (`/some/route`),
+  // 'methodPath' (`GET /some/route`), and 'handler' (the name of the route handler
+  // function, if available)
+  transactionNamingScheme: string  // default: 'methodPath',
+};
+```

--- a/src/platforms/node/guides/azure-functions/index.mdx
+++ b/src/platforms/node/guides/azure-functions/index.mdx
@@ -30,7 +30,10 @@ module.exports = async function(context, req) {
   try {
     await notExistFunction();
   } catch (e) {
-    Sentry.captureException(e);
+    Sentry.withScope(scope => {
+      scope.setSDKProcessingMetadata({ request: req });
+      Sentry.captureException(e);
+    });
     await Sentry.flush(2000);
   }
 

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -31,10 +31,8 @@ const app = new Koa();
 Sentry.init({ dsn: "___PUBLIC_DSN___" });
 
 app.on("error", (err, ctx) => {
-  Sentry.withScope((scope) => {
-    scope.addEventProcessor((event) => {
-      return Sentry.addRequestDataToEvent(event, ctx.request);
-    });
+  Sentry.withScope(scope => {
+    scope.setSDKProcessingMetadata({ request: ctx.request });
     Sentry.captureException(err);
   });
 });


### PR DESCRIPTION
This adds documentation for the new `RequestData` integration in the node SDK, which adds request data to events. For frameworks where we don't have wrappers in the SDK, and merely tell people how to use sentry in the docs, this also adds storing the request in scope metadata to our boilerplate.