### PR TITLE
fix(ruby): Use global with_child_span in custom spans example

### DIFF
--- a/src/platform-includes/performance/add-spans-example/ruby.mdx
+++ b/src/platform-includes/performance/add-spans-example/ruby.mdx
@@ -2,33 +2,27 @@
 
 The next example contains the implementation of the hypothetical `process_item` function called from the code snippet in the previous section. Our SDK can determine if there is currently an open transaction and add all newly created spans as child operations to that transaction. Keep in mind that each individual span also needs to be manually finished; otherwise, spans will not show up in the transaction. When using spans and transactions as context managers, they are automatically finished at the end of the `with` block.
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.get_current_scope.get_transaction`. This property will return a `Transaction` in case there is a running Transaction otherwise it returns `None`.
-
-Alternatively, instead of adding to the top-level transaction, you can make a child span of the current span, if there is one. Use `Sentry.get_current_scope.get_span` in that case.
-
 You can choose the values of `op` and `description`.
 
 ```ruby
 class OrdersController < ApplicationController
   def create
     order = Order.new
-    # get the root transaction, which is usually the request's transaction
-    transaction = Sentry.get_current_scope.get_transaction
-    # start a span under the root transaction
-    span = transaction.start_child(op: :process_items, description: "process order's items")
-    span.set_data(:key, "value")
 
-    order.process_items(params)
+    Sentry.with_child_span(op: :process_items, description: "") do |span|
+      span.set_data(:key, "value")
 
-    # finish the span to record its finished time
-    # keep in mind that finishing span doesn't send it to Sentry
-    # it will be sent with the root transaction when it's finished
-    span.finish
+      order.process_items(params)
+    end
   end
 end
 ```
 
-Alternatively, you can use the `with_child_span` method:
+Your new span will be nested under whichever span is currently
+running, otherwise it will be at the root of the transaction event.
+
+Alternatively, you can manually grab the current transaction and use
+its `with_child_span` method to always create a top-level span.
 
 ```ruby
 class OrdersController < ApplicationController
@@ -42,3 +36,5 @@ class OrdersController < ApplicationController
   end
 end
 ```
+
+Keep in mind that there may not be an active transaction, in which case `get_transaction` returns `nil`. This case needs to be handled manually and is missing from this example.


### PR DESCRIPTION
This is much closer to how Python is documented, and is usually what
people want:

1. nests span under currently executing span
2. handles cases where there is no current transaction by discarding the
   span (easily hittable in unittests)
