### PR TITLE
[Python] Improve "custom instrumentation" docs

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -12,7 +12,7 @@ Adding transactions will allow you to instrument and capture certain regions of 
 
 <Note>
 
-If you are using one of the Sentry SDK integrations, those integrations will create transactions for you!
+If you're using one of Sentry's SDK integrations, transactions will be created for you automatically.
 
 </Note>
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -35,7 +35,7 @@ def eat_pizza(pizza):
 If you want to have more fine grained performance monitoring, you can add so called child spans to your transaction. You can do so in multiple ways:
 
 - Using a context manager or
-- Using a decorator
+- Using a decorator (works on sync and `async` functions.)
 
 Calling `sentry_sdk.start_span()` will find the current active transaction, and attach the span to it.
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -4,7 +4,7 @@ sidebar_order: 20
 description: "Learn how to capture performance data on any action in your app."
 ---
 
-The Sentry SDK for Python does a very good job at auto instrumenting your application. If you use one of the popular frameworks we already got you covered. Everything is instrumented out of the box. (The Sentry SDK will check your installed Python packages and will auto enable the matching SDK integrations.)
+The Sentry SDK for Python does a very good job of auto instrumenting your application. If you use one of the popular frameworks, we've got you covered because everything is instrumented out of the box. The Sentry SDK will check your installed Python packages and auto enable the matching SDK integrations.
 
 ## Add a Transaction
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -16,7 +16,7 @@ If you're using one of Sentry's SDK integrations, transactions will be created f
 
 </Note>
 
-The following example creates a transaction for an expensive operation (for example, `eat_pizza`), and sends the result to Sentry:
+The following example creates a transaction for an expensive operation (in this case,`eat_pizza`), and then sends the result to Sentry:
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -69,7 +69,7 @@ def eat_pizza(pizza):
 
 ## Nested Spans
 
