### PR TITLE
fix(jira): Add note about assignable user permissions

### DIFF
--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -191,3 +191,7 @@ We don’t support custom required fields for the Jira integration. The only req
 A `400` error is often generated because the Jira instance is not publicly accessible. Make sure your instance is routable (that is, our server can reach it!). If not, you’ll need to put your Jira instance on the internet so that we can reach it.
 
 For a `500` error, unfortunately the reason can vary. This error means we couldn’t connect to your server from our server. For example, perhaps your proxy is not configured correctly, or not set to allow our IP. If you need to allow our IPs, you can find a list of our IP ranges [here](/product/security/ip-ranges/).
+
+### Unable to find specific user when using Reporter field
+
+Make sure the user has been added to the relevant project in Jira and has the [Assignable User permission](https://confluence.atlassian.com/jiracoreserver/permissions-overview-939937977.html).


### PR DESCRIPTION
This adds a troubleshooting entry to the Jira integration docs covering a hurdle I ran into when setting up the integration.

Ref: WOR-2928