### PR TITLE
fix(apple): Remove Xcode 10 note for dSYMs

### DIFF
--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -123,7 +123,7 @@ echo "warning: sentry-cli not installed, download from https://github.com/getsen
 fi
 ```
 
-3.  If you are using Xcode 10 or newer, you also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
+3.  You also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
 
 [//]: # (Don't use bash here. Clicking the copy button on the code sample with bash)
 [//]: # (removes the leading $.)

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -205,7 +205,7 @@ echo "error: sentry-cli not installed, download from https://github.com/getsentr
 fi
 ```
 
-3.  If you are using Xcode 10 or newer, you also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
+3.  You also need to add the following line to the _Input Files_ section in the _Run Script_ from step 2:
 
 [//]: # "Don't use bash here. Clicking the copy button on the code sample with bash"
 [//]: # "removes the leading $."


### PR DESCRIPTION
Xcode 10 was released four years ago, and not one should be using it anymore. 