### PR TITLE
Drop back from auto-merge; try to fix auth bug

### DIFF
--- a/bin/react-to-product-owners-yml-changes.sh
+++ b/bin/react-to-product-owners-yml-changes.sh
@@ -7,9 +7,10 @@ sha=$(git -C /tmp/security-as-code rev-parse @)
 pip3 install pyyaml==6.0
 ./bin/react-to-product-owners-yml-changes.py /tmp/security-as-code/rbac/lib/product-owners.yml
 branch="getsantry/update-product-area-labels-${sha:0:8}"
+git config user.email "getsantry[bot]@users.noreply.github.com"
+git config user.name "getsantry[bot]"
 git checkout -b "$branch"
 git add .
 git commit -m "Sync with product-owners.yml in security-as-code@${sha:0:8}"
 git push --set-upstream origin "$branch"
 gh pr create --fill
-gh pr merge --squash --auto


### PR DESCRIPTION
- minimal protections on sentry-docs, we want review to avoid label disaster
- got an [auth bug](https://github.com/getsentry/sentry-docs/actions/runs/4889060391/jobs/8727273173)