### PR TITLE
ref(integrations): Add note about `@netlify/sentry` to Netlify plugin docs

### DIFF
--- a/src/docs/product/releases/setup/release-automation/netlify/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/netlify/index.mdx
@@ -11,6 +11,14 @@ If you make changes to your organization slug, you'll need to update your config
 
 </Alert>
 
-The [Sentry Netlify build plugin](https://github.com/getsentry/sentry-netlify-build-plugin) automates Sentry release management in Netlify with just one step. After sending Sentry release information, you’ll be able to associate commits with releases. You'll also be able to apply source maps to see the original code in Sentry.
+The Sentry Netlify build plugin automates Sentry release management in Netlify. Once set up, it automatically sends release and commit information to Sentry, and uploads source maps, enabling you to see original code in your stackraces.
 
-For more details about Sentry release management concepts, see the full documentation on [releases](/product/releases/).
+Full docs are available in the [plugin's README](https://github.com/getsentry/sentry-netlify-build-plugin).
+
+For more details about Sentry release management concepts, see our docs on [releases](/product/releases/).
+
+<Alert level="note">
+
+Note: This build plugin is separate from `@netlify/sentry`, which is a monitoring plugin built by Netlify. Docs for that plugin can be found [here](https://docs.netlify.com/netlify-labs/experimental-features/sentry-integration/). For more information, see [`@sentry/netlify-build-plugin` vs. `@netlify/sentry`](https://github.com/getsentry/sentry-netlify-build-plugin#sentrynetlify-build-plugin-vs-netlifysentry).
+
+</Alert>


### PR DESCRIPTION
This does some minor wordsmithing to our docs on the Netlify integration, and adds a note about the difference between it and the new Netlify-built sentry plugin.

Ref: WOR-2818