### PR TITLE
fix(onboarding-docs): Fix small glitch in react docs

### DIFF
--- a/src/wizard/javascript/react/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/react/with-error-monitoring-and-replay.md
@@ -12,6 +12,9 @@ Sentry captures data by using an SDK within your application’s runtime.
 ```bash
 # Using yarn
 yarn add @sentry/react
+
+# Using npm
+npm install --save @sentry/react
 ```
 
 ## Configure


### PR DESCRIPTION
the command `npm install...` was missing in the ("error monitoring" + "replay") only doc, causing a glitch

**Bug Record:**


https://github.com/getsentry/sentry-docs/assets/29228205/18cb7288-affb-44f6-9a2d-9ccaafa96765

