### PR TITLE
docs(metric-alerts): Explain available search properties

### DIFF
--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -85,6 +85,10 @@ For some metric alerts, you can set the event type that you want to be alerted a
 
 Add filters in the field provided to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available fields depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction alerts, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
+#### Invalid Properties
+
+Sentry will not allow you to create filters that include invalid or unavailable fields. However, this does not affect pre-existing alerts. Pre-existing alerts that use an unavailable fields will continue to work, however you will not be able to edit them or duplicate them without removing the unavailable properties.
+
 ## Thresholds
 
 There are two threshold types:

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -81,13 +81,13 @@ For some metric alerts, you can set the event type that you want to be alerted a
 - `event.type:error`
 - `event.type:transaction`
 
-### Tags & Attributes
+### Tags & Properties
 
-Add filters in the field provided to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available fields depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction alerts, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
+Add filters in the provided input to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available properties depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
 #### Invalid Properties
 
-Sentry will not allow you to create filters that include invalid or unavailable fields. However, this does not affect pre-existing alerts. Pre-existing alerts that use an unavailable fields will continue to work, however you will not be able to edit them or duplicate them without removing the unavailable properties.
+Sentry will not allow you to create alerts that include invalid or unavailable properties. However, this does not affect pre-existing alerts. Pre-existing alerts that use unavailable fields will continue to work, however you will have not be able to edit them or duplicate them without removing the unavailable properties.
 
 ## Thresholds
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -83,7 +83,7 @@ For some metric alerts, you can set the event type that you want to be alerted a
 
 ### Tags & Properties
 
-Add filters in the provided input to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available properties depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
+Add filters in the provided input to narrow down what you'll be alerted about, such as URL tags or other event properties. Available properties depend on your alert's event type. For error events, all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
 #### Invalid Filters
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -85,7 +85,7 @@ For some metric alerts, you can set the event type that you want to be alerted a
 
 Add filters in the provided input to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available properties depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
-#### Invalid Properties
+#### Invalid Filters
 
 Sentry will not allow you to create alerts that include invalid or unavailable properties. However, this does not affect pre-existing alerts. Pre-existing alerts that use unavailable fields will continue to work, however you will have not be able to edit them or duplicate them without removing the unavailable properties.
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -83,7 +83,7 @@ For some metric alerts, you can set the event type that you want to be alerted a
 
 ### Tags & Attributes
 
-Add filters in the field provided to narrow down what you'll be alerted about, such as URL, tags, or other event properties.
+Add filters in the field provided to narrow down what you'll be alerted about, such as URL, tags, or other event properties. Available fields depend on your alert's event type. For error events all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction alerts, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
 ## Thresholds
 

--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -87,7 +87,7 @@ Add filters in the provided input to narrow down what you'll be alerted about, s
 
 #### Invalid Filters
 
-Sentry will not allow you to create alerts that include invalid or unavailable properties. However, this does not affect pre-existing alerts. Pre-existing alerts that use unavailable fields will continue to work, however you will have not be able to edit them or duplicate them without removing the unavailable properties.
+While Sentry won’t allow you to create new alerts with invalid or unavailable properties, any existing alerts with unavailable fields won’t be affected. But if you need to edit or duplicate them, you'll need to remove the unavailable properties.
 
 ## Thresholds
 


### PR DESCRIPTION
Adds some documentation to explain which fields are available for metric alert filters, and what happens if you try to use an unavailable filter.
