### PR TITLE
Update options.mx  - deprecated option fix

### DIFF
--- a/src/platforms/elixir/configuration/options.mdx
+++ b/src/platforms/elixir/configuration/options.mdx
@@ -103,7 +103,7 @@ The backend can also be configured to capture Logger metadata, which is detailed
 
 : The sampling factor to apply to events. A value of 0.0 will deny sending any events, and a value of 1.0 will send 100% of events.
 
-`in_app_module_whitelist`
+`in_app_module_allow_list`
 
 : Expects a list of modules that is used to distinguish among stack trace frames that belong to your app and ones that are part of libraries or core Elixir. This is used to better display the significant part of stack traces. The logic is greedy, so if your app's root module is `MyApp` and your setting is `[MyApp]`, that module as well as any submodules like `MyApp.Submodule` would be considered part of your app. Defaults to `[]`.
 


### PR DESCRIPTION
Updates the documentation to reflect the option `in_app_module_whitelist` was renamed to `in_app_module_allow_list` in https://github.com/getsentry/sentry-elixir/blob/master/CHANGELOG.md#805-2021-02-14.

The elixir sentry sdk warns if you use the old option.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
