### PR TITLE
Add "Product Area: Docs" label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -222,6 +222,8 @@
   color: '8D5494'
 - name: 'Product Area: SDKs - Native'
   color: '8D5494'
+- name: 'Product Area: Docs'
+  color: '8D5494'
 
 # Teams
 - name: 'Team: Crons'


### PR DESCRIPTION
This is for docs-related things that don't fit a more specific product area.