### PR TITLE
Add docs for JS browser user feedback API

### DIFF
--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
@@ -1,0 +1,33 @@
+_Requires JS SDK version v7.47.0 or higher._
+
+```js
+import * as Sentry from '@sentry/browser';
+
+const eventId = Sentry.captureMessage('User Feedback');
+// OR: const eventId = Sentry.lastEventId();
+
+const userFeedback = {
+  event_id: eventId;
+  name: 'John Doe',
+  email: 'john@doe.com',
+  comments: 'I really like your App, thanks!'
+}
+Sentry.captureUserFeedback(userFeedback);
+```
+
+You could also collect feedback and send it when an error occurs via the SDK's `beforeSend` callback:
+
+```js
+Sentry.init({
+  dsn: '__DSN__',
+  beforeSend: event => {
+    const userFeedback = collectYourUserFeedback();
+    const feedback = {
+      ...userFeedback,
+      event_id: event.event_id.
+    }
+    Sentry.captureUserFeedback(feedback);
+    return event;
+  }
+})
+```

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -20,7 +20,7 @@ While this feature isn't currently supported for Ruby or most of its frameworks,
 
 </PlatformSection>
 
-<PlatformSection supported={["java", "apple", "android", "dart", "flutter", "unreal", "react-native", "kotlin-multiplatform"]} >
+<PlatformSection supported={["javascript", "java", "apple", "android", "dart", "flutter", "unreal", "react-native", "kotlin-multiplatform"]} >
 
 ## User Feedback API
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-docs/issues/6602

We released the User Feedback API in https://github.com/getsentry/sentry-javascript/releases/tag/7.47.0, this PR adds docs for it.

Thanks for the reminder @sdzhong!