### PR TITLE
Add quotes around rust crate version

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -210,7 +210,7 @@ In order to use Profiling, you first need to enable the `profiling` feature in t
 
 ```cargo
 [dependencies]
-sentry = { version = {{ packages.version('sentry.rust') }}, features = ["profiling"] }
+sentry = { version = "{{ packages.version('sentry.rust') }}", features = ["profiling"] }
 ```
 
 Once you've completed the step above, you can proceed by enabling it in the SDK:

--- a/src/wizard/rust/profiling-onboarding/rust/1.install.md
+++ b/src/wizard/rust/profiling-onboarding/rust/1.install.md
@@ -11,5 +11,5 @@ For the Profiling integration to work, you must have the Sentry Rust SDK crate (
 
 ```toml {filename:Cargo.toml}
 [dependencies]
-sentry = { version = {{ packages.version('sentry.rust') }}, features = ["profiling"] }
+sentry = { version = "{{ packages.version('sentry.rust') }}", features = ["profiling"] }
 ```


### PR DESCRIPTION
This should make it possible to paste the snippet directly into the config. Config.toml requires that rust version should be a string. 