### PR TITLE
chore(regex): Add note about escaping punctuation characters

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -54,7 +54,7 @@ Rules generally consist of three parts:
   - Do not write `/[a-zA-Z0-9]+/g`, as that will search for a literal `/` and `/g`.
   - For case-insensitivity, prefix your regex with `(?i)`.
   - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/), Golang is usually closest to how Sentry understands your regex.
-  - Escape using `\`, e.g. `\*` literal *, works for any punctuation character: `\.+*?()|[]{}^$`.
+  - Escape using `\`, e.g. `\*` literal `*`, works for any punctuation character: `\.+*?()|[]{}^$`.
 
 - _Credit Card Numbers_: Any substrings that look like credit card numbers.
 - _Password Fields_: Any substrings that look like they may contain passwords. Any string that mentions passwords, auth tokens or credentials, any variable that is called `password` or `auth`.

--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -54,7 +54,7 @@ Rules generally consist of three parts:
   - Do not write `/[a-zA-Z0-9]+/g`, as that will search for a literal `/` and `/g`.
   - For case-insensitivity, prefix your regex with `(?i)`.
   - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/), Golang is usually closest to how Sentry understands your regex.
-  - Escape using `\`, e.g. `\*` literal `*`, works for any punctuation character: `\.+*?()|[]{}^$`.
+  - Escape using `\`, e.g. `\*` is a literal `*`. This works for any of the following character: `\.+*?()|[]{}^$`.
 
 - _Credit Card Numbers_: Any substrings that look like credit card numbers.
 - _Password Fields_: Any substrings that look like they may contain passwords. Any string that mentions passwords, auth tokens or credentials, any variable that is called `password` or `auth`.

--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -54,6 +54,7 @@ Rules generally consist of three parts:
   - Do not write `/[a-zA-Z0-9]+/g`, as that will search for a literal `/` and `/g`.
   - For case-insensitivity, prefix your regex with `(?i)`.
   - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/), Golang is usually closest to how Sentry understands your regex.
+  - Escape using `\`, e.g. `\*` literal *, works for any punctuation character: `\.+*?()|[]{}^$`.
 
 - _Credit Card Numbers_: Any substrings that look like credit card numbers.
 - _Password Fields_: Any substrings that look like they may contain passwords. Any string that mentions passwords, auth tokens or credentials, any variable that is called `password` or `auth`.

--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -54,7 +54,7 @@ Rules generally consist of three parts:
   - Do not write `/[a-zA-Z0-9]+/g`, as that will search for a literal `/` and `/g`.
   - For case-insensitivity, prefix your regex with `(?i)`.
   - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/), Golang is usually closest to how Sentry understands your regex.
-  - Escape using `\`, e.g. `\*` is a literal `*`. This works for any of the following character: `\.+*?()|[]{}^$`.
+  - Escape using `\`, e.g. `\*` is a literal `*`. This works for any of the following characters: `\.+*?()|[]{}^$`.
 
 - _Credit Card Numbers_: Any substrings that look like credit card numbers.
 - _Password Fields_: Any substrings that look like they may contain passwords. Any string that mentions passwords, auth tokens or credentials, any variable that is called `password` or `auth`.


### PR DESCRIPTION
Add the mention about how and what to escape in the regexes. 


related: https://github.com/getsentry/relay/issues/1836