### PR TITLE
feat(gatsby): standardize gatsby docs

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.mdx
+++ b/src/platform-includes/getting-started-config/javascript.mdx
@@ -16,6 +16,5 @@ Sentry.init({
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production
   tracesSampleRate: 1.0,
-
 });
 ```

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -22,7 +22,7 @@ yarn add @sentry/gatsby
 
 </Note>
 
-First add `@sentry/gatsby` as a plugin to your `gatsby-config.js`.
+Register the `@sentry/gatsby` plugin in your Gatsby configuration file (typically `gatsby-config.js`).
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {
@@ -41,16 +41,11 @@ import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0, // Adjust this value in production
-  beforeSend(event) {
-    // Modify the event here
-    if (event.user) {
-      // Don't send user's email address
-      delete event.user.email;
-    }
-    return event;
-  },
-  // ...
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
 });
 ```
 
@@ -59,15 +54,10 @@ import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0, // Adjust this value in production
-  beforeSend(event) {
-    // Modify the event here
-    if (event.user) {
-      // Don't send user's email address
-      delete event.user.email;
-    }
-    return event;
-  },
-  // ...
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
 });
 ```

--- a/src/wizard/javascript/gatsby.md
+++ b/src/wizard/javascript/gatsby.md
@@ -17,20 +17,29 @@ npm install --save @sentry/gatsby
 
 ## Connecting the SDK to Sentry
 
-Register the plugin in your Gatsby configuration file (typically `gatsby-config.js`).
+Register the `@sentry/gatsby` plugin in your Gatsby configuration file (typically `gatsby-config.js`).
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {
-  // ...
   plugins: [
     {
       resolve: "@sentry/gatsby",
-      options: {
-        dsn: "___PUBLIC_DSN___",
-        sampleRate: 0.7,
-      },
     },
-    // ...
   ],
 };
+```
+
+Then, configure your `Sentry.init`:
+
+```javascript {filename:sentry.config.js}
+import * as Sentry from "@sentry/gatsby";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
 ```

--- a/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/gatsby/2.configure.md
@@ -9,7 +9,7 @@ type: language
 
 Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/gatsby/session-replay/).
 
-Include the `@sentry/gatsby` plugin:
+Register the `@sentry/gatsby` plugin in your Gatsby configuration file (typically `gatsby-config.js`).
 
 ```javascript {filename:gatsby-config.js}
 module.exports = {


### PR DESCRIPTION
Clean up our gatsby docs so that `Sentry.init` works the same for all platforms.