### PR TITLE
Fix to add step one

### DIFF
--- a/src/includes/sourcemaps-cli-step-one.mdx
+++ b/src/includes/sourcemaps-cli-step-one.mdx
@@ -1,0 +1,7 @@
+<Include name="debug-id-requirement.mdx" />
+
+## 1. Generate Source Maps
+
+You will need to generate source maps with a tooling of your choice. See our examples from our other guides linked under [Uploading Source Maps](https://docs.sentry.io/platforms/javascript/sourcemaps/?uploading-source-maps).
+
+<Include name="sentry-cli-sourcemaps.mdx" />

--- a/src/includes/sourcemaps-systemjs.mdx
+++ b/src/includes/sourcemaps-systemjs.mdx
@@ -2,7 +2,7 @@
 
 ## 1. Generate Source Maps
 
-Next, configure SystemJS to output source maps:
+First, configure SystemJS to output source maps:
 
 ```
 builder.bundle("src/app.js", "dist/app.min.js", {

--- a/src/includes/sourcemaps-uglifyjs.mdx
+++ b/src/includes/sourcemaps-uglifyjs.mdx
@@ -2,7 +2,7 @@
 
 ## 1. Generate Source Maps
 
-Next, configure UglifyJS to output source maps:
+First, configure UglifyJS to output source maps:
 
 ```
 uglifyjs app.js \

--- a/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/cli/javascript.mdx
@@ -1,3 +1,3 @@
 In this guide, you'll learn how to successfully upload source maps using our `sentry-cli` tool.
 
-<Include name="sentry-cli-sourcemaps.mdx" />
+<Include name="sourcemaps-cli-step-one.mdx" />


### PR DESCRIPTION
should also act to guide people to selected a known tooling if for some reason they missed those. Find examples of how to generate source maps.

Should we call out that source maps aren't needed if they're not using any bundlier, minify, etc?

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
