### PR TITLE
Update otel node propagator instructions

### DIFF
--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -32,9 +32,8 @@ const sdk = new opentelemetry.NodeSDK({
 
   // Sentry config
   spanProcessor: new SentrySpanProcessor(),
+  textMapPropagator: new SentryPropagator(),
 });
-
-otelApi.propagation.setGlobalPropagator(new SentryPropagator());
 
 sdk.start();
 ```


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/7538

Update these docs based on work in https://github.com/getsentry/sentry-javascript/pull/7548

Passing in a propagator in the otel SDK constructor is more correct than using the `setGlobalPropagator` API.