### PR TITLE
Remove references to `@sentry/tracing` for node performance

### DIFF
--- a/src/platform-includes/performance/configure-sample-rate/node.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/node.mdx
@@ -1,7 +1,5 @@
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import * as _ from "@sentry/tracing"
-// Note: You MUST import the package in some way for tracing to work
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/performance/enable-tracing/node.mdx
+++ b/src/platform-includes/performance/enable-tracing/node.mdx
@@ -1,0 +1,1 @@
+`@sentry/node` has tracing enabled by default.

--- a/src/platforms/node/common/performance/database/auto-instrument.mdx
+++ b/src/platforms/node/common/performance/database/auto-instrument.mdx
@@ -1,34 +1,49 @@
 ---
-title: Auto-instrumented
+title: Auto-discovered
 ---
 
-Node.js integrations support tracking database queries as spans. Starting in version `6.4.0`, `@sentry/tracing` will auto-detect supported database drivers or ORMs being used in your project, and automatically enable the relevant integrations with default options - without needing additional code.
+Node.js integrations support tracking database queries as spans. `@sentry/node`
+can auto-detect supported database drivers or ORMs being used in your project.
 
-Supported packages and their integration name: 
+<Note>
+
+Automatic discovery can fail if your code has been bundled. In that case you
+will need to manually add the required integrations.
+
+</Note>
+
+```javascript
+const Sentry = require("@sentry/node");
+
+const client = new Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations()],
+});
+```
+
+Supported packages and their integration name:
 - `pg` (Postgres)
-- `pg-native` (Postgres) _Available from version 6.12.0_
+- `pg-native` (Postgres)
 - `mongodb` (Mongo)
 - `mongoose` (Mongo)
 - `mysql` (MySQL)
