### PR TITLE
Add docs for `traceOptionsRequests`

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -749,6 +749,16 @@ If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trac
 
 </ConfigKey>
 
+<ConfigKey name="trace-options-requests" supported={["java"]}>
+
+<PlatformSection supported={["java"]}>
+
+Set this boolean to `false` to disable tracing for `OPTIONS` requests. This options default value will likely be changed in the next major version, meaning you will have to set it to `true` if you want to keep tracing `OPTIONS` requests.
+
+</PlatformSection>
+
+</ConfigKey>
+
 </PlatformSection>
 
 <PlatformSection supported={["react-native", "javascript.cordova", "javascript.capacitor", "flutter"]}>


### PR DESCRIPTION
Document `traceOptionsRequests` option.

Need to wait for https://github.com/getsentry/sentry-java/pull/2453 to land.