### PR TITLE
fix: Silence 'Error executing variable-like construct'

### DIFF
--- a/src/gatsby/plugins/gatsby-remark-variables/index.js
+++ b/src/gatsby/plugins/gatsby-remark-variables/index.js
@@ -61,7 +61,9 @@ module.exports = ({markdownAST, markdownNode}, options) => {
             result = await result;
           }
         } catch (err) {
-          console.warn(`Error executing variable-like construct: ${match[0]}`);
+          // no-op. We previously had a warning here, but the we have so many
+          // "variable-like" cosntructs in our codeblocks that this becomes
+          // very spammy.
         }
         if (result) {
           node.value = node.value.replace(match[0], result);

--- a/src/gatsby/plugins/gatsby-remark-variables/index.js
+++ b/src/gatsby/plugins/gatsby-remark-variables/index.js
@@ -62,7 +62,7 @@ module.exports = ({markdownAST, markdownNode}, options) => {
           }
         } catch (err) {
           // no-op. We previously had a warning here, but the we have so many
-          // "variable-like" cosntructs in our codeblocks that this becomes
+          // "variable-like" constructs in our codeblocks that this becomes
           // very spammy.
         }
         if (result) {


### PR DESCRIPTION
This warning is produced far to much for it to be of any value