### PR TITLE
Update bundler plugin snippets to use new Debug ID process by default

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -49,12 +49,14 @@ export default defineConfig({
       org: "___ORG_SLUG___",
       project: "___PROJECT_SLUG___",
 
-      // Specify the directory containing build artifacts
-      include: "./dist",
-
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
+
+      sourcemaps: {
+        // Specify the directory containing build artifacts
+        assets: "./out/**",
+      },
 
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 
       sourcemaps: {
         // Specify the directory containing build artifacts
-        assets: "./out/**",
+        assets: "./dist/**",
       },
 
       // Optionally uncomment the line below to override automatic release name detection

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -1,6 +1,5 @@
 ## Upload Source Maps for a Svelte Project
 
-Sentry uses [releases](/product/releases/) to match the correct source maps to your events.
 This page is a guide on how to create releases and upload source maps to Sentry when bundling your Svelte app.
 
 To generate source maps with your Svelte project, you need to set the source map [compiler options](https://svelte.dev/docs#compile-time-svelte-compile) in your Svelte config:

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -57,6 +57,9 @@ export default defineConfig({
         assets: "./dist/**",
       },
 
+      // Use the following option if you're on an SDK version lower than 7.47.0:
+      // include: "./dist",
+
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
     }),

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -44,7 +44,7 @@ export default defineConfig({
 
       sourcemaps: {
         // Specify the directory containing build artifacts
-        assets: "./out/**",
+        assets: "./dist/**",
       },
 
       // Optionally uncomment the line below to override automatic release name detection

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -38,12 +38,14 @@ export default defineConfig({
       org: "___ORG_SLUG___",
       project: "___PROJECT_SLUG___",
 
-      // Specify the directory containing build artifacts
-      include: "./dist",
-
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
-      // and needs the `project:releases` and `org:read` scopes
+      // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
+
+      sourcemaps: {
+        // Specify the directory containing build artifacts
+        assets: "./out/**",
+      },
 
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
@@ -54,19 +56,6 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
-});
-```
-
-The Sentry Vite plugin will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release` option exactly:
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // When using the plugin, either remove the `release`` property here entirely or
-  // make sure that the plugin's release option and the Sentry.init()'s release
-  // option match exactly.
-  // release: "my-example-release-1"
 });
 ```
 

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -47,6 +47,9 @@ export default defineConfig({
         assets: "./dist/**",
       },
 
+      // Use the following option if you're on an SDK version lower than 7.47.0:
+      // include: "./dist",
+
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
     }),

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -30,29 +30,18 @@ require("esbuild").build({
       org: "___ORG_SLUG___",
       project: "___PROJECT_SLUG___",
 
-      // Specify the directory containing build artifacts
-      include: "./dist",
-
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
+
+      sourcemaps: {
+        // Specify the directory containing build artifacts
+        assets: "./out/**",
+      },
 
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
     }),
   ],
-});
-```
-
-The Sentry esbuild plugin will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release` option exactly:
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // When using the plugin, either remove the `release`` property here entirely or
-  // make sure that the plugin's release option and the Sentry.init()'s release
-  // option match exactly.
-  // release: "my-example-release-1"
 });
 ```

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -1,4 +1,4 @@
-Sentry uses [releases](/product/releases/) to match the correct source maps to your events. You can use the Sentry esbuild plugin to automatically create releases and upload source maps to Sentry when bundling your app.
+You can use the Sentry esbuild plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Install
 

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -36,7 +36,7 @@ require("esbuild").build({
 
       sourcemaps: {
         // Specify the directory containing build artifacts
-        assets: "./out/**",
+        assets: "./dist/**",
       },
 
       // Optionally uncomment the line below to override automatic release name detection

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -39,6 +39,9 @@ require("esbuild").build({
         assets: "./dist/**",
       },
 
+      // Use the following option if you're on an SDK version lower than 7.47.0:
+      // include: "./dist",
+
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
     }),

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -28,12 +28,14 @@ export default {
       org: "___ORG_SLUG___",
       project: "___PROJECT_SLUG___",
 
-      // Specify the directory containing build artifacts
-      include: "./out",
-
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
+
+      sourcemaps: {
+        // Specify the directory containing build artifacts
+        assets: "./out/**",
+      },
 
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
@@ -44,17 +46,4 @@ export default {
     dir: "./out",
   },
 };
-```
-
-The Sentry Rollup plugin will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release` option exactly:
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // When using the plugin, either remove the `release`` property here entirely or
-  // make sure that the plugin's release option and the Sentry.init()'s release
-  // option match exactly.
-  // release: "my-example-release-1"
-});
 ```

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -36,6 +36,9 @@ export default {
         assets: "./out/**",
       },
 
+      // Use the following option if you're on an SDK version lower than 7.47.0:
+      // include: "./out",
+
       // Optionally uncomment the line below to override automatic release name detection
       // release: process.env.RELEASE,
     }),

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -1,4 +1,3 @@
-Sentry uses [releases](/product/releases/) to match the correct source maps to your events.
 You can use the Sentry Rollup plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Installation

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -43,6 +43,9 @@ export default defineConfig(({ command, mode }) => {
           assets: "./dist/**",
         },
 
+        // Use the following option if you're on an SDK version lower than 7.47.0:
+        // include: "./dist",
+
         // Optionally uncomment the line below to override automatic release name detection
         // release: env.RELEASE,
       }),

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -1,4 +1,4 @@
-Sentry uses [releases](/product/releases/) to match the correct source maps to your events. You can use the Sentry Vite plugin to automatically create releases and upload source maps to Sentry when bundling your app.
+You can use the Sentry Vite plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Installation
 

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -24,7 +24,6 @@ export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), "");
-
   return {
     build: {
       sourcemap: true, // Source map generation must be turned on
@@ -37,15 +36,15 @@ export default defineConfig(({ command, mode }) => {
 
         // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
         // and need `project:releases` and `org:read` scopes
-        authToken: process.env.SENTRY_AUTH_TOKEN,
+        authToken: env.SENTRY_AUTH_TOKEN,
 
         sourcemaps: {
           // Specify the directory containing build artifacts
-          assets: "./out/**",
+          assets: "./dist/**",
         },
 
         // Optionally uncomment the line below to override automatic release name detection
-        // release: process.env.RELEASE,
+        // release: env.RELEASE,
       }),
     ],
   };

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -23,7 +23,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), "");
 
   return {
     build: {
@@ -35,30 +35,19 @@ export default defineConfig(({ command, mode }) => {
         org: "___ORG_SLUG___",
         project: "___PROJECT_SLUG___",
 
-        // Specify the directory containing build artifacts
-        include: "./dist",
-
         // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
-        // and needs the `project:releases` and `org:read` scopes
-        authToken: env.SENTRY_AUTH_TOKEN,
+        // and need `project:releases` and `org:read` scopes
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+
+        sourcemaps: {
+          // Specify the directory containing build artifacts
+          assets: "./out/**",
+        },
 
         // Optionally uncomment the line below to override automatic release name detection
-        // release: env.RELEASE,
+        // release: process.env.RELEASE,
       }),
     ],
-  }
-});
-```
-
-The Sentry Vite plugin will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release` option exactly:
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // When using the plugin, either remove the `release`` property here entirely or
-  // make sure that the plugin's release option and the Sentry.init()'s release
-  // option match exactly.
-  // release: "my-example-release-1"
+  };
 });
 ```


### PR DESCRIPTION
Waiting for the release of https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/204

Resolves https://github.com/getsentry/sentry/issues/47230