### PR TITLE
Update manage-transaction-quota.mdx

### DIFF
--- a/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
+++ b/src/docs/product/accounts/quotas/manage-transaction-quota.mdx
@@ -47,7 +47,7 @@ Once the changes are applied, sort the "Results" table by the "COUNT()" column t
 
 ![Busiest Issues](manage-trans-quota-02.png)
 
-## 1. Adjusting Quotas
+## Adjusting Quotas
 
 <Note>
 
@@ -107,7 +107,7 @@ We strongly recommend that you make subscription changes **before** the last day
 
 </Note>
 
-## 2. Inbound Filters {#2-inbound-data-filters}
+## Inbound Filters {#2-inbound-data-filters}
 
 While SDK configuration requires changes to your source code and depends on your next deployment, server-side filters can be easily configured per project in the "Data Filters" section of **[Project] > Settings > Inbound Filters**.
 
@@ -144,10 +144,10 @@ If you have a rogue client, Sentry supports blocking an IP from sending data. Na
 
 If you discover a problematic release causing excessive noise, Sentry supports ignoring all events and attachments from that release. Navigate to **[Project] > Settings > Inbound Filters**, then add the release to the "Releases" field.
 
-## 3. SDK Filtering: beforeSendTransaction {#1-sdk-filtering-beforesendtransaction}
+## SDK Filtering: beforeSendTransaction {#1-sdk-filtering-beforesendtransaction}
 
 Some Sentry SDKs support the `beforeSendTransaction` callback method. Once implemented, this method is invoked when the SDK captures a transaction event, right before sending it to your Sentry account. Because it receives the transaction event object as a parameter, you can use it to modify the event's data or drop the event completely (by returning `null`) based on your custom logic and the data available on the event, such as _tags_, _environment_, _release version_, _transaction name_, and so on. Note that only transaction events pass through `beforeSendTransaction`. Error and message events have a separate method, `beforeSend`, which is supported in all SDKs. Learn more about both methods in [Filtering Events](/platform-redirect/?next=/configuration/filtering/).
 
-## 4. SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
+## SDK Configuration: Tracing Options {#2-sdk-configuration-tracing-options}
 
 When you configure your the SDK, you can control the number of transactions that are sent to Sentry by setting the [tracing options](/platform-redirect/?next=/configuration/options/%23tracing-options), including either setting a sample rate or providing a function for sampling. You can also set up [custom instrumentation](/platform-redirect/?next=/performance/instrumentation/custom-instrumentation/) for performance monitoring to capture certain types of transactions.


### PR DESCRIPTION
Remove numbers from https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/ because it's not really clear why they're there.




