### PR TITLE
feat(perf-issues): Add consec db thresholds to docs

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
@@ -21,9 +21,9 @@ The detector for this performance issue looks for a set of sequential, non-overl
 
 Once these spans are found, the following must also hold true:
 
-- Maximum time saved from parallelization must exceed a threshold (100ms)
-- The ratio between the maximum time saved and the duration of the sequential spans must exceed a threshold (0.1)
-- Total duration of each parallelizable span must exceed a threshold (30ms)
+- Maximum time saved from parallelization must exceed a 100ms threshold 
+- Ratio between the maximum time saved and the duration of the sequential spans must exceed a 0.1 threshold 
+- Total duration of each parallelizable span must exceed a 30ms threshold 
 
 If Sentry isn't detecting a Consecutive DB issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
 

--- a/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/consecutive-db-queries/index.mdx
@@ -21,9 +21,9 @@ The detector for this performance issue looks for a set of sequential, non-overl
 
 Once these spans are found, the following must also hold true:
 
-- Maximum time saved from parallelization must exceed a threshold
-- The ratio between the maximum time saved and the duration of the sequential spans must exceed a threshold
-- Total duration of each parallelizable span must exceed a threshold
+- Maximum time saved from parallelization must exceed a threshold (100ms)
+- The ratio between the maximum time saved and the duration of the sequential spans must exceed a threshold (0.1)
+- Total duration of each parallelizable span must exceed a threshold (30ms)
 
 If Sentry isn't detecting a Consecutive DB issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
 


### PR DESCRIPTION
Now that we're in GA, i've added the current thresholds to the doc.