### PR TITLE
chore(java): InstallationId is not auto-generated

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -17,7 +17,7 @@ Users consist of a few critical pieces of information that construct a unique id
 
 ### `id`
 
-<PlatformSection notSupported={["java"]}, supported={["android"]}>
+<PlatformSection notSupported={["java"]} supported={["android"]}>
 
 <Note>
 

--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -17,11 +17,15 @@ Users consist of a few critical pieces of information that construct a unique id
 
 ### `id`
 
+<PlatformSection notSupported={["java"]}, supported={["android"]}>
+
 <Note>
 
 If you don't provide an `id`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>
+
+</PlatformSection>
 
 Your internal identifier for the user.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The `InstallationId` is not auto-generated for pure java apps, because there's no offline cache enabled by default.

