### PR TITLE
Fix misleading description of `config.logger` default.

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -121,7 +121,7 @@ config.inspect_exception_causes_for_exclusion = true
 
 `logger`
 
-: The logger used by Sentry. Default is an instance of Sentry::Logger.
+: The logger used by Sentry. Default is `Rails.logger` in Rails, otherwise an instance of `Sentry::Logger`.
 
 ```ruby
 config.logger = Sentry::Logger.new(STDOUT)


### PR DESCRIPTION
This document is transcluded in the [docs for `sentry-rails`](https://docs.sentry.io/platforms/ruby/guides/rails/configuration/options/) as well as [those for `sentry-ruby`](https://docs.sentry.io/platforms/ruby/configuration/options/). This results in the statement about the default setting for `config.logger` being misleading in the Rails case, because the reader might reasonably assume that it's safe to mutate the default logger.

For example, based on these docs I might reasonably expect to be able to set `config.logger.level = Sentry::Logger::WARN` when initialising Sentry, but if I'm in a Rails app I'd be shooting myself in the foot by unwittingly mutating `Rails.logger` through a shared reference.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
