### PR TITLE
Grammar fix to dsn-explainer - DSN Utilization section

### DIFF
--- a/src/docs/product/sentry-basics/dsn-explainer.mdx
+++ b/src/docs/product/sentry-basics/dsn-explainer.mdx
@@ -20,7 +20,7 @@ DSNs are safe to keep public because they only allow submission of new events an
 
 While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to **[Project] > Settings > Client Keys (DSN)**.
 
-If your application is shipped to client devices, if possible, we recommend having a way to configure the DSN dynamically. In an ideal scenario, you can "ship" a new DSN to your application without the customer downloading the latest version. We recognize that this may not always be practical, but we cannot offer further advice as this scenario is implementation specific.
+If your application is shipped to client devices, if possible, we recommend having a way to configure the DSN dynamically. In an ideal scenario, you can "ship" a new DSN to your application without the customer downloading the latest version. We recognize that this may not always be practical, but we cannot offer further advise as this scenario is implementation specific.
 
 ### Where to Find Your DSN
 


### PR DESCRIPTION
Change 'advice' to 'advise'