### PR TITLE
fix(quota): Remove `sampleRate` section in transaction quota guide

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -86,7 +86,7 @@ If an inbound filter is applied for a type of error, transaction, or attachment,
 
 ### 6. SDK Sample Rate
 
-If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events, effectively limiting the number of errors and transactions you send to Sentry. Setting a sample rate is documented [for each SDK](/platform-redirect/?next=/configuration/sampling/), but you can also learn more in [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-sdk-sample-rate) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#3-sdk-sample-rate).
+If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events, effectively limiting the number of errors and transactions you send to Sentry. Setting a sample rate is documented [for each SDK](/platform-redirect/?next=/configuration/sampling/), but you can also learn more in [Manage Your Error Quota](/product/accounts/quotas/manage-event-stream-guide/#6-sdk-sample-rate) and [Manage Your Transaction Quota](/product/accounts/quotas/manage-transaction-quota/#2-sdk-configuration-tracing-options).
 
 ### 7. SDK Filtering: `beforeSend`
 

--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -138,12 +138,6 @@ If you have a rogue client, Sentry supports blocking an IP from sending data. Na
 
 If you discover a problematic release causing excessive noise, Sentry supports ignoring all events and attachments from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the release to the "Releases" field.
 
-## 3. SDK Sample Rate
+## 3. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
 
-If a sample rate is defined for the SDK, the SDK evaluates whether this event should be sent as a representative fraction of events. Setting a sample rate is [documented for each SDK](/platform-redirect/?next=/configuration/sampling/).
-
-The SDK sample rate is not dynamic; changing it requires re-deployment. Also, keep in mind that setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project may better suit your needs.
-
-## 4. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
-
-When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options). You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.
+When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options), including either setting a sample rate or providing a function for sampling. You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.


### PR DESCRIPTION
This removes the SDK Sample Rate section from the guide on transaction quota management, because `sampleRate` doesn't apply to transactions, and `tracesSampleRate` is covered by the next heading, SDK Tracing options.