### PR TITLE
ref(vue): Update `logErrors` description

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.vue.mdx
+++ b/src/platform-includes/getting-started-config/javascript.vue.mdx
@@ -100,17 +100,11 @@ Sentry.init({
 
 const miscApp = createApp(MiscApp);
 miscApp.mixin(Sentry.createTracingMixins({ trackComponents: true }));
-Sentry.attachErrorHandler(miscApp, { logErrors: true });
+Sentry.attachErrorHandler(miscApp);
 ```
 
 The SDK accepts a few different configuration options that let you change its behavior:
 
 - `attachProps` (defaults to `true`) - Includes all Vue components' props with the events.
-- `logErrors` (defaults to `false`) - Decides whether SDK should call Vue's original `logError` function as well.
+- `logErrors` (defaults to `true`) - Decides whether SDK should call Vue's original `logError` function as well.
 - `trackComponents` (defaults to `false`) - Track your app's components. Learn more about [component tracking](./features/component-tracking) and all its options.
-
-<Note>
-
-If you enable the SDK, Vue will not call its `logError` internally. As a result, errors occurring in the Vue renderer will not display in the developer console. To preserve this functionality, pass the `logErrors: true` option.
-
-</Note>

--- a/src/wizard/javascript/vue.md
+++ b/src/wizard/javascript/vue.md
@@ -100,10 +100,3 @@ app.mount("#app");
 ```
 
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/configuration/sampling/).
-
-<div class="alert alert-warning" role="alert"><h5 class="no_toc">Vue Error Handling</h5><div class="alert-body content-flush-bottom">
-Please note that if you enable this integration, by default Vue will not call its `logError` internally.
-This means that errors occurring in the Vue renderer will not show up in the developer console.
-If you want to preserve this functionality, make sure to pass the `logErrors: true` option.
-</div>
-</div>


### PR DESCRIPTION
This PR updates the Vue SDK getting started and wizard docs:

Following https://github.com/getsentry/sentry-javascript/pull/7310 where we flipped the default value of `logErrors` from `false` to `true`, this PR updates the docs accordingly and removes the IMO now obsolete warning regarding the SDK supressing error logs by default.