### PR TITLE
feat(apple): Add docs for pre-warmed app starts

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -80,6 +80,7 @@ SentrySDK.start { options in
 
     // Enable all experimental features
     options.enableUserInteractionTracing = true
+    options.enablePreWarmedAppStartTracking = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
 }
@@ -92,6 +93,7 @@ SentrySDK.start { options in
 
     // Enable all experimental features
     options.enableUserInteractionTracing = YES;
+    options.enablePreWarmedAppStartTracking = YES;
     options.attachScreenshot = YES;
     options.attachViewHierarchy = YES;
 }];

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -83,7 +83,7 @@ With this feature, the SDK differentiates between four different app start types
 
 You can filter for different app start types in Discover with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
 
-To enable pre-warmed app start tracking:
+To enable prewarmed app start tracking:
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -58,7 +58,7 @@ To enable this feature, enable `AutoUIPerformanceTracking`.
 <Alert level="info" title="Important">
 
 Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
-Since [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we have a still experimental feature `enablePreWarmedAppStartTracking` to collect pre-warmed app starts. If you don't enable the feature, we drop pre-warmed app starts.
+Since [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we have a still experimental feature `enablePreWarmedAppStartTracking` to collect pre-warmed app starts, see below for more information. If you don't enable the feature, we drop pre-warmed app starts.
 
 </Alert>
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -82,10 +82,10 @@ Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/do
 You can enable the experimental feature `enablePreWarmedAppStartTracking` to report pre-warmed app starts. Once enabled, the SDK will drop the first app start spans if pre-warming paused during these steps. This approach will shorten the app start duration, but it represents the duration a user has to wait after clicking the app icon until the app is responsive.
 With this feature, the SDK differentiates between four different app start types:
 
-* __Cold start__: Same as _cold start_ above, and __not__ prewarmed.
-* __Warm start__: Same as _warm start_ above, and __not__ prewarmed.
-* __Cold start pre-warmed__: Same as _warm start_, and prewarmed.
-* __Warm start pre-warmed__: Same as _warm start_, and prewarmed.
+* __Non-prewarmed cold start__ (See _cold start_  definition above.)
+* __Non-prewarmed warm start__ (See _warm start_  definition above.)
+* __Prewarmed cold start__
+* __Prewrmed warm start__
 
 You can filter for different app start types in Discover with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -76,7 +76,7 @@ The SDK uses the process start time as the beginning of the app start and the [`
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
-### Pre-warmed app start tracking
+### Prewarmed App Start Tracking
 
 Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
 You can enable the experimental feature `enablePreWarmedAppStartTracking` to report pre-warmed app starts. Once enabled, the SDK will drop the first app start spans if pre-warming paused during these steps. This approach will shorten the app start duration, but it represents the duration a user has to wait after clicking the app icon until the app is responsive.

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -78,8 +78,9 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracking
 
-Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
-You can enable the experimental feature `enablePreWarmedAppStartTracking` to report pre-warmed app starts. Once enabled, the SDK will drop the first app start spans if pre-warming paused during these steps. This approach will shorten the app start duration, but it represents the duration a user has to wait after clicking the app icon until the app is responsive.
+Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we won’t be able to reliably measure the app start. But with [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we’ve introduced a `enablePreWarmedAppStartTracking` feature, (still in its experimental phase), which allows us to collect prewarmed app starts.
+
+Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive. 
 With this feature, the SDK differentiates between four different app start types:
 
 * __Non-prewarmed cold start__ (See _cold start_  definition above.)

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -73,7 +73,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. However, with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced an `enablePreWarmedAppStartTracking` feature (still in its experimental phase), which allows us to collect prewarmed app starts.
 
-Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive.
+Once enabled, the SDK drops the first app start span if prewarming pauses. This approach shortens the app start duration, but it accurately represents the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:
 
 * __Non-prewarmed cold start__ (See _cold start_  definition above.)

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -55,11 +55,6 @@ This feature is available for iOS, tvOS, and Mac Catalyst.
 App Start Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
 To enable this feature, enable `AutoUIPerformanceTracking`.
 
-<Alert level="info" title="Important">
-
-
-</Alert>
-
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
 * __Cold start__: App launched for the first time, after a reboot or update. The app is not in memory and no process exists.
@@ -78,7 +73,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we won’t be able to reliably measure the app start. But with [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we’ve introduced a `enablePreWarmedAppStartTracking` feature, (still in its experimental phase), which allows us to collect prewarmed app starts.
 
-Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive. 
+Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:
 
 * __Non-prewarmed cold start__ (See _cold start_  definition above.)

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -57,8 +57,6 @@ To enable this feature, enable `AutoUIPerformanceTracking`.
 
 <Alert level="info" title="Important">
 
-Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
-Since [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we have a still experimental feature `enablePreWarmedAppStartTracking` to collect pre-warmed app starts, see below for more information. If you don't enable the feature, we drop pre-warmed app starts.
 
 </Alert>
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -79,7 +79,7 @@ With this feature, the SDK differentiates between four different app start types
 * __Non-prewarmed cold start__ (See _cold start_  definition above.)
 * __Non-prewarmed warm start__ (See _warm start_  definition above.)
 * __Prewarmed cold start__
-* __Prewrmed warm start__
+* __Prewarmed warm start__
 
 You can filter for different app start types in Discover with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -81,7 +81,7 @@ With this feature, the SDK differentiates between four different app start types
 * __Prewarmed cold start__
 * __Prewarmed warm start__
 
-You can filter for different app start types in Discover with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
+You can filter for different app start types in [Discover](/product/discover-queries/) with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
 
 To enable prewarmed app start tracking:
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -71,7 +71,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracking
 
-Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we won’t be able to reliably measure the app start. But with [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we’ve introduced a `enablePreWarmedAppStartTracking` feature, (still in its experimental phase), which allows us to collect prewarmed app starts.
+Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we won’t be able to reliably measure the app start. But with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced a `enablePreWarmedAppStartTracking` feature, (still in its experimental phase), which allows us to collect prewarmed app starts.
 
 Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -57,7 +57,8 @@ To enable this feature, enable `AutoUIPerformanceTracking`.
 
 <Alert level="info" title="Important">
 
-Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we can't reliably measure the app start, so we drop it as of [sentry-cocoa 7.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.0). We are working on a fix for this. Follow the [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/1897) for more details.
+Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
+Since [sentry-cocoa 7.30.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.3), we have a still experimental feature `enablePreWarmedAppStartTracking` to collect pre-warmed app starts. If you don't enable the feature, we drop pre-warmed app starts.
 
 </Alert>
 
@@ -74,6 +75,39 @@ The SDK uses the process start time as the beginning of the app start and the [`
 ![App Start Transaction](app-start-transaction.png)
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
+
+### Pre-warmed app start tracking
+
+Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it.
+You can enable the experimental feature `enablePreWarmedAppStartTracking` to report pre-warmed app starts. Once enabled, the SDK will drop the first app start spans if pre-warming paused during these steps. This approach will shorten the app start duration, but it represents the duration a user has to wait after clicking the app icon until the app is responsive.
+With this feature, the SDK differentiates between four different app start types:
+
+* __Cold start__: Same as _cold start_ above, and __not__ prewarmed.
+* __Warm start__: Same as _warm start_ above, and __not__ prewarmed.
+* __Cold start pre-warmed__: Same as _warm start_, and prewarmed.
+* __Warm start pre-warmed__: Same as _warm start_, and prewarmed.
+
+You can filter for different app start types in Discover with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
+
+To enable pre-warmed app start tracking:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enablePreWarmedAppStartTracking = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enablePreWarmedAppStartTracking = YES;
+}];
+```
 
 ## Slow and Frozen Frames
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -71,7 +71,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracking
 
-Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we won’t be able to reliably measure the app start. But with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced a `enablePreWarmedAppStartTracking` feature, (still in its experimental phase), which allows us to collect prewarmed app starts.
+Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. However, with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced an `enablePreWarmedAppStartTracking` feature (still in its experimental phase), which allows us to collect prewarmed app starts.
 
 Once enabled, the SDK will drop the first app start span if prewarming pauses. This approach will shorten the app start duration, but it will accurately represent the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -118,6 +118,7 @@ SentrySDK.start { options in
 
     // Enable all experimental features
     options.enableUserInteractionTracing = true
+    options.enablePreWarmedAppStartTracking = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
 }


### PR DESCRIPTION
Add docs for the experimental feature enablePreWarmedAppStartTracking, which will be released with
https://github.com/getsentry/sentry-cocoa/pull/1969.

Only merge after releasing https://github.com/getsentry/sentry-cocoa/pull/1969.