### PR TITLE
fix(icons): updated large remix icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gray-matter": "^4.0.2",
     "jsdom": "^16.3.0",
     "node-sass": "^4.14.1",
-    "platformicons": "^5.2.3",
+    "platformicons": "^5.3.5",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13865,10 +13865,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.3.tgz#180f85a0a973cad36dd9a8abe30b5f38461f3a6e"
-  integrity sha512-8bQtN1qWQJ0wI2p9+xpCOtjCupuJ9HeNzbabRVO5fmivjyvwRxQPDbOS3G5GmKZH1PvZaMyFxWG1mLawgWDGxQ==
+platformicons@^5.3.5:
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.3.5.tgz#32ac95444e53a713160be9ee9c8f5eec466b56f4"
+  integrity sha512-F8wt/IeA44vaJfGcdGHOZ3KhDtDIxzuy3ONPtne4NJ0fVDklICHDe1IJsrbj+xbRNWsijn2l7yXr7AUfq1yzQQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
- Updated to the proper version of platform icons
- Fixes large Remix icon to make it more readable 

### Before 

<img width="172" alt="CleanShot 2022-10-21 at 10 36 41@2x" src="https://user-images.githubusercontent.com/1900676/197256398-91f36e5b-bc6d-4684-9748-e669ec730a16.png">

### After
<img width="172" alt="CleanShot 2022-10-21 at 10 41 07@2x" src="https://user-images.githubusercontent.com/1900676/197256657-74d1f049-82d1-4d2e-b6aa-16b1426a5a36.png">

