### PR TITLE
feat: Add docs for `ignoreErrors` & `ignoreTransactions`

### DIFF
--- a/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
+++ b/src/docs/product/accounts/quotas/manage-event-stream-guide.mdx
@@ -355,6 +355,7 @@ The integration is enabled by default and adds the following configuration optio
 - `allowUrls`: Domains that might raise acceptable exceptions represented in a regex pattern format.
 - `denyUrls`: A list of strings or regex patterns which match error URLs that should be blocked from sending events. Configuring both `allowUrls` and `denyUrls` on the SDK can be used to block subdomains of the domains listed in `allowUrls`.
 - `ignoreErrors`: Instructs the SDK to never send an error to Sentry if it matches any of the listed error messages or regular expressions. The SDK will try to match against the message or, if there is no message, a string containing the exception type and value formatted like so: `ExceptionType: value`.
+- `ignoreTransactions`: Instructs the SDK to never send a transaction to Sentry if it matches any of the listed transaction names or regular expressions.
 
 To learn more and see code samples, check out:
 

--- a/src/platform-includes/configuration/ignore-errors/javascript.mdx
+++ b/src/platform-includes/configuration/ignore-errors/javascript.mdx
@@ -1,0 +1,6 @@
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  ignoreErrors: ["fb_xd_fragment", /^Exact Match Message$/],
+});
+```

--- a/src/platform-includes/configuration/ignore-transactions/javascript.mdx
+++ b/src/platform-includes/configuration/ignore-transactions/javascript.mdx
@@ -1,0 +1,6 @@
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  ignoreTransactions: ["partial/match", /^Exact Transaction Name$/],
+});
+```

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -76,6 +76,15 @@ In this example, the fingerprint is forced to a common value if an exception of 
 
 </PlatformSection>
 
+<PlatformSection supported={["javascript", "node"]} >
+
+### Using <PlatformIdentifier name="ignore-errors" /> 
+
+You can use the <PlatformIdentifier name="ignore-errors" />  option to filter out errors that match a certain pattern. This option receives a list of strings and regular expressions to match against the error message.
+
+<PlatformContent includePath="configuration/ignore-errors" />
+</PlatformSection>
+
 <PlatformSection supported={["android", "javascript", "java", "python"]} >
 
 ### Decluttering Sentry
@@ -108,6 +117,15 @@ Learn more about <PlatformLink to="/configuration/sampling/">configuring the sam
 
 <PlatformContent includePath="configuration/before-send-transaction" />
 
+</PlatformSection>
+
+<PlatformSection supported={["javascript", "node"]} >
+
+### Using <PlatformIdentifier name="ignore-transactions" /> 
+
+You can use the <PlatformIdentifier name="ignore-transactions" />  option to filter out transactions that match a certain pattern. This option receives a list of strings and regular expressions to match against the transaction name.
+
+<PlatformContent includePath="configuration/ignore-transactions" />
 </PlatformSection>
 
 </PlatformSection>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -268,13 +268,13 @@ For ASP.NET and ASP.NET Core applications, the value will default to the server'
 
 <ConfigKey name="ignore-errors" supported={["javascript", "node"]} notSupported={[]}>
 
-A list of strings or regex patterns that match error messages that should not be sent to Sentry. This expects a list of the messages to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the messages, so if you need to achieve an exact match, use RegExp patterns instead. By default, all errors are sent.
+A list of strings or regex patterns that match error messages that shouldn't be sent to Sentry. Messages that match these strings or regular expressions will be filtered out before they're sent to Sentry. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead. By default, all errors are sent.
 
 </ConfigKey>
 
 <ConfigKey name="ignore-transactions" supported={["javascript", "node"]} notSupported={[]}>
 
-A list of strings or regex patterns that match transaction names that should not be sent to Sentry. This expects a list of the names to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the name, so if you need to achieve an exact match, use RegExp patterns instead. By default, all transactions are sent.
+A list of strings or regex patterns that match transaction names that shouldn't be sent to Sentry. Transactions that match these strings or regular expressions will be filtered out before they're sent to Sentry. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead. By default, all transactions are sent.
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -266,6 +266,18 @@ For ASP.NET and ASP.NET Core applications, the value will default to the server'
 
 </ConfigKey>
 
+<ConfigKey name="ignore-errors" supported={["javascript", "node"]} notSupported={[]}>
+
+A list of strings or regex patterns that match error messages that should not be sent to Sentry. This expects a list of the messages to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the messages, so if you need to achieve an exact match, use RegExp patterns instead. By default, all errors are sent.
+
+</ConfigKey>
+
+<ConfigKey name="ignore-transactions" supported={["javascript", "node"]} notSupported={[]}>
+
+A list of strings or regex patterns that match transaction names that should not be sent to Sentry. This expects a list of the names to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the name, so if you need to achieve an exact match, use RegExp patterns instead. By default, all transactions are sent.
+
+</ConfigKey>
+
 <ConfigKey name="deny-urls" supported={["javascript"]} notSupported={["node"]}>
 
 A list of strings or regex patterns that match error URLs that should not be sent to Sentry. Errors whose entire file URL contains (string) or matches (regex) at least one entry in the list will not be sent. As a result, if you add `'foo.com'` to the list, it will also match on `https://bar.com/myfile/foo.com`. By default, all errors are sent.

--- a/src/platforms/javascript/common/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/default.mdx
@@ -20,7 +20,7 @@ message, or URLs in a given exception.
 
 It ignores errors that start with `Script error` or `Javascript error: Script error` by default.
 
-To configure this integration, use the `ignoreErrors`, `denyUrls`,
+To configure this integration, use the `ignoreErrors`, `ignoreTransactions`, `denyUrls`,
 and `allowUrls` SDK options directly. Keep in mind that `denyURLs` and `allowURLs`
 only work for captured exceptions, not raw message events.
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -17,7 +17,7 @@ _Import name: `Sentry.Integrations.InboundFilters`_
 
 This integration allows you to ignore specific errors based on the error message or the URL from which the exception originated.
 
-To configure it, use the `ignoreErrors`, `denyUrls`, and `allowUrls` SDK options directly.
+To configure it, use the `ignoreErrors`, `ignoreTransactions`, `denyUrls`, and `allowUrls` SDK options directly.
 Keep in mind that `denyUrls` and `allowUrls` only work for captured exceptions, not raw message events.
 
 ### FunctionToString


### PR DESCRIPTION
This adds proper docs for `ignoreErrors` & `ignoreTransactions` as ways to filter events.

I've only added them for JavaScript for now, but I believe it also exists for other languages already - we may also add these then?