### PR TITLE
fix(apple): Clarify no support for NSURLConnection

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -133,7 +133,7 @@ Slow and frozen frames are Mobile Vitals, which you can learn about in the [full
 
 ## Network Tracking
 
-Network Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection] yet.
+Network Tracking is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. The Sentry SDK adds spans for outgoing HTTP requests to ongoing transactions bound to the Scope. Currently, the SDK supports requests with [NSURLSession][NSURLSession], but not the legacy [NSURLConnection][NSURLConnection].
 
 To disable the HTTP instrumentation:
 


### PR DESCRIPTION
Remove the yet for NSURLConnection to clarify that we don't have plans to support it.
