### PR TITLE
Migration page for Dart and Flutter v7

### DIFF
--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -10,11 +10,12 @@ API changes:
 
 - Sentry's Dart SDK version 7.0.0 and above requires Dart `2.17.0`.
 - Methods that used to take a `dynamic hint` optional parameter now take `Hint? hint` instead.
-- Remove deprecated fields from the `SentryDevice` class.
-  - `screenResolution`, using the `screenHeightPixels` and `screenWidthPixels` instead.
-  - `timezone`, using the `SentryCulture#timezone` instead.
-  - `language`, using the `SentryCulture#locale` instead.
-  - `theme`, using the `SentryOperatingSystem#theme` instead.
+- The following deprecated fields have been removed from the `SentryDevice` class and replaced:
+
+  - `screenResolution` replaced with `screenHeightPixels` and `screenWidthPixels`.
+  - `timezone` replaced with `SentryCulture#timezone`.
+  - `language` replaced with `SentryCulture#locale`.
+  - `theme` replaced with `SentryOperatingSystem#theme`.
 - Remove deprecated field from the `Contexts#dart_context` databag.
   - `isolate`, using the `SentryThread#name` instead.
 - `SentryMeasurementUnit` has been redesigned to be strongly typed.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -18,7 +18,8 @@ API changes:
   - `theme` replaced with `SentryOperatingSystem#theme`.
 - Remove deprecated field from the `Contexts#dart_context` databag.
   - `isolate`, using the `SentryThread#name` instead.
-- `SentryMeasurementUnit` has been redesigned to be strongly typed.
+-  The following`SentryMeasurementUnit`s are now strongly typed:
+
   - `DurationSentryMeasurementUnit`
   - `InformationSentryMeasurementUnit`
   - `FractionSentryMeasurementUnit`

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -9,7 +9,7 @@ description: "Migrate between versions of Sentry's SDK for Dart."
 API changes:
 
 - Sentry's Dart SDK version 7.0.0 and above requires Dart `2.17.0`.
-- Methods that used to take a `dynamic hint` optional parameter now takes `Hint? hint` instead.
+- Methods that used to take a `dynamic hint` optional parameter now take `Hint? hint` instead.
 - Remove deprecated fields from the `SentryDevice` class.
   - `screenResolution`, using the `screenHeightPixels` and `screenWidthPixels` instead.
   - `timezone`, using the `SentryCulture#timezone` instead.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -16,8 +16,8 @@ API changes:
   - `timezone` replaced with `SentryCulture#timezone`.
   - `language` replaced with `SentryCulture#locale`.
   - `theme` replaced with `SentryOperatingSystem#theme`.
-- Remove deprecated field from the `Contexts#dart_context` databag.
-  - `isolate`, using the `SentryThread#name` instead.
+- The following deprecated field has been removed from the `Contexts#dart_context` databag:
+  - `isolate` replaced with `SentryThread#name`.
 -  The following`SentryMeasurementUnit`s are now strongly typed:
 
   - `DurationSentryMeasurementUnit`

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -9,7 +9,7 @@ description: "Migrate between versions of Sentry's SDK for Dart."
 API changes:
 
 - Sentry's Dart SDK version 7.0.0 and above requires Dart `2.17.0`.
-- Methods that used to take a `dynamic hint` optional param now takes `Hint? hint` instead.
+- Methods that used to take a `dynamic hint` optional parameter now takes `Hint? hint` instead.
 - Remove deprecated fields from the `SentryDevice` class.
   - `screenResolution`, using the `screenHeightPixels` and `screenWidthPixels` instead.
   - `timezone`, using the `SentryCulture#timezone` instead.
@@ -23,6 +23,12 @@ API changes:
   - `FractionSentryMeasurementUnit`
   - `CustomSentryMeasurementUnit`
   - `NoneSentryMeasurementUnit`
+- Classes or methods that used to take the bellow optional parameters were moved.
+  - `captureFailedRequests`, using `SentryOptions#captureFailedRequests` instead.
+  - `sendDefaultPii`, using `SentryOptions#sendDefaultPii` instead.
+  - `maxRequestBodySize`, using `SentryOptions#maxRequestBodySize` instead.
+  - `networkTracing`, using `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler` instead.
+  - `recordBreadcrumbs`, using `SentryOptions#recordHttpBreadcrumbs` instead.
 
 Behavior changes:
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -20,12 +20,12 @@ API changes:
 - The following fields have been removed from the `Scope` class and replaced:
   - `user(SentryUser? user)` replaced with `setUser(SentryUser? user)`.
   - `attachements` replaced with `attachments`.
