### PR TITLE
clarify wording to indicate location of content

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -7,7 +7,7 @@ notSupported: ["javascript.capacitor"]
 sidebar_order: 1000
 ---
 
-If you need help solving issues with your Sentry JavaScript SDK integration, you can read the edge cases documented here. If you need additional help, you can [ask on GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose). Customers on a paid plan may also contact support.
+If you need help solving issues with your Sentry JavaScript SDK integration, you can read the edge cases documented below. If you need additional help, you can [ask on GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose). Customers on a paid plan may also contact support.
 
 ## Updating to a New Sentry SDK Version
 


### PR DESCRIPTION
Changes "here" to "below" to make clear the content is on the current page
