### PR TITLE
feat(Python): Added docs for Python `asyncio` integration

### DIFF
--- a/src/platforms/python/common/configuration/integrations/asyncio.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncio.mdx
@@ -1,0 +1,38 @@
+---
+title: asyncio
+description: "Learn about the asyncio integration and how it adds support for applications the asyncio module."
+sidebar_order: 11
+---
+
+The `AsyncioIntegration` integrates with applications doing concurrent code execution using Pythons [asyncio](https://docs.python.org/3/library/asyncio.html) module.
+
+## Install
+
+```bash
+pip install --upgrade 'sentry-sdk'
+```
+
+## Configure
+
+Add `AsyncioIntegration()` to your `integrations` list:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        AsyncioIntegration(),
+    ],
+)
+```
+
+## Behavior
+
+- All unhandled exceptions in tasks will be captured
+- Every executed Task will be instrumented and show up in the performance waterfall on Sentry.io
+
+## Supported Versions
+
+- Python: 3.7+

--- a/src/platforms/python/common/configuration/integrations/index.mdx
+++ b/src/platforms/python/common/configuration/integrations/index.mdx
@@ -17,6 +17,7 @@ If you don't want integrations to be enabled automatically, set the `default_int
 ## Available Integrations
 
 - [ASGI](asgi/)
+- [asyncio](asyncio/)
 - [Enhanced Locals](pure_eval/)
 - [GNU Backtrace](gnu_backtrace/)
 - [HTTPX](httpx/)


### PR DESCRIPTION
Added missing documentation for the `asyncio` integration in the Python SDK.

NEW docs:
https://sentry-docs-git-antonpirker-python-asyncio-integration.sentry.dev/platforms/python/configuration/integrations/asyncio/