### PR TITLE
feat(source-maps): adds Vercel and Github actions to source map tools

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.mdx
@@ -9,6 +9,8 @@ We've compiled a list of guides on how to upload source maps to Sentry for the m
 - <PlatformLink to="/sourcemaps/uploading/esbuild/">esbuild</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
+- [Vercel + Next.js](/product/integrations/deployment/vercel/)
+- [Github Actions](/product/releases/setup/release-automation/github-actions/)
 
 ### Other Tools
 

--- a/src/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.mdx
@@ -9,7 +9,6 @@ We've compiled a list of guides on how to upload source maps to Sentry for the m
 - <PlatformLink to="/sourcemaps/uploading/esbuild/">esbuild</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
-- [Vercel + Next.js](/product/integrations/deployment/vercel/)
 - [Github Actions](/product/releases/setup/release-automation/github-actions/)
 
 ### Other Tools

--- a/src/platform-includes/sourcemaps/primer/javascript.nextjs.mdx
+++ b/src/platform-includes/sourcemaps/primer/javascript.nextjs.mdx
@@ -1,5 +1,5 @@
 `@sentry/nextjs` will generate and upload source maps automatically, in order to enable errors to have readable stacktraces.
 
-To upload source maps, the `@sentry/nextjs` SDK uses the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) under the hood. See the [Manual Configuration](../manual-setup/#configure-source-maps) page and the Sentry [Webpack Plugin documentation](https://github.com/getsentry/sentry-webpack-plugin#cli-configuration) for more details.
+To upload source maps, the `@sentry/nextjs` SDK uses the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-webpack-plugin) under the hood. See the [Manual Configuration](../manual-setup/#configure-source-maps) page and the Sentry [Webpack Plugin documentation](https://github.com/getsentry/sentry-webpack-plugin#cli-configuration) for more details. If you are using Vercel, then you can also use the [Vercel integration](/product/integrations/deployment/vercel/) to upload source maps during deployments automatically.
 
 ![Minified stack trace vs. readable stack trace](readable-stacktraces.png)


### PR DESCRIPTION
This PR adds Vercel and Github Actions as a way to set up source maps. Note I did not make separate pages within `/sourcemaps/uploading/` so they won't show up in the sidebar as they exist in other parts of documentation.