### PR TITLE
Add last event id to the feedback example react-native

### DIFF
--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/react-native.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/react-native.mdx
@@ -2,7 +2,8 @@
 import * as Sentry from '@sentry/react-native';
 import { UserFeedback } from '@sentry/react-native';
 
-const sentryId = Sentry.captureMessage('My Message');
+const sentryId = Sentry.lastEventId();
+// OR: const sentryId = Sentry.captureMessage('My Message');
 
 const userFeedback: UserFeedback = {
   event_id: sentryId,

--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/react-native.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/react-native.mdx
@@ -2,8 +2,8 @@
 import * as Sentry from '@sentry/react-native';
 import { UserFeedback } from '@sentry/react-native';
 
-const sentryId = Sentry.lastEventId();
-// OR: const sentryId = Sentry.captureMessage('My Message');
+const sentryId = Sentry.captureMessage('My Message');
+// OR: const sentryId = Sentry.lastEventId();
 
 const userFeedback: UserFeedback = {
   event_id: sentryId,


### PR DESCRIPTION
Not released yet.

- https://github.com/getsentry/sentry-react-native/pull/2675