### PR TITLE
fix(ruby): Add explicit require in main getting started sample

### DIFF
--- a/src/platform-includes/getting-started-config/ruby.mdx
+++ b/src/platform-includes/getting-started-config/ruby.mdx
@@ -1,4 +1,6 @@
 ```ruby
+require 'sentry-ruby'
+
 Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'
   config.breadcrumbs_logger = [:sentry_logger, :http_logger]


### PR DESCRIPTION
fixes #5485 