### PR TITLE
Added docs for cache spans in Django

### DIFF
--- a/src/platforms/python/guides/django/index.mdx
+++ b/src/platforms/python/guides/django/index.mdx
@@ -71,6 +71,7 @@ The following parts of your Django project are monitored:
 - Signals
 - Database queries
 - Redis commands
+- Access to Django caches
 
 <Note>
 
@@ -94,6 +95,7 @@ sentry_sdk.init(
             transaction_style='url',
             middleware_spans=True,
             signals_spans=False,
+            cache_spans=False,
         ),
     ],
 )
@@ -119,6 +121,12 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 - `signals_spans`:
 
   Create spans and track performance of all [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/) receiver functions in your Django project. Set to `False` to disable.
+
+  The default is `True`.
+
+- `cache_spans`:
+
+  Create spans and track performance of all read operations to configured caches. Set to `False` to disable. The spans also include information if the cache access was a hit or a miss.
 
   The default is `True`.
 

--- a/src/platforms/python/guides/django/index.mdx
+++ b/src/platforms/python/guides/django/index.mdx
@@ -126,7 +126,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 - `cache_spans`:
 
-  Create spans and track performance of all read operations to configured caches. Set to `False` to disable. The spans also include information if the cache access was a hit or a miss.
+  Create spans and track performance of all read operations to configured caches. The spans also include information if the cache access was a hit or a miss. Set to `False` to disable.
 
   The default is `True`.
 


### PR DESCRIPTION
The DjangoIntegration can now record access to Django caches and also include information if it was a cache hit or miss.

Old version: 
https://docs.sentry.io/platforms/python/guides/django/

New version: 
https://sentry-docs-git-antonpirker-python-django-cache-spans.sentry.dev/platforms/python/guides/django/
