### PR TITLE
fix: missing snippets dotnet

### DIFF
--- a/src/platform-includes/performance/always-inherit-sampling-decision/dotnet.mdx
+++ b/src/platform-includes/performance/always-inherit-sampling-decision/dotnet.mdx
@@ -1,0 +1,20 @@
+```csharp
+using Sentry;
+
+sentryOptions.TracesSampler = context =>
+{
+    if (context.TransactionContext.IsParentSampled is true)
+    {
+        return 1.0; // Keep all traces complete
+    }
+
+    // the rest of sampling logic, for example:
+    if (context.TransactionContext.Name == "important-endpoint")
+    {
+        return 1.0; // 100% for
+    }
+
+    return 0.5; // 50% for everything else
+
+};
+```

--- a/src/platform-includes/upload-dif/dotnet.mdx
+++ b/src/platform-includes/upload-dif/dotnet.mdx
@@ -1,0 +1,4 @@
+```bash
+sentry-cli login
+sentry-cli upload-dif -o {YOUR ORGANISATION} -p {PROJECT} bin/Release
+```

--- a/src/platforms/common/data-management/debug-files/upload/index.mdx
+++ b/src/platforms/common/data-management/debug-files/upload/index.mdx
@@ -20,6 +20,15 @@ application:
 
 ![](debug-files-workflow.png)
 
+<PlatformSection supported={["dotnet"]}>
+<Note>
+
+The Sentry support for .NET requires uploading debug files only on mobile (Android and iOS) apps.
+Managed PDBs are not yet supported.
+
+</Note>
+</PlatformSection>
+
 Files can be uploaded using the `upload-dif` command. This command will scan a
 given folder recursively for files and upload them to Sentry:
 


### PR DESCRIPTION
Adding missing snippets listed on #3107

The Debug File Upload page needs to be restructured. It was built for Native, and we're now including it on more platforms.

Unity bundles `sentry-cli` and uploads things automatically as stated in the top note. The instructions that follow are not helpful there.
The .NET SDK support only requires symbol upload for iOS/MacCatalyst/Android at the moment, and the goal is to bundle sentry-cli within the SDK and run it automatically with the build.