### PR TITLE
fix(rust): fix rust code for identify-users

### DIFF
--- a/src/platform-includes/enriching-events/set-user/rust.mdx
+++ b/src/platform-includes/enriching-events/set-user/rust.mdx
@@ -1,7 +1,7 @@
 ```rust
 sentry::configure_scope(|scope| {
     scope.set_user(Some(sentry::User {
-        email: "jane.doe@example.com".to_owned()
+        email: Some("jane.doe@example.com".to_owned()),
         ..Default::default()
     }));
 });


### PR DESCRIPTION
The old code snippet wouldn't compile, so this is a fix. 