### PR TITLE
replay: capacitor continue in beta

### DIFF
--- a/src/platforms/javascript/common/session-replay/index.mdx
+++ b/src/platforms/javascript/common/session-replay/index.mdx
@@ -37,6 +37,12 @@ We’re investigating possible performance degradation in <b>some</b> Angular ap
 </Alert>
 </PlatformSection>
 
+<PlatformSection supported={["javascript.capacitor"]}>
+ <Alert level="warning" title="Warning">
+ Session Replay is generally available for all Browser SDKs. Capacitor support is still in Beta. Feel free to reach <a href="https://github.com/getsentry/sentry-javascript/issues/6946">out on GitHub</a> if you experience issues.
+ </Alert>
+ </PlatformSection>
+
 ## Install
 
 <PlatformContent includePath="session-replay/install" />


### PR DESCRIPTION
# To be merged on Monday 13th


Very little testing went into Capacitor and we still have issues such as: https://github.com/getsentry/sentry-capacitor/issues/318

For that reason we'll keep Capacitor-only still in Beta until we get more validation.


To track GA: https://github.com/getsentry/sentry-capacitor/issues/319