### PR TITLE
fix(various): Small formatting and language fixes

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -15,7 +15,7 @@ To see which of your projects are using up your quota, you can review the "Usage
 
 You can also download a project breakdown report in the "Usage History" tab of **Settings > Subscriptions** (only accessible to Owner and Billing members of your Sentry organization).
 
-Sentry’s flexibility means you can exercise fine-grained control over which events and attachments count toward your quota. This page provides you with high-level information about strategies for managing your quota, but you can get more detailed information in:
+Sentry's flexibility means you can exercise fine-grained control over which events and attachments count toward your quota. This page provides you with high-level information about strategies for managing your quota, but you can get more detailed information in:
 
 - [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/)
 - [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/)
@@ -43,7 +43,7 @@ This list of strategies for managing your quota is ordered from easiest or least
 
 ## Key Terms
 
-Let’s clarify a few terms to start:
+Let's clarify a few terms to start:
 
 - **Event** - An event is one instance of you sending data to Sentry, excluding attachments. Generally, this data is an error or a transaction.
 - **Error** - What counts as an error varies by platform, but in general, if there's something that looks like an exception, it can be captured as an error in Sentry. Sentry automatically captures errors, uncaught exceptions, and unhandled rejections, as well as other types of errors, depending on platform. A grouping of similar errors makes [an issue](/product/issues/).

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -274,7 +274,7 @@ You can find a list of deleted and discarded issues in the "Discarded Issues" ta
 
 ![List of Discarded Issues](manage-event-stream-07-new.png)
 
-Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `before-send` client-side filtering.
+Once you've identified a set of discarded issues, it might make sense to go back to your SDK configuration and add the related errors into your `beforeSend` client-side filtering.
 
 ## 5. Inbound Data Filters {#3-inbound-data-filters}
 

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -32,23 +32,15 @@ Sentry already scrubs PII in two places:
 1. In the SDK before sending the event
 2. Upon arrival on Sentry's infrastructure
 
-Relay adds a third option that scrubs data in a central place prior to sending
-it to Sentry.
+Relay adds a third option that scrubs data in a central place prior to sending it to Sentry.
 
 To choose the right place for data scrubbing, consider:
 
-- If you prefer to configure data scrubbing in a central place, you can let
-  Sentry handle data scrubbing. Upon arrival, Sentry immediately applies
-  [server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/) and guarantees that personal information is never
-  stored.
+- If you prefer to configure data scrubbing in a central place, you can let Sentry handle data scrubbing. Upon arrival, Sentry immediately applies [server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/) and guarantees that personal information is never stored.
 
-- If you cannot send PII outside your infrastructure, but you still prefer to
-  configure data scrubbing in a centralized place, configure your SDK to send events to Relay. Relay uses the privacy settings configured in Sentry, and scrubs PII before forwarding data to Sentry.
+- If you cannot send PII outside your infrastructure, but you still prefer to configure data scrubbing in a centralized place, configure your SDK to send events to Relay. Relay uses the privacy settings configured in Sentry, and scrubs PII before forwarding data to Sentry.
 
-- If you must enforce strict data privacy requirements, you can configure SDKs to
-  scrub PII using the [`before-send` hooks](/platform-redirect/?next=/configuration/options/%23hooks), which prevents data from being
-  collected on the device. This may require you to replicate the same logic across
-  your applications, and may impact performance.
+- If you must enforce strict data privacy requirements, you can configure SDKs to scrub PII using the [`beforeSend` hook](/platform-redirect/?next=/configuration/options/%23hooks), which prevents data from being collected on the device. This may require you to replicate the same logic across your applications, and may impact performance.
 
 ### Response Time
 

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -36,9 +36,9 @@ Relay adds a third option that scrubs data in a central place prior to sending i
 
 To choose the right place for data scrubbing, consider:
 
-- If you prefer to configure data scrubbing in a central place, you can let Sentry handle data scrubbing. Upon arrival, Sentry immediately applies [server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/) and guarantees that personal information is never stored.
+- If you prefer to configure data scrubbing in a central place, you can let Sentry handle it. When an event arrives, Sentry will immediately apply [server-side scrubbing](/product/data-management-settings/scrubbing/server-side-scrubbing/), guaranteeing that personal information won't ever be stored.
 
