### PR TITLE
feat(apple): Docs for the MetricKit integration

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -17,6 +17,7 @@ func application(_ application: UIApplication,
         options.enableFileIOTracking = true
         options.enableCoreDataTracking = true
         options.enableCaptureFailedRequests = true
+        options.enableMetricKit = true
     }
 
     return true
@@ -37,6 +38,7 @@ func application(_ application: UIApplication,
         options.enableFileIOTracking = YES;
         options.enableCoreDataTracking = YES;
         options.enableCaptureFailedRequests = YES;
+        options.enableMetricKit = YES;
     }];
 
     return YES;
@@ -60,6 +62,7 @@ struct SwiftUIApp: App {
             options.enableFileIOTracking = true
             options.enableCoreDataTracking = true
             options.enableCaptureFailedRequests = true
+            options.enableMetricKit = true
         }
     }
 }
@@ -83,6 +86,7 @@ SentrySDK.start { options in
     options.enablePreWarmedAppStartTracking = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
+    options.enableMetricKit = true
 }
 ```
 ```objc {tabTitle:Objective-C}
@@ -96,6 +100,7 @@ SentrySDK.start { options in
     options.enablePreWarmedAppStartTracking = YES;
     options.attachScreenshot = YES;
     options.attachViewHierarchy = YES;
+    options.enableMetricKit = YES;
 }];
 ```
 

--- a/src/platforms/apple/common/configuration/metric-kit.mdx
+++ b/src/platforms/apple/common/configuration/metric-kit.mdx
@@ -12,7 +12,7 @@ Once enabled, this feature subscribes to [MXDiagnosticPayload](https://developer
 * [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic)
 * [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic)
 
-The SDK supports this feature from iOS 15 and later and macOS 12 and later because, on these versions, MetricKit delivers diagnostic reports immediately, which allows the Sentry SDK to apply the current data from the scope.
+The SDK supports this feature from iOS 15 and up and macOS 12 and up because in these versions, MetricKit delivers diagnostic reports immediately, which allows the Sentry SDK to apply current data from the scope.
 
 This is an experimental feature requiring opt-in, and can be enabled by setting the `enableMetricKit` option to `true`:
 

--- a/src/platforms/apple/common/configuration/metric-kit.mdx
+++ b/src/platforms/apple/common/configuration/metric-kit.mdx
@@ -6,7 +6,9 @@ description: "This feature, once enabled, subscribes to MXDiagnosticPayload data
 
 <Include name="alpha-note.mdx" />
 
-Once enabled, this feature subscribes to [MXDiagnosticPayload](https://developer.apple.com/documentation/metrickit/mxdiagnosticpayload) data of [MetricKit](https://developer.apple.com/documentation/metrickit), converts it to events and sends it to Sentry. This feature is available on Cocoa 8.0.0 and above. The MetricKit integration subscribes to
+Once enabled, this feature subscribes to [MetricKit's](https://developer.apple.com/documentation/metrickit) [MXDiagnosticPayload](https://developer.apple.com/documentation/metrickit/mxdiagnosticpayload) data, converts it to events, and sends it to Sentry. This feature is available on Cocoa 8.0.0 and up. 
+
+The MetricKit integration subscribes to:
 
 * [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic)
 * [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic)

--- a/src/platforms/apple/common/configuration/metric-kit.mdx
+++ b/src/platforms/apple/common/configuration/metric-kit.mdx
@@ -1,0 +1,35 @@
+---
+title:  Metric Kit
+sidebar_order: 20
+description: "This feature, once enabled, subscribes to MXDiagnosticPayload data of MetricKit and it to Sentry."
+---
+
+<Include name="alpha-note.mdx" />
+
+Once enabled, this feature subscribes to [MXDiagnosticPayload](https://developer.apple.com/documentation/metrickit/mxdiagnosticpayload) data of [MetricKit](https://developer.apple.com/documentation/metrickit), converts it to events and sends it to Sentry. This feature is available on Cocoa 8.0.0 and above. The MetricKit integration subscribes to
+
+* [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic)
+* [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic)
+* [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic)
+
+The SDK supports this feature from iOS 15 and later and macOS 12 and later because, on these versions, MetricKit delivers diagnostic reports immediately, which allows the Sentry SDK to apply the current data from the scope.
+
+This feature is experimental feature requiring opt-in and can be enabled by setting the `enableMetricKit` option to `true`:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enableMetricKit = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enableMetricKit = YES;
+}];
+```

--- a/src/platforms/apple/common/configuration/metric-kit.mdx
+++ b/src/platforms/apple/common/configuration/metric-kit.mdx
@@ -14,7 +14,7 @@ Once enabled, this feature subscribes to [MXDiagnosticPayload](https://developer
 
 The SDK supports this feature from iOS 15 and later and macOS 12 and later because, on these versions, MetricKit delivers diagnostic reports immediately, which allows the Sentry SDK to apply the current data from the scope.
 
-This feature is experimental feature requiring opt-in and can be enabled by setting the `enableMetricKit` option to `true`:
+This is an experimental feature requiring opt-in, and can be enabled by setting the `enableMetricKit` option to `true`:
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -43,6 +43,7 @@ func application(_ application: UIApplication,
         options.enableFileIOTracking = true
         options.enableCoreDataTracking = true
         options.enableCaptureFailedRequests = true
+        options.enableMetricKit = true
     }
 
     return true
@@ -70,6 +71,7 @@ struct SwiftUIApp: App {
             options.enableFileIOTracking = true
             options.enableCoreDataTracking = true
             options.enableCaptureFailedRequests = true
+            options.enableMetricKit = true
         }
     }
 }
@@ -121,5 +123,6 @@ SentrySDK.start { options in
     options.enablePreWarmedAppStartTracking = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
+    options.enableMetricKit = true
 }
 ```


### PR DESCRIPTION
Add docs for the experimental MetricKit integration available on Sentry Cocoa 8.0.0 and above.

Merge after releasing Cocoa 8.0.0.