### PR TITLE
fix(unity): Native screenshots

### DIFF
--- a/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/unity.mdx
@@ -10,4 +10,6 @@ options.AttachScreenshot = true;
 
 ## Screenshot capture mechanism
 
-The Unity SDK uses Unity's built-in [ScreenCapture](https://docs.unity3d.com/ScriptReference/ScreenCapture.html) functionality to capture a screenshot. This means that screenshots only contain things visible within your game. If you're for example using native plugins on Android or iOS to display overlays, those will not be visible on the screenshot.
+Since the Unity SDK internally consists of multiple SDKs, the mechanism with which a screenshot gets captured depends on where the error originates.
+- C# errors from within your game will be captured through Unity's built-in [ScreenCapture](https://docs.unity3d.com/ScriptReference/ScreenCapture.html). This means that screenshots only contain things visible within your game. Overlays on top of your game will not be visible.
+- Native errors get captured by their respective SDK. If you're using a native plugin to display an overlay and an error occurs then that SDK will try to capture a screenshot that contains the overlay.


### PR DESCRIPTION
Went into more detail on the difference of which SDK tries to capture a screenshot.