### PR TITLE
Fixing typos in code examples

### DIFF
--- a/src/platform-includes/performance/file-io-instrumentation/java.mdx
+++ b/src/platform-includes/performance/file-io-instrumentation/java.mdx
@@ -10,7 +10,7 @@ File file1 = new File("file1.txt");
 File file2 = new File("file2.txt");
 try (FileInputStream fis = new FileInputStream(file1)) {
   byte[] buffer = new byte[1024];
-  try (FileOutputStream fos = FileOutputStream(file2)) {
+  try (FileOutputStream fos = new FileOutputStream(file2)) {
     int read;
     while (true) {
       read = fis.read(buffer);
@@ -45,7 +45,7 @@ File file1 = new File("file1.txt");
 File file2 = new File("file2.txt");
 try (FileInputStream fis = new SentryFileInputStream(file1)) {
   byte[] buffer = new byte[1024];
-  try (FileOutputStream fos = SentryFileOutputStream(file2)) {
+  try (FileOutputStream fos = new SentryFileOutputStream(file2)) {
     int read;
     while (true) {
       read = fis.read(buffer);
@@ -80,7 +80,7 @@ File file1 = new File("file1.txt");
 File file2 = new File("file2.txt");
 try (FileReader reader = new FileReader(file1)) {
   char[] buffer = new char[1024];
-  try (FileWriter writer = FileWriter(file2, true)) {
+  try (FileWriter writer = new FileWriter(file2, true)) {
     int read;
     while (true) {
       read = reader.read(buffer, 0, buffer.length);
@@ -116,7 +116,7 @@ File file1 = new File("file1.txt");
 File file2 = new File("file2.txt");
 try (FileReader reader = new SentryFileReader(file1)) {
   char[] buffer = new char[1024];
-  try (FileWriter writer = SentryFileWriter(file2, true)) {
+  try (FileWriter writer = new SentryFileWriter(file2, true)) {
     int read;
     while (true) {
       read = reader.read(buffer, 0, buffer.length);


### PR DESCRIPTION
Code examples were missing `new` statement on second file open. 
