### PR TITLE
Added Server category in Profiling Getting Started

### DIFF
--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -26,6 +26,7 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)
+- Server
   - [Node.js](/platforms/node/profiling)
   - [Python](/platforms/python/profiling/)
   - [Rust](/platforms/rust/profiling)


### PR DESCRIPTION
Before, Node.js, Python and Rust were listed in the "Mobile" Category




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
