### PR TITLE
Add an alert about the usage stats tab

### DIFF
--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -11,6 +11,12 @@ Applying the proper SDK configuration is an iterative and on-going process, but 
 
 ## Before You Begin: Check Your Quota Usage {#3-event-usage-stats}
 
+<Alert title="Note" level="info">
+  
+  <p>The "Usage Stats" tab is only visible if you're on a Team, Business, or Enterprise plan.</p>
+  
+</Alert>
+
 You can look at your events in aggregate in the "Usage Stats" tab of **Stats**. This information will help you answer key questions about the breakdown of your incoming events or which projects are consuming your quota. The answers to these questions can help you figure out where you need to do further fine-tuning of your SDK filters and configuration.
 
 This page is accessible to all members of your organization, so Owners in your Sentry org can share this page with the developers directly responsible for a given project. Also, you can come back to this page to check if the changes you've made are having the desired effect.


### PR DESCRIPTION
Let users know that this tab is only visible if you have a team, business or enterprise plan.

