### PR TITLE
fix: Various invalid codeblock language identifiers

### DIFF
--- a/src/docs/contributing/pages/index.mdx
+++ b/src/docs/contributing/pages/index.mdx
@@ -14,13 +14,13 @@ Documentation is written in Markdown (via Remark) and MDX.
 
 MDX has its flaws. When rendering components, any text inside of them is treated as raw text (_not_ markdown). To work around this you can use the `` tag, but it also has its issues. Generally speaking, put an empty line after the opening tag, and before the closing tag.
 
-```Incorrect
+```plain {tabTitle:Incorrect}
 <Note>
 Don't do this as parsing will hit weird breakages
 </Note>
 ```
 
-```Correct
+```plain {tabTitle:Correct}
 <Note>
 
 Do this

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -73,7 +73,7 @@ location ~ ^/static/dist/(.+)\.map$ {
 
 To allow access to source maps with Apache you can use this example. It can either go into your _.htaccess_ or global config. This example assumes your source maps live in `/static/dist`:
 
-```apache
+```apacheconf
 <FilesMatch "\.map$">
     Order deny,allow
     Deny from all

--- a/src/docs/product/sentry-basics/integrate-frontend/upload-source-maps.mdx
+++ b/src/docs/product/sentry-basics/integrate-frontend/upload-source-maps.mdx
@@ -97,7 +97,7 @@ Now we can invoke the `sentry-cli` to let Sentry know we have a new release, and
 
 3. Replace the existing `setup_release` with:
 
-   ```Shell
+   ```shell
    setup_release: create_release upload_sourcemaps
    ```
 
@@ -124,7 +124,7 @@ Now we can invoke the `sentry-cli` to let Sentry know we have a new release, and
 
 2. Build, deploy, and rerun the project by running:
 
-   ```Node
+   ```
    > npm run deploy
    ```
 

--- a/src/platform-includes/getting-started-install/react-native.mdx
+++ b/src/platform-includes/getting-started-install/react-native.mdx
@@ -6,7 +6,7 @@ If you wish to install Sentry's React Native SDK v4, follow the steps [here](/pl
 
 Run `@sentry/wizard`:
 
-```npm
+```bash {tabTitle:npm}
 npx @sentry/wizard -s -i reactNative
 ```
 

--- a/src/platform-includes/session-replay/install/javascript.capacitor.mdx
+++ b/src/platform-includes/session-replay/install/javascript.capacitor.mdx
@@ -2,6 +2,6 @@
 yarn add @sentry/capacitor @sentry/replay
 ```
 
-```html {tabTitle: NPM}
+```html {tabTitle: npm}
 npm install --save @sentry/capacitor @sentry/replay
 ```

--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -1,6 +1,6 @@
 The Replay integration is **already included** in your browser or framework SDK NPM packages. If you're using CDN bundles instead of NPM packages, you need to load the Replay integration CDN bundle in addition to your browser bundle:
 
-```bash {tabTitle: NPM}
+```bash {tabTitle: npm}
 # Make sure to have @sentry/browser or a Framework SDK (e.g. @sentry/react) installed
 npm install --save @sentry/browser
 ```

--- a/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -39,14 +39,14 @@ export SENTRY_PROJECT=___PROJECT_SLUG___
 
 Next, run the upload script with the following command:
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn sentry-upload-sourcemaps
 
 # For usage details run
 yarn sentry-upload-sourcemaps --help
 ```
 
-```npm
+```bash {tabTitle:npm}
 node ./node_modules/@sentry/remix/scripts/sentry-upload-sourcemaps.js
 
 # For usage details run

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -21,11 +21,11 @@ export default config;
 
 If you're using Vite in you Svelte project, you can use Sentry's Vite plugin for convenience:
 
-```npm
+```bash {tabTitle:npm}
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/vite-plugin --dev
 ```
 

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -5,11 +5,11 @@ You can use the Sentry Vite plugin to automatically create [releases](/product/r
 
 ### Installation
 
-```npm
+```bash {tabTitle:npm}
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/vite-plugin --dev
 ```
 

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -2,11 +2,11 @@ You can use the Sentry esbuild plugin to automatically create releases and uploa
 
 ## Install
 
-```npm
+```bash {tabTitle:npm}
 npm install @sentry/esbuild-plugin --save-dev
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/esbuild-plugin --dev
 ```
 

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -2,11 +2,11 @@ You can use the Sentry Rollup plugin to automatically create releases and upload
 
 ## Installation
 
-```npm
+```bash {tabTitle:npm}
 npm install @sentry/rollup-plugin --save-dev
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/rollup-plugin --dev
 ```
 

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -2,11 +2,11 @@ You can use the Sentry Vite plugin to automatically create releases and upload s
 
 ## Installation
 
-```npm
+```bash {tabTitle:npm}
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/vite-plugin --dev
 ```
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -84,7 +84,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objective-c
+```objc
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
@@ -198,7 +198,7 @@ SentrySDK.start { options in
 }
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
@@ -228,7 +228,7 @@ if (nil != eventId) {
 }
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryId *eventId = [SentrySDK captureMessage:@"A message"];
@@ -252,7 +252,7 @@ if (eventId != SentryId.empty) {
 }
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryId *eventId = [SentrySDK captureMessage:@"A message"];
@@ -276,7 +276,7 @@ let event = Event()
 event.message = "Hello World"
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryEvent *event = [[SentryEvent alloc] init];
@@ -292,7 +292,7 @@ let event = Event()
 event.message = SentryMessage(formatted: "Hello World")
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 @import Sentry;
 
 SentryEvent *event = [[SentryEvent alloc] init];