-- If you cannot send PII outside your infrastructure, but you still prefer to configure data scrubbing in a centralized place, configure your SDK to send events to Relay. Relay uses the privacy settings configured in Sentry, and scrubs PII before forwarding data to Sentry.
+- If you can't send PII outside your infrastructure, but still prefer to configure data scrubbing in a centralized place, configure your SDK to send events to Relay, which uses the privacy settings configured in Sentry, and scrubs PII before forwarding any data.
 
 - If you must enforce strict data privacy requirements, you can configure SDKs to scrub PII using the [`beforeSend` hook](/platform-redirect/?next=/configuration/options/%23hooks), which prevents data from being collected on the device. This may require you to replicate the same logic across your applications, and may impact performance.
 

--- a/src/platform-includes/configuration/decluttering/javascript.mdx
+++ b/src/platform-includes/configuration/decluttering/javascript.mdx
@@ -10,7 +10,7 @@ You can also use `denyUrls` if you want to block specific URLs forever.
 
 <Alert level="warning" title="Note">
 
-Previously, `allowUrls` and `denyUrls` were called `whitelistUrls` and `blacklistUrls` respectively. These options are removed in version 7.0. For more information, please see our [Inclusive Language Policy](https://develop.sentry.dev/inclusion/).
+Previously, `allowUrls` and `denyUrls` were called `whitelistUrls` and `blacklistUrls`, respectively. These options were removed in version 7.0. For more information, please see our [Inclusive Language Policy](https://develop.sentry.dev/inclusion/).
 
 </Alert>
 

--- a/src/platform-includes/configuration/decluttering/javascript.mdx
+++ b/src/platform-includes/configuration/decluttering/javascript.mdx
@@ -2,9 +2,7 @@ You can construct an allowed list of domains which might raise acceptable except
 
 ```javascript
 Sentry.init({
-  allowUrls: [
-    /https?:\/\/((cdn|www)\.)?example\.com/
-  ]
+  allowUrls: [/https?:\/\/((cdn|www)\.)?example\.com/],
 });
 ```
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -559,7 +559,7 @@ thread-safe APIs and only use Unity-specific APIs after you've checked that you'
 
 <ConfigKey name="before-send">
 
-This function is called with an SDK-specific event object, and can return a modified event object or nothing to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
 </ConfigKey>
 

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -53,13 +53,13 @@ SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked 
 
 <PlatformContent includePath="configuration/before-send" />
 
-There are a few areas you should consider where sensitive data may appear:
+Sensitive data may appear in the following areas:
 
-- Stack-locals → Some SDKs (Python + PHP), will pick up variable values within the stacktrace. This can be scrubbed or disabled altogether, if necessary.
-- Breadcrumbs → Some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed.
+- Stack-locals → Some SDKs (Python and PHP) will pick up variable values within the stacktrace. These can be scrubbed, or this behavior can be disabled altogether if necessary.
+- Breadcrumbs → Some SDKs (JavaScript and the Java logging integrations, for example) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will also record database queries, which may need to be scrubbed.
 - User context → Automated behavior is controlled via `send-default-pii`.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
-- Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework you use, your routing configurations, timings, and a few other factors, the SDKs might not be able to completely parameterize all your URLs.
+- Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -55,15 +55,11 @@ SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked 
 
 There's a few areas you should consider that sensitive data may appear:
 
-- Stack-locals → some SDKs (Python + PHP), will pick up variable values within the stacktrace. This can be scrubbed or disabled altogether, if necessary
-- Breadcrumbs → some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed
-- User context → automated behavior is controlled via `send-default-pii`
-- HTTP context → query strings may be picked up in some frameworks as part of the HTTP request context
-- Transaction Names → In certain situations, transaction names might contain sensitive data.
-  For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII).
-In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`.
-  However, depending on the framework you use, your routing configurations, timings, and a few other factors, the SDKs might not be able to
-  completely parameterize all your URLs.
+- Stack-locals → Some SDKs (Python + PHP), will pick up variable values within the stacktrace. This can be scrubbed or disabled altogether, if necessary.
+- Breadcrumbs → Some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed.
+- User context → Automated behavior is controlled via `send-default-pii`.
+- HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
+- Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework you use, your routing configurations, timings, and a few other factors, the SDKs might not be able to completely parameterize all your URLs.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -53,7 +53,7 @@ SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked 
 
 <PlatformContent includePath="configuration/before-send" />
 
-There's a few areas you should consider that sensitive data may appear:
+There are a few areas you should consider where sensitive data may appear:
 
 - Stack-locals → Some SDKs (Python + PHP), will pick up variable values within the stacktrace. This can be scrubbed or disabled altogether, if necessary.
 - Breadcrumbs → Some SDKs (for example, JavaScript, Java logging integrations) will pick up previously executed log statements. **Do not log PII** if using this feature and including log statements as breadcrumbs in the event. Some backend SDKs will surface DB queries which may need to be scrubbed.

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -28,7 +28,7 @@ The user feedback API provides the ability to collect user information when an e
 
 <PlatformSection notSupported={["unreal"]}>
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. To get the `eventId`, for example, you can use the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>, or the return value of the methods capturing an event.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> or the return value of the method capturing an event.
 
 </PlatformSection>
 

--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -42,7 +42,9 @@ This integration captures all `Console API` calls and redirects them to Sentry u
 
 _Import name: `Sentry.Integrations.Debug`_
 
-This integration allows you to inspect the content of the processed event that will be passed to `beforeSend`, and effectively send it to the Sentry SDK. It will *always* run as the last integration, no matter when it was registered.
+This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend`. It will _always_ run as the last integration, no matter when it was registered.
+
+Note that this is different than setting `debug: true` in your `Sentry.init` options, which will enable debug logging in the console.
 
 Available options:
 

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -321,7 +321,7 @@ hub.withScope(function(scope) {
 });
 ```
 
-### Dealing with integrations
+### Dealing with Integrations
 
 Integrations are setup on the `Client`, if you need to deal with multiple clients and hubs you have to make sure to also do the integration handling correctly.
 Here is a working example of how to use multiple clients with multiple hubs running global integrations.
@@ -356,7 +356,7 @@ const client1 = new Sentry.BrowserClient({
   integrations: [...Sentry.defaultIntegrations, new HappyIntegration()],
   beforeSend(event) {
     console.log("client 1", event);
-    return null; // Returning null does not send the event
+    return null; // Returning `null` prevents the event from being sent
   },
 });
 const hub1 = new Sentry.Hub(client1);
@@ -368,13 +368,13 @@ const client2 = new Sentry.BrowserClient({
   integrations: [...Sentry.defaultIntegrations, new HappyIntegration()],
   beforeSend(event) {
     console.log("client 2", event);
-    return null; // Returning null does not send the event
+    return null; // Returning `null` prevents the event from being sent
   },
 });
 const hub2 = new Sentry.Hub(client2);
 
 hub1.run(currentHub => {
-  // The hub.run method makes sure that Sentry.getCurrentHub() returns this hub during the callback
+  // The `hub.run` method makes sure that `Sentry.getCurrentHub()` returns this hub during the callback
   currentHub.captureMessage("a");
   currentHub.configureScope(function(scope) {
     scope.setTag("a", "b");
@@ -382,7 +382,7 @@ hub1.run(currentHub => {
 });
 
 hub2.run(currentHub => {
-  // The hub.run method makes sure that Sentry.getCurrentHub() returns this hub during the callback
+  // The `hub.run` method makes sure that `Sentry.getCurrentHub()` returns this hub during the callback
   currentHub.captureMessage("x");
   currentHub.configureScope(function(scope) {
     scope.setTag("c", "d");

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -266,7 +266,12 @@ This also helps to prevent tracking of any parent application errors in case you
 inside of it. In this example we use `@sentry/browser` but it's also applicable to `@sentry/node`.
 
 ```javascript
-import { BrowserClient, defaultStackParser, defaultIntegrations, makeFetchTransport } from "@sentry/browser";
+import {
+  BrowserClient,
+  defaultStackParser,
+  defaultIntegrations,
+  makeFetchTransport,
+} from "@sentry/browser";
 
 const client = new BrowserClient({
   dsn: "___PUBLIC_DSN___",
@@ -281,7 +286,12 @@ client.captureException(new Error("example"));
 While the above sample should work perfectly fine, some methods like `configureScope` and `withScope` are missing on the `Client` because the `Hub` takes care of the state management. That's why it may be easier to create a new `Hub` and bind your `Client` to it. The result is the same but you will also get state management with it.
 
 ```javascript
-import { BrowserClient, defaultStackParser, defaultIntegrations, makeFetchTransport } from "@sentry/browser";
+import {
+  BrowserClient,
+  defaultStackParser,
+  defaultIntegrations,
+  makeFetchTransport,
+} from "@sentry/browser";
 
 const client = new BrowserClient({
   dsn: "___PUBLIC_DSN___",

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -42,45 +42,45 @@ module.exports = {
     {
       resolve: "@sentry/gatsby",
     },
-  ]
+  ],
 };
 ```
 
 Configure your `Sentry.init`:
 
 ```javascript {filename:sentry.config.js}
-import * as Sentry from '@sentry/gatsby';
+import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0, // Adjust this value in production
-    beforeSend(event) {
-      // Modify the event here
-      if (event.user) {
-        // Don't send user's email address
-        delete event.user.email;
-      }
-      return event;
-    },
-    // ...
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0, // Adjust this value in production
+  beforeSend(event) {
+    // Modify the event here
+    if (event.user) {
+      // Don't send user's email address
+      delete event.user.email;
+    }
+    return event;
+  },
+  // ...
 });
 ```
 
 ```typescript {filename:sentry.config.ts}
-import * as Sentry from '@sentry/gatsby';
+import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0, // Adjust this value in production
-    beforeSend(event) {
-      // Modify the event here
-      if (event.user) {
-        // Don't send user's email address
-        delete event.user.email;
-      }
-      return event;
-    },
-    // ...
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0, // Adjust this value in production
+  beforeSend(event) {
+    // Modify the event here
+    if (event.user) {
+      // Don't send user's email address
+      delete event.user.email;
+    }
+    return event;
+  },
+  // ...
 });
 ```
 
@@ -90,6 +90,7 @@ Another alternative is to use Gatsby's [plugin configuration options](https://ww
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {
+  plugins: [
     {
       resolve: "@sentry/gatsby",
       options: {
@@ -98,8 +99,7 @@ module.exports = {
         // Cannot set `beforeSend`
       },
     },
-
-  ]
+  ],
 };
 ```
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -86,7 +86,7 @@ Sentry.init({
 
 ### Gatsby Plugin Configuration
 
-Another alternative is to use Gatsby's [plugin configuration options](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site/#using-plugin-configuration-options). While this keeps the SDK options with the plugin definition, it doesn't support non-serializable options.
+Another alternative is to use Gatsby's [plugin configuration options](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site/#using-plugin-configuration-options). While this keeps the SDK options with the plugin definition, it doesn't support non-serializable options like `integrations`, `transport`, `stackParser`,`beforeSend`, and `tracesSampler`.
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {
@@ -96,7 +96,7 @@ module.exports = {
       options: {
         dsn: "___PUBLIC_DSN___",
         tracesSampleRate: 1.0, // Adjust this value in production
-        // Cannot set `beforeSend`
+        // Cannot set any non-serializable options
       },
     },
   ],

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -35,7 +35,9 @@ This integration deduplicates certain events. It can be helpful if you're receiv
 
 _Import name: `Sentry.Integrations.Debug`_
 
-This integration allows you to quickly inspect the content of the processed event that will be passed to `beforeSend` and effectively send it to Sentry.
+This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend`. It will _always_ run as the last integration, no matter when it was registered.
+
+Note that this is different than setting `debug: true` in your `Sentry.init` options, which will enable debug logging in the console.
 
 Available options:
 


### PR DESCRIPTION
This is a bunch of small fixes and tweaks extracted from my work adding `beforeSendTransaction` to the docs - autoformatting, proofreading, and the occasional clarification. 

Note to reviewers: Each commit is atomic and accurately described, so it may be easier to review just going through them that way.