### PR TITLE
feat(apple): Mention source context

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -87,4 +87,10 @@ If you want to find out the performance of your Views in a SwiftUI project, [try
 
 ## Provide Debug Information {#debug-symbols}
 
-Before capturing crashes, you need to provide debug information to Sentry. Debug information is provided by <PlatformLink to="/dsym">uploading dSYM files</PlatformLink>.
+Before capturing crashes, you need to provide debug information to Sentry. Furthermore, Sentry can display snippets of your code next to the event stacktraces. This feature is called source context. To enable it use the `include-sources` option when uploading your debug information files. Debug information is provided by <PlatformLink to="/dsym">uploading dSYM files</PlatformLink>.
+
+
+
+
+
+

--- a/src/wizard/apple/index.md
+++ b/src/wizard/apple/index.md
@@ -45,7 +45,7 @@ func application(_ application: UIApplication,
 
 ## Debug Symbols
 
-Before capturing crashes, you need to provide debug information to Sentry. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
+Before capturing crashes, you need to provide debug information to Sentry. Furthermore, Sentry can display snippets of your code next to the event stacktraces. This feature is called source context. To enable it use the `include-sources` option when uploading your debug information files. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
 
 ## Performance Monitoring
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -65,7 +65,7 @@ struct SwiftUIApp: App {
 
 ## Debug Symbols
 
-Before capturing crashes, you need to provide debug information to Sentry. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym).
+Before capturing crashes, you need to provide debug information to Sentry. Furthermore, Sentry can display snippets of your code next to the event stacktraces. This feature is called source context. To enable it use the `include-sources` option when uploading your debug information files. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
 
 ## Performance Monitoring
 

--- a/src/wizard/apple/macos.md
+++ b/src/wizard/apple/macos.md
@@ -65,7 +65,7 @@ struct SwiftUIApp: App {
 
 ## Debug Symbols
 
-Before capturing crashes, you need to provide debug information to Sentry. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
+Before capturing crashes, you need to provide debug information to Sentry. Furthermore, Sentry can display snippets of your code next to the event stacktraces. This feature is called source context. To enable it use the `include-sources` option when uploading your debug information files. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
 
 ## Performance Monitoring
 


### PR DESCRIPTION
Mention enabling the source context feature in the wizard and getting started.
