### PR TITLE
Remove non-existing `Transaction` integration from Node.js docs

### DIFF
--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -103,12 +103,6 @@ For example, `C:\\Program Files\\Apache\\www` won't work, however, `/Program Fil
 
 ## Node-specific
 
-### Transaction
-
-_Import name: `Transaction`_
-
-This integration tries to extract useful transaction names that will be used to distinguish the event from the rest. It walks through all stack trace frames and reads the first in-app frame's module and function name.
-
 ### Undici
 
 _(New in version 7.46.0)_


### PR DESCRIPTION
Stumbled across this and I don't think this integration exists anymore.