### PR TITLE
unity il2cpp release builds

### DIFF
--- a/src/platforms/unity/configuration/il2cpp.mdx
+++ b/src/platforms/unity/configuration/il2cpp.mdx
@@ -4,11 +4,7 @@ description: "Learn how the SDK provides line numbers to issues from IL2CPP buil
 sidebar_order: 10
 ---
 
-<Note>
-
-This feature is available from Unity versions `2020.3` and `2021.3` onwards. We are running tests in CI against the current LTS, starting from `2020.3.37f1` and `2021.3.6f1`.
-
-</Note>
+Sentry can give you line numbers on C# exceptions in **release builds** with IL2CPP, on Unity versions `2020.3` and `2021.3` and later.
 
 Unity provides you the option to select [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) as your scripting backend. This leads to C++ code being generated from your compiled C# (IL) code, hence the name `IL to CPP`.
 

--- a/src/platforms/unity/configuration/il2cpp.mdx
+++ b/src/platforms/unity/configuration/il2cpp.mdx
@@ -4,7 +4,7 @@ description: "Learn how the SDK provides line numbers to issues from IL2CPP buil
 sidebar_order: 10
 ---
 
-Sentry can give you line numbers on C# exceptions in **release and development builds** with IL2CPP, on Unity versions `2020.3` and `2021.3` and later.
+Sentry can provide you with line numbers on C# exceptions in **release and development builds** with IL2CPP, on Unity versions `2020.3`, `2021.3` and later.
 
 Unity provides you the option to select [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) as your scripting backend. This leads to C++ code being generated from your compiled C# (IL) code, hence the name `IL to CPP`.
 

--- a/src/platforms/unity/configuration/il2cpp.mdx
+++ b/src/platforms/unity/configuration/il2cpp.mdx
@@ -4,7 +4,7 @@ description: "Learn how the SDK provides line numbers to issues from IL2CPP buil
 sidebar_order: 10
 ---
 
-Sentry can give you line numbers on C# exceptions in **release builds** with IL2CPP, on Unity versions `2020.3` and `2021.3` and later.
+Sentry can give you line numbers on C# exceptions in **release and development builds** with IL2CPP, on Unity versions `2020.3` and `2021.3` and later.
 
 Unity provides you the option to select [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) as your scripting backend. This leads to C++ code being generated from your compiled C# (IL) code, hence the name `IL to CPP`.
 

--- a/src/platforms/unity/configuration/il2cpp.mdx
+++ b/src/platforms/unity/configuration/il2cpp.mdx
@@ -4,7 +4,7 @@ description: "Learn how the SDK provides line numbers to issues from IL2CPP buil
 sidebar_order: 10
 ---
 
-Sentry can provide you with line numbers on C# exceptions in **release and development builds** with IL2CPP, on Unity versions `2020.3`, `2021.3` and later.
+Sentry can provide you with line numbers on C# exceptions in **release and development builds** with IL2CPP, on Unity versions `2020.3`, `2021.3`, and later.
 
 Unity provides you the option to select [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) as your scripting backend. This leads to C++ code being generated from your compiled C# (IL) code, hence the name `IL to CPP`.
 


### PR DESCRIPTION
Came up on Twitter where people were not sure this affected Release Builds

Debug Builds anyway have line numbers

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
