### PR TITLE
ref(vue): Declutter Vue Getting Started page

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.vue.mdx
+++ b/src/platform-includes/getting-started-config/javascript.vue.mdx
@@ -1,8 +1,47 @@
-To initialize Sentry in your Vue application, add this to your `app.js`:
+To initialize Sentry in your Vue application, add the following code snippet to your `main.js`:
+
+### Vue 3
+
+```javascript {filename:main.js}
+import { createApp } from "vue";
+import { createRouter } from "vue-router";
+import * as Sentry from "@sentry/vue";
+
+const app = createApp({
+  // ...
+});
+const router = createRouter({
+  // ...
+});
+
+Sentry.init({
+  app,
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.BrowserTracing({
+      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+    }),
+    new Sentry.Replay(),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Capture Replay for 10% of all sessions,
+  // plus for 100% of sessions with an error
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
+
+app.use(router);
+app.mount("#app");
+```
 
 ### Vue 2
 
-```javascript
+```javascript {filename:main.js}
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -42,71 +81,11 @@ new Vue({
 }).$mount("#app");
 ```
 
-### Vue 3
+If you're creating more than one Vue 3 app within your application, check out how to initialize the SDK for [multiple apps](./features/multiple-apps).
 
-```javascript
-import { createApp } from "vue";
-import { createRouter } from "vue-router";
-import * as Sentry from "@sentry/vue";
+### Vue-Specific configuration
 
-const app = createApp({
-  // ...
-});
-const router = createRouter({
-  // ...
-});
-
-Sentry.init({
-  app,
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-    }),
-  ],
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-});
-
-app.use(router);
-app.mount("#app");
-```
-
-Additionally, Vue 3 allows you to use multiple apps with the same Sentry SDK instance, as well as add more apps dynamically after the SDK has been already initialized.
-
-### Vue 3 - Multiple Apps
-
-```javascript
-const appOne = Vue.createApp(App);
-const appTwo = Vue.createApp(App);
-const appThree = Vue.createApp(App);
-
-Sentry.init({
-  app: [appOne, appTwo, appThree],
-});
-```
-
-### Vue 3 - Manual Initialization
-
-```javascript
-import * as Sentry from "@sentry/vue";
-
-// ...
-const app = createApp(App);
-
-Sentry.init({
-  app,
-  // ...
-});
-
-const miscApp = createApp(MiscApp);
-miscApp.mixin(Sentry.createTracingMixins({ trackComponents: true }));
-Sentry.attachErrorHandler(miscApp);
-```
-
-The SDK accepts a few different configuration options that let you change its behavior:
+The SDK accepts a few Vue-specific `Sentry.init` configuration options:
 
 - `attachProps` (defaults to `true`) - Includes all Vue components' props with the events.
 - `logErrors` (defaults to `true`) - Decides whether SDK should call Vue's original `logError` function as well.

--- a/src/platforms/javascript/guides/vue/features/component-tracking.mdx
+++ b/src/platforms/javascript/guides/vue/features/component-tracking.mdx
@@ -1,6 +1,7 @@
 ---
 title: Track Vue Components
 description: "Learn how Sentry's Vue SDK allows you to monitor the rendering performance of your application and its components."
+sidebar_order: 10
 ---
 
 Sentry's Vue SDK offers a feature to monitor the performance of your Vue components: component tracking. Enabling this feature provides you with spans in your transactions that represent the component life cycle events and durations. This allows you to get a drilled-down view into how your components are behaving so you can do things like identify slow initializations or frequent updates, which might have an impact on your app's performance.

--- a/src/platforms/javascript/guides/vue/features/multiple-apps.mdx
+++ b/src/platforms/javascript/guides/vue/features/multiple-apps.mdx
@@ -1,0 +1,33 @@
+---
+title: Multiple Vue Apps
+description: "Learn how to use the SDK to instrument multiple Vue 3 apps."
+sidebar_order: 20
+---
+
+Vue 3 allows you to use multiple apps with the same Sentry SDK instance, as well as add more apps dynamically after the SDK has been already initialized.
+
+### Multiple Apps
+
+Pass all your initially created apps to the `app` option in `Sentry.init`:
+
+```javascript {filename:main.js}
+const appOne = Vue.createApp(App);
+const appTwo = Vue.createApp(App);
+const appThree = Vue.createApp(App);
+
+Sentry.init({
+  app: [appOne, appTwo, appThree],
+});
+```
+
+### Dynamic Initialization
+
+If some of your apps are initialized at a later point, you can add Sentry to them like so:
+
+```javascript {filename:main.js}
+// ...
+const myLazyApp = createApp(MiscApp);
+
+myLazyApp.mixin(Sentry.createTracingMixins({ trackComponents: true }));
+Sentry.attachErrorHandler(myLazyApp);
+```


### PR DESCRIPTION
This PR declutters the "Getting Started" page for the Vue SDK/platform: 

* Move Vue 3 above Vue 2 init
* Remove multiple apps configuration from getting started and move it to its own page
* Minor rewordings