### PR TITLE
Update self-hosted backup instructions

### DIFF
--- a/src/docs/product/sentry-basics/migration/index.mdx
+++ b/src/docs/product/sentry-basics/migration/index.mdx
@@ -49,19 +49,13 @@ If you're expecting higher volumes or you're interested in our Enterprise capabi
 
 ### 3. Export your data
 
-Self-hosted Sentry provides a command line interface that allows you to perform various operations that are unachievable within [sentry.io](https://sentry.io). One of those is `export`, which exports your data into a transport JSON.
+Self-hosted Sentry provides a script that allows you to perform a backup of your basic data into a json file. For versions of self-hosted under 23.3.1, an `export` command is required instead. See [here](https://develop.sentry.dev/self-hosted/backup/) for more.
 
-Run the following command in your terminal to start the export script and redirect the output (_containing_ the transport JSON) to a file:
+Run the following command in your terminal to start the backup script and export your data:
 
-    $ docker-compose run --rm web export > sentry_export.json
+    $ ./scripts/backup.sh
 
 This invokes the sentry CLI `export` command on a new isolated instance of our Docker web container.
-
-If you don't want to use the docker command, you can run the following command instead:
-
-    sentry export > sentry_export.json
-
-Wherever you run the `sentry` command, you can use this command as well.
 
 The export migrates your account's settings and configurations, including:
 


### PR DESCRIPTION
This updates the docs to use the most up to date backup scripts for self-hosted sentry