### PR TITLE
ref(apple): Remove misleading wording wrt network transaction generation

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -133,7 +133,7 @@ Slow and frozen frames are Mobile Vitals, which you can learn about in the [full
 
 ## Network Tracking
 
-Network Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection] yet. The SDK attaches auto-generated transactions automatically to the Scope if there is no other transaction bound. When starting a transaction, you can use `bindToScope` to indicate whether the SDK should bind the new transaction to the Scope or not.
+Network Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection] yet.
 
 To disable the HTTP instrumentation:
 


### PR DESCRIPTION
This PR removes a sentence that wrongly suggests that transactions will be created for network spans if there isn’t one on the scope.