### PR TITLE
Remove platform specific “New in”

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -571,12 +571,6 @@ This function is called with an SDK-specific message or error event object, and 
 
 This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
-<PlatformSection supported={["javascript", "node"]}>
-
-_(New in version 7.18.0)_
-
-</PlatformSection>
-
 </ConfigKey>
 
 <ConfigKey name="on-crash" supported={["native"]}>


### PR DESCRIPTION
This approach doesn't scale well, as this page is platform agnostic, hence I removed it.

cc @lobsterkatie 