### PR TITLE
ci: Use gatsby-cache action to cache gatsby build outputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,8 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
 
-      - uses: actions/cache@v2
+      - uses: jongwooo/gatsby-cache@v1.2.1
         with:
-          path: |
-            .cache
-            public
           key: node14-${{ runner.os }}-${{ hashfiles('**/yarn.lock') }}-gatsby-build
       - name: yarn build
         run: yarn build


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

I created an action to cache Gatsby's build outputs. This action is easy to set up. 

**AS-IS**

```yaml
- uses: actions/cache@v2
  with:
    path: |
      .cache
      public
    key: node14-${{ runner.os }}-${{ hashfiles('**/yarn.lock') }}-gatsby-build
```

**TO-BE**

```yaml
- uses: jongwooo/gatsby-cache@v1.2.1
  with:
    key: node14-${{ runner.os }}-${{ hashfiles('**/yarn.lock') }}-gatsby-build # optional
```

## References

- [https://github.com/jongwooo/gatsby-cache](https://github.com/jongwooo/gatsby-cache)