### PR TITLE
feat(otel): add NextJS OpenTelemetry docs

### DIFF
--- a/src/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
@@ -1,0 +1,22 @@
+<Alert level="info" title="Note">
+
+OpenTelemetry support is only supported for server-side instrumentation.
+
+</Alert>
+
+```bash {tabTitle:npm}
+npm install @sentry/nextjs @sentry/opentelemetry-node
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/nextjs @sentry/opentelemetry-node
+```
+
+<Note>
+
+Note that @sentry/opentelemetry-node depends on the following peer dependencies:
+
+- @opentelemetry/api, version 1.0.0 or greater
+- @opentelemetry/sdk-trace-base, version 1.0.0 or greater, or a package that implements it, like @opentelemetry/sdk-node
+
+</Note>

--- a/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
@@ -1,0 +1,40 @@
+You need to register `SentrySpanProcessor` and `SentryPropagator` with your OpenTelemetry installation in your `sentry.server.config.js` file:
+
+```javascript {filename:sentry.server.config.js}
+const Sentry = require("@sentry/nextjs");
+const {
+  SentrySpanProcessor,
+  SentryPropagator,
+} = require("@sentry/opentelemetry-node");
+
+const opentelemetry = require("@opentelemetry/sdk-node");
+const otelApi = require("@opentelemetry/api");
+const {
+  getNodeAutoInstrumentations,
+} = require("@opentelemetry/auto-instrumentations-node");
+const {
+  OTLPTraceExporter,
+} = require("@opentelemetry/exporter-trace-otlp-grpc");
+
+// Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
+Sentry.init({
+  dsn: "__DSN__",
+  tracesSampleRate: 1.0,
+  // set the instrumenter to use OpenTelemetry instead of Sentry
+  instrumenter: "otel",
+  // ...
+});
+
+const sdk = new opentelemetry.NodeSDK({
+  // Existing config
+  traceExporter: new OTLPTraceExporter(),
+  instrumentations: [getNodeAutoInstrumentations()],
+
+  // Sentry config
+  spanProcessor: new SentrySpanProcessor(),
+});
+
+otelApi.propagation.setGlobalPropagator(new SentryPropagator());
+
+sdk.start();
+```

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -3,6 +3,7 @@ title: OpenTelemetry Support
 sidebar_order: 20
 supported:
   - node
+  - javascript.nextjs
 notSupported:
   - javascript
   - python


### PR DESCRIPTION
Basically the same as Node docs (https://github.com/getsentry/sentry-docs/pull/5760), but with some adjustments.