### PR TITLE
SPM: package(name:url:from:) is deprecated

### DIFF
--- a/src/platforms/apple/common/install/swift-package-manager.mdx
+++ b/src/platforms/apple/common/install/swift-package-manager.mdx
@@ -14,7 +14,7 @@ You can define your dependency rule by selecting the SDK version (or branch), an
 Alternatively, when using SPM version 5.2 or later and your project uses `Package.swift` file to manage dependencies, you can specify the target with name:
 
 ```swift {tabTitle:Swift}
-.package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "{{ packages.version('sentry.cocoa') }}"),
+.package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{ packages.version('sentry.cocoa') }}"),
 ```
 
 <Note>

--- a/src/platforms/apple/common/install/swift-package-manager.mdx
+++ b/src/platforms/apple/common/install/swift-package-manager.mdx
@@ -11,7 +11,7 @@ https://github.com/getsentry/sentry-cocoa.git
 
 You can define your dependency rule by selecting the SDK version (or branch), and then click the "Add Package" button.
 
-Alternatively, when using SPM version 5.2 or later and your project uses `Package.swift` file to manage dependencies, you can specify the target with name:
+Alternatively, when your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
 
 ```swift {tabTitle:Swift}
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{ packages.version('sentry.cocoa') }}"),


### PR DESCRIPTION
Problem: package(name:url:from:) is [deprecated since SPM 5.6](https://github.com/apple/swift-package-manager/blob/dd7e9cc68fccd6aad5db11aca2becfc24746905a/Sources/PackageDescription/PackageDependency.swift#L256).

Solution: switch to the new syntax.