### PR TITLE
Fixed Django guide mistakenly mentioning FastAPI

### DIFF
--- a/src/platforms/python/guides/django/index.mdx
+++ b/src/platforms/python/guides/django/index.mdx
@@ -65,7 +65,7 @@ urlpatterns = [
 
 ### Performance Monitoring
 
-The following parts of your FastAPI project are monitored:
+The following parts of your Django project are monitored:
 
 - Middleware stack
 - Signals


### PR DESCRIPTION
Recent changes in Django guide mention FastAPI where it meant to be Django.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
