### PR TITLE
feat(integrations): Add Rootly Docs

### DIFF
--- a/src/docs/product/integrations/index.mdx
+++ b/src/docs/product/integrations/index.mdx
@@ -28,8 +28,9 @@ For more details, see the [full Integration Platform documentation](/product/int
 | OpsGenie                                                                 | X            |               |                |
 | [PagerDuty](/product/integrations/notification-incidents/pagerduty/)     | X            | X             |                |
 | Pushover                                                                 | X            |               |                |
+| [Rootly](/product/integrations/notification-incidents/rootly/)           | X            | X             |                |
 | [Slack](/product/integrations/notification-incidents/slack/)             | X            | X             | X              |
-| [Spike.sh](/product/integrations/notification-incidents/spikesh/)        | X            | X             |
+| [Spike.sh](/product/integrations/notification-incidents/spikesh/)        | X            | X             |                |
 | [Threads](/product/integrations/notification-incidents/threads/)         | X            | X             |                |
 | Twilio                                                                   | X            |               |                |
 | VictorOps                                                                | X            |               |                |

--- a/src/docs/product/integrations/notification-incidents/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/index.mdx
@@ -11,6 +11,7 @@ Learn more about Sentry's notification and incidents integrations:
 - OpsGenie
 - [PagerDuty](/product/integrations/notification-incidents/pagerduty/)
 - Pushover
+- [Rootly](/product/integrations/notification-incidents/rootly/)
 - [Slack](/product/integrations/notification-incidents/slack/)
 - [Spike.sh](/product/integrations/notification-incidents/spikesh/)
 - [Threads](/product/integrations/notification-incidents/threads/)

--- a/src/docs/product/integrations/notification-incidents/rootly/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/rootly/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Rootly
+sidebar_order: 1
+redirect_from:
+  - /product/integrations/rootly/
+description: "Learn about Sentry's Rootly integration and how it creates incidents from Sentry Alerts."
+---
+
+Rootly is a Slack-native incident management app and platform that automates tedious manual work during incidents.
+
+
+This integration is maintained and supported by the company that created it. For more details, check out our [Integration Platform documentation](/product/integrations/integration-platform/).
+
+## Install and Configure
+
+<Note>
+
+Sentry owner, manager, or admin permissions are required to install this integration.
+
+Rootly **won't** work with self-hosted Sentry.
+
+</Note>
+
+1. Navigate to **Settings > Integrations > Rootly**
+
+2. Follow the full [Rootly installation instructions](https://docs.rootly.com/integrations/sentry).


### PR DESCRIPTION
Add a new docs page for the Rootly integration published on our integration platform.