### PR TITLE
ref(android): Clarify initial Android SDK gradle setup step

### DIFF
--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -1,8 +1,8 @@
 ### Auto-Installation With the Sentry Android Gradle Plugin
 
-To install the plugin, add it your app's `build.gradle` file:
+To install the plugin, add it your app module's `build.gradle` file:
 
-```groovy
+```groovy {filename:app/build.gradle}
 buildscript {
   repositories {
     mavenCentral()
@@ -13,7 +13,7 @@ plugins {
 }
 ```
 
-```kotlin
+```kotlin {filename:app/build.gradle}
 buildscript {
   repositories {
     mavenCentral()
@@ -30,7 +30,7 @@ The plugin will automatically add the latest version of the Sentry SDK for Andro
 
 If you don't want the Sentry Gradle plugin to install the Sentry SDK automatically for you, you can define the dependency directly to your `build.gradle` file:
 
-```groovy {filename:build.gradle}
+```groovy {filename:app/build.gradle}
 // Make sure mavenCentral is there.
 repositories {
     mavenCentral()
@@ -47,6 +47,26 @@ android {
 // Add Sentry's SDK as a dependency.
 dependencies {
     implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}'
+}
+```
+
+```kotlin {filename:app/build.gradle}
+// Make sure mavenCentral is there.
+repositories {
+    mavenCentral()
+}
+
+// Enable Java 1.8 source compatibility if you haven't yet.
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+// Add Sentry's SDK as a dependency.
+dependencies {
+    implementation("io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}")
 }
 ```
 

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -9,6 +9,7 @@ buildscript {
   }
 }
 plugins {
+  id "com.android.application"
   id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
@@ -20,6 +21,7 @@ buildscript {
   }
 }
 plugins {
+  id("com.android.application")
   id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```

--- a/src/platforms/android/common/gradle.mdx
+++ b/src/platforms/android/common/gradle.mdx
@@ -19,7 +19,7 @@ seamless integration with the Gradle build system. It supports the following fea
 
 Using Gradle (Android Studio) in your `app/build.gradle` add:
 
-```groovy
+```groovy {filename:app/build.gradle}
 buildscript {
     repositories {
         mavenCentral()
@@ -27,11 +27,12 @@ buildscript {
 }
 
 plugins {
+    id "com.android.application"
     id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
-```kotlin
+```kotlin {filename:app/build.gradle}
 buildscript {
     repositories {
         mavenCentral()
@@ -39,6 +40,7 @@ buildscript {
 }
 
 plugins {
+    id("com.android.application")
     id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
@@ -114,7 +116,7 @@ sentry {
       // Defaults to the latest published sentry version.
       sentryVersion = '{{ packages.version('sentry.java.android', '5.0.0') }}'
     }
-    
+
     // Disables or enables dependencies metadata reporting for Sentry.
     // If enabled, the plugin will collect external dependencies and
     // upload them to Sentry as part of events. If disabled, all the logic
@@ -187,9 +189,9 @@ sentry {
       // Defaults to the latest published sentry version.
       sentryVersion.set("{{ packages.version('sentry.java.android', '5.0.0') }}")
     }
-    
+
     // Disables or enables dependencies metadata reporting for Sentry.
-    // If enabled, the plugin will collect external dependencies and 
+    // If enabled, the plugin will collect external dependencies and
     // upload them to Sentry as part of events. If disabled, all the logic
     // related to the dependencies metadata report will be excluded.
     //


### PR DESCRIPTION
We got some feedback that it's not clear if the Sentry SDK should be applied on the project root or on the app level. This is an effort to make it more clear that the SDK needs be added on a module level.
