### PR TITLE
feat(cli): Replace bash w/ sh for installer

### DIFF
--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -17,14 +17,14 @@ You can find the list of releases on [the GitHub release page](https://github.co
 If you are on OS X or Linux, you can use the automated downloader which will fetch the latest release version for you and install it:
 
 ```bash
-curl -sL https://sentry.io/get-cli/ | bash
+curl -sL https://sentry.io/get-cli/ | sh
 ```
 
 We do however, encourage you to pin the specific version of the CLI, so your builds are always reproducible.
 To do that, you can use the exact same method, with an additional version specifier:
 
 ```bash
-curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="{{ apps.version('sentry-cli') }}" bash
+curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="{{ apps.version('sentry-cli') }}" sh
 ```
 
 This will automatically download the correct version of `sentry-cli` for your operating system and install it. If necessary, it will prompt for your admin password for `sudo`. For a different installation location or for systems without `sudo` (like Windows), you can `export INSTALL_DIR=/custom/installation/path` before running this command.


### PR DESCRIPTION
The script is updated to imply sh usage here 