### PR TITLE
chore(nextjs): Add next 13 compatibility warning

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.nextjs.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.nextjs.mdx
@@ -4,7 +4,7 @@ Sentry's Next.js SDK enables automatic reporting of errors and exceptions.
 
 </Note>
 
-Currently, the minimum Next.js supported version is `10.0.8`.
+The minimum Next.js supported version is `10.0.8`. While Next.js version 13 is itself supported, the new features it introduces are not yet. In particular, building with Turbopack will currently cause the Sentry SDK not to be included in your app.
 
 Features:
 


### PR DESCRIPTION
Next 13 has just been released, and it includes new features we don't yet support. This adds a note saying so to the top of our nextjs docs.

Issue tracking support in the SDK: https://github.com/getsentry/sentry-javascript/issues/6056