### PR TITLE
chore(android): Clarify how to disable Timber integration

### DIFF
--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -54,7 +54,7 @@ However, you can still override the default behaviour by adding your own instanc
 
 ### Disable
 
-If you would like to disable the Timber integration (e.g. to not exceed your event quota), but keep using other auto-installation features, remove the `sentry-android-timber` dependency from the app configurations in `app/build.gradle`:
+If you want to disable the Timber integration (to not exceed your event quota, for example), but keep using other auto-installation features, remove the `sentry-android-timber` dependency from the app configurations in `app/build.gradle`:
 
 ```groovy
 configurations.configureEach {

--- a/src/platforms/android/configuration/integrations/timber.mdx
+++ b/src/platforms/android/configuration/integrations/timber.mdx
@@ -52,6 +52,22 @@ The Android SDK automatically adds the `SentryTimberIntegration` if the `sentry-
 
 However, you can still override the default behaviour by adding your own instance of the `SentryTimberIntegration`. For that, refer to the [manual installation](/platforms/android/configuration/integrations/timber/#configure) section below.
 
+### Disable
+
+If you would like to disable the Timber integration (e.g. to not exceed your event quota), but keep using other auto-installation features, remove the `sentry-android-timber` dependency from the app configurations in `app/build.gradle`:
+
+```groovy
+configurations.configureEach {
+  exclude group: "io.sentry", module: "sentry-android-timber"
+}
+```
+
+```kotlin
+configurations.configureEach {
+  exclude(group = "io.sentry", module = "sentry-android-timber")
+}
+```
+
 ## Manual Installation
 
 ### Install


### PR DESCRIPTION
Came up here https://github.com/getsentry/sentry-java/issues/2468, and apparently, we do not have an easy way to disable the timber integration, but keep using other auto-installation features. This is a workaround for now, until we implement the proper solution https://github.com/getsentry/sentry-android-gradle-plugin/issues/426