### PR TITLE
feat(electron): Remove references to `@sentry/tracing` for Electron SDK

### DIFF
--- a/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
@@ -2,7 +2,7 @@
 // BrowserTracing should only be configured in Electron renderer processes
 import * as Sentry from "@sentry/electron/renderer";
 
-// If manually tracing without BrowserTracing, you need to add tracing extensions
+// If you're using manual tracing without BrowserTracing, you'll need to add tracing extensions
 // Sentry.addTracingExtensions();
 
 Sentry.init({

--- a/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
@@ -2,18 +2,15 @@
 // BrowserTracing should only be configured in Electron renderer processes
 import * as Sentry from "@sentry/electron/renderer";
 
-// If taking advantage of automatic instrumentation (highly recommended)
-import { BrowserTracing } from "@sentry/tracing";
-// Or, if only manually tracing
-// import * as _ from "@sentry/tracing"
-// Note: You MUST import the package in some way for tracing to work
+// If manually tracing without BrowserTracing, you need to add tracing extensions
+// Sentry.addTracingExtensions();
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
   // This enables automatic instrumentation (highly recommended), but is not
   // necessary for purely manual usage
-  integrations: [new BrowserTracing()],
+  integrations: [new Sentry.BrowserTracing()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
@@ -1,17 +1,16 @@
-To enable tracing, include the `BrowserTracing` integration in your SDK configuration options. (Note that when using ESM modules, the main `@sentry/*` import must come before the `@sentry/tracing` import.)
+To enable tracing, include the `BrowserTracing` integration in your SDK configuration options.
 
 After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
 
 ```javascript
 // BrowserTracing should only be configured in Electron renderer processes
 import * as Sentry from "@sentry/electron/renderer";
-import { BrowserTracing } from "@sentry/tracing"; // Must import second
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
   integrations: [
-    new BrowserTracing({
+    new Sentry.BrowserTracing({
       tracePropagationTargets: ["localhost", "my-site-url.com", /^\//],
       // ... other options
     }),


### PR DESCRIPTION
After updating to the latest JavaScript SDKs, users no longer need to use `@sentry/tracing` with the Electron SDK to support performance.