### PR TITLE
Update list of platforms that support stacktrace linking

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -223,7 +223,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with a 
 
 <Note>
 
-This feature is currently only supported for JavaScript and Python.
+This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
 
 </Note>
 

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -126,7 +126,7 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 
 <Note>
 
-This feature is currently only supported for JavaScript and Python.
+This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
 
 </Note>
 


### PR DESCRIPTION
This is to update the list added in #5642.