-- Classes or methods that used to take the bellow optional parameters, have been moved to the `SentryOptions` class:
-  - `captureFailedRequests` replaced with `SentryOptions#captureFailedRequests` instead.
-  - `sendDefaultPii` replaced with `SentryOptions#sendDefaultPii` instead.
-  - `maxRequestBodySize` replaced with `SentryOptions#maxRequestBodySize` instead.
-  - `networkTracing` replaced with `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler` instead.
-  - `recordBreadcrumbs` replaced with `SentryOptions#recordHttpBreadcrumbs` instead.
+- Classes or methods that used to take the below optional parameters, have been moved to the `SentryOptions` class and replaced:
+  - `captureFailedRequests` replaced with `SentryOptions#captureFailedRequests`.
+  - `sendDefaultPii` replaced with `SentryOptions#sendDefaultPii`.
+  - `maxRequestBodySize` replaced with `SentryOptions#maxRequestBodySize`.
+  - `networkTracing` replaced with `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler`.
+  - `recordBreadcrumbs` replaced with `SentryOptions#recordHttpBreadcrumbs`.
 -  The following`SentryMeasurementUnit`s are now strongly typed:
   - `DurationSentryMeasurementUnit`
   - `InformationSentryMeasurementUnit`

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -11,31 +11,27 @@ API changes:
 - Sentry's Dart SDK version 7.0.0 and above requires Dart `2.17.0`.
 - Methods that used to take a `dynamic hint` optional parameter now take `Hint? hint` instead.
 - The following deprecated fields have been removed from the `SentryDevice` class and replaced:
-
   - `screenResolution` replaced with `screenHeightPixels` and `screenWidthPixels`.
   - `timezone` replaced with `SentryCulture#timezone`.
   - `language` replaced with `SentryCulture#locale`.
   - `theme` replaced with `SentryOperatingSystem#theme`.
-- The following deprecated field has been removed from the `Contexts#dart_context` databag:
+- The following deprecated field has been removed from the `Contexts#dart_context` databag and replaced:
   - `isolate` replaced with `SentryThread#name`.
--  The following`SentryMeasurementUnit`s are now strongly typed:
-
-  - `DurationSentryMeasurementUnit`
-  - `InformationSentryMeasurementUnit`
-  - `FractionSentryMeasurementUnit`
-  - `CustomSentryMeasurementUnit`
-  - `NoneSentryMeasurementUnit`
 - The following fields have been removed from the `Scope` class and replaced:
-
   - `user(SentryUser? user)` replaced with `setUser(SentryUser? user)`.
   - `attachements` replaced with `attachments`.
 - Classes or methods that used to take the bellow optional parameters, have been moved to the `SentryOptions` class:
-
   - `captureFailedRequests` replaced with `SentryOptions#captureFailedRequests` instead.
   - `sendDefaultPii` replaced with `SentryOptions#sendDefaultPii` instead.
   - `maxRequestBodySize` replaced with `SentryOptions#maxRequestBodySize` instead.
   - `networkTracing` replaced with `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler` instead.
   - `recordBreadcrumbs` replaced with `SentryOptions#recordHttpBreadcrumbs` instead.
+-  The following`SentryMeasurementUnit`s are now strongly typed:
+  - `DurationSentryMeasurementUnit`
+  - `InformationSentryMeasurementUnit`
+  - `FractionSentryMeasurementUnit`
+  - `CustomSentryMeasurementUnit`
+  - `NoneSentryMeasurementUnit`
 
 Behavior changes:
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -4,6 +4,34 @@ sidebar_order: 1000
 description: "Migrate between versions of Sentry's SDK for Dart."
 ---
 
+## Migrating From `sentry` `6.6.x` to `sentry` `7.0.0`
+
+API changes:
+
+- Sentry's Dart SDK version 7.0.0 and above requires Dart `2.17.0`.
+- Methods that used to take a `dynamic hint` optional param now takes `Hint? hint` instead.
+- Remove deprecated fields from the `SentryDevice` class.
+  - `screenResolution`, using the `screenHeightPixels` and `screenWidthPixels` instead.
+  - `timezone`, using the `SentryCulture#timezone` instead.
+  - `language`, using the `SentryCulture#locale` instead.
+  - `theme`, using the `SentryOperatingSystem#theme` instead.
+- Remove deprecated field from the `Contexts#dart_context` databag.
+  - `isolate`, using the `SentryThread#name` instead.
+- `SentryMeasurementUnit` has been redesigned to be strongly typed.
+  - `DurationSentryMeasurementUnit`
+  - `InformationSentryMeasurementUnit`
+  - `FractionSentryMeasurementUnit`
+  - `CustomSentryMeasurementUnit`
+  - `NoneSentryMeasurementUnit`
+
+Behavior changes:
+
+- Sentry's Dart SDK version 7.0.0 and above supports Dart `3.0.0`.
+- When an unhandled error happens and there's a running transaction, the transaction status will be set to `internal_error`.
+- The `captureFailedRequests` feature is now enabled by default.
+- The `enableStructuredDataTracing` feature is now enabled by default.
+- The `enableUserInteractionTracing` feature is now enabled by default.
+
 ## Migrating From `sentry` `6.5.x` to `sentry` `6.6.x`
 
 - `SentryOptions#sendClientReports` is now enabled by default. To disable it, use the code snippet below:

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -25,9 +25,10 @@ API changes:
   - `FractionSentryMeasurementUnit`
   - `CustomSentryMeasurementUnit`
   - `NoneSentryMeasurementUnit`
