### PR TITLE
ref(replay): Add note about SVG `<use>` CORS limitations

### DIFF
--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -9,7 +9,7 @@ redirect_from:
   - /platforms/javascript/guides/capacitor/troubleshooting/session-replay/
   - /platforms/javascript/guides/cordova/troubleshooting/session-replay/
   - /platforms/javascript/guides/ember/troubleshooting/session-replay/
-  - /platforms/javascript/guides/electron/troubleshooting/session-replay/  
+  - /platforms/javascript/guides/electron/troubleshooting/session-replay/
   - /platforms/javascript/guides/gatsby/troubleshooting/session-replay/
   - /platforms/javascript/guides/nextjs/troubleshooting/session-replay/
   - /platforms/javascript/guides/react/troubleshooting/session-replay/
@@ -25,9 +25,15 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 There's currently no support for `canvas`. It's being tracked in this [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/6519). Feel free to 👍 and help us prioritize it.
 
-##  My Custom CSS/Images/Fonts/Media Aren't Appearing When I View the Replay
+## My Custom CSS/Images/Fonts/Media Aren't Appearing When I View the Replay
 
-The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site.  Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources. 
+The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site. Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources.
+
+<Alert>
+
+Due to [browser limitations](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use), SVGs containing `<use>` tags with links to your domain cannot be accessed from other origins, even if you add `sentry.io` to your CORS policy. This is a known issue and we are working on a solution.
+
+</Alert>
 
 ## Replay on My Bowser Extension Doesn't Work
 


### PR DESCRIPTION
This PR adds a note to the Replay Troubleshooting guide that SVGs with cross-origin-link `<use>` tags cannot be shown in the replayer due to a browser limitation.

ref: https://github.com/getsentry/sentry-javascript/issues/7020