### PR TITLE
docs: Add product docs for screenshots

### DIFF
--- a/src/docs/product/issues/issue-details/error-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/error-issues/index.mdx
@@ -51,7 +51,7 @@ A _suspect commit_ is a commit that's been identified as potentially having caus
 
 The tags displayed in the main section of this page are specific to the event that you're viewing. In contrast, the tags displayed in the right-hand sidebar are a summary of all tag values for all events included in the issue. You can set your own tags to make them more useful for debugging as described in <PlatformLink to="/enriching-events/tags/">Customize Tags</PlatformLink>.
 
-## Screenshots
+## Screenshot
 
 Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface. It's supported for the following SDKs:
 

--- a/src/docs/product/issues/issue-details/error-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/error-issues/index.mdx
@@ -51,6 +51,10 @@ A _suspect commit_ is a commit that's been identified as potentially having caus
 
 The tags displayed in the main section of this page are specific to the event that you're viewing. In contrast, the tags displayed in the right-hand sidebar are a summary of all tag values for all events included in the issue. You can set your own tags to make them more useful for debugging as described in <PlatformLink to="/enriching-events/tags/">Customize Tags</PlatformLink>.
 
+## Screenshots
+
+Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface.
+
 ## Exception (Stack Trace)
 
 The "Exception" section of the page displays the stack trace, which shows you the line of code that the event errored on:

--- a/src/docs/product/issues/issue-details/error-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/error-issues/index.mdx
@@ -53,7 +53,15 @@ The tags displayed in the main section of this page are specific to the event th
 
 ## Screenshots
 
-Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface.
+Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface. It's supported for the following SDKs:
+
+- [.NET Xamarin](/platforms/dotnet/guides/xamarin/)
+- [Android](/platforms/android/enriching-events/screenshots/)
+- [Flutter](/platforms/flutter/enriching-events/screenshots/)
+- [iOS](/platforms/apple/guides/ios/enriching-events/screenshots/)
+- [JavaScript Electron](/platforms/javascript/guides/electron/enriching-events/screenshots/)
+- [Unity](/platforms/unity/enriching-events/screenshots/)
+
 
 ## Exception (Stack Trace)
 

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -19,7 +19,7 @@ There are two categories of issues: [error issues](/product/issues/issue-details
 - **Trace Navigator** - An abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction.
 - **Suspect Commits** - A commit that's been identified as potentially having caused an error event.
 - **Tags** - Searchable key/value string pairs providing information such as the browser or device.
-- **Screenshot** - Screenshot taken when a user experiences an error, only available on certain SDKs.
+- **Screenshot** - Screenshot taken when a user experiences an error; only available on [certain SDKs](/product/issues/issue-details/error-issues/#screenshots).
 - **Exception (Stack Trace)** - Shows you the line of code that the event errored on.
 - **Span Evidence** - Information about the performance problem in the context of the current event
 - **Breadcrumbs** - Provide a history and timeline leading up to the error event and are customizable.

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -19,6 +19,7 @@ There are two categories of issues: [error issues](/product/issues/issue-details
 - **Trace Navigator** - An abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction.
 - **Suspect Commits** - A commit that's been identified as potentially having caused an error event.
 - **Tags** - Searchable key/value string pairs providing information such as the browser or device.
+- **Screenshot** - Screenshot taken when a user experiences an error, only available on certain SDKs.
 - **Exception (Stack Trace)** - Shows you the line of code that the event errored on.
 - **Span Evidence** - Information about the performance problem in the context of the current event
 - **Breadcrumbs** - Provide a history and timeline leading up to the error event and are customizable.
@@ -33,7 +34,7 @@ This page displays the "Details" tab when it first opens, but several other tabs
 
 - **Activity** - A history of activity for the event where team members can share comments.
 - **User Feedback** - Any feedback collected from users through the <PlatformLink to="/enriching-events/user-feedback/">SDK's user feedback</PlatformLink>.
-- <PlatformLink to="/enriching-events/attachments/">**Attachments**</PlatformLink> - Stored additional files, such as config or log files that are related to the error event.
+- **<PlatformLink to="/enriching-events/attachments/">Attachments</PlatformLink>** - Stored additional files, such as config, log or screenshot files that are related to the error event.
 - **Tags** - More detailed information about the tags across all the events included in the issue.
 - **All Events** - A list of all the error events included in the issue.
 - **Merged Issues** - A list of error issues that have been merged with this one.

--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -35,4 +35,4 @@ Additionally, screenshots appear in the "Attachments" tab, where you can view al
 
 ![Screenshots List Example](screenshots/screenshot-list-example.png)
 
-You can get an overview of all the screenshots associated with the events in your issue by clicking the "Screenshots" tab in the "Attachments" tab.
+You can get an overview of all the screenshots associated with the events in your issue by clicking the "Screenshots" tab under the "Attachments" tab.

--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -34,3 +34,5 @@ A thumbnail of the screenshot shows up at the top of the **Issue Details** page:
 Additionally, screenshots appear in the "Attachments" tab, where you can view all attachments, as well as associated events. Click the event ID to open the **Issue Details** page of that specific event.
 
 ![Screenshots List Example](screenshots/screenshot-list-example.png)
+
+You can get an overview of all the screenshots associated with the events in your issue by clicking the "Screenshots" tab in the "Attachments" tab.

--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -35,4 +35,4 @@ Additionally, screenshots appear in the "Attachments" tab, where you can view al
 
 ![Screenshots List Example](screenshots/screenshot-list-example.png)
 
-You can get an overview of all the screenshots associated with the events in your issue by clicking the "Screenshots" tab under the "Attachments" tab.
+You can see an overview of all the screenshots associated with the events in your issue by clicking "Screenshots" in the "Attachments" tab.


### PR DESCRIPTION
Add a couple lines of product docs for the screenshot feature.
There is already a Screenshot section in the relevant SDKs.
Fixed "Attachments" formatting:

Before

![Screen Shot 2022-11-21 at 11 36 31 AM](https://user-images.githubusercontent.com/63818634/203305392-195994b6-ac8c-4b65-be19-0d22f37459ec.png)

After
![Screen Shot 2022-11-22 at 6 39 59 AM](https://user-images.githubusercontent.com/63818634/203305271-9473ca44-af10-43fa-8fa8-b9f75e215dab.png)
