### PR TITLE
Add note about spend allocation to pricing page

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -130,7 +130,11 @@ Each Sentry plan includes different amounts of reserved volume. For example, our
 
 Buying on-demand volume lets you control the maximum amount you’ll pay for overage each month after your reserved volume runs out. If you go over your on-demand volume, you’ll still have access to previous event data, but any new data you send will be rejected and you won’t be charged for it.
 
-With on-demand volume, you pay for any event or attachment processed, (rounded up to the nearest cent), after your reserved volume has run out. On-demand volume is billed at the end of each billing month. To see on-demand pricing per plan type, check out our [per-category-pricing](#per-category-pricing).
+With on-demand volume, you pay for any event or attachment processed, (rounded up to the nearest cent), after your reserved volume has run out, unless you have [spend allocation](/product/accounts/quotas/spend-allocation/) enabled. 
+
+If you’ve enabled spend allocation and your project has burned through both its dedicated project allocation and the unallocated pool, you’ll start dipping into your on-demand budget for that project even if your total reserved volume hasn’t run out yet. 
+
+On-demand volume is billed at the end of each billing month. To see on-demand pricing per plan type, check out our [per-category-pricing](#per-category-pricing).
 
 #### Shared and Per-Category On-Demand {#on-demand-cap}
 


### PR DESCRIPTION
Clarifies that on-demand works differently if you have spend allocation enabled.

