### PR TITLE
feat(android): Add Jetpack Compose navigation instrumentation docs

### DIFF
--- a/src/platforms/android/common/gradle.mdx
+++ b/src/platforms/android/common/gradle.mdx
@@ -314,7 +314,7 @@ To learn more about the internals of auto-instrumentation, check out this [blog 
 
 ## Auto-Installation
 
-The plugin offers the automated installation feature of the Sentry Android SDK and the [Fragment](/platforms/android/configuration/integrations/fragment/), [Timber](/platforms/android/configuration/integrations/timber/), [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Jetpack Compose](/platforms/android/configuration/integrations/jetpack-compose/) integrations. Starting with version 3.1.0, the feature is enabled by default, so you don't need to add any dependencies — you just use the Sentry Gradle plugin.
+The plugin offers the automated installation feature of the Sentry Android SDK and the [Fragment](/platforms/android/configuration/integrations/fragment/), [Timber](/platforms/android/configuration/integrations/timber/), [OkHttp](/platforms/android/configuration/integrations/okhttp/), and [Jetpack Compose](/platforms/android/configuration/integrations/jetpack-compose/) integrations. Starting with version 3.1.0, the feature is enabled by default, so you don't need to add any dependencies — you just use the Sentry Gradle plugin.
 
 The plugin algorithm does the following when defining dependency versions:
 

--- a/src/platforms/android/common/gradle.mdx
+++ b/src/platforms/android/common/gradle.mdx
@@ -89,7 +89,7 @@ sentry {
 
       // Specifies a set of instrumentation features that are eligible for bytecode manipulation.
       // Defaults to all available values of InstrumentationFeature enum class.
-      features = [InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP]
+      features = [InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP, InstrumentationFeature.COMPOSE]
     }
 
     // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
@@ -154,10 +154,10 @@ sentry {
 
       // Specifies a set of instrumentation features that are eligible for bytecode manipulation.
       // Defaults to all available values of InstrumentationFeature enum class.
-      features.set(setOf(InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP))
+      features.set(setOf(InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO, InstrumentationFeature.OKHTTP, InstrumentationFeature.COMPOSE))
     }
 
-    // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
+    // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber, fragment and compose integrations).
     // Default is enabled.
     // Only available v3.1.0 and above.
     autoInstallation {
@@ -292,7 +292,15 @@ enum class InstrumentationFeature {
      * Requires sentry-android SDK version 5.0.0 and above.
      * Only available v3.1.0 and above of the Sentry Android Gradle plugin.
      */
-    OKHTTP
+    OKHTTP,
+
+    /**
+     * When enabled the SDK will create breadcrumbs when navigating
+     * using [androidx.navigation.NavController].
+     * This feature uses bytecode manipulation and adds an OnDestinationChangedListener to all
+     * navigation controllers used in Jetpack Compose.
+     */
+    COMPOSE
 }
 ```
 
@@ -306,7 +314,7 @@ To learn more about the internals of auto-instrumentation, check out this [blog 
 
 ## Auto-Installation
 
-The plugin offers the automated installation feature of the Sentry Android SDK and the [Fragment](/platforms/android/configuration/integrations/fragment/), [Timber](/platforms/android/configuration/integrations/timber/), and [OkHttp](/platforms/android/configuration/integrations/okhttp/) integrations. Starting with version 3.1.0, the feature is enabled by default, so you don't need to add any dependencies — you just use the Sentry Gradle plugin.
+The plugin offers the automated installation feature of the Sentry Android SDK and the [Fragment](/platforms/android/configuration/integrations/fragment/), [Timber](/platforms/android/configuration/integrations/timber/), [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Jetpack Compose](/platforms/android/configuration/integrations/jetpack-compose/) integrations. Starting with version 3.1.0, the feature is enabled by default, so you don't need to add any dependencies — you just use the Sentry Gradle plugin.
 
 The plugin algorithm does the following when defining dependency versions:
 

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -24,7 +24,7 @@ Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/and
 
 ### Disable
 
-If you would like to disable the Jetpack Compose instrumentation feature, you can adapt your `build.gradle(.kts)` file accordingly.
+If you want to disable the Jetpack Compose instrumentation feature, you can adapt your `build.gradle(.kts)` file like so:
 
 ```groovy
 import io.sentry.android.gradle.extensions.InstrumentationFeature

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -49,7 +49,6 @@ sentry {
 }
 ```
 
-
 ## Manual Installation
 
 Sentry captures data by adding a `withSentryObservableEffect` extension function to `NavHostController`. To add the Navigation integration, install the [Android SDK](/platforms/android/), then add the `sentry-compose` dependency using Gradle:

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -8,11 +8,49 @@ categories:
   - mobile
 ---
 
-The `sentry-compose` library provides [Jetpack Compose](https://developer.android.com/jetpack/androidx/releases/compose) Navigation support for Sentry using the [SentryNavigationIntegration](https://github.com/getsentry/sentry-java/blob/524ee49b212c3f2eead20960c3c6825ccdbf8007/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt). The source can be found [on GitHub](https://github.com/getsentry/sentry-java/blob/main/sentry-compose/src/androidMain/kotlin/io/sentry/compose/).
+The `sentry-compose` library provides [Jetpack Compose](https://developer.android.com/jetpack/androidx/releases/compose) Navigation support for Sentry.
 
 On this page, we get you up and running with Sentry's Compose Navigation Integration, so that it will automatically add a breadcrumb and start a transaction for each navigation event.
 
-## Install
+## Auto-Installation With the Sentry Android Gradle Plugin
+
+If you're using the [Sentry Android Gradle Plugin](/platforms/android/gradle/), the Jetpack Compose Navigation Integration is automatically applied. In this case both breadcrumbs and transactions are automatically created for every navigation event.
+
+<Note>
+
+Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/gradle/) documentation. Details about the Auto-Installation can be found in the [Auto Instrumentation section](/platforms/android/gradle/#tracing-auto-instrumentation).
+
+</Note>
+
+### Disable
+
+If you would like to disable the Jetpack Compose instrumentation feature, you can adapt your `build.gradle(.kts)` file accordingly.
+
+```groovy
+import io.sentry.android.gradle.extensions.InstrumentationFeature
+
+sentry {
+  tracingInstrumentation {
+    enabled = true
+    features = EnumSet.allOf(InstrumentationFeature) - InstrumentationFeature.COMPOSE
+  }
+}
+```
+
+```kotlin
+import java.util.EnumSet
+import io.sentry.android.gradle.extensions.InstrumentationFeature
+
+sentry {
+  tracingInstrumentation {
+    enabled.set(true)
+    features.set(EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.COMPOSE)
+  }
+}
+```
+
+
+## Manual Installation
 
 Sentry captures data by adding a `withSentryObservableEffect` extension function to `NavHostController`. To add the Navigation integration, install the [Android SDK](/platforms/android/), then add the `sentry-compose` dependency using Gradle:
 
@@ -21,7 +59,7 @@ implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.androi
 implementation 'io.sentry:sentry-compose-android:{{ packages.version('sentry.java.compose.android', '6.2.0') }}'
 ```
 
-## Configure
+### Configure
 
 Configuration should happen in the respective `@Composable` function, once you obtain an instance of `NavHostController`:
 
@@ -43,7 +81,7 @@ NavHost(
 
 By default, the navigation transaction finishes automatically after it reaches the specified [idleTimeout](/platforms/android/configuration/options/#idle-timeout) and all of its child spans are finished. You can customize the timeout to your needs.
 
-## Verify
+### Verify
 
 This snippet includes a sample `Activity` with a couple of navigation events between composables and captures an intentional message, so you can test that everything is working as soon as you set it up:
 

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -14,7 +14,35 @@ On this page, we get you up and running with Sentry's Compose Navigation Integra
 
 ## Auto-Installation With the Sentry Android Gradle Plugin
 
+### Install
+
 If you're using the [Sentry Android Gradle Plugin](/platforms/android/gradle/), the Jetpack Compose Navigation Integration is automatically applied, and both breadcrumbs and transactions are automatically created for every navigation event.
+
+Add the Sentry Android Gradle plugin in `build.gradle`:
+
+```groovy
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
+}
+```
+
+```kotlin
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
+}
+```
 
 <Note>
 
@@ -51,6 +79,8 @@ sentry {
 
 ## Manual Installation
 
+### Install
+
 Sentry captures data by adding a `withSentryObservableEffect` extension function to `NavHostController`. To add the Navigation integration, install the [Android SDK](/platforms/android/), then add the `sentry-compose` dependency using Gradle:
 
 ```groovy
@@ -80,7 +110,7 @@ NavHost(
 
 By default, the navigation transaction finishes automatically after it reaches the specified [idleTimeout](/platforms/android/configuration/options/#idle-timeout) and all of its child spans are finished. You can customize the timeout to your needs.
 
-### Verify
+## Verify
 
 This snippet includes a sample `Activity` with a couple of navigation events between composables and captures an intentional message, so you can test that everything is working as soon as you set it up:
 

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -18,7 +18,7 @@ If you're using the [Sentry Android Gradle Plugin](/platforms/android/gradle/), 
 
 <Note>
 
-Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/gradle/) documentation. Details about the Auto-Installation can be found in the [Auto Instrumentation section](/platforms/android/gradle/#tracing-auto-instrumentation).
+Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/gradle/) documentation. Details about auto-installation can be found in the [Auto Instrumentation](/platforms/android/gradle/#tracing-auto-instrumentation) section.
 
 </Note>
 

--- a/src/platforms/android/configuration/integrations/jetpack-compose.mdx
+++ b/src/platforms/android/configuration/integrations/jetpack-compose.mdx
@@ -14,7 +14,7 @@ On this page, we get you up and running with Sentry's Compose Navigation Integra
 
 ## Auto-Installation With the Sentry Android Gradle Plugin
 
-If you're using the [Sentry Android Gradle Plugin](/platforms/android/gradle/), the Jetpack Compose Navigation Integration is automatically applied. In this case both breadcrumbs and transactions are automatically created for every navigation event.
+If you're using the [Sentry Android Gradle Plugin](/platforms/android/gradle/), the Jetpack Compose Navigation Integration is automatically applied, and both breadcrumbs and transactions are automatically created for every navigation event.
 
 <Note>
 


### PR DESCRIPTION
Add docs for the upcoming Android Jetpack Compose navigation instrumentation feature.

Relevant code changes:
- https://github.com/getsentry/sentry-android-gradle-plugin/pull/392
- https://github.com/getsentry/sentry-java/pull/2320

Todos
- [x] Wait for feature to be released (should be 6.7.0)