### PR TITLE
Remove @sentry/tracing from profiling node instructions

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -121,7 +121,7 @@ SentrySDK.start { options in
 
 <Note>
 
-The <PlatformIdentifier name="profiles-sample-rate" /> setting is *relative* to the <PlatformIdentifier name="traces-sample-rate" /> setting.
+The <PlatformIdentifier name="profiles-sample-rate" /> setting is _relative_ to the <PlatformIdentifier name="traces-sample-rate" /> setting.
 
 </Note>
 
@@ -141,7 +141,7 @@ In `AndroidManifest.xml`:
 
 <Note>
 
-The `io.sentry.traces.profiling.sample-rate` setting is *relative* to the `io.sentry.traces.sample-rate` setting.
+The `io.sentry.traces.profiling.sample-rate` setting is _relative_ to the `io.sentry.traces.sample-rate` setting.
 
 </Note>
 
@@ -167,31 +167,29 @@ sentry_sdk.init(
 
 <Note>
 
-The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to the <PlatformIdentifier name="traces_sample_rate" /> setting.
+The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
 </Note>
 
 </PlatformSection>
 
-
 <PlatformSection supported={["node"]}>
 
 ```javascript
-import * as Sentry from '@sentry/node';
-import { ProfilingIntegration } from '@sentry/profiling-node';
-import '@sentry/tracing';
+import * as Sentry from "@sentry/node";
+import { ProfilingIntegration } from "@sentry/profiling-node";
 
 Sentry.init({
-  dsn: '___DSN___',
+  dsn: "___DSN___",
   tracesSampleRate: 1,
   profilesSampleRate: 1,
-  integrations: [new ProfilingIntegration()]
+  integrations: [new ProfilingIntegration()],
 });
 ```
 
 <Note>
 
-The <PlatformIdentifier name="profilesSampleRate" /> setting is *relative* to the <PlatformIdentifier name="tracesSampleRate" /> setting.
+The <PlatformIdentifier name="profilesSampleRate" /> setting is _relative_ to the <PlatformIdentifier name="tracesSampleRate" /> setting.
 
 </Note>
 
@@ -229,7 +227,7 @@ sentry::init((
 
 <Note>
 
-The <PlatformIdentifier name="profiles_sample_rate" /> setting is *relative* to the <PlatformIdentifier name="traces_sample_rate" /> setting.
+The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
 </Note>
 

--- a/src/platforms/javascript/common/install/cdn.mdx
+++ b/src/platforms/javascript/common/install/cdn.mdx
@@ -87,7 +87,7 @@ For example:
 
 - `bundle.js` is `@sentry/browser`, compiled to ES6 but not minified, with debug logging included (as it is for all unminified bundles)
 - `rewriteframes.es5.min.js` is the `RewriteFrames` integration, compiled to ES5 and minified, with no debug logging
-- `bundle.tracing.es5.debug.min.js` is `@sentry/browser` and `@sentry/tracing` bundled together, compiled to ES5 and minified, with debug logging included
+- `bundle.tracing.es5.debug.min.js` is `@sentry/browser` with performance monitoring enabled, compiled to ES5 and minified, with debug logging included
 
 <Alert level="info" title="Updates to naming scheme in SDK version 7">
 

--- a/src/platforms/node/common/profiling/index.mdx
+++ b/src/platforms/node/common/profiling/index.mdx
@@ -7,14 +7,13 @@ By default, Sentry error events will not get trace context unless you configure 
 
 <Note>
 
-Node.js profiling is currently in beta, which means that it's still in progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io). If you’re adopting Profiling in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
+Node.js profiling is currently in beta, which means that it's still in progress and may have bugs. We recognize the irony. If you have any questions or feedback, please email us at [profiling@sentry.io](mailto:profiling@sentry.io). If you're adopting Profiling in a high-throughput environment, we recommend testing prior to deployment to ensure that your service's performance characteristics maintain expectations.
 
 </Note>
 
 For the Profiling integration to work, you must have the Sentry Node SDK package (minimum version 7.x) installed.
 
 ## Installation
-
 
 ```bash
 # Using yarn
@@ -25,12 +24,12 @@ npm install --save @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling
+
 To enable profiling, import @sentry/profiling-node, add ProfilingIntegration to your integrations, and set the profilesSampleRate.
 
 ```javascript
 const Sentry = require("@sentry/node");
-const {ProfilingIntegration} = require("@sentry/profiling-node");
-require("@sentry/tracing");
+const { ProfilingIntegration } = require("@sentry/profiling-node");
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -72,4 +71,5 @@ SENTRY_PROFILER_LOGGING_MODE=eager node script.js
 We recommend you have your own CPU resource-monitoring in place, because the actual resource use could be environment-dependent.
 
 ## Precompiled Binaries
+
 Starting from version 0.1.0, @sentry/profiling-node package precompiles binaries for a number of common architectures. This minimizes the tooling required to run the package and avoids compiling the package from source in most cases, which speeds up installation. The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue on the sentry/profiling-node repository.

--- a/src/wizard/node/profiling-onboarding/node/1.install.md
+++ b/src/wizard/node/profiling-onboarding/node/1.install.md
@@ -11,8 +11,8 @@ For the Profiling integration to work, you must have the Sentry Node SDK package
 
 ```bash
 # Using yarn
-yarn add @sentry/node @sentry/tracing @sentry/profiling-node
+yarn add @sentry/node @sentry/profiling-node
 
 # Using npm
-npm install --save @sentry/node @sentry/tracing @sentry/profiling-node
+npm install --save @sentry/node @sentry/profiling-node
 ```

--- a/src/wizard/node/profiling-onboarding/node/2.configure-performance.md
+++ b/src/wizard/node/profiling-onboarding/node/2.configure-performance.md
@@ -11,7 +11,6 @@ Sentry’s performance monitoring product has to be enabled in order for Profili
 
 ```javascript
 import * as Sentry from "@sentry/node";
-import "@sentry/tracing";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/wizard/node/profiling-onboarding/node/3.configure-profiling.md
+++ b/src/wizard/node/profiling-onboarding/node/3.configure-profiling.md
@@ -11,8 +11,7 @@ Add the `profilesSampleRate` option to your SDK config.
 
 ```javascript
 import * as Sentry from "@sentry/node";
-import {ProfilingIntegration} from "@sentry/profiling-node";
-import "@sentry/tracing";
+import { ProfilingIntegration } from "@sentry/profiling-node";
 
 Sentry.init({
   // ... SDK config
@@ -20,7 +19,7 @@ Sentry.init({
   profilesSampleRate: 1.0, // Profiling sample rate is relative to tracesSampleRate
   integrations: [
     // Add profiling integration to list of integrations
-    new ProfilingIntegration()
+    new ProfilingIntegration(),
   ],
 });
 ```


### PR DESCRIPTION
Also runs code through prettier - so formatting has changed slightly.