### PR TITLE
feat(perf-issues): Add table to root performance issue docs

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -40,7 +40,7 @@ The "Event Grouping Information" section provides details of how Sentry fingerpr
 
 ## Performance Issue Types
 
-The following table outlines the availble performance issues categorized by
+The following is a list of available performance issues:
 
 <table>
    <tr>

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -80,7 +80,7 @@ The following table outlines the availble performance issues categorized by
     </tr>
 </table>
 <Note>
-* indicates that a performance issue is only availble to Early Adopters.
+* Currently only available to Early Adopters.
 </Note>
 
 ## Performance Issue Limitations

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -38,18 +38,55 @@ Span evidence is information that explains the performance problem in the contex
 
 The "Event Grouping Information" section provides details of how Sentry fingerprinted the event into the group. You can see which parts of the span evidence contributed to the fingerprint.
 
+## Performance Issue Types
+
+The following table outlines the availble performance issues categorized by
+
+<table>
+   <tr>
+       <th>Browser</th>
+       <td>
+          <ul>
+            <li><a href="./n-one-api-calls/">*N+1 Api Calls</a></li>
+          </ul>  
+        </td>
+    </tr>
+   <tr>
+       <th>Server</th>
+       <td>
+          <ul>
+            <li><a href="./n-one-queries/">N+1 Queries</a></li>
+            <li><a href="./consecutive-db-queries/">*Consecuitive DB Queries</a></li>
+          </ul>  
+        </td>
+    </tr>
+   <tr>
+    <th>Mobile</th>
+       <td>
+          <ul>
+            <li><a href="./main-thread-io/">*File IO on Main Thread</a></li>
+          </ul>  
+        </td> 
+    </tr>
+   <tr>
+    <th>Serverless</th>
+       <td>
+          <ul>
+            <li><a href="./n-one-queries/">N+1 Queries</a></li>
+            <li><a href="./consecutive-db-queries/">*Consecuitive DB Queries</a></li>
+          </ul>  
+        </td> 
+    </tr>
+</table>
+<Note>
+* indicates that a performance issue is only availble to Early Adopters.
+</Note>
+
 ## Performance Issue Limitations
 
 Performance issues currently have the following limitations:
 
-- Only one type of issue* is available to all Sentry users: [N+1 Queries](n-one-queries)
 - Performance issues can't be merged or deleted
 - Custom fingerprinting and grouping can't be applied to performance issues
 
 We're working on removing some or all of these limitations.
-
-<Note>
-  
- *<a class href="/product/issues/issue-details/performance-issues/main-thread-io/">File IO on Main Thread</a> is another issue that's currently available to Early Adopters on the latest version of Sentry Android or iOS SDK. 
-  
-</Note>  

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -65,6 +65,7 @@ The following table outlines the availble performance issues categorized by
        <td>
           <ul>
             <li><a href="./main-thread-io/">*File IO on Main Thread</a></li>
+            <li><a href="./n-one-api-calls/">*N+1 Api Calls</a></li>
           </ul>  
         </td> 
     </tr>


### PR DESCRIPTION
Resolves PERF-1940

As more performance issues arise, we should have a more clear way to breakdown all the available issue types by category. 
- The categories used match the categories seen when you create a new project in sentry.
- I’m not sure if I completely like the duplicated server and serverless entries, but I think it’s better to stay consistent with the categories we have.
- I omitted Desktop and Other as they currently don't have detectors (correct me if i'm wrong)



<img width="751" alt="image" src="https://user-images.githubusercontent.com/44422760/214616434-d5d38bc3-6372-4b06-9cee-2b63958b7eab.png">
