### PR TITLE
Remove wrong, copied over ini/bash config for Webpack

### DIFF
--- a/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
@@ -53,21 +53,6 @@ module.exports = {
 };
 ```
 
-```ìni {filename:.sentryclirc}
-[auth]
-token=your-auth-token
-
-[defaults]
-org=___ORG_SLUG___
-project=___PROJECT_SLUG___
-```
-
-```bash
-export SENTRY_AUTH_TOKEN=your-auth-token
-export SENTRY_ORG=___ORG_SLUG___
-export SENTRY_PROJECT=___PROJECT_SLUG___
-```
-
 ## 3. Inject Debug IDs Into Artifacts
 
 Debug IDs are used to match the stack frame of an event with its corresponding minified source and source map file. Visit [Artifact vs. Release bundles](/platforms/javascript/sourcemaps/artifact-and-release-bundles/) if you want to learn more about Artifact Bundles and Debug IDs.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
  - works great! https://sentry-docs-git-fork-igorsantos07-patch-1.sentry.dev/platforms/javascript/guides/react/sourcemaps/uploading/cli/#2-generate-source-maps
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This simply doesn't make much sense :)
![image](https://user-images.githubusercontent.com/532299/236712806-53f77a61-f98e-4a18-80f7-d45d472fcfed.png)

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
