### PR TITLE
ref(serverless): Improve GCP functions onboarding wizard and docs

### DIFF
--- a/src/platforms/node/guides/gcp-functions/index.mdx
+++ b/src/platforms/node/guides/gcp-functions/index.mdx
@@ -15,7 +15,7 @@ Add `@sentry/serverless` as a dependency to `package.json`:
 
 To set up Sentry for a Google Cloud Function:
 
-```javascript {tabTitle:http functions}
+```javascript {tabTitle:Http functions}
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({
@@ -24,11 +24,11 @@ Sentry.GCPFunction.init({
 });
 
 exports.helloHttp = Sentry.GCPFunction.wrapHttpFunction((req, res) => {
-  throw new Error('oh, hello there!');
+  throw new Error("oh, hello there!");
 });
 ```
 
-```javascript {tabTitle:background functions}
+```javascript {tabTitle:Background functions}
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({
@@ -36,12 +36,14 @@ Sentry.GCPFunction.init({
   tracesSampleRate: 1.0,
 });
 
-exports.helloEvents = Sentry.GCPFunction.wrapEventFunction((data, context, callback) => {
-  throw new Error('oh, hello there!');
-});
+exports.helloEvents = Sentry.GCPFunction.wrapEventFunction(
+  (data, context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
 ```
 
-```javascript {tabTitle:cloudEvents}
+```javascript {tabTitle:CloudEvent functions}
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({
@@ -49,9 +51,11 @@ Sentry.GCPFunction.init({
   tracesSampleRate: 1.0,
 });
 
-exports.helloEvents = Sentry.GCPFunction.wrapCloudEventFunction((context, callback) => {
-  throw new Error('oh, hello there!');
-});
+exports.helloEvents = Sentry.GCPFunction.wrapCloudEventFunction(
+  (context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
 ```
 
 Check out Sentry's [GCP sample apps](https://github.com/getsentry/examples/tree/master/gcp-cloud-functions/node) for detailed examples. Refer to the [JavaScript docs](/platforms/javascript/) for more configuration options.

--- a/src/wizard/node/gcpfunctions.md
+++ b/src/wizard/node/gcpfunctions.md
@@ -7,13 +7,18 @@ type: framework
 
 Add `@sentry/serverless` as a dependency to `package.json`:
 
-```bash
-  "@sentry/serverless": "^5.26.0"
+```javascript
+dependencies: {
+  //...
+  "@sentry/serverless": "^7"
+}
 ```
 
 To set up Sentry for a Google Cloud Function:
 
-```javascript {tabTitle:http functions}
+### Http Functions
+
+```javascript
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({
@@ -30,7 +35,9 @@ exports.helloHttp = Sentry.GCPFunction.wrapHttpFunction((req, res) => {
 });
 ```
 
-```javascript {tabTitle:background functions}
+### Background Functions
+
+```javascript
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({
@@ -49,7 +56,9 @@ exports.helloEvents = Sentry.GCPFunction.wrapEventFunction(
 );
 ```
 
-```javascript {tabTitle:cloudEvents}
+### CloudEvent Functions
+
+```javascript
 const Sentry = require("@sentry/serverless");
 
 Sentry.GCPFunction.init({


### PR DESCRIPTION
Just noticed that in our onboarding wizard, we had docs that assumed that source code tabs would be available which - unfortunately - they are not. This PR just adds headings instead for the three different kinds of GCP functions. 
Also it slightly renames the tab title in the actual docs page for GCP functions.

 