### PR TITLE
Add Session Replay to Sentry docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@mdx-js/react": "^1.6.18",
     "@sentry-internal/global-search": "0.1.3",
     "@sentry/gatsby": "^7.36.0",
-    "@sentry/tracing": "^7.36.0",
     "@sentry/webpack-plugin": "^1.18.3",
     "@types/dompurify": "^2.0.3",
     "@types/node": "^12",

--- a/sentry.config.js
+++ b/sentry.config.js
@@ -1,0 +1,19 @@
+import * as Sentry from "@sentry/gatsby";
+
+const activeEnv =
+  process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
+
+Sentry.init({
+  debug: true,
+  dsn: process.env.SENTRY_DSN,
+  release: process.env.SENTRY_RELEASE,
+  integrations: [
+    new Sentry.Replay({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+  tracesSampleRate: activeEnv === "development" ? 0 : 1,
+  replaysSessionSampleRate: activeEnv === "development" ? 0 : 0.1,
+  replaysOnErrorSampleRate: activeEnv === "development" ? 0 : 1,
+});

--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -6,9 +6,6 @@ import resolveOpenAPI from "./utils/resolveOpenAPI";
 const packages = new PackageRegistry();
 const apps = new AppRegistry();
 
-const activeEnv =
-  process.env.GATSBY_ENV || process.env.NODE_ENV || "development";
-
 const root = `${__dirname}/../..`;
 
 process.env.DISABLE_THUMBNAILS = process.env.DISABLE_THUMBNAILS || "0";
@@ -83,11 +80,6 @@ const getPlugins = () => {
   const plugins = [
     {
       resolve: "@sentry/gatsby",
-      options: {
-        dsn: process.env.SENTRY_DSN,
-        release: process.env.SENTRY_RELEASE,
-        tracesSampleRate: activeEnv === "development" ? 0 : 1,
-      },
     },
     "gatsby-plugin-sharp",
     "gatsby-plugin-sass",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,7 +2204,7 @@
     "@sentry/types" "7.36.0"
     "@sentry/utils" "7.36.0"
 
-"@sentry/tracing@7.36.0", "@sentry/tracing@^7.36.0":
+"@sentry/tracing@7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.36.0.tgz#aa38319ed07f3b642134cf47da81f43df7835629"
   integrity sha512-5R5mfWMDncOcTMmmyYMjgus1vZJzIFw4LHaSbrX7e1IRNT/6vFyNeVxATa2ePXb9mI3XHo5f2p7YrnreAtaSXw==


### PR DESCRIPTION
Update to use https://docs.sentry.io/platforms/javascript/guides/gatsby/#sentry-configuration-file, so we can use the Replay integration.

I'm going to remove the plugin config docs, since folks should not be using this anymore (and add a deprecation message as well).