### PR TITLE
feat(node): Add docs for Undici integration

### DIFF
--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -66,6 +66,7 @@ Available options:
 ```
 
 Where `TracingOptions` is:
+
 ```javascript
 {
   /**
@@ -159,6 +160,7 @@ Available options:
   captureAllExceptions?: boolean;
 }
 ```
+
 <Alert level="warning">
 
 Due to an [open Node.js issue](https://github.com/nodejs/node/issues/38439), we
@@ -170,7 +172,7 @@ enabling the `captureAllExceptions` option:
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.Integrations.LocalVariables({
       captureAllExceptions: true,
@@ -186,7 +188,6 @@ try {
 ```
 
 </Alert>
-
 
 ### Modules
 
@@ -237,7 +238,7 @@ To override an integration's settings, provide a new instance to the `integratio
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.Integrations.OnUncaughtException({
       onFatalError: () => {
@@ -258,7 +259,7 @@ Sentry.init({
 
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return integrations.filter(integration => integration.name !== 'Console');
+    return integrations.filter(integration => integration.name !== "Console");
   },
 });
 ```

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -24,10 +24,10 @@ npm install --save @sentry/integrations
 After installation, you can import the integration and provide a new instance with your config to the `integrations` option.
 
 ```javascript
-import { CaptureConsole } from '@sentry/integrations';
+import { CaptureConsole } from "@sentry/integrations";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [new CaptureConsole()],
 });
 ```
@@ -108,3 +108,36 @@ For example, `C:\\Program Files\\Apache\\www` won't work, however, `/Program Fil
 _Import name: `Transaction`_
 
 This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stack trace frames and reads the first in-app frame's module and function name.
+
+### Undici
+
+_(New in version 7.46.0)_
+
+_Import name: `Sentry.Integrations.Undici`_
+
+Instruments outgoing HTTP requests made with [undici](https://github.com/nodejs/undici) and [Node 18's Node Fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch) by adding breadcrumbs and spans.
+
+Available options:
+
+```typescript
+{
+  /**
+   * If breadcrumbs should be created for outgoing requests.
+   * Defaults to true.
+   */
+  breadcrumbs?: boolean;
+  /**
+   * Function determining whether or not to create spans to track outgoing requests to the given URL.
+   * By default, spans will be created for all outgoing requests.
+   */
+  shouldCreateSpanForRequest?: (url: string) => boolean;
+}
+```
+
+To change what requests get the `sentry-trace` and `baggage` headers attached (for use in distributed tracing), use the top level `tracePropagationTargets` option.
+
+```typescript
+Sentry.init({
+  tracePropagationTargets: ["my-site-url.com"],
+});
+```


### PR DESCRIPTION
Add docs for the new Undici Node integration tracked by https://github.com/getsentry/sentry-javascript/issues/7624

For now it is a pluggable optional integration, but this will change in future versions of the SDK.