### PR TITLE
feat(node): Add `LocalVariables` integration

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -533,6 +533,12 @@ _(New in version 7.30.0)_
 
 </ConfigKey>
 
+<ConfigKey name="_experiments.include-stack-locals" supported={["node"]}>
+
+Enables the `LocalVariables` integration, which adds stack local variables to stack traces.
+
+</ConfigKey>
+
 <PlatformSection supported={["javascript", "python", "node", "dart", "java", "apple"]}>
 
 ## Integration Configuration

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -535,7 +535,19 @@ _(New in version 7.30.0)_
 
 <ConfigKey name="_experiments.include-stack-locals" supported={["node"]}>
 
-Enables the `LocalVariables` integration, which adds stack local variables to stack traces.
+Enables the `LocalVariables` integration, which adds stack local variables to
+stack traces.
+
+```javascript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  _experiments: {
+    includeStackLocals: true,
+  },
+});
+```
 
 </ConfigKey>
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -139,6 +139,17 @@ Available options:
 }
 ```
 
+### LocalVariables
+
+_Import name: `Sentry.Integrations.LocalVariables`_
+
+_(Available in version 7.30.0 and above)_
+
+This integration adds stack local variables to stack frames for uncaught exceptions.
+
+It's currently enabled via the <PlatformLink to="/configuration/options/#_experiments.include-stack-locals">_experiments.includeStackLocals</PlatformLink>
+`init` option.
+
 ### Modules
 
 _(New in version 7.13.0.)_


### PR DESCRIPTION
Closes #6060

Adds docs for the `LocalVariables` integration.