-- Remove deprecated fields from the `Scope` class.
-  - `user(SentryUser? user)`, using the `setUser(SentryUser? user)` instead.
-  - `attachements`, using the `attachments` instead.
+- The following fields have been removed from the `Scope` class and replaced:
+
+  - `user(SentryUser? user)` replaced with `setUser(SentryUser? user)`.
+  - `attachements` replaced with `attachments`.
 - Classes or methods that used to take the bellow optional parameters were moved to the `SentryOptions` class.
   - `captureFailedRequests`, using `SentryOptions#captureFailedRequests` instead.
   - `sendDefaultPii`, using `SentryOptions#sendDefaultPii` instead.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -4,7 +4,7 @@ sidebar_order: 1000
 description: "Migrate between versions of Sentry's SDK for Dart."
 ---
 
-## Migrating From `sentry` `6.6.x` to `sentry` `7.0.0`
+## Migrating From `sentry` `6.18.x` to `sentry` `7.0.0`
 
 API changes:
 
@@ -23,6 +23,9 @@ API changes:
   - `FractionSentryMeasurementUnit`
   - `CustomSentryMeasurementUnit`
   - `NoneSentryMeasurementUnit`
+- Remove deprecated fields from the `Scope` class.
+  - `user(SentryUser? user)`, using the `setUser(SentryUser? user)` instead.
+  - `attachements`, using the `attachments` instead.
 - Classes or methods that used to take the bellow optional parameters were moved to the `SentryOptions` class.
   - `captureFailedRequests`, using `SentryOptions#captureFailedRequests` instead.
   - `sendDefaultPii`, using `SentryOptions#sendDefaultPii` instead.

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -29,12 +29,13 @@ API changes:
 
   - `user(SentryUser? user)` replaced with `setUser(SentryUser? user)`.
   - `attachements` replaced with `attachments`.
-- Classes or methods that used to take the bellow optional parameters were moved to the `SentryOptions` class.
-  - `captureFailedRequests`, using `SentryOptions#captureFailedRequests` instead.
-  - `sendDefaultPii`, using `SentryOptions#sendDefaultPii` instead.
-  - `maxRequestBodySize`, using `SentryOptions#maxRequestBodySize` instead.
-  - `networkTracing`, using `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler` instead.
-  - `recordBreadcrumbs`, using `SentryOptions#recordHttpBreadcrumbs` instead.
+- Classes or methods that used to take the bellow optional parameters, have been moved to the `SentryOptions` class:
+
+  - `captureFailedRequests` replaced with `SentryOptions#captureFailedRequests` instead.
+  - `sendDefaultPii` replaced with `SentryOptions#sendDefaultPii` instead.
+  - `maxRequestBodySize` replaced with `SentryOptions#maxRequestBodySize` instead.
+  - `networkTracing` replaced with `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler` instead.
+  - `recordBreadcrumbs` replaced with `SentryOptions#recordHttpBreadcrumbs` instead.
 
 Behavior changes:
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -26,12 +26,12 @@ API changes:
   - `maxRequestBodySize` replaced with `SentryOptions#maxRequestBodySize`.
   - `networkTracing` replaced with `SentryOptions#tracesSampleRate` or `SentryOptions#tracesSampler`.
   - `recordBreadcrumbs` replaced with `SentryOptions#recordHttpBreadcrumbs`.
--  The following`SentryMeasurementUnit`s are now strongly typed:
-  - `DurationSentryMeasurementUnit`
-  - `InformationSentryMeasurementUnit`
-  - `FractionSentryMeasurementUnit`
-  - `CustomSentryMeasurementUnit`
-  - `NoneSentryMeasurementUnit`
+-  The following `SentryMeasurementUnits` are now strongly typed:
+   -  `DurationSentryMeasurementUnit`
+   -  `InformationSentryMeasurementUnit`
+   -  `FractionSentryMeasurementUnit`
+   -  `CustomSentryMeasurementUnit`
+   - ` NoneSentryMeasurementUnit`
 
 Behavior changes:
 

--- a/src/platforms/dart/migration.mdx
+++ b/src/platforms/dart/migration.mdx
@@ -23,7 +23,7 @@ API changes:
   - `FractionSentryMeasurementUnit`
   - `CustomSentryMeasurementUnit`
   - `NoneSentryMeasurementUnit`
