### PR TITLE
feat(react): Add note about `useEffect` and Sentry.captureException

### DIFF
--- a/src/platform-includes/capture-error/javascript.react.mdx
+++ b/src/platform-includes/capture-error/javascript.react.mdx
@@ -11,3 +11,11 @@ try {
   Sentry.captureException(err);
 }
 ```
+
+Sentry calls like `captureException` or `captureMessage` are side effects, so they should be wrapped in a `useEffect` hook to avoid triggering them on every render.
+
+```javascript
+useEffect(() => {
+  Sentry.captureException(error);
+}, [error]);
+```

--- a/src/platform-includes/capture-error/javascript.react.mdx
+++ b/src/platform-includes/capture-error/javascript.react.mdx
@@ -15,7 +15,17 @@ try {
 Sentry calls like `captureException` or `captureMessage` are side effects, so they should be wrapped in a `useEffect` hook to avoid triggering them on every render.
 
 ```javascript
-useEffect(() => {
-  Sentry.captureException(error);
-}, [error]);
+import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+
+function App() {
+  const [info, error] = useQuery("/api/info");
+  useEffect(() => {
+    if (error) {
+      Sentry.captureException(error);
+    }
+  }, [error]);
+
+  // ...
+}
 ```


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/7698

`Sentry.captureException` is a side effect, so let's make that clear to users in our docs.