### PR TITLE
Document jakarta packages for Spring 6 and Spring Boot 3

### DIFF
--- a/src/platform-includes/getting-started-config/java.spring.mdx
+++ b/src/platform-includes/getting-started-config/java.spring.mdx
@@ -1,6 +1,6 @@
-The `sentry-spring` library provides `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including the main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
+The `sentry-spring` and `sentry-spring-jakarta` libraries provide an `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including the main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.spring.EnableSentry;
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
 // project/dashboard
@@ -10,8 +10,27 @@ class SentryConfiguration {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.spring.jakarta.EnableSentry;
+// NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
+// project/dashboard
+@EnableSentry(dsn = "___PUBLIC_DSN___")
+@Configuration
+class SentryConfiguration {
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.spring.EnableSentry
+// NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
+// project/dashboard
+@EnableSentry(dsn = "___PUBLIC_DSN___")
+@Configuration
+class SentryConfiguration
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.spring.jakarta.EnableSentry
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
 // project/dashboard
 @EnableSentry(dsn = "___PUBLIC_DSN___")
@@ -25,7 +44,7 @@ Once this integration is configured you can _also_ use Sentry’s static API, [a
 
 By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring the `exceptionResolverOrder` property. For example, setting it to `Ordered#HIGHEST_PRECEDENCE` ensures exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.spring.EnableSentry;
 import org.springframework.core.Ordered;
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
@@ -38,8 +57,33 @@ class SentryConfiguration {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.spring.jakarta.EnableSentry;
+import org.springframework.core.Ordered;
+// NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
+// project/dashboard
+@EnableSentry(
+  dsn = "___PUBLIC_DSN___",
+  exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE
+)
+class SentryConfiguration {
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.spring.EnableSentry
+import org.springframework.core.Ordered
+// NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
+// project/dashboard
+@EnableSentry(
+  dsn = "___PUBLIC_DSN___",
+  exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE
+)
+class SentryConfiguration
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.spring.jakarta.EnableSentry
 import org.springframework.core.Ordered
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
 // project/dashboard

--- a/src/platform-includes/getting-started-install/java.spring-boot.mdx
+++ b/src/platform-includes/getting-started-install/java.spring-boot.mdx
@@ -1,4 +1,4 @@
-```xml {tabTitle:Maven}
+```xml {tabTitle:Maven (Spring Boot 2)}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring-boot-starter</artifactId>
@@ -6,8 +6,20 @@
 </dependency>
 ```
 
-```groovy {tabTitle:Gradle}
+```xml {tabTitle:Maven (Spring Boot 3)}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+    <version>{{ packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}</version>
+</dependency>
+```
+
+```groovy {tabTitle:Gradle (Spring Boot 2)}
 implementation 'io.sentry:sentry-spring-boot-starter:{{ packages.version('sentry.java.spring-boot', '4.2.0') }}'
+```
+
+```groovy {tabTitle:Gradle (Spring Boot 3)}
+implementation 'io.sentry:sentry-spring-boot-starter-jakarta:{{ packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}'
 ```
 
 <Note>

--- a/src/platform-includes/getting-started-install/java.spring.mdx
+++ b/src/platform-includes/getting-started-install/java.spring.mdx
@@ -1,4 +1,4 @@
-```xml {tabTitle:Maven}
+```xml {tabTitle:Maven (Spring 5)}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring</artifactId>
@@ -6,15 +6,30 @@
 </dependency>
 ```
 
-```groovy {tabTitle:Gradle}
+```xml {tabTitle:Maven (Spring 6)}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-jakarta</artifactId>
+    <version>{{ packages.version('sentry.java.spring.jakarta', '6.7.0') }}</version>
+</dependency>
+```
+
+```groovy {tabTitle:Gradle (Spring 5)}
 implementation 'io.sentry:sentry-spring:{{ packages.version('sentry.java.spring', '4.2.0') }}'
 ```
 
-```scala {tabTitle: SBT}
-libraryDependencies += "io.sentry" % "sentry-spring" % "{{ packages.version('sentry.java.spring', '4.2.0') }}"
+```groovy {tabTitle:Gradle (Spring 6)}
+implementation 'io.sentry:sentry-spring-jakarta:{{ packages.version('sentry.java.spring.jakarta', '6.7.0') }}'
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-spring).
+```scala {tabTitle: SBT (Spring 5)}
+libraryDependencies += "io.sentry" % "sentry-spring" % "{{ packages.version('sentry.java.spring', '4.2.0') }}"
+```
+```scala {tabTitle: SBT (Spring 6)}
+libraryDependencies += "io.sentry" % "sentry-spring-jakarta" % "{{ packages.version('sentry.java.spring.jakarta', '6.7.0') }}"
+```
+
+For other dependency managers see the [central Maven repository (Spring 5)](https://search.maven.org/artifact/io.sentry/sentry-spring) and [central Maven repository (Spring 6)](https://search.maven.org/artifact/io.sentry/sentry-spring-jakarta).
 
 <Note>
 

--- a/src/platform-includes/getting-started-primer/java.spring-boot.mdx
+++ b/src/platform-includes/getting-started-primer/java.spring-boot.mdx
@@ -1,8 +1,10 @@
 <Note>
 
+There are two variants of Sentry available for Spring Boot. If you are using Spring Boot 2, please use `sentry-spring-boot-starter` ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter)). If you are using Spring Boot 3, please use `sentry-spring-boot-starter-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter-jakarta)).
+
 Sentry's integration with [Spring Boot](https://spring.io/projects/spring-boot) supports Spring Boot 2.1.0 and above to report unhandled exceptions as well as release and registration of beans. If you're on an older version, use [our legacy integration](/platforms/java/legacy/spring/).
 
-The `sentry-spring-boot-starter` library enhances [Sentry Spring](/platforms/java/guides/spring/) to:
+The `sentry-spring-boot-starter` and `sentry-spring-boot-starter-jakarta` libraries enhance [Sentry Spring](/platforms/java/guides/spring/) to:
 
 - manage a fine-grained configuration using `application.properties` or `application.yaml`
 - automatically include the release when [Spring Boot Git integration is configured](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-git-info)

--- a/src/platform-includes/getting-started-primer/java.spring.mdx
+++ b/src/platform-includes/getting-started-primer/java.spring.mdx
@@ -1,8 +1,8 @@
 <Note>
 
-Sentry's integration with [Spring](https://spring.io/projects/spring-framework) supports Spring Framework 5.1.2 and above to report unhandled exceptions and optional user information. If you're on an older version, use [our legacy integration](/platforms/java/legacy/spring/).
+There are two variants of Sentry available for Spring. If you are using Spring 5, please use `sentry-spring` ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring)). If you are using Spring 6, please use `sentry-spring-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-jakarta)).
 
-The `sentry-spring` library can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring):
+Sentry's integration with [Spring](https://spring.io/projects/spring-framework) supports Spring Framework 5.1.2 and above to report unhandled exceptions and optional user information. If you're on an older version, use [our legacy integration](/platforms/java/legacy/spring/).
 
 - Provides a [HandlerExceptionResolver](https://docs.spring.io/spring/docs/4.3.9.RELEASE/javadoc-api/org/springframework/web/servlet/HandlerExceptionResolver.html) to send unhandled exceptions to Sentry
 - Attaches HTTP request information to every `SentryEvent` recorded within the scope of the request

--- a/src/platform-includes/performance/enable-manual-instrumentation/java.spring-boot.mdx
+++ b/src/platform-includes/performance/enable-manual-instrumentation/java.spring-boot.mdx
@@ -15,7 +15,7 @@ Every Spring bean method execution can be turned into a transaction or a span. T
 
 Methods executed outside of Spring MVC request processing can be turned into transactions by annotating them with `@SentryTransaction` annotation:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring Boot 2)}
 import org.springframework.stereotype.Component;
 import org.springframework.scheduling.annotation.Scheduled;
 import io.sentry.spring.tracing.SentryTransaction;
