### PR TITLE
renamed reportFullDisplayed to reportFullyDisplayed

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -376,16 +376,16 @@ _The span has to be finished manually, by using:_
 ```java
 import io.sentry.Sentry;
 
-Sentry.reportFullDisplayed();
+Sentry.reportFullyDisplayed();
 ```
 
 ```kotlin
 import io.sentry.Sentry
 
-Sentry.reportFullDisplayed()
+Sentry.reportFullyDisplayed()
 ```
 
-Time to initial display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically. 
+Time to initial display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
 If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
 If the span finishes before the Activity is first drawn and displayed as measured by the `Time to initial display`, the reported time will be shifted to `Time to initial display` measured time.


### PR DESCRIPTION
I just renamed reportFullDisplayed to reportFullyDisplayed, as it was updated in code, too.
It's more correct in english