### PR TITLE
fix: include yarn in bootstrap

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -12,7 +12,7 @@ if ! [ -x $(command -v homebrew) ]; then
 fi
 
 # Install system toolchain
-brew install volta pre-commit
+brew install volta pre-commit yarn
 
 # App dependencies
 make


### PR DESCRIPTION
- Yarn wasn't included in the bootstrap, which meant the next step in the contributing docs of running `make` would fail