### PR TITLE
feat(js): Add SvelteKit Onboarding Wizard docs

### DIFF
--- a/src/wizard/javascript/replay-onboarding/sveltekit/1.install.md
+++ b/src/wizard/javascript/replay-onboarding/sveltekit/1.install.md
@@ -1,0 +1,10 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+You need a minimum version 7.47.0 of `@sentry/sveltekit` in order to use Session Replay. You don't need to install any additional packages.

--- a/src/wizard/javascript/replay-onboarding/sveltekit/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/sveltekit/2.configure.md
@@ -1,0 +1,29 @@
+---
+name: JavaScript
+doc_link: https://docs.sentry.io/platforms/javascript/replay/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Add the following to your SDK config in `hooks.client.(js|ts)`. There are several privacy and sampling options available, all of which can be set using the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/guides/svelte/session-replay/).
+
+```javascript
+// hooks.client.(js|ts):
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
+  // Session Replay
+  integrations: [new Sentry.Replay()],
+
+  // This sets the sample rate at 10%. You may want to change it to 100% while in development
+  // and then sample at a lower rate in production:
+  replaysSessionSampleRate: 0.1,
+  // If you're not already sampling the entire session, change the sample rate to 100% when
+  // sampling sessions where errors occur:
+  replaysOnErrorSampleRate: 1.0,
+});
+```

