### PR TITLE
Fix typo MonogDB to MongoDB

### DIFF
--- a/src/platforms/python/common/configuration/integrations/pymongo.mdx
+++ b/src/platforms/python/common/configuration/integrations/pymongo.mdx
@@ -48,7 +48,7 @@ automatically.
 
 ## Behavior
 
-The following information about your MonogDB queries will be available to you on Sentry.io:
+The following information about your MongoDB queries will be available to you on Sentry.io:
 
 - Performance traces for all MongoDB queries
 - Breadcrumbs for all MongoDB queries


### PR DESCRIPTION
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
