### PR TITLE
Added docs for "functions_to_trace" option.

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -780,7 +780,7 @@ If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trac
 An optional list of functions that should be set up for performance monitoring. For each function in the list, a span will be created when the function is executed.
 Functions in the list are represented as strings containing the fully qualified name of the fuction.
 
-This is a convenience option to not have manual instrumentation scattered all over your code base, but have one central place to configure what functions to trace.
+This is a convenient option, making it possible to have one central place for configuring what functions to trace, instead of having manual instrumentation scattered all over your code base.
 
 To learn more see the [Custom Instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/#define-span-creation-in-a-central-place) documentation.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -775,6 +775,17 @@ If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trac
 
 </ConfigKey>
 
+<ConfigKey name="functions-to-trace" supported={["python"]}>
+
+An optional list of functions that should be set up for performance monitoring. For each function in the list a span will be created when the function is executed.
+Functions in the list are represented as strings containing the fully qualified name of the fuction.
+
+This is a convenience option to not have manual instrumentation scattered all over your code base, but have one central place to configure what functions to trace.
+
+To learn more see the [Custom Instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/#define-span-creation-in-a-central-place) documentation.
+
+</ConfigKey>
+
 <ConfigKey name="trace-options-requests" supported={["java"]}>
 
 <PlatformSection supported={["java"]}>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -782,7 +782,7 @@ Functions in the list are represented as strings containing the fully qualified 
 
 This is a convenient option, making it possible to have one central place for configuring what functions to trace, instead of having manual instrumentation scattered all over your code base.
 
-To learn more see the [Custom Instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/#define-span-creation-in-a-central-place) documentation.
+To learn more, see the [Custom Instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/#define-span-creation-in-a-central-place) documentation.
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -777,7 +777,7 @@ If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trac
 
 <ConfigKey name="functions-to-trace" supported={["python"]}>
 
-An optional list of functions that should be set up for performance monitoring. For each function in the list a span will be created when the function is executed.
+An optional list of functions that should be set up for performance monitoring. For each function in the list, a span will be created when the function is executed.
 Functions in the list are represented as strings containing the fully qualified name of the fuction.
 
 This is a convenience option to not have manual instrumentation scattered all over your code base, but have one central place to configure what functions to trace.

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -127,7 +127,7 @@ sentry_sdk.init(
 )
 ```
 
-Now whenever a function specified in `functions_to_trace` is executed a span is created and attached as child to the currently running span.
+Now, whenever a function specified in `functions_to_trace` will be executed, a span will be created and attached as a child to the currently running span.
 
 <Alert level="warning" title="Important">
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -108,7 +108,7 @@ def eat_slice(slice):
 
 ## Define Span Creation in a Central Place
 
-If you do not want to have custom performance instrumentation code scattered all over your code base, you can pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
+To avoid having custom performance instrumentation code scattered all over your code base, pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -8,7 +8,7 @@ The Sentry SDK for Python does a very good job of auto instrumenting your applic
 
 ## Add a Transaction
 
-Adding transactions will allow you to instrument and capture certain regions of your code. 
+Adding transactions will allow you to instrument and capture certain regions of your code.
 
 <Note>
 
@@ -105,6 +105,35 @@ def eat_slice(slice):
     chew()
     swallow()
 ```
+
+## Define Span Creation in a Central Place
+
+If you do not want to have custom performance instrumentation code scattered all over your code base, you can pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
+
+```python
+import sentry_sdk
+
+functions_to_trace = [
+    "myrootmodule.eat_slice",
+    "myrootmodule.swallow",
+    "myrootmodule.chew",
+    "myrootmodule.someothermodule.another.some_function",
+    "myrootmodule.SomePizzaClass.some_method",
+]
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    functions_to_trace=functions_to_trace,
+)
+```
+
+Now whenever a function specified in `functions_to_trace` is executed a span is created and attached as child to the currently running span.
+
+<Alert level="warning" title="Important">
+
+The SDK needs to load the modules of the functions specified in `functions_to_trace` in order to enable performance monitoring for those functions. There can be code in modules that is executing during loading of the module. Please be aware of this. If you do not want this to happen you can use the ways described above to trace your functions.
+
+</Alert>
 
 ## Accessing the Current Transaction
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -131,7 +131,7 @@ Now, whenever a function specified in `functions_to_trace` will be executed, a s
 
 <Alert level="warning" title="Important">
 
-The SDK needs to load the modules of the functions specified in `functions_to_trace` in order to enable performance monitoring for those functions. There can be code in modules that is executing during loading of the module. Please be aware of this. If you do not want this to happen you can use the ways described above to trace your functions.
+To enable performance monitoring for the functions specified in `functions_to_trace`, the SDK needs to load the function modules. Be aware, there may be code being executed in modules during module loading. To avoid this, use the method described above to trace your functions.
 
 </Alert>
 


### PR DESCRIPTION
This is a new feature in the Python SDK to have a central place to define which functions should be performance instrumented.

See feature implementation: https://github.com/getsentry/sentry-python/pull/1960