### PR TITLE
ref(replay): Change default value of `networkDetailAllowUrls`

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -49,7 +49,7 @@ Any URL matching the given pattern(s) will then be captured with additional deta
 
 ```javascript
 new Replay({
-  networkDetailAllowUrls: ["https://my-website.com/api"],
+  networkDetailAllowUrls: [window.location.origin],
 });
 ```
 
@@ -65,7 +65,7 @@ If you want to capture additional headers, you'll have to configure them with th
 
 ```javascript
 new Replay({
-  networkDetailAllowUrls: ["https://my-website.com/api"],
+  networkDetailAllowUrls: [window.location.origin],
   networkRequestHeaders: ["Cache-Control"],
   networkResponseHeaders: ["Referrer-Policy"],
 });


### PR DESCRIPTION
... from an example placeholder to `window.location.origin`
