### PR TITLE
Update to beta note on Session Replay SDK Docs

### DIFF
--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -2,7 +2,7 @@
 
 Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please open a [GitHub issue](https://github.com/getsentry/sentry/issues/new/choose). Alternatively, you can email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
 
-**Currently, this feature is supported for only browser JavaScript, including these frameworks:**
+**Currently, this feature is only supported for browser JavaScript, including these frameworks:**
 
 - Angular
 - Ember

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -6,6 +6,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 - Angular
 - Ember
 - Gatsby
-- Next.js
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -1,7 +1,8 @@
 <Note>
 
 Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions, feedback or would like to report a bug, please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new/choose) with a link to a relevant replay or, if possible, a publicly accessible URL to the page you're attempting to record a replay of. You can also email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
-**Currently, this feature is only supported for browser JavaScript, including these frameworks:**
+
+Session Replay supports all browser JavaScript applications. It is built to work with @sentry/browser, and our browser framework SDKs.
 
 - Gatsby
 

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -4,7 +4,6 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 **Currently, this feature is only supported for browser JavaScript, including these frameworks:**
 
 - Angular
-- Ember
 - Gatsby
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -1,5 +1,16 @@
 <Note>
 
-Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
+Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please open a [GitHub issue](https://github.com/getsentry/sentry/issues/new/choose). Alternatively, you can email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
+
+**Currently, this feature is supported for only browser JavaScript, including these frameworks:**
+
+- Angular
+- Ember
+- Gatsby
+- Next.js
+- React
+- Remix
+- Svelte
+- Vue
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -1,7 +1,6 @@
 <Note>
 
-Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions, feedback or would like to report a bug, please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new/choose) with a link to a relevant replay or if possible a publicly accessible URL to the page you are attempting to record a replay of. Alternatively, you can email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
-
+Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions, feedback or would like to report a bug, please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new/choose) with a link to a relevant replay or, if possible, a publicly accessible URL to the page you're attempting to record a replay of. You can also email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
 **Currently, this feature is only supported for browser JavaScript, including these frameworks:**
 
 - Angular

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please open a [GitHub issue](https://github.com/getsentry/sentry/issues/new/choose). Alternatively, you can email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
+Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions, feedback or would like to report a bug, please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new/choose) with a link to a relevant replay or if possible a publicly accessible URL to the page you are attempting to record a replay of. Alternatively, you can email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
 
 **Currently, this feature is only supported for browser JavaScript, including these frameworks:**
 

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -4,6 +4,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 
 Session Replay supports all browser JavaScript applications. It is built to work with @sentry/browser, and our browser framework SDKs.
 
-- Gatsby
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -10,6 +10,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 - React
 - Remix
 - Svelte
-- Vue
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -9,6 +9,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 - Next.js
 - React
 - Remix
-- Svelte
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -3,7 +3,6 @@
 Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions, feedback or would like to report a bug, please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new/choose) with a link to a relevant replay or, if possible, a publicly accessible URL to the page you're attempting to record a replay of. You can also email us at [session-replay@sentry.io](mailto:session-replay@sentry.io).
 **Currently, this feature is only supported for browser JavaScript, including these frameworks:**
 
-- Angular
 - Gatsby
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -8,6 +8,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 - Gatsby
 - Next.js
 - React
-- Remix
 
 </Note>

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -7,6 +7,5 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 - Ember
 - Gatsby
 - Next.js
-- React
 
 </Note>


### PR DESCRIPTION
To encourage users to open GitHub issues for their feedback, and to list the supported SDKs on the Session Replay SDK docs.

