### PR TITLE
replace toSentryTrace with toTraceparent

### DIFF
--- a/src/platform-includes/performance/connect-services/javascript.mdx
+++ b/src/platform-includes/performance/connect-services/javascript.mdx
@@ -25,7 +25,7 @@ For traces that begin in your backend, you can connect the automatically-generat
 ```html
 <html>
   <head>
-    <meta name="sentry-trace" content="{{ span.toSentryTrace() }}" />
+    <meta name="sentry-trace" content="{{ span.toTraceparent() }}" />
     <meta name="baggage" content="{{ serializeBaggage(span.getBaggage()) }}" />
     <!-- ... -->
   </head>


### PR DESCRIPTION
the correct function to get traceID for sentry-trace header is now toTraceparent, see: https://github.com/getsentry/sentry-javascript/blob/master/packages/tracing/src/span.ts#L259-L265

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
