### PR TITLE
feat(Apple): SentrySwiftUI from cocoapod

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
@@ -17,7 +17,7 @@ target 'YourApp' do
 end
 ```
 
-> If you plan to add _SentrySwiftUI_, you don`t need to also add _Sentry_ library since the former dependents on the latter.
+> If you plan to add _SentrySwiftUI_, you don`t need to also add _Sentry_ library since the former depends on the latter.
 
 In order to start monitoring the performance of your views, you need to wrap it with `SentryTracedView`, like this:
 ```swift {tabTitle:Swift}

--- a/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
@@ -6,7 +6,17 @@ description: "Learn how to monitor the performance of your SwiftUI views."
 
 <Include name="beta-note.mdx" />
 
-You can monitor the performance of your views in a SwiftUI project with the SentrySwiftUI library, which you can install via <PlatformLink to="/install/swift-package-manager/">SPM (Swift package manager)</PlatformLink>.
+You can monitor the performance of your views in a SwiftUI project with the SentrySwiftUI library, which you can install via <PlatformLink to="/install/swift-package-manager/">SPM (Swift package manager)</PlatformLink> or cocoapod:
+
+
+```ruby
+platform :ios, '13.0'
+use_frameworks! # This is important
+
+target 'YourApp' do
+  pod 'SentrySwifUI', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
+end
+```
 
 > If you plan to add _SentrySwiftUI_, you don`t need to also add _Sentry_ library since the former dependents on the latter.
 

--- a/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
@@ -6,7 +6,7 @@ description: "Learn how to monitor the performance of your SwiftUI views."
 
 <Include name="beta-note.mdx" />
 
-You can monitor the performance of your views in a SwiftUI project with the SentrySwiftUI library, which you can install via <PlatformLink to="/install/swift-package-manager/">SPM (Swift package manager)</PlatformLink> or cocoapod:
+You can monitor the performance of your views in a SwiftUI project with the SentrySwiftUI library, which you can install via <PlatformLink to="/install/swift-package-manager/">SPM (Swift package manager)</PlatformLink> or CocoaPods:
 
 
 ```ruby

--- a/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
@@ -8,7 +8,6 @@ description: "Learn how to monitor the performance of your SwiftUI views."
 
 You can monitor the performance of your views in a SwiftUI project with the SentrySwiftUI library, which you can install via <PlatformLink to="/install/swift-package-manager/">SPM (Swift package manager)</PlatformLink> or CocoaPods:
 
-
 ```ruby
 platform :ios, '13.0'
 use_frameworks! # This is important


### PR DESCRIPTION
Updated the docs on how to install SentrySwiftUI to include cocoapod.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
