### PR TITLE
fix(go): Fix links to examples in sentry-go repository

### DIFF
--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 This page shows how to use the Echo framework with Sentry.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/echo) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/echo) at the
 Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -9,7 +9,7 @@ This page shows how to add Sentry instrumentation to programs using the FastHTTP
 package.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/fasthttp)
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/fasthttp)
 available directly at the Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 This page shows how to use the Gin framework with Sentry.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/gin) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/gin) at the
 Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -10,7 +10,7 @@ This page shows how to add Sentry instrumentation to programs using the net/http
 package.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/http) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/http) at the
 Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 This page shows how to use the Iris framework with Sentry.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/iris) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/iris) at the
 Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 This page shows how to use the Martini framework with Sentry.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/martini) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/martini) at the
 Go SDK source code repository.
 
 [GoDoc-style API

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -8,7 +8,7 @@ redirect_from:
 This page shows how to use the Negroni framework with Sentry.
 
 For a quick reference, there is a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/example/negroni) at the
+example](https://github.com/getsentry/sentry-go/tree/master/_examples/negroni) at the
 Go SDK source code repository.
 
 [GoDoc-style API


### PR DESCRIPTION
We're changing the location of the examples directory in sentry-go repository.
Companion PR: https://github.com/getsentry/sentry-go/pull/521 (should be merged first).
