### PR TITLE
feat(otel): Add docs for Python OpenTelemetry

### DIFF
--- a/src/platform-includes/performance/opentelemetry-install/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-install/python.mdx
@@ -1,0 +1,9 @@
+<Note>
+
+Sentry requires `opentelemetry-distro` version `0.350b0` or higher.
+
+</Note>
+
+```bash
+pip install --upgrade 'sentry-sdk[opentelemetry]'
+```

--- a/src/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -1,0 +1,26 @@
+Initialize Sentry for tracing and set the `instrumenter` to `otel`:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    traces_sample_rate=1.0,
+    # set the instrumenter to use OpenTelemetry instead of Sentry
+    instrumenter="otel",
+)
+```
+
+This disables all Sentry instrumentation and relies on the chosen OpenTelemetry tracers for creating spans.
+
+Next, configure OpenTelemetry as you need and hook in the Sentry span processor and propagator:
+
+```python
+from opentelemetry import trace
+from opentelemetry.propagate import set_global_textmap
+from sentry_sdk.integrations.opentelemetry import SentrySpanProcessor, SentryPropagator
+
+provider = trace.get_tracer_provider()
+provider.add_span_processor(SentrySpanProcessor())
+set_global_textmap(SentryPropagator())
+```

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -2,12 +2,12 @@
 title: OpenTelemetry Support
 sidebar_order: 20
 supported:
-  - node
   - javascript.nextjs
+  - node
+  - python
   - ruby
 notSupported:
   - javascript
-  - python
   - dart
   - flutter
   - react-native


### PR DESCRIPTION
Basically the same as Ruby docs (https://github.com/getsentry/sentry-docs/pull/5856), but for Python.