### PR TITLE
Update Svelte source maps docs to refer to new bundler plugins

### DIFF
--- a/src/platform-includes/sourcemaps/upload/primer/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/upload/primer/javascript.svelte.mdx
@@ -1,6 +1,8 @@
 To upload your Svelte project's source maps to Sentry, you currently have two options:
 
+- Use the [Sentry Vite plugin](https://www.npmjs.com/package/@sentry/vite-plugin) to set releases and upload source maps.
 - Upload source maps manually using [Sentry-CLI](./cli/). Take a look at this [bash script](https://github.com/getsentry/sentry-javascript/tree/master/packages/svelte#sourcemaps-and-releases) as an example of how to configure the CLI for a typical Svelte project.
-- Use the [unofficial Sentry Vite plugin](https://github.com/ikenfin/vite-plugin-sentry) to set releases and upload source maps. **Please note that this plugin is not maintained by Sentry and we do not offer support for it.**
 
 For other bundlers or more advanced configurations, take a look at the following guides and options for uploading sourcemaps:
+
+<PageGrid />

--- a/src/platforms/javascript/common/sourcemaps/uploading/typescript.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/typescript.mdx
@@ -2,6 +2,8 @@
 title: TypeScript (tsc)
 description: "Upload your source maps using tsc and Sentry CLI."
 sidebar_order: 2
+notSupported:
+  - javascript.svelte
 ---
 
 <PlatformContent includePath="sourcemaps/upload/typescript" />


### PR DESCRIPTION
Updates the Svelte source maps docs to refer to the new vite bundler plugin. Also removes tsc as a recommended tool and adds a section that was accidentally removed.
