### PR TITLE
added platform section hidden from dotnet for server name

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -242,8 +242,13 @@ If possible, we recommended turning on this feature to send all such data by def
 
 <ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java", "dart", "dotnet"]} notSupported={["android"]}>
 
-This option can be used to supply a "server name." When provided, the name of the server is sent along and persisted in the event. For many integrations the server name actually corresponds to the device hostname, even in situations where the machine is not actually a server. Most SDKs
-will attempt to auto-discover this value.
+This option can be used to supply a "server name." When provided, the name of the server is sent along and persisted in the event. For many integrations the server name actually corresponds to the device hostname, even in situations where the machine is not actually a server.
+
+<PlatformSection notSupported={["dotnet"]}>
+
+Most SDKs will attempt to auto-discover this value.
+
+</PlatformSection>
 
 </ConfigKey>
 


### PR DESCRIPTION
Adds a platform section within the description for server-name to hide the last sentence from .NET.