### PR TITLE
feat: order platforms by their natural name

### DIFF
--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -163,9 +163,11 @@ export const usePlatformList = (): Platform[] => {
   const {
     allPlatform: { nodes: platformList },
   } = useStaticQuery(query);
-  return platformList.sort((a: Platform, b: Platform) =>
-    a.title.localeCompare(b.title)
-  );
+  return platformList.sort((a: Platform, b: Platform) => {
+    // Exclude leading non-alphanumeric characters to order .NET between Native and NodeJS instead of the beginning.
+    const skippedPrefix = /^[^a-zA-Z]+/;
+    return a.title.replace(skippedPrefix, '').localeCompare(b.title.replace(skippedPrefix, ''))
+  });
 };
 
 /**


### PR DESCRIPTION
Sorts `.NET` as `NET`

| Before | After |
| ----------- | ----------- |
| ![old](https://user-images.githubusercontent.com/6349682/215562693-3b993b24-c8fb-4603-a9e0-ec1ae80e0fde.gif)      | ![new](https://user-images.githubusercontent.com/6349682/215562697-49aed2cb-0246-4ad8-b5ff-37942f5232f1.gif)       |
