### PR TITLE
feat(android): Improve Android SDK docs entry point

### DIFF
--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -5,14 +5,13 @@ import { ArrowDown } from "react-feather";
 type Props = {
   title: string;
   children: any;
-  expanded?: boolean;
 };
 
 type ExpandedProps = {
-  expanded: boolean;
+  isExpanded: boolean;
 }
 
-const ExpandedIndicator = styled(ArrowDown)<{ isExpanded: boolean }>`
+const ExpandedIndicator = styled(ArrowDown) <ExpandedProps>`
   user-select: none;
   transition: transform 200ms ease-in-out;
   transform: rotate(${(p) => (p.isExpanded ? "180deg" : "0")});
@@ -20,22 +19,21 @@ const ExpandedIndicator = styled(ArrowDown)<{ isExpanded: boolean }>`
 `;
 
 const ExpandableBody = styled.div<ExpandedProps>`
-  display: ${props => (props.expanded ? 'block' : 'none')};
+  display: ${props => (props.isExpanded ? 'block' : 'none')};
 `
 
 export default ({
   title,
-  children,
-  expanded
+  children
 }: Props): JSX.Element => {
-  const [isExpanded, setIsExpanded] = useState(expanded === true);
+  const [isExpanded, setIsExpanded] = useState(false);
   return (
     <div className="note">
-      <p className="note-header expandable-header" onClick={() => {setIsExpanded(!isExpanded);}}>
+      <p className="note-header expandable-header" onClick={() => { setIsExpanded(!isExpanded); }}>
         {title}
         <ExpandedIndicator className="expandable-header-arrow" isExpanded={isExpanded} />
       </p>
-      <ExpandableBody expanded={isExpanded}>
+      <ExpandableBody isExpanded={isExpanded}>
         {children}
       </ExpandableBody>
     </div>

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { ArrowDown } from "react-feather";
+
+type Props = {
+  title: string;
+  children: any;
+  expanded?: boolean;
+};
+
+type ExpandedProps = {
+  expanded: boolean;
+}
+
+const ExpandedIndicator = styled(ArrowDown)<{ isExpanded: boolean }>`
+  user-select: none;
+  transition: transform 200ms ease-in-out;
+  transform: rotate(${(p) => (p.isExpanded ? "180deg" : "0")});
+  stroke-width: 3px;
+`;
+
+const ExpandableBody = styled.div<ExpandedProps>`
+  display: ${props => (props.expanded ? 'block' : 'none')};
+`
+
+export default ({
+  title,
+  children,
+  expanded
+}: Props): JSX.Element => {
+  const [isExpanded, setIsExpanded] = useState(expanded === true);
+  return (
+    <div className="note">
+      <p className="note-header expandable-header" onClick={() => {setIsExpanded(!isExpanded);}}>
+        {title}
+        <ExpandedIndicator className="expandable-header-arrow" isExpanded={isExpanded} />
+      </p>
+      <ExpandableBody expanded={isExpanded}>
+        {children}
+      </ExpandableBody>
+    </div>
+  );
+};

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -25,6 +25,7 @@ import PlatformIdentifier from "./platformIdentifier";
 import RelayMetrics from "./relayMetrics";
 import SandboxLink, { SandboxOnly } from "./sandboxLink";
 import { VimeoEmbed, YouTubeEmbed } from "./video";
+import Expandable from "./expandable";
 
 const mdxComponents = {
   Alert,
@@ -33,6 +34,7 @@ const mdxComponents = {
   CodeBlock,
   CodeTabs,
   ConfigKey,
+  Expandable,
   GuideGrid,
   Include,
   JsCdnTag,

--- a/src/css/_includes/alert.scss
+++ b/src/css/_includes/alert.scss
@@ -11,7 +11,9 @@
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
 
-  > h5 {
+  > h5, .alert-header, .note-header {
+    font-weight: bold;
+    position: relative;
     font-size: 1em;
     margin-bottom: 0.5rem;
     margin-top: 0.25rem;

--- a/src/css/_includes/expandable.scss
+++ b/src/css/_includes/expandable.scss
@@ -1,0 +1,7 @@
+.expandable-header {
+ cursor: pointer;
+}
+
+.expandable-header-arrow {
+  float: right;
+ }

--- a/src/css/screen.scss
+++ b/src/css/screen.scss
@@ -40,6 +40,7 @@
 @import "_includes/global-header";
 @import "_includes/breadcrumb";
 @import "_includes/alert";
+@import "_includes/expandable";
 @import "_includes/steps";
 @import "_includes/platform-specific-content";
 @import "_includes/interactive-content";

--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -1,9 +1,23 @@
-Configuration is done via `AndroidManifest.xml`:
-
+Configuration is done via the application `AndroidManifest.xml` Here's an example config which should get you started:
 ```xml {filename:AndroidManifest.xml}
 <application>
+  <!-- Required: set your sentry.io project identifier (DSN) -->
   <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
+
+  <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+  <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+  <!-- enable screenshot for crashes -->
+  <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
+  <!-- enable view hierarchy for crashes -->
+  <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
+
+  <!-- enable the performance API by setting a sample-rate -->
+  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+  <!-- enable profiling when starting transactions -->
+  <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 </application>
 ```
 
-Or, if you are manually instrumenting Sentry, follow the [Manual Initialization](/platforms/android/configuration/manual-init/) configuration.
+Under the hood Sentry uses a `ContentProvider` to initalize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
+
+If you want to customize the SDK init behaviour, you can still use the [Manual Initialization method](/platforms/android/configuration/manual-init/).

--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -11,13 +11,15 @@ Configuration is done via the application `AndroidManifest.xml` Here's an exampl
   <!-- enable view hierarchy for crashes -->
   <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
 
-  <!-- enable the performance API by setting a sample-rate -->
+  <!-- enable the performance API by setting a sample-rate, adjust in production env -->
   <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-  <!-- enable profiling when starting transactions -->
+  <!-- enable profiling when starting transactions, adjust in production env -->
   <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 </application>
 ```
 
 Under the hood Sentry uses a `ContentProvider` to initalize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
 
-If you want to customize the SDK init behaviour, you can still use the [Manual Initialization method](/platforms/android/configuration/manual-init/).
+Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
+
+If you want to customize the SDK init behaviour, you can still use the <PlatformLink to="/configuration/manual-init/">Manual Initialization method</PlatformLink>.

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -1,4 +1,4 @@
-The easiest way to get started is to install the Sentry Android Gradle Plugin. Simple add our Gradle plugin your app module's `build.gradle` file.
+The easiest way to get started is to install the Sentry Android Gradle plugin to your app module's `build.gradle` file.
 
 ```groovy {filename:app/build.gradle}
 buildscript {

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -1,6 +1,4 @@
-### Auto-Installation With the Sentry Android Gradle Plugin
-
-To install the plugin, add it your app module's `build.gradle` file:
+The easiest way to get started is to install the Sentry Android Gradle Plugin. Simple add our Gradle plugin your app module's `build.gradle` file.
 
 ```groovy {filename:app/build.gradle}
 buildscript {
@@ -8,74 +6,24 @@ buildscript {
     mavenCentral()
   }
 }
+
 plugins {
   id "com.android.application"
   id "io.sentry.android.gradle" version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
-```kotlin {filename:app/build.gradle}
+```kotlin {filename:app/build.gradle.kts}
 buildscript {
   repositories {
     mavenCentral()
   }
 }
+
 plugins {
   id("com.android.application")
   id("io.sentry.android.gradle") version "{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
 }
 ```
 
-The plugin will automatically add the latest version of the Sentry SDK for Android as a dependency.
-
-### Manual Installation
-
-If you don't want the Sentry Gradle plugin to install the Sentry SDK automatically for you, you can define the dependency directly to your `build.gradle` file:
-
-```groovy {filename:app/build.gradle}
-// Make sure mavenCentral is there.
-repositories {
-    mavenCentral()
-}
-
-// Enable Java 1.8 source compatibility if you haven't yet.
-android {
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-// Add Sentry's SDK as a dependency.
-dependencies {
-    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}'
-}
-```
-
-```kotlin {filename:app/build.gradle}
-// Make sure mavenCentral is there.
-repositories {
-    mavenCentral()
-}
-
-// Enable Java 1.8 source compatibility if you haven't yet.
-android {
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-// Add Sentry's SDK as a dependency.
-dependencies {
-    implementation("io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}")
-}
-```
-
-<Note>
-
-[NDK integration](/platforms/android/using-ndk/) is packed with the SDK and requires API level 16, though other levels are supported.
-
-If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
-
-</Note>
+The plugin version `{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` will automatically add the Sentry Android SDK (version `{{ packages.version('sentry.java.android', '4.2.0') }}`) to your app.

--- a/src/platform-includes/getting-started-primer/android.mdx
+++ b/src/platform-includes/getting-started-primer/android.mdx
@@ -1,46 +1,9 @@
-<Note>
+<Expandable title="Already using Sentry for Android? Here are some recent highlights">
 
-Sentry's Android SDK reports an error automatically whenever a thrown exception goes uncaught in your application causing the application to crash.
+Try out our new [Jetpack Compose](https://docs.sentry.io/platforms/android/configuration/integrations/jetpack-compose/) integration!
 
-The SDK builds a crash report that persists to disk and tries to send the report right after the crash. Since the environment may be unstable at the crash time, the report is guaranteed to send once the application is started again. This process for sending a report is true if there is a fatal error in your native code as well as for the NDK. In addition, the NDK is not only catching unhandled exceptions but is also set as a signal handler to react to signals from the OS.
+This feature is available starting from version `6.10.0` of the [Sentry Android SDK](https://docs.sentry.io/platforms/android/). It automatically adds a breadcrumb and starts a transaction for each navigation or user interaction event.
 
-</Note>
+Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-java/issues/new?assignees=&labels=Platform%3A+Android%2CType%3A+Bug&template=bug_report_android.yml).
 
-**Features:**
-
-- The Native Development Kit (NDK), the set of tools that that allows you to use C and C++ code with Android, is packed with the SDK.
-- Events [enriched](/platforms/android/enriching-events/context/) with device data
-- Offline caching when a device is offline; we send a report once the application is restarted
-- [Breadcrumbs automatically](/platforms/android/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for:
-  - Android activity lifecycle events
-  - Application lifecycle events (lifecycle of the application process)
-  - System events (low battery, low storage space, airplane mode started, shutdown, changes of the configuration, and so forth)
-  - App. component callbacks
-  - User Interactions (view click, scroll, swipe, etc.)
-  - Android fragment lifecycle events with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
-  - OkHttp requests with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
-  - Apollo requests with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
-  - Timber logs with [Timber Integration](/platforms/android/configuration/integrations/timber/)
-  - Navigation destination changes with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
-- [Release health](/product/releases/health/) tracks crash free users and sessions
-- [Attachments](/platforms/android/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files.
-- [User Feedback](/platforms/android/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs.
-- [Performance Monitoring](/product/performance/) creates transactions for:
-    - Android activity transactions
-    - User interaction transactions (view click, scroll, swipe, and so on)
-    - Navigation transactions with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
-    - Android fragment spans with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
-    - [Cold and warm app start](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
-    - [Slow and frozen frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
-    - OkHttp request spans with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
-    - SQLite and Room query spans with [Room and SQLite Integration](/platforms/android/configuration/integrations/room-and-sqlite/)
-    - File I/O spans with [File I/O Integration](/platforms/android/configuration/integrations/file-io/)
-    - Apollo request spans with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
-    - Distributed tracing through [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Apollo](/platforms/android/configuration/integrations/apollo/) integrations
-- [Application Not Responding (ANR)](/platforms/android/configuration/app-not-respond/) reported if the application is blocked for more than five seconds
-- [HTTP Client Errors](/platforms/android/configuration/integrations/okhttp/#http-client-errors)
-- [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/)
-- [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
-- Code samples provided in both Kotlin and Java as the Android SDK uses both languages
-- We provide a [sample application](https://github.com/getsentry/sentry-java/tree/master/sentry-samples/sentry-samples-android) for our Android users
-- Our [video tutorial](/platforms/android/android-video/) visually demonstrates how to set up our SDK
+</Expandable>

--- a/src/platforms/android/manual-configuration.mdx
+++ b/src/platforms/android/manual-configuration.mdx
@@ -1,0 +1,104 @@
+---
+title: Manual Configuration
+sidebar_order: 2
+description: "Learn how to manually configure the Sentry Android SDK."
+---
+<PlatformContent includePath="getting-started-primer" />
+
+<PlatformSection noGuides notSupported={["android", "dart", "elixir", "flutter", "perl", "react-native", "unity", "unreal"]}>
+
+<Alert level="info" title="Using a framework?">
+
+Get started using a guide listed in the right sidebar.
+
+</Alert>
+
+</PlatformSection>
+
+## Installation
+
+If you don't want the Sentry Gradle plugin to install the Sentry SDK automatically for you, you can define the dependency directly to your `build.gradle` file of your app module.
+
+```groovy {filename:app/build.gradle}
+// Make sure mavenCentral is there.
+repositories {
+    mavenCentral()
+}
+
+// Enable Java 1.8 source compatibility if you haven't yet.
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+// Add Sentry's SDK as a dependency.
+dependencies {
+    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}'
+}
+```
+
+```kotlin {filename:app/build.gradle.kts}
+// Make sure mavenCentral is there.
+repositories {
+    mavenCentral()
+}
+
+// Enable Java 1.8 source compatibility if you haven't yet.
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+// Add Sentry's SDK as a dependency.
+dependencies {
+    implementation("io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.2.0') }}")
+}
+```
+
+<Note>
+
+[NDK integration](/platforms/android/using-ndk/) is packed with the SDK and requires API level 16, though other levels are supported.
+
+If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+
+</Note>
+
+## Configuration
+
+<Note>
+
+Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+
+</Note>
+
+<PlatformContent includePath="getting-started-config" />
+
+## Verify
+
+<PlatformSection notSupported={["unreal"]}>
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+
+</PlatformSection>
+
+<PlatformContent includePath="getting-started-verify" />
+
+<Note>
+
+Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
+
+</Note>
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+
+<PlatformSection supported={["javascript", "node"]}>
+
+<PlatformContent includePath="getting-started-sourcemaps" />
+
+</PlatformSection>
+
+<PageGrid header="Next Steps" nextSteps />

--- a/src/platforms/android/manual-configuration.mdx
+++ b/src/platforms/android/manual-configuration.mdx
@@ -17,7 +17,7 @@ Get started using a guide listed in the right sidebar.
 
 ## Installation
 
-If you don't want the Sentry Gradle plugin to install the Sentry SDK automatically for you, you can define the dependency directly to your `build.gradle` file of your app module.
+If you don't want the Sentry Gradle plugin to install the Sentry SDK automatically, you can define the dependency directly in the `build.gradle` file of your app module.
 
 ```groovy {filename:app/build.gradle}
 // Make sure mavenCentral is there.
@@ -61,13 +61,13 @@ dependencies {
 
 <Note>
 
-[NDK integration](/platforms/android/using-ndk/) is packed with the SDK and requires API level 16, though other levels are supported.
-
-If you are using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
+The [NDK integration](/platforms/android/using-ndk/) comes packaged with the SDK and requires API level 16, though other levels are supported. If you're using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
 </Note>
 
 ## Configuration
+
+<PlatformContent includePath="getting-started-config" />
 
 <Note>
 
@@ -75,25 +75,23 @@ Don't already have an account and Sentry project established? Head over to [sent
 
 </Note>
 
-<PlatformContent includePath="getting-started-config" />
-
 ## Verify
 
 <PlatformSection notSupported={["unreal"]}>
 
-This snippet includes an intentional error, so you can test that everything is working as soon as you set it up:
+This snippet includes an intentional error, so you can test to make sure that everything's working as soon as you set it up:
 
 </PlatformSection>
 
 <PlatformContent includePath="getting-started-verify" />
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 <Note>
 
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
 </Note>
-
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 <PlatformSection supported={["javascript", "node"]}>
 

--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Android Native Development Kit (NDK)
-sidebar_order: 2
+sidebar_order: 3
 redirect_from:
   - /platforms/android/advanced-usage/
 description: "Learn how to configure the NDK integration."

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -22,7 +22,7 @@ Sentry captures data by using an SDK within your application’s runtime.
 
 ## Configure
 
-<PlatformSection notSupported={["unity", "unreal"]}>
+<PlatformSection notSupported={["android", "unity", "unreal"]}>
 
 Configuration should happen as early as possible in your application's lifecycle.
 

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -5,12 +5,6 @@ support_level: production
 type: framework
 ---
 
-> Using Jetpack Compose? Try out our new [Jetpack Compose](https://docs.sentry.io/platforms/android/configuration/integrations/jetpack-compose/) integration.
->  
-> This feature is available starting from version `6.10.0` of the [Sentry Android SDK](https://docs.sentry.io/platforms/android/). It automatically adds a breadcrumb and starts a transaction for each navigation or user interaction event.
->
-> Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-java/issues/new?assignees=&labels=Platform%3A+Android%2CType%3A+Bug&template=bug_report_android.yml).
-
 ## Integrating the SDK
 
 Sentry captures data by using an SDK within your application’s runtime. These are platform-specific and allow Sentry to have a deep understanding of how your app works.
@@ -21,7 +15,7 @@ The Sentry Android Gradle plugin will install the Android SDK and integrations r
 
 To install the plugin, please update your app's `build.gradle` file as follows:
 
-```groovy
+```groovy {filename:app/build.gradle}
 buildscript {
   repositories {
     mavenCentral()
@@ -32,48 +26,37 @@ plugins {
 }
 ```
 
-### Manual Installation
-
-If using the Gradle plugin is not an option, you can add the SDK manually.
-
-To install the Android SDK, please update your build.gradle file as follows:
-
-```groovy
-// Make sure mavenCentral is there.
-repositories {
-    mavenCentral()
-}
-
-// Enable Java 1.8 source compatibility if you haven't yet.
-android {
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-// Add Sentry's SDK as a dependency.
-dependencies {
-    implementation 'io.sentry:sentry-android:{{ packages.version('sentry.java.android', '4.0.0') }}'
-}
-```
+The plugin version `{{ packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` will automatically add the Sentry Android SDK (version `{{ packages.version('sentry.java.android', '4.2.0') }}`) to your app.
 
 ## Connecting the SDK to Sentry
 
-The code snippet below includes the DSN, which tells the SDK to send the events to this project.
+Configuration is done via the application `AndroidManifest.xml`. The code snippet below includes the DSN, which tells the SDK to send the events to this project.
 
-Add your DSN to the manifest file.
-
+Here's an example config which should get you started:
 ```xml {filename:AndroidManifest.xml}
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
-    <!-- Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-       We recommend adjusting this value in production. -->
-    <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-    <!-- Enable user interaction tracing to capture transactions for various UI events (such as clicks or scrolls). -->
-    <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+  <!-- Required: set your sentry.io project identifier (DSN) -->
+  <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
+
+  <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+  <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+  <!-- enable screenshot for crashes -->
+  <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
+  <!-- enable view hierarchy for crashes -->
+  <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
+
+  <!-- enable the performance API by setting a sample-rate, adjust in production env -->
+  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+  <!-- enable profiling when starting transactions, adjust in production env -->
+  <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 </application>
 ```
+
+Under the hood Sentry uses a `ContentProvider` to initalize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
+
+Additional options can be found [on our dedicated options page](/platforms/android/configuration/options/).
+
+If you want to customize the SDK init behaviour, you can still use the [Manual Initialization method](/platforms/android/configuration/manual-init/).
 
 ## Verifying Your Setup
 
@@ -149,4 +132,8 @@ Check out [the documentation](https://docs.sentry.io/platforms/android/performan
 
 Using ProGuard/DexGuard or R8 to obfuscate your app? Check out [our docs on how to set it up](https://docs.sentry.io/platforms/android/proguard/).
 
+Using Jetpack Compose? Try out our new [Jetpack Compose](https://docs.sentry.io/platforms/android/configuration/integrations/jetpack-compose/) integration. It automatically adds a breadcrumb and starts a transaction for each navigation or user interaction event.
+
 [The documentation](https://docs.sentry.io/platforms/android/configuration/) has more information about the many configurations and API available in Sentry's SDK.
+
+> Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-java/issues/new?assignees=&labels=Platform%3A+Android%2CType%3A+Bug&template=bug_report_android.yml).

--- a/src/wizard/android/index.md
+++ b/src/wizard/android/index.md
@@ -54,9 +54,9 @@ Here's an example config which should get you started:
 
 Under the hood Sentry uses a `ContentProvider` to initalize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
 
-Additional options can be found [on our dedicated options page](/platforms/android/configuration/options/).
+Additional options can be found [on our dedicated options page](https://docs.sentry.io/platforms/android/configuration/options/).
 
-If you want to customize the SDK init behaviour, you can still use the [Manual Initialization method](/platforms/android/configuration/manual-init/).
+If you want to customize the SDK init behaviour, you can still use the [Manual Initialization method](https://docs.sentry.io/platforms/android/configuration/manual-init/).
 
 ## Verifying Your Setup
 


### PR DESCRIPTION
Our Android SDK docs entry point is quite overwhelming. This is an attempt to make the "Getting Started" section more concise and easy to consume. Less text, more value 😉 

- Provide better default SDK configuration
- Split up automatic/manual configuration, choosing between those two is probably hard in the beginning. Let's default to automatic, as we can provide more value here
- Simplify first steps / remove huge text walls
- Added basic expandable widget to highlight recent changes (#5748)