### PR TITLE
docs(ios): Change CLI flag from include_sources to include-sources

### DIFF
--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -20,7 +20,7 @@ If this is your situation, please read [Info.plist Is Missing in Xcode 13 — He
 
 Use the `sentry-cli upload-dif` command to upload dSYMs to Sentry. The command will recursively scan the provided folders or ZIP archives. Files that have already been uploaded will be skipped automatically.
 
-Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
+Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include-sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
 ```bash
 sentry-cli upload-dif --auth-token YOUR_AUTH_TOKEN \
@@ -66,7 +66,7 @@ Follow these steps to upload the debug symbols:
 1.  Download and install [sentry-cli](/product/cli/installation/).
 2.  Copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_.
 
-Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include_sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include_sources` in the copied script.
+Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include-sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include-sources` in the copied script.
 
 <Alert level="" title="Warnings vs. Errors">
 

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -66,7 +66,7 @@ Follow these steps to upload the debug symbols:
 1.  Download and install [sentry-cli](/product/cli/installation/).
 2.  Copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_.
 
-Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include-sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. Simply change `sentry-cli upload-dif` to `sentry-cli upload-dif --include-sources` in the copied script.
+Sentry can display snippets of your code next to the event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `--include-sources` option, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry. To use the feature, change `sentry-cli upload-dif` to `sentry-cli upload-dif --include-sources` in the copied script.
 
 <Alert level="" title="Warnings vs. Errors">
 


### PR DESCRIPTION
This is not currently valid call.