### PR TITLE
feat(perf): Note wildcard support in transaction name search

### DIFF
--- a/src/docs/product/performance/filters-display/index.mdx
+++ b/src/docs/product/performance/filters-display/index.mdx
@@ -42,7 +42,7 @@ When you select "All Transactions", the table includes all transactions across a
 
 ### Transaction Name Search
 
-Rather than searching for transactions by matching event properties, the search bar on the **Performance** page filters by transaction name only. You can search for specific transaction names or use wildcards, which can take the place of one or more characters in a search term.
+Rather than searching for transactions by matching event properties, the search bar on the **Performance** page filters by transaction name only. You can search for specific transaction names or use wildcards, which can take the place of one or more characters in a search term (e.g., `/api/*/organization`).
 
 ![Updated transaction search](transaction-name-search.png)
 

--- a/src/docs/product/performance/filters-display/index.mdx
+++ b/src/docs/product/performance/filters-display/index.mdx
@@ -42,7 +42,7 @@ When you select "All Transactions", the table includes all transactions across a
 
 ### Transaction Name Search
 
-On the **Performance** page, the search bar filters by transaction name only, rather than searching for transactions by matching event properties.
+On the **Performance** page, the search bar filters by transaction name only, rather than searching for transactions by matching event properties. You can search for specific transaction names as well as [wildcards](/product/sentry-basics/search/#wildcards).
 
 ![Updated transaction search](transaction-name-search.png)
 

--- a/src/docs/product/performance/filters-display/index.mdx
+++ b/src/docs/product/performance/filters-display/index.mdx
@@ -42,7 +42,7 @@ When you select "All Transactions", the table includes all transactions across a
 
 ### Transaction Name Search
 
-On the **Performance** page, the search bar filters by transaction name only, rather than searching for transactions by matching event properties. You can search for specific transaction names as well as [wildcards](/product/sentry-basics/search/#wildcards).
+Rather than searching for transactions by matching event properties, the search bar on the **Performance** page filters by transaction name only. You can search for specific transaction names or use wildcards, which can take the place of one or more characters in a search term.
 
 ![Updated transaction search](transaction-name-search.png)
 


### PR DESCRIPTION
Wildcards are supported in the UI as of https://github.com/getsentry/sentry/pull/41268! I opted to link to the "Wildcards" section, but I think that might be a mistake, since that section talks about wildcards in tag values and so on. Maybe it'd be better to do something like "(e.g., '/transaction/*')" instead of the link?
