### PR TITLE
feat(profiling): add wizard onboarding docs for rust

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -196,7 +196,7 @@ In order to use Profiling, you first need to enable the `profiling` feature in t
 
 ```cargo
 [dependencies]
-sentry = { version = "0.29.0", features = ["profiling"] }
+sentry = { version = {{ packages.version('sentry.rust') }}, features = ["profiling"] }
 ```
 
 Once you've completed the step above, you can proceed by enabling it in the SDK:

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -205,6 +205,7 @@ Once you've completed the step above, you can proceed by enabling it in the SDK:
 sentry::init((
     "___DSN___",
     sentry::ClientOptions {
+        release: sentry::release_name!(),
         traces_sample_rate: 1.0,
         enable_profiling: true,
         profiles_sample_rate: 1.0,

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -107,6 +107,7 @@ sentry_sdk.init(
 sentry::init((
     "___DSN___",
     sentry::ClientOptions {
+        release: sentry::release_name!(),
         traces_sample_rate: 1.0,
         ..Default::default()
     },

--- a/src/wizard/rust/profiling-onboarding/rust/0.alert.md
+++ b/src/wizard/rust/profiling-onboarding/rust/0.alert.md
@@ -1,0 +1,10 @@
+---
+name: Rust
+doc_link: https://docs.sentry.io/platforms/rust/profiling/
+support_level: alpha
+type: language
+---
+
+<div class='alert warning'>
+Profiling for Rust is currently in Alpha, and there may be some bugs. We recognize the irony. If you have any questions or feedback, join our <a href="https://discord.gg/zrMjKA4Vnz">discord channel</a>.
+</div>

--- a/src/wizard/rust/profiling-onboarding/rust/1.install.md
+++ b/src/wizard/rust/profiling-onboarding/rust/1.install.md
@@ -1,0 +1,15 @@
+---
+name: Rust
+doc_link: https://docs.sentry.io/platforms/rust/profiling/
+support_level: alpha
+type: language
+---
+
+#### Install
+
+For the Profiling integration to work, you must have the Sentry Rust SDK crate (minimum version 0.29.0). Learn more about installation methods in our [full documentation](https://docs.sentry.io/platforms/rust/#install).
+
+```cargo
+[dependencies]
+sentry = { version = "0.29.0", features = ["profiling"] }
+```

--- a/src/wizard/rust/profiling-onboarding/rust/1.install.md
+++ b/src/wizard/rust/profiling-onboarding/rust/1.install.md
@@ -9,7 +9,7 @@ type: language
 
 For the Profiling integration to work, you must have the Sentry Rust SDK crate (minimum version 0.29.0). Learn more about installation methods in our [full documentation](https://docs.sentry.io/platforms/rust/#install).
 
-```cargo
+```toml {filename:Cargo.toml}
 [dependencies]
-sentry = { version = "0.29.0", features = ["profiling"] }
+sentry = { version = {{ packages.version('sentry.rust') }}, features = ["profiling"] }
 ```

--- a/src/wizard/rust/profiling-onboarding/rust/2.configure-performance.md
+++ b/src/wizard/rust/profiling-onboarding/rust/2.configure-performance.md
@@ -13,6 +13,7 @@ Sentry’s performance monitoring product has to be enabled in order for Profili
 sentry::init((
     "___DSN___",
     sentry::ClientOptions {
+        release: sentry::release_name!(),
         traces_sample_rate: 1.0,
         ..Default::default()
     },

--- a/src/wizard/rust/profiling-onboarding/rust/2.configure-performance.md
+++ b/src/wizard/rust/profiling-onboarding/rust/2.configure-performance.md
@@ -1,0 +1,21 @@
+---
+name: Rust
+doc_link: https://docs.sentry.io/platforms/rust/profiling/
+support_level: alpha
+type: language
+---
+
+#### Configure Performance
+
+Sentry’s performance monitoring product has to be enabled in order for Profiling to work. To enable performance monitoring in the SDK:
+
+```rust
+sentry::init((
+    "___DSN___",
+    sentry::ClientOptions {
+        traces_sample_rate: 1.0,
+        ..Default::default()
+    },
+));
+```
+

--- a/src/wizard/rust/profiling-onboarding/rust/3.configure-profiling.md
+++ b/src/wizard/rust/profiling-onboarding/rust/3.configure-profiling.md
@@ -13,6 +13,7 @@ Add the `enable_profiling` and `profiles_sample_rate` options to your SDK config
 sentry::init((
     "___DSN___",
     sentry::ClientOptions {
+        release: sentry::release_name!(),
         traces_sample_rate: 1.0,
         enable_profiling: true,
         profiles_sample_rate: 1.0,

--- a/src/wizard/rust/profiling-onboarding/rust/3.configure-profiling.md
+++ b/src/wizard/rust/profiling-onboarding/rust/3.configure-profiling.md
@@ -1,0 +1,22 @@
+---
+name: Rust
+doc_link: https://docs.sentry.io/platforms/rust/profiling/
+support_level: alpha
+type: language
+---
+
+#### Configure Profiling
+
+Add the `enable_profiling` and `profiles_sample_rate` options to your SDK config.
+
+```rust
+sentry::init((
+    "___DSN___",
+    sentry::ClientOptions {
+        traces_sample_rate: 1.0,
+        enable_profiling: true,
+        profiles_sample_rate: 1.0,
+        ..Default::default()
+    },
+));
+```

--- a/src/wizard/rust/profiling-onboarding/rust/4.upload.md
+++ b/src/wizard/rust/profiling-onboarding/rust/4.upload.md
@@ -1,0 +1,10 @@
+---
+name: Rust
+doc_link: https://docs.sentry.io/platforms/rust/profiling/
+support_level: alpha
+type: language
+---
+
+#### Upload Debug Information Files
+
+Upload the Debug Symbols using `sentry-cli`. Learn more about uploading debug information files in our [full documentation](https://docs.sentry.io/platforms/native/data-management/debug-files/).


### PR DESCRIPTION
This PR adds "wizard" docs for Rust profiling.