### PR TITLE
fix(apple): UserId remove note on v 6.0.1

### DIFF
--- a/src/platforms/common/enriching-events/identify-user.mdx
+++ b/src/platforms/common/enriching-events/identify-user.mdx
@@ -37,7 +37,7 @@ Your internal identifier for the user.
 
 <Note>
 
-Since version 6.0.1, if you don't provide a `userId`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
+If you don't provide a `userId`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
 </Note>
 


### PR DESCRIPTION



## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

[Cocoa SDK 6.0.1 ](https://github.com/getsentry/sentry-cocoa/releases/tag/6.0.1)was released 2,5 years ago. We can remove the note.

