### PR TITLE
chore(otel): Update otel node installation instructions

### DIFF
--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -7,7 +7,7 @@ const {
   SentryPropagator,
 } = require("@sentry/opentelemetry-node");
 
-const opentelemetry = require("@opentelemetry/api");
+const opentelemetry = require("@opentelemetry/sdk-node");
 const {
   getNodeAutoInstrumentations,
 } = require("@opentelemetry/auto-instrumentations-node");

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -1,16 +1,25 @@
 You need to register `SentrySpanProcessor` and `SentryPropagator` with your OpenTelemetry installation:
 
 ```js
-import * as Sentry from "@sentry/node";
-import { SentrySpanProcessor } from "@sentry/opentelemetry-node";
+const Sentry = require("@sentry/node");
+const {
+  SentrySpanProcessor,
+  SentryPropagator,
+} = require("@sentry/opentelemetry-node");
 
-import * as otelApi from "@opentelemetry/api";
-import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+const opentelemetry = require("@opentelemetry/api");
+const {
+  getNodeAutoInstrumentations,
+} = require("@opentelemetry/auto-instrumentations-node");
+const {
+  OTLPTraceExporter,
+} = require("@opentelemetry/exporter-trace-otlp-grpc");
 
 // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  dsn: "__DSN__",
+  // set the instrumenter to use OpenTelemetry instead of Sentry
+  instrumenter: "otel",
   // ...
 });
 
@@ -23,5 +32,7 @@ const sdk = new opentelemetry.NodeSDK({
   spanProcessor: new SentrySpanProcessor(),
 });
 
-otelApi.propagation.setGlobalPropagator(new SentryPropagator());
+opentelemetry.propagation.setGlobalPropagator(new SentryPropagator());
+
+sdk.start();
 ```

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -7,7 +7,8 @@ const {
   SentryPropagator,
 } = require("@sentry/opentelemetry-node");
 
-const opentelemetry = require("@opentelemetry/sdk-node");
+const opentelemetry = require("@opentelemetry/api");
+const otelApi = require("@opentelemetry/api");
 const {
   getNodeAutoInstrumentations,
 } = require("@opentelemetry/auto-instrumentations-node");
@@ -32,7 +33,7 @@ const sdk = new opentelemetry.NodeSDK({
   spanProcessor: new SentrySpanProcessor(),
 });
 
-opentelemetry.propagation.setGlobalPropagator(new SentryPropagator());
+otelApi.propagation.setGlobalPropagator(new SentryPropagator());
 
 sdk.start();
 ```

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -7,7 +7,7 @@ const {
   SentryPropagator,
 } = require("@sentry/opentelemetry-node");
 
-const opentelemetry = require("@opentelemetry/api");
+const opentelemetry = require("@opentelemetry/sdk-node");
 const otelApi = require("@opentelemetry/api");
 const {
   getNodeAutoInstrumentations,

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -19,6 +19,7 @@ const {
 // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
 Sentry.init({
   dsn: "__DSN__",
+  tracesSampleRate: 1.0,
   // set the instrumenter to use OpenTelemetry instead of Sentry
   instrumenter: "otel",
   // ...


### PR DESCRIPTION
Mapping over the changes from https://github.com/getsentry/sentry-javascript/pull/6262

1. Convert from ES modules to `require`
2. Specify to set the `instrumenter` option to turn off Sentry instrumentation
3. Clean up imports 
4. Add `sdk.start` command to match otel docs: https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/#setup