### PR TITLE
Clarify that Next.js `tunnelRoute` option does not work with self-hosted

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -428,6 +428,8 @@ const moduleExports = {
 
 Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.
 
+The `tunnelRoute` option does not work with self-hosted Sentry instances.
+
 Learn more about tunneling in the <PlatformLink to="/troubleshooting/#dealing-with-ad-blockers">troubleshooting section</PlatformLink>.
 
 ### Opt Out of Sentry SDK bundling in Client or Server side


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/7061#issuecomment-1418964265