### PR TITLE
feat(replays): Bump the min version for using Replay>Network>Details

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -36,7 +36,7 @@ To learn more about how session sampling works, check out our <PlatformLink to="
 
 By default, Replay will capture basic information about all outgoing fetch and XHR requests in your application. This includes the URL, request and response body size, method, and status code. The intention is to limit the chance of collecting private data.
 
-To capture additional information such as request and response headers or bodies, you'll need to opt-in via `networkDetailAllowUrls` (requires SDK version >= [7.50.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.50.0)). This will make it possible for you to elect to only add URLs that are safe for capturing bodies and avoid any endpoints that may contain Personal Identifiable Information, (PII).
+To capture additional information such as request and response headers or bodies, you'll need to opt-in via `networkDetailAllowUrls` (requires SDK version >= [7.51.1](https://github.com/getsentry/sentry-javascript/releases/tag/7.51.1)). This will make it possible for you to elect to only add URLs that are safe for capturing bodies and avoid any endpoints that may contain Personal Identifiable Information, (PII).
 
 <Note>
 


### PR DESCRIPTION
Updating the min version for the Replay > Network > Details "Capture Request/Response Headers & Bodies" feature

The new min is version 7.51.1, because it includes https://github.com/getsentry/sentry-javascript/pull/8011

Here are links to the releases:
- https://github.com/getsentry/sentry-javascript/releases/tag/7.50.0
- https://github.com/getsentry/sentry-javascript/releases/tag/7.51.0
- https://github.com/getsentry/sentry-javascript/releases/tag/7.51.1


Relates to: https://github.com/getsentry/sentry/issues/48733
In Sync with: https://github.com/getsentry/sentry/pull/48967
