### PR TITLE
fix(python): Remove legacy channels section from Troubleshooting

### DIFF
--- a/src/platforms/python/common/troubleshooting.mdx
+++ b/src/platforms/python/common/troubleshooting.mdx
@@ -29,9 +29,11 @@ taken. This is specially true when working with a code base doing concurrency
 outside of the provided framework integrations.
 
 The general recommendation is to have one hub per "concurrency unit"
-(thread/coroutine/etc). The SDK ensures every thread has an independent hub. If
-you do concurrency with `asyncio` coroutines, clone the current hub for use
-within a block that runs concurrent code:
+(thread/coroutine/etc). The SDK ensures every thread has an independent hub via the `ThreadingIntegration`.
+If you do concurrency with `asyncio` coroutines, make sure to use the `AsyncioIntegration`
+that will clone the current hub in your `Task`s.
+
+The general pattern of usage for cloning the hub is:
 
 ```python
 with Hub(Hub.current):
@@ -39,10 +41,6 @@ with Hub(Hub.current):
     # of the original hub, with the same client and
     # the same initial scope data.
 ```
-
-Issues with `asyncio` have then an easy workaround: every `asyncio` coroutine
-that really does run concurrently with other coroutines needs to be made into a
-task, then the hub needs to be cloned and reassigned.
 
 See the [Threading](../configuration/integrations/default-integrations/#threading) section
 for a more complete example that involves cloning the current hub.
@@ -114,13 +112,3 @@ be fixed from within the SDK.
 
 This [issue has been fixed with gevent 20.5](https://github.com/gevent/gevent/issues/1407) but continues to be one for
 eventlet.
-
-<PlatformSection supported={["python.django"]}>
-
-## Django Channels
-
-A Django application using Channels 2.0 will be correctly instrumented under Python 3.7. For older versions of Python, install `aiocontextvars` from PyPI or your application will not start.
-
-If you experience memory leaks in your channels' consumers while using the SDK, you need to wrap your entire application in [Sentry's ASGI middleware](/platforms/python/guides/asgi/). Unfortunately the SDK is not able to do so by itself, as [Channels is missing some hooks for instrumentation](https://github.com/django/channels/issues/1348).
-
-</PlatformSection>


### PR DESCRIPTION
* clarify new `AsyncioIntegration`
* Remove channels clarification since it adds to confusion

resolves #6261 