### PR TITLE
chore(unreal): Add `unreal.crash_type` to properties table 

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -210,6 +210,7 @@ Release properties overlap with event and issue search properties, so they don't
 | transaction.duration | Duration, in milliseconds, of the transaction. | x |  |  | duration |
 | transaction.op | Short code identifying the [type of operation](https://develop.sentry.dev/sdk/performance/span-operations/) the span is measuring. | x |  |  | string |
 | transaction.status | Describes the status of the span/transaction. Check out our [Transaction Payloads documentation](https://develop.sentry.dev/sdk/event-payloads/transaction/) for all possible statuses. | x |  |  | string |
+| unreal.crash_type | The [Unreal Crash Context Type](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/GenericPlatform/ECrashContextType/) | x | x |  | string |
 | url | A specific URL that the user visited during the replay. |  |  | x | string |
 | user.display | In order, the first available user field available: email, then username, ID, and then IP address. | x |  |  | string |
 | user.email | An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities. | x | x | x | string |


### PR DESCRIPTION
The `unreal.crash_type` based on Unreals enum is now searchable.