### PR TITLE
Address overhead concerns when sending 100% tx

### DIFF
--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -25,7 +25,7 @@ Sentry's retention priorities work best when you send high volumes of data. The 
 
 If possible, send us 100% of your data by setting your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. Otherwise, the system will operate based on what it can see and will adapt automatically if you purchase more [Performance Units](/product/accounts/pricing/#performance-pricing).
 
-If you want to offset overhead, (with high-volume back-end applications, for example), you can set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
+If you want to offset overhead, (with high-volume back-end applications, for example), you can set a lower value, or switch to sampling selectively by using the <PlatformIdentifier name="traces-sampler" /> to filter your transactions based on contextual data.
 
 ## Avoid Data Gaps
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -21,7 +21,7 @@ Sentry's [retention priorities](/product/performance/performance-at-scale/#reten
 
 Sentry's retention priority features automatically identify and retain the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. Sentry will identify valuable samples to retain on your behalf, while also giving you the ability to specify the priorities that best fit your use case.
 
-Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues.
+Sentry's retention priorities work best when you send high volumes of data. The more data you send, the more accurate a picture of your application we get. This makes it possible to make more precise data retention decisions and to detect and create new issues.
 
 If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -21,7 +21,9 @@ Sentry's [retention priorities](/product/performance/performance-at-scale/#reten
 
 If you're using our retention priority features, Sentry automatically identifies and retains the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. We'll take care of picking valuable samples to retain on your behalf, while also giving you controls to express priorities that best fit your use case.
 
-Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues. If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. As your transaction volume goes up, the per-transaction pricing goes down accordingly, so you can truly scale affordably.
+Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues. 
+
+If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
 
 ## Avoid Data Gaps
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -23,7 +23,7 @@ Sentry's retention priority features automatically identify and retain the highe
 
 Sentry's retention priorities work best when you send high volumes of data. The more data you send, the more accurate a picture of your application we get. This makes it possible to make more precise data retention decisions and to detect and create new issues.
 
-If possible, send us 100% of your data by setting your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. Otherwise, the system will operate based on what it can see and will adapt automatically if you purchase more [Performance Units](/product/accounts/pricing/#performance-pricing). 
+If possible, send us 100% of your data by setting your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. Otherwise, the system will operate based on what it can see and will adapt automatically if you purchase more [Performance Units](/product/accounts/pricing/#performance-pricing).
 
 If you want to offset overhead, (with high-volume back-end applications, for example), you can set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -23,7 +23,9 @@ Sentry's retention priority features automatically identify and retain the highe
 
 Sentry's retention priorities work best when you send high volumes of data. The more data you send, the more accurate a picture of your application we get. This makes it possible to make more precise data retention decisions and to detect and create new issues.
 
-If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
+If possible, send us 100% of your data by setting your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. Otherwise, the system will operate based on what it can see and will adapt automatically if you purchase more [Performance Units](/product/accounts/pricing/#performance-pricing). 
+
+If you want to offset overhead, (with high-volume back-end applications, for example), you can set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
 
 ## Avoid Data Gaps
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -19,7 +19,7 @@ Sentry's [retention priorities](/product/performance/performance-at-scale/#reten
 
 ## Automatic Retention of High Quality Data
 
-If you're using our retention priority features, Sentry automatically identifies and retains the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. We'll take care of picking valuable samples to retain on your behalf, while also giving you controls to express priorities that best fit your use case.
+Sentry's retention priority features automatically identify and retain the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. Sentry will identify valuable samples to retain on your behalf, while also giving you the ability to specify the priorities that best fit your use case.
 
 Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues. 
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -4,7 +4,7 @@ sidebar_order: 25
 redirect_from:
   - /product/sentry-basics/metrics/
   - /product/sentry-basics/sampling/
-description: 'Learn more about the benefits of Performance at Scale.'
+description: "Learn more about the benefits of Performance at Scale."
 ---
 
 <Note>
@@ -21,8 +21,7 @@ Sentry's [retention priorities](/product/performance/performance-at-scale/#reten
 
 Sentry's retention priority features automatically identify and retain the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. Sentry will identify valuable samples to retain on your behalf, while also giving you the ability to specify the priorities that best fit your use case.
 
-
-Sentry's retention priorities work best when you send high volumes of data. The more data you send, the more accurate a picture of your application we get. This makes it possible to make more precise data retention decisions and to detect and create new issues.
+Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues.
 
 If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
 

--- a/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
+++ b/src/docs/product/performance/performance-at-scale/benefits-performance-at-scale.mdx
@@ -21,7 +21,8 @@ Sentry's [retention priorities](/product/performance/performance-at-scale/#reten
 
 Sentry's retention priority features automatically identify and retain the highest quality transaction samples for your application at higher volumes. This allows you to scale up affordably without having to micromanage your SDK sampling configuration. Sentry will identify valuable samples to retain on your behalf, while also giving you the ability to specify the priorities that best fit your use case.
 
-Our retention priorities work best when you send us as much data as you can. The more a complete picture of your application we have, the better decisions we make on your behalf to retain data and detect and create new issues. 
+
+Sentry's retention priorities work best when you send high volumes of data. The more data you send, the more accurate a picture of your application we get. This makes it possible to make more precise data retention decisions and to detect and create new issues.
 
 If feasible, send us 100% of your data (that is, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0). If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume we'll adapt automatically. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -89,7 +89,7 @@ Sentry offers SDK sampling configuration options: using `tracesSampleRate` enabl
 
 Retention priorities and your SDK sampling configuration act independently of each other, but work best when you send us as much data as you can. The more complete a picture of your application we have, the more accurately we can monitor your application health, detect problems faster, surface issues, and make better decisions about data retention on your behalf.
 
-In order to send us 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
+To send 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you want to offset overhead, (with high-volume back-end applications, for example), set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
 
 As your transaction volume goes up, the per-transaction pricing goes down accordingly, so you can truly scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -91,7 +91,7 @@ Retention priorities and your SDK sampling configuration act independently of ea
 
 To send 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you want to offset overhead, (with high-volume back-end applications, for example), set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
 
-As your transaction volume goes up, the per-transaction pricing goes down accordingly, so you can truly scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
+As your transaction volume goes up, the per-transaction pricing will go down accordingly, making it possible to scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
 
 ## Next Steps
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -89,7 +89,9 @@ Sentry offers SDK sampling configuration options: using `tracesSampleRate` enabl
 
 Retention priorities and your SDK sampling configuration act independently of each other, but work best when you send us as much data as you can. The more complete a picture of your application we have, the more accurately we can monitor your application health, detect problems faster, surface issues, and make better decisions about data retention on your behalf.
 
-In order to send us 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you can't do so initially, the system will operate on what it can see and when you purchase more transaction volume, we'll adapt automatically. As your transaction volume goes up, the per-transaction pricing goes down accordingly, so you can truly scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
+In order to send us 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. When facing overhead concerns, for example with high volume back-end applications, you may want to consider setting a lower value, or switching to using to selectively sample and filter your transactions, based on contextual data.
+
+As your transaction volume goes up, the per-transaction pricing goes down accordingly, so you can truly scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
 
 ## Next Steps
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -89,7 +89,7 @@ Sentry offers SDK sampling configuration options: using `tracesSampleRate` enabl
 
 Retention priorities and your SDK sampling configuration act independently of each other, but work best when you send us as much data as you can. The more complete a picture of your application we have, the more accurately we can monitor your application health, detect problems faster, surface issues, and make better decisions about data retention on your behalf.
 
-To send 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you want to offset overhead, (with high-volume back-end applications, for example), set a lower value, or switch to using selective sampling and start filtering your transactions based on contextual data.
+To send 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you want to offset overhead, (with high-volume back-end applications, for example), set a lower value, or switch to sampling selectively by using the <PlatformIdentifier name="traces-sampler" /> to filter your transactions based on contextual data.
 
 As your transaction volume goes up, the per-transaction pricing will go down accordingly, making it possible to scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
 


### PR DESCRIPTION
We currently have inconsistent messaging in docs:
- on the [Performance at Scale](https://github.com/getsentry/sentry-docs/pull/6427) page we encourage people to send 100% of transactions no matter what
- in SDK docs we caution people about needing to lower the sample rate when going to production. 

We need to acknowledge that there is the “ideal” situation, where sending all transactions is possible and this enables Performance to work best, but there are some scenarios where this just isn’t realistic. For some industries where latency is highly important or even just a large enough scale, it’s not an option. Adding a note about this for clarity.

Related to https://github.com/getsentry/sentry-docs/pull/6427