### PR TITLE
feat(apple): Automatic breadcrumb for UIControl events

### DIFF
--- a/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
@@ -1,6 +1,5 @@
 The Cocoa SDK captures breadcrumbs automatically for:
   - Application lifecycle events (`didBecomeActive`, `didEnterBackground`, `viewDidAppear`)
-  - Touch events
   - UIControl events (with the exception of UITextField `.editingChanged`)
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests

--- a/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/apple.mdx
@@ -1,5 +1,6 @@
 The Cocoa SDK captures breadcrumbs automatically for:
   - Application lifecycle events (`didBecomeActive`, `didEnterBackground`, `viewDidAppear`)
   - Touch events
+  - UIControl events (with the exception of UITextField `.editingChanged`)
   - System events (battery level or state changed, memory warnings, device orientation changed, keyboard did show and did hide, screenshot taken)
   - Outgoing HTTP requests


### PR DESCRIPTION
Added UIControl events to the list of automatic breadcrumbs created by the SDK.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
