### PR TITLE
feat(perf-issues): document new threshold for consecutive db detector

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
@@ -22,6 +22,7 @@ The detector for this performance issue looks for a set of sequential, non-overl
 Once these spans are found, the following must also hold true:
 
 - Maximum time saved from parallelization must exceed a threshold
+- The ratio between the maximum time saved and the duration of the sequential spans must exceed a threshold
 - Total duration of each parallelizable span must exceed a threshold
 
 If Sentry isn't detecting a Consecutive DB issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.


### PR DESCRIPTION
A new threshold has been added to consec db detector recently, this PR documents the new threshold.