### PR TITLE
move note from snippets into common content

### DIFF
--- a/src/platform-includes/enriching-events/set-user/android.mdx
+++ b/src/platform-includes/enriching-events/set-user/android.mdx
@@ -16,9 +16,3 @@ val user = User().apply {
 }
 Sentry.setUser(user)
 ```
-
-<Note>
-
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
-
-</Note>

--- a/src/platform-includes/enriching-events/set-user/apple.mdx
+++ b/src/platform-includes/enriching-events/set-user/apple.mdx
@@ -13,9 +13,3 @@ SentryUser *user = [[SentryUser alloc] init];
 user.email = @"john.doe@example.com";
 [SentrySDK setUser:user];
 ```
-
-<Note>
-
-Since 6.0.1: If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
-
-</Note>

--- a/src/platform-includes/enriching-events/set-user/flutter.mdx
+++ b/src/platform-includes/enriching-events/set-user/flutter.mdx
@@ -5,9 +5,3 @@ Sentry.configureScope(
   (scope) => scope.setUser(SentryUser(id: '1234', email: 'jane.doe@example.com')),
 );
 ```
-
-<Note>
-
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
-
-</Note>

--- a/src/platform-includes/enriching-events/set-user/react-native.mdx
+++ b/src/platform-includes/enriching-events/set-user/react-native.mdx
@@ -1,9 +1,3 @@
 ```javascript
 Sentry.setUser({ email: "john.doe@example.com" });
 ```
-
-<Note>
-
-If you do not provide a user identity, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
-
-</Note>

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -17,14 +17,28 @@ Users consist of a few critical pieces of information that construct a unique id
 
 ### `id`
 
+<Note>
+
+If you don't provide an `id`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
+
+</Note>
+
 Your internal identifier for the user.
+
 </PlatformSection>
 
 <PlatformSection supported={["apple"]}>
 
 ### `userId`
 
+<Note>
+
+Since version 6.0.1, if you don't provide a `userId`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
+
+</Note>
+
 Your internal identifier for the user.
+
 </PlatformSection>
 
 ### `username`


### PR DESCRIPTION
Removes notes about fallback behavior from snippets to common content. Clarified language of note by using the name of the option/property vs a descriptor.
