### PR TITLE
Add note to disable ad-blocker when installing JIRA

### DIFF
--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -29,6 +29,8 @@ Sentry owner, manager, or admin permissions, and Jira admin permissions are requ
 2. Install the Sentry app through the [Jira marketplace](https://marketplace.atlassian.com/apps/1219432/sentry-for-jira?hosting=cloud&tab=overview).
 
 3. Select which Sentry organizations you’d like to use with Jira, and **Save Settings**.
+  * If you have an ad-blocker, disabled it now before you try to save the settings
+  * A link back to Sentry will be presented
 
 4. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -28,9 +28,9 @@ Sentry owner, manager, or admin permissions, and Jira admin permissions are requ
 
 2. Install the Sentry app through the [Jira marketplace](https://marketplace.atlassian.com/apps/1219432/sentry-for-jira?hosting=cloud&tab=overview).
 
-3. If you have an ad-blocker enabled you will not be able to complete step number 4.
+3. If you have an ad-blocker enabled, disable it now or you won't be able to complete step number 4.
 
-4. Select which Sentry organizations you’d like to use with Jira. A link back to Sentry will be presented.
+4. Select which Sentry organizations you’d like to use with Jira. Then click the presented link to return to Sentry.
 
 5. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -29,8 +29,7 @@ Sentry owner, manager, or admin permissions, and Jira admin permissions are requ
 2. Install the Sentry app through the [Jira marketplace](https://marketplace.atlassian.com/apps/1219432/sentry-for-jira?hosting=cloud&tab=overview).
 
 3. Select which Sentry organizations you’d like to use with Jira, and **Save Settings**.
-  * If you have an ad-blocker, disabled it now before you try to save the settings
-  * A link back to Sentry will be presented
+  * If you have an ad-blocker, disable it now before you try to save the settings. A link back to Sentry will be presented.
 
 4. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -28,8 +28,7 @@ Sentry owner, manager, or admin permissions, and Jira admin permissions are requ
 
 2. Install the Sentry app through the [Jira marketplace](https://marketplace.atlassian.com/apps/1219432/sentry-for-jira?hosting=cloud&tab=overview).
 
-3. Select which Sentry organizations you’d like to use with Jira, and **Save Settings**.
-  * If you have an ad-blocker, disable it now before you try to save the settings. A link back to Sentry will be presented.
+3. Select which Sentry organizations you’d like to use with Jira, make sure your ad-blocker is not enabled (if applicable) and **Save Settings**. A link back to Sentry will be presented.
 
 4. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -28,9 +28,11 @@ Sentry owner, manager, or admin permissions, and Jira admin permissions are requ
 
 2. Install the Sentry app through the [Jira marketplace](https://marketplace.atlassian.com/apps/1219432/sentry-for-jira?hosting=cloud&tab=overview).
 
-3. Select which Sentry organizations you’d like to use with Jira, make sure your ad-blocker is not enabled (if applicable) and **Save Settings**. A link back to Sentry will be presented.
+3. If you have an ad-blocker enabled you will not be able to complete step number 4.
 
-4. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
+4. Select which Sentry organizations you’d like to use with Jira. A link back to Sentry will be presented.
+
+5. In Sentry, you’ll see a new Jira instance appear on the Integrations page.
 
    ![Jira integration directory](jira-install.png)
 


### PR DESCRIPTION
There's a note in the troubleshooting section but it is too common for customers to use ad-blockers.