### PR TITLE
feat(view-hierarchy): Update platform support note

### DIFF
--- a/src/platforms/common/enriching-events/viewhierarchy.mdx
+++ b/src/platforms/common/enriching-events/viewhierarchy.mdx
@@ -28,7 +28,7 @@ This feature only applies to SDKs with a user interface, such as the ones for mo
 
 <Note>
 
-Deobfuscation for view hierarchies is available for iOS, Android, React Native (iOS), and Flutter (Android) platforms. We are actively working on deobfuscation for Flutter (iOS) and React Native (Android) and will update this page with the latest changes.
+Deobfuscation for view hierarchies is fully supported for native SDKs, and React Native, but will currently not be supported for Flutter. We will update this page with the latest changes.
 
 </Note>
 

--- a/src/platforms/common/enriching-events/viewhierarchy.mdx
+++ b/src/platforms/common/enriching-events/viewhierarchy.mdx
@@ -28,7 +28,7 @@ This feature only applies to SDKs with a user interface, such as the ones for mo
 
 <Note>
 
-Deobfuscation for view hierarchies is fully supported for native SDKs, and React Native, but will currently not be supported for Flutter. We will update this page with the latest changes.
+Deobfuscation for view hierarchies is fully supported for native SDKs, and React Native, but is currently not supported for Flutter.
 
 </Note>
 


### PR DESCRIPTION
Updating the platform support note to call out that deobfuscation for Flutter currently isn't supported and we will update if there are any changes in the future.