### PR TITLE
docs(profiling): Update python profiling docs for 1.18.0

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -185,7 +185,7 @@ The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to 
 
 ### Upgrading from older SDK versions
 
-The feature was marked experimental prior to version `1.17.0`. To update to the latest SDK, simply remove `profiles_sample_rate` from the experiment option and use the new option.
+The feature was experimental prior to version `1.17.0`. To update to the latest SDK, remove `profiles_sample_rate` from `_experiments` and set it in the top-level options.
 
 ```python
 sentry_sdk.init(

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -151,17 +151,29 @@ The `io.sentry.traces.profiling.sample-rate` setting is _relative_ to the `io.se
 
 <Note>
 
-Python profiling beta is available starting in SDK version `1.16.0`.
+Python profiling beta is available starting in SDK version `1.18.0`.
 
 </Note>
 
 ```python
+import sentry_sdk
+
+def profiles_sampler(sampling_context):
+    # ...
+    # return a number between 0 and 1 or a boolean
+
 sentry_sdk.init(
-  dsn="___DSN___",
-  traces_sample_rate=1.0,
-  _experiments={
-    "profiles_sample_rate": 1.0,
-  },
+    dsn="___DSN___",
+    traces_sample_rate=1.0,
+
+    # To set a uniform sample rate
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production,
+    profiles_sample_rate=1.0,
+
+    # Alternatively, to control sampling dynamically
+    profiles_sampler=profiles_sampler
 )
 ```
 
@@ -170,6 +182,20 @@ sentry_sdk.init(
 The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
 </Note>
+
+### Upgrading from older SDK versions
+
+The feature was marked experimental prior to version `1.17.0`. To update to the latest SDK, simply remove `profiles_sample_rate` from the experiment option and use the new option.
+
+```python
+sentry_sdk.init(
+    dsn="___DSN___",
+    traces_sample_rate=1.0,
+    _experiments={
+      "profiles_sample_rate": 1.0,  # for versions before 1.17.0
+    },
+)
+```
 
 </PlatformSection>
 

--- a/src/wizard/python/profiling-onboarding/python/1.install.md
+++ b/src/wizard/python/profiling-onboarding/python/1.install.md
@@ -7,7 +7,7 @@ type: language
 
 #### Install
 
-For the Profiling integration to work, you should have the Sentry Python SDK package (minimum version 1.16.0) installed.
+For the Profiling integration to work, you should have the Sentry Python SDK package (minimum version 1.18.0) installed.
 
 ```bash
 pip install --upgrade sentry-sdk

--- a/src/wizard/python/profiling-onboarding/python/3.configure-profiling.md
+++ b/src/wizard/python/profiling-onboarding/python/3.configure-profiling.md
@@ -13,9 +13,15 @@ Add the `profiles_sample_rate` option to your SDK config.
 import sentry_sdk
 
 sentry_sdk.init(
-  # ... SDK config
-  _experiments={
-    "profiles_sample_rate": 1.0,
-  }
+    # ... SDK config
+
+    # To set a uniform sample rate
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production,
+    profiles_sample_rate=1.0,
+
+    # Alternatively, to control sampling dynamically
+    profiles_sampler=profiles_sampler
 )
 ```

--- a/src/wizard/python/profiling-onboarding/python/3.configure-profiling.md
+++ b/src/wizard/python/profiling-onboarding/python/3.configure-profiling.md
@@ -18,7 +18,7 @@ sentry_sdk.init(
     # To set a uniform sample rate
     # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
-    # We recommend adjusting this value in production,
+    # We recommend adjusting this value in production
     profiles_sample_rate=1.0,
 
     # Alternatively, to control sampling dynamically


### PR DESCRIPTION
Update the docs for python profiling for the latest min version 1.18.0 which moves python profiling out of the experiment option.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
