### PR TITLE
fix(js): Eager load registry data

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -3,12 +3,9 @@
 /* eslint import/no-nodejs-modules:0 */
 
 import queries from './utils/algolia';
-import appRegistry from './utils/appRegistry';
-import packageRegistry from './utils/packageRegistry';
+import getAppRegistry from './utils/appRegistry';
+import getPackageRegistry from './utils/packageRegistry';
 import resolveOpenAPI from './utils/resolveOpenAPI';
-
-const packages = packageRegistry;
-const apps = appRegistry;
 
 const root = `${__dirname}/../..`;
 
@@ -28,9 +25,13 @@ const getPlugins = () => {
     {
       resolve: require.resolve('./plugins/gatsby-remark-variables'),
       options: {
-        scope: {
-          packages,
-          apps,
+        resolveScopeData: async function () {
+          const [apps, packages] = await Promise.all([
+            getAppRegistry,
+            getPackageRegistry,
+          ]);
+
+          return {apps, packages};
         },
         excludeExpr: ['default', 'secrets.SENTRY_AUTH_TOKEN'],
       },

--- a/src/gatsby/sourceNodes/appRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/appRegistryNodes.ts
@@ -1,9 +1,10 @@
-import appRegistry from '../utils/appRegistry';
+import getAppRegistry from '../utils/appRegistry';
 
 export const sourceAppRegistryNodes = async ({actions, createContentDigest}) => {
   const {createNode} = actions;
 
-  const allApps = await appRegistry.getList();
+  const appRegistry = await getAppRegistry();
+  const allApps = appRegistry.data;
 
   Object.entries(allApps).forEach(([appName, appData]) => {
     const data = {

--- a/src/gatsby/sourceNodes/packageRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/packageRegistryNodes.ts
@@ -1,9 +1,10 @@
-import packageRegistry from '../utils/packageRegistry';
+import getPackageRegistry from '../utils/packageRegistry';
 
 export const sourcePackageRegistryNodes = async ({actions, createContentDigest}) => {
   const {createNode} = actions;
 
-  const allSdks = await packageRegistry.getList();
+  const packageRegistry = await getPackageRegistry();
+  const allSdks = packageRegistry.data;
 
   Object.entries(allSdks).forEach(([sdkName, sdkData]) => {
     const data = {

--- a/src/gatsby/utils/appRegistry.ts
+++ b/src/gatsby/utils/appRegistry.ts
@@ -1,5 +1,5 @@
-import {makeGenericRegistry} from './genericRegistry';
+import {makeRegistry} from './genericRegistry';
 
-const appRegistry = makeGenericRegistry({name: 'app registry', path: 'apps'});
+const getAppRegistry = makeRegistry({name: 'app registry', path: 'apps'});
 
-export default appRegistry;
+export default getAppRegistry;

--- a/src/gatsby/utils/packageRegistry.ts
+++ b/src/gatsby/utils/packageRegistry.ts
@@ -1,5 +1,5 @@
-import {makeGenericRegistry} from './genericRegistry';
+import {makeRegistry} from './genericRegistry';
 
-const packageRegistry = makeGenericRegistry({name: 'package registry', path: 'sdks'});
+const getPackageRegistry = makeRegistry({name: 'package registry', path: 'sdks'});
 
-export default packageRegistry;
+export default getPackageRegistry;


### PR DESCRIPTION
The problem here was the registry data was being loaded lazily **inside of a `eval` expression**. There was some logic to `await` the result of the eval, but it's unclear how well that works in a JavaScript VM and is likely cause of all of the intermittent 'Socket closed' errors we were seeing.

This explicitly updates the gatsby-remark-variables plugin to first load the data in the registries, and THEN handle the replacements using synchronous accessor functions from the registry.