### PR TITLE
Add error.main_thread search fields

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties.mdx
@@ -87,7 +87,7 @@ Release properties overlap with event and issue search properties, so they don't
 | activity | Replay activity is calculated based on the number of errors, the number of ui events, and the duration of the replay. It's represented as a number from `1` to `10`. | | | x | number |
 | age | Returns issues created since the time defined by the value. The syntax is similar to the Unix find command. Supported suffixes: `m - minutes`, `h - hours`, `d - days`, `w - weeks`. For example, `age:-24h` returns isssues that are new in the last 24 hours, while `age:+12h` returns ones that are older than 12 hours. Entering `age:+12h age:-24h` would return issues created between 12 and 24 hours ago. |  | x |  | relative time |
 | apdex(threshold) | Returns results with the [Apdex score](/product/performance/metrics/#apdex) that you entered. Values must be between `0` and `1`. Higher apdex values indicate higher user satisfaction. | x |  |  | number |
-| app.in_foreground | Indicates if the app is in the foreground or background. | x | x |  | boolean |
+| app.in_foreground | Indicates if the app is in the foreground or background. Values are `1/0` or `true/false` | x | x |  | boolean |
 | assigned | Returns issues assigned to the defined user. Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee, or # followed by the team name, that is `#team-name`. |  | x |  | team or org user |
 | assigned_<br></br>or_suggested | Returns issues assigned to or suggested to be assigned to the defined user. Suggested assignees are determined by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `me_or_none` for yourself or no assignee/suggestions, or # followed by the team name, that is `#team-name`. |  | x |  | team or org user |
 | avg(field) | Returns results with matching averages for the field selected. The field can be either a number or a duration. Typically used with a comparison operator. | x |  |  | matches field |
@@ -127,6 +127,7 @@ Release properties overlap with event and issue search properties, so they don't
 | eps() | Returns results with a matching events-per-second count. Doesn't take a parameter. | x |  |  | number |
 | error_id | Error instances that have occurred within a replay. |  |  | x | array |
 | error.handled | Indicates whether the user has handled the exception — for example, using try...catch. An error is considered handled if all stack traces handle the error. Values are `1/0` or `true/false` | x | x |  | boolean |
+| error.main_thread | Indicates if the error occurred on the main thread. Values are `1/0` or `true/false` | x | x |  | boolean |
 | error.mechanism | An object describing the mechanism that created this exception. | x | x |  | array |
 | error.type | The type of exception. For example, `ValueError`. | x | x |  | array |
 | error.unhandled | The inversion of `error.handled`. | x | x |  | boolean |


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Follow up https://github.com/getsentry/sentry/pull/47446

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
