### PR TITLE
feat(go): Add BeforeSendTransaction example snippet

### DIFF
--- a/src/platform-includes/configuration/before-send-transaction/go.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/go.mdx
@@ -5,7 +5,7 @@ sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
 		// Called for transaction events
 		BeforeSendTransaction: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			if strings.Contains(event.Message, "test-transaction") {
+			if event.Message == "test-transaction" {
 				// Don't send the transaction to Sentry
 				return nil
 			}

--- a/src/platform-includes/configuration/before-send-transaction/go.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/go.mdx
@@ -1,16 +1,15 @@
-A function can be passed to `sentry.Init` via `BeforeSendTransaction` configuration option:
+`BeforeSendTransaction` hook is a function that can be passed to `sentry.Init` via the corresponding configuration option. In this function you can either update the transaction event before it is sent to Sentry, or drop it by returning `nil`, for example:
 
 ```go
 sentry.Init(sentry.ClientOptions{
-		Dsn: "___PUBLIC_DSN___",
-		// Called for transaction events
-		BeforeSendTransaction: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			if event.Message == "test-transaction" {
-				// Don't send the transaction to Sentry
-				return nil
-			}
-			// Update the message for every sent transaction
-			event.Message += " [example]"
-			return event
-		},
+	// ...
+	BeforeSendTransaction: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		if event.Message == "test-transaction" {
+			// Don't send the transaction to Sentry
+			return nil
+		}
+		// Update the message for every sent transaction
+		event.Message += " [example]"
+		return event
+	},
 ```

--- a/src/platform-includes/configuration/before-send-transaction/go.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/go.mdx
@@ -1,4 +1,4 @@
-`BeforeSendTransaction` hook is a function that can be passed to `sentry.Init` via the corresponding configuration option. In this function you can either update the transaction event before it is sent to Sentry, or drop it by returning `nil`, for example:
+The `BeforeSendTransaction` hook is a function that can be passed to `sentry.Init` via the corresponding configuration option. In this function you can either update the transaction event before it's sent to Sentry, or drop it by returning `nil`, for example:
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platform-includes/configuration/before-send-transaction/go.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/go.mdx
@@ -1,0 +1,16 @@
+A function can be passed to `sentry.Init` via `BeforeSendTransaction` configuration option:
+
+```go
+sentry.Init(sentry.ClientOptions{
+		Dsn: "___PUBLIC_DSN___",
+		// Called for transaction events
+		BeforeSendTransaction: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if strings.Contains(event.Message, "test-transaction") {
+				// Don't send the transaction to Sentry
+				return nil
+			}
+			// Update the message for every sent transaction
+			event.Message += " [example]"
+			return event
+		},
+```

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -101,7 +101,7 @@ It also allows you to sample different transactions at different rates.
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 
-<PlatformSection supported={["node", "javascript", "php"]} notSupported={["php.symfony"]}>
+<PlatformSection supported={["node", "javascript", "php", "go"]} notSupported={["php.symfony"]}>
 
 ### Using <PlatformIdentifier name="before-send-transaction" />
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -566,7 +566,7 @@ This function is called with an SDK-specific message or error event object, and 
 
 </ConfigKey>
 
-<ConfigKey name="before-send-transaction" supported={["javascript", "node", "php"]} notSupported={["php.symfony"]}>
+<ConfigKey name="before-send-transaction" supported={["javascript", "node", "php", "go"]} notSupported={["php.symfony"]}>
 
 This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 


### PR DESCRIPTION
BeforeSendTransaction is added to sentry-go here: https://github.com/getsentry/sentry-go/pull/517
The change is not released yet, so we'll be merging this together with the release of the next sentry-go version.

Similarly to https://github.com/getsentry/sentry-docs/pull/6039, not touching any other pages for now, given the on-going refactorings of BeforeSendTransaction docs in https://github.com/getsentry/sentry-docs/pull/6038, https://github.com/getsentry/sentry-docs/pull/5804, and https://github.com/getsentry/sentry-docs/pull/5838.