### PR TITLE
Document HTTP Client Errors (enableCaptureFailedRequests) 

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -577,7 +577,7 @@ _(New in version 6.6.0)_
 
 </ConfigKey>
 
-<ConfigKey name="capture-failed-requests" supported={["apple"]}>
+<ConfigKey name="capture-failed-requests" supported={["apple","dotnet"]}>
 
 Once enabled, this feature automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry.
 

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -28,7 +28,7 @@ using var httpClient = new HttpClient(new SentryHttpMessageHandler());
 let httpClient = new HttpClient(new SentryHttpMessageHandler())
 ```
 
-By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `FailedRequestStatusCodes` option:
+By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by modifying the `FailedRequestStatusCodes` option:
 
 ```csharp
 options.FailedRequestStatusCodes = new []{ new HttpStatusCodeRange(400, 599) };

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -28,6 +28,14 @@ using var httpClient = new HttpClient(new SentryHttpMessageHandler());
 let httpClient = new HttpClient(new SentryHttpMessageHandler())
 ```
 
+<Alert title="Tip">
+
+You can skip the above step when using any of the Sentry .NET SDKs that are registered via dependency injection (`Senry.AspNetCore`, `Sentry.Maui`, `Sentry.Extensions.Logging`, etc.).
+
+Instead, create your `HttpClient` using the `IHttpClientFactory` pattern, as described in [the documentation from Microsoft](https://learn.microsoft.com/aspnet/core/fundamentals/http-requests).  The `SentryHttpMessageHandler` will automatically be added to the factory during initialization, so no additional wire-up is needed.
+
+</Alert>
+
 By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by modifying the `FailedRequestStatusCodes` option:
 
 ```csharp

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -38,7 +38,7 @@ options.FailedRequestStatusCodes = new []{ new HttpStatusCodeRange(400, 599) };
 options.FailedRequestStatusCodes <- ResizeArray<_> [ HttpStatusCodeRange(400, 599) ]
 ```
 
-HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option:
+HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by updating the `FailedRequestTargets` option with either regular expressions or plain strings. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a substring provided through the option:
 
 ```csharp
 options.FailedRequestTargets = new[]{ new SubstringOrRegexPattern("www.example.com") };

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -48,7 +48,7 @@ options.FailedRequestTargets = new[]{ new SubstringOrRegexPattern("www.example.c
 options.FailedRequestTargets <- ResizeArray<_> [ SubstringOrRegexPattern("www.example.com") ]
 ```
 
-Error events may contain PII data, such as `Headers` and `Cookies`. Sentry already does data scrubbing by default, but you can scrub any data before it is sent. Learn more in [Scrubbing Sensitive Data](/platforms/dotnet/data-management/sensitive-data/).
+When the `SendDefaultPii` option is enabled, error events may contain PII data such as `Headers` and `Cookies`. Sentry already does data scrubbing by default, but you can also scrub any data before it is sent. Learn more in [Scrubbing Sensitive Data](/platforms/dotnet/data-management/sensitive-data/).
 
 These events are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
 

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -39,21 +39,23 @@ Instead, create your `HttpClient` using the `IHttpClientFactory` pattern, as des
 By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by modifying the `FailedRequestStatusCodes` option:
 
 ```csharp
-options.FailedRequestStatusCodes = new []{ new HttpStatusCodeRange(400, 599) };
+options.FailedRequestStatusCodes.Add((400, 499));
 ```
 
 ```fsharp
-options.FailedRequestStatusCodes <- ResizeArray<_> [ HttpStatusCodeRange(400, 599) ]
+options.FailedRequestStatusCodes.Add(HttpStatusCodeRange(400, 599))
 ```
 
 HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by updating the `FailedRequestTargets` option with either regular expressions or plain strings. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a substring provided through the option:
 
 ```csharp
-options.FailedRequestTargets = new[]{ new SubstringOrRegexPattern("www.example.com") };
+options.FailedRequestTargets.Add("foo");      // substring
+options.FailedRequestTargets.Add("foo.*bar"); // regex
 ```
 
 ```fsharp
-options.FailedRequestTargets <- ResizeArray<_> [ SubstringOrRegexPattern("www.example.com") ]
+options.FailedRequestTargets.Add("foo")      // substring
+options.FailedRequestTargets.Add("foo.*bar") // regex
 ```
 
 When the `SendDefaultPii` option is enabled, error events may contain PII data such as `Headers` and `Cookies`. Sentry already does data scrubbing by default, but you can also scrub any data before it is sent. Learn more in [Scrubbing Sensitive Data](/platforms/dotnet/data-management/sensitive-data/).
@@ -67,14 +69,41 @@ The captured error event can be customized or dropped with a `beforeSend`:
 ```csharp
 options.SetBeforeSend((@event, hint) =>
 {
-    // modify event here or return null to discard the event
+    if (hint.Items.TryGetValue(HintTypes.HttpResponseMessage, out var responseHint))
+    {
+        var response = (HttpResponseMessage)responseHint!;
+        var request = response.RequestMessage!;
+
+        // Do something with the request and/or response... for example, you could add
+        // some custom context to the event for specific scenarios
+        var statusCode = response.StatusCode;
+        if (statusCode == HttpStatusCode.Unauthorized)
+        {
+            @event.Contexts["Unauthorized"] = request.RequestUri.GetComponents(
+                UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped
+                );
+        }
+    }
+
+    // return the modified event
     return @event;
 });
 ```
 
 ```fsharp
 options.SetBeforeSend(fun event hint ->
-    // modify event here or return null to discard the event
-    event;
+    let (isHint, responseHint) = hint.Items.TryGetValue(HintTypes.HttpResponseMessage)
+    if isHint then
+        let response = responseHint :?> HttpResponseMessage
+        let request = response.RequestMessage :> HttpRequestMessage
+
+        // Do something with the request and/or response... for example, you could add
+        // some custom context to the event for specific scenarios
+        let statusCode = response.StatusCode
+        if statusCode = HttpStatusCode.Unauthorized then
+            event.Contexts.["Unauthorized"] <- request.RequestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped)
+
+    // return the modified event
+    event
 )
 ```

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -32,7 +32,7 @@ let httpClient = new HttpClient(new SentryHttpMessageHandler())
 
 You can skip the above step when using any of the Sentry .NET SDKs that are registered via dependency injection (`Senry.AspNetCore`, `Sentry.Maui`, `Sentry.Extensions.Logging`, etc.).
 
-Instead, create your `HttpClient` using the `IHttpClientFactory` pattern, as described in [the documentation from Microsoft](https://learn.microsoft.com/aspnet/core/fundamentals/http-requests).  The `SentryHttpMessageHandler` will automatically be added to the factory during initialization, so no additional wire-up is needed.
+Instead, create your `HttpClient` using the `IHttpClientFactory` pattern, as described in [the documentation from Microsoft](https://learn.microsoft.com/aspnet/core/fundamentals/http-requests). The `SentryHttpMessageHandler` will automatically be added to the factory during initialization, so no additional wire-up is needed.
 
 </Alert>
 

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -4,7 +4,7 @@ sidebar_order: 25
 description: "This feature, once enabled, automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry"
 ---
 
-Once enabled, this feature automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
+Once enabled, this feature automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain information from the HTTP request and response, such as `url`, `status_code`, and so on.
 
 To enable it:
 

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -18,6 +18,16 @@ options.CaptureFailedRequests = true;
 options.CaptureFailedRequests <- true
 ```
 
+HTTP client errors will then be captured for any requests from the Sentry SDK. To capture HTTP client errors for outbound requests from your own application, pass `SentryHttpMessageHandler` as the inner handler when creating your `HttpClient`:
+
+```csharp
+using var httpClient = new HttpClient(new SentryHttpMessageHandler());
+```
+
+```fsharp
+let httpClient = new HttpClient(new SentryHttpMessageHandler())
+```
+
 By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `FailedRequestStatusCodes` option:
 
 ```csharp
@@ -31,7 +41,7 @@ options.FailedRequestStatusCodes <- ResizeArray<_> [ HttpStatusCodeRange(400, 59
 HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option:
 
 ```csharp
-options.FailedRequestTargets = new[] {new SubstringOrRegexPattern("www.example.com")};
+options.FailedRequestTargets = new[]{ new SubstringOrRegexPattern("www.example.com") };
 ```
 
 ```fsharp

--- a/src/platforms/dotnet/common/configuration/http-client-errors.mdx
+++ b/src/platforms/dotnet/common/configuration/http-client-errors.mdx
@@ -1,0 +1,62 @@
+---
+title: HTTP Client Errors
+sidebar_order: 25
+description: "This feature, once enabled, automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry"
+---
+
+Once enabled, this feature automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
+
+To enable it:
+
+```csharp
+// Add this to the SDK initialization callback
+options.CaptureFailedRequests = true;
+```
+
+```fsharp
+// Add this to the SDK initialization callback
+options.CaptureFailedRequests <- true
+```
+
+By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `FailedRequestStatusCodes` option:
+
+```csharp
+options.FailedRequestStatusCodes = new []{ new HttpStatusCodeRange(400, 599) };
+```
+
+```fsharp
+options.FailedRequestStatusCodes <- ResizeArray<_> [ HttpStatusCodeRange(400, 599) ]
+```
+
+HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option:
+
+```csharp
+options.FailedRequestTargets = new[] {new SubstringOrRegexPattern("www.example.com")};
+```
+
+```fsharp
+options.FailedRequestTargets <- ResizeArray<_> [ SubstringOrRegexPattern("www.example.com") ]
+```
+
+Error events may contain PII data, such as `Headers` and `Cookies`. Sentry already does data scrubbing by default, but you can scrub any data before it is sent. Learn more in [Scrubbing Sensitive Data](/platforms/dotnet/data-management/sensitive-data/).
+
+These events are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
+
+### Customize or Drop the Error Event
+
+The captured error event can be customized or dropped with a `beforeSend`:
+
+```csharp
+options.SetBeforeSend((@event, hint) =>
+{
+    // modify event here or return null to discard the event
+    return @event;
+});
+```
+
+```fsharp
+options.SetBeforeSend(fun event hint ->
+    // modify event here or return null to discard the event
+    event;
+)
+```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Issue #6984 Document HTTP Client Errors (enableCaptureFailedRequests).

These are very similar to the Java and Apple iOS docs, with minor variations. 

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
