### PR TITLE
update some feature lists for lack of watchOS support

### DIFF
--- a/src/docs/product/projects/index.mdx
+++ b/src/docs/product/projects/index.mdx
@@ -18,7 +18,7 @@ The project homepage lists the projects by teams of which you're a member, provi
 
 - A snapshot of both errors and transactions
 - The team and team members associated with each project (remember, projects can be associated to multiple teams, so a project may be listed more than once)
-- The percentage of crash free sessions (if you have configured [release health](/product/releases/health/)) (unavailable on watchOS; no Mach exception support on tvOS)
+- The percentage of crash free sessions (if you have configured [release health](/product/releases/health/)) (not available for watchOS; no Mach exception support on tvOS)
 - Deploys, if you have configured your SDK to [provide a release identifier](/platform-redirect/?next=/configuration/releases/) and are tracking [deploys](/product/cli/releases/#creating-deploys)
 
 The projects are displayed in alphabetical order, separated by team. **Note:** For faster access, star your favorites to ensure they display at the top of the page each time you view.

--- a/src/docs/product/projects/index.mdx
+++ b/src/docs/product/projects/index.mdx
@@ -18,7 +18,7 @@ The project homepage lists the projects by teams of which you're a member, provi
 
 - A snapshot of both errors and transactions
 - The team and team members associated with each project (remember, projects can be associated to multiple teams, so a project may be listed more than once)
-- The percentage of crash free sessions (if you have configured [release health](/product/releases/health/))
+- The percentage of crash free sessions (if you have configured [release health](/product/releases/health/)) (unavailable on watchOS; no Mach exception support on tvOS)
 - Deploys, if you have configured your SDK to [provide a release identifier](/platform-redirect/?next=/configuration/releases/) and are tracking [deploys](/product/cli/releases/#creating-deploys)
 
 The projects are displayed in alphabetical order, separated by team. **Note:** For faster access, star your favorites to ensure they display at the top of the page each time you view.

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -67,6 +67,12 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 
 A _crash_ is when the application had an explicit unhandled error or hard crash. You'll typically be able to view the corresponding issue that captures this event in [sentry.io](https://sentry.io), and errors that did not cause the end of the application should not be included. To search for crash events in **Discover** or on the **Issues** page, filter by `error.unhandled:true`. The number of unhandled events is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/product/data-management-settings/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
 
+<Note>
+
+Crash detection is not available for watchOS.
+
+</Note>
+
 ### Crash Free Sessions/Users
 
 The _crash free sessions_ number is the percentage of sessions in the specified time range not ended by a crash of the application.

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -17,6 +17,12 @@ A _release_ is a version of your code deployed to an environment. When you notif
 - The percentage of crash-free users
 - The percentage of crash-free sessions
 
+<Note>
+
+Crash and app hang detection are not available for watchOS.
+
+</Note>
+
 ![View of the release index page showing each version of projects related to the release and the project details.](release_index.png)
 
 Notifying Sentry of a release enables auto discovery of which commits to associate with a release and identifies what we consider "the most recent release" when searching in [sentry.io](https://sentry.io).

--- a/src/platform-includes/getting-started-install/apple.watchos.mdx
+++ b/src/platform-includes/getting-started-install/apple.watchos.mdx
@@ -1,4 +1,4 @@
-The minimum version for watchOS is 2.0. Our SDK has limited symbolication support and no crash handling for watchOS.
+The minimum version for watchOS is 2.0. Our SDK has limited symbolication support and no crash or app hang detection for watchOS.
 
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 

--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -9,7 +9,7 @@
   - C++ exceptions
   - Objective-C exceptions
   - Error messages of fatalError, assert, and precondition
-  - [App Hang Detection](/platforms/apple/configuration/app-hangs/) (not available on watchOS)
+  - [App Hang Detection](/platforms/apple/configuration/app-hangs/) (not available for watchOS)
   - <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink>
   - [HTTP Client Errors](/platforms/apple/configuration/http-client-errors/)
   - Start-up crashes. The SDK init waits synchronously for up to 5 seconds to flush out events if the app crashes within 2 seconds after the SDK init.

--- a/src/platform-includes/getting-started-primer/apple.mdx
+++ b/src/platform-includes/getting-started-primer/apple.mdx
@@ -9,7 +9,7 @@
   - C++ exceptions
   - Objective-C exceptions
   - Error messages of fatalError, assert, and precondition
-  - [App Hang Detection](/platforms/apple/configuration/app-hangs/)
+  - [App Hang Detection](/platforms/apple/configuration/app-hangs/) (not available on watchOS)
   - <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink>
   - [HTTP Client Errors](/platforms/apple/configuration/http-client-errors/)
   - Start-up crashes. The SDK init waits synchronously for up to 5 seconds to flush out events if the app crashes within 2 seconds after the SDK init.

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -4,7 +4,7 @@ sidebar_order: 11
 description: "Learn about how to add app hang detection reporting."
 ---
 
-This integration tracks app hangs. This feature is available on iOS, tvOS, macOS, and watchOS.
+This integration tracks app hangs. This feature is available on iOS, tvOS, and macOS.
 
 There are many reasons an app can become unresponsive, from long running code to an infinite loop bug, and this can be frustrating to the end user.
 With app hang tracking, you can detect and fix this problem.

--- a/src/platforms/apple/common/configuration/integrations/default.mdx
+++ b/src/platforms/apple/common/configuration/integrations/default.mdx
@@ -11,6 +11,12 @@ System integrations are enabled by default to integrate into the standard librar
 
 This integration is the core part of the SDK. It hooks into all signal and exception handlers to capture uncaught errors or crashes. This integration is also responsible for adding most of the device information to events. If it is disabled, you will not receive crash reports, nor will events contain much device data.
 
+<Note>
+
+Crash detection is not available for watchOS, and Mach exceptions are not reported on tvOS.
+
+</Note>
+
 ### SentryAutoBreadcrumbTrackingIntegration
 
 This integration will swizzle some methods to create breadcrumbs. For example, for `UIApplicationDidReceiveMemoryWarningNotification`, `sendAction:to:from:forEvent:` (UI interactions) or `viewDidAppear:` those breadcrumbs will be attached to your events.

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -21,7 +21,7 @@ The following features are now enabled by default:
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">The File I/O tracing integration</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracing">Core Data tracing integration</PlatformLink>
 - <PlatformLink to="/configuration/http-client-errors/">Capture failed requests</PlatformLink>
-- <PlatformLink to="/configuration/app-hangs/">App Hangs</PlatformLink> (not available on watchOS)
+- <PlatformLink to="/configuration/app-hangs/">App Hangs</PlatformLink> (not available for watchOS)
 
 ### Changes to Grouping
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -21,7 +21,7 @@ The following features are now enabled by default:
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#file-io-tracking">The File I/O tracing integration</PlatformLink>
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#core-data-tracing">Core Data tracing integration</PlatformLink>
 - <PlatformLink to="/configuration/http-client-errors/">Capture failed requests</PlatformLink>
-- <PlatformLink to="/configuration/app-hangs/">App Hangs</PlatformLink>
+- <PlatformLink to="/configuration/app-hangs/">App Hangs</PlatformLink> (not available on watchOS)
 
 ### Changes to Grouping
 

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -82,6 +82,12 @@ After configuring your SDK, you can install a repository integration or manually
 
 Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
+<Note>
+
+Crash and app hang detection are not available for watchOS.
+
+</Note>
+
 In order to monitor release health, the SDK sends session data.
 
 ### Sessions

--- a/src/platforms/common/configuration/releases.mdx
+++ b/src/platforms/common/configuration/releases.mdx
@@ -84,7 +84,7 @@ Monitor the [health of releases](/product/releases/health/) by observing user ad
 
 <Note>
 
-Crash and app hang detection are not available for watchOS.
+Crash reporting and app hang detection are not available for watchOS.
 
 </Note>
 


### PR DESCRIPTION


<!-- Describe your PR here. -->

We have some features that aren't available on watchOS due to hardcoded limitations (see https://github.com/getsentry/sentry-cocoa/issues/406#issuecomment-1171872518), so call out the features that rely on the unavailable API in the docs to make sure customers are aware.

Also related to https://github.com/getsentry/sentry-cocoa/issues/2726