### PR TITLE
fix(ui): Avoid scroll chaining on code block selector

### DIFF
--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -261,6 +261,7 @@ const Selections = styled('div')`
   background: #fff;
   border-radius: 3px;
   overflow: scroll;
+  overscroll-behavior: contain;
   max-height: 210px;
   min-width: 300px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
When picking a DSN etc, do not let the scroll chain outside of the
selector box