### PR TITLE
fix(replay): Fix bad unblock classname in privacy docs

### DIFF
--- a/src/docs/product/session-replay/protecting-user-privacy.mdx
+++ b/src/docs/product/session-replay/protecting-user-privacy.mdx
@@ -19,13 +19,13 @@ Below we expand on what data is potentially collected, how they are treated by d
 ### HTML Content
 To reduce the risk of Personally Identifiable Information (PII) being ingested and stored on our servers, Sentry’s Session Replay SDK is designed to be “private by default”. The Session Replay SDK in its default configuration redacts **all** HTML text nodes and images before it leaves the browser. During playback, redacted text nodes and images are clearly denoted using asterisks and static gray boxes, respectively.
 
-To see unredacted HTML content – for example, your static navigation items, menus, and links – you may additionally opt-in static HTML elements that are known not to contain PII by denoting those elements with `$classname`. It’s strongly recommended not to opt-in any known, user-generated content.
+To see unredacted HTML content – for example, your static navigation items, menus, and links – you may additionally opt-in static HTML elements that are known not to contain PII by denoting those elements with the `sentry-unmask` class name. It’s strongly recommended not to opt-in any known, user-generated content.
 
 ![Replay PII Scrubbing example](Replay-PIIScrubbing.png)
 
 Alternatively, you can turn off the default privacy configuration, which will cause all text nodes and images to be transferred unredacted. This is only recommended when working with static content websites known not to contain any sensitive user information. Note that when using this configuration option, failure to carefully identify HTML elements containing PII means risking sensitive content leaving the user’s browser.
 
-To learn more, including available configuration options, see [Session Replay Privacy](/platforms/javascript/session-replay/privacy/).
+To learn more, including other additional configuration options, see [Session Replay Privacy](/platforms/javascript/session-replay/privacy/).
 
 ### User Input
 


### PR DESCRIPTION
This placeholder was accidentally left in.