### PR TITLE
docs(rust): Add note about debug-images integration quirk

### DIFF
--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -63,6 +63,14 @@ and libraries.
 A list of integrations and their feature flags can be found
 [in the integration API docs](https://docs.rs/sentry/0/sentry/integrations/index.html).
 
+<Note>
+
+If you are not stripping down or splitting debug information files, but rather keep them in the produced binary instead,
+make sure to not add `debug_images` integration and it's corresponding `debug-images` feature flag,
+as it will collide with the built-in debug files processing.
+
+</Note>
+
 ## More Information
 
 - [API Docs](https://docs.rs/sentry)

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -65,9 +65,9 @@ A list of integrations and their feature flags can be found
 
 <Note>
 
-If you are not stripping down or splitting debug information files, but rather keep them in the produced binary instead,
-make sure to not add `debug_images` integration and it's corresponding `debug-images` feature flag,
-as it will collide with the built-in debug files processing.
+If you keep debug information files in the produced binary, rather than strip them down or split them,
+do not add the `debug_images` integration and the corresponding `debug-images` feature flag,
+as it will collide with the built-in debug file processing.
 
 </Note>
 


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-rust/issues/574#issuecomment-1542816871

I decided to keep this on the main page, as `debug-images` is the default, and it should be visible right away.