### PR TITLE
ref(node): Mention limitation around Apollo intergation

### DIFF
--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -71,3 +71,6 @@ If you use `NestJs`, initialize the integration with the `useNestjs` option
 ```javascript
 new Tracing.Integrations.Apollo({ useNestjs: true });
 ```
+
+**Known Limitation:**
+This integration does not support Apollo servers where the schema was loaded using the `schema` property (`new ApolloServer({ schema: ... })`).


### PR DESCRIPTION
Since I'm already working on docs today, this PR adds a quick note around a limitation of our `Apollo` integration.

I don't have a lot of context around this integration, so not sure if we can offer an alternative path what to do to get the integration working.

closes #6346 