### PR TITLE
fix(native): add missing description for proxy option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -600,6 +600,10 @@ Options used to configure the transport. This is an object with the following po
 
 </ConfigKey>
 
+<ConfigKey name="proxy" supported={["native"]}>
+Configures an HTTP proxy for outgoing requests to the backend (i.e. HTTPS requests tunneled through that proxy). The Native SDK doesn't pick up the `http_proxy` environment variable. You can find more details on the [transport page](/platforms/native/configuration/transports/#using-an-http-proxy).
+</ConfigKey>
+
 <ConfigKey name="http-proxy" supported={["php", "python", "java", "dotnet", "rust"]}>
 
 When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https-proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -601,7 +601,7 @@ Options used to configure the transport. This is an object with the following po
 </ConfigKey>
 
 <ConfigKey name="proxy" supported={["native"]}>
-Configures an HTTP proxy for outgoing requests to the backend (i.e. HTTPS requests tunneled through that proxy). The Native SDK doesn't pick up the `http_proxy` environment variable. You can find more details on the [transport page](/platforms/native/configuration/transports/#using-an-http-proxy).
+Configures an HTTP proxy for outgoing requests to the backend, (HTTPS requests tunneled through that proxy). The Native SDK doesn't pick up the `http_proxy` environment variable. You can find more details on the [transport page](/platforms/native/configuration/transports/#using-an-http-proxy).
 </ConfigKey>
 
 <ConfigKey name="http-proxy" supported={["php", "python", "java", "dotnet", "rust"]}>

--- a/src/platforms/native/configuration/transports.mdx
+++ b/src/platforms/native/configuration/transports.mdx
@@ -60,4 +60,6 @@ sentry_init(options);
 /* ... */
 ```
 
-Both transport implementations (`Curl` and `WinHTTP`) honor the configuration on all supported platforms.
+<Alert level="warning" title="Crashpad Handler Does Not Support HTTP Proxies">
+While both transport implementations (`Curl` and `WinHTTP`) honor the configuration on all supported platforms, the `crashpad-handler` does not provide a proxy configuration and will thus not be able to send crash reports from behind a proxy.
+</Alert>

--- a/src/platforms/native/configuration/transports.mdx
+++ b/src/platforms/native/configuration/transports.mdx
@@ -10,6 +10,8 @@ transport depends on the target platform:
 - **Linux**: Curl
 - **macOS**: Curl
 
+## Custom Transports
+
 To specify a custom transport, use the `sentry_options_set_transport` function
 and supply a transport that implements the `sentry_transport_t` interface.
 
@@ -45,3 +47,17 @@ int main(void) {
 The transport is invoked in the same thread as the call to
 `sentry_capture_event`. Consider to offload network communication to a
 background thread or thread pool to avoid blocking execution.
+
+## Using an HTTP proxy
+
+The Native SDK allows the configuration of an HTTP proxy through which requests can be  tunneled to our backend. This proxy must allow `CONNECT` requests to establish a proxy connection. It can be configured via the following option interface:
+
+```c
+sentry_options_t *options = sentry_options_new();
+sentry_options_set_http_proxy(options, "http://my.proxy:10010");
+sentry_init(options);
+
+/* ... */
+```
+
+Both transport implementations (`Curl` and `WinHTTP`) honor the configuration on all supported platforms.

--- a/src/platforms/native/configuration/transports.mdx
+++ b/src/platforms/native/configuration/transports.mdx
@@ -48,9 +48,9 @@ The transport is invoked in the same thread as the call to
 `sentry_capture_event`. Consider to offload network communication to a
 background thread or thread pool to avoid blocking execution.
 
-## Using an HTTP proxy
+## Using an HTTP Proxy
 
-The Native SDK allows the configuration of an HTTP proxy through which requests can be  tunneled to our backend. This proxy must allow `CONNECT` requests to establish a proxy connection. It can be configured via the following option interface:
+The Native SDK allows the configuration of an HTTP proxy through which requests can be tunneled to our backend. This proxy must allow `CONNECT` requests to establish a proxy connection. It can be configured via the following option interface:
 
 ```c
 sentry_options_t *options = sentry_options_new();
@@ -60,6 +60,6 @@ sentry_init(options);
 /* ... */
 ```
 
-<Alert level="warning" title="Crashpad Handler Does Not Support HTTP Proxies">
-While both transport implementations (`Curl` and `WinHTTP`) honor the configuration on all supported platforms, the `crashpad-handler` does not provide a proxy configuration and will thus not be able to send crash reports from behind a proxy.
+<Alert level="warning" title="Note">
+While both transport implementations (`Curl` and `WinHTTP`) honor the configuration on all supported platforms, the `crashpad-handler` doesn't provide a proxy configuration and will be unable to send crash reports from behind a proxy.
 </Alert>


### PR DESCRIPTION
The option for configuring HTTP proxies in the Native SDK is currently not reflected in the docs. I've added this to the transport page, which is presently a native-specific page because it makes sense due to their interaction. But it probably also makes sense to mention the option in `Basic Options` (where it would require a platform-specific description because it doesn't fit the description of the other platforms) under transport.

@Swatinem: should we place it in both or only one (and which one)? I am not sure the interface is complicated enough to warrant a separate "usage" section, but it doesn't feel wrong on the transport page.