### PR TITLE
fix(apple): Capture Swift Error in verify

### DIFF
--- a/src/platform-includes/getting-started-verify/apple.mdx
+++ b/src/platform-includes/getting-started-verify/apple.mdx
@@ -1,8 +1,11 @@
 ```swift {tabTitle:Swift}
 import Sentry
 
-let error = NSError(domain: "YourErrorDomain", code: 0, userInfo: nil)
-SentrySDK.capture(error: error)
+do {
+    try aMethodThatMightFail()
+} catch {
+    SentrySDK.capture(error: error)
+}
 ```
 
 ```objc {tabTitle:Objective-C}


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs

## Description of changes

Capture a Swift error in getting-started-verify instead of an NSError.

