### PR TITLE
fix(docs): api sidebar styling

### DIFF
--- a/src/components/apiSidebar.tsx
+++ b/src/components/apiSidebar.tsx
@@ -60,7 +60,7 @@ export default function ApiSidebar() {
                             context: {title: contextTitle},
                           },
                         }) => (
-                          <SidebarLink key={childPath} to={path}>
+                          <SidebarLink key={path} to={childPath}>
                             {contextTitle}
                           </SidebarLink>
                         )


### PR DESCRIPTION
seems like we accidentally used the wrong variable during the https://github.com/getsentry/sentry-docs/pull/6694 refactor/renaming of variables here. this should fix it. can verify by looking at the vercel deploy preview.