### PR TITLE
ref(replay): Flush before manually stopping recording

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -16,8 +16,8 @@ The following options can be configured on the root level of your browser-based 
 
 | Key                      | Type   | Default | Description                                                                                                                                                                                                                                                       |
 | ------------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| replaysSessionSampleRate | number | `0`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. `1.0` collects all replays, and `0` collects none.                                                                                                      |
-| replaysOnErrorSampleRate | number | `0`   | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. `1.0` captures all sessions with an error, and `0` captures none. |
+| replaysSessionSampleRate | number | `0`     | The sample rate for replays that begin recording immediately and last the entirety of the user's session. `1.0` collects all replays, and `0` collects none.                                                                                                      |
+| replaysOnErrorSampleRate | number | `0`     | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. `1.0` captures all sessions with an error, and `0` captures none. |
 
 The following options can be configured as options to the integration, in `new Replay({})`:
 
@@ -51,7 +51,9 @@ getCurrentHub()
   .addIntegration(replay);
 
 // sometime later
+await replay.flush(); // wait for any pending recording data to be sent
 replay.stop();
+
 replay.start();
 ```
 
@@ -69,7 +71,9 @@ Sentry.getCurrentHub()
   .addIntegration(replay);
 
 // sometime later
+await replay.flush(); // wait for any pending recording data to be sent
 replay.stop();
+
 replay.start();
 ```
 


### PR DESCRIPTION
Before stopping recording manually, users should flush one more time to not loose any recording data before the `stop` call.

This came up in https://github.com/getsentry/sentry-javascript/issues/7255