### PR TITLE
aspnet: remove out of support dotnet snippets

### DIFF
--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -101,44 +101,7 @@ ASP.NET Core will automatically read this environment variable and bind it to th
 
 When configuring the SDK via the frameworks configuration system, it's possible to add the SDK by simply calling `UseSentry` without providing any further information:
 
-ASP.NET Core 2.x:
-
-```csharp
-public static IWebHost BuildWebHost(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        // Add the following line:
-        .UseSentry()
-```
-
-```fsharp
-let CreateHostBuilder args =
-    WebHost.CreateDefaultBuilder(args)
-        // Add the following line:
-        .UseSentry()
-```
-
-ASP.NET Core 3.0:
-
-```csharp
-public static IHostBuilder CreateHostBuilder(string[] args) =>
-    Host.CreateDefaultBuilder(args)
-        .ConfigureWebHostDefaults(webBuilder =>
-        {
-            // Add the following line:
-            webBuilder.UseSentry();
-        });
-```
-
-```fsharp
-let CreateHostBuilder args =
-    Host.CreateDefaultBuilder(args)
-        .ConfigureWebHostDefaults(fun webBuilder ->
-            // Add the following line:
-            webBuilder.UseSentry() |> ignore
-        )
-```
-
-ASP.NET Core 6.0 With minimal API:
+ASP.NET Core with minimal API:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
