### PR TITLE
feat(onboarding): Add replay and performance docs for browser javascript

### DIFF
--- a/src/wizard/javascript/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/with-error-monitoring-and-performance.md
@@ -1,0 +1,47 @@
+---
+name: Browser JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/
+support_level: production
+type: language
+---
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+# Using npm
+npm install --save @sentry/browser
+```
+
+## Configure
+
+Initialize Sentry as early as possible in your application's lifecycle.
+
+```javascript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [new Sentry.BrowserTracing()],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```javascript
+myUndefinedFunction();
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/with-error-monitoring-and-replay.md
@@ -1,0 +1,48 @@
+---
+name: Browser JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/
+support_level: production
+type: language
+---
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+# Using npm
+npm install --save @sentry/browser
+```
+
+## Configure
+
+Initialize Sentry as early as possible in your application's lifecycle.
+
+```javascript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [new Sentry.Replay()],
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```javascript
+myUndefinedFunction();
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.

--- a/src/wizard/javascript/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/with-error-monitoring-performance-and-replay.md
@@ -1,0 +1,49 @@
+---
+name: Browser JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/
+support_level: production
+type: language
+---
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+# Using npm
+npm install --save @sentry/browser
+```
+
+## Configure
+
+Initialize Sentry as early as possible in your application's lifecycle.
+
+```javascript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```javascript
+myUndefinedFunction();
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.

--- a/src/wizard/javascript/with-error-monitoring.md
+++ b/src/wizard/javascript/with-error-monitoring.md
@@ -1,0 +1,45 @@
+---
+name: Browser JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/
+support_level: production
+type: language
+---
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+# Using npm
+npm install --save @sentry/browser
+```
+
+## Configure
+
+Initialize Sentry as early as possible in your application's lifecycle.
+
+```javascript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```javascript
+myUndefinedFunction();
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.


### PR DESCRIPTION
In the onboarding, if users prefer `yarn` and `npm` over the loader, we display the docs with the product selection. Docs for the BRowser JavaScript were missing and this PR fixes it.