### PR TITLE
Highlight limitations of transaction filters

### DIFF
--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -83,7 +83,9 @@ For some metric alerts, you can set the event type that you want to be alerted a
 
 ### Tags & Properties
 
-Add filters in the provided input to narrow down what you'll be alerted about, such as URL tags or other event properties. Available properties depend on your alert's event type. For error events, all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list. For transaction events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
+Add filters in the provided input to narrow down what you'll be alerted about, such as URL tags or other event properties. Available properties depend on your alert's event type: 
+- for **error** events, all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list
+- for **transaction** events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
 
 #### Invalid Filters
 


### PR DESCRIPTION
It's pretty easy to miss the limitations on filtering for transactions, trying to make it a bit easier to spot.