### PR TITLE
docs(profiling): add rust profiling alpha doc

### DIFF
--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -26,6 +26,6 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)
-  - [Python](/platforms/python/profiling/)
   - [Node.js](/platforms/node/profiling)
+  - [Python](/platforms/python/profiling/)
   - [Rust](/platforms/rust/profiling)

--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -28,3 +28,4 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
   - [iOS](/platforms/apple/guides/ios/profiling/)
   - [Python](/platforms/python/profiling/)
   - [Node.js](/platforms/node/profiling)
+  - [Rust](/platforms/rust/profiling)

--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -14,8 +14,8 @@ Profiling is currently in beta. Beta features are still in-progress and may have
 
   * Android (Java and Kotlin only)
   * iOS (Swift and Objective-C only)
-  * Python
   * Node.js
+  * Python
   * Rust
 
 </Note>

--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -16,6 +16,7 @@ Profiling is currently in beta. Beta features are still in-progress and may have
   * iOS (Swift and Objective-C only)
   * Python
   * Node.js
+  * Rust
 
 </Note>
 

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -101,6 +101,20 @@ sentry_sdk.init(
 
 </PlatformSection>
 
+<PlatformSection supported={["rust"]}>
+
+```rust
+sentry::init((
+    "___DSN___",
+    sentry::ClientOptions {
+        traces_sample_rate: 1.0,
+        ..Default::default()
+    },
+));
+```
+
+</PlatformSection>
+
 Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured. By default, some transactions will be created automatically for common operations like loading a view controller/activity and app startup.
 
 ## Enable Profiling
@@ -177,6 +191,15 @@ The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to 
 Rust profiling alpha is available starting in SDK version `0.29.0`.
 
 </Note>
+
+In order to use profiling you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
+
+```cargo
+[dependencies]
+sentry = { version = "0.29.0", features = ["profiling"] }
+```
+
+Once you've completed the step above, you can proceed by enabling it in the SDK:
 
 ```rust
 sentry::init((

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -5,11 +5,11 @@ supported:
   - android
   - apple
   - python
+  - rust
 notSupported:
   - unity
   - dart
   - flutter
-  - rust
   - native
   - php
   - ruby
@@ -45,6 +45,14 @@ Profiling is currently in beta. Beta features are still in-progress and may have
 <Note>
 
 Python profiling is currently in alpha. Alpha features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
+
+</Note>
+
+<PlatformSection supported={["rust"]}>
+
+<Note>
+
+Rust profiling is currently in alpha. Alpha features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
 
 </Note>
 
@@ -90,6 +98,7 @@ sentry_sdk.init(
 ```
 
 </PlatformSection>
+
 
 Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured. By default, some transactions will be created automatically for common operations like loading a view controller/activity and app startup.
 
@@ -149,6 +158,35 @@ sentry_sdk.init(
     "profiles_sample_rate": 1.0,
   },
 )
+```
+
+<Note>
+
+The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to the <PlatformIdentifier name="traces_sample_rate" /> setting.
+
+</Note>
+
+</PlatformSection>
+
+
+<PlatformSection supported={["rust"]}>
+
+<Note>
+
+Rust profiling alpha is available starting in SDK version `0.29.0`.
+
+</Note>
+
+```rust
+sentry::init((
+    "___DSN___",
+    sentry::ClientOptions {
+        traces_sample_rate: 1.0,
+        enable_profiling: true,
+        profiles_sample_rate: 1.0,
+        ..Default::default()
+    },
+));
 ```
 
 <Note>

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -188,11 +188,11 @@ The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to 
 
 <Note>
 
-Rust profiling alpha is available starting in SDK version `0.29.0`.
+Rust Profiling alpha is available starting in SDK version `0.29.0`.
 
 </Note>
 
-In order to use profiling you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
+In order to use Profiling you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
 
 ```cargo
 [dependencies]

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -192,7 +192,7 @@ Rust Profiling alpha is available starting in SDK version `0.29.0`.
 
 </Note>
 
-In order to use Profiling you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
+In order to use Profiling, you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
 
 ```cargo
 [dependencies]

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -101,7 +101,6 @@ sentry_sdk.init(
 
 </PlatformSection>
 
-
 Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured. By default, some transactions will be created automatically for common operations like loading a view controller/activity and app startup.
 
 ## Enable Profiling

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -54,7 +54,7 @@ Python profiling is currently in alpha. Alpha features are still in-progress and
 
 <Note>
 
-Rust profiling is currently in alpha. Alpha features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
+Rust Profiling is currently in alpha. Alpha features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io).
 
 </Note>
 

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -48,6 +48,8 @@ Python profiling is currently in alpha. Alpha features are still in-progress and
 
 </Note>
 
+</PlatformSection>
+
 <PlatformSection supported={["rust"]}>
 
 <Note>


### PR DESCRIPTION
In preparation for the rust profiling alpha, this adds the rust profiling setup.