### PR TITLE
Enable before_send_transaction for python

### DIFF
--- a/src/platform-includes/configuration/before-send-transaction/python.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/python.mdx
@@ -1,0 +1,15 @@
+In Python a function can be used to modify the transaction event or return a completely new one. If you return `None`, the event will be discarded.
+
+```python
+import sentry_sdk
+
+def strip_sensitive_data(event, hint):
+    # modify event here
+    return event
+
+sentry_sdk.init(
+    # ...
+
+    before_send_transaction=strip_sensitive_data,
+)
+```

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -101,7 +101,7 @@ It also allows you to sample different transactions at different rates.
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 
-<PlatformSection supported={["node", "javascript", "php", "go"]} notSupported={["php.symfony"]}>
+<PlatformSection supported={["node", "javascript", "php", "go", "python"]} notSupported={["php.symfony"]}>
 
 ### Using <PlatformIdentifier name="before-send-transaction" />
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -533,7 +533,7 @@ _(New in version 7.30.0)_
 
 </ConfigKey>
 
-<ConfigKey name="_experiments.include-stack-locals" supported={["node"]}>
+<ConfigKey name="\_experiments.include-stack-locals" supported={["node"]}>
 
 Enables the `LocalVariables` integration, which adds stack local variables to
 stack traces.
@@ -584,7 +584,7 @@ This function is called with an SDK-specific message or error event object, and 
 
 </ConfigKey>
 
-<ConfigKey name="before-send-transaction" supported={["javascript", "node", "php", "go"]} notSupported={["php.symfony"]}>
+<ConfigKey name="before-send-transaction" supported={["javascript", "node", "php", "go", "python"]} notSupported={["php.symfony"]}>
 
 This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 


### PR DESCRIPTION
Python is now also able to specify a `before_send_transaction` option.