### PR TITLE
docs(express-sdk): Fix Express SDK wizard example code

### DIFF
--- a/src/wizard/node/express.md
+++ b/src/wizard/node/express.md
@@ -33,7 +33,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // enable Express.js middleware tracing
-    new Tracing.Integrations.Express({ app }),
+    new Sentry.Integrations.Express({ app }),
     // Automatically instrument Node.js libraries and frameworks
     ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
   ],


### PR DESCRIPTION
Fix `Tracing is not defined` when you try to run the example code here.