### PR TITLE
Update proguard docs

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -250,9 +250,9 @@ of Breakpad symbols.
 
 `sentry-cli` can be used to upload ProGuard files to Sentry; however, in most
 situations, you would use the [Gradle
-plugin](https://github.com/getsentry/sentry-android-gradle-plugin) to do that. There are some
-situations, however, where you would upload ProGuard files manually (for instance
-when you only release some of the builds you are creating).
+plugin](https://github.com/getsentry/sentry-android-gradle-plugin) to do that. Nevertheless, there may be
+situations where you would upload ProGuard files manually. For instance
+when you only release some of the builds you are creating.
 
 <Note>
 
@@ -265,23 +265,14 @@ because ProGuard files work on projects. For more information about this refer t
 The `upload-proguard` command is the one to use for uploading ProGuard files. It
 takes the path to one or more ProGuard mapping files and will upload them to
 Sentry.
-Example:
 
 ```bash
 sentry-cli upload-proguard \
     app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 
-Since the Android SDK needs to know the UUID of the mapping file, you need
-to associate it with the upload. If you supply `--uuid`, it sets that value:
-
-```bash
-sentry-cli upload-proguard \
-    --uuid A_VALID_UUID \
-    app/build/outputs/mapping/{BuildVariant}/mapping.txt
-```
-
-Which then also needs to be included in your `AndroidManifest.xml` file:
+Since the Android Sentry SDK needs to know the UUID of the mapping file, you need
+to associate it with the upload. However, you first have to place that UUID to the `AndroidManifest.xml` file:
 
 ```xml
 <application>
@@ -289,7 +280,17 @@ Which then also needs to be included in your `AndroidManifest.xml` file:
 </application>
 ```
 
-After the upload, Sentry deobfuscates future events. If you want to send an obfuscated crash to Sentry to verify the correct operation, ensure that the ProGuard mapping files are listed in _Project Settings > ProGuard_.
+The same UUID needs to be used to upload the mapping file:
+
+
+```bash
+sentry-cli upload-proguard \
+    --uuid A_VALID_UUID \
+    app/build/outputs/mapping/{BuildVariant}/mapping.txt
+```
+
+After the upload, Sentry deobfuscates future events. 
+To make sure that it worked, you can check _Project Settings > ProGuard_ if the upload mapping files are listed.
 
 ### Upload Options
 

--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -251,8 +251,8 @@ of Breakpad symbols.
 `sentry-cli` can be used to upload ProGuard files to Sentry; however, in most
 situations, you would use the [Gradle
 plugin](https://github.com/getsentry/sentry-android-gradle-plugin) to do that. Nevertheless, there may be
-situations where you would upload ProGuard files manually. For instance
-when you only release some of the builds you are creating.
+situations where you would upload ProGuard files manually. For instance,
+when you only release some of the builds you're creating.
 
 <Note>
 
@@ -272,7 +272,7 @@ sentry-cli upload-proguard \
 ```
 
 Since the Android Sentry SDK needs to know the UUID of the mapping file, you need
-to associate it with the upload. However, you first have to place that UUID to the `AndroidManifest.xml` file:
+to associate it with the upload. However, you first have to place that UUID into the `AndroidManifest.xml` file:
 
 ```xml
 <application>
@@ -290,7 +290,7 @@ sentry-cli upload-proguard \
 ```
 
 After the upload, Sentry deobfuscates future events. 
-To make sure that it worked, you can check _Project Settings > ProGuard_ if the upload mapping files are listed.
+To make sure that it worked, you can check _Project Settings > ProGuard_  and see if the upload mapping files are listed.
 
 ### Upload Options
 

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -6,7 +6,7 @@ description: "Learn about using the Sentry Gradle Plugin or sentry-cli to upload
 
 If you want to see de-obfuscated stack traces, you'll need to use [ProGuard](https://www.guardsquare.com/proguard) with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our [Gradle integration](/platforms/android/gradle/) or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 
-But either way, it works the same way. A (random) UUID will be or has to be generated and placed into the `AndroidManifest.xml`. The same UUID has to be used to upload the mapping file(s). In case a crash happens in the app, the Sentry Android SDK will, along with the stacktrace, send the UUID to the Sentry server instance. Sentry can now de-obfuscate the stacktrace by searching for the associated mapping file with the same UUID.
+It works the same either way. A (random) UUID will be or has to be generated and placed into the `AndroidManifest.xml`. The same UUID has to be used to upload the mapping file(s). In case a crash happens in the app, the Sentry Android SDK will send the UUID along with the stacktrace to the Sentry server instance. Sentry will then de-obfuscate the stacktrace by searching for the associated mapping file with the same UUID.
 
 Support for Guardsquare's ProGuard and [DexGuard](https://www.guardsquare.com/dexguard) was added in version 3.0.0 of the [Sentry Android Gradle Plugin](/platforms/android/gradle/).
 

--- a/src/platforms/android/common/proguard.mdx
+++ b/src/platforms/android/common/proguard.mdx
@@ -6,6 +6,8 @@ description: "Learn about using the Sentry Gradle Plugin or sentry-cli to upload
 
 If you want to see de-obfuscated stack traces, you'll need to use [ProGuard](https://www.guardsquare.com/proguard) with Sentry. To do so, upload the ProGuard mapping files by either the recommended method of using our [Gradle integration](/platforms/android/gradle/) or manually by using [sentry-cli](/product/cli/dif/#proguard-mapping-upload).
 
+But either way, it works the same way. A (random) UUID will be or has to be generated and placed into the `AndroidManifest.xml`. The same UUID has to be used to upload the mapping file(s). In case a crash happens in the app, the Sentry Android SDK will, along with the stacktrace, send the UUID to the Sentry server instance. Sentry can now de-obfuscate the stacktrace by searching for the associated mapping file with the same UUID.
+
 Support for Guardsquare's ProGuard and [DexGuard](https://www.guardsquare.com/dexguard) was added in version 3.0.0 of the [Sentry Android Gradle Plugin](/platforms/android/gradle/).
 
 <Note>


### PR DESCRIPTION
Hey guys 👋 

I enabled R8 in our Android app and found that the docs around this can be more precise.
So here we are 🙂 

I updated the Android -> Proguard page which includes a rough overview about how deobfuscating works.
I also updated the cli manual by reordering the examples.
It was abit missleading that you first explain "upload with UUID" and **afterwards** set it into the `AndroidManifest`.
Because the `AndroidManifest` needs the UUID **first**, otherwise you can't use the same UUID as the APK doesn't contain that UUID 🙃. And if you then add the UUID and build again *you might* have another mapping file and you have to upload the new mapping file again ♻️ . I hope you get the point 😬 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
