### PR TITLE
replay: move troubleshooting page

### DIFF
--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sidebar_order: 6000
 excerpt: ""
 description: "Troubleshooting Session Replay-specific Issues"
 redirect_from:

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -1,7 +1,21 @@
 ---
-title: Session Replay
+title: Troubleshooting
 excerpt: ""
 description: "Troubleshooting Session Replay-specific Issues"
+redirect_from:
+  - /platforms/javascript/troubleshooting/session-replay/
+  - /platforms/javascript/guides/angular/troubleshooting/session-replay/
+  - /platforms/javascript/guides/capacitor/troubleshooting/session-replay/
+  - /platforms/javascript/guides/cordova/troubleshooting/session-replay/
+  - /platforms/javascript/guides/ember/troubleshooting/session-replay/
+  - /platforms/javascript/guides/electron/troubleshooting/session-replay/  
+  - /platforms/javascript/guides/gatsby/troubleshooting/session-replay/
+  - /platforms/javascript/guides/nextjs/troubleshooting/session-replay/
+  - /platforms/javascript/guides/react/troubleshooting/session-replay/
+  - /platforms/javascript/guides/remix/troubleshooting/session-replay/
+  - /platforms/javascript/guides/svelte/troubleshooting/session-replay/
+  - /platforms/javascript/guides/vue/troubleshooting/session-replay/
+  - /platforms/javascript/guides/wasm/troubleshooting/session-replay/
 ---
 
 This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubleshooting</PlatformLink> guide covering Replay-specific scenarios.


### PR DESCRIPTION
Aligns with Performance that has its own troubleshooting doc at the root

# Before:
![image](https://user-images.githubusercontent.com/1633368/215837780-33f087ee-c115-4604-8ad4-b85cde8e31c4.png)


# After:
![image](https://user-images.githubusercontent.com/1633368/215863603-51bd8bd8-234c-4842-8c88-6d2a16719693.png)
