### PR TITLE
ref(prettier): Ignore symfomy yaml configs

### DIFF
--- a/src/platform-includes/configuration/before-send-fingerprint/php.symfony.mdx
+++ b/src/platform-includes/configuration/before-send-fingerprint/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/configuration/before-send-hint/php.symfony.mdx
+++ b/src/platform-includes/configuration/before-send-hint/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/configuration/before-send-transaction/php.symfony.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/php.symfony.mdx
@@ -1,5 +1,6 @@
 In the Symfony config, a service can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/configuration/before-send/php.symfony.mdx
+++ b/src/platform-includes/configuration/before-send/php.symfony.mdx
@@ -1,5 +1,6 @@
 In the Symfony config, a service can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/configuration/config-intro/php.symfony.mdx
+++ b/src/platform-includes/configuration/config-intro/php.symfony.mdx
@@ -1,5 +1,6 @@
 Options are configured in the `config/packages/sentry.yaml` config file:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     dsn: "%env(SENTRY_DSN)%"

--- a/src/platform-includes/configuration/sample-rate/php.symfony.mdx
+++ b/src/platform-includes/configuration/sample-rate/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.symfony.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/performance/always-inherit-sampling-decision/php.symfony.mdx
+++ b/src/platform-includes/performance/always-inherit-sampling-decision/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/performance/configure-sample-rate/php.symfony.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/performance/traces-sample-rate/php.symfony.mdx
+++ b/src/platform-includes/performance/traces-sample-rate/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/performance/traces-sampler-as-filter/php.symfony.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-filter/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/set-environment/php.symfony.mdx
+++ b/src/platform-includes/set-environment/php.symfony.mdx
@@ -1,5 +1,6 @@
 The environment option defaults to the same environment of your Symfony application.
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platform-includes/set-release/php.symfony.mdx
+++ b/src/platform-includes/set-release/php.symfony.mdx
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -10,6 +10,7 @@ In addition to the [configuration available in the PHP SDK](../options/), there 
 
 All configuration for Symfony is done in `config/packages/sentry.yaml`.
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     dsn: "___PUBLIC_DSN___"
@@ -76,6 +77,7 @@ In this bundle it has three default values:
 The `before_breadcrumb`, `before_send`, `before_send_transaction` and `traces_sampler` options accept a `callable`; so, you cannot provide it directly through
 a YAML file. The bundle accepts a service reference, which you can build in your DIC container like this:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:
@@ -111,6 +113,7 @@ This example shows how to ignore not found exceptions, but you can ignore any ex
 
 1. Declare the integrations:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:
@@ -120,6 +123,7 @@ sentry:
 
 2. Configure the list of ignored exceptions:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/services.yaml}
 services:
     Sentry\Integration\IgnoreErrorsIntegration:

--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -21,6 +21,7 @@ composer require sentry/sentry-symfony
 
 Due to a bug in all versions below `6.0` of the [`SensioFrameworkExtraBundle`](https://github.com/sensiolabs/SensioFrameworkExtraBundle) bundle, you will likely receive an error during the execution of the command above related to the missing `Nyholm\Psr7\Factory\Psr17Factory` class. To workaround the issue, if you are not using the PSR-7 bridge, please change the configuration of that bundle as follows:
 
+<!-- prettier-ignore -->
 ```yaml
 sensio_framework_extra:
    psr_message:
@@ -35,6 +36,7 @@ For more details about the issue see [https://github.com/sensiolabs/SensioFramew
 
 Add your DSN to `config/packages/sentry.yaml`:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     dsn: "%env(SENTRY_DSN)%"
@@ -71,6 +73,7 @@ return [
 
 If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the typical error listener approach, you need this additional configuration to log the errors correctly:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
@@ -87,6 +90,7 @@ monolog:
 If you are using a version of [MonologBundle](https://github.com/symfony/monolog-bundle) prior to `3.7`, you need to
 configure the handler as a service instead:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 monolog:
     handlers:
@@ -103,6 +107,7 @@ services:
 
 Additionally, you can register the `PsrLogMessageProcessor` to resolve PSR-3 placeholders in reported messages:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 services:
     Monolog\Processor\PsrLogMessageProcessor:

--- a/src/platforms/php/guides/symfony/profiling/index.mdx
+++ b/src/platforms/php/guides/symfony/profiling/index.mdx
@@ -62,6 +62,7 @@ phpenmod -s apache2 excimer
 Sentry's performance monitoring product has to be enabled in order for Profiling to work.
 Check out the <PlatformLink to="/performance/">performance setup</PlatformLink> documentation for more detailed information.
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:
@@ -70,6 +71,7 @@ sentry:
 
 ## Enable Profiling
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     options:

--- a/src/wizard/php/profiling-onboarding/symfony2/2.configure-performance.md
+++ b/src/wizard/php/profiling-onboarding/symfony2/2.configure-performance.md
@@ -10,6 +10,7 @@ type: language
 Sentry’s performance monitoring product has to be enabled in order for Profiling to work.
 Add the `traces_sample_rate` option to the `config/packages/sentry.yaml` config file.
 
+<!-- prettier-ignore -->
 ```yaml
 sentry:
     options:

--- a/src/wizard/php/profiling-onboarding/symfony2/3.configure-profiling.md
+++ b/src/wizard/php/profiling-onboarding/symfony2/3.configure-profiling.md
@@ -9,6 +9,7 @@ type: language
 
 Add the `profiles_sample_rate` option to the `config/packages/sentry.yaml` config file.
 
+<!-- prettier-ignore -->
 ```yaml
 sentry:
     options:

--- a/src/wizard/php/symfony.md
+++ b/src/wizard/php/symfony.md
@@ -19,6 +19,7 @@ composer require sentry/sentry-symfony
 
 Due to a bug in all versions below `6.0` of the [`SensioFrameworkExtraBundle`](https://github.com/sensiolabs/SensioFrameworkExtraBundle) bundle, you will likely receive an error during the execution of the command above related to the missing `Nyholm\Psr7\Factory\Psr17Factory` class. To workaround the issue, if you are not using the PSR-7 bridge, please change the configuration of that bundle as follows:
 
+<!-- prettier-ignore -->
 ```yaml
 sensio_framework_extra:
    psr_message:
@@ -33,6 +34,7 @@ For more details about the issue see [https://github.com/sensiolabs/SensioFramew
 
 Add your DSN to `config/packages/sentry.yaml`:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     dsn: "%env(SENTRY_DSN)%"
@@ -69,6 +71,7 @@ return [
 
 If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the typical error listener approach, you need this additional configuration to log the errors correctly:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:
     register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
@@ -85,6 +88,7 @@ monolog:
 If you are using a version of [MonologBundle](https://github.com/symfony/monolog-bundle) prior to `3.7`, you need to
 configure the handler as a service instead:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 monolog:
     handlers:
@@ -101,6 +105,7 @@ services:
 
 Additionally, you can register the `PsrLogMessageProcessor` to resolve PSR-3 placeholders in reported messages:
 
+<!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 services:
     Monolog\Processor\PsrLogMessageProcessor:


### PR DESCRIPTION
We don't want to reformat these