### PR TITLE
fix: remove BrowserTracing integration from Remix server example

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -42,15 +42,7 @@ import { useEffect } from "react";
 
 Sentry.init({
   dsn: "___DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      routingInstrumentation: Sentry.remixRouterInstrumentation(
-        useEffect,
-        useLocation,
-        useMatches
-      ),
-    }),
-  ],
+  integrations: [],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -42,7 +42,6 @@ import { useEffect } from "react";
 
 Sentry.init({
   dsn: "___DSN___",
-  integrations: [],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

I followed the docs to setup Sentry with Remix and kept getting errors, until I realized I was including the BrowserTracing integration in the server side file. (`Uncaught TypeError: Sentry.Integrations.BrowserTracing is not a constructor`). I'm assuming given the name "Browser" this does not belong in the server entry file. Once removed all worked as expected. 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
