### PR TITLE
fix(native): hub abstraction not implemented

### DIFF
--- a/src/platform-includes/enriching-events/scopes/configure-scope/native.mdx
+++ b/src/platform-includes/enriching-events/scopes/configure-scope/native.mdx
@@ -1,4 +1,4 @@
-In the Native SDK configures all data on the global scope.
+The Native SDK maintains all data in a single global scope.
 
 ```c
 #include <sentry.h>

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -64,7 +64,7 @@ then merge the event with the topmost scope's data.
 
 <Alert level="warning" title="Hub Abstraction Is Not Implemented">
 
-The Native SDK currently only provides a single scope shared by all threads in the program and maintains no thread-local state by way of a hub. Because of this limitation, you must make sure that your threads don't logically interfere with each other's changes to the global scope, even though they are safe to do so purely from a data-race perspective. This, for example, affects use cases where you want to track many users in server-like programs while capturing events or when you want to trace multiple threads in performance monitoring.
+The Native SDK currently only provides a single scope shared by all threads in the program and maintains no thread-local state by way of a hub. Because of this limitation, you must make sure that your threads don't logically interfere with each other's changes to the global scope, even though they are safe to do so purely from a data-race perspective. This affects use cases where, for example, you want to track many users in server-like programs while capturing events or when you want to trace multiple threads in performance monitoring.
 
 For details on how this affects performance monitoring, check out the [Connect Errors With Spans](/platforms/native/performance/instrumentation/custom-instrumentation/#connect-errors-with-spans) section of "Custom Instrumentation".
 

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -60,6 +60,14 @@ When you call a global function such as `capture_event` internally Sentry
 discovers the current hub and asks it to capture an event. Internally the hub will
 then merge the event with the topmost scope's data.
 
+<PlatformSection supported={["native"]}>
+<Alert level="warning" title="Hub abstraction is not implemented">
+The Native SDK currently only provides a single Scope shared by all threads in the program and maintains no thread-local state via a Hub. As a result of this limitation, client code must ensure that threads do not interfere with their changes to the global scope, even though it is safe to do so from a data-race perspective. This, for example, affects use cases where you want to track many users in server-like programs while capturing events or when you want to trace multiple threads in performance monitoring.
+
+For details on how this affects performance monitoring, please consult the [Connect Errors With Spans](/platforms/native/performance/instrumentation/custom-instrumentation/#connect-errors-with-spans) section of "Custom Instrumentation".
+</Alert> 
+</PlatformSection>
+
 ## Configuring the Scope
 
 The most useful operation when working with scopes is the `configure-scope` function. It can be used to reconfigure the current scope.

--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -61,10 +61,13 @@ discovers the current hub and asks it to capture an event. Internally the hub wi
 then merge the event with the topmost scope's data.
 
 <PlatformSection supported={["native"]}>
-<Alert level="warning" title="Hub abstraction is not implemented">
-The Native SDK currently only provides a single Scope shared by all threads in the program and maintains no thread-local state via a Hub. As a result of this limitation, client code must ensure that threads do not interfere with their changes to the global scope, even though it is safe to do so from a data-race perspective. This, for example, affects use cases where you want to track many users in server-like programs while capturing events or when you want to trace multiple threads in performance monitoring.
 
-For details on how this affects performance monitoring, please consult the [Connect Errors With Spans](/platforms/native/performance/instrumentation/custom-instrumentation/#connect-errors-with-spans) section of "Custom Instrumentation".
+<Alert level="warning" title="Hub Abstraction Is Not Implemented">
+
+The Native SDK currently only provides a single scope shared by all threads in the program and maintains no thread-local state by way of a hub. Because of this limitation, you must make sure that your threads don't logically interfere with each other's changes to the global scope, even though they are safe to do so purely from a data-race perspective. This, for example, affects use cases where you want to track many users in server-like programs while capturing events or when you want to trace multiple threads in performance monitoring.
+
+For details on how this affects performance monitoring, check out the [Connect Errors With Spans](/platforms/native/performance/instrumentation/custom-instrumentation/#connect-errors-with-spans) section of "Custom Instrumentation".
+
 </Alert> 
 </PlatformSection>
 


### PR DESCRIPTION
Let's clarify in the explanation of Hub & Scope that the Hub abstraction is not yet implemented in the Native SDK. While the tracing docs mention this shortcoming, changes to the scope from multiple threads are currently not coordinated (besides locking for mutually exclusive access) and affect other use cases too.

Please, @Swatinem and @imatwawana, I welcome your input.
