### PR TITLE
Enable node and electron to custom perf metrics docs

### DIFF
--- a/src/platforms/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/common/performance/instrumentation/performance-metrics.mdx
@@ -3,6 +3,8 @@ title: Performance Metrics
 sidebar_order: 20
 supported:
   - javascript
+  - node
+  - javascript.electron
   - python
   - dart
   - flutter
@@ -14,7 +16,6 @@ supported:
   - dotnet
 notSupported:
   - javascript.cordova
-  - javascript.electron
   - go
   - ruby
   - unity
@@ -31,7 +32,7 @@ description: "Learn how to attach performance metrics to your transactions."
 
 Sentry's SDKs support sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
 
-<PlatformSection supported={["javascript", "android", "apple", "flutter", "react-native"]}>
+<PlatformSection supported={["javascript", "android", "apple", "flutter", "react-native"]} notSupported={["node", "javascript.electron"]}>
 
 <PlatformContent includePath="performance/automatic-performance-metrics" />
 


### PR DESCRIPTION
Node and Electron both work since it is enabled for JavaScript.