### PR TITLE
fix(manual-setup-nextjs): fix typo

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -377,7 +377,7 @@ For data fetching methods, use the following functions:
 
 _(New in version 7.20.0)_
 
-If you want auto-instrumenatation to apply by default, but want to exclude certain routes, use the `excludeServerRoutes` option in the `sentry` object in your `next.config.js`:
+If you want auto-instrumentation to apply by default, but want to exclude certain routes, use the `excludeServerRoutes` option in the `sentry` object in your `next.config.js`:
 
 ```javascript {filename:next.config.js}
 const moduleExports = {


### PR DESCRIPTION


<!-- Describe your PR here. -->
Hey What's up?!

This PR fixes a typo in the manual setup for NextJS application.
![image](https://user-images.githubusercontent.com/52766091/211083769-8110d256-cfcb-4027-97d1-deed45586944.png)
[doc page](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#opt-out-of-auto-instrumentation-on-specific-routes)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
