### PR TITLE
Fix typo in Xcode Cloud troubleshooting

### DIFF
--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -171,7 +171,7 @@ If you're using `React Navigation 5` and you're not receiving transactions anymo
 
 If you experience mismatched line numbers on [sentry.io](https://sentry.io) when using RAM Bundles, this is due to a [bug](https://github.com/facebook/metro/issues/399) on the Metro tooling.
 
-## Uploading source maps from Xcode Could
+## Uploading source maps from Xcode Cloud
 
 The Xcode integration reads `dist` from `CFBundleVersion` but Xcode Cloud builds use `CI_BUILD_NUMBER` variable. Add the following code to `Bundle React Native code and images` build phase to enable correct source maps uploads. 
 


### PR DESCRIPTION
This fixes a minor typo in one of the troubleshooting steps. Xcode Cloud was misspelled as "Xcode Could"

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
