### PR TITLE
fix(apple): Clarify source context uploads code

### DIFF
--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -36,7 +36,7 @@ Visit the [sentry-cli docs](/product/cli/dif/#uploading-files) for more informat
 If you're already using Fastlane, you can use the [Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin)
 to upload your dSYMs to Sentry.
 
-Sentry can display snippets of your code next to event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
+Sentry can display snippets of your code next to event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```ruby
 sentry_upload_dif(

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -19,7 +19,8 @@ If this is your situation, please read [Info.plist Is Missing in Xcode 13 — He
 ## Sentry-cli
 
 Use the `sentry-cli upload-dif` command to upload dSYMs to Sentry. The command will recursively scan the provided folders or ZIP archives. Files that have already been uploaded will be skipped automatically.
-For <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink> to work, we recommend setting the `--include_sources` option.
+
+Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```bash
 sentry-cli upload-dif --auth-token YOUR_AUTH_TOKEN \
@@ -34,7 +35,8 @@ Visit the [sentry-cli docs](/product/cli/dif/#uploading-files) for more informat
 
 If you're already using Fastlane, you can use the [Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin)
 to upload your dSYMs to Sentry.
-For <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink> to work, we recommend setting the `include_sources` parameter to `true`:
+
+Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```ruby
 sentry_upload_dif(
@@ -64,7 +66,7 @@ Follow these steps to upload the debug symbols:
 1.  Download and install [sentry-cli](/product/cli/installation/).
 2.  Copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_.
 
-For <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink> to work, we recommend setting the `--include_sources` option. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include_sources` in the copied script.
+Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include_sources` in the copied script.
 
 <Alert level="" title="Warnings vs. Errors">
 
@@ -131,7 +133,7 @@ The App Store Connect integration doesn't support <PlatformLink to="/data-manage
 
 When you use the App Store Connect integration, Sentry will automatically discover and fetch dSYMs for builds as they become available on App Store Connect.
 
-To configure the integration, select an existing project from the "Projects" page, then go to **Settings > Debug Files** and add "App Store Connect" in the "Custom Repositories" section.  
+To configure the integration, select an existing project from the "Projects" page, then go to **Settings > Debug Files** and add "App Store Connect" in the "Custom Repositories" section.
 
 ![Adding an App Store Connect Integration to a project](adding-asc-repository.png)
 

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -20,7 +20,7 @@ If this is your situation, please read [Info.plist Is Missing in Xcode 13 — He
 
 Use the `sentry-cli upload-dif` command to upload dSYMs to Sentry. The command will recursively scan the provided folders or ZIP archives. Files that have already been uploaded will be skipped automatically.
 
-Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
+Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```bash
 sentry-cli upload-dif --auth-token YOUR_AUTH_TOKEN \
@@ -66,7 +66,7 @@ Follow these steps to upload the debug symbols:
 1.  Download and install [sentry-cli](/product/cli/installation/).
 2.  Copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_.
 
-Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include_sources` in the copied script.
+Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include_sources` in the copied script.
 
 <Alert level="" title="Warnings vs. Errors">
 

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -36,7 +36,7 @@ Visit the [sentry-cli docs](/product/cli/dif/#uploading-files) for more informat
 If you're already using Fastlane, you can use the [Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin)
 to upload your dSYMs to Sentry.
 
-Sentry can display snippets of your code next to the events stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
+Sentry can display snippets of your code next to event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```ruby
 sentry_upload_dif(


### PR DESCRIPTION
Specify clearly that include sources uploads users' source code to Sentry.