### PR TITLE
Fix tracingOrigins was renamed to tracePropagationTargets

### DIFF
--- a/src/platform-includes/performance/enable-tracing/react-native.mdx
+++ b/src/platform-includes/performance/enable-tracing/react-native.mdx
@@ -1,6 +1,6 @@
 <Alert level="Info" title="Prior Versions">
 
-If you use a version of our SDK prior to version `3.0.0`, you will need to include the `ReactNativeTracing` integration to use automatic instrumentation. You do not need to do this in versions `3.0.0` and above.
+If you use a version of our SDK prior to version `3.0.0`, you will need to include the `ReactNativeTracing` integration to use automatic instrumentation. You do not need to do this in versions `3.0.0` and above. The `tracingOrigins` option was renamed to `tracePropagationTargets` in version `4.9.0`.
 
 </Alert>
 
@@ -12,7 +12,7 @@ Sentry.init({
 
   integrations: [
     new Sentry.ReactNativeTracing({
-      tracingOrigins: ["localhost", "my-site-url.com", /^\//],
+      tracePropagationTargets: ["localhost", "my-site-url.com", /^\//],
       // ... other options
     }),
   ],

--- a/src/platform-includes/performance/enable-tracing/react-native.mdx
+++ b/src/platform-includes/performance/enable-tracing/react-native.mdx
@@ -1,6 +1,6 @@
 <Alert level="Info" title="Prior Versions">
 
-If you use a version of our SDK prior to version `3.0.0`, you will need to include the `ReactNativeTracing` integration to use automatic instrumentation. You do not need to do this in versions `3.0.0` and above. The `tracingOrigins` option was renamed to `tracePropagationTargets` in version `4.9.0`.
+If you use a version of our SDK prior to version `3.0.0`, you will need to include the `ReactNativeTracing` integration to use automatic instrumentation. You do not need to do this in versions `3.0.0` and above.
 
 </Alert>
 

--- a/src/platform-includes/performance/tracePropagationTargets-example/react-native.mdx
+++ b/src/platform-includes/performance/tracePropagationTargets-example/react-native.mdx
@@ -3,7 +3,7 @@ For example:
 - A frontend application is served from `example.com`
 - A backend service is served from `api.example.com`
 - The frontend application makes API calls to the backend
-- Therefore, the option needs to be configured like this: `new Sentry.ReactNativeTracing({tracingOrigins: ['api.example.com']})`
+- Therefore, the option needs to be configured like this: `new Sentry.ReactNativeTracing({tracePropagationTargets: ['api.example.com']})`
 - Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
 
 ```javascript
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.ReactNativeTracing({
-      tracingOrigins: ["localhost", "my-site-url.com"],
+      tracePropagationTargets: ["localhost", "my-site-url.com"],
     }),
   ],
 


### PR DESCRIPTION
Renamed in RN SDK 4.9.0