### PR TITLE
fix links to sourcemaps blog post

### DIFF
--- a/src/docs/clients/javascript/sourcemaps.mdx
+++ b/src/docs/clients/javascript/sourcemaps.mdx
@@ -8,7 +8,7 @@ noindex: true
 tags: []
 ---
 
-Sentry supports un-minifying JavaScript via [Source Maps](https://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
+Sentry supports un-minifying JavaScript via [Source Maps](https://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps/). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
 
 Most of the process is the same whether you're using this SDK or the [new unified JavaScript Browser SDK](/platforms/javascript/), so the main docs for dealing with source maps can be found [there](/platforms/javascript/sourcemaps/). The one difference is how you specify the release in your SDK configuration.
 

--- a/src/docs/clients/node/sourcemaps.mdx
+++ b/src/docs/clients/node/sourcemaps.mdx
@@ -8,7 +8,7 @@ noindex: true
 tags: []
 ---
 
-Sentry supports un-minifying JavaScript via [Source Maps](https://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
+Sentry supports un-minifying JavaScript via [Source Maps](https://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps/). This lets you view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level language (e.g. TypeScript, ES6).
 
 ## Generating a Source Map
 


### PR DESCRIPTION
Ben P. mentioned these links were broken, so this PR fixes that. However, they're linking to a super old blog post. 

It may be better to link to https://docs.sentry.io/platforms/javascript/sourcemaps and https://docs.sentry.io/platforms/node/sourcemaps (respectively), or a newer blog post instead.