### PR TITLE
feat(algolia): send analytics tags

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -99,7 +99,7 @@ export default ({ path, platforms = [] }: Props): JSX.Element => {
           platforms: platforms.map(platform => standardSDKSlug(platform).slug),
           searchAllIndexes: showOffsiteResults,
           ...args,
-        }, {clickAnalytics: true})
+        }, {clickAnalytics: true, analyticsTags: ["source:documentation"]})
         .then((results: Result[], ) => {
           if (loading) setLoading(false);
 


### PR DESCRIPTION
Send analytics tags so we can distinguish from different sources of traffic in algolia analytics