### PR TITLE
fix(profiling): Remove mobile only sections from profiling docs

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -127,7 +127,13 @@ sentry::init((
 
 </PlatformSection>
 
-Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured. By default, some transactions will be created automatically for common operations like loading a view controller/activity and app startup.
+Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured.
+
+<PlatformSection supported={["apple", "android"]}>
+
+By default, some transactions will be created automatically for common operations like loading a view controller/activity and app startup.
+
+</PlatformSection>
 
 ## Enable Profiling
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This message is only applicable for mobile platforms.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
