### PR TITLE
sentry-cli-sourcemaps.mdx: Make TODO for explaining `dist`

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -149,7 +149,7 @@ The following options exist to change the behavior of the upload command:
 
 `--dist`
 
-: Sets the distribution identifier for uploaded files. This identifier is used to make a distinction between multiple files of the same name within a single release. Learn more in [Troubleshooting Source Maps](/platforms/javascript/sourcemaps/troubleshooting_js/#verify-artifact-distribution-value-matches-value-configured-in-your-sdk).
+: Sets the distribution identifier for uploaded files. This identifier is used to make a distinction between multiple files of the same name within a single release. `dist` can be used to disambiguate build or deployment variants. For example, `dist` can be the build number of an XCode build or the version code of an Android build.
 
 `--no-sourcemap-reference`
 

--- a/src/includes/sentry-cli-sourcemaps.mdx
+++ b/src/includes/sentry-cli-sourcemaps.mdx
@@ -94,6 +94,12 @@ Running `upload` with `--release` **doesn't automatically create a release in Se
 
 In addition to `release`, you can also add a `dist` to your uploaded artifacts. For that, run the `sourcemaps upload` command with the additional `--dist` option.
 
+<Note>
+  
+  `dist` is useful for X. Sentry currently does not handle the release any different when using it, but it will show you this info.
+  
+</Note>
+
 ```bash
 sentry-cli sourcemaps upload --release=<release_name> --dist=<dist_name> /path/to/directory
 ```

--- a/src/includes/sentry-cli-sourcemaps.mdx
+++ b/src/includes/sentry-cli-sourcemaps.mdx
@@ -92,13 +92,9 @@ Running `upload` with `--release` **doesn't automatically create a release in Se
 
 ### Associating `dist` with Artifact Bundle
 
-In addition to `release`, you can also add a `dist` to your uploaded artifacts. For that, run the `sourcemaps upload` command with the additional `--dist` option.
+In addition to `release`, you can also add a `dist` to your uploaded artifacts, to set the distribution identifier for uploaded files. To do so, run the `sourcemaps upload` command with the additional `--dist` option.
 
-<Note>
-  
-  `dist` is useful for X. Sentry currently does not handle the release any different when using it, but it will show you this info.
-  
-</Note>
+The distribution identifier is used to distinguish between multiple files of the same name within a single release. `dist` can be used to disambiguate build or deployment variants.
 
 ```bash
 sentry-cli sourcemaps upload --release=<release_name> --dist=<dist_name> /path/to/directory


### PR DESCRIPTION

This is a TODO. I don't quite 'get' what the 'dist' of a sourcemap is supposed to help with.

We have a problem where we are making a separate release of every PR, that gets a custom release number that is `<main_version>.<branch_height_of_main_since_main_version>.0-the-branch-name`. We've made it this way, so that hopefully Sentry can see that these releases isn't that important (due to semver). It's not really working super great.

I'm wondering if `dist` is somewhat meant to help with this? Probably not, but anyway it'd be nice to explain what `dist` is meant to do, rather than being self-referential as it is now ^_^

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
