### PR TITLE
Add dedicated RN example to performance metrics

### DIFF
--- a/src/platform-includes/performance/automatic-performance-metrics/react-native.mdx
+++ b/src/platform-includes/performance/automatic-performance-metrics/react-native.mdx
@@ -1,0 +1,4 @@
+If configured, the React Native SDK automatically collects the following performance metrics:
+
+* <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation">Cold and warm app start time</PlatformLink>.
+* <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames">Slow and frozen frame rendering</PlatformLink>.

--- a/src/platform-includes/performance/custom-performance-metrics/react-native.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/react-native.mdx
@@ -1,0 +1,16 @@
+Adding custom metrics is supported in Sentry's React Native SDK version `4.0.0` and above.
+
+```javascript
+import * as Sentry from '@sentry/react-native';
+
+const transaction = Sentry.getCurrentHub().getScope().getTransaction();
+
+// Record amount of memory used
+transaction.setMeasurement('memoryUsed', 123, 'byte');
+
+// Record time when Footer component renders on page
+transaction.setMeasurement('ui.footerComponent.render', 1.3, 'second');
+
+// Record amount of times localStorage was read
+transaction.setMeasurement('localStorageRead', 4);
+```

--- a/src/platforms/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/common/performance/instrumentation/performance-metrics.mdx
@@ -31,7 +31,7 @@ description: "Learn how to attach performance metrics to your transactions."
 
 Sentry's SDKs support sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
 
-<PlatformSection supported={["javascript", "android", "apple", "flutter"]} notSupported={["react-native"]}>
+<PlatformSection supported={["javascript", "android", "apple", "flutter", "react-native"]}>
 
 <PlatformContent includePath="performance/automatic-performance-metrics" />
 


### PR DESCRIPTION
RN example was missing and the RN page showed JS SDK info.

Context: https://github.com/getsentry/team-mobile/issues/51#issuecomment-1292472679