### PR TITLE
feat(scim): clarify that you can deprovision owners

### DIFF
--- a/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
+++ b/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
@@ -112,7 +112,7 @@ Here's how to assign an organization-level role to an Okta group:
   - Billing
   - Member
 - Invalid role names will prevent group members from being provisioned. To try again, you'll need to remove the group first.
-- For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry but are not provisioned through SCIM.
+- For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry, but aren't provisioned through SCIM.
   - For self-hosted users with custom roles, this extends to any role with the `org:admin` permission
 
 <Alert level="note">

--- a/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
+++ b/src/docs/product/accounts/sso/okta-sso/okta-scim.mdx
@@ -112,7 +112,7 @@ Here's how to assign an organization-level role to an Okta group:
   - Billing
   - Member
 - Invalid role names will prevent group members from being provisioned. To try again, you'll need to remove the group first.
-- For security reasons, the "Owner" role cannot be provisioned through SCIM.
+- For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry but are not provisioned through SCIM.
   - For self-hosted users with custom roles, this extends to any role with the `org:admin` permission
 
 <Alert level="note">


### PR DESCRIPTION
From Rodolfo:

> From the docs we cannot provision owners via SCIM, but this note is only under Configuring Organization-level Roles, which makes thing confusing as SCIM can (and will) remove owners from organisation if they are deprovisioned in the IdP.
> i managed to remove owners using the SCIM api with no problem:
> Can we can it be clarified in the docs and/or prevent it from happening?