### PR TITLE
Exit cleanly if there is nothing to commit

### DIFF
--- a/bin/react-to-product-owners-yml-changes.sh
+++ b/bin/react-to-product-owners-yml-changes.sh
@@ -12,6 +12,6 @@ git config user.email "getsantry[bot]@users.noreply.github.com"
 git config user.name "getsantry[bot]"
 git checkout -b "$branch"
 git add .github/labels.yml
-git commit -n -m "$message"
+git commit -n -m "$message" || exit 0
 git push --set-upstream origin "$branch"
 gh pr create --title "meta(routing) $message" --body="Syncing with [``product-owners.yml``](https://github.com/getsentry/security-as-code/blob/$sha/rbac/lib/product-owners.yml) ([docs](https://www.notion.so/473791bae5bf43399d46093050b77bf0))."


### PR DESCRIPTION
In the automation to react to `product-owner.yml` changes, if there is nothing to commit we can exit cleanly.