### PR TITLE
fix(apple): Clarify app start tracing

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -63,6 +63,7 @@ SentrySDK.start { options in
 This feature is available for iOS, tvOS, and Mac Catalyst.
 
 App Start Tracing is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
+The SDK adds the spans to the first started transaction during the app launch with the operation `ui.load`, which the UIViewController tracing uses. Suppose the time interval between the transaction start time and the end timestamp of the measured app start is more significant than 5 seconds. In that case, the SDK doesn't attach the app start spans to avoid attaching it to possibly unrelated transactions.
 To enable this feature, enable `enableAutoPerformanceTracing`.
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -63,7 +63,8 @@ SentrySDK.start { options in
 This feature is available for iOS, tvOS, and Mac Catalyst.
 
 App Start Tracing is enabled by default once you <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. This feature provides insight into how long your application takes to launch. It adds spans for different phases, from the application launch to the first auto-generated UI transaction.
-The SDK adds the spans to the first started transaction during the app launch with the operation `ui.load`, which the UIViewController tracing uses. Suppose the time interval between the transaction start time and the end timestamp of the measured app start is more significant than 5 seconds. In that case, the SDK doesn't attach the app start spans to avoid attaching it to possibly unrelated transactions.
+
+The SDK adds these spans to the first transaction that starts during the app launch with the operation `ui.load`. This is what UIViewController tracing uses. If the duration between the transaction start time and the end timestamp of the app start is more than 5 seconds, the SDK doesn't attach the spans from the app start. This helps prevent attaching spans to unrelated transactions.
 To enable this feature, enable `enableAutoPerformanceTracing`.
 
 The SDK differentiates between a cold and a warm start, but doesn't track hot starts/resumes.


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Clarify to which transaction the Cocoa SDK attaches the app start spans.

