### PR TITLE
feat(go): Add BeforeSendTransaction to Basic Options page

### DIFF
--- a/src/platforms/go/common/configuration/options.mdx
+++ b/src/platforms/go/common/configuration/options.mdx
@@ -43,8 +43,10 @@ type ClientOptions struct {
 	SendDefaultPII bool
 	// BeforeSend is called before error events are sent to Sentry.
 	// Use it to mutate the event or return nil to discard the event.
-	// See EventProcessor if you need to mutate transactions.
 	BeforeSend func(event *Event, hint *EventHint) *Event
+	// BeforeSendTransaction is called before transaction events are sent to Sentry.
+	// Use it to mutate the transaction or return nil to discard the transaction.
+	BeforeSendTransaction func(event *Event, hint *EventHint) *Event
 	// Before breadcrumb add callback.
 	BeforeBreadcrumb func(breadcrumb *Breadcrumb, hint *BreadcrumbHint) *Breadcrumb
 	// Integrations to be installed on the current Client, receives default


### PR DESCRIPTION
BeforeSendTransaction is added to sentry-go here: https://github.com/getsentry/sentry-go/pull/517
The change is not released yet, so we'll be merging this together with the release of the next sentry-go version.

Not touching any other pages for now, given the on-going refactorings of BeforeSendTransaction docs in https://github.com/getsentry/sentry-docs/pull/6038, https://github.com/getsentry/sentry-docs/pull/5804, and https://github.com/getsentry/sentry-docs/pull/5838.

