### PR TITLE
Update Replay README.md wrong default values

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -16,7 +16,7 @@ The following options can be configured on the root level of your browser-based 
 
 | Key                      | Type   | Default | Description                                                                                                                                                                                                                                                       |
 | ------------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| replaysSessionSampleRate | number | `0.1`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. `1.0` collects all replays, and `0` collects none.                                                                                                      |
+| replaysSessionSampleRate | number | `0`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. `1.0` collects all replays, and `0` collects none.                                                                                                      |
 | replaysOnErrorSampleRate | number | `0`   | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. `1.0` captures all sessions with an error, and `0` captures none. |
 
 The following options can be configured as options to the integration, in `new Replay({})`:

--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -17,7 +17,7 @@ The following options can be configured on the root level of your browser-based 
 | Key                      | Type   | Default | Description                                                                                                                                                                                                                                                       |
 | ------------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | replaysSessionSampleRate | number | `0.1`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. `1.0` collects all replays, and `0` collects none.                                                                                                      |
-| replaysOnErrorSampleRate | number | `1.0`   | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. `1.0` captures all sessions with an error, and `0` captures none. |
+| replaysOnErrorSampleRate | number | `0`   | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. `1.0` captures all sessions with an error, and `0` captures none. |
 
 The following options can be configured as options to the integration, in `new Replay({})`:
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/6878 altered on version 7.33.0 the default to 0 but the docs still point as if the default was 1.0
