### PR TITLE
Add node and browser sdk transport option docs

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -47,10 +47,10 @@ Specifies whether to use global scope management mode. Should be `true` for clie
 
 Example scenarios where it should be explicitly set to true:
 
- * Universal Windows platform (UWP) applications
- * WinForms applications
- * Windows Presentation Foundation (WPF) applications
- * Single user console applications
+- Universal Windows platform (UWP) applications
+- WinForms applications
+- Windows Presentation Foundation (WPF) applications
+- Single user console applications
 
 Defaults to `false`, unless in Blazor WASM, MAUI, Unity, or Xamarin where the default is `true`.
 
@@ -577,13 +577,36 @@ Switches out the transport used to send events. How this works depends on the SD
 
 </ConfigKey>
 
-<ConfigKey name="http-proxy" supported={["node", "php", "python", "java", "dotnet", "rust"]}>
+<ConfigKey name="transport-options" supported={["javascript", "node"]}>
+
+Options used to configure the transport. This is an object with the following possible optional keys:
+
+<PlatformSection supported={["node"]}>
+
+- `headers`: An object containing headers to be sent with every request.
+- `proxy`: A proxy used for outbound requests. Can be http or https.
+- `caCerts`: A single or list of a path to a file or directory, or a buffer of CA certificates
+- `httpModule`: A custom HTTP module to use for requests. Defaults to the the native `http` and `https` modules.
+- `keepAlive`: Whether to keep the socket alive between requests. Defaults to `false`.
+
+</PlatformSection>
+
+<PlatformSection supported={["javascript"]}>
+
+- `headers`: An object containing headers to be sent with every request. Used by the SDK's fetch and XHR transports.
+- `fetchOptions`: An object containing options to be passed to the `fetch` call. Used by the SDK's fetch transport.
+
+</PlatformSection>
+
+</ConfigKey>
+
+<ConfigKey name="http-proxy" supported={["php", "python", "java", "dotnet", "rust"]}>
 
 When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https-proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.
 
 </ConfigKey>
 
-<ConfigKey name="https-proxy" supported={["python", "node", "rust"]}>
+<ConfigKey name="https-proxy" supported={["python", "rust"]}>
 
 Configures a separate proxy for outgoing HTTPS requests. This value might not be supported by all SDKs. When not supported the `http-proxy` value is also used for HTTPS requests at all times.
 


### PR DESCRIPTION
Only can get merged once https://github.com/getsentry/sentry-javascript/pull/6161 getting released

Add documentation for Node Transport options.