### PR TITLE
Split Phoenix vs Plug config for better skimmability

### DIFF
--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -69,19 +69,23 @@ config :sentry, dsn: "___PUBLIC_DSN___",
 
 In this example, we are getting the environment name from the `RELEASE_LEVEL` environment variable. If that variable does not exist, it will default to `"development"`. Now, on our servers, we can set the environment variable appropriately. On our local development machines, exceptions will never be sent, because the default value is not in the list of `included_environments`.
 
-If using an environment with Plug or Phoenix, add the following to `Plug.Router` or `Phoenix.Endpoint`:
+If using an environment with Phoenix, add the following to `Plug.Router` and `Phoenix.Endpoint`:
 
 ```elixir
-# Phoenix
+# Endpoint
 use Sentry.PlugCapture
 use Phoenix.Endpoint, otp_app: :my_app
-# ...
+
+# Endpoint or Router
 plug Plug.Parsers,
  parsers: [:urlencoded, :multipart, :json],
  pass: ["*/*"],
  json_decoder: Phoenix.json_library()
 plug Sentry.PlugContext
-# Plug
+```
+
+If you are not using Phoenix but are using Plug, add the following to your plug pipeline:
+```elixir
 use Plug.Router
 use Sentry.PlugCapture
 # ...


### PR DESCRIPTION
After being confused by the one code block containing code for both Phoenix projects and Plug-only projects, I figured it would be best to split that code into two blocks, one for each environment type.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
