### PR TITLE
(Performance) reconsider onboarding wording

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -94,11 +94,11 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
+Once testing is complete, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data. 
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
-Leaving the sample rate at `1.0` means that automatic instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which is a lot of transactions. Sampling enables you to collect representative data without overwhelming either your system or your Sentry transaction quota.
+Leaving the sample rate at `1.0` means that automatic instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which can be a lot of transactions. Sampling enables you to collect representative data without overwhelming either your system or your Sentry transaction quota. For lower traffic applications there may not be a concern at all. It is mainly of interest to high load backend applications, where you may want to explore sampling consider load on the network or system resources are high.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -94,7 +94,7 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to dynamically sample and filter your transactions.
+Once testing is complete, **we recommend lowering this value in production** by either lowering your <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -67,7 +67,7 @@ Automatic instrumentation for monitoring the performance of your application is 
 
 ## Configure the Sample Rate
 
-First, enable both tracing and configure the sampling rate for transacations. Set the sample rate for your transactions by either:
+First, enable both tracing and configure the sampling rate for transactions. Set the sample rate for your transactions by either:
 
 1. Setting a uniform sample rate for all transactions using the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 2. Controlling the sample rate based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -98,7 +98,7 @@ Once testing is complete, you may want to consider setting a lower <PlatformIden
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
-Leaving the sample rate at `1.0` means that automatic instrumentation will send a transaction each time a user loads any page or navigates anywhere in your app, which can be a lot of transactions. Sampling enables you to collect representative data without overwhelming either your system or your Sentry transaction quota. For lower traffic applications there may not be a concern at all. It is mainly of interest to high load backend applications, where you may want to explore sampling consider load on the network or system resources are high.
+If you leave your sample rate at `1.0`, a transaction will be sent every time a user loads a page or navigates within your app. Depending on the amount of traffic your application gets, this may mean a lot of transactions. If you have a high-load, backend application, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -67,7 +67,7 @@ Automatic instrumentation for monitoring the performance of your application is 
 
 ## Configure the Sample Rate
 
-Sampling for transactions must also be configured before tracing is enabled in your app. Set the sample rate for your transactions by either:
+First, enable both tracing and configure the sampling rate for transacations. Set the sample rate for your transactions by either:
 
 1. Setting a uniform sample rate for all transactions using the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 2. Controlling the sample rate based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -94,7 +94,7 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry.
 
-Once testing is complete, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data. 
+Once testing is complete, you may want to set a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switch to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data. 
 
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 


### PR DESCRIPTION
This is a shared component for documentation. So merging this would impact all SDKs across the docs which reference this page.

This PR proposes 2 changes:
1. around turning on tracing and configuring a sample rate
Is:

> Sampling for transactions must also be configured before tracing

To be (something simpler):
> Enable tracing and configure the sampling rate for transacations with....

2. dynamic sampling has become too loaded
Updating to avoid that this is not conflated with "dynamic sampling" which is something on server side, and instead proposing to call it "selective" sampling, based on contextual data, Which is more accurate to what it actually is

[Example:](https://sentry-docs-git-smeubank-perf-tracing-config.sentry.dev/platforms/javascript/guides/react/performance/#configure-the-sample-rate)