### PR TITLE
chore(rn): Add note about zero bytes size bundle with Hermes on Android

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -91,3 +91,9 @@ Upload your source maps following [Step 3 on the normal source maps guide](/plat
 You will upload the `index.android.bundle` and `index.android.bundle.map` for Android, `main.jsbundle` and `main.jsbundle.map` for iOS.
 
 </Note>
+
+<Note>
+
+The `index.android.bundle` file will be uploaded with 0 bytes size. This is expected with Hermes bytecode and doesn't affect the source maps resolution.
+
+</Note>

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -94,6 +94,6 @@ You will upload the `index.android.bundle` and `index.android.bundle.map` for An
 
 <Note>
 
-The `index.android.bundle` file will be uploaded with 0 bytes size. This is expected with Hermes bytecode and doesn't affect the source maps resolution.
+When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
 
 </Note>


### PR DESCRIPTION
Add note about the zero sized bundle.

- https://github.com/getsentry/sentry-react-native/issues/2683