### PR TITLE
fix: vite configuration for sourcemap

### DIFF
--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -17,30 +17,36 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 Example:
 
 ```javascript {filename:vite.config.js}
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import sentryVitePlugin from "@sentry/vite-plugin";
 
-export default defineConfig({
-  build: {
-    sourcemap: true, // Source map generation must be turned on
-  },
-  plugins: [
-    // Put the Sentry vite plugin after all other plugins
-    sentryVitePlugin({
-      org: "___ORG_SLUG___",
-      project: "___PROJECT_SLUG___",
+export default defineConfig(({ command, mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '')
 
-      // Specify the directory containing build artifacts
-      include: "./dist",
+  return {
+    build: {
+      sourcemap: true, // Source map generation must be turned on
+    },
+    plugins: [
+      // Put the Sentry vite plugin after all other plugins
+      sentryVitePlugin({
+        org: "___ORG_SLUG___",
+        project: "___PROJECT_SLUG___",
 
-      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
-      // and needs the `project:releases` and `org:read` scopes
-      authToken: process.env.SENTRY_AUTH_TOKEN,
+        // Specify the directory containing build artifacts
+        include: "./dist",
 
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
-    }),
-  ],
+        // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+        // and needs the `project:releases` and `org:read` scopes
+        authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
+
+        // Optionally uncomment the line below to override automatic release name detection
+        // release: env.RELEASE,
+      }),
+    ],
+  }
 });
 ```
 


### PR DESCRIPTION
Explanation here:
https://main.vitejs.dev/config/#environment-variables

AND I don't know but with Tailwind I add to do that also:
`releaseInjectionTargets: resolve(__dirname, 'src', 'main.js')`




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
