### PR TITLE
fix(react-native): add missing argument for ios debug symbols upload

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -74,7 +74,7 @@ export SENTRY_PROPERTIES=sentry.properties
 
 [[ $SENTRY_INCLUDE_NATIVE_SOURCES == "true" ]] && INCLUDE_SOURCES_FLAG="--include-sources" || INCLUDE_SOURCES_FLAG=""
 SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
-$SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG"
+$SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"
 ```
 
 For bitcode enabled builds via iTunes Connect, additional steps are required.

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -74,7 +74,7 @@ export SENTRY_PROPERTIES=sentry.properties
 
 [[ $SENTRY_INCLUDE_NATIVE_SOURCES == "true" ]] && INCLUDE_SOURCES_FLAG="--include-sources" || INCLUDE_SOURCES_FLAG=""
 SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
-$SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app"
+$SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 ```
 
 For bitcode enabled builds via iTunes Connect, additional steps are required.


### PR DESCRIPTION

<!-- Describe your PR here. -->

I think there is a mistake in the iOS symbols upload script at https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/#upload-debug-symbols-to-sentry.

By using it "as is" it will upload nothing and yield "Warning: No paths were provided."

To get it working I needed to add the path to my built .app so it can look for files to upload.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
