### PR TITLE
fix(sourcemaps): Add clarification for javascript SDK version

### DIFF
--- a/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
@@ -47,7 +47,7 @@ Visit the [auth token user settings page](https://sentry.io/settings/account/api
 
 <Note>
 
-`sentry-cli >= 2.17.0` is required to upload artifact bundles.
+Uploading artifact bundles is supported from **Sentry CLI** version `2.17.0` onwards and the **Sentry JavaScript SDK** needs to be on version `7.47.0` or later.
 
 </Note>
 

--- a/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
@@ -47,7 +47,9 @@ Visit the [auth token user settings page](https://sentry.io/settings/account/api
 
 <Note>
 
-Uploading artifact bundles is supported from **Sentry CLI** version `2.17.0` onwards and the **Sentry JavaScript SDK** needs to be on version `7.47.0` or later.
+Uploading artifact bundles requires:
+- `sentry-cli` version >= `2.17.0`
+- Sentry Javascript SDK version >= `7.47.0`
 
 </Note>
 


### PR DESCRIPTION
This PR adds the Sentry Javascript SDK version to new sourcemaps docs.