### PR TITLE
Enable trace_propagation_targets docs for python

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -763,7 +763,7 @@ An optional property that configures which downstream services receive the `sent
 
 </ConfigKey>
 
-<ConfigKey name="trace-propagation-targets" supported={["node", "apple", "dart", "flutter", "java"]}>
+<ConfigKey name="trace-propagation-targets" supported={["node", "apple", "dart", "flutter", "java", "python"]}>
 
 An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
 


### PR DESCRIPTION
The feature is there but the docs section was not yet enabled.