### PR TITLE
making content class more specific

### DIFF
--- a/src/css/_includes/content.scss
+++ b/src/css/_includes/content.scss
@@ -1,4 +1,4 @@
-.content {
+div.content {
   height: 100%;
   width: 100%;
   padding-left: calc(18em - 15px);


### PR DESCRIPTION
there is a `.content` class style for padding being applied to parts of highlighted code in example blocks, so making this style specific to divs, as I believe that's the intent of it. I'm also not sure this class is being used in our docs anyway.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
