### PR TITLE
docs(options): adjust send_default_pii recommendation

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -236,7 +236,7 @@ If you are using Sentry in your mobile app, read our [frequently asked questions
 
 </Note>
 
-If possible, we recommended turning on this feature to send all such data by default, and manually removing what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
+If you enable this option, be sure to manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
 
 </ConfigKey>
 


### PR DESCRIPTION
We should not suggest setting `send_default_pii` as `True` by default without further details on what sensitive information it will send in each platform/framework. It's too risky and can expose credentials, session cookies, etc.