### PR TITLE
Note for Alerts

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -26,6 +26,12 @@ You can search by event properties in the following [sentry.io](https://sentry.i
 - Issues - as indicated in the table below
 - Alerts - when creating a metric alert
 
+<Note>
+
+Please note that in Alerts only a limited number of properties are available for [filtering transaction events](/product/alerts/create-alerts/metric-alert-config/#tags--properties).
+
+</Note>
+
 When searching on event properties within the **Issues** page, the search will return any issue that has _one or more events_ matching the supplied event properties filter.
 
 ### Replay Properties


### PR DESCRIPTION
Added a note about the limited number of properties one can search for when configuring a filter in a performance metric alert.