### PR TITLE
feat(replays):  Update onPostBuild step to generate replay onboarding docs

### DIFF
--- a/src/gatsby/onPostBuild.ts
+++ b/src/gatsby/onPostBuild.ts
@@ -73,18 +73,18 @@ export default async ({ graphql }) => {
 };
 
 const parsePathSlug = (slug: string) => {
-  if (slug.includes("performance-onboarding")) {
+  if (slug.includes("/performance-onboarding/") || slug.includes("/replay-onboarding/")) {
     const pathMatch = slug.match(
-      /^\/(?<platform>[^/]+)\/performance-onboarding\/(?<sub_platform>[^/]+)\/(?<step>[^/]+)\/$/
+      /^\/(?<platform>[^/]+)\/(?<product>performance|replay)-onboarding\/(?<sub_platform>[^/]+)\/(?<step>[^/]+)\/$/
     );
-    
+
     if(!pathMatch) {
       throw new Error(`Unable to parse performance onboarding from slug: ${slug}`);
     }
-    
-    const { platform, sub_platform } = pathMatch.groups;
+
+    const { platform, product, sub_platform } = pathMatch.groups;
     const step = String(pathMatch.groups.step).replace(/\./g, "-");
-    const sub = platform === sub_platform ? `performance-onboarding-${step}` : `${sub_platform}-performance-onboarding-${step}`;
+    const sub = platform === sub_platform ? `${product}-onboarding-${step}` : `${sub_platform}-${product}-onboarding-${step}`;
 
     return {
       platform,

--- a/src/wizard/javascript/replay-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/javascript/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/browser @sentry/replay
+
+# Using npm
+npm install --save @sentry/browser @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/javascript/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/javascript/2.configure.md
@@ -1,0 +1,24 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+
+```javascript
+import * as Sentry from "@sentry/browser";
+import { Replay } from "@sentry/replay";
+
+Sentry.init({
+  dsn: "”https://examplePublicKey@o0.ingest.sentry.io/0",
+  integrations: [
+    new Replay({
+      replaysSamplingRate: 0.1, // 10% Sample Rate
+    })
+  ],
+})
+```

--- a/src/wizard/javascript/replay-onboarding/javascript/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/javascript/2.configure.md
@@ -17,7 +17,11 @@ Sentry.init({
   dsn: "”https://examplePublicKey@o0.ingest.sentry.io/0",
   integrations: [
     new Replay({
-      replaysSamplingRate: 0.1, // 10% Sample Rate
+      // Capture 10% of all sessions
+      sessionSampleRate: 0.1,
+
+      // Of the remaining 90% of sessions, if an error happens start capturing
+      errorSampleRate: 1.0,
     })
   ],
 })


### PR DESCRIPTION
This is some setup so that we can implement this onboarding experience for Session Replay:

<img width="682" alt="199103347-20928682-bcc3-4387-9c81-9d8a77d1aa53" src="https://user-images.githubusercontent.com/187460/200044204-715a7746-9dcc-4920-aacf-f2e0f9b39d19.png">

I'm modeling this on the existing code for performance: https://github.com/getsentry/sentry-docs/pull/4888

What we're doing is putting the copy/instructions inside the docs repo, then pulling that into sentry as a checklist so developers can track their progress and get things setup smoothly!

Followup PRs for this will probably include creating more md files, one for each JS framework, so that the instructions are 100% copy+paste ready for any JS project.

See also: https://docs.sentry.io/contributing/onboarding-wizard/
