### PR TITLE
fix(go): Replace deprecated usage of TransactionName

### DIFF
--- a/src/platform-includes/performance/enable-manual-instrumentation/go.mdx
+++ b/src/platform-includes/performance/enable-manual-instrumentation/go.mdx
@@ -5,7 +5,7 @@ ctx := context.Background()
 
 for item := range ch {
 	span := sentry.StartSpan(ctx, "doWork",
-		sentry.TransactionName(fmt.Sprintf("doWork: %s", item.Type)))
+		sentry.WithTransactionName(fmt.Sprintf("doWork: %s", item.Type)))
 	doWork(span.Context(), item) // doWork may create additional spans
 	span.Finish()
 }

--- a/src/platform-includes/performance/force-sampling-decision/go.mdx
+++ b/src/platform-includes/performance/force-sampling-decision/go.mdx
@@ -1,7 +1,7 @@
 ```go
 // If starting the first span in a transaction (no other spans in the context):
 sentry.StartSpan(context.Background(), "operation",
-	sentry.TransactionName("name"),
+	sentry.WithTransactionName("name"),
 	func(s *sentry.Span) { s.Sampled = sentry.SampledTrue },
 )
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

`TransactionName` will be deprecated in sentry-go version 0.21.0, so changing it to the recommended `WithTransactionName`.