### PR TITLE
fix(docs): Update text for android configure profiling step

### DIFF
--- a/src/wizard/android/profiling-onboarding/android/3.configure-profiling.md
+++ b/src/wizard/android/profiling-onboarding/android/3.configure-profiling.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure Profiling
 
-Sentry’s performance monitoring product has to be enabled in order for Profiling to work. To enable performance monitoring in the SDK:
+Add the `io.sentry.traces.profiling.sample-rate` tag to your SDK config.
 
 ```xml {filename:AndroidManifest.xml}
 <application>


### PR DESCRIPTION
This was a typo. Instead of the same text as the configure performance step, it should tell the user to add the option.