### PR TITLE
Fix misplaced content in GitLab docs

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -136,8 +136,10 @@ Stack trace linking takes you from a file in your Sentry stack trace to that sam
    - **repo** (required): This is the GitLab project associated with the Sentry project above. If you have more than one GitLab project being used per Sentry project, you'll need multiple code mappings.
    - **branch** (required): This is the default branch of your code we fall back to if you do not have commit tracking set up.
    - **stack trace root** and **source code root** (optional):
-
-     1. If the file path in your Sentry stack trace frame matches the path to your source code, you do not need to set these values.
+     - If the file path in your Sentry stack trace frame matches the path to your source code, you do not need to set these values.
+         - For example, if everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, you don't need to set either **stack trace root** or **source code root**.
+     - If the file path in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the **stack_root** part of the file path with your **source_root** to make the file path match the source code path.
+         - For example, to get `src/code.py` to match `code.py` when the source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, change the **stack trace root** to be set as `src/`, and leave **source code root** empty.
 
 ### Suspect Commits
 
@@ -146,13 +148,6 @@ Once you've set up stack trace linking, Sentry can use information from your sou
 ![Issue detail highlighting suspect commits](highlighting-suspect-commits.png)
 
 Learn about setting up this functionality in [Suspect Commits](/product/issues/suspect-commits/).
-
-### Code Owners
-
-        - ex. For example, everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py` so you don't need to set a **stack trace root** and **source code root**.
-
-     1. If the file path in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the **stack_root** part of the file path with your **source_root** to make the file path match the source code path.
-        - ex. For example, to get `src/code.py` to match `code.py` when the source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, change the **stack trace root** to be set as `src/`, and leave **source code root** empty.
 
 ### Code Owners
 

--- a/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/gitlab/index.mdx
@@ -136,10 +136,10 @@ Stack trace linking takes you from a file in your Sentry stack trace to that sam
    - **repo** (required): This is the GitLab project associated with the Sentry project above. If you have more than one GitLab project being used per Sentry project, you'll need multiple code mappings.
    - **branch** (required): This is the default branch of your code we fall back to if you do not have commit tracking set up.
    - **stack trace root** and **source code root** (optional):
-     - If the file path in your Sentry stack trace frame matches the path to your source code, you do not need to set these values.
-         - For example, if everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, you don't need to set either **stack trace root** or **source code root**.
-     - If the file path in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the **stack_root** part of the file path with your **source_root** to make the file path match the source code path.
-         - For example, to get `src/code.py` to match `code.py` when the source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, change the **stack trace root** to be set as `src/`, and leave **source code root** empty.
+     - If the file path in your Sentry stack trace frame matches the path to your source code, you don't need to set these values.
+         - For example, if everything after the branch (`main`) matches the file path of `code.py` using a source code path of `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, you don't need to set either `stack trace root` or `source code root`
+     - If the file path in your Sentry stack trace frame doesn't match the path to your source code, you will need to replace the `stack_root` part of the file path with your `source_root` to make the file path match the source code path.
+         - For example, to get `src/code.py` to match `code.py` when the source code path is `https://gitlab.com/murdith-group/issa-project/-/blob/main/code.py`, change the `stack trace root` to be set as `src/`, and leave `source code root` empty.
 
 ### Suspect Commits
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

In the [Gitlab docs](https://docs.sentry.io/product/integrations/source-code-mgmt/gitlab/#stack-trace-linking), part of the bullet list that should go under the "Stack Trace Linking" heading is instead under the "Code owners" heading ([showing up as a txt code block](https://docs.sentry.io/product/integrations/source-code-mgmt/gitlab/#code-owners)), and this last heading is also repeating twice.

This PR fixes these two issues without any change in the substance of the text being moved.

Cheers!

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
