### PR TITLE
fix: Add Ownership Rules 100K char limitation

### DIFF
--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -62,7 +62,7 @@ When you create a rule from the **Issue Details** page, you'll see some suggeste
 
 #### Limitations
 
-We support Ownership Rules with a maximum of 100,000 characters. If your rule exceeds this size, we suggest using wildcard rules to consolidate multiple entries into a single one.
+We support ownership rules with up to 100,000 characters. If your rule exceeds this size, we suggest using wildcard rules to consolidate multiple entries into one.
 
 ### Code Owners
 

--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -60,6 +60,10 @@ You can also add a rule from the **Issue Details** page:
 
 When you create a rule from the **Issue Details** page, you'll see some suggested paths and URLs based on the events in the issue. Note that [sentry.io](https://sentry.io) doesn't suggest tags.
 
+#### Limitations
+
+We support Ownership Rules with a maximum of 100,000 characters. If your file exceeds this size, we suggest using wildcard rules to consolidate multiple entries into a single one.
+
 ### Code Owners
 
 <Note>

--- a/src/docs/product/issues/issue-owners/index.mdx
+++ b/src/docs/product/issues/issue-owners/index.mdx
@@ -62,7 +62,7 @@ When you create a rule from the **Issue Details** page, you'll see some suggeste
 
 #### Limitations
 
-We support Ownership Rules with a maximum of 100,000 characters. If your file exceeds this size, we suggest using wildcard rules to consolidate multiple entries into a single one.
+We support Ownership Rules with a maximum of 100,000 characters. If your rule exceeds this size, we suggest using wildcard rules to consolidate multiple entries into a single one.
 
 ### Code Owners
 


### PR DESCRIPTION
Fixes WOR-2497

Add 100K char limitation to Ownership Rules doc, similarly to how it's added for Codeowners
