### PR TITLE
Revert "replay: cdn non minified (#5943)"

### DIFF
--- a/src/platform-includes/session-replay/install-session-replay/javascript.mdx
+++ b/src/platform-includes/session-replay/install-session-replay/javascript.mdx
@@ -13,21 +13,18 @@ npm install --save @sentry/replay
 ```html {tabTitle: CDN}
 <!--
 Note that the Replay bundle only contains the Replay integration and not the
-entire Sentry SDK. You have to add it in addition to the Sentry Browser SDK bundle.
-
-The CDN bundle below is not minified. That's because of a known issue in the minified bundle.
-See: https://github.com/getsentry/sentry-javascript/issues/6466#issuecomment-1344491020
+entire Sentry SDK. You have to add it in addition to the Sentry Browser SDK bundle:
 -->
 
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/replay.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'replay.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/replay.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'replay.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```


### PR DESCRIPTION
⚠️ Only merge after 7.25.0 of the JS SDK is released

This reverts #5943 as we fixed the bug with minified CDN bundles. 