### PR TITLE
ref(js): Add Angular 16 compatibility note

### DIFF
--- a/src/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/src/platform-includes/getting-started-install/javascript.angular.mdx
@@ -29,3 +29,9 @@ Because of the way Angular libraries are compiled, you need to use a specific ve
 Support for any Angular version below 10 was discontinued in version 7 of the SDK. If you need to use Angular 9 or older, try version 6 (`@sentry/angular@^6.x`) of the SDK. For AngularJS/1.x, use `@sentry/browser@^6.x` and our [AngularJS integration](/platforms/javascript/guides/angular/angular1). Note, that these versions of the SDK are no longer maintained or tested.
 
 </Alert>
+
+<Alert level="warning">
+
+If you are using Angular 16 or newer, `@sentry/angular` will no longer work as it doesn't support Angular's rendering engine Ivy natively. Please use `@sentry/angular-ivy` instead.
+
+</Alert>


### PR DESCRIPTION
This PR adds a note that `@sentry/angular` is no longer compatible with Angular 16 or newer. This is fine though, as our newer package, `@sentry/angular-ivy` supports it just fine. 

Given that the compatibility table already recommends the Ivy package for NG12+ I think just leaving this additional note is fine. 