### PR TITLE
Update example to follow HMAC best practice

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -65,7 +65,7 @@ import hashlib
 import hmac
 import json
 
-expected_digest = request.headers.get('sentry-hook-signature') # returns None if header is missing
+expected_digest = request.headers.get('sentry-hook-signature')  # returns None if header is missing
 body = json.dumps(request.body)
 
 digest = hmac.new(
@@ -74,8 +74,10 @@ digest = hmac.new(
     digestmod=hashlib.sha256,
 ).hexdigest()
 
+if not expected_digest:  # The signature is missing
+    raise UnauthorizedError
 
-if expected_digest and not hmac.compare_digest(digest, expected_digest):
+if not hmac.compare_digest(digest, expected_digest):
     raise UnauthorizedError
 ```
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -65,7 +65,7 @@ import hashlib
 import hmac
 import json
 
-expected_digest = request.headers['sentry-hook-signature']
+expected_digest = request.headers.get('sentry-hook-signature') # returns None if header is missing
 body = json.dumps(request.body)
 
 digest = hmac.new(
@@ -75,7 +75,7 @@ digest = hmac.new(
 ).hexdigest()
 
 
-if digest != expected_digest:
+if expected_digest and not hmac.compare_digest(digest, expected_digest):
     raise UnauthorizedError
 ```
 


### PR DESCRIPTION
Update the Python example for the webhook signature comparison to follow best practices.

Using `hmac.compare_digest()` mitigates [timing-based attacks](https://en.wikipedia.org/wiki/Timing_attack) on the signature verification.

I've also updated the line to pull the signature header value to use the `.get()` method in order to avoid a `KeyError` exception.