### PR TITLE
feat(apple): Connect Errors with Spans

### DIFF
--- a/src/platform-includes/performance/connect-errors-spans/apple.mdx
+++ b/src/platform-includes/performance/connect-errors-spans/apple.mdx
@@ -1,0 +1,33 @@
+## Connect Errors with Spans
+
+Sentry errors can be linked with transactions and spans.
+
+Errors reported to Sentry while transaction or span **bound to the scope** is running are linked automatically:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+let transaction = SentrySDK.startTransaction(name: "Transaction Name", operation: "operation", bindToScope: true)
+
+do {
+  try processItem()
+  span.finish()
+} catch {
+  SentrySDK.capture(error: error)
+  span.finish(status: .internalError)
+}
+```
+
+```objc {tabTitle:Objective-C}
+#import <Sentry/Sentry.h>
+
+id<SentrySpan> transaction = [SentrySDK startTransactionWithName:@"Transaction Name" operation:@"operation" bindToScope:YES];
+NSError * error;
+
+if (processItem(error: &error)) {
+  [transaction finish];
+} else {
+  [SentrySDK captureError:error];
+  [transaction finishWithStatus:kSentrySpanStatusInternalError];
+}
+```

--- a/src/platform-includes/performance/connect-errors-spans/apple.mdx
+++ b/src/platform-includes/performance/connect-errors-spans/apple.mdx
@@ -1,8 +1,6 @@
 ## Connect Errors with Spans
 
-Sentry errors can be linked with transactions and spans.
-
-Errors reported to Sentry while transaction or span **bound to the scope** is running are linked automatically:
+Sentry errors can be linked to transactions and spans. Errors that are sent to Sentry while the transaction or span **bound to the scope** method is running, will be linked automatically:
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -71,7 +71,7 @@ To instrument certain regions of your code, you can create transactions to captu
 
 </PlatformSection>
 
-<PlatformSection supported={["java", "dart", "flutter", "rust", "native"]}>
+<PlatformSection supported={["java", "dart", "flutter", "rust", "native", "apple"]}>
 
 <PlatformContent includePath="performance/connect-errors-spans" />
 


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Added information on how to connect errors with spans.

Related to https://github.com/getsentry/sentry-cocoa/issues/1324