@@ -31,10 +31,42 @@ class ScheduledJob {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring Boot 3)}
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Scheduled;
+import io.sentry.spring.jakarta.tracing.SentryTransaction;
+
+@Component
+class ScheduledJob {
+
+  @Scheduled(...)
+  @SentryTransaction(operation = "task")
+  void execute() {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 2)}
 import org.springframework.stereotype.Component
 import org.springframework.scheduling.annotation.Scheduled
 import io.sentry.spring.tracing.SentryTransaction
+
+@Component
+class ScheduledJob {
+
+  @Scheduled(...)
+  @SentryTransaction(operation = "task")
+  fun execute() {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 3)}
+import org.springframework.stereotype.Component
+import org.springframework.scheduling.annotation.Scheduled
+import io.sentry.spring.jakarta.tracing.SentryTransaction
 
 @Component
 class ScheduledJob {
@@ -57,7 +89,7 @@ Advanced Spring AOP users can redefine transaction pointcut by providing a custo
 
 To create a span around a method execution, annotate method with `@SentrySpan` annotation:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring Boot 2)}
 import org.springframework.stereotype.Component;
 import io.sentry.spring.tracing.SentrySpan;
 
@@ -71,9 +103,37 @@ class PersonService {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring Boot 3)}
+import org.springframework.stereotype.Component;
+import io.sentry.spring.jakarta.tracing.SentrySpan;
+
+@Component
+class PersonService {
+
+  @SentrySpan
+  Person findById(Long id) {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 2)}
 import org.springframework.stereotype.Component
 import io.sentry.spring.tracing.SentrySpan
