### PR TITLE
fix: Show uncaught exceptions only for macOS

### DIFF
--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -19,6 +19,8 @@ SentrySDK.capture(exception: exception)
 [SentrySDK captureException:exception];
 ```
 
+<PlatformSection supported={["apple.macos"]}>
+
 ## Capturing Uncaught Exceptions in macOS
 
 By default, macOS applications do not crash whenever an uncaught exception occurs. To enable this with Sentry:
@@ -26,6 +28,8 @@ By default, macOS applications do not crash whenever an uncaught exception occur
 1. Open the application's `Info.plist` file
 2. Search for `Principal class` (the entry is expected to be `NSApplication`)
 3. Replace `NSApplication` with `SentryCrashExceptionApplication`
+
+</PlatformSection>
 
 ## Customizing Error Descriptions
 


### PR DESCRIPTION


## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Use a PlatformSection to show the uncaught exceptions paragraph only for macOS.

