### PR TITLE
fix: Typo in JS treeshaking docs

### DIFF
--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -25,7 +25,7 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 : Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
 **Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're directly using the `@sentry/tracing` package, or when you're using any performance monitoring related SDK features (e.g. `Sentry.startTransaction()`).
-This flag is intended to be used in combination with packages like `@sentry/next` where the `@sentry/trace` package is used implicitly.
+This flag is intended to be used in combination with packages like `@sentry/next` where the `@sentry/tracing` package is used implicitly.
 
 <PlatformSection notSupported={["javascript.nextjs"]}>
 


### PR DESCRIPTION
`@sentry/trace` -> `@sentry/tracing`