### PR TITLE
feat(Android): Add docs for View Hierarchy

### DIFF
--- a/src/platform-includes/enriching-events/attach-viewhierarchy/android.mdx
+++ b/src/platform-includes/enriching-events/attach-viewhierarchy/android.mdx
@@ -1,0 +1,5 @@
+```xml {filename:AndroidManifest.xml}
+<application>
+  <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
+</application>
+```

--- a/src/platform-includes/getting-started-primer/android.mdx
+++ b/src/platform-includes/getting-started-primer/android.mdx
@@ -40,6 +40,7 @@ The SDK builds a crash report that persists to disk and tries to send the report
 - [Application Not Responding (ANR)](/platforms/android/configuration/app-not-respond/) reported if the application is blocked for more than five seconds
 - [HTTP Client Errors](/platforms/android/configuration/integrations/okhttp/#http-client-errors)
 - [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/)
+- [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
 - Code samples provided in both Kotlin and Java as the Android SDK uses both languages
 - We provide a [sample application](https://github.com/getsentry/sentry-java/tree/master/sentry-samples/sentry-samples-android) for our Android users
 - Our [video tutorial](/platforms/android/android-video/) visually demonstrates how to set up our SDK

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -436,7 +436,7 @@ _(New in version 6.0.0)_
 
 </ConfigKey>
 
-<ConfigKey name="attach-viewhierarchy" supported={["apple.ios", "flutter"]}>
+<ConfigKey name="attach-viewhierarchy" supported={["apple.ios", "flutter", "android"]}>
 
 Renders an ASCII represention of the entire view hierarchy of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with the view hierarchy in our <PlatformLink to="/enriching-events/viewhierarchy/">View Hierarchy documentation</PlatformLink>.

--- a/src/platforms/common/enriching-events/viewhierarchy.mdx
+++ b/src/platforms/common/enriching-events/viewhierarchy.mdx
@@ -5,8 +5,8 @@ description: "Learn more about debugging the view hierarchy when an error occurs
 supported:
   - apple.ios
   - flutter
-notSupported:
   - android
+notSupported:
   - apple.macos
   - apple.tvos
   - apple.watchos


### PR DESCRIPTION
Add documentation on how to enable the View Hierarchy feature for Android.
Our `sentry-java` needs to be shipped first before merging this, will probably be part of the `6.12.0` release.
