### PR TITLE
Move from alpha -> beta note for OpenTelemetry

### DIFF
--- a/src/includes/beta-note-opentelemetry.mdx
+++ b/src/includes/beta-note-opentelemetry.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+OpenTelemetry Support is currently in Beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please reach out via [GitHub](https://github.com/getsentry/sentry/discussions/40712).
+
+</Note>

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -31,8 +31,6 @@ notSupported:
 description: "Using OpenTelemetry with Sentry Performance."
 ---
 
-<Include name="alpha-note.mdx" />
-
 You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
 
 ## Install

--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -31,6 +31,8 @@ notSupported:
 description: "Using OpenTelemetry with Sentry Performance."
 ---
 
+<Include name="beta-note-opentelemetry.mdx" />
+
 You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
 
 ## Install


### PR DESCRIPTION
Otel SDKs are in beta - let's update docs to reflect this.