### PR TITLE
fix(apple): Typo for SwiftUI for CocoaPods

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/swiftui-instrumentation.mdx
@@ -13,7 +13,7 @@ platform :ios, '13.0'
 use_frameworks! # This is important
 
 target 'YourApp' do
-  pod 'SentrySwifUI', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
+  pod 'SentrySwiftUI', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{ packages.version('sentry.cocoa') }}'
 end
 ```
 


### PR DESCRIPTION
SentrySwiftUI instead of SentrySwifUI.