### PR TITLE
fix(ai): Update docs link to redirect to the correct org

### DIFF
--- a/src/docs/product/issues/issue-details/suggested-fix/index.mdx
+++ b/src/docs/product/issues/issue-details/suggested-fix/index.mdx
@@ -20,7 +20,7 @@ undisclosed in our [subprocessor list](https://sentry.io/legal/subprocessors/).
 Because of this you need to provide consent to do so.  If your organization has
 signed a DPA with us, an owner of the organization will need to sign a
 "OpenAI Subprocessor Acknowledgement" in the organization [Legal & Compliance
-page](https://sentry-sdks.sentry.io/settings/legal/).  Otherwise an individual
+page](<https://sentry.io/orgredirect/organizations/:orgslug/settings/legal/>).  Otherwise an individual
 user will receive a prompt to confirm that data will be sent to a third party.
 
 Under all circumstance we will not send any event data to OpenAI without an


### PR DESCRIPTION
Link was pointing always to `sentry-sdks`. This PR makes it dynamically according to the user org