### PR TITLE
ref(rn): Remove expo troubleshooting and reword the expo package info

### DIFF
--- a/src/platform-includes/getting-started-primer/react-native.mdx
+++ b/src/platform-includes/getting-started-primer/react-native.mdx
@@ -17,6 +17,6 @@ Features:
 - On Device symbolication for JavaScript (in Debug)
 - [RAM bundle support](/platforms/react-native/manual-setup/ram-bundles/)
 - [Hermes support](/platforms/react-native/manual-setup/hermes/)
-- [Expo package](https://docs.expo.io/guides/using-sentry/) supported by the Expo team
+- [Expo package](https://docs.expo.io/guides/using-sentry/) maintained by the Expo team
 - [Attachments](/platforms/react-native/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files.
 - [User Feedback](/platforms/react-native/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs.

--- a/src/platform-includes/getting-started-primer/react-native.mdx
+++ b/src/platform-includes/getting-started-primer/react-native.mdx
@@ -17,6 +17,6 @@ Features:
 - On Device symbolication for JavaScript (in Debug)
 - [RAM bundle support](/platforms/react-native/manual-setup/ram-bundles/)
 - [Hermes support](/platforms/react-native/manual-setup/hermes/)
-- [Expo support](https://docs.expo.io/guides/using-sentry/)
+- [Expo package](https://docs.expo.io/guides/using-sentry/) supported by the Expo team
 - [Attachments](/platforms/react-native/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files.
 - [User Feedback](/platforms/react-native/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs.

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -121,10 +121,6 @@ Try passing `--force-foreground` to the Sentry CLI command in the build script. 
 - If your release health statistics are being attributed to the wrong release, confirm that you [pass the `release` and `dist` to the `init` call](/platforms/react-native/configuration/releases/#bind-the-version).
 - If you are using Code Push, check that you are not using `setRelease` and `setDist` as they will break release health. You can read more on the [CodePush guide](/platforms/react-native/manual-setup/codepush/).
 
-## Expo
-
-If you use the [sentry-expo](https://github.com/expo/sentry-expo) SDK, make sure that you do not manually upgrade the version of the `@sentry/react-native` SDK and instead rely on the version that the `sentry-expo` SDK depends on. Upgrading could cause a version mismatch that could lead to errors being unreported and other undefined behavior. This is due to the `sentry-expo` SDK not being officially maintained by Sentry but instead by the Expo team.
-
 ## Minified Names in Production
 
 When bundling for production, React Native will minify class and function names to reduce the bundle size. This means that you won't get the full original component names in your Touch Event breadcrumbs or Profiler spans.


### PR DESCRIPTION
Remove the Expo troubleshooting page

And reword the Expo package text to explicitely point to the Expo team

closes: https://github.com/getsentry/sentry-docs/issues/5696