### PR TITLE
fix(apple): Replace iOS 9 with 11 for pods

### DIFF
--- a/src/platform-includes/getting-started-install/apple.ios.mdx
+++ b/src/platform-includes/getting-started-install/apple.ios.mdx
@@ -3,7 +3,7 @@ The minimum version for iOS is 9.0.
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do

--- a/src/platform-includes/getting-started-install/apple.mdx
+++ b/src/platform-includes/getting-started-install/apple.mdx
@@ -1,7 +1,7 @@
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 
 ```ruby {filename:Podfile}
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do

--- a/src/platforms/apple/common/install/cocoapods.mdx
+++ b/src/platforms/apple/common/install/cocoapods.mdx
@@ -6,7 +6,7 @@ description: "Learn about installing the Sentry SDK with CocoaPods."
 We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do

--- a/src/wizard/apple/index.md
+++ b/src/wizard/apple/index.md
@@ -8,7 +8,7 @@ type: language
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -8,7 +8,7 @@ type: language
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do

--- a/src/wizard/apple/macos.md
+++ b/src/wizard/apple/macos.md
@@ -8,7 +8,7 @@ type: language
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your _Podfile_:
 
 ```ruby
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks! # This is important
 
 target 'YourApp' do


### PR DESCRIPTION
Since Cocoa 8.0.0 the min iOS version is 11, so we can bump it for the podfiles as well.


Follow up on https://github.com/getsentry/sentry-docs/pull/6334.