### PR TITLE
chore(docs): Bump min python sdk for profiling to 1.16.0

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -152,7 +152,7 @@ The `io.sentry.traces.profiling.sample-rate` setting is *relative* to the `io.se
 
 <Note>
 
-Python profiling beta is available starting in SDK version `1.15.0`.
+Python profiling beta is available starting in SDK version `1.16.0`.
 
 </Note>
 

--- a/src/wizard/python/profiling-onboarding/python/1.install.md
+++ b/src/wizard/python/profiling-onboarding/python/1.install.md
@@ -7,7 +7,7 @@ type: language
 
 #### Install
 
-For the Profiling integration to work, you should have the Sentry Python SDK package (minimum version 1.15.0) installed.
+For the Profiling integration to work, you should have the Sentry Python SDK package (minimum version 1.16.0) installed.
 
 ```bash
 pip install --upgrade sentry-sdk


### PR DESCRIPTION
1.16.0 contains some bug fixes that ensure things work out of the box on more configurations.