### PR TITLE
fix(apple): Replace OOM with watchdog termination

### DIFF
--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -10,7 +10,7 @@
   - Objective-C exceptions
   - Error messages of fatalError, assert, and precondition
   - [App Hang Detection](/platforms/apple/configuration/app-hangs/)
-  - [Out of memory](/platforms/apple/configuration/out-of-memory/)
+  - <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink>
   - [HTTP Client Errors](/platforms/apple/configuration/http-client-errors/)
   - Start-up crashes. The SDK init waits synchronously for up to 5 seconds to flush out events if the app crashes within 2 seconds after the SDK init.
 - Events [enriched](/platforms/apple/enriching-events/context/) with device data

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -12,7 +12,7 @@ With app hang tracking, you can detect and fix this problem.
 The app hang detection integration has a default timeout of two (2) seconds, which means if the app becomes unresponsive for two seconds, an error event is created.
 The event has the stack trace of all running threads so you can easily detect where the problem occurred. The SDK reports an app hang immediately but doesn't report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app any time when blocking the main thread.
 
-The app hangs code runs in the background when disabled when keeping out-of-memory tracking enabled, but it won't report app hangs. The out-of-memory tracking otherwise would report false errors if the OS kills your app caused by an app hang.
+The app hangs code runs in the background when disabled when keeping watchdog termination tracking enabled, but it won't report app hangs. The watchdog termination tracking otherwise would report false errors if the OS kills your app caused by an app hang.
 
 Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, if SentryCrashIntegration is disabled, the integration won’t work.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -859,7 +859,7 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 Available since version 8.0.0 of Sentry Apple SDK. It was named `enableOutOfMemoryTracking` before the 8.0.0 release.
 </Note>
 
-Set this boolean to `true` to disable [watchdog termination](/platforms/apple/guides/ios/configuration/watchdog-terminations/) tracking on iOS.
+Set this boolean to `false` to disable [watchdog termination](/platforms/apple/guides/ios/configuration/watchdog-terminations/) tracking on iOS.
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -853,6 +853,16 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 
 </ConfigKey>
 
+<ConfigKey name="enableWatchdogTerminationTracking" supported={["apple"]}>
+
+<Note>
+Available since version 8.0.0 of Sentry Apple SDK. It was named `enableOutOfMemoryTracking` before the 8.0.0 release.
+</Note>
+
+Set this boolean to `true` to disable [watchdog termination](/platforms/apple/guides/ios/configuration/watchdog-terminations/) tracking on iOS.
+
+</ConfigKey>
+
 <ConfigKey name="onReady" supported={["react-native"]}>
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).


### PR DESCRIPTION
Replace remaining occurrences of out-of-memory with watchdog termination.
