### PR TITLE
feat(apple): Migration guide for sentry-cocoa 7 -> 8

### DIFF
--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -3,7 +3,66 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
-To upgrade from the 4.x version of the SDK to the 7.x version of the SDK, you must first migrate from 4.x to 5.x, then 5.x to 6.x and finally from 6.x to 7.x.
+To upgrade from the 4.x version of the SDK to the 8.x version of the SDK, you must first migrate from 4.x to 5.x, then 5.x to 6.x, then 6.x to 7.x, and finally from 7.x to 8.x.
+
+## Migrating from 7.x to 8.x
+
+Migrating to 8.x from 7.x includes a few breaking changes. We provide this guide to help you to update your SDK.
+
+### Configuration Changes
+
+This version includes the following configuration changes:
+
+- Rename `SentryOptions.enableAutoPerformanceTracking` to `SentryOptions.enableAutoPerformanceTracing`
+- Rename `SentryOptions.enableUIViewControllerTracking` to `SentryOptions.enableUIViewControllerTracing`
+- Rename `SentryOptions.enablePreWarmedAppStartTracking` to `SentryOptions.enablePreWarmedAppStartTracing`
+- Rename `SentryOptions.enableFileIOTracking` to `SentryOptions.enableFileIOTracing`
+- Rename `SentryOptions.enableCoreDataTracking` to `SentryOptions.enableCoreDataTracing`
+- Rename `SentryOptions.enableOutOfMemoryTracking` to `SentryOptions.enableWatchdogTerminationsTracking`
+
+### Breaking Changes
+
+#### SDK Inits
+
+We removed the version of `SentrySDK.startWithOptions` which took a dictionary, and renamed `SentrySDK.startWithOptionsObject` to `SentrySDK.startWithOptions`. The recommended way to initialize Sentry has not changed:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    // ...
+}
+```
+
+```objective-c
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    // ...
+}];
+```
+
+#### Swift API improvements
+
+We made some changes to make the API more ergonomic in Swift:
+
+- Rename `SentrySDK.addBreadcrumb(crumb:)` to `SentrySDK.addBreadcrumb(_ crumb:)`
+- Rename `SentryScope.add(_ crumb:)` to `SentryScope.addBreadcrumb(_ crumb:)`
+- Rename `SentryScope.add(_ attachment:)` to `SentryScope.addAttachment(_ attachment:)`
+- Rename `Client` to `SentryClient`
+
+#### Default integrations
+
+- The user interaction tracing integration is now enabled by default.
+- The File I/O tracing integration is now enabled by default.
+
+#### Changes to minimum OS versions and Xcode
+
+The minimum supported OS versions have been bumped to macOS 10.13, iOS 11, tvOS 11, and watchOS 4.
+
+The minimum Xcode version has been bumbed to 13.
 
 ## Migrating from 6.x to 7.x
 
@@ -52,8 +111,8 @@ on `SentryOptions` to align with other Sentry SDKs, and set the default `diagnos
 `SentryLevel.debug`. Furthermore, we removed setting the `logLevel` statically on the `SentrySDK`.
 Please use the `SentryOptions` to set the `diagnosticLevel` instead.
 
-
 6.x
+
 ```swift
 SentrySDK.start { options in
   options.logLevel = SentryLogLevel.verbose
@@ -65,6 +124,7 @@ SentrySDK.logLevel = SentryLogLevel.verbose
 ```
 
 7.x
+
 ```swift
 SentrySDK.start { options in
   options.diagnosticLevel = SentryLevel.debug

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -131,7 +131,7 @@ SentrySDK.start { options in
 }
 ```
 
-## Migrating from 5.x to 6.x
+## Migrating From 5.x to 6.x
 
 Migrating to 6.x from 5.x includes a few breaking changes. We provide this guide to help you to update your SDK.
 
@@ -272,7 +272,7 @@ In 5.x, you could pass a nullable scope to capture methods of the SDK, Hub, and 
 
 Please see the [Changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md) for a complete list of changes.
 
-## Upgrading from 4.x to 5.x
+## Upgrading From 4.x to 5.x
 
 The samples below illustrate how the SDK works:
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -58,7 +58,7 @@ We made some changes to make the API more ergonomic in Swift:
 - The user interaction tracing integration is now enabled by default.
 - The File I/O tracing integration is now enabled by default.
 
-#### Changes to minimum OS versions and Xcode
+#### Changes to Minimum OS Versions and Xcode
 
 The minimum supported OS versions have been bumped to macOS 10.13, iOS 11, tvOS 11, and watchOS 4.
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -24,7 +24,7 @@ This version includes the following configuration changes:
 
 #### SDK Inits
 
-We removed the version of `SentrySDK.startWithOptions` which took a dictionary, and renamed `SentrySDK.startWithOptionsObject` to `SentrySDK.startWithOptions`. The recommended way to initialize Sentry has not changed:
+We removed the version of `SentrySDK.startWithOptions` that took a dictionary, and renamed `SentrySDK.startWithOptionsObject` to `SentrySDK.startWithOptions`. The recommended way to initialize Sentry has not changed:
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -62,7 +62,7 @@ We made some changes to make the API more ergonomic in Swift:
 
 The minimum supported OS versions have been bumped to macOS 10.13, iOS 11, tvOS 11, and watchOS 4.
 
-The minimum Xcode version has been bumbed to 13.
+The minimum Xcode version has been bumped to 13.
 
 ## Migrating From 6.x to 7.x
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -53,7 +53,7 @@ We made some changes to make the API more ergonomic in Swift:
 - Rename `SentryScope.add(_ attachment:)` to `SentryScope.addAttachment(_ attachment:)`
 - Rename `Client` to `SentryClient`
 
-#### Default integrations
+#### Default Integrations
 
 - The user interaction tracing integration is now enabled by default.
 - The File I/O tracing integration is now enabled by default.

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -5,7 +5,7 @@ sidebar_order: 1000
 
 To upgrade from version 4.x of the SDK to version 8.x of the SDK, you must first migrate from 4.x to 5.x, then 5.x to 6.x, then 6.x to 7.x, and finally from 7.x to 8.x.
 
-## Migrating from 7.x to 8.x
+## Migrating From 7.x to 8.x
 
 Migrating to 8.x from 7.x includes a few breaking changes. We provide this guide to help you to update your SDK.
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -64,7 +64,7 @@ The minimum supported OS versions have been bumped to macOS 10.13, iOS 11, tvOS 
 
 The minimum Xcode version has been bumbed to 13.
 
-## Migrating from 6.x to 7.x
+## Migrating From 6.x to 7.x
 
 <Alert level="info" title="Important">
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -3,7 +3,7 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
-To upgrade from the 4.x version of the SDK to the 8.x version of the SDK, you must first migrate from 4.x to 5.x, then 5.x to 6.x, then 6.x to 7.x, and finally from 7.x to 8.x.
+To upgrade from version 4.x of the SDK to version 8.x of the SDK, you must first migrate from 4.x to 5.x, then 5.x to 6.x, then 6.x to 7.x, and finally from 7.x to 8.x.
 
 ## Migrating from 7.x to 8.x
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -44,7 +44,7 @@ SentrySDK.start { options in
 }];
 ```
 
-#### Swift API improvements
+#### Swift API Improvements
 
 We made some changes to make the API more ergonomic in Swift:
 


### PR DESCRIPTION
Merge after 8.0.0 is released.