### PR TITLE
Update dotnet msbuild page

### DIFF
--- a/src/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/src/platforms/dotnet/common/configuration/msbuild.mdx
@@ -150,21 +150,6 @@ you do not need to upload them to Sentry separately.  In other words, use *eithe
 
 </ConfigKey>
 
-<ConfigKey name="SentryIncludeIntermediateOutputPath">
-
-When uploading symbols, the `bin` folder of each project is always searched for debug information files.
-Set this option to `true` to also search the `obj` folder.  Defaults to `false`.
-
-<Note>
-
-For some application types, such as those that use AOT compilation, this will collect significantly more
-files than you may expect.  Typically, these files are not needed for symbolication, but can add additional
-information for *native* crashes.
-
-</Note>
-
-</ConfigKey>
-
 <ConfigKey name="UseSentryCLI">
 
 Controls whether the Sentry CLI is enabled in your build.  `true` by default.


### PR DESCRIPTION
Remove `SentryIncludeIntermediateOutputPath`.  This was available only briefly. The default behavior is now to always use the `obj` folder.