### PR TITLE
Move File IO out of list of limitations

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -50,6 +50,6 @@ We're working on removing some or all of these limitations.
 
 <Note>
   
- *<a class href=“/product/issues/issue-details/performance-issues/main-thread-io/”>File IO on Main Thread</a> is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK. 
+ *<a class href="/product/issues/issue-details/performance-issues/main-thread-io/">File IO on Main Thread</a> is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK. 
   
 </Note>  

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -50,6 +50,6 @@ We're working on removing some or all of these limitations.
 
 <Note>
   
- *[File IO on Main Thread](main-thread-io) is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK.
+ *<a class href=“/product/issues/issue-details/performance-issues/main-thread-io/”>File IO on Main Thread</a> is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK. 
   
 </Note>  

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -42,9 +42,14 @@ The "Event Grouping Information" section provides details of how Sentry fingerpr
 
 Performance issues currently have the following limitations:
 
-- Only one type of issue is available to all Sentry users: [N+1 Queries](n-one-queries)
-- Another issue is available to Early Adopters on the latest version of Sentry Android or iOS SDKs: [File IO on Main Thread](main-thread-io)
-- Performance issues cannot be merged or deleted
-- Custom fingerprinting and grouping do not apply to performance issues
+- Only one type of issue is available to all Sentry users: [N+1 Queries](n-one-queries)*
+- Performance issues can't be merged or deleted
+- Custom fingerprinting and grouping can't be applied to performance issues
 
 We're working on removing some or all of these limitations.
+
+<Note>
+  
+ *[File IO on Main Thread](main-thread-io) is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK.
+  
+</Note>  

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -42,7 +42,7 @@ The "Event Grouping Information" section provides details of how Sentry fingerpr
 
 Performance issues currently have the following limitations:
 
-- Only one type of issue is available to all Sentry users: [N+1 Queries](n-one-queries)*
+- Only one type of issue* is available to all Sentry users: [N+1 Queries](n-one-queries)
 - Performance issues can't be merged or deleted
 - Custom fingerprinting and grouping can't be applied to performance issues
 


### PR DESCRIPTION
Since this isn't a limitation, it doesn't make sense to keep it as part of this list. I suggest we move it into a note at the bottom of the page.
