### PR TITLE
feat(browser): Add offline transport docs

### DIFF
--- a/src/platform-includes/configuration/offline/javascript.mdx
+++ b/src/platform-includes/configuration/offline/javascript.mdx
@@ -1,38 +1,12 @@
-```javascript {tabTitle: JavaScript}
+
+```javascript
 import * as Sentry from "@sentry/browser";
-import { Offline as OfflineIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new OfflineIntegration(
-    {
-      // limit how many events will be saved locally. Defaults to 30.
-      maxStoredEvents: number;
-    }
-  )],
-});
-```
-
-```javascript {tabTitle: CDN}
-<script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/bundle.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
-
-<script
-  src="https://browser.sentry-cdn.com/{{ packages.version('sentry.javascript.browser') }}/offline.min.js"
-  integrity="sha384-{{ packages.checksum('sentry.javascript.browser', 'offline.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.Integrations.Offline(
-    {
-      // limit how many events will be saved locally. Defaults to 30.
-      maxStoredEvents: number;
-    }
-  )],
-});
+  transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport)
+  transportOptions: {
+    // see below
+  }
+})
 ```

--- a/src/platforms/javascript/common/configuration/integrations/plugin.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pluggable Integrations
-description: "Learn more about pluggable integrations ExtraErrorData, CaptureConsole, Debug, HttpClient, Offline, RewriteFrames, and ReportingObserver, which are snippets of code that augment functionality for specific applications and/or frameworks."
+description: "Learn more about pluggable integrations ExtraErrorData, CaptureConsole, Debug, HttpClient, RewriteFrames, and ReportingObserver, which are snippets of code that augment functionality for specific applications and/or frameworks."
 redirect_from:
   - /platforms/javascript/integrations/plugin/
   - /platforms/javascript/pluggable-integrations/
@@ -69,20 +69,6 @@ Available options:
 Due to the limitations of both the Fetch and XHR API, the cookie and header collection for both requests and responses is based on best effort. Certain headers may be missing in the event created by the integration.
 
 </Alert>
-
-<PlatformSection notSupported={["javascript.electron"]}>
-
-### Offline
-
-_Import name: `Sentry.Integrations.Offline`_
-
-This integration uses the web browser's [online and offline events](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events) to detect when no network connectivity is available. If offline, it saves events to the web browser's client-side storage (typically IndexedDB), then automatically uploads events when network connectivity is restored.
-
-This plugin does not attempt to provide local storage or retries for other scenarios. For example, if the browser has a local area connection but no internet connection, then it may report that it's online, and Sentry's `Offline` plugin will not attempt to save or retry any send failures in this case:
-
-<PlatformContent includePath="configuration/offline" />
-
-</PlatformSection>
 
 ### RewriteFrames
 

--- a/src/platforms/javascript/common/configuration/transports.mdx
+++ b/src/platforms/javascript/common/configuration/transports.mdx
@@ -1,0 +1,67 @@
+---
+title: Transports
+sidebar_order: 30
+description: "Transports let you change the way in which events are delivered to Sentry."
+notSupported:
+  - javascript.capacitor
+  - javascript.cordova
+  - javascript.electron
+  - javascript.wasm
+---
+
+The JavaScript SDK uses a `transport` to send events to Sentry. On modern
+browsers, the default transport uses the browsers `fetch` API to send events.
+
+The default transports drop events if they fail to send due to a lack of connection.
+
+### Offline Caching
+
+If your JavaScript application is designed to continue working offline,
+dropping events when no connection is available could mean you are missing
+events that occur in that mode.
+
+To enable offline caching of events, `makeBrowserOfflineTransport` can be used
+to wrap existing transports and queue events in the browsers IndexedDB storage.
+Sending of events is then retried later.
+
+<PlatformContent includePath="configuration/offline" />
+
+This adds a number of optional properties to `transportOptions`:
+
+```javascript
+transportOptions:{
+  /**
+   * Name of IndexedDb database to store events
+   * Default: 'sentry-offline'
+   */
+  dbName: string;
+  /**
+   * Name of IndexedDb object store to store events
+   * Default: 'queue'
+   */
+  storeName: string;
+  /**
+   * Maximum number of events to store
+   * Default: 30
+   */
+  maxQueueSize: number;
+  /**
+   * Flush the store shortly after startup.
+   * Default: false
+   */
+  flushAtStartup: boolean;
+  /**
+   * Called before an event is stored.
+   * Return false to drop the envelope rather than store it.
+   *
+   * @param envelope The envelope that failed to send.
+   * @param error The error that occurred.
+   * @param retryDelay The current retry delay in milliseconds.
+   */
+  shouldStore: (envelope: Envelope, error: Error, retryDelay: number) => boolean | Promise<boolean>;
+}
+```
+
+#### Browser Support
+
+Offline caching is not supported in IE due to a lack of IndexedDB features.

--- a/src/platforms/javascript/common/configuration/transports.mdx
+++ b/src/platforms/javascript/common/configuration/transports.mdx
@@ -9,24 +9,21 @@ notSupported:
   - javascript.wasm
 ---
 
-The JavaScript SDK uses a `transport` to send events to Sentry. On modern
-browsers, the default transport uses the browsers `fetch` API to send events.
 
-The default transports drop events if they fail to send due to a lack of connection.
+The JavaScript SDK uses a `transport` to send events to Sentry. On modern browsers, most transports use the browsers' `fetch` API to send events. Transports will drop an event if it fails to send due to a lack of connection.
 
 ### Offline Caching
 
 If your JavaScript application is designed to continue working offline,
-dropping events when no connection is available could mean you are missing
-events that occur in that mode.
+dropping events when no connection is available and missing
+offline events, could mean you're missing important information.
 
-To enable offline caching of events, `makeBrowserOfflineTransport` can be used
-to wrap existing transports and queue events using the browsers IndexedDB storage.
-Sending of events is then retried later.
+To enable offline events caching, use `makeBrowserOfflineTransport` to wrap existing transports and queue events 
+using the browsers' IndexedDB storage. Once your application comes back online, all events will be sent together.
 
 <PlatformContent includePath="configuration/offline" />
 
-This adds a number of optional properties to `transportOptions`:
+Here are a few optional properties you can add to `transportOptions`:
 
 ```javascript
 transportOptions:{

--- a/src/platforms/javascript/common/configuration/transports.mdx
+++ b/src/platforms/javascript/common/configuration/transports.mdx
@@ -21,7 +21,7 @@ dropping events when no connection is available could mean you are missing
 events that occur in that mode.
 
 To enable offline caching of events, `makeBrowserOfflineTransport` can be used
-to wrap existing transports and queue events in the browsers IndexedDB storage.
+to wrap existing transports and queue events using the browsers IndexedDB storage.
 Sending of events is then retried later.
 
 <PlatformContent includePath="configuration/offline" />


### PR DESCRIPTION
This PR:
- Removes reference to the `Offline` integration since this will be deprecated
- Add a `Transports` section to the JavaScript configuration
  - Excludes this from sub-plartforms which already have their own specialised offline support
- Documents how to use `makeBrowserOfflineTransport` to create an offline transport

Does this need separate platform includes with differing imports for Angular/React/etc/etc? 