### PR TITLE
docs(node): Add setup instructions for pluggable integrations

### DIFF
--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -6,13 +6,37 @@ redirect_from:
 description: "Learn about the different pluggable integrations and how to enable them."
 ---
 
-Pluggable integrations are integrations that can be additionally enabled to provide specific features. They're documented so you can understand what they do and enable them, if needed. To enable pluggable integrations, provide a new instance with your config to the `integrations` option. For example: `integrations: [new Sentry.Integrations.Modules()]`.
+Pluggable integrations are integrations that can be additionally enabled to provide specific features. They're documented so you can understand what they do and enable them, if needed.
+
+## Install
+
+To enable pluggable integrations, install the package `@sentry/integrations`.
+
+```shell
+# Using yarn
+yarn add @sentry/integrations
+# Using npm
+npm install --save @sentry/integrations
+```
+
+## Configure
+
+After installation, you can import the integration and provide a new instance with your config to the `integrations` option.
+
+```javascript
+import { CaptureConsole } from '@sentry/integrations';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [new CaptureConsole()],
+});
+```
 
 ## Core
 
 ### CaptureConsole
 
-_Import name: `Sentry.Integrations.CaptureConsole`_
+_Import name: `CaptureConsole`_
 
 This integration captures all `Console API` calls and redirects them to Sentry using `captureMessage` call.
 It then re-triggers to preserve default native behavior.
@@ -27,13 +51,13 @@ Available options:
 
 ### Dedupe
 
-_Import name: `Sentry.Integrations.Dedupe`_
+_Import name: `Dedupe`_
 
 This integration deduplicates certain events. It can be helpful if you're receiving many duplicate errors. Be aware that we will only compare stack traces and fingerprints.
 
 ### Debug
 
-_Import name: `Sentry.Integrations.Debug`_
+_Import name: `Debug`_
 
 This integration allows you to inspect the contents of the processed event and `hint` object that will be passed to `beforeSend` or `beforeSendTransaction`. It will _always_ run as the last integration, no matter when it was registered.
 
@@ -51,7 +75,7 @@ Available options:
 
 ### ExtraErrorData
 
-_Import name: `Sentry.Integrations.ExtraErrorData`_
+_Import name: `ExtraErrorData`_
 
 This integration extracts all non-native attributes from the `error` object and attaches them to the event as the `extra` data.
 
@@ -68,7 +92,7 @@ Available options:
 
 ### RewriteFrames
 
-_Import name: `Sentry.Integrations.RewriteFrames`_
+_Import name: `RewriteFrames`_
 
 This integration allows you to apply a transformation to each frame of the stack trace. In the streamlined scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
 
@@ -81,6 +105,6 @@ For example, `C:\\Program Files\\Apache\\www` won't work, however, `/Program Fil
 
 ### Transaction
 
-_Import name: `Sentry.Integrations.Transaction`_
+_Import name: `Transaction`_
 
 This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stack trace frames and reads the first in-app frame's module and function name.


### PR DESCRIPTION
Previously, the documentation page for Node.js's "Pluggable Integrations" used the wrong import names and did not explain that the user must install a separate package. This commit fixes both of these issues.

[Vercel preview for the modified docs page.](https://sentry-docs-git-fork-dannynemer-patch-2.sentry.dev/platforms/node/configuration/integrations/pluggable-integrations/)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
