### PR TITLE
Add device screen fields to searchable properties entries

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -93,6 +93,10 @@ Release properties overlap with event and issue search properties, so they don't
 | device.name | Details of the device | x |  | string |
 | device.online | Whether the device was online or not. A string that is either `True` or `False`. | x |  | string |
 | device.orientation | Describes the orientation of the device and can be either `portrait` or `landscape`. | x | x | string |
+| device.screen_density | The density of the device screen in pixel units. | x | x | string |
+| device.screen_dpi | Dots per inch of the device screen. | x | x | string |
+| device.screen_height | Device screen height in pixels. | x | x | string |
+| device.screen_width | Device screen width in pixels. | x | x | string |
 | device.simulator | Indicates whether this device is a simulator or a real device. A string that is either `True` or `False`. | x |  | string |
 | device.uuid | Deprecated | x | x | uuid |
 | dist | Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build. | x | x | string |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -93,8 +93,8 @@ Release properties overlap with event and issue search properties, so they don't
 | device.name | Details of the device | x |  | string |
 | device.online | Whether the device was online or not. A string that is either `True` or `False`. | x |  | string |
 | device.orientation | Describes the orientation of the device and can be either `portrait` or `landscape`. | x | x | string |
-| device.screen_density | The density of the device screen in pixel units. | x | x | string |
-| device.screen_dpi | Dots per inch of the device screen. | x | x | string |
+| device.screen_density | Device screen density in pixels. | x | x | string |
+| device.screen_dpi | Number of dots per inch of the device screen. | x | x | string |
 | device.screen_height_pixels | Device screen height in pixels. | x | x | string |
 | device.screen_width_pixels | Device screen width in pixels. | x | x | string |
 | device.simulator | Indicates whether this device is a simulator or a real device. A string that is either `True` or `False`. | x |  | string |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -95,8 +95,8 @@ Release properties overlap with event and issue search properties, so they don't
 | device.orientation | Describes the orientation of the device and can be either `portrait` or `landscape`. | x | x | string |
 | device.screen_density | The density of the device screen in pixel units. | x | x | string |
 | device.screen_dpi | Dots per inch of the device screen. | x | x | string |
-| device.screen_height | Device screen height in pixels. | x | x | string |
-| device.screen_width | Device screen width in pixels. | x | x | string |
+| device.screen_height_pixels | Device screen height in pixels. | x | x | string |
+| device.screen_width_pixels | Device screen width in pixels. | x | x | string |
 | device.simulator | Indicates whether this device is a simulator or a real device. A string that is either `True` or `False`. | x |  | string |
 | device.uuid | Deprecated | x | x | uuid |
 | dist | Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build. | x | x | string |


### PR DESCRIPTION
<img width="866" alt="image" src="https://user-images.githubusercontent.com/83961295/200355856-acee1c69-febd-4f24-9971-a2d42da60535.png">