### PR TITLE
Fix xcode bundle build phase sentry properties path

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -44,7 +44,7 @@ REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
 To this:
 
 ```bash
-export SENTRY_PROPERTIES=../sentry.properties
+export SENTRY_PROPERTIES=sentry.properties
 export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"
 set -e
 


### PR DESCRIPTION
fixes: https://github.com/getsentry/sentry-react-native/issues/2886