-- Classes or methods that used to take the bellow optional parameters were moved.
+- Classes or methods that used to take the bellow optional parameters were moved to the `SentryOptions` class.
   - `captureFailedRequests`, using `SentryOptions#captureFailedRequests` instead.
   - `sendDefaultPii`, using `SentryOptions#sendDefaultPii` instead.
   - `maxRequestBodySize`, using `SentryOptions#maxRequestBodySize` instead.

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -15,6 +15,7 @@ API changes:
 - `enableOutOfMemoryTracking` was renamed to `enableWatchdogTerminationTracking`.
 - Remove deprecated field from the `SentryFlutterOptions` class.
   - `anrTimeoutIntervalMillis`, using the `anrTimeoutInterval` instead.
+  - `autoSessionTrackingIntervalMillis`, using the `autoSessionTrackingInterval` instead.
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -3,7 +3,7 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
-## Migrating From `sentry_flutter` `6.6.x` to `sentry` `7.0.0`
+## Migrating From `sentry_flutter` `6.18.x` to `sentry` `7.0.0`
 
 In addition to the changes introduced in [sentry](/platforms/dart/migration/):
 
@@ -13,6 +13,8 @@ API changes:
 - The Sentry Cocoa SDK was upgraded to `8.0.0` which introduces breaking changes, see the [migration guide](/platforms/apple/migration/#migrating-from-7x-to-8x).
 - `enableAutoPerformanceTracking` was renamed to `enableAutoPerformanceTracing`.
 - `enableOutOfMemoryTracking` was renamed to `enableWatchdogTerminationTracking`.
+- Remove deprecated field from the `SentryFlutterOptions` class.
+  - `anrTimeoutIntervalMillis`, using the `anrTimeoutInterval` instead.
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -11,11 +11,11 @@ API changes:
 
 - Sentry's Flutter SDK version 7.0.0 and above requires Flutter `3.0.0`.
 - The Sentry Cocoa SDK was upgraded to `8.0.0` which introduces breaking changes, see the [migration guide](/platforms/apple/migration/#migrating-from-7x-to-8x).
-- `enableAutoPerformanceTracking` was renamed to `enableAutoPerformanceTracing`.
-- `enableOutOfMemoryTracking` was renamed to `enableWatchdogTerminationTracking`.
-- Remove deprecated field from the `SentryFlutterOptions` class.
-  - `anrTimeoutIntervalMillis`, using the `anrTimeoutInterval` instead.
-  - `autoSessionTrackingIntervalMillis`, using the `autoSessionTrackingInterval` instead.
+- The following fields have been removed from the `SentryFlutterOptions` class and replaced:
+  - `enableAutoPerformanceTracking` replaced with `enableAutoPerformanceTracing`.
+  - `enableOutOfMemoryTracking` replaced with `enableWatchdogTerminationTracking`.
+  - `anrTimeoutIntervalMillis` replaced with `anrTimeoutInterval` instead.
+  - `autoSessionTrackingIntervalMillis` replaced with `autoSessionTrackingInterval` instead.
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -3,6 +3,17 @@ title: Migration Guide
 sidebar_order: 1000
 ---
 
+## Migrating From `sentry_flutter` `6.6.x` to `sentry` `7.0.0`
+
+In addition to the changes introduced in [sentry](/platforms/dart/migration/):
+
+API changes:
+
+- Sentry's Flutter SDK version 7.0.0 and above requires Flutter `3.0.0`.
+- The Sentry Cocoa SDK was upgraded to `8.0.0` which introduces breaking changes, see the [migration guide](/platforms/apple/migration/#migrating-from-7x-to-8x).
+- `enableAutoPerformanceTracking` was renamed to `enableAutoPerformanceTracing`.
+- `enableOutOfMemoryTracking` was renamed to `enableWatchdogTerminationTracking`.
+
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 
 The SDK already runs your init `callback` on an error handler, such as [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) on Flutter versions prior to `3.3`, or [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) on Flutter versions 3.3 and higher, so that errors are automatically captured. No code changes are needed on your part.

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -14,8 +14,8 @@ API changes:
 - The following fields have been removed from the `SentryFlutterOptions` class and replaced:
   - `enableAutoPerformanceTracking` replaced with `enableAutoPerformanceTracing`.
   - `enableOutOfMemoryTracking` replaced with `enableWatchdogTerminationTracking`.
-  - `anrTimeoutIntervalMillis` replaced with `anrTimeoutInterval` instead.
-  - `autoSessionTrackingIntervalMillis` replaced with `autoSessionTrackingInterval` instead.
+  - `anrTimeoutIntervalMillis` replaced with `anrTimeoutInterval`.
+  - `autoSessionTrackingIntervalMillis` replaced with `autoSessionTrackingInterval`.
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-dart/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+milestone%3A7.0.0