### PR TITLE
ref(data-scrubbing): Clarify rule preference

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing.mdx
@@ -7,7 +7,7 @@ keywords: ["pii", "gdpr", "personally identifiable data", "compliance"]
 description: "Learn about the data scrubbing Sentry enables by default."
 ---
 
-If you cannot - or do not want to - <PlatformLink to="/data-management/sensitive-data/">scrub data within the SDK</PlatformLink>, Sentry provides a number of options to achieve this in the product itself. You'll find these settings under the **Data Scrubber** option within both your Organization and individual Project settings. By default this is enabled, and we highly recommend you keep it that way.
+If you cannot - or do not want to - <PlatformLink to="/data-management/sensitive-data/">scrub data within the SDK</PlatformLink>, Sentry provides a number of options to achieve this in the product itself. You'll find these settings under the **Data Scrubber** option within both your Organization and individual Project settings (organization settings have preference over project settings). By default this is enabled, and we highly recommend you keep it that way.
 
 With it enabled, Sentry will scrub the following:
 


### PR DESCRIPTION
Rules from organizations have preference over rules from projects, see: 
https://github.com/getsentry/sentry/blob/bc89d976a0dbe0d169d7dedc072975befb6d2ff6/src/sentry/datascrubbing.py#L45