### PR TITLE
feat(replay): More detail for performance overhead

### DIFF
--- a/src/docs/product/session-replay/performance-overhead.mdx
+++ b/src/docs/product/session-replay/performance-overhead.mdx
@@ -6,10 +6,21 @@ description: "Session Replay SDK performance overhead."
 
 <Include name="beta-note-session-replay.mdx" />
 
-Sentry’s Session Replay SDK takes several steps to avoid negatively impacting the performance of the page on which it’s running:
+Session Replay works by observing and recording changes to your web application's DOM, and transmitting that data to event ingestion servers over the public internet. In order to perform this work without negatively impacting the host page's performance, the Session Replay SDK takes care to introduce minimal additional filesize, observe and record DOM content in a non-intrusive way, send the absolute minimum number of bytes required, and use low-latency ingestion endpoints geographically close to your end-users.
 
-- At the time of publishing this document, the Session Replay plugin is an additional ~36KB gzipped. In our own research, this is among the smallest Session Replay SDKs available.
+**For most web applications, the performance overhead of our client SDK is imperceptible to end-users.**
+
+Below, you can learn more about the individual measures we've taken to ensure smooth performance of our Session Replay SDK.
+
+## How is Session Replay optimized?
+
+Sentry's Session Replay SDK takes several measures to avoid negatively impacting the performance of the page on which it's running:
+
+- At the time of publishing this document, the Session Replay plugin is an additional ~36KB gzipped.
+    - In our own research, this is among the smallest filesize Session Replay SDKs available.
+    - We provide multiple ways to load the Replay bundle, including [directly from our CDN](https://docs.sentry.io/platforms/javascript/install/cdn/).
 - The Session Replay SDK works by snapshotting the web page’s Document Object Model (DOM) and transmitting its content to Sentry’s servers. To minimize the amount of bytes transferred, multiple strategies are employed:
-    - Once the initial DOM tree is snapshotted, the SDK records and transmits *changes* to the DOM rather than snapshotting the entire tree again. This significantly reduces the amount of bytes transferred.
+    - Once the initial DOM tree is snapshotted, the SDK records and transmits *changes* (deltas) to the DOM rather than snapshotting the entire tree again. This ensures the smallest amount of state is transmitted to facilitate playback. Additionally, the SDK does not spend CPU cycles scanning for changes itself; instead it listens for changes emitted by [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver), an internal browser API.
     - DOM content itself is gzip compressed client-side before transmission over HTTP. The compression operation is executed in a background thread using a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers), which means the browser’s UI thread is unaffected.
+    - The SDK does not cause the browser to download and transmit other static assets, like images, video, etc. Instead during playback, those assets are fetched directly from the original host server.
 - Sentry’s event ingestion infrastructure uses [distributed Points-of-Presence (PoPs)](https://blog.sentry.io/2022/03/31/sentry-points-of-presence-how-we-built-a-distributed-ingestion/) which place ingestion servers around the world and close to your users. When a Session Replay event is transmitted, the user’s browser connects and transmits the event payload to the closest PoP available for their region. This greatly reduces end-to-end latency and minimizes the amount of networking overhead placed on the browser.


### PR DESCRIPTION
Users had commented that our performance overhead page lacked sufficient detail. I've added some new high-level statements to open this section and expanded detail in the bullet point items.