### PR TITLE
Mention OTEL for WebFlux performance

### DIFF
--- a/src/platforms/java/guides/spring-boot/webflux.mdx
+++ b/src/platforms/java/guides/spring-boot/webflux.mdx
@@ -4,4 +4,4 @@ sidebar_order: 6
 description: "Learn more about using Spring WebFlux with Sentry."
 ---
 
-Similar to Spring MVC, Sentry offers support for Spring WebFlux. When developing a reactive web application, Sentry Spring Boot Starter creates the infrastructure required for capturing errors triggered during HTTP request processing.
+Similar to Spring MVC, Sentry offers support for Spring WebFlux. When developing a reactive web application, Sentry Spring Boot Starter creates the infrastructure required for capturing errors triggered during HTTP request processing. If you would like to use [performance monitoring](/product/performance/) with WebFlux, please take a look at our <PlatformLink to="/performance/instrumentation/opentelemetry/">OpenTelemetry integration</PlatformLink>.


### PR DESCRIPTION
Closes #6020 by directing users to use OpenTelemetry for WebFlux performance.