### PR TITLE
ref: Add full border to table

### DIFF
--- a/src/css/_includes/type.scss
+++ b/src/css/_includes/type.scss
@@ -78,6 +78,9 @@
 
   table {
     @extend .table;
+    td, th {
+      border: $border-width solid $border-color;
+    }
   }
 
   dt + dd {


### PR DESCRIPTION
I haven't checked all the tables but here is the one I did check
https://sentry-docs-git-ref-table-border.sentry.dev/api/permissions/#organizations

It should apply to all tables

Before:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/363802/217169596-e5d9a02c-8195-4a6e-a266-d6000fd78414.png">


After:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/363802/217169510-cf7145fb-4e6e-41ec-a673-f99106c9379d.png">
