### PR TITLE
feat(replay): Remove advanced configuration

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -26,32 +26,12 @@ The following options can be configured as options to the integration, in `new R
 | ------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | stickySession | boolean | `true`  | Keep track of the user across page loads. Note, a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
 
-## Optimization Configuration
-
-The following options can be configured as options to the integration, in `new Replay({})`:
-
-| Key              | Type    | Default | Description                                     |
-| ---------------- | ------- | ------- | ----------------------------------------------- |
-| collectFonts     | boolean | `false` | Should collect fonts used on the website        |
-| inlineImages     | boolean | `false` | Should inline `<image>` content                 |
-| inlineStylesheet | boolean | `true`  | Should inline stylesheets used in the recording |
-
 ## Identifying Users
 
 You can use the Sentry SDK to set the user of a session. To associate a user identity to a session replay, refer to the <PlatformLink to="/enriching-events/identify-user">Identifying User Docs</PlatformLink>.
 
 ```javascript
 Sentry.setUser({ email: "jane.doe@example.com" });
-```
-
-## rrweb Configuration
-
-In addition to the options described above, you can also directly pass configuration to [rrweb](https://github.com/rrweb-io/rrweb/blob/rrweb%401.1.3/guide.md), which is the underlying library used to make the recordings:
-
-```javascript
-new Replay({
-  // any further configuration here is passed directly to rrweb
-});
 ```
 
 ## Start and Stop Recording


### PR DESCRIPTION
Remove the advanced recording configuration options as we want greater control over how recording should be done. The SDK API will be changed at a later point so that these options will not be passed. Instead we will provide good defaults that shouldnt need to be configured.
