### PR TITLE
Update general-configuration - remove Canvas

### DIFF
--- a/src/platforms/javascript/common/session-replay/custom-instrumentation/general-configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/custom-instrumentation/general-configuration.mdx
@@ -74,7 +74,6 @@ The following options can be configured as options to the integration, in `new R
 | collectFonts     | boolean | `false` | Should collect fonts used on the website |
 | inlineImages     | boolean | `false` | Should inline `<image>` content |
 | inlineStylesheet | boolean | `true`  | Should inline stylesheets used in the recording |
-| recordCanvas     | boolean | `false` | Should record `<canvas>` elements |
 
 ## rrweb Configuration
 


### PR DESCRIPTION
Removing reference to Canvas since it's not supported in Session Replay.




