### PR TITLE
feat(apple): More detail to when screenshots are captured

### DIFF
--- a/src/docs/product/issues/issue-details/error-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/error-issues/index.mdx
@@ -53,7 +53,7 @@ The tags displayed in the main section of this page are specific to the event th
 
 ## Screenshot
 
-Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface. It's supported for the following SDKs:
+Sentry provides the ability to take a screenshot and include it as an attachment when a user experiences an error, an exception or a crash. Screenshot attachments sent as a part of an event are displayed in this section. This feature only applies to SDKs with a user interface. It's supported for the following SDKs:
 
 - [.NET Xamarin](/platforms/dotnet/guides/xamarin/)
 - [Android](/platforms/android/enriching-events/screenshots/)

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -19,7 +19,7 @@ There are two categories of issues: [error issues](/product/issues/issue-details
 - **Trace Navigator** - An abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction.
 - **Suspect Commits** - A commit that's been identified as potentially having caused an error event.
 - **Tags** - Searchable key/value string pairs providing information such as the browser or device.
-- **Screenshot** - Screenshot taken when a user experiences an error; only available on [certain SDKs](/product/issues/issue-details/error-issues/#screenshots).
+- **Screenshot** - Screenshot taken when a user experiences an error, an exception or a crash; only available on [certain SDKs](/product/issues/issue-details/error-issues/#screenshots).
 - **Exception (Stack Trace)** - Shows you the line of code that the event errored on.
 - **Span Evidence** - Information about the performance problem in the context of the current event
 - **Breadcrumbs** - Provide a history and timeline leading up to the error event and are customizable.

--- a/src/platforms/common/enriching-events/screenshots.mdx
+++ b/src/platforms/common/enriching-events/screenshots.mdx
@@ -16,7 +16,7 @@ notSupported:
   - apple.watchos
 ---
 
-When a user experiences an error, Sentry provides the ability to take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink>.
+When a user experiences an error, an exception or a crash, Sentry provides the ability to take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink>.
 
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, taking a screenshot requires the UI thread and in the event of a crash, that might not be available. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 


### PR DESCRIPTION
Add the information the screenshots are capture not only with errors, but also when the app crashes

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
