### PR TITLE
ref(replay): Update Replay CDN bundle descriptions

### DIFF
--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -11,14 +11,14 @@ yarn add @sentry/browser
 ```
 
 ```html {tabTitle: CDN}
-<!-- Recommended: Use this bundle for replay, error and performance monitoring -->
+<!-- Recommended: Use this bundle for replay, error, and performance monitoring -->
 <script
   src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.replay.min.js"
   integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.replay.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 
-<!-- Alternatively, you can use this bundle for just replay and error monitoring -->
+<!-- Alternatively, you can use this bundle for replay and error monitoring only -->
 <script
   src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.replay.min.js"
   integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.replay.min.js', 'sha384-base64') }}"

--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -11,10 +11,17 @@ yarn add @sentry/browser
 ```
 
 ```html {tabTitle: CDN}
+<!-- Recommended: Use this bundle for replay, error and performance monitoring -->
 <script
   src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.tracing.replay.min.js"
   integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.tracing.replay.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 
+<!-- Alternatively, you can use this bundle for just replay and error monitoring -->
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.replay.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.replay.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
 ```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -38,7 +38,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
 
   integrations: [
-    new Sentry.Integrations.Replay({
+    new Sentry.Replay({
       // Additional SDK configuration goes in here, for example:
       maskAllText: true,
       blockAllMedia: true,
@@ -61,11 +61,12 @@ Once you've added the integration, Replay will start automatically. If you don't
 ```js
 Sentry.init({
   // Note, Replay is NOT instantiated below:
-  integrations: []
+  integrations: [],
 });
 
 // Sometime later
-const { Replay } = await import('@sentry/browser');
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/browser");
+getCurrentHub()
+  .getClient()
+  .addIntegration(new Replay());
 ```
-

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -32,6 +32,18 @@ To use Sentry for error and performance monitoring, as well as for [Session Repl
 ></script>
 ```
 
+## Errors & Replay Bundle
+
+To use Sentry for error monitoring, as well as for [Session Replay](../../session-replay), but **not for performance monoitoring**, you can use the following bundle:
+
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.replay.min.js"
+  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.replay.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
 ## Errors-only Bundle
 
 If you only use Sentry for error monitoring, and don't need performance tracing or replay functionality, you can use the following bundle:

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -34,7 +34,7 @@ To use Sentry for error and performance monitoring, as well as for [Session Repl
 
 ## Errors & Replay Bundle
 
-To use Sentry for error monitoring, as well as for [Session Replay](../../session-replay), but **not for performance monoitoring**, you can use the following bundle:
+To use Sentry for error monitoring, as well as for [Session Replay](../../session-replay), but **not for performance monitoring**, you can use the following bundle:
 
 ```html {tabTitle: CDN}
 <script

--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -42,11 +42,13 @@ const replay = new Replay();
 
 // Load replay when you configure Sentry SDK
 Sentry.init({
-  integrations: [replay]
+  integrations: [replay],
 });
 
 // Or if you want to defer loading Replay
-getCurrentHub().getClient().addIntegration(replay);
+getCurrentHub()
+  .getClient()
+  .addIntegration(replay);
 
 // sometime later
 replay.stop();
@@ -54,15 +56,17 @@ replay.start();
 ```
 
 ```javascript {tabTitle: CDN}
-const replay = new Sentry.Integrations.Replay();
+const replay = new Sentry.Replay();
 
 // Load replay when you configure Sentry SDK
 Sentry.init({
-  integrations: [replay]
+  integrations: [replay],
 });
 
 // Or if you want to defer loading Replay
-Sentry.getCurrentHub().getClient().addIntegration(replay);
+Sentry.getCurrentHub()
+  .getClient()
+  .addIntegration(replay);
 
 // sometime later
 replay.stop();


### PR DESCRIPTION
This updates the replay installation/configuration docs with some of the recent changes/additions to the Replay CDN bundles.

With version 7.37.0:
* We now have an errors+replay CDN bundle, so we mention it in the Replay setup page
  * We also list it in the Sentry JS SDK installation page
* We update the namespace of the `Replay` integration so that people always use `Sentry.Replay` instead of `Sentry.Integrations.Replay`. Note: This change is backward-compatible, so people who previously used `Sentry.Integrations.Replay` will not be impacted.  

closes #6263