### PR TITLE
fix(onboarding): Remove invalid remix links

### DIFF
--- a/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
@@ -106,5 +106,4 @@ You can trigger your first event from your development environment by raising an
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/remix/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Remix Features](https://docs.sentry.io/platforms/javascript/guides/remix/features/): Learn about our first class integration with the Remix framework.
 - [Session Replay](https://docs.sentry.io/platforms/javascript/guides/remix/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/remix/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-and-replay.md
@@ -94,5 +94,4 @@ You can trigger your first event from your development environment by raising an
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/remix/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Remix Features](https://docs.sentry.io/platforms/javascript/guides/remix/features/): Learn about our first class integration with the Remix framework.
 - [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/remix/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.

--- a/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
@@ -110,4 +110,3 @@ You can trigger your first event from your development environment by raising an
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/remix/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Remix Features](https://docs.sentry.io/platforms/javascript/guides/remix/features/): Learn about our first class integration with the Remix framework.

--- a/src/wizard/javascript/remix/with-error-monitoring.md
+++ b/src/wizard/javascript/remix/with-error-monitoring.md
@@ -90,6 +90,5 @@ return <button onClick={() => methodDoesNotExist()}>Break the world</button>;
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/remix/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Remix Features](https://docs.sentry.io/platforms/javascript/guides/remix/features/): Learn about our first class integration with the Remix framework.
 - [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/remix/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
 - [Session Replay](https://docs.sentry.io/platforms/javascript/guides/remix/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.


### PR DESCRIPTION
Noticed that the link https://docs.sentry.io/platforms/javascript/guides/remix/features/ does not exist, so I am removing it from the docs