### PR TITLE
fix(unity): Screenshot capture mechanim

### DIFF
--- a/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
@@ -7,3 +7,7 @@ Or, like so, if you're [configuring things programatically](/platforms/unity/con
 ```csharp {tabTitle:ScriptableOptionsConfiguration}
 options.AttachScreenshot = true;
 ```
+
+## Screenshot capture mechanism
+
+The Unity SDK uses Unity's built-in [ScreenCapture](https://docs.unity3d.com/ScriptReference/ScreenCapture.html) functionality. This means that screenshots only contain things visible within your game. If you're for example using native plugins on Android or iOS to display overlays, those will not be visible on the screenshot.

--- a/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
@@ -10,4 +10,4 @@ options.AttachScreenshot = true;
 
 ## Screenshot capture mechanism
 
-The Unity SDK uses Unity's built-in [ScreenCapture](https://docs.unity3d.com/ScriptReference/ScreenCapture.html) functionality. This means that screenshots only contain things visible within your game. If you're for example using native plugins on Android or iOS to display overlays, those will not be visible on the screenshot.
+The Unity SDK uses Unity's built-in [ScreenCapture](https://docs.unity3d.com/ScriptReference/ScreenCapture.html) functionality to capture a screenshot. This means that screenshots only contain things visible within your game. If you're for example using native plugins on Android or iOS to display overlays, those will not be visible on the screenshot.


### PR DESCRIPTION
The Unity SDK does not simply "capture a screenshot" but instead captures what is currently visible on screen from there game's perspective. This means that overlays from native plugins won't be visible on the screenshot. Which is important for PII reasons.