### PR TITLE
The `enableNdkScopeSync` feature is now enabled by default.

### DIFF
--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -17,6 +17,7 @@ API changes:
   - `enableOutOfMemoryTracking` replaced with `enableWatchdogTerminationTracking`.
   - `anrTimeoutIntervalMillis` replaced with `anrTimeoutInterval`.
   - `autoSessionTrackingIntervalMillis` replaced with `autoSessionTrackingInterval`.
+- The `enableNdkScopeSync` feature is now enabled by default.
 
 ## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-dart/pull/1276/