### PR TITLE
docs(profiling): Add python profiling alpha docs

### DIFF
--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -26,3 +26,4 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)
+  - [Python](/platforms/python/profiling/)

--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -26,4 +26,6 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)
+
+- Backend
   - [Python](/platforms/python/profiling/)

--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -26,6 +26,4 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)
-
-- Backend
   - [Python](/platforms/python/profiling/)

--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -14,6 +14,7 @@ Profiling is currently in beta. Beta features are still in-progress and may have
 
   * Android (Java and Kotlin only)
   * iOS (Swift and Objective-C only)
+  * Python
 
 </Note>
 

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -4,6 +4,7 @@ sidebar_order: 5000
 supported:
   - android
   - apple
+  - python
 notSupported:
   - unity
   - dart
@@ -16,7 +17,6 @@ notSupported:
   - javascript.vue
   - react-native
   - dotnet
-  - python
   - java
   - java.spring-boot
   - java.spring
@@ -30,11 +30,25 @@ notSupported:
 description: "Learn how to enable profiling in your app if it is not already set up."
 ---
 
+<PlatformSection supported={["apple", "android"]}>
+
 <Note>
 
 Profiling is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
 
 </Note>
+
+</PlatformSection>
+
+<PlatformSection supported={["python"]}>
+
+<Note>
+
+Python profiling is currently in alpha. Alpha features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
+
+</Note>
+
+</PlatformSection>
 
 With [profiling](/product/profiling/), Sentry allows you to collect and analyze performance profiles from real user devices in production to give you a complete picture of how your application performs in a variety of environments.
 
@@ -46,7 +60,7 @@ Profiling depends on Sentry’s performance monitoring product being enabled bef
 
 ```swift
 SentrySDK.start { options in
-    options.dsn = "..."
+    options.dsn = "___DSN___"
     options.tracesSampleRate = 1.0
 }
 ```
@@ -59,9 +73,20 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="..." />
+    <meta-data android:name="io.sentry.dsn" android:value="___DSN___" />
     <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
 </application>
+```
+
+</PlatformSection>
+
+<PlatformSection supported={["python"]}>
+
+```python
+sentry_sdk.init(
+  dsn="___DSN___",
+  traces_sample_rate=1.0,
+)
 ```
 
 </PlatformSection>
@@ -74,7 +99,7 @@ Check out the <PlatformLink to="/performance/">performance setup documentation</
 
 ```swift
 SentrySDK.start { options in
-    options.dsn = "..."
+    options.dsn = "___DSN___"
     options.tracesSampleRate = 1.0
     options.profilesSampleRate = 1.0
 }
@@ -94,7 +119,7 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="..." />
+    <meta-data android:name="io.sentry.dsn" android:value="___DSN___" />
     <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
     <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 </application>
@@ -105,6 +130,20 @@ In `AndroidManifest.xml`:
 The `io.sentry.traces.profiling.sample-rate` setting is *relative* to the `io.sentry.traces.sample-rate` setting.
 
 </Note>
+
+</PlatformSection>
+
+<PlatformSection supported={["python"]}>
+
+```python
+sentry_sdk.init(
+  dsn="___DSN___",
+  traces_sample_rate=1.0,
+  _experiments={
+    "profiles_sample_rate": 1.0,
+  },
+)
+```
 
 </PlatformSection>
 

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -135,6 +135,12 @@ The `io.sentry.traces.profiling.sample-rate` setting is *relative* to the `io.se
 
 <PlatformSection supported={["python"]}>
 
+<Note>
+
+Python profiling alpha is available starting in SDK version `1.11.0` and only for WSGI applications.
+
+</Note>
+
 ```python
 sentry_sdk.init(
   dsn="___DSN___",
@@ -144,6 +150,12 @@ sentry_sdk.init(
   },
 )
 ```
+
+<Note>
+
+The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to the <PlatformIdentifier name="traces_sample_rate" /> setting.
+
+</Note>
 
 </PlatformSection>
 


### PR DESCRIPTION
In preparation for the python profiling alpha, this adds the python profiling setup.