### PR TITLE
Update Sentry Flutter migration page for dio 

### DIFF
--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -10,6 +10,7 @@ In addition to the changes introduced in [sentry](/platforms/dart/migration/):
 API changes:
 
 - Sentry's Flutter SDK version 7.0.0 and above requires Flutter `3.0.0`.
+- [`sentry_dio`](https://pub.dev/packages/sentry_dio) version 7.0.0 requires [`dio 5.0.0`](https://pub.dev/packages/dio) 
 - The Sentry Cocoa SDK was upgraded to `8.0.0` which introduces breaking changes, see the [migration guide](/platforms/apple/migration/#migrating-from-7x-to-8x).
 - The following fields have been removed from the `SentryFlutterOptions` class and replaced:
   - `enableAutoPerformanceTracking` replaced with `enableAutoPerformanceTracing`.


### PR DESCRIPTION
Updates the migration page for Dart/Flutter for the dio integration

cc @marandaneto 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
