### PR TITLE
feat(replays): Add more example snippets for Replay onboarding

### DIFF
--- a/src/wizard/javascript/replay-onboarding/angular/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/angular/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/angular @sentry/replay
+
+# Using npm
+npm install --save @sentry/angular @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/angular/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/angular/2.configure.md
@@ -10,7 +10,7 @@ type: language
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/angular";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({

--- a/src/wizard/javascript/replay-onboarding/ember/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/ember/1.install.md
@@ -1,0 +1,14 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash {tabTitle:ember-cli}
+ember install @sentry/ember @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/ember/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/ember/2.configure.md
@@ -10,7 +10,7 @@ type: language
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/ember";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({

--- a/src/wizard/javascript/replay-onboarding/gatsby/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/gatsby/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/gatsby @sentry/replay
+
+# Using npm
+npm install --save @sentry/gatsby @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
@@ -9,8 +9,22 @@ type: language
 
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
-```javascript
-import * as Sentry from "@sentry/browser";
+Include the `@sentry/gatsby` plugin:
+
+```javascript {filename:gatsby-config.js}
+module.exports = {
+  plugins: [
+    {
+      resolve: "@sentry/gatsby",
+    },
+  ]
+};
+```
+
+Configure your `Sentry.init`:
+
+```javascript {filename:sentry.config.js}
+import * as Sentry from "@sentry/gatsby";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({
@@ -26,3 +40,5 @@ Sentry.init({
   ],
 });
 ```
+
+Note: If `gatsby-config.js` has any settings for the `@sentry/gatsby` plugin they need to be moved into `sentry.config.js`. `gatsby-config.js` doesn't support non-serializable options, like `new Replay()`.

--- a/src/wizard/javascript/replay-onboarding/nextjs/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/nextjs/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/nextjs @sentry/replay
+
+# Using npm
+npm install --save @sentry/nextjs @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/nextjs/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/nextjs/2.configure.md
@@ -1,0 +1,30 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Add the following to your Client SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+
+```javascript {filename:sentry.client.config.js}
+import * as Sentry from "@sentry/nextjs";
+import { Replay } from "@sentry/replay";
+
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  integrations: [
+    new Replay({
+      // Capture 10% of all sessions
+      sessionSampleRate: 0.1,
+
+      // Of the remaining 90% of sessions, if an error happens start capturing
+      errorSampleRate: 1.0,
+    })
+  ],
+});
+```
+
+Note: The `@sentry/repaly` integration only needs to be added to your `sentry.client.config.js` file. There will be no effect if it is added into `sentry.server.config.js`.

--- a/src/wizard/javascript/replay-onboarding/react/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/react/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/react @sentry/replay
+
+# Using npm
+npm install --save @sentry/react @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/react/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/react/2.configure.md
@@ -10,7 +10,7 @@ type: language
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from "@sentry/react";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({

--- a/src/wizard/javascript/replay-onboarding/remix/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/remix/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/remix @sentry/replay
+
+# Using npm
+npm install --save @sentry/remix @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/remix/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/remix/2.configure.md
@@ -9,8 +9,8 @@ type: language
 
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
-```javascript
-import * as Sentry from "@sentry/browser";
+```javascript {filename: entry.client.tsx}
+import * as Sentry from "@sentry/remix";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({
@@ -26,3 +26,5 @@ Sentry.init({
   ],
 });
 ```
+
+Note: The `@sentry/repaly` integration only needs to be added to your `entry.client.tsx` file. There will be no effect if it is added into `entry.server.tsx`.

--- a/src/wizard/javascript/replay-onboarding/svelte/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/svelte/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/svelte @sentry/replay
+
+# Using npm
+npm install --save @sentry/svelte @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/svelte/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/svelte/2.configure.md
@@ -10,7 +10,10 @@ type: language
 Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import "./app.css";
+import App from "./App.svelte";
+
+import * as Sentry from "@sentry/svelte";
 import { Replay } from "@sentry/replay";
 
 Sentry.init({
@@ -25,4 +28,10 @@ Sentry.init({
     })
   ],
 });
+
+const app = new App({
+  target: document.getElementById("app"),
+});
+
+export default app;
 ```

--- a/src/wizard/javascript/replay-onboarding/vue/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/vue/1.install.md
@@ -1,0 +1,18 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the sentry-replay integration to work, you must have the Sentry browser SDK package (minimum version 7.x), or an equivalent framework SDK (e.g. @sentry/react) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/vue @sentry/replay
+
+# Using npm
+npm install --save @sentry/vue @sentry/replay
+```

--- a/src/wizard/javascript/replay-onboarding/vue/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/vue/2.configure.md
@@ -1,0 +1,79 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Add the following to your SDK config. There are several privacy and performance options available, all of which can be set via the `integrations` constructor. Learn more about configuring Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+
+#### Vue 2
+
+```javascript
+import Vue from "vue";
+import Router from "vue-router";
+import * as Sentry from "@sentry/vue";
+import { Replay } from "@sentry/replay";
+
+Vue.use(Router);
+
+const router = new Router({
+  // ...
+});
+
+Sentry.init({
+  Vue,
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  integrations: [
+    new Replay({
+      // Capture 10% of all sessions
+      sessionSampleRate: 0.1,
+
+      // Of the remaining 90% of sessions, if an error happens start capturing
+      errorSampleRate: 1.0,
+    })
+  ],
+});
+
+// ...
+
+new Vue({
+  router,
+  render: h => h(App),
+}).$mount("#app");
+```
+
+#### Vue 3
+
+```javascript
+import { createApp } from "vue";
+import { createRouter } from "vue-router";
+import * as Sentry from "@sentry/vue";
+import { Replay } from "@sentry/replay";
+
+const app = createApp({
+  // ...
+});
+const router = createRouter({
+  // ...
+});
+
+Sentry.init({
+  app,
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  integrations: [
+    new Replay({
+      // Capture 10% of all sessions
+      sessionSampleRate: 0.1,
+
+      // Of the remaining 90% of sessions, if an error happens start capturing
+      errorSampleRate: 1.0,
+    })
+  ],
+});
+
+app.use(router);
+app.mount("#app");
+```


### PR DESCRIPTION
Following up on https://github.com/getsentry/sentry-docs/pull/5711
Related to https://github.com/getsentry/sentry/issues/40787


Previously when the docs exist for a framework they will appear inside sentry in a slide out (implemented in https://github.com/getsentry/sentry/pull/41141) 
<img width="1121" alt="Screen Shot 2022-11-07 at 12 31 20 PM" src="https://user-images.githubusercontent.com/187460/200409224-2ab4d2b6-4616-42d7-a6a4-65d5d8be3526.png">

And when there are no docs for a framework the user will get a placeholder message:
<img width="1167" alt="Screen Shot 2022-11-07 at 12 30 12 PM" src="https://user-images.githubusercontent.com/187460/200409285-f97fa403-6986-4a1d-bfe1-8b35424667df.png">


This PR fills in all the missing framework types that replay supports so some kind of docs appear in all cases.
- intentionally missing is `angularjs`, because that depends on the old 6.x javascript SDK which is incompatible with Replay.

I checked the code examples against the existing js docs: https://docs.sentry.io/platforms/javascript/ 

After this lands we need to update `sentry` so it knows to lookup docs for these frameworks: https://github.com/getsentry/sentry/pull/41144