### PR TITLE
Make source maps troubleshooting page bundler-agnostic

### DIFF
--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -6,7 +6,7 @@ description: "Troubleshooting for source maps."
 sidebar_order: 8
 ---
 
-Source maps can sometimes be tricky to get going. If you’re having trouble, you can try using our verification tool inside `sentry-cli`, or go through the steps listed below yourself. Please keep in mind, that the `sentry-cli` is a work-in-progress, and we’re actively working to improve it.
+Source maps can sometimes be tricky to get going. If you're having trouble, you can try using our verification tool inside `sentry-cli`, or go through the steps listed below yourself. Please keep in mind, that the `sentry-cli` is a work-in-progress, and we're actively working to improve it.
 
 To use the automated verification process, [install and configure](/product/cli/) `sentry-cli`. Once completed, use the `sourcemaps explain` command, by calling it with the event ID that can be found at the top of the **Issue Details** page in [sentry.io](https://sentry.io). For example, "Event fdfd1337e3964cd6a4d11f35357a4c43 | JSON (42.0 KiB)".
 
@@ -15,7 +15,7 @@ sentry-cli sourcemaps explain fdfd1337e3964cd6a4d11f35357a4c43
 ```
 
 This should provide you with some useful hints about what exactly went wrong with the source maps setup process.
-If it doesn’t, let us know so we can make it better.
+If it doesn't, let us know so we can make it better.
 
 <PlatformSection notSupported={["javascript.electron"]}>
 
@@ -46,7 +46,7 @@ Alternately, instead of `sourceMappingURL`, you can set a `SourceMap` HTTP heade
 ## Verify artifact distribution value matches value configured in your SDK
 
 Whenever you are using a distribution identifier (the `dist` configuration option in the SDK), the same value has to be used during source map upload. Conversely, if your source maps are getting uploaded with a `dist` value, the same value must be set in your SDK.
-To add a `dist` value to your uploaded source maps, use the `--dist` flag with `sentry-cli` or the `dist` option with `@sentry/webpack-plugin`. To set the `dist` value in the SDK, use the `dist` option in your `Sentry.init()`.
+To add a `dist` value to your uploaded source maps, use the `--dist` flag with `sentry-cli` or the `dist` option in our [Sentry Bundler Plugins](https://github.com/getsentry/sentry-javascript-bundler-plugins) (like for example `@sentry/webpack-plugin`). To set the `dist` value in the SDK, use the `dist` option in your `Sentry.init()`.
 
 To verify that the distribution has been set correctly in the SDK, open an issue in the Sentry UI and check that the `dist` tag is present. For artifacts, go to the `Source Maps` page in project settings, choose the release shown on the event you just checked, and verify that the `dist` value (in the small oval next to the upload time) matches that on the event.
 
@@ -54,7 +54,7 @@ To verify that the distribution has been set correctly in the SDK, open an issue
 
 ## Verify artifact names match stack trace frames
 
-If you’ve uploaded source maps and they aren’t applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we’re attempting to resolve the file - for example, `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
+If you've uploaded source maps and they aren't applying to your code in an issue in Sentry, take a look at the JSON of the event and look for the `abs_path` to see exactly where we're attempting to resolve the file - for example, `http://localhost:8000/scripts/script.js` (`abs_path` will appear once for each frame in the stack trace - match this up with the file(s) that are not deminified.). A link to the JSON view can be found at the top of the issue page next to the date the event occurred. The uploaded artifact names must match these values.
 
 If you have **dynamic values in your path** (for example, `https://www.site.com/{some_value}/scripts/script.js`), you may want to use the <PlatformLink to="/configuration/integrations/plugin/#rewriteframes">`rewriteFrames` integration</PlatformLink> to change your `abs_path` values.
 
@@ -67,7 +67,7 @@ If your `sourceMappingURL` comment is similar to:
 //# sourceMappingURL=script.min.js.map
 ```
 
-An example `sentry-cli` command to upload these files correctly would look like this (assuming you’re in the `/scripts` directory, running your web server from one directory higher, which is why we’re using the `--url-prefix` option):
+An example `sentry-cli` command to upload these files correctly would look like this (assuming you're in the `/scripts` directory, running your web server from one directory higher, which is why we're using the `--url-prefix` option):
 
 ```shell
 sentry-cli releases files VERSION upload-sourcemaps . --url-prefix '~/scripts'
@@ -185,7 +185,7 @@ Alternatively, if you are using Sentry CLI to upload source maps to Sentry, you 
 
 ## Verify your source maps work locally
 
-If you find that Sentry is not mapping filename, line, or column mappings correctly, you should verify that your source maps are functioning locally. To do so, you can use Node.js coupled with Mozilla’s [source-map library](https://github.com/mozilla/source-map).
+If you find that Sentry is not mapping filename, line, or column mappings correctly, you should verify that your source maps are functioning locally. To do so, you can use Node.js coupled with Mozilla's [source-map library](https://github.com/mozilla/source-map).
 
 First, install `source-map` globally as an npm module:
 
@@ -193,25 +193,25 @@ First, install `source-map` globally as an npm module:
 npm install -g source-map
 ```
 
-Then, write a script that reads your source map file and tests a mapping. Here’s an example:
+Then, write a script that reads your source map file and tests a mapping. Here's an example:
 
 ```javascript
 var fs = require("fs"),
   path = require("path"),
   sourceMap = require("source-map");
 
-// file output by Webpack, Uglify, and so forth
+// Path to file that is generated by your build tool (webpack, tsc, ...)
 var GENERATED_FILE = path.join(".", "app.min.js.map");
 
-// line and column located in your generated file (for example, the source of your error
-// from your minified file)
+// Line and column located in your generated file (for example, the source
+// of error from your minified file)
 var GENERATED_LINE_AND_COLUMN = { line: 1, column: 1000 };
 
 var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();
 new sourceMap.SourceMapConsumer(rawSourceMap).then(function(smc) {
   var pos = smc.originalPositionFor(GENERATED_LINE_AND_COLUMN);
 
-  // should see something like:
+  // You should see something like:
   // { source: 'original.js', line: 57, column: 9, name: 'myfunc' }
   console.log(pos);
 });
@@ -223,7 +223,7 @@ If you have the same (incorrect) results locally as you do via Sentry, double-ch
 
 For an individual artifact, Sentry accepts a max filesize of **40 MB**.
 
-Often users hit this limit because they are transmitting source files at an interim build stage. For example, after Webpack/Browserify has combined all your source files, but before minification has taken place. If possible, send the original source files.
+Often users hit this limit because they are transmitting source files at an interim build stage. For example, after your bundler has combined all your source files, but before minification has taken place. If possible, send the original source files.
 
 ## Verify artifacts are not gzipped
 
@@ -231,7 +231,7 @@ The Sentry API currently only works with source maps and source files that are u
 
 If you are using `sentry-cli` to upload your artifacts, starting with version `2.4.0` you can add the `--decompress` flag to your `sourcemaps upload` or `files upload` commands.
 
-Sometimes build scripts and plugins produce pre-compressed minified files (for example, Webpack’s [compression plugin](https://github.com/webpack/compression-webpack-plugin)). In these cases, you’ll need to disable such plugins and perform the compression **after** the generated source maps/source files have been uploaded to Sentry.
+Sometimes build scripts and plugins produce pre-compressed minified files (for example, Webpack's [compression plugin](https://github.com/webpack/compression-webpack-plugin)). In these cases, you'll need to disable such plugins and perform the compression **after** the generated source maps/source files have been uploaded to Sentry.
 
 ## Verify workers are sharing the same volume as web (if running self-hosted Sentry via Docker)
 

--- a/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
+++ b/src/platforms/javascript/common/sourcemaps/troubleshooting_js.mdx
@@ -204,7 +204,7 @@ var fs = require("fs"),
 var GENERATED_FILE = path.join(".", "app.min.js.map");
 
 // Line and column located in your generated file (for example, the source
-// of error from your minified file)
+// of the error from your minified file)
 var GENERATED_LINE_AND_COLUMN = { line: 1, column: 1000 };
 
 var rawSourceMap = fs.readFileSync(GENERATED_FILE).toString();


### PR DESCRIPTION
This PR checks and adjusts all places in the source maps troubleshooting docs that assume our webpack plugin is the only plugin, which is not the case anymore since we support multiple bundlers now: https://github.com/getsentry/sentry-javascript-bundler-plugins

Also, adjusts some random wrong backticks.

Ref https://github.com/getsentry/sentry-docs/issues/5718