### PR TITLE
feat(otel): Move otel <-> Sentry transformation description to bottom of page

### DIFF
--- a/src/platforms/common/performance/instrumentation/opentelemetry.mdx
+++ b/src/platforms/common/performance/instrumentation/opentelemetry.mdx
@@ -44,11 +44,6 @@ There are multiple ways to configure your [OpenTelemetry SDK](https://openteleme
 
 </PlatformSection>
 
-## OpenTelemetry and Sentry
-
-This introduction is meant to help those who are familiar with OpenTelemetry, but new to Sentry become familiar with our naming conventions.
-With Sentry’s OpenTelemetry SDK, an OpenTelemetry `Span` becomes a Sentry `Transaction` or `Span`. The first `Span` sent through the Sentry `SpanProcessor` is a `Transaction`, and any child `Span` gets attached to the first `Transaction` upon checking the parent `Span` context. This is true for the OpenTelemetry root `Span` and any top level `Span` in the system. For example, a request sent from frontend to backend will create an OpenTelemetry root `Span` with a corresponding Sentry `Transaction`. The backend request will create a new Sentry `Transaction` for the OpenTelemetry `Span`. The Sentry `Transaction` and `Span` are linked as a trace for navigation and error tracking purposes.
-
 <PlatformSection notSupported={["java"]}>
 
 ## Install
@@ -118,6 +113,10 @@ You'll have to configure both OpenTelemetry and Sentry to see transactions in Se
 <PlatformContent includePath="performance/opentelemetry-setup/without-java-agent" />
 
 </PlatformSection>
+
+## OpenTelemetry and Sentry
+
+With Sentry’s OpenTelemetry SDK, an OpenTelemetry `Span` becomes a Sentry `Transaction` or `Span`. The first `Span` sent through the Sentry `SpanProcessor` is a `Transaction`, and any child `Span` gets attached to the first `Transaction` upon checking the parent `Span` context. This is true for the OpenTelemetry root `Span` and any top level `Span` in the system. For example, a request sent from frontend to backend will create an OpenTelemetry root `Span` with a corresponding Sentry `Transaction`. The backend request will create a new Sentry `Transaction` for the OpenTelemetry `Span`. The Sentry `Transaction` and `Span` are linked as a trace for navigation and error tracking purposes.
 
 ## Filtering
 


### PR DESCRIPTION
It can be a little overwhelming to see the wall of text when trying to set up the SDK. In order to make this process as easy as possible, move our description of span transformation to the bottom of the page, so users can still read it after they completed the installation process.