### PR TITLE
clarify s3 instructions

### DIFF
--- a/src/platforms/common/data-management/debug-files/symbol-servers.mdx
+++ b/src/platforms/common/data-management/debug-files/symbol-servers.mdx
@@ -61,7 +61,7 @@ repositories:
 - **Amazon S3 Bucket**: Either an entire S3 bucket or a subdirectory. This
   requires `s3:GetObject`, and optionally `s3:ListBucket` permissions for the
   configured Access Key. Lookups in the bucket are case sensitive, which is why
-  we recommend storing all files lower-cased.
+  we recommend storing all files lower-cased and using a lowercased path casing configuration.
 
 - **Google Cloud Storage Bucket**: Either an entire GCS bucket or a
   subdirectory. This requires `storage.objects.get` and `storage.objects.list`


### PR DESCRIPTION
We recommend using lowercased directories and filenames but not using the lowercased path casing for symbol lookups. When combining this with the default (Mixed-case) we see many issues with missing symbols.
