### PR TITLE
feat(replay): Update replay CDN usage docs

### DIFF
--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -11,20 +11,10 @@ yarn add @sentry/browser
 ```
 
 ```html {tabTitle: CDN}
-<!--
-Note that the Replay bundle only contains the Replay integration and not the
-entire Sentry SDK. You have to add it in addition to the Sentry Browser SDK bundle:
--->
-
 <script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.replay.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.replay.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 
-<script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/replay.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'replay.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
 ```

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -22,7 +22,7 @@ To use Sentry for error and performance monitoring, you can use the following bu
 
 ## Performance & Replay Bundle
 
-To use Sentry for error monitoring, performance tracing, and Replay, you can use the following bundle:
+To use Sentry for error and performance monitoring, as well as for [Session Replay](../session-replay), you can use the following bundle:
 
 ```html {tabTitle: CDN}
 <script

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -10,7 +10,7 @@ Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest usin
 
 ## Performance Bundle
 
-To use Sentry for error monitoring and performance tracing, you can use the following bundle:
+To use Sentry for error and performance monitoring, you can use the following bundle:
 
 ```html {tabTitle: CDN}
 <script

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -8,24 +8,9 @@ import JsBundleList from "~src/components/jsBundleList";
 
 Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest using our npm package (`@sentry/browser`) instead, as using the CDN can create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/), which provides a deferred version of our minified ES5 browser bundle. To see what other bundles are available, see [Available Bundles](#available-bundles) below.
 
-```html {tabTitle: CDN}
-<script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
-```
-
-<Alert level="info" title="Updates to naming scheme in SDK version 7">
-
-Version 7 of the Sentry JavaScript SDKs changed the bundles to be ES6 by default.
-Previously, the default bundles were compiled to ES5. If you need to support ES5, see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#upgrading-from-6x-to-7x).
-
-</Alert>
-
 ## Performance Bundle
 
-To use Sentry's performance tracing, an alternative bundle is needed. This allows us to keep the filesize down for users who only need error monitoring.
+To use Sentry for error monitoring and performance tracing, you can use the following bundle:
 
 ```html {tabTitle: CDN}
 <script
@@ -35,11 +20,31 @@ To use Sentry's performance tracing, an alternative bundle is needed. This allow
 ></script>
 ```
 
-<Note>
+## Performance & Replay Bundle
 
-You only need to load `bundle.tracing.min.js`, which provides both error and performance monitoring. There is also an ES5 version of the tracing bundle, `bundle.tracing.es5.min.js`.
+To use Sentry for error monitoring, performance tracing, and Replay, you can use the following bundle:
 
-</Note>
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.replay.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.replay.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+## Errors-only Bundle
+
+If you only use Sentry for error monitoring, and don't need performance tracing or replay functionality, you can use the following bundle:
+
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+## Usage & Configuration
 
 Once you've included the Sentry SDK bundle in your page, you can use Sentry in your own bundle:
 
@@ -71,6 +76,13 @@ For example:
 - `bundle.js` is `@sentry/browser`, compiled to ES6 but not minified, with debug logging included (as it is for all unminified bundles)
 - `rewriteframes.es5.min.js` is the `RewriteFrames` integration, compiled to ES5 and minified, with no debug logging
 - `bundle.tracing.es5.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES5 and minified, with debug logging included
+
+<Alert level="info" title="Updates to naming scheme in SDK version 7">
+
+Version 7 of the Sentry JavaScript SDKs changed the bundles to be ES6 by default.
+Previously, the default bundles were compiled to ES5. If you need to support ES5, see [Available Bundles](#available-bundles) or the [Migration Guide to Version 7](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#upgrading-from-6x-to-7x).
+
+</Alert>
 
 <JsBundleList />
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -8,7 +8,7 @@ import JsBundleList from "~src/components/jsBundleList";
 
 Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest using our npm package (`@sentry/browser`) instead, as using the CDN can create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you _must_ use a CDN, take a look at [loading Sentry lazily with our JS loader](../lazy-load-sentry/), which provides a deferred version of our minified ES5 browser bundle. To see what other bundles are available, see [Available Bundles](#available-bundles) below.
 
-## Performance Bundle
+## Default Bundle
 
 To use Sentry for error and performance monitoring, you can use the following bundle:
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -22,7 +22,7 @@ To use Sentry for error and performance monitoring, you can use the following bu
 
 ## Performance & Replay Bundle
 
-To use Sentry for error and performance monitoring, as well as for [Session Replay](../session-replay), you can use the following bundle:
+To use Sentry for error and performance monitoring, as well as for [Session Replay](../../session-replay), you can use the following bundle:
 
 ```html {tabTitle: CDN}
 <script


### PR DESCRIPTION
This updates the CDN usage docs to use the new full replay bundle by default, streamlining this.

While at it, I also reordered the "CDN installation" page generally a bit:

1. I moved the tracing bundle to top, as that is the default experience we want to provide.
2. After that, I added a new tracing + replay section
3. After that, there is the error only bundle
4. Moved the "Updates to naming scheme in SDK version 7" section further down, as it is not really very up to date anymore

Related to https://github.com/getsentry/sentry-docs/pull/6082, and dependent on https://github.com/getsentry/sentry-javascript/pull/6818.

Closes https://github.com/getsentry/sentry-javascript/issues/6573
Closes #5972 