### PR TITLE
feat(js): Add `beforeSendTransaction` option

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -35,7 +35,7 @@ This list of strategies for managing your quota is ordered from easiest or least
 | 4. [Review repeated events](#4-event-repetition) | &check; |  |  |
 | 5. [Filter your events](#inbound-data-filters) | &check; | &check; | &check; |
 | 6. [Update your SDK sample rate](#6-sdk-sample-rate) | &check; | &check; |  |
-| 7. [Apply SDK filtering](#7-sdk-filtering-beforesend) | &check; |  |  |
+| 7. [Apply SDK filtering](#7-sdk-filtering-beforesend) | &check; | &check; |  |
 | 8. [Update your SDK configuration](#8-sdk-configuration) | &check; | &check; |  |
 | 9. [Manage data size](#size-limits) | &check; | &check; | &check; |
 
@@ -88,9 +88,9 @@ If an inbound filter is applied for a type of error, transaction, or attachment,
 
 If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events, effectively limiting the number of errors and transactions you send to Sentry. Setting a sample rate is documented [for each SDK](/platform-redirect/?next=/configuration/sampling/), but you can also learn more in [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-sdk-sample-rate) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-sdk-configuration-tracing-options).
 
-### 7. SDK Filtering: `beforeSend`
+### 7. SDK Filtering: `beforeSend` and `beforeSendTransaction`
 
-All Sentry SDKs support the `beforeSend` callback method, which you can use to modify the data of an error event or to drop it completely. Learn more in [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#1-sdk-filtering-beforesend).
+All Sentry SDKs support the `beforeSend` callback method, which you can use to modify the data of an error event or to drop it completely. Many also support `beforeSendTransaction`. Learn more in [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#1-sdk-filtering-beforesend) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#1-sdk-filtering-beforesendtransaction).
 
 ### 8. SDK Configuration
 

--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -324,7 +324,7 @@ The SDK sample rate is not dynamic; changing it requires re-deployment. Also, ke
 
 ## 7. SDK Filtering: beforeSend {#1-sdk-filtering-beforesend}
 
-All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Learn more in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
+All Sentry SDKs support the `beforeSend` callback method. Once implemented, the method is invoked when the SDK captures an error event, right before sending it to your Sentry account. It receives the event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _error attributes_, and so on. Note that only error and message events pass through `beforeSend`. Tansaction events have a separate method, `beforeSendTransaction`, though it is not yet supported in all SDKs. Learn more about both methods in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
 
 ## 8. SDK Configuration {#2-sdk-configuration}
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -138,6 +138,10 @@ If you have a rogue client, Sentry supports blocking an IP from sending data. Na
 
 If you discover a problematic release causing excessive noise, Sentry supports ignoring all events and attachments from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the release to the "Releases" field.
 
-## 3. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
+## 3. SDK Filtering: beforeSendTransaction {#1-sdk-filtering-beforesendtransaction}
+
+Some Sentry SDKs support the `beforeSendTransaction` callback method. Once implemented, the method is invoked when the SDK captures a transaction event, right before sending it to your Sentry account. It receives the transaction event object as a parameter, so you can use that to modify the event's data or drop it completely (by returning `null`) based on your custom logic and the data available on the event, like _tags_, _environment_, _release version_, _transaction name_, and so on. Note that only transaction events pass through `beforeSendTransaction`. Error and message events have a separate method, `beforeSend`, which is supported in all SDKs. Learn more about both methods in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
+
+## 4. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
 
 When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options), including either setting a sample rate or providing a function for sampling. You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.

--- a/src/docs/product/relay/index.mdx
+++ b/src/docs/product/relay/index.mdx
@@ -40,7 +40,7 @@ To choose the right place for data scrubbing, consider:
 
 - If you can't send PII outside your infrastructure, but still prefer to configure data scrubbing in a centralized place, configure your SDK to send events to Relay, which uses the privacy settings configured in Sentry, and scrubs PII before forwarding any data.
 
-- If you must enforce strict data privacy requirements, you can configure SDKs to scrub PII using the [`beforeSend` hook](/platform-redirect/?next=/configuration/options/%23hooks), which prevents data from being collected on the device. This may require you to replicate the same logic across your applications, and may impact performance.
+- If you must enforce strict data privacy requirements, you can configure SDKs to scrub PII using the [`beforeSend` and `beforeSendTransaction` hooks](/platform-redirect/?next=/configuration/options/%23hooks), which will prevent data from being collected on the device. This may require you to replicate the same logic across your applications, and may impact performance.
 
 ### Response Time
 

--- a/src/platform-includes/configuration/before-send-transaction/javascript.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/javascript.mdx
@@ -1,0 +1,15 @@
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Called for transaction events
+  beforeSendTransaction(event) {
+    // Modify or drop the event here
+    if (event.transaction === "/unimportant/route") {
+      // Don't send the event to Sentry
+      return null;
+    }
+    return event;
+  },
+});
+```

--- a/src/platform-includes/configuration/before-send/javascript.mdx
+++ b/src/platform-includes/configuration/before-send/javascript.mdx
@@ -3,8 +3,10 @@ In JavaScript, you can use a function to modify the event or return a completely
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
+
+  // Called for message and error events
   beforeSend(event) {
-    // Modify the event here
+    // Modify or drop the event here
     if (event.user) {
       // Don't send user's email address
       delete event.user.email;

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -22,6 +22,8 @@ All Sentry SDKs support the <PlatformIdentifier name="before-send" /> callback m
 
 <PlatformContent includePath="configuration/before-send" />
 
+<PlatformContent includePath="configuration/before-send-transaction" />
+
 Note also that breadcrumbs can be filtered, as discussed in [our Breadcrumbs documentation](/product/error-monitoring/breadcrumbs/).
 
 <PlatformSection notSupported={["apple", "dotnet"]}>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -563,6 +563,18 @@ This function is called with an SDK-specific message or error event object, and 
 
 </ConfigKey>
 
+<ConfigKey name="before-send-transaction" supported={["javascript", "node"]}>
+
+This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+
+<PlatformSection supported={["javascript", "node"]}>
+
+_(New in version 7.18.0)_
+
+</PlatformSection>
+
+</ConfigKey>
+
 <ConfigKey name="on-crash" supported={["native"]}>
 
 This function is called with a backend-specific event object, and can return a modified event object or nothing to skip reporting the event. In contrast to `before_send`, it is only called when a crash occured. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).

--- a/src/platforms/common/data-management/sensitive-data/index.mdx
+++ b/src/platforms/common/data-management/sensitive-data/index.mdx
@@ -49,7 +49,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ## Scrubbing Data
 
-SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an event is sent and can be used to modify event data to remove sensitive information. Using <PlatformIdentifier name="before-send" /> in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, so sensitive data never leaves the local environment.
+SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. (Some SDKs also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions.) Using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDKs to **scrub any data before it is sent** is the recommended scrubbing approach, so sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send" />
 

--- a/src/platforms/common/enriching-events/event-processors.mdx
+++ b/src/platforms/common/enriching-events/event-processors.mdx
@@ -22,12 +22,12 @@ notSupported:
   - unreal
 ---
 
-You can enrich events with additional data by adding your own event processors, either on the scope level or globally. Though event processors are similar to `beforeSend`, there are two key differences:
+You can enrich events with additional data by adding your own event processors, either on the scope level or globally. Though event processors are similar to `beforeSend` and `beforeSendTransaction`, there are two key differences:
 
-- `beforeSend` is guaranteed to be run last, after all other event processors, which means it gets the final version of the event right before it's sent (hence the name). Event processors added with either of the methods below run in an undetermined order, which means changes to the event may still be made after the event processor runs.
-- While `beforeSend` and processors added with `Sentry.addGlobalEventProcessor` run globally, regardless of scope, processors added with `scope.addEventProcessor` only run on events captured while that scope is active.
+- `beforeSend` and `beforeSendTransaction` are guaranteed to be run last, after all other event processors, which means they gets the final version of the event right before it's sent (hence the name). Event processors added with either of the methods below run in an undetermined order, which means changes to the event may still be made after the event processor runs.
+- While `beforeSend`, `beforeSendTransaction`, and processors added with `Sentry.addGlobalEventProcessor` run globally, regardless of scope, processors added with `scope.addEventProcessor` only run on events captured while that scope is active.
 
-Both `beforeSend` and event processors are passed two arguments, the event itself and <PlatformLink to="/configuration/filtering/#using-hints">a `hint` object</PlatformLink> containing extra metadata.
+Like `beforeSend` and `beforeSendTransaction`, event processors are passed two arguments, the event itself and <PlatformLink to="/configuration/filtering/#using-hints">a `hint` object</PlatformLink> containing extra metadata.
 
 Event processors added to the global scope will run on every event sent after they are added.
 

--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -42,7 +42,7 @@ This integration captures all `Console API` calls and redirects them to Sentry u
 
 _Import name: `Sentry.Integrations.Debug`_
 
-This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend`. It will _always_ run as the last integration, no matter when it was registered.
+This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend` or `beforeSendTransaction`. It will _always_ run as the last integration, no matter when it was registered.
 
 Note that this is different than setting `debug: true` in your `Sentry.init` options, which will enable debug logging in the console.
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -86,7 +86,7 @@ Sentry.init({
 
 ### Gatsby Plugin Configuration
 
-Another alternative is to use Gatsby's [plugin configuration options](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site/#using-plugin-configuration-options). While this keeps the SDK options with the plugin definition, it doesn't support non-serializable options like `integrations`, `transport`, `stackParser`,`beforeSend`, and `tracesSampler`.
+Another alternative is to use Gatsby's [plugin configuration options](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site/#using-plugin-configuration-options). While this keeps the SDK options with the plugin definition, it doesn't support non-serializable options like `integrations`, `transport`, `stackParser`,`beforeSend`, `beforeSendTransaction`, and `tracesSampler`.
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -35,7 +35,7 @@ This integration deduplicates certain events. It can be helpful if you're receiv
 
 _Import name: `Sentry.Integrations.Debug`_
 
-This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend`. It will _always_ run as the last integration, no matter when it was registered.
+This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend` or `beforeSendTransaction`. It will _always_ run as the last integration, no matter when it was registered.
 
 Note that this is different than setting `debug: true` in your `Sentry.init` options, which will enable debug logging in the console.
 


### PR DESCRIPTION
This adds the new `beforeSendTransaction` option to the docs, both on the options page and alongside `beforeSend` in many places in the text. Because you can't selectively turn certain phrases on and off for different platforms, I tried to indicate where I could that it's not universally supported. (Right now, I believe JS is in fact the only platform to support it, though I expect that to change in the near future.) It also does a tiny bit of wordsmithing of the text around the additions, courtesy of @lizokm and @imatwawana.

Note that the one spot where updates haven't been done in this PR is the text of the Filtering page, as it's being worked on separately in https://github.com/getsentry/sentry-docs/pull/5804. Once the changes there are done, https://github.com/getsentry/sentry-docs/pull/5838 will add `beforeSendTransaction`.