### PR TITLE
fix(apple): Delete experimental note GA features

### DIFF
--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -30,7 +30,7 @@
     - Slow and frozen frames
   - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">file I/O</PlatformLink> operations
   - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Core Data</PlatformLink> queries
-  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User Interaction</PlatformLink> transactions for UI clicks (experimental)
+  - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User Interaction</PlatformLink> transactions for UI clicks
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs
 - [Screenshot attachments for errors](/platforms/apple/guides/ios/enriching-events/screenshots/)

--- a/src/platforms/apple/common/configuration/swizzling.mdx
+++ b/src/platforms/apple/common/configuration/swizzling.mdx
@@ -23,7 +23,7 @@ __iOS, tvOS and Catalyst__
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations</PlatformLink>
 - <PlatformLink to="/performance/connect-services/">Automatically added sentry-trace header to HTTP requests for distributed tracing</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User interaction transactions for UI clicks (experimental)</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User interaction transactions for UI clicks</PlatformLink>
 - <PlatformLink to="/configuration/http-client-errors/">HTTP Client Errors</PlatformLink>
 
 Since Cocoa 7.5.0, you can opt out of swizzling using options. When you disable swizzling, the SDK disables the features above:

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -196,12 +196,6 @@ SentrySDK.start { options in
 
 ## User Interaction Tracing
 
-<Alert level="info" title="Important">
-
-This is an experimental feature and requires an opt-in. Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
-
-</Alert>
-
 User interaction tracing, once enabled, captures transactions for clicks. User interaction tracing is disabled by default, but you can enable it by setting:
 
 ```swift {tabTitle:Swift}


### PR DESCRIPTION
Remove experimental suffixes for user interaction tracing, which is now GA. See https://github.com/getsentry/sentry-cocoa/pull/2503/
