### PR TITLE
Update outdated set-transaction-name python code

### DIFF
--- a/src/platform-includes/enriching-events/set-transaction-name/python.mdx
+++ b/src/platform-includes/enriching-events/set-transaction-name/python.mdx
@@ -2,5 +2,5 @@
 from sentry_sdk import configure_scope
 
 with configure_scope() as scope:
-    scope.transaction.name = "UserListView"
+    scope.set_transaction_name("UserListView")
 ```


### PR DESCRIPTION


<!-- Describe your PR here. -->
Update the `set-transaction-name` outdated doc to use the latest `scope.set_transaction_name("UserListView")` api 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
