### PR TITLE
feat(otel): Add docs for Ruby OpenTelemetry

### DIFF
--- a/src/platform-includes/performance/opentelemetry-install/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/ruby.mdx
@@ -1,3 +1,9 @@
+<Note>
+
+The `sentry-opentelemetry` gem requires `opentelemetry-sdk` `1.0.0` or higher.
+
+</Note>
+
 ```ruby
 gem "sentry-ruby"
 gem "sentry-rails"

--- a/src/platform-includes/performance/opentelemetry-install/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/ruby.mdx
@@ -1,9 +1,3 @@
-<Note>
-
-`@sentry/opentelemetry-node` depends on `opentelemetry-sdk` `1.0.0` or higher.
-
-</Note>
-
 ```ruby
 gem "sentry-ruby"
 gem "sentry-rails"

--- a/src/platform-includes/performance/opentelemetry-install/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/ruby.mdx
@@ -1,0 +1,14 @@
+<Note>
+
+`@sentry/opentelemetry-node` depends on `opentelemetry-sdk` `1.0.0` or higher.
+
+</Note>
+
+```ruby
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "sentry-opentelemetry"
+
+gem "opentelemetry-sdk"
+gem "opentelemetry-instrumentation-all"
+```

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -1,4 +1,4 @@
-Initialize Sentry for tracing and set the `instrumenter` to `:otel`.
+Initialize Sentry for tracing and set the `instrumenter` to `:otel`:
 
 ```ruby {filename:config/initializers/sentry.rb}
 Sentry.init do |config|

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -9,7 +9,7 @@ Sentry.init do |config|
 end
 ```
 
-This will disable all Sentry instrumentation and rely on the chosen OpenTelemetry tracers for creating spans.
+This disables all Sentry instrumentation and relies on the chosen OpenTelemetry tracers for creating spans.
 
 Next, configure OpenTelemetry as per your needs and hook in the Sentry span processor and propagator.
 

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -11,7 +11,7 @@ end
 
 This disables all Sentry instrumentation and relies on the chosen OpenTelemetry tracers for creating spans.
 
-Next, configure OpenTelemetry as per your needs and hook in the Sentry span processor and propagator.
+Next, configure OpenTelemetry as you need and hook in the Sentry span processor and propagator:
 
 ```ruby {filename:config/initializers/otel.rb}
 OpenTelemetry::SDK.configure do |c|

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -1,4 +1,4 @@
-Initialize Sentry for tracing and set the `instrumenter` to `:otel`. Make sure that Sentry is initialized before the OpenTelemetry SDK is.
+Initialize Sentry for tracing and set the `instrumenter` to `:otel`.
 
 ```ruby {filename:config/initializers/sentry.rb}
 Sentry.init do |config|

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -1,0 +1,23 @@
+Initialize Sentry for tracing and set the `instrumenter` to `:otel`. Make sure that Sentry is initialized before the OpenTelemetry SDK is.
+
+```ruby {filename:config/initializers/sentry.rb}
+Sentry.init do |config|
+  config.dsn = "__DSN__"
+  config.traces_sample_rate = 1.0
+  # set the instrumenter to use OpenTelemetry instead of Sentry
+  config.instrumenter = :otel
+end
+```
+
+This will disable all Sentry instrumentation and rely on the chosen OpenTelemetry tracers for creating spans.
+
+Next, configure OpenTelemetry as per your needs and hook in the Sentry span processor and propagator.
+
+```ruby {filename:config/initializers/otel.rb}
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+  c.add_span_processor(Sentry::OpenTelemetry::SpanProcessor.instance)
+end
+
+OpenTelemetry.propagation = Sentry::OpenTelemetry::Propagator.new
+```

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -3,6 +3,7 @@ title: OpenTelemetry Support
 sidebar_order: 20
 supported:
   - node
+  - ruby
 notSupported:
   - javascript
   - python
@@ -17,7 +18,6 @@ notSupported:
   - javascript.cordova
   - javascript.electron
   - go
-  - ruby
   - unity
   - rust
   - native


### PR DESCRIPTION
Blocked on next release of Ruby SDK so draft PR as a result.