### PR TITLE
fix(apple): Capturing errors

### DIFF
--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -1,3 +1,5 @@
+You can capture errors with the `captureError` method. This method takes an `Error` object as a parameter. The `Error` object can be an `NSError` or a `Swift.Error` object.
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -1,22 +1,22 @@
 ```swift {tabTitle:Swift}
 import Sentry
 
-SentrySDK.capture(error: error)
-
-// Or
-
-SentrySDK.capture(exception: exception)
-
+do {
+    try aMethodThatMightFail()
+} catch {
+    SentrySDK.capture(error: error)
+}
 ```
 
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-[SentrySDK captureError:error];
+NSError *error = nil;
+[self aMethodThatMightFail:&error]
 
-// Or
-
-[SentrySDK captureException:exception];
+if (error) {
+    [SentrySDK captureError:error];
+}
 ```
 
 ## Capturing Uncaught Exceptions in macOS

--- a/src/platform-includes/getting-started-verify/apple.mdx
+++ b/src/platform-includes/getting-started-verify/apple.mdx
@@ -11,8 +11,12 @@ do {
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-NSError *error = [NSError errorWithDomain:@"YourErrorDomain"
-                                   code:0
-                               userInfo: nil];
-[SentrySDK captureError:error];
+@import Sentry;
+
+NSError *error = nil;
+[self aMethodThatMightFail:&error]
+
+if (error) {
+    [SentrySDK captureError:error];
+}
 ```


### PR DESCRIPTION

## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Use do catch for usage in Swift. Pass an NSError from a method to the SentrySDK instead of creating an NSError, which reflects a more accurate use case. Furthermore, remove the reference to captureException, as they are rarely used on Apple. This is related to https://github.com/getsentry/sentry-docs/pull/6768.

