### PR TITLE
Remove incorrect reprocessing text from IO issue

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/main-thread-io.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/main-thread-io.mdx
@@ -4,13 +4,7 @@ sidebar_order: 20
 description: "Learn more about File IO on Main Thread and how to diagnose and fix these issues."
 ---
 
-<Note>
-
-This feature is available only if you're in the Early Adopter program, and have the latest version of either the Android or iOS Mobile SDK. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily. You can find information about the previous version of reprocessing in [Legacy Reprocessing](#legacy-reprocessing).
-
-</Note>
+<Include name="early-adopter-note.mdx" />
 
 The Main UI thread in a mobile application handles user interface events such as button presses and page scrolls. If the Main UI thread performs long running operations like File IO, it will block the whole UI until the operation is complete, preventing the user from interacting with the app. If the Main UI thread is blocked for a long period of time, it can cause App Hangs and Application Not Responding errors.
 


### PR DESCRIPTION
Okay maybe using the include is not quite right since there's an SDK note, but the reprocessing thing is definitely wrong, right? Anyway you tell me, feel free to just push to this PR or ignore it or whatever works 🙏🏻 