### PR TITLE
Clarify offline caching behavior of Flutter SDK

### DIFF
--- a/src/platform-includes/getting-started-primer/flutter.mdx
+++ b/src/platform-includes/getting-started-primer/flutter.mdx
@@ -12,7 +12,7 @@ Features:
   - Flutter and Android encapsulated exceptions (PlatformException)
 - Offline storage of events
   - Android: Offline caching when a device is offline; we send a report once the application is restarted
-  - iOS: Offline caching when a device is unable to connect; we send a report once we receive another event 
+  - iOS: Offline caching when a device is unable to connect; we send a report once we receive another event
 - Events [enriched](/platforms/flutter/enriching-events/context/) with device data
 - Breadcrumbs automatically captured:
   - by the [Dart SDK](/platforms/dart/enriching-events/breadcrumbs/#automatic-breadcrumbs)

--- a/src/platform-includes/getting-started-primer/flutter.mdx
+++ b/src/platform-includes/getting-started-primer/flutter.mdx
@@ -11,8 +11,8 @@ Features:
   - ObjC, Swift, and C for iOS and macOS
   - Flutter and Android encapsulated exceptions (PlatformException)
 - Offline storage of events
-  - Android: cached reports are sent once the application is restarted
-  - iOS: cached reports are sent once we receive another event 
+  - Android: Offline caching when a device is offline; we send a report once the application is restarted
+  - iOS: Offline caching when a device is unable to connect; we send a report once we receive another event 
 - Events [enriched](/platforms/flutter/enriching-events/context/) with device data
 - Breadcrumbs automatically captured:
   - by the [Dart SDK](/platforms/dart/enriching-events/breadcrumbs/#automatic-breadcrumbs)

--- a/src/platform-includes/getting-started-primer/flutter.mdx
+++ b/src/platform-includes/getting-started-primer/flutter.mdx
@@ -11,6 +11,8 @@ Features:
   - ObjC, Swift, and C for iOS and macOS
   - Flutter and Android encapsulated exceptions (PlatformException)
 - Offline storage of events
+  - Android: cached reports are sent once the application is restarted
+  - iOS: cached reports are sent once we receive another event 
 - Events [enriched](/platforms/flutter/enriching-events/context/) with device data
 - Breadcrumbs automatically captured:
   - by the [Dart SDK](/platforms/dart/enriching-events/breadcrumbs/#automatic-breadcrumbs)

--- a/src/platform-includes/getting-started-primer/javascript.cordova.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.cordova.mdx
@@ -11,6 +11,8 @@ Features:
 - Automatic Native crash [error tracking](/product/issues/) using both [iOS](/platforms/apple/guides/ios/) and [Android](/platforms/android/) supports
   - [Release health](/product/releases/health/) to track crash free users and sessions
 - Offline storage of events
+  - Android: Offline caching when a device is offline; we send a report once the application is restarted
+  - iOS: Offline caching when a device is unable to connect; we send a report once we receive another event
 - Events [enriched](/platforms/javascript/guides/cordova/enriching-events/context/) with device data
 - [Breadcrumbs](/platforms/javascript/guides/cordova/enriching-events/breadcrumbs/) created for location changes, outgoing HTTP requests with XHR and Fetch, console logs, and HTML touch events
 - On-device symbolication for JavaScript (in `Debug` mode)

--- a/src/platform-includes/getting-started-primer/react-native.mdx
+++ b/src/platform-includes/getting-started-primer/react-native.mdx
@@ -8,6 +8,8 @@ Features:
 
 - Automatic Native Crash [Error Tracking](/product/issues/) (using both `sentry-cocoa` & `sentry-android`)
 - Offline storage of events
+  - Android: Offline caching when a device is offline; we send a report once the application is restarted
+  - iOS: Offline caching when a device is unable to connect; we send a report once we receive another event
 - Events [enriched](/platforms/react-native/enriching-events/context/) with device data
 - [Autolinking](https://reactnative.dev/blog/2019/07/03/version-60#native-modules-are-now-autolinked)
 - [Breadcrumbs](/platforms/react-native/enriching-events/breadcrumbs/) created for outgoing `http` request with XHR and Fetch; UI and system events; and console logs


### PR DESCRIPTION
Offline caching functionality for iOS and Android behave differently; reports are retried under slightly different conditions. This is already clear in the respective iOS and Android docs:

- [iOS](https://docs.sentry.io/platforms/apple/guides/ios/): "Offline caching when a device is unable to connect; we send a report once we receive another event"
- [Android](https://docs.sentry.io/platforms/android/): "Offline caching when a device is offline; we send a report once the application is restarted"

However, the [Flutter docs](https://docs.sentry.io/platforms/flutter/) are vague about how offline caching works in a way that has confused at least one customer. This change clarifies how offline caching works for Flutter.