### PR TITLE
React Router: Add info about wrapping Routes

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -120,6 +120,8 @@ ReactDOM.render(
 );
 ```
 
+This is only needed at the top level of your app, rather than how v4/v5 required wrapping every `<Route/>` you wanted parametrized.
+
 ### Usage With `useRoutes` Hook
 
 _(Available in version 7.12.1 and above)_
@@ -175,7 +177,7 @@ ReactDOM.render(
 );
 ```
 
-Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (for example, `/teams/:teamid/user/:userid`), where applicable.
+Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (for example, `/teams/:teamid/user/:userid`), where applicable. This is only needed at the top level of your app, rather than how v4/v5 required wrapping every `<Route/>` you wanted parametrized.
 
 ## React Router v4/v5
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This adds a comment about how you don't need to wrap *all* the Routes in RRv6, as compared to needing to wrap every Route in RRv5.

Another question I have is whether you need to use SentryRoutes if you're already using `sentryCreateBrowserRouter`, or are those mutually exclusive options?

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
