### PR TITLE
Update bundler plugin docs to reflect new export structure

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -35,7 +35,7 @@ Configure Vite to emit source maps and use the Sentry Vite plugin:
 ```JavaScript {filename:vite.config.js}
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
-import sentryVitePlugin from "@sentry/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 export default defineConfig({
   build: {

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -23,7 +23,7 @@ Example:
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-import sentryVitePlugin from "@sentry/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -17,7 +17,7 @@ Learn more about configuring the plugin in our [Sentry esbuild Plugin documentat
 Example:
 
 ```javascript {filename:esbuild.config.js}
-const sentryEsbuildPlugin = require("@sentry/esbuild-plugin");
+const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 
 require("esbuild").build({
   entryPoints: ["./src/index.js"],

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -18,7 +18,7 @@ Learn more about configuring the plugin in our [Sentry Rollup Plugin documentati
 Example:
 
 ```javascript {filename:rollup.config.js}
-import sentryRollupPlugin from "@sentry/rollup-plugin";
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 
 export default {
   input: "./src/index.js",

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -18,7 +18,7 @@ Example:
 
 ```javascript {filename:vite.config.js}
 import { defineConfig } from "vite";
-import sentryVitePlugin from "@sentry/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 export default defineConfig({
   build: {


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/165 changed how the bundler plugins are exported.

This PR updates the sourcemap upload docs accordingly.
