### PR TITLE
doc(search): update searchable properties to include functionality reflected in search

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -139,7 +139,7 @@ Release properties overlap with event and issue search properties, so they don't
 | http.url | Full URL of the request that caused the error, but without any parameters | x | x |  | string |
 | id | The event or replay id. In **Issues**, use only the ID value without the `id` key. | x | x | x | uuid |
 | is | The properties of an issue. Values can be: `unresolved`, `resolved`, `ignored`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not. |  | x |  | status |
-| issue | The short issue code, for example `SENTRY-ABC`. | x |  |  | string |
+| issue | The short issue code, for example `SENTRY-ABC`. | x | x |  | string |
 | issue.category | The category of the issue (either `error` or `performance`). | | x |  | string |
 | last_seen() | Datetime when the event was last seen. Equivalent to `max(timestamp)`. Doesn't take a parameter. | x |  |  | datetime |
 | lastSeen | Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`. |  | x |  | datetime |
@@ -173,7 +173,8 @@ Release properties overlap with event and issue search properties, so they don't
 | percentile(field,level) | Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`. | x |  |  | number |
 | platform | Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`. | x |  | x | string |
 | platform.name | Name of the platform |  | x |  | string |
-| project | The name of the project. In **Issues** you can only search by project ID.<br></br><br></br>In some pages of [sentry.io](https://sentry.io), you filter on project using a dropdown. | x | x |  | string |
+| project | The name of the project. In some pages of [sentry.io](https://sentry.io), you can also filter on project using a dropdown. | x | x |  | string |
+| project.id | The id of the project.  | x | x |  | number |
 | pXY(duration field) | Returns results with an approximate percentile of the field. Replace "XY" with 50, 75, 95, 99, or 100. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `p50(transaction.duration)`. | x |  |  | number |
 | release | A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release. | x | x | x | string |
 | release.build | The number that identifies an iteration of your app. For example, `CFBundleVersion` on iOS or `versionCode` on Android. [Learn more](/product/releases/usage/sorting-filtering/). | x | x |  | number |


### PR DESCRIPTION
We recently made some changes to search to include some additional searchable properties. Updating the docs to reflect those changes.