### PR TITLE
feat(node): Bump LocalVariables min version to 7.46.0

### DIFF
--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -66,6 +66,7 @@ Available options:
 ```
 
 Where `TracingOptions` is:
+
 ```javascript
 {
   /**
@@ -143,7 +144,7 @@ Available options:
 
 _Import name: `Sentry.Integrations.LocalVariables`_
 
-_(Available in version 7.32.0 and above)_
+_(Available in version 7.46.0 and above)_
 
 This integration adds stack local variables to stack frames for uncaught exceptions.
 
@@ -159,6 +160,7 @@ Available options:
   captureAllExceptions?: boolean;
 }
 ```
+
 <Alert level="warning">
 
 Due to an [open Node.js issue](https://github.com/nodejs/node/issues/38439), we
@@ -170,7 +172,7 @@ enabling the `captureAllExceptions` option:
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.Integrations.LocalVariables({
       captureAllExceptions: true,
@@ -186,7 +188,6 @@ try {
 ```
 
 </Alert>
-
 
 ### Modules
 
@@ -237,7 +238,7 @@ To override an integration's settings, provide a new instance to the `integratio
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.Integrations.OnUncaughtException({
       onFatalError: () => {
@@ -258,7 +259,7 @@ Sentry.init({
 
   integrations: function(integrations) {
     // integrations will be all default integrations
-    return integrations.filter(integration => integration.name !== 'Console');
+    return integrations.filter(integration => integration.name !== "Console");
   },
 });
 ```


### PR DESCRIPTION
Given https://github.com/getsentry/sentry-javascript/issues/7230 merging in and getting release, let us bump the min node version required here so that users use a version that has no memory leak issues.