### PR TITLE
fix: Do not recommend using `env.VITE_XXX`

### DIFF
--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -40,7 +40,7 @@ export default defineConfig(({ command, mode }) => {
 
         // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
         // and needs the `project:releases` and `org:read` scopes
-        authToken: env.VITE_SENTRY_AUTH_TOKEN,
+        authToken: env.SENTRY_AUTH_TOKEN,
 
         // Optionally uncomment the line below to override automatic release name detection
         // release: env.RELEASE,


### PR DESCRIPTION
As anything prefixed with `VITE_` will be made available to the client, which we do not want for the auth token - see:
https://vitejs.dev/guide/env-and-mode.html#env-files


Closes https://github.com/getsentry/sentry-docs/issues/6459