### PR TITLE
feat: Improve docs for node & express auto instrumentation

### DIFF
--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -10,7 +10,7 @@ redirect_from:
 
 By default, Sentry's Node.js SDK can automatically instrument HTTP calls.
 
-Read more about [Custom Instrumentation](./custom-instrumentation/) to learn how to add your own spans and transactions.
+Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn how to add your own spans and transactions.
 
 <Note>
 

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,9 +8,10 @@ redirect_from:
   - /performance/included-instrumentation
 ---
 
-By default, Sentry's Node.js SDK can automatically instrument HTTP calls.
+By default, Sentry's Node.js SDK can automatically instrument HTTP calls. 
+In order for this to work, you have to create transactions which the HTTP calls will be added to as spans.
 
-Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn how to add your own spans and transactions.
+Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn how to create transactions and add your own spans.
 
 <Note>
 

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,7 +8,9 @@ redirect_from:
   - /performance/included-instrumentation
 ---
 
-By default, Sentry error events will not get trace context unless you configure the scope with the transaction, as illustrated in the example below.
+By default, Sentry's Node.js SDK can automatically instrument HTTP calls.
+
+Read more about [Custom Instrumentation](./custom-instrumentation/) to learn how to add your own spans and transactions.
 
 <Note>
 
@@ -21,8 +23,6 @@ const Sentry = require("@sentry/node");
 const Tracing = require("@sentry/tracing");
 // Note: You MUST import the package for tracing to work
 
-const http = require("http");
-
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
@@ -33,59 +33,5 @@ Sentry.init({
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control
   tracesSampleRate: 1.0,
-});
-
-const transaction = Sentry.startTransaction({
-  op: "transaction",
-  name: "My Transaction",
-});
-
-// Note that we set the transaction as the span on the scope.
-// This step makes sure that if an error happens during the lifetime of the transaction
-// the transaction context will be attached to the error event
-Sentry.configureScope(scope => {
-  scope.setSpan(transaction);
-});
-
-let request;
-
-try {
-  // this should generate an http span
-  request = http.get("http://sentry.io", res => {
-    console.log(`STATUS: ${res.statusCode}`);
-    console.log(`HEADERS: ${JSON.stringify(res.headers)}`);
-  });
-
-  // this error event should have trace context
-  foo();
-} catch (err) {
-  Sentry.captureException(err);
-}
-
-request.on("close", () => {
-  transaction.finish();
-});
-```
-
-
-### Retrieving a Transaction
-
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` in case there is a running Transaction otherwise it returns `undefined`. If you are using our Express integration by default we attach the Transaction to the Scope. So you could do something like this:
-
-```javascript
-app.get("/success", function successHandler(req, res) {
-  const transaction = Sentry.getCurrentHub()
-    .getScope()
-    .getTransaction();
-
-  if (transaction) {
-    let span = transaction.startChild({
-      op: "encode",
-      description: "parseAvatarImages",
-    });
-    // Do something
-    span.finish();
-  }
-  res.status(200).end();
 });
 ```

--- a/src/platforms/node/guides/express/performance/automatic-instrumentation.mdx
+++ b/src/platforms/node/guides/express/performance/automatic-instrumentation.mdx
@@ -1,0 +1,56 @@
+---
+title: Automatic Instrumentation
+sidebar_order: 10
+supported:
+  - node
+description: "Learn what transactions are captured after tracing is enabled."
+redirect_from:
+  - /performance/included-instrumentation
+---
+
+When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument the performance of your application.
+
+<Note>
+
+If you’re adopting Performance in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
+
+</Note>
+
+```javascript
+const Sentry = require("@sentry/node");
+const SentryTracing = require("@sentry/tracing");
+const express = require("express");
+const app = express();
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // enable HTTP calls tracing
+    new Sentry.Integrations.Http({ tracing: true }),
+    // enable Express.js middleware tracing
+    new SentryTracing.Integrations.Express({
+      // to trace all requests to the default router
+      app,
+      // alternatively, you can specify the routes you want to trace:
+      // router: someRouter,
+    }),
+  ],
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+
+// RequestHandler creates a separate execution context using domains, so that every
+// transaction/span/breadcrumb is attached to its own Hub instance
+app.use(Sentry.Handlers.requestHandler());
+// TracingHandler creates a trace for every incoming request
+app.use(Sentry.Handlers.tracingHandler());
+
+// the rest of your app
+
+// The error handler must be before any other error middleware and after all controllers
+app.use(Sentry.Handlers.errorHandler());
+
+app.listen(3000);
+```

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -3,7 +3,7 @@ title: Performance Monitoring
 description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
 ---
 
-By default, Sentry error events will not get trace context unless you configure the scope with the transaction, as illustrated in the code sample below.
+When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument the performance of your application.
 
 <Note>
 

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -3,7 +3,7 @@ title: Performance Monitoring
 description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
 ---
 
-When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument the performance of your application.
+When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument and monitor the performance of your application.
 
 <Note>
 

--- a/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
@@ -3,7 +3,7 @@ title: Automatic Instrumentation
 description: "Learn what transactions are captured after tracing is enabled."
 ---
 
-When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument the performance of your application.
+When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument and monitor the performance of your application.
 
 <Note>
 

--- a/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
@@ -1,11 +1,6 @@
 ---
 title: Automatic Instrumentation
-sidebar_order: 10
-supported:
-  - node
 description: "Learn what transactions are captured after tracing is enabled."
-redirect_from:
-  - /performance/included-instrumentation
 ---
 
 When integrating Sentry with an Express application, you can leverage provided middlewares to automatically instrument the performance of your application.


### PR DESCRIPTION
Currently, the auto instrumentation docs for Node.js are actually manual instrumentation docs, as we don't really have a lot of auto-instrumentation there.

Also, for express we just re-use the auto-instrumentation docs, even though we actually _have_ auto instrumentation there.

Closes https://github.com/getsentry/sentry-docs/issues/6377