### PR TITLE
Add OpenTelemetry Node SDK docs

### DIFF
--- a/src/platform-includes/performance/opentelemetry-install/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/node.mdx
@@ -10,7 +10,7 @@ npm install @sentry/node @sentry/opentelemetry-node
 
 Note that @sentry/opentelemetry-node depends on the following peer dependencies:
 
-- @opentelemetry/api version 1.0.0 or greater
-- @opentelemetry/sdk-trace-base version 1.0.0 or greater, or a package that implements that, like @opentelemetry/sdk-node.
+- @opentelemetry/api, version 1.0.0 or greater
+- @opentelemetry/sdk-trace-base, version 1.0.0 or greater, or a package that implements it, like @opentelemetry/sdk-node
 
 </Note>

--- a/src/platform-includes/performance/opentelemetry-install/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/node.mdx
@@ -1,0 +1,16 @@
+```bash {tabTitle:npm}
+npm install @sentry/node @sentry/opentelemetry-node
+```
+
+```bash {tabTitle:yarn}
+npm install @sentry/node @sentry/opentelemetry-node
+```
+
+<Note>
+
+Note that @sentry/opentelemetry-node depends on the following peer dependencies:
+
+- @opentelemetry/api version 1.0.0 or greater
+- @opentelemetry/sdk-trace-base version 1.0.0 or greater, or a package that implements that, like @opentelemetry/sdk-node.
+
+</Note>

--- a/src/platform-includes/performance/opentelemetry-install/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/node.mdx
@@ -3,7 +3,7 @@ npm install @sentry/node @sentry/opentelemetry-node
 ```
 
 ```bash {tabTitle:yarn}
-npm install @sentry/node @sentry/opentelemetry-node
+yarn add @sentry/node @sentry/opentelemetry-node
 ```
 
 <Note>

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -1,0 +1,24 @@
+You need to register the SentrySpanProcessor and SentryPropagator with your OpenTelemetry installation:
+
+```js
+import _ as Sentry from '@sentry/node';
+import _ as otelApi from '@opentelemetry/api';
+import { SentrySpanProcessor } from '@sentry/opentelemetry-node';
+
+// Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  // ...
+});
+
+const sdk = new opentelemetry.NodeSDK({
+  // Existing config
+  traceExporter: new OTLPTraceExporter(),
+  instrumentations: [getNodeAutoInstrumentations()],
+
+  // Sentry config
+  spanProcessor: new SentrySpanProcessor(),
+});
+
+otelApi.propagation.setGlobalPropagator(new SentryPropagator());
+```

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -1,13 +1,16 @@
 You need to register the SentrySpanProcessor and SentryPropagator with your OpenTelemetry installation:
 
 ```js
-import _ as Sentry from '@sentry/node';
-import _ as otelApi from '@opentelemetry/api';
-import { SentrySpanProcessor } from '@sentry/opentelemetry-node';
+import * as Sentry from "@sentry/node";
+import { SentrySpanProcessor } from "@sentry/opentelemetry-node";
+
+import * as otelApi from "@opentelemetry/api";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 
 // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // ...
 });
 

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -1,4 +1,4 @@
-You need to register the SentrySpanProcessor and SentryPropagator with your OpenTelemetry installation:
+You need to register `SentrySpanProcessor` and `SentryPropagator` with your OpenTelemetry installation:
 
 ```js
 import * as Sentry from "@sentry/node";

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -1,0 +1,47 @@
+---
+title: OpenTelemetry Support
+sidebar_order: 20
+supported:
+  - node
+notSupported:
+  - javascript
+  - python
+  - dart
+  - flutter
+  - react-native
+  - java
+  - java.spring-boot
+  - android
+  - apple
+  - dotnet
+  - javascript.cordova
+  - javascript.electron
+  - go
+  - ruby
+  - unity
+  - rust
+  - native
+  - php
+  - native.breakpad
+  - native.crashpad
+  - native.minidumps
+  - unreal
+  - native.wasm
+description: "Using OpenTelemetry with Sentry Performance."
+---
+
+<Alert level="warning" title="Note">
+
+OpenTelemetry support for Sentry SDKs are in an alpha state. Features in alpha are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>
+
+You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
+
+## Installation
+
+<PlatformContent includePath="performance/opentelemetry-install" />
+
+## Usage
+
+<PlatformContent includePath="performance/opentelemetry-install" />

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -38,7 +38,7 @@ OpenTelemetry support for Sentry SDKs are in an alpha state. Features in alpha a
 
 You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
 
-## Installation
+## Install
 
 <PlatformContent includePath="performance/opentelemetry-install" />
 

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -40,4 +40,4 @@ You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send tr
 
 ## Usage
 
-<PlatformContent includePath="performance/opentelemetry-install" />
+<PlatformContent includePath="performance/opentelemetry-setup" />

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -30,11 +30,7 @@ notSupported:
 description: "Using OpenTelemetry with Sentry Performance."
 ---
 
-<Alert level="warning" title="Note">
-
-OpenTelemetry support for Sentry SDKs are in an alpha state. Features in alpha are still in-progress and may have bugs. We recognize the irony.
-
-</Alert>
+<Include name="alpha-note.mdx" />
 
 You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
 


### PR DESCRIPTION
Mainly based on the README here: https://www.npmjs.com/package/@sentry/opentelemetry-node

Initial Context: https://github.com/getsentry/sentry/discussions/40712

Node SDK work: https://github.com/getsentry/sentry-javascript/issues/6000
