### PR TITLE
fix(apple): Remove master branch from migration

### DIFF
--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -7,7 +7,7 @@ To upgrade from version 4.x of the SDK to version 8.x of the SDK, you must first
 
 ## Migrating From 7.x to 8.x
 
-Migrating to 8.x from 7.x includes a few breaking changes. We provide this guide to help you update your SDK. It's important to note that this version adds a dependency to Swift, and that we renamed the default branch on the [sentry-cocoa repository](https://github.com/getsentry/sentry-cocoa) from `master` to `main`. We're keeping the `master` branch to ensure backwards compatibility for package managers that are pointing to the `master` branch.
+Migrating to 8.x from 7.x includes a few breaking changes. We provide this guide to help you update your SDK. It's important to note that this version adds a dependency to Swift, and that we renamed the default branch on the [sentry-cocoa repository](https://github.com/getsentry/sentry-cocoa) from `master` to `main`.
 
 ### Changes to Minimum OS Versions and Xcode
 


### PR DESCRIPTION
We decided to remove the master branch from the GH repo, as users pointing to it won't notice that we migrated to the main branch. Pointing to the master branch is considered a bit experimental cause you always point to the latest changes without relying on official SDK releases.
