### PR TITLE
feat(replays): Add link to session replay product docs from homepage footer

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,7 +82,13 @@ const IndexPage = () => {
               </Nav.Item>
               <SandboxOnly>
                 <Nav.Item>
-                  <Nav.Link className="text-primary" href={getSandboxURL().toString()} target="_blank">Demo</Nav.Link>
+                  <Nav.Link
+                    className="text-primary"
+                    href={getSandboxURL().toString()}
+                    target="_blank"
+                  >
+                    Demo
+                  </Nav.Link>
                 </Nav.Item>
               </SandboxOnly>
               <Nav.Item>
@@ -140,9 +146,7 @@ const IndexPage = () => {
           <a href="https://develop.sentry.dev/self-hosted/">
             Self-Hosted Sentry
           </a>
-          <a href="https://help.sentry.io/">
-            Support
-          </a>
+          <a href="https://help.sentry.io/">Support</a>
         </div>
 
         <h3>Learn more...</h3>
@@ -150,9 +154,7 @@ const IndexPage = () => {
           <div>
             <ul className="unstyled-list">
               <li>
-                <a href="/product/performance/">
-                  Performance Monitoring
-                </a>
+                <a href="/product/performance/">Performance Monitoring</a>
               </li>
               <li>
                 <a href="/product/sentry-basics/tracing/distributed-tracing/">
@@ -160,13 +162,13 @@ const IndexPage = () => {
                 </a>
               </li>
               <li>
+                <a href="/product/session-replay/">Session Replay</a>
+              </li>
+              <li>
                 <a href="/product/releases/health/">Release Health</a>
               </li>
               <li>
                 <a href="/product/releases/">Releases</a>
-              </li>
-              <li>
-                <a href="/product/cli/">Sentry-CLI</a>
               </li>
             </ul>
           </div>
@@ -179,8 +181,9 @@ const IndexPage = () => {
                 <a href="/product/sentry-basics/environments/">Environments</a>
               </li>
               <li>
-                <a href="/product/integrations/">Integrations</a>
+                <a href="/product/cli/">Sentry-CLI</a>
               </li>
+
               <li>
                 <a href="/product/discover-queries/">Discover Queries</a>
               </li>
@@ -191,6 +194,9 @@ const IndexPage = () => {
           </div>
           <div>
             <ul className="unstyled-list">
+              <li>
+                <a href="/product/integrations/">Integrations</a>
+              </li>
               <li>
                 <a href="/product/integrations/integration-platform/">
                   Integration Platform


### PR DESCRIPTION
This might spark a conversation, but I've added links to the (forthcoming) Session Replay product docs from the footer on the homepage:

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/187460/206037079-79122da0-ef73-437d-865f-ef6f5d2859c0.png)  | ![after](https://user-images.githubusercontent.com/187460/206037106-1b392431-0c11-4c77-8eb7-9fd9df282d7a.png) |

Changes:
1. `Session Replay` is added to the 1st column,
2. `Sentry-CLI` moved from column 1 into 2
3. `Integrations` moved from column 2 into 3, next to Integration Platform

This is just a suggestion!
We should add a link down here imo, but what position does it take?


Also DONT MERGE this until the product docs actually exist