### PR TITLE
fix(native): hide "Enable Tracing" section in...

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -66,7 +66,7 @@ Automatic instrumentation for monitoring the performance of your application is 
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript", "javascript.vue", "java.spring", "react-native", "native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet", "dart"]}>
+<PlatformSection supported={["javascript", "javascript.vue", "java.spring", "react-native"]} notSupported={["java", "go", "android", "ruby", "python", "dotnet", "dart", "native"]}>
 
 ## Enable Tracing
 


### PR DESCRIPTION
... Performance Monitoring setup. `sentry-native` has no separate "Enabling" setup step (beyond configuring the trace sampling). This currently renders a misleading message raised here: https://github.com/getsentry/sentry-native/issues/601#issuecomment-1259977174.

@Swatinem pls have a look.