+
+@Component
+class PersonService {
+
+  @SentrySpan(operation = "task")
+  fun findById(id: Long): Person {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 3)}
+import org.springframework.stereotype.Component
+import io.sentry.spring.jakarta.tracing.SentrySpan
 
 @Component
 class PersonService {

--- a/src/platform-includes/performance/enable-manual-instrumentation/java.spring.mdx
+++ b/src/platform-includes/performance/enable-manual-instrumentation/java.spring.mdx
@@ -20,7 +20,7 @@ To enable this feature, you must include `spring-aop` and `aspectj` in your appl
 
 Then, import `SentryTracingConfiguration` in one of your `@Configuration` classes:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import io.sentry.spring.tracing.SentryTracingConfiguration;
@@ -30,7 +30,17 @@ class SentryConfig {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import io.sentry.spring.jakarta.tracing.SentryTracingConfiguration;
+
+@Import(SentryTracingConfiguration.class)
+class SentryConfig {
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import io.sentry.spring.tracing.SentryTracingConfiguration
@@ -40,9 +50,19 @@ class SentryConfig {
 }
 ```
 
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import io.sentry.spring.jakarta.tracing.SentryTracingConfiguration
+
+@Import(SentryTracingConfiguration::class)
+class SentryConfig {
+}
+```
+
 Methods executed outside of Spring MVC request processing can be turned into transactions by annotating them with `@SentryTransaction` annotation:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.stereotype.Component;
 import org.springframework.scheduling.annotation.Scheduled;
 import io.sentry.spring.tracing.SentryTransaction;
@@ -58,10 +78,42 @@ class ScheduledJob {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Scheduled;
+import io.sentry.spring.jakarta.tracing.SentryTransaction;
+
+@Component
+class ScheduledJob {
+
+  @Scheduled(...)
+  @SentryTransaction(operation = "task")
+  void execute() {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.stereotype.Component
 import org.springframework.scheduling.annotation.Scheduled
 import io.sentry.spring.tracing.SentryTransaction
+
+@Component
+class ScheduledJob {
+
+  @Scheduled(...)
+  @SentryTransaction(operation = "task")
+  fun execute() {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.stereotype.Component
+import org.springframework.scheduling.annotation.Scheduled
+import io.sentry.spring.jakarta.tracing.SentryTransaction
 
 @Component
 class ScheduledJob {
@@ -84,7 +136,7 @@ Advanced Spring AOP users can redefine transaction pointcut by providing a custo
 
 To create a span around a method execution, annotate method with `@SentrySpan` annotation:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.stereotype.Component;
 import io.sentry.spring.tracing.SentrySpan;
 
@@ -98,9 +150,37 @@ class PersonService {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.stereotype.Component;
+import io.sentry.spring.jakarta.tracing.SentrySpan;
+
+@Component
+class PersonService {
+
+  @SentrySpan
+  Person findById(Long id) {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.stereotype.Component
 import io.sentry.spring.tracing.SentrySpan
+
+@Component
+class PersonService {
+
+  @SentrySpan(operation = "task")
+  fun findById(id: Long): Person {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.stereotype.Component
+import io.sentry.spring.jakarta.tracing.SentrySpan
 
 @Component
 class PersonService {

--- a/src/platform-includes/performance/enable-tracing/java.spring.mdx
+++ b/src/platform-includes/performance/enable-tracing/java.spring.mdx
@@ -1,6 +1,6 @@
 To automatically send traces, you must configure `SentryTracingFilter` in `web.xml` for Servlet applications configured with XML, or `WebApplicationInitializer` for Servlet applications configured with Java code:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.spring.tracing.SentryTracingFilter;
 import javax.servlet.Filter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
@@ -14,8 +14,32 @@ public class AppInitializer extends AbstractAnnotationConfigDispatcherServletIni
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.spring.jakarta.tracing.SentryTracingFilter;
+import jakarta.servlet.Filter;
+import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
+
+public class AppInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
+  // ...
+  @Override
+  protected Filter[] getServletFilters() {
+    return new Filter[] {new SentryTracingFilter()};
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.spring.tracing.SentryTracingFilter
+import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer
+
+class AppInitializer : AbstractAnnotationConfigDispatcherServletInitializer() {
+  // ...
+  override fun getServletFilters() = arrayOf(SentryTracingFilter())
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.spring.jakarta.tracing.SentryTracingFilter
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer
 
 class AppInitializer : AbstractAnnotationConfigDispatcherServletInitializer() {

--- a/src/platform-includes/performance/traces-sampler-as-sampler/java.spring-boot.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-sampler/java.spring-boot.mdx
@@ -1,4 +1,4 @@
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring Boot 2)}
 import io.sentry.SamplingContext;
 import io.sentry.SentryOptions.TracesSamplerCallback;
 import org.springframework.stereotype.Component;
@@ -27,11 +27,77 @@ class CustomTracesSamplerCallback implements TracesSamplerCallback {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring Boot 3)}
+import io.sentry.SamplingContext;
+import io.sentry.SentryOptions.TracesSamplerCallback;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+class CustomTracesSamplerCallback implements TracesSamplerCallback {
+  @Override
+  public Double sample(SamplingContext context) {
+    HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request");
+    String url = request.getRequestURI();
+    if ("/payment".equals(url)) {
+      // These are important - take a big sample
+      return 0.5;
+    } else if ("/search".equals(url)) {
+      // Search is less important and happen much more frequently - only take 1%
+      return 0.01;
+    } else if ("/health".equals(url)) {
+      // The health check endpoint is just noise - drop all transactions
+      return 0d;
+    } else {
+      // Default sample rate
+      return 0.1;
+    }
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 2)}
 import io.sentry.SamplingContext
 import io.sentry.SentryOptions.TracesSamplerCallback
 import org.springframework.stereotype.Component
 import javax.servlet.http.HttpServletRequest
+
+@Component
+class CustomTracesSamplerCallback : TracesSamplerCallback {
+  override fun sample(context: SamplingContext): Double? {
+    val customSamplingContext = context.customSamplingContext
+    if (customSamplingContext != null) {
+      val request = customSamplingContext["request"] as HttpServletRequest
+      return when (request.requestURI) {
+        "/payment" -> {
+          // These are important - take a big sample
+          0.5
+        }
+        "/search" -> {
+          // Search is less important and happen much more frequently - only take 1%
+          0.01
+        }
+        "/health" -> {
+          // The health check endpoint is just noise - drop all transactions
+          0.0
+        }
+        else -> {
+          // Default sample rate
+          0.1
+        }
+      }
+    } else {
+      return 0.1
+    }
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 3)}
+import io.sentry.SamplingContext
+import io.sentry.SentryOptions.TracesSamplerCallback
+import org.springframework.stereotype.Component
+import jakarta.servlet.http.HttpServletRequest
 
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {

--- a/src/platform-includes/performance/traces-sampler-as-sampler/java.spring.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-sampler/java.spring.mdx
@@ -1,4 +1,4 @@
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.SamplingContext;
 import io.sentry.SentryOptions.TracesSamplerCallback;
 import org.springframework.stereotype.Component;
@@ -27,11 +27,77 @@ class CustomTracesSamplerCallback implements TracesSamplerCallback {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.SamplingContext;
+import io.sentry.SentryOptions.TracesSamplerCallback;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+class CustomTracesSamplerCallback implements TracesSamplerCallback {
+  @Override
+  public Double sample(SamplingContext context) {
+    HttpServletRequest request = (HttpServletRequest) context.getCustomSamplingContext().get("request");
+    String url = request.getRequestURI();
+    if ("/payment".equals(url)) {
+      // These are important - take a big sample
+      return 0.5;
+    } else if ("/search".equals(url)) {
+      // Search is less important and happen much more frequently - only take 1%
+      return 0.01;
+    } else if ("/health".equals(url)) {
+      // The health check endpoint is just noise - drop all transactions
+      return 0d;
+    } else {
+      // Default sample rate
+      return 0.1;
+    }
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 2)}
 import io.sentry.SamplingContext
 import io.sentry.SentryOptions.TracesSamplerCallback
 import org.springframework.stereotype.Component
 import javax.servlet.http.HttpServletRequest
+
+@Component
+class CustomTracesSamplerCallback : TracesSamplerCallback {
+  override fun sample(context: SamplingContext): Double? {
+    val customSamplingContext = context.customSamplingContext
+    if (customSamplingContext != null) {
+      val request = customSamplingContext["request"] as HttpServletRequest
+      return when (request.requestURI) {
+        "/payment" -> {
+          // These are important - take a big sample
+          0.5
+        }
+        "/search" -> {
+          // Search is less important and happen much more frequently - only take 1%
+          0.01
+        }
+        "/health" -> {
+          // The health check endpoint is just noise - drop all transactions
+          0.0
+        }
+        else -> {
+          // Default sample rate
+          0.1
+        }
+      }
+    } else {
+      return 0.1
+    }
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 3)}
+import io.sentry.SamplingContext
+import io.sentry.SentryOptions.TracesSamplerCallback
+import org.springframework.stereotype.Component
+import jakarta.servlet.http.HttpServletRequest
 
 @Component
 class CustomTracesSamplerCallback : TracesSamplerCallback {

--- a/src/platforms/java/common/async.mdx
+++ b/src/platforms/java/common/async.mdx
@@ -13,7 +13,7 @@ Sentry's SDK for Java stores the scope and the context in a thread-local variabl
 
 To propagate Sentry scope to Spring MVC methods returning a `Callable` or a `StreamingResponseBody`, a `ThreadPoolTaskExecutor` decorated with `SentryTaskDecorator` must be set on the `AsyncSupportConfigurer` through an implementation of `WebMvcConfigurer`:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -39,7 +39,33 @@ class AsyncWebMvcConfiguration implements WebMvcConfigurer {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import io.sentry.spring.jakarta.SentryTaskDecorator;
+
+@Configuration
+class AsyncWebMvcConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setTaskExecutor(asyncExecutor());
+    }
+
+    private AsyncTaskExecutor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setTaskDecorator(new SentryTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
@@ -63,11 +89,35 @@ class AsyncWebMvcConfiguration : WebMvcConfigurer {
 }
 ```
 
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.AsyncTaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+import io.sentry.spring.jakarta.SentryTaskDecorator
+
+@Configuration
+class AsyncWebMvcConfiguration : WebMvcConfigurer {
+    override fun configureAsyncSupport(configurer: AsyncSupportConfigurer) {
+        configurer.setTaskExecutor(asyncExecutor())
+    }
+
+    private fun asyncExecutor(): AsyncTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.setTaskDecorator(SentryTaskDecorator())
+        executor.initialize()
+        return executor
+    }
+}
+```
+
 <PlatformSection supported={["java.spring-boot"]}>
 
 Alternatively, if there is a single bean of type `TaskDecorator` in the context, instead of custom `WebMvcConfigurer`, it is enough to create a `SentryTaskDecorator` bean.
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -83,11 +133,41 @@ class SentryConfig {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.sentry.spring.jakarta.SentryTaskDecorator;
+
+@Configuration
+class SentryConfig {
+
+    @Bean
+    public SentryTaskDecorator sentryTaskDecorator() {
+        return new SentryTaskDecorator();
+    }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 import io.sentry.spring.SentryTaskDecorator
+
+@Configuration
+class SentryConfig {
+
+    @Bean
+    fun sentryTaskDecorator() = SentryTaskDecorator()
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+import io.sentry.spring.jakarta.SentryTaskDecorator
 
 @Configuration
 class SentryConfig {
@@ -102,7 +182,7 @@ class SentryConfig {
 
 To propagate Sentry scope to Spring `@Async` annotated methods, a custom `AsyncConfigurerSupport` must be configured to return a `ThreadPoolTaskExecutor` decorated with `SentryTaskDecorator`:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -123,12 +203,53 @@ class AsyncMethodConfiguration extends AsyncConfigurerSupport {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import io.sentry.spring.jakarta.SentryTaskDecorator;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+class AsyncMethodConfiguration extends AsyncConfigurerSupport {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setTaskDecorator(new SentryTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 import io.sentry.spring.SentryTaskDecorator
+
+import java.util.concurrent.Executor
+
+@Configuration
+class AsyncMethodConfiguration : AsyncConfigurerSupport() {
+    override fun getAsyncExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.setTaskDecorator(SentryTaskDecorator())
+        executor.initialize()
+        return executor
+    }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+import io.sentry.spring.jakarta.SentryTaskDecorator
 
 import java.util.concurrent.Executor
 

--- a/src/platforms/java/guides/spring-boot/record-user.mdx
+++ b/src/platforms/java/guides/spring-boot/record-user.mdx
@@ -27,7 +27,7 @@ sentry:
 
 To record custom user information, you can register a bean that implements `SentryUserProvider` interface.
 
-```java
+```java {tabTitle:Java (Spring Boot 2)}
 import org.springframework.stereotype.Component;
 import io.sentry.protocol.User;
 import io.sentry.spring.SentryUserProvider;
@@ -42,10 +42,40 @@ class CustomSentryUserProvider implements SentryUserProvider {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring Boot 3)}
+import org.springframework.stereotype.Component;
+import io.sentry.protocol.User;
+import io.sentry.spring.jakarta.SentryUserProvider;
+
+@Component
+class CustomSentryUserProvider implements SentryUserProvider {
+  public User provideUser() {
+    User user = new User();
+    // ... set user information
+    return user
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 2)}
 import org.springframework.stereotype.Component
 import io.sentry.protocol.User
 import io.sentry.spring.SentryUserProvider
+
+@Component
+class CustomSentryUserProvider : SentryUserProvider {
+  override fun provideUser(): User? {
+    val user = User()
+    // ... set user information
+    return user
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring Boot 3)}
+import org.springframework.stereotype.Component
+import io.sentry.protocol.User
+import io.sentry.spring.jakarta.SentryUserProvider
 
 @Component
 class CustomSentryUserProvider : SentryUserProvider {

--- a/src/platforms/java/guides/spring/advanced-usage.mdx
+++ b/src/platforms/java/guides/spring/advanced-usage.mdx
@@ -12,7 +12,7 @@ To record the user's IP address and `Principal#name` as the username so you can 
 
 1. Set the personal information flag on `@EnableSentry` to `true`.
 
-```Java {tabTitle:Java}
+```Java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Configuration;
 import io.sentry.spring.EnableSentry;
 
@@ -22,7 +22,17 @@ class SentryConfiguration {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```Java {tabTitle:Java (Spring 6)}
+import org.springframework.context.annotation.Configuration;
+import io.sentry.spring.jakarta.EnableSentry;
+
+@EnableSentry(dsn = "___PUBLIC_DSN___", sendDefaultPii = true)
+@Configuration
+class SentryConfiguration {
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.context.annotation.Configuration
 import io.sentry.spring.EnableSentry
 
@@ -31,9 +41,18 @@ import io.sentry.spring.EnableSentry
 class SentryConfiguration
 ```
 
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.context.annotation.Configuration
+import io.sentry.spring.jakarta.EnableSentry
+
+@EnableSentry(dsn = "...", sendDefaultPii = true)
+@Configuration
+class SentryConfiguration
+```
+
 2. Register the servlet filter bean `SentryUserFilter`:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.IHub;
 import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
@@ -52,7 +71,26 @@ public class SentryFilterConfig {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.IHub;
+import io.sentry.spring.jakarta.SentryUserFilter;
+import io.sentry.spring.jakarta.SentryUserProvider;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SentryFilterConfig {
+
+  @Bean
+  public SentryUserFilter sentryUserFilter(
+      final IHub hub, final List<SentryUserProvider> sentryUserProviders) {
+    return new SentryUserFilter(hub, sentryUserProviders);
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.IHub
 import io.sentry.spring.SentryUserProvider
 import io.sentry.spring.SentryUserFilter
@@ -66,9 +104,23 @@ class SentryFilterConfig {
 }
 ```
 
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.IHub
+import io.sentry.spring.jakarta.SentryUserProvider
+import io.sentry.spring.jakarta.SentryUserFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SentryFilterConfig {
+    @Bean
+    fun sentryUserFilter(hub: IHub, sentryUserProviders: List<SentryUserProvider>) = SentryUserFilter(hub, sentryUserProviders)
+}
+```
+
 3. Configure `SentryUserFilter` in `web.xml` or `WebApplicationInitializer` using `DelegatingFilterProxy`:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import javax.servlet.Filter;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.filter.RequestContextFilter;
@@ -99,7 +151,38 @@ public class AppInitializer extends AbstractAnnotationConfigDispatcherServletIni
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import jakarta.servlet.Filter;
+import org.springframework.web.filter.DelegatingFilterProxy;
+import org.springframework.web.filter.RequestContextFilter;
+import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
+
+public class AppInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
+
+  // ...
+
+  @Override
+  protected Filter[] getServletFilters() {
+    // filter required by Spring Security
+    DelegatingFilterProxy springSecurityFilterChain = new DelegatingFilterProxy();
+    springSecurityFilterChain.setTargetBeanName("springSecurityFilterChain");
+
+    // sets request on RequestContextHolder
+    // alternatively configure RequestContextListener
+    RequestContextFilter requestContextFilter = new RequestContextFilter();
+
+    // sets Sentry user on the scope
+    DelegatingFilterProxy sentryUserFilterProxy = new DelegatingFilterProxy();
+    sentryUserFilterProxy.setTargetBeanName("sentryUserFilter");
+
+    return new Filter[] {
+      springSecurityFilterChain, requestContextFilter, sentryUserFilterProxy
+    };
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.web.filter.DelegatingFilterProxy
 import org.springframework.web.filter.RequestContextFilter
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer
@@ -128,9 +211,38 @@ class AppInitializer : AbstractAnnotationConfigDispatcherServletInitializer() {
 }
 ```
 
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.web.filter.DelegatingFilterProxy
+import org.springframework.web.filter.RequestContextFilter
+import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer
+import jakarta.servlet.Filter
+
+class AppInitializer : AbstractAnnotationConfigDispatcherServletInitializer() {
+
+    // ...
+
+    override fun getServletFilters(): Array<Filter> {
+        // filter required by Spring Security
+        val springSecurityFilterChain = DelegatingFilterProxy()
+        springSecurityFilterChain.setTargetBeanName("springSecurityFilterChain")
+
+        // sets request on RequestContextHolder
+        // alternatively configure RequestContextListener
+        val requestContextFilter = RequestContextFilter()
+
+        // sets Sentry user on the scope
+        val sentryUserFilterProxy = DelegatingFilterProxy()
+        sentryUserFilterProxy.setTargetBeanName("sentryUserFilter")
+        return arrayOf(
+            springSecurityFilterChain, requestContextFilter, sentryUserFilterProxy
+        )
+    }
+}
+```
+
 By default, the username is retrieved from `HttpServletRequest#userPrincipal`. To retrieve the username from Spring Security context, register the `SpringSecuritySentryUserProvider` bean:
 
-```java
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.SentryOptions;
 import io.sentry.spring.SpringSecuritySentryUserProvider;
 import org.springframework.context.annotation.Bean;
@@ -146,9 +258,38 @@ class SecuritySentryConfig {
 }
 ```
 
-```kotlin
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.SentryOptions;
+import io.sentry.spring.jakarta.SpringSecuritySentryUserProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class SecuritySentryConfig {
+  @Bean
+  public SpringSecuritySentryUserProvider springSecuritySentryUserProvider(
+      SentryOptions sentryOptions) {
+    return new SpringSecuritySentryUserProvider(sentryOptions);
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.SentryOptions
 import io.sentry.spring.SpringSecuritySentryUserProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SecuritySentryConfig {
+  @Bean
+  fun springSecuritySentryUserProvider(sentryOptions: SentryOptions) = SpringSecuritySentryUserProvider(sentryOptions)
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.SentryOptions
+import io.sentry.spring.jakarta.SpringSecuritySentryUserProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -163,7 +304,7 @@ class SecuritySentryConfig {
 
 To record custom user information, you can register a bean that implements `SentryUserProvider` interface.
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import org.springframework.stereotype.Component;
 import io.sentry.protocol.User;
 import io.sentry.spring.SentryUserProvider;
@@ -178,10 +319,40 @@ class CustomSentryUserProvider implements SentryUserProvider {
 }
 ```
 
-```kotlin {tabTitle:Kotlin}
+```java {tabTitle:Java (Spring 6)}
+import org.springframework.stereotype.Component;
+import io.sentry.protocol.User;
+import io.sentry.spring.jakarta.SentryUserProvider;
+
+@Component
+class CustomSentryUserProvider implements SentryUserProvider {
+  public User provideUser() {
+    User user = User();
+    // ... set user information
+    return user
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import org.springframework.stereotype.Component
 import io.sentry.protocol.User
 import io.sentry.spring.SentryUserProvider
+
+@Component
+class CustomSentryUserProvider : SentryUserProvider {
+  override fun provideUser(): User? {
+    val user = User()
+    // ... set user information
+    return user
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import org.springframework.stereotype.Component
+import io.sentry.protocol.User
+import io.sentry.spring.jakarta.SentryUserProvider
 
 @Component
 class CustomSentryUserProvider : SentryUserProvider {

--- a/src/platforms/java/guides/spring/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/java/guides/spring/performance/instrumentation/automatic-instrumentation.mdx
@@ -52,7 +52,7 @@ Each sampled request executed by this controller method will be turned into a tr
 
 Sentry Spring integration provides `SentrySpanClientHttpRequestInterceptor` that creates a span for each outgoing HTTP request executed with a `RestTemplate`. To use instrumented `RestTemplate` make sure to set interceptor on the `RestTemplate` bean:
 
-```java {tabTitle:Java}
+```java {tabTitle:Java (Spring 5)}
 import io.sentry.IHub;
 import io.sentry.spring.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.Collections;
@@ -74,10 +74,54 @@ class AppConfig {
   }
 }
 ```
+```java {tabTitle:Java (Spring 6)}
+import io.sentry.IHub;
+import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor;
+import java.util.Collections;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplateHandler;
 
-```kotlin {tabTitle:Kotlin}
+@Configuration
+class AppConfig {
+
+  @Bean
+  RestTemplate restTemplate(IHub hub) {
+    RestTemplate restTemplate = new RestTemplate();
+    SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
+        new SentrySpanClientHttpRequestInterceptor(hub);
+    restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
+    return restTemplate;
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 5)}
 import io.sentry.IHub
 import io.sentry.spring.tracing.SentrySpanClientHttpRequestInterceptor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriTemplateHandler
+
+@Configuration
+class AppConfig {
+
+  @Bean
+  fun restTemplate(hub: IHub): RestTemplate {
+    val sentryRestTemplateInterceptor = SentrySpanClientHttpRequestInterceptor(hub)
+
+    return RestTemplate().apply {
+      interceptors = listOf(sentryRestTemplateInterceptor)
+    }
+  }
+}
+```
+
+```kotlin {tabTitle:Kotlin (Spring 6)}
+import io.sentry.IHub
+import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestTemplate

--- a/src/platforms/java/usage.mdx
+++ b/src/platforms/java/usage.mdx
@@ -24,7 +24,7 @@ implementation 'io.sentry:sentry:{{ packages.version('sentry.java', '4.2.0') }}'
 libraryDependencies += "io.sentry" % "sentry" % "{{ packages.version('sentry.java', '4.2.0') }}"
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-spring).
+For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry).
 
 <!--TODO - evaluate these install instructions. Are they more comprehensive that we currently provide in includes/getting-started-install/java.mdx? -->
 

--- a/src/wizard/java/spring-boot.md
+++ b/src/wizard/java/spring-boot.md
@@ -6,6 +6,10 @@ type: framework
 ---
 
 <Alert level="info">
+There are two variants of Sentry available for Spring Boot. If you are using Spring Boot 2, please use `sentry-spring-boot-starter` ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter)). If you are using Spring Boot 3, please use `sentry-spring-boot-starter-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter-jakarta)).
+</Alert>
+
+<Alert level="info">
 Sentry's integration with <a href=https://spring.io/projects/spring-boot>Spring Boot</a> supports Spring Boot 2.1.0 and above to report unhandled exceptions as well as release and registration of beans. If you're on an older version, use <a href=https://docs.sentry.io/platforms/java/legacy/spring>our legacy integration</a>.
 </Alert>
 
@@ -13,7 +17,7 @@ Install using either Maven or Gradle:
 
 ### Maven
 
-```xml
+```xml {tabTitle: Spring Boot 2}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring-boot-starter</artifactId>
@@ -21,10 +25,22 @@ Install using either Maven or Gradle:
 </dependency>
 ```
 
+```xml {tabTitle: Spring Boot 3}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+    <version>{{ packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}</version>
+</dependency>
+```
+
 ### Gradle
 
-```groovy {tabTitle:Gradle}
+```groovy {tabTitle: Spring Boot 2}
 implementation 'io.sentry:sentry-spring-boot-starter:{{ packages.version('sentry.java.spring-boot', '4.0.0') }}'
+```
+
+```groovy {tabTitle: Spring Boot 3}
+implementation 'io.sentry:sentry-spring-boot-starter-jakarta:{{ packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}'
 ```
 
 Open up `src/main/application.properties` (or `src/main/application.yml`) and configure the DSN, and any other [_settings_](/platforms/java/configuration/#options) you need:
@@ -104,7 +120,7 @@ Each incoming Spring MVC HTTP request is automatically turned into a transaction
 
 ### Java
 
-```java
+```java {tabTitle: Spring Boot 2}
 import org.springframework.stereotype.Component;
 import io.sentry.spring.tracing.SentrySpan;
 
@@ -118,11 +134,39 @@ class PersonService {
 }
 ```
 
+```java {tabTitle: Spring Boot 3}
+import org.springframework.stereotype.Component;
+import io.sentry.spring.jakarta.tracing.SentrySpan;
+
+@Component
+class PersonService {
+
+  @SentrySpan
+  Person findById(Long id) {
+    ...
+  }
+}
+```
+
 ### Kotlin
 
-```kotlin
+```kotlin {tabTitle: Spring Boot 2}
 import org.springframework.stereotype.Component
 import io.sentry.spring.tracing.SentrySpan
+
+@Component
+class PersonService {
+
+  @SentrySpan(operation = "task")
+  fun findById(id: Long): Person {
+    ...
+  }
+}
+```
+
+```kotlin {tabTitle: Spring Boot 3}
+import org.springframework.stereotype.Component
+import io.sentry.spring.jakarta.tracing.SentrySpan
 
 @Component
 class PersonService {

--- a/src/wizard/java/spring.md
+++ b/src/wizard/java/spring.md
@@ -6,6 +6,10 @@ type: framework
 ---
 
 <Alert level="info">
+    There are two variants of Sentry available for Spring. If you are using Spring 5, please use `sentry-spring` ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring)). If you are using Spring 6, please use `sentry-spring-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-jakarta)).
+</Alert>
+
+<Alert level="info">
     Sentry's integration with Spring supports Spring Framework 5.1.2 and above to report unhandled exceptions and optional user information. If you're on an older version, use <a href=https://docs.sentry.io/platforms/java/guides/spring/legacy/>our legacy integration</a>.
 </Alert>
 
@@ -13,7 +17,7 @@ Install Sentry's integration with Spring using either Maven or Gradle:
 
 ### Maven:
 
-```xml {tabTitle:Maven}{filename:pom.xml}
+```xml {tabTitle:Spring 5}{filename:pom.xml}
 <dependency>
     <groupId>io.sentry</groupId>
     <artifactId>sentry-spring</artifactId>
@@ -21,26 +25,47 @@ Install Sentry's integration with Spring using either Maven or Gradle:
 </dependency>
 ```
 
+```xml {tabTitle:Spring 6}{filename:pom.xml}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-jakarta</artifactId>
+    <version>{{ packages.version('sentry.java.spring.jakarta', '6.7.0') }}</version>
+</dependency>
+```
+
 ### Gradle:
 
-```groovy {filename:build.gradle}
+```groovy {tabTitle:Spring 5}{filename:build.gradle}
 implementation 'io.sentry:sentry-spring:{{ packages.version('sentry.java.spring', '4.0.0') }}'
 ```
 
-For other dependency managers see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-spring).
+```groovy {tabTitle:Spring 6}{filename:build.gradle}
+implementation 'io.sentry:sentry-spring-jakarta:{{ packages.version('sentry.java.spring.jakarta', '6.7.0') }}'
+```
+
+For other dependency managers see the [central Maven repository (Spring 5)](https://search.maven.org/artifact/io.sentry/sentry-spring) and [central Maven repository (Spring 6)](https://search.maven.org/artifact/io.sentry/sentry-spring-jakarta).
 
 Configure Sentry as soon as possible in your application's lifecycle:
 
 <Note>
 
-The `sentry-spring` library provides `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including the main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
+The `sentry-spring` and `sentry-spring-jakarta` libraries provide an `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including the main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
 
 </Note>
 
 ### Java
 
-```java {tabTitle: Java}
+```java {tabTitle: Spring 5}
 import io.sentry.spring.EnableSentry;
+
+@EnableSentry(dsn = "___PUBLIC_DSN___")
+@Configuration
+class SentryConfiguration {
+}
+```
+
+```java {tabTitle: Spring 6}
+import io.sentry.spring.jakarta.EnableSentry;
 
 @EnableSentry(dsn = "___PUBLIC_DSN___")
 @Configuration
@@ -50,8 +75,18 @@ class SentryConfiguration {
 
 ### Kotlin
 
-```kotlin
+```kotlin {tabTitle: Spring 5}
 import io.sentry.spring.EnableSentry
+import org.springframework.core.Ordered
+
+@EnableSentry(
+  dsn = "___PUBLIC_DSN___",
+  exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE
+)
+```
+
+```kotlin {tabTitle: Spring 6}
+import io.sentry.spring.jakarta.EnableSentry
 import org.springframework.core.Ordered
 
 @EnableSentry(


### PR DESCRIPTION
This documents the new `-jakarta` packages for Spring 6 (`sentry-spring-jakarta`) and Spring Boot (`sentry-spring-boot-starter-jakarta`) that were added in `6.7.0` of the Java SDK.