### PR TITLE
fix extension for typescript with jsx file

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -93,7 +93,7 @@ CustomErrorComponent.getInitialProps = async contextData => {
 export default CustomErrorComponent;
 ```
 
-```typescript {filename:pages/_error.ts}
+```typescript {filename:pages/_error.tsx}
 /**
  * NOTE: This requires `@sentry/nextjs` version 7.3.0 or higher.
  *


### PR DESCRIPTION
My smallest contribution ever but it makes a big difference ;)

In the docs for the nextjs manual setup (https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/) there is a tiny error which has a big impact, the extension for the "_error" file in a nextjs project when using typescript should be ".tsx" and not ".ts", so this PR adds the x to the "_error.ts" filename and fixes the compilation error one will get if using the .ts extension instead of the .tsx extension

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
