### PR TITLE
add platform links to beta note

### DIFF
--- a/src/docs/product/session-replay/index.mdx
+++ b/src/docs/product/session-replay/index.mdx
@@ -4,23 +4,9 @@ sidebar_order: 3
 description: "Learn about Sentry's Session Replay, which provides video-like reproductions of user interactions on a site or web app."
 ---
 
-<Note>
 
-Session Replay is currently in beta. Beta features are still in-progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [support@sentry.io](mailto:support@sentry.io).
+<Include name="beta-note-session-replay.mdx" />
 
-**Currently, this feature is supported for only browser JavaScript, including these frameworks:**
-
-- Angular
-- Capacitor
-- Ember
-- Gatsby
-- Next.js
-- React
-- Remix
-- Svelte
-- Vue
-
-</Note>
 
 Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application. **Session Replay** provides a video-like reproduction of user interactions on a site or web app. All user interactions — including page visits, mouse movements, clicks, and scrolls — are captured, helping developers connect the dots between a known issue and how a user experienced it in the UI.
 

--- a/src/includes/beta-note-session-replay.mdx
+++ b/src/includes/beta-note-session-replay.mdx
@@ -4,5 +4,15 @@ Session Replay is currently in beta. Beta features are still in-progress and may
 
 Session Replay supports all browser JavaScript applications. It is built to work with @sentry/browser, and our browser framework SDKs.
 
+- [Vanilla JavaScript](https://docs.sentry.io/platforms/javascript/guides/javascript/session-replay/)
+- [Angular](https://docs.sentry.io/platforms/javascript/guides/angular/session-replay/)
+- [Capacitor](https://docs.sentry.io/platforms/javascript/guides/capacitor/session-replay/)
+- [Ember](https://docs.sentry.io/platforms/javascript/guides/ember/session-replay/)
+- [Gatsby](https://docs.sentry.io/platforms/javascript/guides/gatsby/session-replay/)
+- [Next.js](https://docs.sentry.io/platforms/javascript/guides/nextjs/session-replay/)
+- [React](https://docs.sentry.io/platforms/javascript/guides/react/session-replay/)
+- [Remix](https://docs.sentry.io/platforms/javascript/guides/remix/session-replay/)
+- [Svelte](https://docs.sentry.io/platforms/javascript/guides/svelte/session-replay/)
+- [Vue](https://docs.sentry.io/platforms/javascript/guides/vue/session-replay/)
 
 </Note>


### PR DESCRIPTION
replay links in notes to get to frameworks specific docs easier