### PR TITLE
fix: Code samples for react components

### DIFF
--- a/src/platform-includes/getting-started-verify/javascript.react.mdx
+++ b/src/platform-includes/getting-started-verify/javascript.react.mdx
@@ -1,3 +1,3 @@
 ```javascript
-return <button onClick={methodDoesNotExist}>Break the world</button>;
+return <button onClick={() => methodDoesNotExist()}>Break the world</button>;
 ```

--- a/src/wizard/javascript/react.md
+++ b/src/wizard/javascript/react.md
@@ -47,7 +47,7 @@ After this step, Sentry will report any uncaught exceptions triggered by your ap
 You can trigger your first event from your development environment by raising an exception somewhere within your application. An example of this would be rendering a button whose `onClick` handler attempts to invoke a method that does not exist:
 
 ```javascript
-return <button onClick={methodDoesNotExist}>Break the world</button>;
+return <button onClick={() => methodDoesNotExist()}>Break the world</button>;
 ```
 
 Once you've verified the library is initialized properly and sent a test event, consider visiting our [complete React docs](https://docs.sentry.io/platforms/javascript/guides/react/). There you'll find additional instructions for surfacing valuable context from React error boundaries, React Router, Redux, and more.

--- a/src/wizard/javascript/remix.md
+++ b/src/wizard/javascript/remix.md
@@ -90,8 +90,8 @@ After this step, Sentry will report any uncaught exceptions triggered by your ap
 You can trigger your first event from your development environment by raising an exception somewhere within your application. An example of this would be rendering a button whose `onClick` handler attempts to invoke a method that does not exist:
 
 ```javascript
-<button type="button" onClick={methodDoesNotExist}>
-  Throw error
+<button onClick={() => methodDoesNotExist()}>
+  Break the world
 </button>
 ```
 


### PR DESCRIPTION
When going through the process of instrumenting Sentry on Javascript (React as an example) I uncovered this small annoyance.
To verify if Sentry is instrumented you’re asked to intentionally create an error with this snippet of code.
`return <button onClick={methodDoesNotExist}>Break the world</button>;`
The Problem here is that, you get a blank white screen by adding this `-> onClick={methodDoesNotExist}` because your in fact not declaring anything. I know a developer would know this, but I don’t think we should rely on people reading the snippet of code to get the intended value.

