### PR TITLE
Add node docs for tRPC middleware

### DIFF
--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -143,3 +143,26 @@ Sentry.init({
   tracePropagationTargets: ["my-site-url.com"],
 });
 ```
+
+## Frameworks
+
+### tRPC Middleware
+
+_(New in version TODO)_
+
+The Sentry tRPC middleware guarantees your transactions related to RPCs are well-named.
+Additionally, it can attach RPC input via the `attachRpcInput` option.
+
+```typescript
+import { initTRPC } from "@trpc/server";
+import * as Sentry from "@sentry/node";
+
+const t = initTRPC.context().create();
+const sentryMiddleware = t.middleware(
+  Sentry.Handlers.trpcMiddleware({
+    attachRpcInput: true,
+  })
+);
+
+const sentrifiedProcedure = t.procedure.use(sentryMiddleware);
+```

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -148,7 +148,7 @@ Sentry.init({
 
 ### tRPC Middleware
 
-_(New in version TODO)_
+_(New in version 7.48.0)_
 
 The Sentry tRPC middleware helps make sure your transactions related to RPCs are well-named.
 Additionally, it can attach RPC input via the `attachRpcInput` option.

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -150,7 +150,7 @@ Sentry.init({
 
 _(New in version TODO)_
 
-The Sentry tRPC middleware guarantees your transactions related to RPCs are well-named.
+The Sentry tRPC middleware helps make sure your transactions related to RPCs are well-named.
 Additionally, it can attach RPC input via the `attachRpcInput` option.
 
 ```typescript


### PR DESCRIPTION
Waiting on a fix + release (https://github.com/getsentry/sentry-javascript/pull/7802) before adding the version number.