### PR TITLE
Add `sentry.gradle` to all RN manual examples

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -97,6 +97,8 @@ You can also enable logging for `sentry-cli` by adding this config before the ab
 project.ext.sentryCli = [
     logLevel: "debug"
 ]
+
+apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 ```
 
 ### Fetch `sentry.properties`
@@ -108,6 +110,8 @@ project.ext.sentryCli = [
     logLevel: "debug",
     flavorAware: true
 ]
+
+apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 ```
 
 The corresponding flavor files should also be placed within the specific build type folder where you intend to use them. For example, the "Android demo release" flavor would be `react-native/android/sentry-demo-release.properties`.


### PR DESCRIPTION
The text note that the configuration must be before the `apply` call can be easily overlooked. 

Showing the code with the `apply` ensures the correct order when users copy the code snippets.

Context: https://discord.com/channels/621778831602221064/750735628932612096/1076132995494326322