### PR TITLE
fix(apple): Disabling crashes disables watchdog

### DIFF
--- a/src/platforms/apple/common/configuration/watchdog-terminations.mdx
+++ b/src/platforms/apple/common/configuration/watchdog-terminations.mdx
@@ -46,3 +46,6 @@ SentrySDK.start { options in
     options.enableWatchdogTerminationTracking = NO;
 }];
 ```
+
+If you disable the `enableCrashHandler` option, the SDK disables the watchdog termination tracking as well, cause
+the SDK would report false positive watchdog terminations for each crash.

--- a/src/platforms/apple/common/configuration/watchdog-terminations.mdx
+++ b/src/platforms/apple/common/configuration/watchdog-terminations.mdx
@@ -47,5 +47,4 @@ SentrySDK.start { options in
 }];
 ```
 
-If you disable the `enableCrashHandler` option, the SDK disables the watchdog termination tracking as well, cause
-the SDK would report false positive watchdog terminations for each crash.
+If you disable the `enableCrashHandler` option, the SDK will disable watchdog termination tracking. This will prevent false positive watchdog termination reporting for every crash.


### PR DESCRIPTION
Explain that disabling the crash handler on Apple also disables the watchdog termination integration.