### PR TITLE
fix(search): add level to docs

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -128,7 +128,7 @@ Release properties overlap with event and issue search properties, so they don't
 | issue.category | The category of the issue (either `error` or `performance`). | | x | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x | datetime |
-| level | Severity of the event (i.e., fatal, error, warning). Always set to info for transactions. | x | x | string |
+| level | Severity of the event (such as: fatal, error, warning). Always set to info for transactions. | x | x | string |
 | location | Location where the error happened. | x | x | string |
 | max(numeric field) | Returns results with a matching maximum value for the field entered. | x |  | matches field |
 | measurements.<br></br>app_start_cold | A [cold start](/product/performance/mobile-vitals/#app-start) refers to when the app launches for the first time after a reboot or update. The app is not in memory and no process exists. | x |  | duration |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -128,7 +128,7 @@ Release properties overlap with event and issue search properties, so they don't
 | issue.category | The category of the issue (either `error` or `performance`). | | x | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x | datetime |
-| level | Severity of the event, e.g. "Error" or "Warning". Always set to info for transactions. | x | x | string |
+| level | Severity of the event (i.e., fatal, error, warning). Always set to info for transactions. | x | x | string |
 | location | Location where the error happened. | x | x | string |
 | max(numeric field) | Returns results with a matching maximum value for the field entered. | x |  | matches field |
 | measurements.<br></br>app_start_cold | A [cold start](/product/performance/mobile-vitals/#app-start) refers to when the app launches for the first time after a reboot or update. The app is not in memory and no process exists. | x |  | duration |

--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -128,6 +128,7 @@ Release properties overlap with event and issue search properties, so they don't
 | issue.category | The category of the issue (either `error` or `performance`). | | x | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x | datetime |
+| level | Severity of the event, e.g. "Error" or "Warning". Always set to info for transactions. | x | x | string |
 | location | Location where the error happened. | x | x | string |
 | max(numeric field) | Returns results with a matching maximum value for the field entered. | x |  | matches field |
 | measurements.<br></br>app_start_cold | A [cold start](/product/performance/mobile-vitals/#app-start) refers to when the app launches for the first time after a reboot or update. The app is not in memory and no process exists. | x |  | duration |


### PR DESCRIPTION
in tandem with https://github.com/getsentry/sentry/pull/43125, adds levels to our docs, which seemed to be missing before.