### PR TITLE
fix(javascript): Make `beforeSend` return values more explicit

### DIFF
--- a/src/platform-includes/configuration/before-send/javascript.mdx
+++ b/src/platform-includes/configuration/before-send/javascript.mdx
@@ -1,4 +1,6 @@
-In JavaScript, you can use a function to modify the event or return a completely new one. If you return `null`, the event will be discarded.
+In JavaScript, you can use a function to modify the event or return a completely new one. 
+You can either return `null` or an event payload - no other return value (including `void`) is allowed. 
+If you return `null`, the event will be discarded. 
 
 ```javascript
 Sentry.init({


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-docs/issues/5988, the current docs for `beforeSend` in JS can be more explicit about which return values are allowed. This PR updates this section to explicitly state that only `null` or an event payload are allowed.
