### PR TITLE
Update .NET compatibility details

### DIFF
--- a/src/platforms/dotnet/common/compatibility.mdx
+++ b/src/platforms/dotnet/common/compatibility.mdx
@@ -23,11 +23,11 @@ that means it should also work well with the following:
 
 <Note>
 
-Though supported in the Sentry SDK, some of these platforms are no longer supported by Microsoft.
-We recommend supported versions of each platform.  For example, the current minimum
-version of .NET Framework supported by Microsoft is 4.6.2, though we would recommend 4.8 or newer.
+Though you can use the Sentry SDK in any of the above versions, some of those are no longer supported by Microsoft.
+Thus, we recommend using Microsoft supported versions of each platform whenever possible.
 
-For .NET and .NET Core, though Sentry can work with .NET Core 2.0 and newer, we recommend using "LTS" or "Current" versions, as labeled on the [.NET downloads page](https://dotnet.microsoft.com/download/dotnet). Currently that means using .NET Core 3.1, or .NET 6 and newer.
+- Most applications should use .NET version 6.0 or newer.  See Microsoft's official [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy) page for more details.
+- Applications targeting .NET Framework should use version 4.6.2 or newer.  See Microsoft's official [.NET Framework Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework) page for more details.
 
 </Note>
 


### PR DESCRIPTION
- .NET Core 3.1 is no longer supported by Microsoft
- Don't make recommendations beyond using supported versions
- Link to official Microsoft support policies
- Cleanup wording