### PR TITLE
feat(apple): Add docs for Swift Error description

### DIFF
--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -1,28 +1,30 @@
+You can capture errors with the `captureError` method. This method takes an `Error` object as a parameter. The `Error` object can be an `NSError` or a `Swift.Error` object.
+
 ```swift {tabTitle:Swift}
 import Sentry
 
-SentrySDK.capture(error: error)
-
-// Or
-
-SentrySDK.capture(exception: exception)
-
+do {
+    try aMethodThatMightFail()
+} catch {
+    SentrySDK.capture(error: error)
+}
 ```
 
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-[SentrySDK captureError:error];
+NSError *error = nil;
+[self aMethodThatMightFail:&error]
 
-// Or
-
-[SentrySDK captureException:exception];
+if (error) {
+    [SentrySDK captureError:error];
+}
 ```
 
 ### Swift Errors
 
 For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK sends the domain, code and the description of the Swift error.
-For older versions of the SDK, prior to [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK only sends the domain and error code.
+Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only the domain and error code.
 
 ```Swift
 enum LoginError: Error {
@@ -32,18 +34,19 @@ enum LoginError: Error {
 
 SentrySDK.capture(error: LoginError.wrongUser("12345678"))
 ```
-For the Swift error above Sentry would display the following, based on SDK version:
 
-| sentry-cocoa SDK | Title | Description |
-| ----------- | ----------- | ----------- |
-| Since 8.7.0 | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
-| Before 8.7.0 | `LoginError` | `Code: 1` |
+For the Swift error above Sentry displays:
+
+| sentry-cocoa SDK | Title        | Description                           |
+| ---------------- | ------------ | ------------------------------------- |
+| Since 8.7.0      | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
+| Before 8.7.0     | `LoginError` | `Code: 1`                             |
 
 ### Customizing Error Descriptions
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
 
-You may want to provide a custom description to make identifying the error in the **Issues** page easier. For `NSError` values, you can do this by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+You may want to provide a custom description to make identifying the error in the _Issues_ page easier. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
 Sentry will group errors based on the error domain and code, and by enum value for Swift enum types, so customizing error descriptions won’t impact grouping.
 

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -46,7 +46,7 @@ For the Swift error above Sentry displays:
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
 
-You may want to provide a custom description to make identifying the error in the _Issues_ page easier. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+You may want to provide a custom description to make identifying the error in the **Issues** page easier. For `NSError` values, you can do this by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
 Sentry will group errors based on the error domain and code, and by enum value for Swift enum types, so customizing error descriptions won’t impact grouping.
 

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -22,7 +22,7 @@ SentrySDK.capture(exception: exception)
 ### Swift Errors
 
 For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK sends the domain, code and the description of the Swift error.
-Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only the domain and error code.
+For older versions of the SDK, prior to [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK only sends the domain and error code.
 
 ```Swift
 enum LoginError: Error {

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -31,6 +31,7 @@ enum LoginError: Error {
     case wrongUser(id: String)
     case wrongPassword
 }
+
 SentrySDK.capture(error: LoginError.wrongUser("12345678"))
 ```
 For the Swift error above Sentry displays

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -48,11 +48,11 @@ For the Swift error above Sentry displays
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
 
-If you want to provide your custom description for your Swift Errors, you may want to provide a custom description to make it easier to identify the error in the _Issues_ page. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+You may want to provide a custom description to make identifying the error in the _Issues_ page easier. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
 Sentry will group errors based on the error domain and code, and by enum value for Swift enum types, so customizing error descriptions won’t impact grouping.
 
-This can be particularly useful for Swift enum error types that conform to `Error`, where the error code can be hard to match with an enum case. To customize the description for Swift `Error` types, you should conform to the `CustomNSError` protocol and return a user info dictionary:
+To customize the description for Swift `Error` types, you should conform to the `CustomNSError` protocol and return a user info dictionary:
 
 ```swift {tabTitle:Swift}
 enum MyCustomError: Error {

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -43,7 +43,7 @@ For the Swift error above Sentry displays:
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
 
-You may want to provide a custom description to make identifying the error in the _Issues_ page easier. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+You may want to provide a custom description to make identifying the error in the **Issues** page easier. For `NSError` values, you can do this by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
 Sentry will group errors based on the error domain and code, and by enum value for Swift enum types, so customizing error descriptions won’t impact grouping.
 

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -41,10 +41,6 @@ For the Swift error above Sentry displays
 | Since 8.7.0 | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
 | Before 8.7.0 | `LoginError` | `Code: 1` |
 
-1. Open the application's `Info.plist` file
-2. Search for `Principal class` (the entry is expected to be `NSApplication`)
-3. Replace `NSApplication` with `SentryCrashExceptionApplication`
-
 ### Customizing Error Descriptions
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -34,7 +34,7 @@ enum LoginError: Error {
 
 SentrySDK.capture(error: LoginError.wrongUser("12345678"))
 ```
-For the Swift error above Sentry displays
+For the Swift error above Sentry displays:
 
 | sentry-cocoa SDK | Title | Description |
 | ----------- | ----------- | ----------- |

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -21,10 +21,8 @@ SentrySDK.capture(exception: exception)
 
 ### Swift Errors
 
-For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK
-sends the domain, code and the description of the Swift error.
-Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only
-the domain and error code.
+For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK sends the domain, code and the description of the Swift error.
+Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only the domain and error code.
 
 ```Swift
 enum LoginError: Error {

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -24,7 +24,7 @@ if (error) {
 ### Swift Errors
 
 For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK sends the domain, code and the description of the Swift error.
-Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only the domain and error code.
+For older versions of the SDK, prior to [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK only sends the domain and error code.
 
 ```Swift
 enum LoginError: Error {

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -19,23 +19,36 @@ SentrySDK.capture(exception: exception)
 [SentrySDK captureException:exception];
 ```
 
-<PlatformSection supported={["apple.macos"]}>
+### Swift Errors
 
-## Capturing Uncaught Exceptions in macOS
+For Swift Errors conforming to the [Error Protocol](https://developer.apple.com/documentation/swift/error) the SDK
+sends the domain, code and the description of the Swift error.
+Before [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) the SDK sends only
+the domain and error code.
 
-By default, macOS applications do not crash whenever an uncaught exception occurs. To enable this with Sentry:
+```Swift
+enum LoginError: Error {
+    case wrongUser(id: String)
+    case wrongPassword
+}
+SentrySDK.capture(error: LoginError.wrongUser("12345678"))
+```
+For the Swift error above Sentry displays
+
+| sentry-cocoa SDK | Title | Description |
+| ----------- | ----------- | ----------- |
+| Since 8.7.0 | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
+| Before 8.7.0 | `LoginError` | `Code: 1` |
 
 1. Open the application's `Info.plist` file
 2. Search for `Principal class` (the entry is expected to be `NSApplication`)
 3. Replace `NSApplication` with `SentryCrashExceptionApplication`
 
-</PlatformSection>
-
-## Customizing Error Descriptions
+### Customizing Error Descriptions
 
 This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
 
-Sentry will display the error code in the error description field by default. For custom error types, you may want to provide a custom description to make it easier to identify the error in the _Issues_ page. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
+If you want to provide your custom description for your Swift Errors, you may want to provide a custom description to make it easier to identify the error in the _Issues_ page. For `NSError` values, this can be done by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 
 Sentry will group errors based on the error domain and code, and by enum value for Swift enum types, so customizing error descriptions won’t impact grouping.
 
@@ -62,3 +75,15 @@ extension MyCustomError: CustomNSError {
     }
 }
 ```
+
+<PlatformSection supported={["apple.macos"]}>
+
+## Capturing Uncaught Exceptions in macOS
+
+By default, macOS applications do not crash whenever an uncaught exception occurs. To enable this with Sentry:
+
+1. Open the application's `Info.plist` file
+2. Search for `Principal class` (the entry is expected to be `NSApplication`)
+3. Replace `NSApplication` with `SentryCrashExceptionApplication`
+
+</PlatformSection>

--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -32,7 +32,7 @@ enum LoginError: Error {
 
 SentrySDK.capture(error: LoginError.wrongUser("12345678"))
 ```
-For the Swift error above Sentry displays:
+For the Swift error above Sentry would display the following, based on SDK version:
 
 | sentry-cocoa SDK | Title | Description |
 | ----------- | ----------- | ----------- |


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Sentry Cocoa 8.7.0 contains improvements for Swift error descriptions. This PR adds the docs for this feature. Please only merge this PR after releasing 8.7.0.
