### PR TITLE
Add Distributed Tracing to Node docs

### DIFF
--- a/src/platform-includes/performance/connect-services/node.mdx
+++ b/src/platform-includes/performance/connect-services/node.mdx
@@ -1,6 +1,6 @@
 ## Distributed Tracing
 
-To obtain a trace from a span, use `toTraceParent()` method. This method returns a string that can be used as a value of the `traceparent` HTTP header.
+To obtain a trace from a span, use `toTraceParent()` method. This method returns a string that can be used as a value of the `traceparent` HTTP header:
 
 ```javascript
 const sentryTraceHeader = span.toTraceparent();

--- a/src/platform-includes/performance/connect-services/node.mdx
+++ b/src/platform-includes/performance/connect-services/node.mdx
@@ -1,0 +1,27 @@
+## Distributed Tracing
+
+To obtain a trace from a span, use `toTraceParent()` method. This method returns a string that can be used as a value of the `traceparent` HTTP header.
+
+```javascript
+const sentryTraceHeader = span.toTraceparent();
+
+requestOptions.headers = {
+  ...requestOptions.headers,
+  'sentry-trace': sentryTraceHeader,
+};
+```
+
+To create a span as a continuation of the trace retrieved from the upstream service, use `extractTraceparentData` function from `@sentry/tracing`:
+
+```javascript
+import { extractTraceparentData } from "@sentry/tracing";
+
+// The request headers sent by your upstream service to your backend.
+const traceparentData = extractTraceparentData(request.headers['sentry-trace']);
+
+const transaction = Sentry.startTransaction({
+  op: 'transaction_op',
+  name: 'transaction_name',
+  ...traceparentData,
+});
+```

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -8,11 +8,13 @@ notSupported:
 
 When tracing is enabled, the SDK will attach an outgoing header called `sentry-trace` to requests. This depends on the out of the box integrations we provide, but you can expect the header `sentry-trace` to be present. If it's not, you can manually add `sentry-trace` headers to any requests by learning more about [its structure](https://develop.sentry.dev/sdk/performance/#header-sentry-trace).
 
-SDKs with performance monitoring support listen to incoming requests and typically automatically pick up the incoming `sentry-trace` header to continue the trace (with the same `trace-id`) from there, connecting backend and frontend transactions into a single coherent trace using the `trace_id` value. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. All your transactions that have the same `trace-id` are connected. Linking transactions in this way makes it possible to navigate among them in [sentry.io](https://sentry.io) to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) docs.
+SDKs with performance monitoring support listen to incoming requests and typically automatically pick up the incoming `sentry-trace` header to continue the trace (with the same `trace-id`) from there, connecting backend and frontend transactions into a single coherent trace using the `trace_id` value. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. 
+
+All your transactions that have the same `trace-id` are connected. Linking transactions in this way makes it possible to navigate among them in [sentry.io](https://sentry.io) to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) docs.
 
 <PlatformSection notSupported={["javascript", "node"]}>
 
-If the instrumentation you are using doesn't automatically pick up the `sentry-trace` header, you can also continue a trace manually by using the `continueFromHeaders` function on a `Transaction`, which you can learn more about in our content for [the Transaction Interface](https://develop.sentry.dev/sdk/performance/#new-span-and-transaction-classes).
+If the instrumentation you're using doesn't automatically pick up the `sentry-trace` header, you can also continue a trace manually by using the `continueFromHeaders` function on a `Transaction`. Learn more about this in our [Transaction Interface](https://develop.sentry.dev/sdk/performance/#new-span-and-transaction-classes) documentation.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/connect-services.mdx
+++ b/src/platforms/common/performance/connect-services.mdx
@@ -10,9 +10,13 @@ When tracing is enabled, the SDK will attach an outgoing header called `sentry-t
 
 SDKs with performance monitoring support listen to incoming requests and typically automatically pick up the incoming `sentry-trace` header to continue the trace (with the same `trace-id`) from there, connecting backend and frontend transactions into a single coherent trace using the `trace_id` value. Depending on the circumstance, this ID is transmitted either in a request header or in an HTML `<meta>` tag. All your transactions that have the same `trace-id` are connected. Linking transactions in this way makes it possible to navigate among them in [sentry.io](https://sentry.io) to better understand how the different parts of your system are affecting one another. You can learn more about this model in our [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) docs.
 
+<PlatformSection notSupported={["javascript", "node"]}>
+
 If the instrumentation you are using doesn't automatically pick up the `sentry-trace` header, you can also continue a trace manually by using the `continueFromHeaders` function on a `Transaction`, which you can learn more about in our content for [the Transaction Interface](https://develop.sentry.dev/sdk/performance/#new-span-and-transaction-classes).
 
-<PlatformSection supported={["android", "javascript"]} notSupported={["node"]}>
+</PlatformSection>
+
+<PlatformSection supported={["android", "javascript", "node"]}> 
 
 <PlatformContent includePath="performance/connect-services" />
 


### PR DESCRIPTION
Potentially Resolves: #5647 (Do we need to open another PR on [getsentry/develop](https://github.com/getsentry/develop)?)

Adds basic examples about:

- How to obtain a trace header from a span using `toTraceparent`
- How to use `extractTraceparentData` to continue upstream service traces.

Also removed the part that mentions `continueFromHeaders` function (which is not available in `sentry-javascript`) for JavaScript and Node docs. 

---

As an aside note, Node docs in general seem to need some restructuring, and I just remembered there is unfinished work in https://github.com/getsentry/sentry-docs/issues/3605.

We previously made a few updates in https://github.com/getsentry/sentry-docs/pull/3693, which have already crossed out some sub-tasks there.

I'm up to finish that next, if the team agrees.