### PR TITLE
Fix syntax error in MFE docs

### DIFF
--- a/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
+++ b/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
@@ -32,12 +32,10 @@ init({
   transport: makeMultiplexedTransport(makeFetchTransport, dsnFromFeature),
 });
 
-captureException(
-  new Error("oh no!", (scope) => {
-    scope.addTag("feature", "cart");
-    return scope;
-  })
-);
+captureException(new Error("oh no!"), (scope) => {
+  scope.setTag("feature", "cart");
+  return scope;
+});
 ```
 
 You can then set tags/contexts on events in individual micro-frontends to decide which Sentry project to send the event to.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Fixes a glitch in one of the MFE doc examples.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
