### PR TITLE
feat(db-on-main-thread): Update docs for iOS GA

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/db-main-thread-io.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/db-main-thread-io.mdx
@@ -6,9 +6,7 @@ description: 'Learn more about Database on Main Thread and how to diagnose and f
 
 <Note>
 
-This feature is available **only for iOS devices** using `sentry-cocoa` >= v8.5.0, and if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+This feature is available **only for iOS devices** using `sentry-cocoa` >= v8.5.0. We are working on adding support for Android devices and will update this page with the latest changes.
 
 </Note>
 


### PR DESCRIPTION
This performance issue (DB on the Main Thread) will not be available on Android for some time, so the team has decided to move forward with GA-ing with only iOS support.