-
-### Disabling Automatic Instrumentation
-
-You can also [remove an automatically-enabled integration](/platforms/node/configuration/integrations/#removing-an-integration), if needed.
+- `graphql` (GraphQL)
+- `apollo-server-core` (Apollo)
+- `@nestjs/graphql` (Apollo)
 
 ### Manually Adding Integrations
 
-If you need to add a specific database integration manually (for example, when using multiple client instances), you can import them from the `@sentry/tracing` package under the `Integrations` namespace.
+If you need to add a specific database integration manually (for example, when using multiple client instances), you can import them from the `Integrations` namespace.
 
 For example:
 
 ```javascript{tabTitle: MongoDB}
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
 const mongodb = require("mongodb");
 
-const client = new Sentry.NodeClient({
+const client = new Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Tracing.Integrations.Mongo({
+  integrations: [new Sentry.Integrations.Mongo({
     useMongoose: true // Default: false
   })],
 });
@@ -36,11 +51,10 @@ const client = new Sentry.NodeClient({
 
 ```javascript{tabTitle: Postgres}
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
 
-const client = new Sentry.NodeClient({
+const client = new Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Tracing.Integrations.Postgres({
+  integrations: [new Sentry.Integrations.Postgres({
     usePgNative: true // Default: false
   })],
 });

--- a/src/platforms/node/common/performance/database/index.mdx
+++ b/src/platforms/node/common/performance/database/index.mdx
@@ -7,20 +7,21 @@ Node.js integrations support tracking database queries as spans.
 
 ## Supported Platforms
 
-Auto-instrumented:
+Auto-discovered:
 
 - `pg` (Postgres)
-- `pg-native` (Postgres) _Available from version 6.12.0_
+- `pg-native` (Postgres)
 - `mongodb` (Mongo)
 - `mongoose` (Mongo)
 - `mysql` (MySQL)
+- `graphql` (GraphQL)
+- `apollo-server-core` (Apollo)
+- `@nestjs/graphql` (Apollo)
 
 Opt-in:
 
-- [Prisma ORM](https://www.prisma.io/) _Available from version 7.0.0_
-- [GraphQL](https://graphql.org/graphql-js/) _Available from version 7.2.0_
-- [Apollo Server](https://www.apollographql.com/docs/apollo-server/) _Available from version 7.2.0_
-
+- [Prisma ORM](https://www.prisma.io/)
+- [Express](https://expressjs.com/)
 
 ## Next Steps
 

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -15,7 +15,6 @@ For example:
 ```javascript
 import { PrismaClient } from "@prisma/client";
 import * as Sentry from "@sentry/node";
-import * as Tracing from "@sentry/tracing";
 
 const client = new PrismaClient();
 
@@ -23,7 +22,7 @@ Sentry.init({
   dsn: ___PUBLIC_DSN___,
   release: "1.0",
   tracesSampleRate: 1.0,
-  integrations: [new Tracing.Integrations.Prisma({ client })],
+  integrations: [new Sentry.Integrations.Prisma({ client })],
 });
 ```
 
@@ -40,11 +39,10 @@ For example:
 
 ```javascript
 import * as Sentry from "@sentry/node";
-import * as Tracing from "@sentry/tracing";
 
 Sentry.init({
   tracesSampleRate: 1.0,
-  integrations: [new Tracing.Integrations.GraphQL()],
+  integrations: [new Sentry.Integrations.GraphQL()],
 });
 ```
 
@@ -58,18 +56,17 @@ The Apollo integration creates `db.graphql.apollo` spans for each resolver and r
 
 ```javascript
 import * as Sentry from "@sentry/node";
-import * as Tracing from "@sentry/tracing";
 
 Sentry.init({
   tracesSampleRate: 1.0,
-  integrations: [new Tracing.Integrations.Apollo()],
+  integrations: [new Sentry.Integrations.Apollo()],
 });
 ```
 
 If you use `NestJs`, initialize the integration with the `useNestjs` option
 
 ```javascript
-new Tracing.Integrations.Apollo({ useNestjs: true });
+new Sentry.Integrations.Apollo({ useNestjs: true });
 ```
 
 **Known Limitation:**

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -8,7 +8,7 @@ redirect_from:
   - /performance/included-instrumentation
 ---
 
-By default, Sentry's Node.js SDK can automatically instrument HTTP calls. 
+By default, Sentry's Node.js SDK can automatically instrument HTTP calls.
 In order for this to work, you have to create transactions which the HTTP calls will be added to as spans.
 
 Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn how to create transactions and add your own spans.
@@ -21,8 +21,6 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 ```javascript
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
-// Note: You MUST import the package for tracing to work
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platforms/node/common/profiling/index.mdx
+++ b/src/platforms/node/common/profiling/index.mdx
@@ -18,10 +18,10 @@ For the Profiling integration to work, you must have the Sentry Node SDK package
 
 ```bash
 # Using yarn
-yarn add @sentry/node @sentry/tracing @sentry/profiling-node
+yarn add @sentry/node @sentry/profiling-node
 
 # Using npm
-npm install --save @sentry/node @sentry/tracing @sentry/profiling-node
+npm install --save @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling
@@ -29,8 +29,6 @@ In order to enable profiling, import @sentry/profiling-node and add ProfilingInt
 
 ```javascript
 const Sentry = require("@sentry/node");
-// Note: You MUST import @sentry/tracing package before @sentry/profiling-node
-require("@sentry/tracing");
 const {ProfilingIntegration} = require("@sentry/profiling-node");
 
 Sentry.init({

--- a/src/platforms/node/guides/express/index.mdx
+++ b/src/platforms/node/guides/express/index.mdx
@@ -141,19 +141,10 @@ app.use(Sentry.Handlers.errorHandler() as express.ErrorRequestHandler);
 
 ## Monitor Performance
 
-```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/tracing
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/node @sentry/tracing
-```
-
 It’s possible to add tracing to all popular frameworks; however, we only provide pre-written handlers for Express.
 
 ```javascript
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
 const express = require("express");
 const app = express();
 
@@ -163,7 +154,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({
+    new Sentry.Integrations.Express({
       // to trace all requests to the default router
       app,
       // alternatively, you can specify the routes you want to trace:

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -13,7 +13,6 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 ```javascript
 const Sentry = require("@sentry/node");
-const SentryTracing = require("@sentry/tracing");
 const express = require("express");
 const app = express();
 
@@ -23,7 +22,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new SentryTracing.Integrations.Express({
+    new Sentry.Integrations.Express({
       // to trace all requests to the default router
       app,
       // alternatively, you can specify the routes you want to trace:
@@ -112,13 +111,11 @@ app.use(function processItems(req, res, next) {
 
 ### Retrieving a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.getCurrentHub().getScope().getTransaction()`. This function will return a `Transaction` in case there is a running Transaction otherwise it returns `undefined`. If you are using our Express integration by default we attach the Transaction to the Scope. So you could do something like this:
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.getActiveTransaction()`. This function will return a `Transaction` in case there is a running Transaction otherwise it returns `undefined`. If you are using our Express integration by default we attach the Transaction to the Scope. So you could do something like this:
 
 ```javascript
 app.get("/success", function successHandler(req, res) {
-  const transaction = Sentry.getCurrentHub()
-    .getScope()
-    .getTransaction();
+  const transaction = Sentry.getActiveTransaction();
 
   if (transaction) {
     let span = transaction.startChild({

--- a/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
@@ -13,7 +13,6 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 ```javascript
 const Sentry = require("@sentry/node");
-const SentryTracing = require("@sentry/tracing");
 const express = require("express");
 const app = express();
 
@@ -23,7 +22,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new SentryTracing.Integrations.Express({
+    new Sentry.Integrations.Express({
       // to trace all requests to the default router
       app,
       // alternatively, you can specify the routes you want to trace:

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -9,11 +9,11 @@ description: "Learn about using Sentry with Koa."
 Add `@sentry/node` as a dependency:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node
+npm install --save @sentry/node @sentry/utils
 ```
 
 ```bash {tabTitle:Yarn}
-yarn add @sentry/node
+yarn add @sentry/node @sentry/utils
 ```
 
 Initialize the Sentry SDK and install the on error hook:
@@ -42,23 +42,11 @@ app.listen(3000);
 
 ## Monitor Performance
 
-```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/tracing
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/node @sentry/tracing
-```
-
 Create and attach a transaction to each request:
 
 ```javascript
 const Sentry = require("@sentry/node");
-const {
-  extractTraceparentData,
-  Span,
-  stripUrlQueryAndFragment,
-} = require("@sentry/tracing");
+const { stripUrlQueryAndFragment } = require("@sentry/utils");
 const Koa = require("koa");
 const app = new Koa();
 const domain = require("domain");
@@ -106,7 +94,7 @@ const tracingMiddleWare = async (ctx, next) => {
   // connect to trace of upstream app
   let traceparentData;
   if (ctx.request.get("sentry-trace")) {
-    traceparentData = extractTraceparentData(ctx.request.get("sentry-trace"));
+    traceparentData = Sentry.extractTraceparentData(ctx.request.get("sentry-trace"));
   }
 
   const transaction = Sentry.startTransaction({

--- a/src/platforms/node/guides/serverless-cloud/index.mdx
+++ b/src/platforms/node/guides/serverless-cloud/index.mdx
@@ -113,13 +113,8 @@ api.use(
 
 ## Monitor Performance
 
-```bash {tabTitle:npm}
-cloud install --save @sentry/node @sentry/tracing
-```
-
 ```javascript
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
 const api = require("@serverless/cloud");
 
 Sentry.init({
@@ -130,7 +125,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({
+    new Sentry.Integrations.Express({
       // to trace all requests to the default router
       api,
       // alternatively, you can specify the routes you want to trace:


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/5815 and #6518

This PR updates our instructions to remove the dependency on using the `@sentry/tracing` package for the node.js SDK and its derivatives. The node.js SDK now enables tracing support by default and the tracing integrations are now available on the `Integrations` namespace.

Before:
```ts
import * as Sentry from '@sentry/node';
import '@sentry/tracing';

Sentry.init({
  dsn: '__DSN__',
  tracesSampleRate: 1.0,
});
```
```ts
import * as Sentry from '@sentry/node';
import * as Tracing from '@sentry/tracing';

Sentry.init({
  dsn: '__DSN__',
  tracesSampleRate: 1.0,
  integrations: [new Tracing.Integrations.Postgres()],
});
```
After:
```ts
import * as Sentry from '@sentry/node';

Sentry.init({
  dsn: '__DSN__',
  tracesSampleRate: 1.0,
  integrations: [...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations()],
});
```
```ts
import * as Sentry from '@sentry/node';

Sentry.init({
  dsn: '__DSN__',
  tracesSampleRate: 1.0,
  integrations: [new Sentry.Integrations.Postgres()],
});
```