### PR TITLE
ref(nextjs): Adjust wording and links in onboarding wizard docs

### DIFF
--- a/src/wizard/javascript/nextjs/index.md
+++ b/src/wizard/javascript/nextjs/index.md
@@ -11,7 +11,7 @@ Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentr
 npx @sentry/wizard@latest -i nextjs
 ```
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`.
 - create `next.config.js` with the default configuration.

--- a/src/wizard/javascript/nextjs/index.md
+++ b/src/wizard/javascript/nextjs/index.md
@@ -5,7 +5,7 @@ support_level: production
 type: framework
 ---
 
-Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#install):
 
 ```bash
 npx @sentry/wizard@latest -i nextjs

--- a/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
@@ -7,7 +7,7 @@ type: framework
 
 ## Install
 
-Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#install):
 
 ```bash
 npx @sentry/wizard -i nextjs

--- a/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i nextjs
 
 ## Configure
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`.
 - create `next.config.js` with the default configuration.

--- a/src/wizard/javascript/nextjs/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-and-replay.md
@@ -7,7 +7,7 @@ type: framework
 
 ## Install
 
-Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#install):
 
 ```bash
 npx @sentry/wizard -i nextjs

--- a/src/wizard/javascript/nextjs/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-and-replay.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i nextjs
 
 ## Configure
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`.
 - create `next.config.js` with the default configuration.

--- a/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
@@ -7,7 +7,7 @@ type: framework
 
 ## Install
 
-Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#install):
 
 ```bash
 npx @sentry/wizard -i nextjs

--- a/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i nextjs
 
 ## Configure
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`.
 - create `next.config.js` with the default configuration.

--- a/src/wizard/javascript/nextjs/with-error-monitoring.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring.md
@@ -7,7 +7,7 @@ type: framework
 
 ## Install
 
-Configure your app automatically with [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure).
+Add Sentry automatically to your app with the [Sentry wizard](https://docs.sentry.io/platforms/javascript/guides/nextjs/#install):
 
 ```bash
 npx @sentry/wizard -i nextjs

--- a/src/wizard/javascript/nextjs/with-error-monitoring.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring.md
@@ -15,7 +15,7 @@ npx @sentry/wizard -i nextjs
 
 ## Configure
 
-Sentry wizard will automatically patch your application:
+The Sentry wizard will automatically patch your application:
 
 - create `sentry.client.config.js` and `sentry.server.config.js` with the default `Sentry.init`.
 - create `next.config.js` with the default configuration.

--- a/src/wizard/node/profiling-onboarding/javascript-nextjs/0.alert.md
+++ b/src/wizard/node/profiling-onboarding/javascript-nextjs/0.alert.md
@@ -6,5 +6,5 @@ type: language
 ---
 
 <div class='alert warning'>
-Note that only nextjs server side profiling is supported, client side (browser profiling) is not supported and you will need to make sure you only enable profiling in `sentry.server.config.js` file.
+Note that only nextjs server side profiling is supported, client side (browser profiling) is not supported and you will need to make sure you only enable profiling in your `sentry.server.config.js` file.
 </div>

--- a/src/wizard/node/profiling-onboarding/javascript-nextjs/1.install.md
+++ b/src/wizard/node/profiling-onboarding/javascript-nextjs/1.install.md
@@ -7,7 +7,7 @@ type: language
 
 #### Install
 
-For the Profiling integration to work, you must have the Sentry Node SDK package (minimum version 7.44.1) installed.
+For the Profiling integration to work, you must have the `@sentry/nextjs` SDK package (minimum version 7.44.1) installed.
 
 ```bash
 # Using yarn

--- a/src/wizard/node/profiling-onboarding/javascript-nextjs/3.configure-profiling.md
+++ b/src/wizard/node/profiling-onboarding/javascript-nextjs/3.configure-profiling.md
@@ -7,7 +7,7 @@ type: language
 
 #### Configure Profiling
 
-Add the `profilesSampleRate` option to `sentry.server.config.js` config file and initialize the SDK integration.
+Add the `profilesSampleRate` option to the `sentry.server.config.js` config file and initialize the SDK integration:
 
 ```javascript
 import * as Sentry from "@sentry/nextjs";


### PR DESCRIPTION
This adjusts the wording about "configuring" the SDK with the onboarding wizard in the NextJS wizard docs. 
Extracted from #6867 

Happy to discuss this but I think we should improve this in some way at least :)
