### PR TITLE
feat(apple): Enable AppHangs by default

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -13,7 +13,6 @@ func application(_ application: UIApplication,
         options.debug = true // Enabled debug when first installing is always helpful
 
         // Features turned off by default, but worth checking out
-        options.enableAppHangTracking = true
         options.enableMetricKit = true
     }
 
@@ -29,10 +28,6 @@ func application(_ application: UIApplication,
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"___PUBLIC_DSN___";
         options.debug = YES; // Enabled debug when first installing is always helpful
-
-        // Features turned off by default, but worth checking out
-        options.enableAppHangTracking = YES;
-        options.enableMetricKit = YES;
     }];
 
     return YES;
@@ -50,10 +45,6 @@ struct SwiftUIApp: App {
         SentrySDK.start { options in
             options.dsn = "___PUBLIC_DSN___"
             options.debug = true // Enabled debug when first installing is always helpful
-
-            // Features turned off by default, but worth checking out
-            options.enableAppHangTracking = true
-            options.enableMetricKit = true
         }
     }
 }

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -16,14 +16,14 @@ The app hangs code runs in the background when disabled when keeping out-of-memo
 
 Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, if SentryCrashIntegration is disabled, the integration won’t work.
 
-To use this feature, add this to your code:
+Since 8.0.0 this feature is enable dy default. To disable this feature:
 
 ```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableAppHangTracking = true
+    options.enableAppHangTracking = false
 }
 ```
 
@@ -32,7 +32,7 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableAppHangTracking = YES;
+    options.enableAppHangTracking = NO;
 }];
 
 ```

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -37,9 +37,6 @@ func application(_ application: UIApplication,
         // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1.0
-
-        // Features turned off by default, but worth checking out
-        options.enableAppHangTracking = true
     }
 
     return true
@@ -61,9 +58,6 @@ struct SwiftUIApp: App {
             // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0
-
-            // Features turned off by default, but worth checking out
-            options.enableAppHangTracking = true
         }
     }
 }


### PR DESCRIPTION
Since Cocoa 8.0.0 AppHangs are enabled by default.

This PR is based on https://github.com/getsentry/sentry-docs/pull/6059 cause they touch the same files to avoid merge conflicts.
