### PR TITLE
doc(ssl): update TLS protocols, ciphers, pinning

### DIFF
--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -13,7 +13,6 @@ apply to Self-hosted or Single Tenant.
 
 </Alert>
 
-
 Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.2 to communicate securely.
 
 Sentry provides a suite of protocols and ciphers that focus on giving our users a balance of security and compatibility. Our servers will negotiate a cipher to the most secure combination the client can support in the preferential order specified below. The set of ciphers depends on the endpoint and negotiated TLS version.
@@ -47,7 +46,7 @@ Supported ciphers:
 - TLS_RSA_WITH_AES_128_CBC_SHA
 - TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
 
-### *.ingest.sentry.io
+### \*.ingest.sentry.io
 
 For ingestion domains, TLS 1.2 and 1.3 are supported.
 

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -13,20 +13,64 @@ apply to Self-hosted or Single Tenant.
 
 </Alert>
 
-Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.0 to communicate securely.
+## Protocols and Ciphers
 
-By the end of February, 2021, Sentry's API and Dashboard will require a minimum TLS version of 1.2.
+Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.2 to communicate securely.
 
-Sentry provides a suite of protocols and ciphers that focus on giving our users a balance of security and compatibility. Our servers will negotiate a cipher to the most secure combination the client can support in the following preferential order:
+Sentry provides a suite of protocols and ciphers that focus on giving our users a balance of security and compatibility. Our servers will negotiate a cipher to the most secure combination the client can support in the preferential order specified below. The set of ciphers depends on the endpoint and negotiated TLS version.
+
+### sentry.io
+
+Sentry's API, Dashboard, and legacy Event Submission (via `sentry.io` domain). Only TLS 1.2 is supported.
+
+Supported ciphers:
 
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
 - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
-- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+- TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+- TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+- TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
 - TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
+- TLS_RSA_WITH_AES_256_CBC_SHA256
 - TLS_RSA_WITH_AES_256_CBC_SHA
+- TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+- TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+- TLS_RSA_WITH_AES_128_GCM_SHA256
+- TLS_RSA_WITH_AES_128_CBC_SHA256
 - TLS_RSA_WITH_AES_128_CBC_SHA
+- TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+### *.ingest.sentry.io
+
+For ingestion domains, TLS 1.2 and 1.3 are supported.
+
+Supported ciphers:
+
+#### TLS 1.3
+
+- TLS_AES_128_GCM_SHA256
+- TLS_AES_256_GCM_SHA384
+- TLS_CHACHA20_POLY1305_SHA256
+
+#### TLS 1.2
+
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+- TLS_RSA_WITH_AES_128_GCM_SHA256
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_CBC_SHA
+- TLS_RSA_WITH_AES_256_CBC_SHA
 - TLS_RSA_WITH_3DES_EDE_CBC_SHA
 
 This suite of protocols and ciphers represents Sentry's official support; however, clients may experience an agreement on individual ciphers that exceed the strength ratings of those listed above.

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -13,7 +13,6 @@ apply to Self-hosted or Single Tenant.
 
 </Alert>
 
-## Protocols and Ciphers
 
 Sentry's API, Dashboard, and Event Submission requires a minimum TLS version of 1.2 to communicate securely.
 
@@ -75,7 +74,7 @@ Supported ciphers:
 
 This suite of protocols and ciphers represents Sentry's official support; however, clients may experience an agreement on individual ciphers that exceed the strength ratings of those listed above.
 
-## Certificate pinning
+## Certificate Pinning
 
 Sentry is using Digicert and Let's Encrypt as certificate authorities for all TLS certificates.
 

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -74,3 +74,35 @@ Supported ciphers:
 - TLS_RSA_WITH_3DES_EDE_CBC_SHA
 
 This suite of protocols and ciphers represents Sentry's official support; however, clients may experience an agreement on individual ciphers that exceed the strength ratings of those listed above.
+
+## Certificate pinning
+
+Sentry SaaS is using Digicert and Let's Encrypt as certificate authorities for all TLS certificates.
+
+Here are corresponding root CA certificates if you would like to pin them in your applications:
+
+- [Digicert](https://www.digicert.com/kb/digicert-root-certificates.htm)
+
+```
+DigiCert Global Root CA
+Valid until: 10/Nov/2031
+Serial Number: 08:3B:E0:56:90:42:46:B1:A1:75:6A:C9:59:91:C7:4A
+SHA1 Fingerprint: A8:98:5D:3A:65:E5:E5:C4:B2:D7:D6:6D:40:C6:DD:2F:B1:9C:54:36
+SHA256 Fingerprint: 43:48:A0:E9:44:4C:78:CB:26:5E:05:8D:5E:89:44:B4:D8:4F:96:62:BD:26:DB:25:7F:89:34:A4:43:C7:01:61
+```
+
+- [Let's Encrypt](https://letsencrypt.org/certificates/)
+
+```
+ISRG Root X1
+Valid until: 04/Jun/2035
+Serial Number: 82:10:cf:b0:d2:40:e3:59:44:63:e0:bb:63:82:8b:00
+SHA1 Fingerprint: CA:BD:2A:79:A1:07:6A:31:F2:1D:25:36:35:CB:03:9D:43:29:A5:E8
+SHA256 Fingerprint: 96:BC:EC:06:26:49:76:F3:74:60:77:9A:CF:28:C5:A7:CF:E8:A3:C0:AA:E1:1A:8F:FC:EE:05:C0:BD:DF:08:C6
+
+ISRG Root X2
+Valid until: 17/Sep/2040
+Serial Number: 41:d2:9d:d1:72:ea:ee:a7:80:c1:2c:6c:e9:2f:87:52
+SHA1 Fingerprint: BD:B1:B9:3C:D5:97:8D:45:C6:26:14:55:F8:DB:95:C7:5A:D1:53:AF
+SHA256 Fingerprint: 69:72:9B:8E:15:A8:6E:FC:17:7A:57:AF:B7:17:1D:FC:64:AD:D2:8C:2F:CA:8C:F1:50:7E:34:45:3C:CB:14:70
+```

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -75,7 +75,7 @@ This suite of protocols and ciphers represents Sentry's official support; howeve
 
 ## Certificate Pinning
 
-Sentry is using Digicert and Let's Encrypt as certificate authorities for all TLS certificates.
+At the moment, Sentry uses Digicert and Let's Encrypt as certificate authorities for all TLS certificates. If this needs to be changed, we will publish an announcement on [status.sentry.io](https://status.sentry.io/).
 
 Here are corresponding root CA certificates if you would like to pin them in your applications:
 

--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -77,7 +77,7 @@ This suite of protocols and ciphers represents Sentry's official support; howeve
 
 ## Certificate pinning
 
-Sentry SaaS is using Digicert and Let's Encrypt as certificate authorities for all TLS certificates.
+Sentry is using Digicert and Let's Encrypt as certificate authorities for all TLS certificates.
 
 Here are corresponding root CA certificates if you would like to pin them in your applications:
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

- Update the minimum required version of TLS to 1.2
- Update the list of supported ciphers based on ssllabs: [o1.ingest.sentry.io](https://www.ssllabs.com/ssltest/analyze.html?d=o1.ingest.sentry.io) and [sentry.io](https://www.ssllabs.com/ssltest/analyze.html?d=sentry.io)
- Propose section about root CA certificates pinning

## Extra resources

- [Sentry blog: Deprecating TLS 1.0 and 1.1](https://blog.sentry.io/2022/08/22/deprecating-tls-1-0-and-1-1/)