--- a/src/wizard/javascript/replay-onboarding/sveltekit/2.configure.md
+++ b/src/wizard/javascript/replay-onboarding/sveltekit/2.configure.md
@@ -11,10 +11,10 @@ Add the following to your SDK config in `hooks.client.(js|ts)`. There are severa
 
 ```javascript
 // hooks.client.(js|ts):
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
 
   // Session Replay
   integrations: [new Sentry.Replay()],

--- a/src/wizard/javascript/sveltekit/index.md
+++ b/src/wizard/javascript/sveltekit/index.md
@@ -29,7 +29,6 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   integrations: [new Sentry.BrowserTracing()],
-
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production

--- a/src/wizard/javascript/sveltekit/index.md
+++ b/src/wizard/javascript/sveltekit/index.md
@@ -1,0 +1,51 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/javascript/guides/sveltekit/
+support_level: production
+type: framework
+---
+
+Configure your app automatically with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/sveltekit/#install).
+
+```bash
+npx @sentry/wizard@latest -i sveltekit
+```
+
+Sentry wizard will automatically patch your application:
+
+- Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and Sentry's hooks handlers.
+- Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
+- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+
+You can also [configure the Sentry SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
+
+Configure the Sentry SDK:
+
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [new Sentry.BrowserTracing()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+```
+
+The above configuration captures both error and performance data. We recommend adjusting `tracesSampleRate` in production, see [Sampling](https://docs.sentry.io/platforms/javascript/configuration/sampling/).
+
+After this step, Sentry will report any uncaught exceptions triggered by your application.
+
+You can trigger your first event from your development environment by raising an exception somewhere within your application. An example of this would be rendering a button whose `on:click` handler attempts to invoke a function that doesn't exist:
+
+```html
+<!-- +page.svelte -->
+<button type="button" on:click="{unknownFunction}">Break the world</button>
+```
+
+Once you've verified the SDK is initialized properly and you've sent a test event, check out our [complete SvelteKit docs](https://docs.sentry.io/platforms/javascript/guides/sveltekit/) for additional configuration instructions.

--- a/src/wizard/javascript/sveltekit/index.md
+++ b/src/wizard/javascript/sveltekit/index.md
@@ -24,10 +24,10 @@ Configure the Sentry SDK:
 To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/wizard/javascript/sveltekit/index.md
+++ b/src/wizard/javascript/sveltekit/index.md
@@ -11,7 +11,7 @@ Configure your app automatically with the [Sentry wizard](https://docs.sentry.io
 npx @sentry/wizard@latest -i sveltekit
 ```
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and Sentry's hooks handlers.
 - Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
@@ -28,7 +28,6 @@ import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production
@@ -42,9 +41,9 @@ After this step, Sentry will report any uncaught exceptions triggered by your ap
 
 You can trigger your first event from your development environment by raising an exception somewhere within your application. An example of this would be rendering a button whose `on:click` handler attempts to invoke a function that doesn't exist:
 
-```html
+```svelte
 <!-- +page.svelte -->
-<button type="button" on:click="{unknownFunction}">Break the world</button>
+<button type="button" on:click={unknownFunction}>Break the world</button>
 ```
 
 Once you've verified the SDK is initialized properly and you've sent a test event, check out our [complete SvelteKit docs](https://docs.sentry.io/platforms/javascript/guides/sveltekit/) for additional configuration instructions.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -1,0 +1,58 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/javascript/guides/sveltekit/
+support_level: production
+type: framework
+---
+
+## Install
+
+Configure your app automatically with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/sveltekit/#install).
+
+```bash
+npx @sentry/wizard -i sveltekit
+```
+
+## Configure
+
+Sentry wizard will automatically patch your application to configure the Sentry SDK:
+
+- Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
+- Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
+- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+
+Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
+
+**Configure the Sentry SDK**:
+
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
+  // Performance Monitoring
+  integrations: [new Sentry.BrowserTracing()],
+  // Capture 100% of the transactions. Adjust this value in production as necessary:
+  tracesSampleRate: 1.0,
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```html
+<!-- +page.svelte -->
+<button type="button" on:click={unknownFunction}>Break the world</button>
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -32,8 +32,7 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-
-  // Performance Monitoring integration
+  // Performance Monitoring
   integrations: [new Sentry.BrowserTracing()],
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
@@ -47,7 +46,6 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
 });
@@ -67,5 +65,4 @@ This snippet contains an intentional error and can be used as a test to make sur
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
 - [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -28,10 +28,10 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 To configure the Sentry SDK on the client-side, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Performance Monitoring
   integrations: [new Sentry.BrowserTracing()],
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
@@ -41,10 +41,10 @@ Sentry.init({
 For the server-side, edit the `Sentry.init` options in `hooks.server.(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```
@@ -55,7 +55,7 @@ This snippet contains an intentional error and can be used as a test to make sur
 
 ```html
 <!-- +page.svelte -->
-<button type="button" on:click={unknownFunction}>Break the world</button>
+<button type="button" on:click="{unknownFunction}">Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -25,7 +25,7 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 
 **Configure the Sentry SDK**:
 
-To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+To configure the Sentry SDK on the client-side, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
 import * as Sentry from '@sentry/sveltekit';
@@ -33,8 +33,21 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
 
-  // Performance Monitoring
+  // Performance Monitoring integration
   integrations: [new Sentry.BrowserTracing()],
+  // Capture 100% of the transactions. Adjust this value in production as necessary:
+  tracesSampleRate: 1.0,
+});
+```
+
+For the server-side, edit the `Sentry.init` options in `hooks.server.(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
 });

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -34,8 +34,7 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   // Performance Monitoring
   integrations: [new Sentry.BrowserTracing()],
-  // Capture 100% of the transactions. Adjust this value in production as necessary:
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```
 
@@ -46,8 +45,7 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  // Capture 100% of the transactions. Adjust this value in production as necessary:
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```
 

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-performance.md
@@ -15,17 +15,17 @@ npx @sentry/wizard -i sveltekit
 
 ## Configure
 
-Sentry wizard will automatically patch your application to configure the Sentry SDK:
+The Sentry wizard will automatically patch your application to configure the Sentry SDK:
 
 - Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
 - Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
-- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+- Create `.sentryclirc` and `sentry.properties` files with the configuration for sentry-cli (which is used when automatically uploading source maps).
 
 Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
 
 **Configure the Sentry SDK**:
 
-To configure the Sentry SDK on the client-side, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(server|client).(js|ts)`:
 
 ```javascript
 import * as Sentry from "@sentry/sveltekit";
@@ -33,18 +33,6 @@ import * as Sentry from "@sentry/sveltekit";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // Performance Monitoring
-  integrations: [new Sentry.BrowserTracing()],
-  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
-});
-```
-
-For the server-side, edit the `Sentry.init` options in `hooks.server.(js|ts)`:
-
-```javascript
-import * as Sentry from "@sentry/sveltekit";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```
@@ -53,9 +41,9 @@ Sentry.init({
 
 This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
 
-```html
+```svelte
 <!-- +page.svelte -->
-<button type="button" on:click="{unknownFunction}">Break the world</button>
+<button type="button" on:click={unknownFunction}>Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -25,7 +25,7 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 
 **Configure the Sentry SDK**:
 
-To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
 import * as Sentry from '@sentry/sveltekit';

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -28,10 +28,10 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Session Replay
   integrations: [new Sentry.Replay()],
   // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
@@ -48,7 +48,7 @@ This snippet contains an intentional error and can be used as a test to make sur
 
 ```html
 <!-- +page.svelte -->
-<button type="button" on:click={unknownFunction}>Break the world</button>
+<button type="button" on:click="{unknownFunction}">Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -32,10 +32,8 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-
   // Session Replay
   integrations: [new Sentry.Replay()],
