### PR TITLE
fix(js): Remove bad trailing comma in args list

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -13,7 +13,7 @@ Sentry.init({
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,
-        useMatches,
+        useMatches
       ),
     }),
   ],


### PR DESCRIPTION
Before ES2017 it was not possible to have trailing commas