### PR TITLE
Highlighting github enterprise

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -37,7 +37,7 @@ Sentry owner, manager, or admin permissions, and GitHub owner permissions are re
 
 The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization, but you **cannot** connect a single GitHub organization to multiple Sentry organizations.
 
-# GitHub Enterprise
+## GitHub Enterprise
 
 #### Add new GitHub App
 

--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -37,7 +37,7 @@ Sentry owner, manager, or admin permissions, and GitHub owner permissions are re
 
 The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization, but you **cannot** connect a single GitHub organization to multiple Sentry organizations.
 
-### GitHub Enterprise
+# GitHub Enterprise
 
 #### Add new GitHub App
 


### PR DESCRIPTION
Changing the highlight for GitHub enterprise steps as it is" hidden" in the steps for Github.


