### PR TITLE
Add pr checklist for docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Pre-merge checklist
 
-*If you work at Sentry, you are *able* to merge your own PR without review, but please don't unless there's a good reason.*
+*If you work at Sentry, you are able to merge your own PR without review, but please don't unless there's a good reason.*
 
 - [ ] Checked Vercel preview for correctness, including links
 - [ ] PR was reviewed and approved by any necessary SMEs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,23 @@
+<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->
 
+## Pre-merge checklist
 
+*If you work at Sentry, you are *able* to merge your own PR without review, but please don't unless there's a good reason.*
 
-<!-- Describe your PR here. -->
+- [ ] Checked Vercel preview for correctness, including links
+- [ ] PR was reviewed and approved by any necessary SMEs
+- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
 
+## Description of changes
 
+*Describe your changes here. If your PR relates to or resolves an issue, link that here.*
 
-<!--
+## Legal Boilerplate
 
-  Sentry employees and contractors can delete or ignore the following.
-
--->
-
-### Legal Boilerplate
+<!-- Sentry employees and contractors can delete or ignore this section. -->
 
 Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
+
+## Extra resources
+
+- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Pre-merge checklist
 
-*If you work at Sentry, you are able to merge your own PR without review, but please don't unless there's a good reason.*
+*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*
 
 - [ ] Checked Vercel preview for correctness, including links
 - [ ] PR was reviewed and approved by any necessary SMEs
@@ -10,7 +10,7 @@
 
 ## Description of changes
 
-*Describe your changes here. If your PR relates to or resolves an issue, link that here.*
+*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*
 
 ## Legal Boilerplate
 


### PR DESCRIPTION
Modify the PR template to add a checklist. The main objective is to remind/encourage internal contributors to get the proper reviews before merging their own PRs.