### PR TITLE
Need to set true boolean

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -535,7 +535,7 @@ _(New in version 7.30.0)_
 
 <ConfigKey name="include-local-variables" supported={["node"]}>
 
-Adds stack local variables to stack traces.
+Set this boolean to `true` to add stack local variables to stack traces.
 
 </ConfigKey>
 


### PR DESCRIPTION
https://develop.sentry.dev/sdk/features/#local-variables

develop docs say it should be `true` but maybe better that it should say "encouraged to be true". We opted not to for sensitive data concerns. But this is a minor point
