### PR TITLE
build: Use new `SENTRY_LOADER_URL` env var

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -6,7 +6,7 @@ import React from 'react';
 import PageContext from '~src/components/pageContext';
 
 const sentryEnvironment = process.env.GATSBY_ENV || process.env.NODE_ENV || 'development';
-const sentryDsn = process.env.GATSBY_SENTRY_DSN;
+const sentryLoaderUrl = process.env.SENTRY_LOADER_URL;
 
 export const wrapPageElement = ({element, props: {pageContext}}) => (
   <PageContext.Provider value={pageContext}>{element}</PageContext.Provider>
@@ -34,11 +34,7 @@ export const onPreRenderHTML = ({getHeadComponents}) => {
 
 function SentryLoaderScript() {
   return (
-    <script
-      key="sentry-loader-script"
-      src={`https://js.sentry-cdn.com/${sentryDsn}.min.js`}
-      crossOrigin="anonymous"
-    />
+    <script key="sentry-loader-script" src={sentryLoaderUrl} crossOrigin="anonymous" />
   );
 }
 
@@ -67,7 +63,7 @@ Sentry.onLoad(function() {
 
 export const onRenderBody = ({setHeadComponents}) => {
   // Sentry SDK setup
-  if (sentryDsn) {
+  if (sentryLoaderUrl) {
     setHeadComponents([SentryLoaderScript(), SentryLoaderConfig()]);
   }
 

--- a/src/gatsby/onCreateWebpackConfig.ts
+++ b/src/gatsby/onCreateWebpackConfig.ts
@@ -13,8 +13,8 @@ const getPlugins = reporter => {
   }
   return [
     new SentryWebpackPlugin({
-      org: 'sentry',
-      project: 'docs',
+      org: process.env.SENTRY_PROJECT,
+      project: process.env.SENTRY_ORG,
       authToken,
       include: ['public'],
       stripPrefix: ['public/'],


### PR DESCRIPTION
This uses a new env var `SENTRY_LOADER_URL`, which is expected to be the full loader URL, e.g. `https://js.sentry-cdn.com/xxx.min.js`.

@lforst has added this to the prod. env of our vercel build.