### PR TITLE
Revert "replay: privacy link from config (#6874)"

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -38,13 +38,6 @@ By default, Replay will capture basic information about all outgoing fetch and X
 
 To capture additional information such as request and response headers or bodies, you'll need to opt-in via `networkDetailAllowUrls`. This will make it possible for you to elect to only add URLs that are safe for capturing bodies and avoid any endpoints that may contain Personal Identifiable Information, (PII).
 
-<Note>
-  Content in bodies will be PII-sanitized server-side, based on object keys and
-  values. Refer to our [Replay Privacy
-  section](https://docs.sentry.io/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers)
-  for more details.
-</Note>
-
 Any URL matching the given pattern(s) will then be captured with additional details:
 
 ```javascript
@@ -71,7 +64,10 @@ new Replay({
 });
 ```
 
-<Note>Captured bodies will be truncated to 150k characters max.</Note>
+<Note>
+  Captured bodies will be truncated to 150k characters max. Content in bodies
+  will be PII-sanitized server-side, based on object keys and values.
+</Note>
 
 ## Identifying Users
 


### PR DESCRIPTION
This reverts commit f3f3d20ec2e6468ffa34445055f8d8c0ede337d2.
Link didn't render