### PR TITLE
Add description for Next.js SDK `tunnelRoute` option

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -167,6 +167,8 @@ const moduleExports = {
     //   'Configure Serverside Auto-instrumentation':
     //     - autoInstrumentServerFunctions
     //     - excludeServerRoutes
+    //   'Configure Tunneling to avoid Ad-Blockers':
+    //     - tunnelRoute
   },
 };
 
@@ -391,3 +393,23 @@ const moduleExports = {
 ```
 
 Excluded routes can be specified either as regexes or strings. When using a string, make sure that it matches the route exactly, and has a leading slash but no trailing one.
+
+## Configure Tunneling to avoid Ad-Blockers
+
+_(New in version 7.25.0)_
+
+You might notice that Sentry events are sometimes blocked by Ad-Blockers.
+Ad-blockers can be circumvented by using <PlatformLink to="/troubleshooting/#dealing-with-ad-blockers">tunneling</PlatformLink>.
+
+The Sentry Next.js SDK provides an easy way to set up tunneling for your application.
+Use the `tunnelRoute` option in the `sentry` object in your `next.config.js` to provide a route the SDK will use to tunnel events to Sentry:
+
+```javascript {filename:next.config.js}
+const moduleExports = {
+  sentry: {
+    tunnelRoute: "/monitoring-tunnel",
+  },
+};
+```
+
+Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -396,7 +396,7 @@ Excluded routes can be specified either as regexes or strings. When using a stri
 
 ## Configure Tunneling to avoid Ad-Blockers
 
-_(New in version 7.25.0)_
+_(New in version 7.26.0)_
 
 You might notice that Sentry events are sometimes blocked by Ad-Blockers.
 Ad-blockers can be circumvented by using **tunneling**.

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -399,7 +399,7 @@ Excluded routes can be specified either as regexes or strings. When using a stri
 _(New in version 7.25.0)_
 
 You might notice that Sentry events are sometimes blocked by Ad-Blockers.
-Ad-blockers can be circumvented by using <PlatformLink to="/troubleshooting/#dealing-with-ad-blockers">tunneling</PlatformLink>.
+Ad-blockers can be circumvented by using **tunneling**.
 
 The Sentry Next.js SDK provides an easy way to set up tunneling for your application.
 Use the `tunnelRoute` option in the `sentry` object in your `next.config.js` to provide a route the SDK will use to tunnel events to Sentry:
@@ -413,3 +413,5 @@ const moduleExports = {
 ```
 
 Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.
+
+Learn more about tunneling in the <PlatformLink to="/troubleshooting/#dealing-with-ad-blockers">troubleshooting section</PlatformLink>.


### PR DESCRIPTION
Adds a description for the `tunnelRoute` option introduced in https://github.com/getsentry/sentry-javascript/pull/6425.