### PR TITLE
Update Replay Wizard links and examples to link to docs and use correct field names

### DIFF
--- a/src/wizard/javascript/replay-onboarding/angular/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/angular/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/angular/session-replay/custom-instrumentation/).
 
 ```javascript
 import * as Sentry from "@sentry/angular";
@@ -15,14 +15,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/ember/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/ember/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/ember/session-replay/custom-instrumentation/).
 
 ```javascript
 import * as Sentry from "@sentry/ember";
@@ -15,14 +15,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/gatsby/session-replay/custom-instrumentation/).
 
 Include the `@sentry/gatsby` plugin:
 
@@ -29,14 +29,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/nextjs/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/nextjs/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your Client SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/nextjs/session-replay/custom-instrumentation/).
 
 ```javascript {filename:sentry.client.config.js}
 import * as Sentry from "@sentry/nextjs";
@@ -15,14 +15,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/react/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/react/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/react/session-replay/custom-instrumentation/).
 
 ```javascript
 import * as Sentry from "@sentry/react";
@@ -15,14 +15,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/remix/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/remix/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/remix/session-replay/custom-instrumentation/).
 
 ```javascript {filename: entry.client.tsx}
 import * as Sentry from "@sentry/remix";
@@ -15,14 +15,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 ```

--- a/src/wizard/javascript/replay-onboarding/svelte/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/svelte/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/svelte/session-replay/custom-instrumentation/).
 
 ```javascript
 import "./app.css";
@@ -18,14 +18,16 @@ import { Replay } from "@sentry/replay";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 

--- a/src/wizard/javascript/replay-onboarding/vue/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/vue/2.configure.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure
 
-Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay in our Github [Readme](https://github.com/getsentry/sentry-replay/blob/main/README.md).
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set via the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/vue/session-replay/custom-instrumentation/).
 
 #### Vue 2
 
@@ -26,14 +26,16 @@ const router = new Router({
 Sentry.init({
   Vue,
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 
@@ -63,14 +65,16 @@ const router = createRouter({
 Sentry.init({
   app,
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    new Replay({
-      // Capture 10% of all sessions
-      sessionSampleRate: 0.1,
 
-      // Of the remaining 90% of sessions, if an error happens start capturing
-      errorSampleRate: 1.0,
-    })
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Replay()
   ],
 });
 


### PR DESCRIPTION
The changed text/url appears in the app inside this onboarding slide-out:

<img width="1514" alt="SCR-20221207-cfs" src="https://user-images.githubusercontent.com/187460/206242426-71098705-003e-496b-a76a-f98a905f32d5.png">


Depends on https://github.com/getsentry/sentry-docs/pull/5899