### PR TITLE
fixing sentryclirc auth sintax

### DIFF
--- a/src/docs/product/crons/getting-started/cli.mdx
+++ b/src/docs/product/crons/getting-started/cli.mdx
@@ -31,8 +31,8 @@ export SENTRY_DSN=___PUBLIC_DSN___
 Alternatively, you can add it to your `~/.sentryclirc` config:
 
 ```ini {filename:~/.sentryclirc}
-[defaults]
-auth.dsn = ___PUBLIC_DSN___
+[auth]
+dsn = ___PUBLIC_DSN___
 ```
 
 Learn more about the CLI's [configuration file](/product/cli/configuration#configuration-file).


### PR DESCRIPTION
Adding the following lines to authenticate cron checkins

```
[defaults]
auth.dsn = MY_DSN
```
 results in a warning message in the CLI:

```
 WARN    2023-04-04 14:54:48.791431 +02:00 Token auth is deprecated for cron monitor checkins. Please use DSN auth.
```

The correct syntax that removes the warning is:

```
[auth]
dsn = MY_DSN
```

