### PR TITLE
chore(js): Bump bootstrap 4.3.1 -> 4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "algoliasearch": "^4.2.0",
     "axios": "^0.21.2",
     "babel-preset-gatsby": "^0.5.8",
-    "bootstrap": "4.3.1",
+    "bootstrap": "4.6.1",
     "copy-to-clipboard": "^3.3.1",
     "dompurify": "^2.0.12",
     "dotenv": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,10 +4500,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
-  integrity sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==
+bootstrap@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.1.tgz#bc25380c2c14192374e8dec07cf01b2742d222a2"
+  integrity sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==
 
 boxen@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
This fixes a large number of warnings during build time related to the
[warning: Using / for division is deprecated][0] error

[0]: https://github.com/twbs/bootstrap/issues/34051