-Spans can be nested to form a span tree. (You can read more about that in the [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.)
+Spans can be nested to form a span tree. If you'd like to learn more, read our [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.
 
 ```python {tabTitle:Context Manager}
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -37,7 +37,7 @@ If you want to have more fine-grained performance monitoring, you can add child 
 - Using a context manager or
 - Using a decorator, (this works on sync and `async` functions)
 
-Calling `sentry_sdk.start_span()` will find the current active transaction, and attach the span to it.
+Calling a `sentry_sdk.start_span()` will find the current active transaction and attach the span to it.
 
 ```python {tabTitle:Context Manager}
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -32,10 +32,10 @@ def eat_pizza(pizza):
 
 ## Add Spans to a Transaction
 
-If you want to have more fine grained performance monitoring, you can add so called child spans to your transaction. You can do so in multiple ways:
+If you want to have more fine-grained performance monitoring, you can add child spans to your transaction, which can be done by either:
 
 - Using a context manager or
-- Using a decorator (works on sync and `async` functions.)
+- Using a decorator, (this works on sync and `async` functions)
 
 Calling `sentry_sdk.start_span()` will find the current active transaction, and attach the span to it.
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -125,9 +125,9 @@ def eat_pizza(pizza):
 
 ## Accessing the Current Span
 
-In cases where you want to change data in the current Span you can use `sentry_sdk.Hub.current.scope.span`. This property will return a Span in case there is a running Span otherwise it returns `None`.
+To change data in the current span, use `sentry_sdk.Hub.current.scope.span`. This property will return a span if there's one running, otherwise it will return `None`.
 
-In this example we will set a tag in the Span created by the `@sentry_sdk.trace` decorator.
+In this example, we'll set a tag in the span created by the `@sentry_sdk.trace` decorator.
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -108,7 +108,7 @@ def eat_slice(slice):
 
 ## Accessing the Current Transaction
 
-In cases where you want to change data in an already ongoing Transaction you can use `Hub.current.scope.transaction`. This property will return a Transaction in case there is a running Transaction otherwise it returns `None`.
+To change data in an already ongoing transaction, use `Hub.current.scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -8,7 +8,7 @@ The Sentry SDK for Python does a very good job of auto instrumenting your applic
 
 ## Add a Transaction
 
-To instrument certain regions of your code, you can create transactions to capture them.
+Adding transactions will allow you to instrument and capture certain regions of your code. 
 
 <Note>
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -1,0 +1,143 @@
+---
+title: Custom Instrumentation
+sidebar_order: 20
+description: "Learn how to capture performance data on any action in your app."
+---
+
+The Sentry SDK for Python does a very good job at auto instrumenting your application. If you use one of the popular frameworks we already got you covered. Everything is instrumented out of the box. (The Sentry SDK will check your installed Python packages and will auto enable the matching SDK integrations.)
+
+## Add a Transaction
+
+To instrument certain regions of your code, you can create transactions to capture them.
+
+<Note>
+
+If you are using one of the Sentry SDK integrations, those integrations will create transactions for you!
+
+</Note>
+
+The following example creates a transaction for an expensive operation (for example, `eat_pizza`), and sends the result to Sentry:
+
+```python
+import sentry_sdk
+
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
+```
+
+## Add Spans to a Transaction
+
+If you want to have more fine grained performance monitoring, you can add so called child spans to your transaction. You can do so in multiple ways:
+
+- Using a context manager or
+- Using a decorator
+
+Calling `sentry_sdk.start_span()` will find the current active transaction, and attach the span to it.
+
+```python {tabTitle:Context Manager}
+import sentry_sdk
+
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            with sentry_sdk.start_span(description="Eat Slice"):
+                eat_slice(pizza.slices.pop())
+
+```
+
+```python {tabTitle:Decorator}
+import sentry_sdk
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
+
+```
+
+## Nested Spans
+
+Spans can be nested to form a span tree. (You can read more about that in the [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.)
+
+```python {tabTitle:Context Manager}
+import sentry_sdk
+
+def chew():
+    ...
+
+def swallow():
+    ...
+
+def eat_slice(slice):
+    with sentry_sdk.start_span(description="Eat Slice"):
+        with sentry_sdk.start_span(description="Chew"):
+            chew()
+        with sentry_sdk.start_span(description="Swallow"):
+            swallow()
+
+```
+
+```python {tabTitle:Decorator}
+import sentry_sdk
+
+@sentry_sdk.trace
+def chew():
+    ...
+
+@sentry_sdk.trace
+def swallow():
+    ...
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    chew()
+    swallow()
+```
+
+## Accessing the Current Transaction
+
+In cases where you want to change data in an already ongoing Transaction you can use `Hub.current.scope.transaction`. This property will return a Transaction in case there is a running Transaction otherwise it returns `None`.
+
+```python
+import sentry_sdk
+
+def eat_pizza(pizza):
+    transaction = sentry_sdk.Hub.current.scope.transaction
+
+    if transaction is not None:
+        transaction.set_tag("num_of_slices", len(pizza.slices))
+
+    while pizza.slices > 0:
+        eat_slice(pizza.slices.pop())
+```
+
+## Accessing the Current Span
+
+In cases where you want to change data in the current Span you can use `sentry_sdk.Hub.current.scope.span`. This property will return a Span in case there is a running Span otherwise it returns `None`.
+
+In this example we will set a tag in the Span created by the `@sentry_sdk.trace` decorator.
+
+```python
+import sentry_sdk
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    span = sentry_sdk.Hub.current.scope.span
+
+    if span is None:
+        span.set_tag("slice_id", slice.id)
+
+    ...
+```

--- a/src/wizard/python/tracing.md
+++ b/src/wizard/python/tracing.md
@@ -5,53 +5,65 @@ support_level: production
 type: language
 ---
 
-To manually instrument certain regions of your code, you can create a transaction to capture them.
+The Sentry SDK for Python does a very good job of auto instrumenting your application. Here a short introduction on how to do custom performance instrumentation. If you'd like to learn more, read our [custom instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/) documentation.
 
-The following example creates a transaction for a scope that contains an expensive operation (for example, `process_item`), and sends the result to Sentry:
+**Adding a Transaction**
+
+Adding transactions will allow you to instrument and capture certain regions of your code.
+
+<Note>
+
+If you're using one of Sentry's SDK integrations, transactions will be created for you automatically.
+
+</Note>
+
+The following example creates a transaction for an expensive operation (in this case,`eat_pizza`), and then sends the result to Sentry:
 
 ```python
-from sentry_sdk import start_transaction
+import sentry_sdk
 
-while True:
-  item = get_from_queue()
+def eat_slice(slice):
+    ...
 
-  with start_transaction(op="task", name=item.get_transaction_name()):
-      # process_item may create more spans internally (see next examples)
-      process_item(item)
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
 ```
 
 **Adding More Spans to the Transaction**
 
-The next example contains the implementation of the hypothetical `process_item` function called from the code snippet in the previous section. Our SDK can determine if there is currently an open transaction and add all newly created spans as child operations to that transaction. Keep in mind that each individual span also needs to be manually finished; otherwise, spans will not show up in the transaction. When using spans and transactions as context managers, they are automatically finished at the end of the `with` block.
+If you want to have more fine-grained performance monitoring, you can add child spans to your transaction, which can be done by either:
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Hub.current.scope.transaction`. This property will return a `Transaction` in case there is a running Transaction otherwise it returns `None`.
+- Using a context manager or
+- Using a decorator, (this works on sync and `async` functions)
 
-Alternatively, instead of adding to the top-level transaction, you can make a child span of the current span, if there is one. Use `Hub.current.scope.span` in that case.
+Calling a `sentry_sdk.start_span()` will find the current active transaction and attach the span to it.
 
-You can choose the values of `op` and `description`.
+```python {tabTitle:Context Manager}
+import sentry_sdk
 
-```python
-from sentry_sdk import Hub
+def eat_slice(slice):
+    ...
 
-def process_item(item):
-    transaction = Hub.current.scope.transaction
-    # omitted code...
-    with transaction.start_child(op="http", description="GET /") as span:
-        response = my_custom_http_library.request("GET", "/")
-        span.set_tag("http.status_code", response.status_code)
-        span.set_data("http.foobarsessionid", get_foobar_sessionid())
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            with sentry_sdk.start_span(description="Eat Slice"):
+                eat_slice(pizza.slices.pop())
+
 ```
 
-The alternative to make a tree of spans:
+```python {tabTitle:Decorator}
+import sentry_sdk
 
-```python
-from sentry_sdk import Hub
+@sentry_sdk.trace
+def eat_slice(slice):
+    ...
 
-def process_item(item):
-    parent_span = Hub.current.scope.span
-    # omitted code...
-    with parent_span.start_child(op="http", description="GET /") as span:
-        response = my_custom_http_library.request("GET", "/")
-        span.set_tag("http.status_code", response.status_code)
-        span.set_data("http.foobarsessionid", get_foobar_sessionid())
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
+
 ```


### PR DESCRIPTION
Made it easier comprehensible (less special words) 
Also added the new way of adding spans (with the decorator)

Before:
https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/

Now:
https://sentry-docs-git-antonpirker-performance-custom-instrumentation.sentry.dev/platforms/python/performance/instrumentation/custom-instrumentation/