### PR TITLE
Add back note about the source-map-support package

### DIFF
--- a/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -228,3 +228,7 @@ Sometimes build scripts and plugins produce pre-compressed minified files (for e
 ## Verify workers are sharing the same volume as web (if running self-hosted Sentry via Docker)
 
 Sentry does source map calculation in its workers. This means the workers need access to the files uploaded through the front end. Double check that the cron workers and web workers can read/write files from the same disk.
+
+## Verify you are not using the `source-map-support` package
+
+To rely on Sentry's source map resolution, your code cannot use the [source-map-support](https://www.npmjs.com/package/source-map-support) package. That package overwrites the captured stack trace in a way that prevents our processors from correctly parsing it.


### PR DESCRIPTION
Somewhere during https://github.com/getsentry/sentry-docs/pull/5799 we dropped a note about the `source-map-support` package.

This PR adds that note back in the source maps troubleshooting section.