### PR TITLE
Update URL format in MSBuild doc

### DIFF
--- a/src/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/src/platforms/dotnet/common/configuration/msbuild.mdx
@@ -55,8 +55,9 @@ In addition to authentication, you must configure your Sentry organization and p
 You may also want to configure other [optional properties](#optional-msbuild-properties).
 
 The slugs can be found in various places from the Sentry UI, such as in the URL after selecting a project.
-For example, if the project URL is `https://sentry.io/organizations/example-org/projects/example-project/?project=1234567`,
-then the organization slug is `example-org` and the project slug is `example-project`.
+For example, the organization slug is `example-org` and the project slug is `example-project` in the following URLs:
+- `https://example-org.sentry.io/projects/example-project/?project=1234567`
+- `https://sentry.io/organizations/example-org/projects/example-project/?project=1234567`
 
 If you are self-hosting Sentry (rather than using sentry.io), then you will also need to provide the URL to your Sentry server.
 


### PR DESCRIPTION
Show both new and old URL formats for the org/project slug example.