### PR TITLE
feat: Update `enableLongTask` docs

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -118,20 +118,8 @@ This option flags transactions when tabs are moved to the background with "cance
 
 The default is `true`.
 
-### \_experiments
+### enableLongTask
 
-This is an object containing experimental flags for features that haven't yet landed in a new major version and might include breaking changes.
-
-The default is
-
-```
-{
-  enableLongTasks: true
-}
-```
-
-#### \_experiments.enableLongTasks
-
-This experimental option determines whether spans for long tasks automatically get created.
+This option determines whether spans for long tasks automatically get created.
 
 The default is `true`.


### PR DESCRIPTION
This depends on https://github.com/getsentry/sentry-javascript/pull/6837 being released in 7.32.0.