### PR TITLE
doc(grouping): Add `{` as escapable character

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
@@ -41,7 +41,7 @@ Now, all the events with the error type `DatabaseUnavailable` or `ConnectionErro
 
 Matchers allow you to use [glob patterns](<https://en.wikipedia.org/wiki/Glob_(programming)>).
 
-If you want to create a rule that includes square brackets `[ ]` or a literal `*`, escape them with a backslash; that is, `\[`, `\]` or `\*`.
+If you want to create a rule that includes brackets `[ ]`, braces `{ }` or a literal `*`, escape them with a backslash; that is, `\[`, `\]`, `\{`, `\}` or `\*`.
 
 The following matchers are available:
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/44408.
