### PR TITLE
fix(rn): Use npx for all rn wizard examples

### DIFF
--- a/src/platform-includes/getting-started-install/react-native.mdx
+++ b/src/platform-includes/getting-started-install/react-native.mdx
@@ -10,10 +10,6 @@ Run `@sentry/wizard`:
 npx @sentry/wizard -s -i reactNative
 ```
 
-```yarn
-yarn sentry-wizard -s -i reactNative
-```
-
 <Note>
 
 The wizard doesn't support React Native versions `0.68` and older. To use the wizard with older versions of React Native, you'll have to `confirm` in the wizard dialogue and manually patch the Xcode project later. Read more on the [Manual Configuration](/platforms/react-native/manual-setup/manual-setup/) page.

--- a/src/wizard/react-native/index.md
+++ b/src/wizard/react-native/index.md
@@ -13,7 +13,7 @@ Sentry captures data by using an SDK within your application’s runtime.
 Run `@sentry/wizard`:
 
 ```bash
-yarn sentry-wizard -s -i reactNative
+npx @sentry/wizard -s -i reactNative
 ```
 
 [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [setup manually](/platforms/react-native/manual-setup/manual-setup/) if you prefer.


### PR DESCRIPTION
Previously we used `npx` and `yarn` interchangeably but since the new one-line command for RN we should use only `npx` to avoid `wizard` not installed errors. 
