### PR TITLE
Include scopes for auth token for uploading Dsyms

### DIFF
--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -105,6 +105,7 @@ api_host: 'https://mysentry.invalid/'
 Your project’s dSYM can be upload during the build phase as a “Run Script”. For this you need to st the _DEBUG_INFORMATION_FORMAT_ to be _DWARF with dSYM File_. By default, an Xcode project will only have _DEBUG_INFORMATION_FORMAT_ set to _DWARF with dSYM File_ in _Release_ so make sure everything is set in your build settings properly.
 
 You need to have an Auth Token for this to work. You can [create an Auth Token here](https://sentry.io/api/).
+The Auth Token permissions must contain the following scopes: _event:admin, event:read, member:read, org:read, project:read, project:releases, team:read
 
 1.  Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory
 2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_


### PR DESCRIPTION


<!-- Describe your PR here. -->

When incorporating the automatic Debug Symbols Upload into our iOS-CI I created an Auth Token. I wanted to keep the permissions for the token to the minimum, but finding out which scopes are required for the token would now require a lot of trial and error. So it would be nice if this information could be included in this doc. I have included the scopes which our now working token has, but I expect some to be unnecessary. I hope you guys have this information available easily. I'm completely fine to editing the PR or you even closing it and add the permission scopes yourself.

Thanks!

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
