### PR TITLE
feat(unity): Updated migration

### DIFF
--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -11,9 +11,10 @@ redirect_from:
 ### Breaking Changes
 
 The base classes for the Scriptable Objects used for programmatic configuration have been updated:
-- `Sentry.Unity.ScriptableOptionsConfiguration` changed to `SentryRuntimeOptionsConfiguration`
-- `Sentry.Unity.Editor.ScriptableOptionsConfiguration` changed to `SentryBuildtimeOptionsConfiguration`
-If you make use of the programmatic configuration, you need to update your implementation with those base classes.
+- `Sentry.Unity.ScriptableOptionsConfiguration` has been changed to `SentryRuntimeOptionsConfiguration`
+- `Sentry.Unity.Editor.ScriptableOptionsConfiguration` has been changed to `SentryBuildtimeOptionsConfiguration`
+
+If you make use of the programmatic configuration, you'll need to update your implementation with these base classes.
 
 ## Migrating to 0.11.0
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -37,7 +37,7 @@ Starting from version 0.7.0, the SDK is [aliasing](https://blog.sentry.io/2022/0
 
 ## Migrating From 0.3.0 or Earlier
 
-The Sentry SDK deprecated the use of a JSON file to store the options in favor of scriptable objects. If you're migrating from version 0.3.0 or older, make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as JSON. When you're opening the Sentry configuration editor window, that file will be automatically converted into a scriptable object. This support will be dropped in version 0.16.0 and going forward.
+The Sentry SDK deprecated the use of JSON files to store options and now uses scriptable objects instead. If you're migrating from version 0.3.0 or older, make sure to upgrade to version 0.15.0 first. It's the last version that supports options stored in JSON format. When you open the Sentry configuration editor window in version 0.15.0, your JSON file will be automatically converted into a scriptable object. This support will be dropped in version 0.16.0 and later.
 
 ## Migrating From `sentry.unity.lite` to `sentry.unity`
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -6,13 +6,14 @@ redirect_from:
   - /platforms/unity/unity-lite/
 ---
 
-## Migrating From 0.3.0 or Earlier
+## Migrating to 0.28.0
 
-The Sentry SDK deprecated the use of a JSON file to store the options in favor of scriptable objects. If you're migrating from version 0.3.0 or older, make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as JSON. When you're opening the Sentry configuration editor window, that file will be automatically converted into a scriptable object. This support will be dropped in version 0.16.0 and going forward.
+### Breaking Changes
 
-## Migrating From 0.7.0 or Earlier
-
-Starting from version 0.7.0, the SDK is [aliasing](https://blog.sentry.io/2022/02/24/alias-an-approach-to-net-assembly-conflict-resolution) its dependencies. We do this to avoid creating conflicts with other packages. This also means that if you were relying on our dependencies for certain types, then you will have to import them into your project yourself going forward.
+The base classes for the Scriptable Objects used for programmatic configuration have been updated:
+- `Sentry.Unity.ScriptableOptionsConfiguration` changed to `SentryRuntimeOptionsConfiguration`
+- `Sentry.Unity.Editor.ScriptableOptionsConfiguration` changed to `SentryBuildtimeOptionsConfiguration`
+If you make use of the programmatic configuration, you need to update your implementation with those base classes.
 
 ## Migrating to 0.11.0
 
@@ -28,6 +29,14 @@ You no longer need to to call `SentryUnity.Init`. Instead, you can let the SDK s
 - Add your code to the newly created script.
 
 Learn more in our [options documentation](/platforms/unity/configuration/options/).
+
+## Migrating From 0.7.0 or Earlier
+
+Starting from version 0.7.0, the SDK is [aliasing](https://blog.sentry.io/2022/02/24/alias-an-approach-to-net-assembly-conflict-resolution) its dependencies. We do this to avoid creating conflicts with other packages. This also means that if you were relying on our dependencies for certain types, then you will have to import them into your project yourself going forward.
+
+## Migrating From 0.3.0 or Earlier
+
+The Sentry SDK deprecated the use of a JSON file to store the options in favor of scriptable objects. If you're migrating from version 0.3.0 or older, make sure to upgrade to version 0.15.0 first, as it is the last version supporting your options stored as JSON. When you're opening the Sentry configuration editor window, that file will be automatically converted into a scriptable object. This support will be dropped in version 0.16.0 and going forward.
 
 ## Migrating From `sentry.unity.lite` to `sentry.unity`
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -33,7 +33,7 @@ Learn more in our [options documentation](/platforms/unity/configuration/options
 
 ## Migrating From 0.7.0 or Earlier
 
-Starting from version 0.7.0, the SDK is [aliasing](https://blog.sentry.io/2022/02/24/alias-an-approach-to-net-assembly-conflict-resolution) its dependencies. We do this to avoid creating conflicts with other packages. This also means that if you were relying on our dependencies for certain types, then you will have to import them into your project yourself going forward.
+Starting from version 0.7.0, the SDK is [aliasing](https://blog.sentry.io/2022/02/24/alias-an-approach-to-net-assembly-conflict-resolution) its dependencies. We do this to avoid creating conflicts with other packages. This also means that if you were relying on our dependencies for certain types like `System.Text.Json`, then you'll have to import them into your project yourself going forward.
 
 ## Migrating From 0.3.0 or Earlier
 


### PR DESCRIPTION
I added a section for the breaking changes in the `0.28.0` release.
Additionally, I flipped the entries around to go from newest to oldest.