### PR TITLE
Remove non existing link to our Expo troubleshooting page

### DIFF
--- a/src/platform-includes/getting-started-install/react-native.mdx
+++ b/src/platform-includes/getting-started-install/react-native.mdx
@@ -14,7 +14,7 @@ If you are using Expo, see [How to Add Sentry to Your Expo Project](https://docs
 
 <Note>
 
-Make sure that the version of `@sentry/react-native` matches what `sentry-expo` depends on, [read more on our troubleshooting page](/platforms/react-native/troubleshooting/#expo).
+Make sure that the version of `@sentry/react-native` matches what `sentry-expo` depends on, [read more in Expo documentation](https://docs.expo.io/guides/using-sentry/).
 
 </Note>
 


### PR DESCRIPTION
The link in our docs doesn't exist anymore.