### PR TITLE
fix(schema): More missing schema types?

### DIFF
--- a/src/gatsby/createSchemaCustomization/index.ts
+++ b/src/gatsby/createSchemaCustomization/index.ts
@@ -11,10 +11,12 @@ function main({actions, schema}) {
     type PageContext {
       title: String
       description: String
-      sidebar_order: Int
-      sidebar_title: String
+      keywords: [String!]
       draft: Boolean
       redirect_from: [String!]
+      noindex: Boolean
+      sidebar_title: String
+      sidebar_order: Int
 
       platform: PlatformContext
       guide: GuideContext


### PR DESCRIPTION
These are defined in the frontmatter, but not in the PageContext schema.

Honestly I Don't understand how this was sometimes working?