-
   // This sets the sample rate at 10%. You may want to change it to 100% while in development
   // and then sample at a lower rate in production:
   replaysSessionSampleRate: 0.1,
@@ -60,4 +58,3 @@ This snippet contains an intentional error and can be used as a test to make sur
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
 - [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
-- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i sveltekit
 
 ## Configure
 
-Sentry wizard will automatically patch your application to configure the Sentry SDK:
+The Sentry wizard will automatically patch your application to configure the Sentry SDK:
 
 - Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
 - Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
@@ -34,11 +34,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // Session Replay
   integrations: [new Sentry.Replay()],
-  // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysSessionSampleRate: 0.1,
-  // If you're not already sampling the entire session, change the sample rate to 100% when
-  // sampling sessions where errors occur:
-  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 });
 ```
 
@@ -46,9 +43,9 @@ Sentry.init({
 
 This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
 
-```html
+```svelte
 <!-- +page.svelte -->
-<button type="button" on:click="{unknownFunction}">Break the world</button>
+<button type="button" on:click={unknownFunction}>Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -34,8 +34,7 @@ Sentry.init({
   dsn: '___PUBLIC_DSN___',
   // Session Replay
   integrations: [new Sentry.Replay()],
-  // This sets the sample rate at 10%. You may want to change it to 100% while in development
-  // and then sample at a lower rate in production:
+  // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysSessionSampleRate: 0.1,
   // If you're not already sampling the entire session, change the sample rate to 100% when
   // sampling sessions where errors occur:

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-and-replay.md
@@ -1,0 +1,63 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/javascript/guides/sveltekit/
+support_level: production
+type: framework
+---
+
+## Install
+
+Configure your app automatically with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/sveltekit/#install).
+
+```bash
+npx @sentry/wizard -i sveltekit
+```
+
+## Configure
+
+Sentry wizard will automatically patch your application to configure the Sentry SDK:
+
+- Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
+- Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
+- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+
+Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
+
+**Configure the Sentry SDK**:
+
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
+  // Session Replay
+  integrations: [new Sentry.Replay()],
+
+  // This sets the sample rate at 10%. You may want to change it to 100% while in development
+  // and then sample at a lower rate in production:
+  replaysSessionSampleRate: 0.1,
+  // If you're not already sampling the entire session, change the sample rate to 100% when
+  // sampling sessions where errors occur:
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```html
+<!-- +page.svelte -->
+<button type="button" on:click={unknownFunction}>Break the world</button>
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -32,17 +32,11 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-
   // Performance Monitoring and Replay integrations
   integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-  // Capture 100% of the transactions. Adjust this value in production as necessary:
-  tracesSampleRate: 1.0,
-  // This sets the Replay sample rate at 10%. You may want to change it to 100% while in
-  // development and then sample at a lower rate in production:
-  replaysSessionSampleRate: 0.1,
-  // If you're not already sampling the entire session, change the sample rate to 100% when
-  // sampling sessions where errors occur:
-  replaysOnErrorSampleRate: 1.0,
+  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary:
+  replaysSessionSampleRate: 0.1, // This sets the Replay sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 });
 ```
 

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -34,7 +34,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // Performance Monitoring:
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
-  // Replay:
+  // Session Replay
   integrations: [new Sentry.Replay()],
   replaysSessionSampleRate: 0.1, // This sets the Replay sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
@@ -48,7 +48,7 @@ import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Performance Monitoring:
+  // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -28,10 +28,10 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 To configure the Sentry SDK on the client-side, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Performance Monitoring and Replay integrations
   integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
   tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary:
@@ -43,10 +43,10 @@ Sentry.init({
 For the server-side, edit the `Sentry.init` options in `hooks.server.(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
 });
@@ -58,7 +58,7 @@ This snippet contains an intentional error and can be used as a test to make sur
 
 ```html
 <!-- +page.svelte -->
-<button type="button" on:click={unknownFunction}>Break the world</button>
+<button type="button" on:click="{unknownFunction}">Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -53,7 +53,6 @@ import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
 });

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i sveltekit
 
 ## Configure
 
-Sentry wizard will automatically patch your application to configure the Sentry SDK:
+The Sentry wizard will automatically patch your application to configure the Sentry SDK:
 
 - Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
 - Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
@@ -32,9 +32,10 @@ import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Performance Monitoring and Replay integrations
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary:
+  // Performance Monitoring:
+  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
+  // Replay:
+  integrations: [new Sentry.Replay()],
   replaysSessionSampleRate: 0.1, // This sets the Replay sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 });
@@ -47,8 +48,8 @@ import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Capture 100% of the transactions. Adjust this value in production as necessary:
-  tracesSampleRate: 1.0,
+  // Performance Monitoring:
+  tracesSampleRate: 1.0, // Capture 100% of the transactions. Adjust this value in production as necessary.
 });
 ```
 
