### PR TITLE
fix(apple): AppHangs need SentryCrash

### DIFF
--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -14,7 +14,7 @@ The event has the stack trace of all running threads so you can easily detect wh
 
 The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
 
-If you disable the SentryCrashIntegration, this integration doesn't work, as it uses the SentryCrashIntegration to capture the stacktrace when creating the app hang event.
+Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, if SentryCrashIntegration is disabled, the integration won’t work.
 
 To use this feature, add this to your code:
 

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -14,6 +14,8 @@ The event has the stack trace of all running threads so you can easily detect wh
 
 The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
 
+If you disable the SentryCrashIntegration, this integration doesn't work, as it uses the SentryCrashIntegration to capture the stacktrace when creating the app hang event.
+
 To use this feature, add this to your code:
 
 ```swift {tabTitle:Swift}


### PR DESCRIPTION
Point out that the app hang integration depends on the SentryCrashIntegration.