### PR TITLE
Commit tracking and Suspect Commits screenshots need to be updated

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -94,11 +94,11 @@ Commit tracking allows you to hone in on problematic commits. With commit tracki
 
 Once you've configured both [release and commit tracking](/product/releases/), you'll be able to see more thorough information about a release: who made commits, which issues were newly introduced by this release, and which deploys were impacted.
 
-![Dashboard with last commit highlighted](last-commit-in-releases.png)
+-> ![Dashboard with last commit highlighted](last-commit-in-releases.png)
 
 When you investigate deeper into that commit, you can leverage information from metadata like tags.
 
-![Issue detail highlighting tags](highlighting-tags.png)
+-> ![Issue detail highlighting tags](highlighting-tags.png)
 
 Broadly, this lets you isolate problems in order to see which commits might be problematic.
 
@@ -110,7 +110,7 @@ Once you are tracking the commits, the 'suspect commit' is the commit that likel
 
 One special benefit of using Sentry's Commit Tracking is the ability to know the suspect commit that likely caused the error, with a suggested plan of action for how to rectify the error. For example, after pinpointing the suspect commit, you can also identify the developer who made the commit and assign them the task of fixing the error.
 
-![Issue detail highlighting suspect commits](highlighting-suspect-commits.png)
+-> ![Issue detail highlighting suspect commits](highlighting-suspect-commits.png)
 
 Here is where you can find info for [suspect commit setup](/product/releases/setup/release-automation/).
 
@@ -120,7 +120,7 @@ Once you've added a repository (see configuration step 8), you can start resolvi
 
 A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
-![Issue detail highlighting suspect commits](short-id.png)
+-> ![Issue detail highlighting suspect commits](short-id.png)
 
 ### Stack Trace Linking
 


### PR DESCRIPTION
The screenshots from the highlighted sections of the documentation are from an older version of the Web UI and need to be updated to avoid confusion.