### PR TITLE
fix(apple): Renamings from tracking to tracing

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -14,9 +14,6 @@ func application(_ application: UIApplication,
 
         // Features turned off by default, but worth checking out
         options.enableAppHangTracking = true
-        options.enableFileIOTracking = true
-        options.enableCoreDataTracking = true
-        options.enableCaptureFailedRequests = true
         options.enableMetricKit = true
     }
 
@@ -35,9 +32,6 @@ func application(_ application: UIApplication,
 
         // Features turned off by default, but worth checking out
         options.enableAppHangTracking = YES;
-        options.enableFileIOTracking = YES;
-        options.enableCoreDataTracking = YES;
-        options.enableCaptureFailedRequests = YES;
         options.enableMetricKit = YES;
     }];
 
@@ -59,9 +53,6 @@ struct SwiftUIApp: App {
 
             // Features turned off by default, but worth checking out
             options.enableAppHangTracking = true
-            options.enableFileIOTracking = true
-            options.enableCoreDataTracking = true
-            options.enableCaptureFailedRequests = true
             options.enableMetricKit = true
         }
     }
@@ -82,8 +73,7 @@ SentrySDK.start { options in
     // ...
 
     // Enable all experimental features
-    options.enableUserInteractionTracing = true
-    options.enablePreWarmedAppStartTracking = true
+    options.enablePreWarmedAppStartTracing = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
     options.enableMetricKit = true
@@ -96,7 +86,6 @@ SentrySDK.start { options in
     // ...
 
     // Enable all experimental features
-    options.enableUserInteractionTracing = YES;
     options.enablePreWarmedAppStartTracking = YES;
     options.attachScreenshot = YES;
     options.attachViewHierarchy = YES;

--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -28,8 +28,8 @@
   - [Mobile Vitals](https://docs.sentry.io/product/performance/mobile-vitals/)
     - Cold and warm start
     - Slow and frozen frames
-  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">file I/O</PlatformLink> operations
-  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Core Data</PlatformLink> queries
+  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracing">file I/O</PlatformLink> operations
+  - Performance of <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracing">Core Data</PlatformLink> queries
   - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User Interaction</PlatformLink> transactions for UI clicks
 - [Attachments](/platforms/apple/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files
 - [User Feedback](/platforms/apple/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs

--- a/src/platforms/apple/common/configuration/swizzling.mdx
+++ b/src/platforms/apple/common/configuration/swizzling.mdx
@@ -9,8 +9,8 @@ The Cocoa SDK uses [swizzling](https://nshipster.com/method-swizzling/) to provi
 __macOS__
 - <PlatformLink to="/enriching-events/breadcrumbs/">Breadcrumbs for touch events</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#network-tracking">Auto instrumentation for HTTP requests</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracing">Auto instrumentation for File I/O operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracing">Auto instrumentation for Core Data operations</PlatformLink>
 - <PlatformLink to="/performance/connect-services/">Automatically added sentry-trace header to HTTP requests for distributed tracing</PlatformLink>
 - <PlatformLink to="/configuration/http-client-errors/">HTTP Client Errors</PlatformLink>
 
@@ -18,10 +18,10 @@ __macOS__
 __iOS, tvOS and Catalyst__
 
 - <PlatformLink to="/enriching-events/breadcrumbs/">Breadcrumbs for touch events and navigation with UIViewControllers</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking">Auto instrumentation for UIViewControllers</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracing">Auto instrumentation for UIViewControllers</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#network-tracking">Auto instrumentation for HTTP requests</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">Auto instrumentation for File I/O operations</PlatformLink>
-- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracking">Auto instrumentation for Core Data operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracing">Auto instrumentation for File I/O operations</PlatformLink>
+- <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracing">Auto instrumentation for Core Data operations</PlatformLink>
 - <PlatformLink to="/performance/connect-services/">Automatically added sentry-trace header to HTTP requests for distributed tracing</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing">User interaction transactions for UI clicks</PlatformLink>
 - <PlatformLink to="/configuration/http-client-errors/">HTTP Client Errors</PlatformLink>

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -163,17 +163,17 @@ SentrySDK.start { options in
 The Sentry SDK adds spans for file I/O operations to ongoing transactions bound to the scope. Currently, the SDK supports operations with [NSData][NSData], but many other APIs like [NSFileManager][NSFileManager], [NSString][NSString] and [NSBundle][NSBundle] uses [NSData][NSData].
 This feature is experimental and is disabled by default.
 
-To enable file I/O tracing:
+To disable file I/O tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableFileIOTracing = true
+    options.enableFileIOTracing = false
 
     // Before 8.0.0
-    options.enableFileIOTracking = true
+    options.enableFileIOTracking = false
 }
 ```
 
@@ -182,10 +182,10 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableFileIOTracing = YES;
+    options.enableFileIOTracing = NO;
 
     // Before 8.0.0
-    options.enableFileIOTracking = YES;
+    options.enableFileIOTracking = NO;
 }];
 ```
 [NSData]: https://developer.apple.com/documentation/foundation/nsdata
@@ -196,17 +196,17 @@ SentrySDK.start { options in
 ## Core Data Tracing
 
 The Sentry SDK adds spans for Core Data operations to ongoing transactions bound to the scope. Currently, the SDK supports fetch and save operations with [NSManagedObjectContext](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext).
-To enable core data tracing:
+To disable core data tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableCoreDataTracing = true
+    options.enableCoreDataTracing = false
 
     // Before 8.0.0
-    options.enableCoreDataTracking = true
+    options.enableCoreDataTracking = false
 }
 ```
 
@@ -215,10 +215,10 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableCoreDataTracing = YES;
+    options.enableCoreDataTracing = NO;
 
     // Before 8.0.0
-    options.enableCoreDataTracking = YES
+    options.enableCoreDataTracking = NO
 }];
 ```
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,25 +8,28 @@ description: "Learn what transactions are captured after tracing is enabled."
 
 Once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>, the SDK enables the following features by default:
 
-- UIViewController Tracking
-- App Start Tracking
+- UIViewController Tracing
+- App Start Tracing
 - Slow and Frozen Frames
 - Network Tracking
+- File I/O Tracing
+- Core Data Tracing
+- User Interaction Tracing
 
 </Note>
 
-## UIViewController Tracking
+## UIViewController Tracing
 
 This feature is available for iOS, tvOS, and Mac Catalyst, is enabled by default, and works for `UIViewControllers`.
 
-UIViewController Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature captures transactions when your app loads an in-app [UIViewController][UIViewController]. However, the SDK doesn't capture transactions for UIViewControllers of third-party libraries or SwiftUI.
+UIViewController Tracing is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature captures transactions when your app loads an in-app [UIViewController][UIViewController]. However, the SDK doesn't capture transactions for UIViewControllers of third-party libraries or SwiftUI.
 The SDK sets the transaction name to the name of the ViewController, including the module — for example, `Your_App.MainViewController` — and the transaction operation to `ui.load`.
 
 The SDK creates spans to provide insight into the time consumed by each of the methods shown in the screenshot below. Due to implementation limitations, the SDK only adds a span for loadView if the instrumented view controller implements it. The SDK adds spans for all other methods, whether you implement them in your view controller or not.
 
 ![`UIViewController` Transaction](ui-view-controller-transaction.png)
 
-To disable the `UIViewController` Tracking:
+To disable the `UIViewController` Tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -34,6 +37,9 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enableUIViewControllerTracing = false
+
+    // Before 8.0.0
+    options.enableUIViewControllerTracking = false
 }
 ```
 
@@ -43,17 +49,21 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.enableUIViewControllerTracing = NO;
+
+
+    // Before 8.0.0
+    options.enableUIViewControllerTracking = NO;
 }];
 ```
 
 [UIViewController]: https://developer.apple.com/documentation/uikit/uiviewcontroller
 
-## App Start Tracking
+## App Start Tracing
 
 This feature is available for iOS, tvOS, and Mac Catalyst.
 
-App Start Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
-To enable this feature, enable `AutoUIPerformanceTracking`.
+App Start Tracing is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
+To enable this feature, enable `enableAutoPerformanceTracing`.
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.
 
@@ -69,7 +79,7 @@ The SDK uses the process start time as the beginning of the app start and the [`
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
-### Prewarmed App Start Tracking
+### Prewarmed App Start Tracing
 
 Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. However, with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced an `enablePreWarmedAppStartTracking` feature (still in its experimental phase), which allows us to collect prewarmed app starts.
 
@@ -83,7 +93,7 @@ With this feature, the SDK differentiates between four different app start types
 
 You can filter for different app start types in [Discover](/product/discover-queries/) with `app_start_type:cold.prewarmed`, `app_start_type:warm.prewarmed`, `app_start_type:cold`, and `app_start_type:warm`.
 
-To enable prewarmed app start tracking:
+To enable prewarmed app start tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -91,6 +101,9 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enablePreWarmedAppStartTracking = true
+
+    // Before 8.0.0
+    options.enablePreWarmedAppStartTracing = true
 }
 ```
 
@@ -99,6 +112,9 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
+    options.enablePreWarmedAppStartTracing = YES;
+
+    // Before 8.0.0
     options.enablePreWarmedAppStartTracking = YES;
 }];
 ```
@@ -142,12 +158,12 @@ SentrySDK.start { options in
 [NSURLSession]: https://developer.apple.com/documentation/foundation/nsurlsession
 [NSURLConnection]: https://developer.apple.com/documentation/foundation/nsurlconnection
 
-## File I/O Tracking
+## File I/O Tracing
 
 The Sentry SDK adds spans for file I/O operations to ongoing transactions bound to the scope. Currently, the SDK supports operations with [NSData][NSData], but many other APIs like [NSFileManager][NSFileManager], [NSString][NSString] and [NSBundle][NSBundle] uses [NSData][NSData].
 This feature is experimental and is disabled by default.
 
-To enable file I/O tracking:
+To enable file I/O tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -155,6 +171,9 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enableFileIOTracing = true
+
+    // Before 8.0.0
+    options.enableFileIOTracking = true
 }
 ```
 
@@ -164,6 +183,9 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.enableFileIOTracing = YES;
+
+    // Before 8.0.0
+    options.enableFileIOTracking = YES;
 }];
 ```
 [NSData]: https://developer.apple.com/documentation/foundation/nsdata
@@ -171,10 +193,10 @@ SentrySDK.start { options in
 [NSString]: https://developer.apple.com/documentation/foundation/nsstring
 [NSBundle]: https://developer.apple.com/documentation/foundation/nsbundle
 
-## Core Data Tracking
+## Core Data Tracing
 
 The Sentry SDK adds spans for Core Data operations to ongoing transactions bound to the scope. Currently, the SDK supports fetch and save operations with [NSManagedObjectContext](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext).
-To enable core data tracking:
+To enable core data tracing:
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -182,6 +204,9 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enableCoreDataTracing = true
+
+    // Before 8.0.0
+    options.enableCoreDataTracking = true
 }
 ```
 
@@ -191,6 +216,9 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.enableCoreDataTracing = YES;
+
+    // Before 8.0.0
+    options.enableCoreDataTracking = YES
 }];
 ```
 
@@ -259,6 +287,9 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enableAutoPerformanceTracing = false
+
+    // Before 8.0.0
+    options.enableAutoPerformanceTracking = false
 }
 ```
 
