### PR TITLE
clarifying pricing tier limitations for App Store Connect sources

### DIFF
--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -34,9 +34,9 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 ![A fully set-up App Store Connect Integration](asc-repository.png)
 
-<Alert level="Note">
+<Alert title="Note" level="info">
 
-Developer and Team subscription plans are limited to one App Store Connect source per project, subscribers to our Business plan are able to integrate multiple App Store Connect sources per project. You can read further about our [plans](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io) if your organization needs more than one App Store Connect source.
+Organizations using _Developer_ and _Team_ plans are limited to one App Store Connect source per project. To be able to use multiple App Store Connect sources per project, upgrade to a _Business_ or _Enterprise_ [plan] (https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io).
 
 </Alert>
 

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -36,7 +36,7 @@ Once the integration is set up it will ensure that new builds are detected and f
 
 <Alert title="Note" level="info">
 
-Organizations using _Developer_ and _Team_ plans are limited to one App Store Connect source per project. To be able to use multiple App Store Connect sources per project, upgrade to a _Business_ or _Enterprise_ [plan] (https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io).
+Organizations using _Developer_ and _Team_ plans are limited to one App Store Connect source per project. To be able to use multiple App Store Connect sources per project, upgrade to a [_Business_ or _Enterprise_ plan](https://sentry.io/pricing/) or contact [sales@sentry.io](mailto:sales@sentry.io).
 
 </Alert>
 


### PR DESCRIPTION
Making the pricing tier limitations clearer for people trying to use multiple App Store Connect sources. 