@@ -322,7 +322,7 @@ do {
 }
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 NSError *error = nil;
 SentryClient *client = [[SentryClient alloc] initWithDsn:@"___PUBLIC_DSN___" didFailWithError:&error];
 SentryClient.sharedClient = client;
@@ -341,7 +341,7 @@ SentrySDK.start(options: [
 ])
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 [SentrySDK startWithOptions:@{
     @"dsn": @"___PUBLIC_DSN___",
     @"debug": @(YES)
@@ -356,7 +356,7 @@ Example in 4.x:`
 Client.shared?.breadcrumbs.add(Breadcrumb(level: .info, category: "test"))
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 [SentryClient.sharedClient.breadcrumbs addBreadcrumb:[[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"test"]];
 ```
 
@@ -366,7 +366,7 @@ Example in 5.x:
 SentrySDK.addBreadcrumb(Breadcrumb(level: .info, category: "test"))
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 [SentrySDK addBreadcrumb:[[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"test"]];
 ```
 
@@ -382,7 +382,7 @@ event.extra = ["ios": true]
 Client.shared?.send(event: event)
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityDebug];
 event.message = @"Test Message";
 event.environment = @"staging";
@@ -402,7 +402,7 @@ SentrySDK.capture(message: "Test Message") { (scope) in
 }
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 [SentrySDK captureMessage:@"Test Message" withScopeBlock:^(SentryScope * _Nonnull scope) {
     [scope setEnvironment:@"staging"];
     [scope setExtras:@{@"ios": @(YES)}];
@@ -422,7 +422,7 @@ u.email = "tony@example.com"
 Client.shared?.user = user
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 SentryUser *user = [[SentryUser alloc] initWithUserId:@"1"];
 user.email = @"tony@example.com";
 SentryClient.sharedClient.user = user;
@@ -436,7 +436,7 @@ u.email = "tony@example.com"
 SentrySDK.setUser(u)
 ```
 
-```objective-c
+```objc {tabTitle:Objective-C}
 SentryUser *user = [[SentryUser alloc] initWithUserId:@"1"];
 user.email = @"tony@example.com";
 [SentrySDK setUser:user];

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -300,7 +300,7 @@ Rust Profiling alpha is available starting in SDK version `0.29.0`.
 
 In order to use Profiling, you first need to enable the `profiling` feature in the `sentry` dependency inside the project `Cargo.toml`:
 
-```cargo
+```toml
 [dependencies]
 sentry = { version = "{{ packages.version('sentry.rust') }}", features = ["profiling"] }
 ```

--- a/src/platforms/java/common/performance/instrumentation/jdbc.mdx
+++ b/src/platforms/java/common/performance/instrumentation/jdbc.mdx
@@ -40,7 +40,7 @@ For other dependency managers, check out the [central Maven repository](https://
 
 Configure the `DataSource` to use `com.p6spy.engine.spy.P6SpyDriver` as a JDBC driver. For Spring Boot applications:
 
-```properies {tabTitle: application.properties}
+```properties {tabTitle: application.properties}
 spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver
 ```
 
@@ -50,7 +50,7 @@ spring.datasource.driver-class-name: com.p6spy.engine.spy.P6SpyDriver
 
 Add the `p6spy` prefix to the database connection URL. For Spring Boot applications:
 
-```properies {tabTitle: application.properties}
+```properties {tabTitle: application.properties}
 spring.datasource.url: jdbc:p6spy:postgresql://localhost:5432/db
 ```
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -8,7 +8,7 @@ description: 'Learn how to use Sentry with Gatsby.'
 
 To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK):
 
-```bash {tabTitle:NPM}
+```bash {tabTitle:npm}
 npm install --save @sentry/gatsby
 ```
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -8,15 +8,15 @@ If you can't (or prefer not to) run the [configuration step](/platforms/javascri
 
 ## Installation
 
-```npm
+```bash {tabTitle:npm}
 npm install --save @sentry/nextjs
 ```
 
-```yarn
+```bash {tabTitle:Yarn}
 yarn add @sentry/nextjs
 ```
 
-```pnpm
+```bash {tabTitle:pnpm}
 pnpm add @sentry/nextjs
 ```
 

--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -42,7 +42,7 @@ sentry:
 
 And in your `.env` file:
 
-```env {filename:.env}
+```plain {filename:.env}
 ###> sentry/sentry-symfony ###
 SENTRY_DSN="___PUBLIC_DSN___"
 ###< sentry/sentry-symfony ###

--- a/src/platforms/react-native/migration.mdx
+++ b/src/platforms/react-native/migration.mdx
@@ -63,7 +63,7 @@ React Native 0.69.0 and above:
 
 _Old_:
 
-```bash;
+```bash
 shellScript = "export SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\"\nset -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT \\\"../node_modules/@sentry/cli/bin/sentry-cli react-native xcode $REACT_NATIVE_XCODE\\\"\"\n";
 ```
 

--- a/src/wizard/php/symfony.md
+++ b/src/wizard/php/symfony.md
@@ -40,7 +40,7 @@ sentry:
 
 And in your `.env` file:
 
-```env {filename:.env}
+```plain {filename:.env}
 ###> sentry/sentry-symfony ###
 SENTRY_DSN="___PUBLIC_DSN___"
 ###< sentry/sentry-symfony ###


### PR DESCRIPTION
Some typos, some just wrong

This fixes a bunch of warnings