### PR TITLE
feat(replay): Update docs for starting/resuming recording

### DIFF
--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -53,3 +53,21 @@ You can verify that with the following:
 ```javascript
 myUndefinedFunction();
 ```
+
+### Lazy loading Replay
+
+Replay will start automatically when you add the integration.
+If you do not want to start Replay immediately (e.g. if you want to lazy-load it),
+you can also use `addIntegration` to load it later:
+
+```js
+Sentry.init({
+  // Do not load it initially
+  integrations: []
+});
+
+// Sometime later
+const { Replay } = await import('@sentry/browser');
+getCurrentHub().getClient().addIntegration(new Replay());
+```
+

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -54,15 +54,13 @@ You can verify that with the following:
 myUndefinedFunction();
 ```
 
-### Lazy loading Replay
+### Lazy-loading Replay
 
-Replay will start automatically when you add the integration.
-If you do not want to start Replay immediately (e.g. if you want to lazy-load it),
-you can also use `addIntegration` to load it later:
+Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
 ```js
 Sentry.init({
-  // Do not load it initially
+  // Note, Replay is NOT instantiated below:
   integrations: []
 });
 

--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -56,22 +56,38 @@ new Replay({
 
 ## Start and Stop Recording
 
-Replay recording only starts automatically when it's included in the integrations key when calling `Sentry.init`. Otherwise, you can initialize the plugin and manually call the `start()` method on the integration instance. To stop recording you can call the `stop()`:
+Replay recording starts automatically when it's included in the `integrations` key when calling `Sentry.init()` or when adding it via `addIntegration()`. Call `stop()` to stop recording and `start()` to resume recording:
 
 ```javascript {tabTitle: ESM}
-const replay = new Replay(); // This will *NOT* begin recording replays
+const replay = new Replay();
 
-replay.start(); // Start recording
+// Load replay when you configure Sentry SDK
+Sentry.init({
+  integrations: [replay]
+});
 
-replay.stop(); // Stop recording
+// Or if you want to defer loading Replay
+getCurrentHub().getClient().addIntegration(replay);
+
+// some time later
+replay.stop();
+replay.start();
 ```
 
 ```javascript {tabTitle: CDN}
-const replay = new Sentry.Integrations.Replay(); // This will *NOT* begin recording replays
+const replay = new Sentry.Integrations.Replay();
 
-replay.start(); // Start recording
+// Load replay when you configure Sentry SDK
+Sentry.init({
+  integrations: [replay]
+});
 
-replay.stop(); // Stop recording
+// Or if you want to defer loading Replay
+Sentry.getCurrentHub().getClient().addIntegration(replay);
+
+// some time later
+replay.stop();
+replay.start();
 ```
 
 ## Privacy

--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -56,7 +56,7 @@ new Replay({
 
 ## Start and Stop Recording
 
-Replay recording starts automatically when it's included in the `integrations` key when calling `Sentry.init()` or when adding it via `addIntegration()`. Call `stop()` to stop recording and `start()` to resume recording:
+Replay recording starts automatically if it's included in the `integrations` array when calling `Sentry.init()` or added via `addIntegration()`. To stop recording, call `stop()`; to resume, call `start()`:
 
 ```javascript {tabTitle: ESM}
 const replay = new Replay();
@@ -69,7 +69,7 @@ Sentry.init({
 // Or if you want to defer loading Replay
 getCurrentHub().getClient().addIntegration(replay);
 
-// some time later
+// sometime later
 replay.stop();
 replay.start();
 ```
@@ -85,7 +85,7 @@ Sentry.init({
 // Or if you want to defer loading Replay
 Sentry.getCurrentHub().getClient().addIntegration(replay);
 
-// some time later
+// sometime later
 replay.stop();
 replay.start();
 ```


### PR DESCRIPTION
This adds docs for lazy loading Replay and fixes the docs for start/stop recording.