@@ -268,6 +299,9 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.enableAutoPerformanceTracing = NO;
+
+    // Before 8.0.0
+    options.enableAutoPerformanceTracking = NO;
 }];
 ```
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -40,10 +40,6 @@ func application(_ application: UIApplication,
 
         // Features turned off by default, but worth checking out
         options.enableAppHangTracking = true
-        options.enableFileIOTracking = true
-        options.enableCoreDataTracking = true
-        options.enableCaptureFailedRequests = true
-        options.enableMetricKit = true
     }
 
     return true
@@ -68,10 +64,6 @@ struct SwiftUIApp: App {
 
             // Features turned off by default, but worth checking out
             options.enableAppHangTracking = true
-            options.enableFileIOTracking = true
-            options.enableCoreDataTracking = true
-            options.enableCaptureFailedRequests = true
-            options.enableMetricKit = true
         }
     }
 }
@@ -116,10 +108,7 @@ SentrySDK.start { options in
     // ...
 
     // Enable all experimental features
-    options.enableFileIOTracing = true
-    options.enableCoreDataTracing = true
-    options.enableUserInteractionTracing = true
-    options.enablePreWarmedAppStartTracking = true
+    options.enablePreWarmedAppStartTracing = true
     options.attachScreenshot = true
     options.attachViewHierarchy = true
     options.enableMetricKit = true


### PR DESCRIPTION
We renamed a couple of features from tracking to tracing for Cocoa 8.0.0. We missed a couple of renamings, which this PR addresses. Furthermore, we can remove some of the renamed features in the wizard and getting started as they are now enabled by default. Finally, this PR also clarifies that core data spans are enabled by default.

I did a bunch of different changes in one PR, as splitting them up would be complicated.

This is a follow-up on https://github.com/getsentry/sentry-docs/pull/5859.