@@ -56,9 +57,9 @@ Sentry.init({
 
 This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
 
-```html
+```svelte
 <!-- +page.svelte -->
-<button type="button" on:click="{unknownFunction}">Break the world</button>
+<button type="button" on:click={unknownFunction}>Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -35,7 +35,6 @@ Sentry.init({
 
   // Performance Monitoring and Replay integrations
   integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-
   // Capture 100% of the transactions. Adjust this value in production as necessary:
   tracesSampleRate: 1.0,
   // This sets the Replay sample rate at 10%. You may want to change it to 100% while in
@@ -74,5 +73,3 @@ This snippet contains an intentional error and can be used as a test to make sur
 ## Next Steps
 
 - [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
-- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
-- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -25,7 +25,7 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 
 **Configure the Sentry SDK**:
 
-To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+To configure the Sentry SDK on the client-side, edit the `Sentry.init` options in `hooks.client.(js|ts)`:
 
 ```javascript
 import * as Sentry from '@sentry/sveltekit';
@@ -33,7 +33,7 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
 
-  // Performance Monitoring and Replay
+  // Performance Monitoring and Replay integrations
   integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
 
   // Capture 100% of the transactions. Adjust this value in production as necessary:
@@ -44,6 +44,19 @@ Sentry.init({
   // If you're not already sampling the entire session, change the sample rate to 100% when
   // sampling sessions where errors occur:
   replaysOnErrorSampleRate: 1.0,
+});
+```
+
+For the server-side, edit the `Sentry.init` options in `hooks.server.(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
+  // Capture 100% of the transactions. Adjust this value in production as necessary:
+  tracesSampleRate: 1.0,
 });
 ```
 

--- a/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring-performance-and-replay.md
@@ -1,0 +1,65 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/javascript/guides/sveltekit/
+support_level: production
+type: framework
+---
+
+## Install
+
+Configure your app automatically with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/sveltekit/#install).
+
+```bash
+npx @sentry/wizard -i sveltekit
+```
+
+## Configure
+
+Sentry wizard will automatically patch your application to configure the Sentry SDK:
+
+- Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
+- Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
+- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+
+Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
+
+**Configure the Sentry SDK**:
+
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+
+  // Performance Monitoring and Replay
+  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+
+  // Capture 100% of the transactions. Adjust this value in production as necessary:
+  tracesSampleRate: 1.0,
+  // This sets the Replay sample rate at 10%. You may want to change it to 100% while in
+  // development and then sample at a lower rate in production:
+  replaysSessionSampleRate: 0.1,
+  // If you're not already sampling the entire session, change the sample rate to 100% when
+  // sampling sessions where errors occur:
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```html
+<!-- +page.svelte -->
+<button type="button" on:click={unknownFunction}>Break the world</button>
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i sveltekit
 
 ## Configure
 
-Sentry wizard will automatically patch your application to configure the Sentry SDK:
+The Sentry wizard will automatically patch your application to configure the Sentry SDK:
 
 - Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
 - Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
@@ -39,9 +39,9 @@ Sentry.init({
 
 This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
 
-```html
+```svelte
 <!-- +page.svelte -->
-<button type="button" on:click="{unknownFunction}">Break the world</button>
+<button type="button" on:click={unknownFunction}>Break the world</button>
 ```
 
 ---

--- a/src/wizard/javascript/sveltekit/with-error-monitoring.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring.md
@@ -1,0 +1,53 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/javascript/guides/sveltekit/
+support_level: production
+type: framework
+---
+
+## Install
+
+Configure your app automatically with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/sveltekit/#install).
+
+```bash
+npx @sentry/wizard -i sveltekit
+```
+
+## Configure
+
+Sentry wizard will automatically patch your application to configure the Sentry SDK:
+
+- Create or update `src/hooks.client.js` and `src/hooks.server.js` with the default `Sentry.init` call and SvelteKit hooks handlers.
+- Update `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins.
+- create `.sentryclirc` and `sentry.properties` files with configuration for sentry-cli (which is used when automatically uploading source maps).
+
+Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/platforms/javascript/guides/sveltekit/manual-setup/).
+
+**Configure the Sentry SDK**:
+
+To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
+
+```javascript
+import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+});
+```
+
+## Verify
+
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected.
+
+```html
+<!-- +page.svelte -->
+<button type="button" on:click={unknownFunction}>Break the world</button>
+```
+
+---
+
+## Next Steps
+
+- [Source Maps](https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/): Learn how to enable readable stack traces in your Sentry errors.
+- [Performance Monitoring](https://docs.sentry.io/platforms/javascript/guides/sveltekit/performance/): Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.
+- [Session Replay](https://docs.sentry.io/platforms/javascript/guides/sveltekit/session-replay/): Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.

--- a/src/wizard/javascript/sveltekit/with-error-monitoring.md
+++ b/src/wizard/javascript/sveltekit/with-error-monitoring.md
@@ -28,10 +28,10 @@ Alternatively, you can also [set up the SDK manually](https://docs.sentry.io/pla
 To configure the Sentry SDK, edit the `Sentry.init` options in `hooks.(client|server).(js|ts)`:
 
 ```javascript
-import * as Sentry from '@sentry/sveltekit';
+import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
 });
 ```
 
@@ -41,7 +41,7 @@ This snippet contains an intentional error and can be used as a test to make sur
 
 ```html
 <!-- +page.svelte -->
-<button type="button" on:click={unknownFunction}>Break the world</button>
+<button type="button" on:click="{unknownFunction}">Break the world</button>
 ```
 
 ---

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/0.alert.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/0.alert.md
@@ -1,0 +1,10 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/node/profiling/
+support_level: production
+type: language
+---
+
+<div class='alert warning'>
+Note that only SvelteKit's server side profiling is supported, client side (browser profiling) is not supported and you will need to make sure you only enable profiling in your `hooks.server.(js|ts)` file.
+</div>

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/0.alert.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/0.alert.md
@@ -6,5 +6,5 @@ type: language
 ---
 
 <div class='alert warning'>
-Note that only SvelteKit's server side profiling is supported, client side (browser profiling) is not supported and you will need to make sure you only enable profiling in your `hooks.server.(js|ts)` file.
+Note that only SvelteKit server side profiling is supported, client side (browser profiling) is not supported and you will need to make sure you only enable profiling in your `hooks.server.(js|ts)` file.
 </div>

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/1.install.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/1.install.md
@@ -7,7 +7,7 @@ type: language
 
 #### Install
 
-For the Profiling integration to work, you must have the `@sentry/sveltekit` SDK package (minimum version 7.47.0) installed.
+The Profiling integration requires the `@sentry/sveltekit` SDK (minimum version 7.47.0).
 
 ```bash
 # Using yarn

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/1.install.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/1.install.md
@@ -1,0 +1,18 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/node/profiling/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the Profiling integration to work, you must have the `@sentry/sveltekit` SDK package (minimum version 7.47.0) installed.
+
+```bash
+# Using yarn
+yarn add @sentry/sveltekit @sentry/profiling-node
+
+# Using npm
+npm install --save @sentry/sveltekit @sentry/profiling-node
+```

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/2.configure-performance.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/2.configure-performance.md
@@ -1,0 +1,23 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/node/profiling/
+support_level: production
+type: language
+---
+
+#### Configure Performance
+
+Sentry’s performance monitoring product has to be enabled in order for Profiling to work.
+To enable performance monitoring in the SDK, set a sample rate in `hooks.server.(js|ts)`
+
+```javascript
+import * as Sentry from "@sentry/sveltekit";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+```

--- a/src/wizard/node/profiling-onboarding/javascript-sveltekit/3.configure-profiling.md
+++ b/src/wizard/node/profiling-onboarding/javascript-sveltekit/3.configure-profiling.md
@@ -1,0 +1,25 @@
+---
+name: SvelteKit
+doc_link: https://docs.sentry.io/platforms/node/profiling/
+support_level: production
+type: language
+---
+
+#### Configure Profiling
+
+Add the `profilesSampleRate` option to `hooks.server.(js|ts)` and initialize the SDK integration:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+import { ProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  // ... SDK config
+  traceSampleRate: 1.0,
+  profilesSampleRate: 1.0, // Profiling sample rate is relative to tracesSampleRate
+  integrations: [
+    // Add profiling integration to list of integrations
+    new ProfilingIntegration(),
+  ],
+});
+```


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds Onboarding Wizard docs for the new SvelteKit SDK:

* General onboarding (with the performance and replay permutations)
* Replay onboarding
* Profiling onboarding

closes #6843 
