### PR TITLE
feat(apple): Add initialScope option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -425,7 +425,6 @@ Sentry.init({
 
 <ConfigKey name="initial-scope" supported={["apple"]}>
 
-This feature is available on [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) and above.
 
 A block that configures the initial scope when starting the SDK.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -451,6 +451,8 @@ SentrySDK.start { options in
 }];
 ```
 
+_(New in [sentry-cocoa version 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870))_
+
 </ConfigKey>
 
 <ConfigKey name="max-value-length" supported={["javascript", "node"]}>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -423,6 +423,38 @@ Sentry.init({
 
 </ConfigKey>
 
+<ConfigKey name="initial-scope" supported={["apple"]}>
+
+This feature is available on [sentry-cocoa 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870) and above.
+
+A block that configures the initial scope when starting the SDK.
+
+```swift
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.initialScope = { scope in
+        scope.setTag(value: "my value", key: "my-tag")
+        return scope
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.initialScope = ^(SentryScope *scope) {
+        scope setTagValue:@"my value" forKey:@"my-tag"];
+        return scope;
+    };
+}];
+```
+
+</ConfigKey>
+
 <ConfigKey name="max-value-length" supported={["javascript", "node"]}>
 
 Maximum number of characters a single value can have before it will be truncated (defaults to `250`).

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -452,6 +452,7 @@ SentrySDK.start { options in
 }];
 ```
 
+_(New in [sentry-cocoa version 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870))_
 </ConfigKey>
 
 <ConfigKey name="max-value-length" supported={["javascript", "node"]}>

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic Options
 sidebar_order: 1
-description: 'Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init function as an object.'
+description: "Learn more about how to configure the SDK. These options are set when the SDK is first initialized, passed to the init function as an object."
 notSupported:
   - perl
 ---
@@ -399,11 +399,11 @@ Object:
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   debug: true,
   initialScope: {
-    tags: {'my-tag': 'my value'},
-    user: {id: 42, email: 'john.doe@example.com'},
+    tags: { "my-tag": "my value" },
+    user: { id: 42, email: "john.doe@example.com" },
   },
 });
 ```
@@ -412,10 +412,10 @@ Callback function:
 
 ```javascript
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   debug: true,
-  initialScope: scope => {
-    scope.setTags({a: 'b'});
+  initialScope: (scope) => {
+    scope.setTags({ a: "b" });
     return scope;
   },
 });
@@ -424,7 +424,6 @@ Sentry.init({
 </ConfigKey>
 
 <ConfigKey name="initial-scope" supported={["apple"]}>
-
 
 A block that configures the initial scope when starting the SDK.
 
@@ -452,7 +451,6 @@ SentrySDK.start { options in
 }];
 ```
 
-_(New in [sentry-cocoa version 8.7.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#870))_
 </ConfigKey>
 
 <ConfigKey name="max-value-length" supported={["javascript", "node"]}>
@@ -468,8 +466,6 @@ Sentry SDKs normalize any contextual data to a given depth. Any data beyond this
 </ConfigKey>
 
 <ConfigKey name="normalize-max-breadth" supported={["javascript", "node"]} notSupported={["electron"]}>
-
-_(New in version 6.19.1)_
 
 This is the maximum number of properties or entries that will be included in any given object or array when the SDK is normalizing contextual data. Any data beyond this depth will be dropped. (defaults to 1000)
 
@@ -618,7 +614,7 @@ For many platform SDKs integrations can be configured alongside it. On some plat
 
 In some SDKs, the integrations are configured through this parameter on library initialization. For more information, please see our documentation for a specific integration.
 
-<ConfigKey name="default-integrations" notSupported={['java', 'dart']} />
+<ConfigKey name="default-integrations" notSupported={["java", "dart"]} />
 
 This can be used to disable integrations that are added by default. When set to `false`, no default integrations are added.
 
@@ -646,8 +642,6 @@ This function is called with an SDK-specific message or error event object, and 
 This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 
 <PlatformSection supported={["javascript", "node"]}>
-
-_(New in version 7.18.0)_
 
 </PlatformSection>
 
@@ -701,10 +695,10 @@ Options used to configure the transport. This is an object with the following po
 
 </ConfigKey>
 
-<ConfigKey name="proxy" supported={['native']}>
-  Configures an HTTP proxy for outgoing requests to the backend, (HTTPS requests tunneled
-  through that proxy). The Native SDK doesn't pick up the `http_proxy` environment
-  variable. You can find more details on the [transport
+<ConfigKey name="proxy" supported={["native"]}>
+  Configures an HTTP proxy for outgoing requests to the backend, (HTTPS requests
+  tunneled through that proxy). The Native SDK doesn't pick up the `http_proxy`
+  environment variable. You can find more details on the [transport
   page](/platforms/native/configuration/transports/#using-an-http-proxy).
 </ConfigKey>
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Add intialScope option for the Apple SDK. Related PR https://github.com/getsentry/sentry-cocoa/pull/2982. Only merge after releasing Cocoa 8.7.0.
