### PR TITLE
replay: link to sentry privacy page

### DIFF
--- a/src/platforms/javascript/common/session-replay/privacy.mdx
+++ b/src/platforms/javascript/common/session-replay/privacy.mdx
@@ -11,6 +11,10 @@ description: "Configuring Session Replay to maintain user and data privacy."
 
 <Include name="beta-note-session-replay.mdx" />
 
+<Note>
+  This document covers Session Replay SDK privacy controls. [Other documentation covers general Sentry data processing and privacy](https://sentry.io/privacy/).
+</Note>
+
 There are several ways to deal with personally identifiable information (PII). By default, the integration will mask all text content with `*` and block all media elements (`img`, `svg`, `video`, `object`, `picture`, `embed`, `map`, `audio`). This can be disabled by setting `maskAllText` to `false`. It's also possible to add the following CSS classes to specific DOM elements to prevent recording their contents: `sentry-block`, `sentry-ignore`, and `sentry-mask`. The following sections will show examples of how content is handled by the differing methods.
 
 ## Masking


### PR DESCRIPTION
I'm not convinced this myself yet, but how about we start with a link to the privacy page on a note?