### PR TITLE
Update Express performance docs for auto-instrumentation

### DIFF
--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -14,8 +14,8 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 ```javascript
 const Sentry = require("@sentry/node");
 const SentryTracing = require("@sentry/tracing");
-
-const http = require("http");
+const express = require("express");
+const app = express();
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -23,13 +23,38 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new SentryTracing.Integrations.Express({ app }),
+    new SentryTracing.Integrations.Express({
+      // to trace all requests to the default router
+      app,
+      // alternatively, you can specify the routes you want to trace:
+      // router: someRouter,
+    }),
   ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control
   tracesSampleRate: 1.0,
 });
+
+// RequestHandler creates a separate execution context using domains, so that every
+// transaction/span/breadcrumb is attached to its own Hub instance
+app.use(Sentry.Handlers.requestHandler());
+// TracingHandler creates a trace for every incoming request
+app.use(Sentry.Handlers.tracingHandler());
+
+// the rest of your app
+
+// The error handler must be before any other error middleware and after all controllers
+app.use(Sentry.Handlers.errorHandler());
+
+app.listen(3000);
+```
+
+You can also manually create transactions in your app:
+
+```js
+const Sentry = require("@sentry/node");
+const http = require("http");
 
 const transaction = Sentry.startTransaction({
   op: "transaction",


### PR DESCRIPTION
Update the Node/Express performance docs to show how to setup auto-instrumentation, which was previously missing from the performance section.

I basically copied the content from the Express index page over there, as the index page has a "Performance" section with full instructions.

I kept the manual tracing docs as separate section below.

Closes https://github.com/getsentry/sentry-docs/issues/5680
