### PR TITLE
ref(heroku): Update Heroku docs

### DIFF
--- a/src/docs/product/integrations/deployment/heroku/index.mdx
+++ b/src/docs/product/integrations/deployment/heroku/index.mdx
@@ -8,23 +8,13 @@ redirect_from:
 description: "Learn more about Sentry's Heroku integration."
 ---
 
-Sentry provides a native add-on for Heroku. While this add-on is not required, it will allow you to maintain consolidated billing inside of Heroku, as well as enable easy configuration of your Sentry credentials.
+Create releases in Sentry when your Heroku app is deployed.
 
 This integration needs to be set up in each project for which you wish to use it. It is maintained and supported by the [Sentry community](https://open.sentry.io/).
 
-## Install and Configure
-
-<Note>
-
-Sentry owner, manager, or admin permissions are required to install this integration.
-
-</Note>
-
-Navigate to **Settings > Integrations > Heroku**
-
-![Install Heroku integration](heroku.png)
-
 ### Register the Add-on
+
+Sentry provides a native add-on for Heroku. While this add-on is not required, it will allow you to maintain consolidated billing inside of Heroku, as well as enable easy configuration of your Sentry credentials.
 
 To add Sentry to an existing Heroku app, head over to the [Sentry Heroku add-on](https://elements.heroku.com/addons/sentry) page.
 
@@ -42,7 +32,7 @@ If you’re not using the add-on, you can still bind the `SENTRY_DSN` environmen
 
 ### Install the SDK
 
-Whether you’re using the add-on or not, you’ll still need to install the SDK per our standard platform-specific instructions.
+Whether you’re using the add-on or not, you’ll still need to [install the SDK](/platforms) per our standard platform-specific instructions.
 
 ### Configure Releases
 
@@ -56,7 +46,7 @@ heroku labs:enable runtime-dyno-metadata -a <app name>
 
 This exposes the `HEROKU_SLUG_COMMIT` environment variable, which most Sentry SDKs will automatically detect and use for configuration.
 
-Next, you’ll want to add your repository and set up a deploy hook:
+Next, you’ll want to add your repository and set up an app webhook:
 
 1.  Start by connecting your repository to your Sentry organization so we automatically retrieve your commit data. Find your repository integration (GitHub, GitLab, Bitbucket, for example) in **Settings > Integrations**. From the Configurations tab, click "Configure".
 
@@ -66,7 +56,7 @@ Next, you’ll want to add your repository and set up a deploy hook:
 
     ![Add repositories](heroku-repo-add.png)
 
-2.  Find the Heroku integration in **Settings > Integrations**, and click "Add to Project" then select the project you want to use with Heroku.
+2.  Find the Heroku integration in **Settings > Integrations**, click "Add to Project", then select the project you want to use with Heroku.
 
     ![Heroku integration details page](heroku-integration-detail.png)
 
@@ -74,8 +64,10 @@ Next, you’ll want to add your repository and set up a deploy hook:
 
     ![Heroku project configuration](heroku-project-config.png)
 
-4.  Navigate to your project’s Release settings and copy the deploy hook command to your Heroku config.
+4.  Navigate to your project’s Release settings and copy the app webhook Heroku cli command to your Heroku configuration.
 
     ![Heroku release configuration](heroku-config.png)
+
+5. After running the Heroku cli command you'll see a Webhooks Signing Secret. Copy and paste this into the "Webhook Secret" field in Sentry.
 
 You’ll start getting rich commit information and deploy emails with each new release, as well as tracking of which release issues were seen within.


### PR DESCRIPTION
Update the Heroku docs to include a line about copying the webhooks signing secret into your Sentry plugin configuration, as well as some small cleanups that confused me when I read through it. 