### PR TITLE
fix(gatsby): Fix performance sample rate option in getting started snippets

### DIFF
--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -53,7 +53,7 @@ import * as Sentry from '@sentry/gatsby';
 
 Sentry.init({
     dsn: "___PUBLIC_DSN___",
-    sampleRate: 1.0, // Adjust this value in production
+    tracesSampleRate: 1.0, // Adjust this value in production
     beforeSend(event) {
       // Modify the event here
       if (event.user) {
@@ -71,7 +71,7 @@ import * as Sentry from '@sentry/gatsby';
 
 Sentry.init({
     dsn: "___PUBLIC_DSN___",
-    sampleRate: 1.0, // Adjust this value in production
+    tracesSampleRate: 1.0, // Adjust this value in production
     beforeSend(event) {
       // Modify the event here
       if (event.user) {
@@ -94,7 +94,7 @@ module.exports = {
       resolve: "@sentry/gatsby",
       options: {
         dsn: "___PUBLIC_DSN___",
-        sampleRate: 1.0, // Adjust this value in production
+        tracesSampleRate: 1.0, // Adjust this value in production
         // Cannot set `beforeSend`
       },
     },


### PR DESCRIPTION
In all of our Getting Started snippets showing people the basic SDK setup, we include `tracesSampleRate: 1.0`, so that people will send transactions by default. In the gatsby docs, though, the option name is wrong - we're turning on error sampling, not transaction sampling. This fixes it to be the right option.