### PR TITLE
feat(crons): Add Node SDK cron monitoring docs

### DIFF
--- a/src/docs/product/crons/getting-started/index.mdx
+++ b/src/docs/product/crons/getting-started/index.mdx
@@ -14,6 +14,7 @@ To set up Sentry Crons, use the links below for supported SDKs or the Sentry CLI
   - [Laravel](/platforms/php/guides/laravel/crons/)
 - [Python](/platforms/python/crons/)
   - [Celery](/platforms/python/guides/celery/crons/)
+- [Node](/platforms/node/crons/)
 
 <Alert level="note" title="Don't see your platform?">
 

--- a/src/platform-includes/crons/connect-errors/node.mdx
+++ b/src/platform-includes/crons/connect-errors/node.mdx
@@ -1,0 +1,7 @@
+```javascript
+Sentry.configureScope(function (scope) {
+  scope.setContext('monitor', {
+    slug: '<monitor-slug>',
+  });
+});
+```

--- a/src/platform-includes/crons/requirements/node.mdx
+++ b/src/platform-includes/crons/requirements/node.mdx
@@ -1,0 +1,2 @@
+- Use our <PlatformLink to="/">getting started</PlatformLink> guide to install and configure the Sentry Node SDK (min v7.51.0) for your recurring job.
+- [Create and configure](https://sentry.io/crons/create/) your first Monitor.

--- a/src/platform-includes/crons/setup/node.mdx
+++ b/src/platform-includes/crons/setup/node.mdx
@@ -1,0 +1,53 @@
+## Check-Ins (Recommended)
+
+Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+```javascript
+// 🟡 Notify Sentry your job is running:
+Sentry.captureCheckIn({
+  monitorSlug: '<monitor-slug>',
+  status: 'in_progress',
+});
+
+// Execute your scheduled task here...
+
+// 🟢 Notify Sentry your job has completed successfully:
+Sentry.captureCheckIn({
+  monitorSlug: '<monitor-slug>',
+  status: 'ok',
+});
+```
+
+If your job execution fails, you can notify Sentry about the failure:
+
+```javascript
+// 🔴 Notify Sentry your job has failed:
+Sentry.captureCheckIn({
+  monitorSlug: '<monitor-slug>',
+  status: 'error',
+});
+```
+
+## Heartbeat
+
+Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
+
+```javascript
+// Execute your scheduled task...
+
+// 🟢 Notify Sentry your job completed successfully:
+Sentry.captureCheckIn({
+  monitorSlug: '<monitor-slug>',
+  status: 'ok',
+});
+```
+
+If your job execution fails, you can:
+
+```javascript
+// 🔴 Notify Sentry your job has failed:
+Sentry.captureCheckIn({
+  monitorSlug: '<monitor-slug>',
+  status: 'error',
+});
+```

--- a/src/platform-includes/crons/setup/php.mdx
+++ b/src/platform-includes/crons/setup/php.mdx
@@ -24,7 +24,7 @@ $event->setCheckIn(new CheckIn(
 SentrySdk::getCurrentHub()->captureEvent($event);
 ```
 
-If your job execution fails, you can do:
+If your job execution fails, you can notify Sentry about the failure:
 
 ```php
 // 🔴 Notify Sentry your job has failed:

--- a/src/platform-includes/crons/troubleshooting/node.mdx
+++ b/src/platform-includes/crons/troubleshooting/node.mdx
@@ -1,0 +1,3 @@
+### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
+
+Attachments aren't supported by our Node SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -4,6 +4,7 @@ sidebar_order: 5000
 supported:
   - python
   - php
+  - node
 description: 'Learn how to enable Cron Monitoring in your app'
 ---
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry/issues/43661

In version`7.51.0` of the Node SDK we'll be releasing support for cron monitoring as implemented here: https://github.com/getsentry/sentry-javascript/pull/8039

This PR adds documentation for it.