### PR TITLE
feat(node): Add warning about Node.js bug for `includeLocalVariables` option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -537,6 +537,17 @@ _(New in version 7.30.0)_
 
 Set this boolean to `true` to add stack local variables to stack traces.
 
+<Alert level="warning">
+
+Due to an [open Node.js issue](https://github.com/nodejs/node/issues/38439), we
+are currently unable to capture local variables for unhandled errors when using
+JavaScript modules (ESM).
+
+See the <PlatformLink to="/configuration/integrations/default-integrations/#localvariables">integration
+options</PlatformLink> for a workaround.
+
+</Alert>
+
 </ConfigKey>
 
 <PlatformSection supported={["javascript", "python", "node", "dart", "java", "apple"]}>

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -159,6 +159,34 @@ Available options:
   captureAllExceptions?: boolean;
 }
 ```
+<Alert level="warning">
+
+Due to an [open Node.js issue](https://github.com/nodejs/node/issues/38439), we
+are currently unable to capture local variables for unhandled errors when using
+JavaScript modules (ESM).
+
+You can work around this issue by wrapping your code in try/catch and
+enabling the `captureAllExceptions` option:
+
+```javascript
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    new Sentry.Integrations.LocalVariables({
+      captureAllExceptions: true,
+    }),
+  ],
+});
+
+try {
+  mainCode();
+} catch (e) {
+  Sentry.captureException(e);
+}
+```
+
+</Alert>
+
 
 ### Modules
 


### PR DESCRIPTION
This PR adds a warning to the `includeLocalVariables` option and also details a workaround in the integration options.

Ref https://github.com/getsentry/sentry-javascript/issues/7046