### PR TITLE
fix(nextjs/remix): Add `RequestData` integration to default integrations page

### DIFF
--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -146,6 +146,43 @@ This integration deduplicates certain events. It can be helpful if you're receiv
 
 <PlatformContent includePath="configuration/dedupe" />
 
+<PlatformSection supported={["javascript.nextjs", "javascript.remix"]}>
+
+### RequestData
+
+_(New in version 7.17.1.)_
+
+_Import name: `Sentry.Integrations.RequestData`_
+
+This integration adds data from incoming requests to transaction and error events that occur during request handling done by the backend.
+
+Available options:
+
+```javascript
+{
+  // Controls what types of data are added to the event
+  include: {
+    cookies: boolean  // default: true,
+    data: boolean  // default: true,
+    headers: boolean  // default: true,
+    ip: boolean  // default: false,
+    query_string: boolean  // default: true,
+    url: boolean  // default: true,
+    user: boolean | {
+      id: boolean  // default: true,
+      username: boolean  // default: true,
+      email: boolean  // default: true,
+    },
+  },
+  // Controls how the transaction will be reported. Options are 'path' (`/some/route`),
+  // 'methodPath' (`GET /some/route`), and 'handler' (the name of the route handler
+  // function, if available)
+  transactionNamingScheme: string  // default: 'methodPath',
+};
+```
+
+</PlatformSection>
+
 ## Modifying System Integrations
 
 To disable system integrations, set `defaultIntegrations: false` when calling `init()`.


### PR DESCRIPTION
When the new `RequestData` integration was [added to the node docs](https://github.com/getsentry/sentry-docs/pull/5674), it should also have been added to the nextjs and remix docs, since both frameworks are combo frontend-backend.