### PR TITLE
feat(apple): Time to Initial display and Time to Full display measurement

### DIFF
--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -385,7 +385,7 @@ import io.sentry.Sentry
 Sentry.reportFullyDisplayed()
 ```
 
-Time to initial display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
+Time to full display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
 If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
 If the span finishes before the Activity is first drawn and displayed as measured by the `Time to initial display`, the reported time will be shifted to `Time to initial display` measured time.

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -306,3 +306,59 @@ SentrySDK.start { options in
 
 [UIWindow]: https://developer.apple.com/documentation/uikit/uiwindowdidbecomevisiblenotification
 [didFinishLaunching]: https://developer.apple.com/documentation/uikit/uiapplication/1622971-didfinishlaunchingnotification
+
+
+### Time to Initial Display
+
+_(New in version 8.4.0)_
+
+Time to initial display provides insight into how long it takes to your view controller to launch and draw their first frame, by adding a span for a view controller when it is loaded. The SDK sets the span operation to `ui.load.initial-display` and the span description to the view controllers's name followed by `initial display`, for example, `MainViewController initial display`.
+
+The span starts when the view of a view controller is loaded, and there is no other view controller transaction happening at the moment.
+
+The span finishes after the view appeared on the screen.
+
+### Time to Full Display
+
+_(New in version 8.4.0)_
+
+Time to full display provides insight into how long it would take your view controller to launch and load all of their content, by adding a span for each launch of an view controller. The SDK sets the span operation to `ui.load.full-display` and the span description to the view controllers's name followed by `full display`, for example, `MainActivity full display`.
+
+The span starts when the view of a view controller is loaded, and there is no other view controller transaction happening at the moment.
+
+_Time to full display is disabled by default, but you can enable it by setting:_
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enableTimeToFullDisplay = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enableTimeToFullDisplay = YES;
+}];
+```
+
+_The span has to be finished manually, by using:_
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.reportFullyDisplayed()
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK reportFullyDisplayed];
+```
+
+If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
+If a call to `reportFullyDisplayed()` happens before the view controller appears, the reported time will be shifted to `Time to initial display` measured time.

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -322,7 +322,7 @@ The span finishes after the view appeared on the screen.
 
 _(New in version 8.4.0)_
 
-Time to full display provides insight into how long it would take your view controller to launch and load all of their content, by adding a span for each launch of an view controller. The SDK sets the span operation to `ui.load.full-display` and the span description to the view controllers's name followed by `full display`, for example, `MainActivity full display`.
+Time to full display provides insight into how long it takes your view controller to launch and load all of its content, by adding a span for each launch of a view controller. The SDK sets the span operation to `ui.load.full-display` and the span description to the view controllers' name followed by `full display`, for example, `MainActivity full display`.
 
 The span starts when the view of a view controller is loaded, and there is no other view controller transaction happening at the moment.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -346,7 +346,8 @@ SentrySDK.start { options in
 }];
 ```
 
-_The span has to be finished manually, by using:_
+We can't detect when your UIViewController is fully loaded. Only you, the user, can achieve this. Therefore, you have to manually call the API to get proper statistics.
+_You can achieve this by using the following code:_
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -360,5 +360,5 @@ SentrySDK.reportFullyDisplayed()
 [SentrySDK reportFullyDisplayed];
 ```
 
-If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
+If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it will be finished by the SDK automatically, and its `status` will be set to `SpanStatus.DEADLINE_EXCEEDED`, also its duration will match the same of the `Time to initial display` span and the description will contain `Deadline Exceeded` suffix.
 If a call to `reportFullyDisplayed()` happens before the view controller appears, the reported time will be shifted to `Time to initial display` measured time.


### PR DESCRIPTION
Added documentation for TTID and TTFD spans during view controller automatic transactions.

This docs should not be merged before [this PR](https://github.com/getsentry/sentry-cocoa/pull/2724).