### PR TITLE
Docs for exclude_beat_tasks

### DIFF
--- a/src/platform-includes/crons/setup/python.celery.mdx
+++ b/src/platform-includes/crons/setup/python.celery.mdx
@@ -53,7 +53,7 @@ You don't need to create Cron Monitors for your tasks on Sentry.io, we'll do it 
 
 ### Excluding Celery Beat Tasks from Auto Discovery
 
-You can exclude Celery Beat tasks from being auto-instrumented. Add a list of tasks as option `exclude_beat_tasks` when creating `CeleryIntegration`. The list can contain simple strings with the full task name as it is specified in the Celery Beat schedule or regular expressions to match multiple tasks.
+You can exclude Celery Beat tasks from being auto-instrumented. To do this, add a list of tasks you want to exclude as option `exclude_beat_tasks` when creating `CeleryIntegration`. The list can contain simple strings with the full task name, as specified in the Celery Beat schedule, or regular expressions to match multiple tasks.
 
 ```python
     exclude_beat_tasks = [

--- a/src/platform-includes/crons/setup/python.celery.mdx
+++ b/src/platform-includes/crons/setup/python.celery.mdx
@@ -75,7 +75,7 @@ You can exclude Celery Beat tasks from being auto-instrumented. To do this, add 
 
 In this example the task `some-task-a` and all tasks with a name starting with `payment-check-` will be ignored.
 
-See also the documentation for <PlatformLink to="/#options">options on CeleryIntegration</PlatformLink>.
+For more information, see the documentation for <PlatformLink to="/#options">options on CeleryIntegration</PlatformLink>.
 
 ## Manual Task Monitoring
 

--- a/src/platform-includes/crons/setup/python.celery.mdx
+++ b/src/platform-includes/crons/setup/python.celery.mdx
@@ -51,6 +51,32 @@ You don't need to create Cron Monitors for your tasks on Sentry.io, we'll do it 
 
 </Note>
 
+### Excluding Celery Beat Tasks from Auto Discovery
+
+You can exclude Celery Beat tasks from being auto-instrumented. Add a list of tasks as option `exclude_beat_tasks` when creating `CeleryIntegration`. The list can contain simple strings with the full task name as it is specified in the Celery Beat schedule or regular expressions to match multiple tasks.
+
+```python
+    exclude_beat_tasks = [
+        "some-task-a",
+        "payment-check-.*",
+    ]
+
+    sentry_sdk.init(
+        dsn='___PUBLIC_DSN___',
+        integrations=[
+            CeleryIntegration(
+                monitor_beat_tasks=True,
+                exclude_beat_tasks=exclude_beat_tasks),
+            ],
+        environment="local.dev.grace",
+        release="v1.0",
+    )
+```
+
+In this example the task `some-task-a` and all tasks with a name starting with `payment-check-` will be ignored.
+
+See also the documentation for <PlatformLink to="/#options">options on CeleryIntegration</PlatformLink>.
+
 ## Manual Task Monitoring
 
 We provide a lightweight decorator to make monitoring individual tasks easier. To use it, add `@sentry_sdk.monitor` to your Celery task (or any function), then supply a `monitor_slug` of a monitor created previously on Sentry.io. Once this is done, every time the task (or function) is executed, telemetry data will be captured when a task is started, when it finishes, and when it fails.

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -88,7 +88,7 @@ sentry_sdk.init(
 )
 ```
 
-You can pass the following keyword arguments to `DjangoIntegration()`:
+You can pass the following keyword arguments to `CeleryIntegration()`:
 
 - `propagate_traces`
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -92,7 +92,7 @@ You can pass the following keyword arguments to `CeleryIntegration()`:
 
 - `propagate_traces`
 
-  Propagate Sentry tracing information to the Celery task. This makes it possible to link errors in Celery tasks to the function that triggered the Celery task. If set to `False` errors in Celery tasks can not be matched to the triggering function.
+  Propagate Sentry tracing information to the Celery task. This makes it possible to link errors in Celery tasks to the function that triggered the Celery task. If this is set to `False`, errors in Celery tasks can't be matched to the triggering function.
 
   The default is `True`.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -108,7 +108,7 @@ You can pass the following keyword arguments to `CeleryIntegration()`:
 
   A list of Celery Beat tasks that should be excluded from auto-instrumentation using Sentry Crons. Only applied if `monitor_beat_tasks` is set to `True`.
 
-  The list can contain simple strings. In this case the task with the same name in the Celery Beat schedule will be excluded. It can also include regular expressions to match multiple tasks. If you for example give `"payment-check-.*"` every task starting with `payment-check-` will be excluded from auto-instrumentation.
+  The list can contain strings with the names of tasks in the Celery Beat schedule to be excluded. It can also include regular expressions to match multiple tasks. For example, if you include `"payment-check-.*"` every task starting with `payment-check-` will be excluded from auto-instrumentation.
 
   See <PlatformLink to="/crons/#celery-beat-auto-discovery">Celery Beat Auto Discovery</PlatformLink> to learn more.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -67,3 +67,49 @@ Sentry uses custom message headers for distributed tracing. For Celery versions 
 The fix for the custom headers propagation issue was introduced to Celery project ([PR](https://github.com/celery/celery/pull/6374)) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
 
 </Alert>
+
+## Options
+
+By adding `CeleryIntegration` explictly to your `sentry_sdk.init()` call you can set options for `CeleryIntegration` to change its behavior:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # ...
+    integrations=[
+        CeleryIntegration(
+            monitor_beat_tasks=True,
+            exclude_beat_tasks=["unimportant-task", "payment-check-.*"],
+        ),
+    ],
+)
+```
+
+You can pass the following keyword arguments to `DjangoIntegration()`:
+
+- `propagate_traces`
+
+  Propagate Sentry tracing information to the Celery task. This makes it possible to link errors in Celery tasks to the function that triggered the Celery task. If set to `False` errors in Celery tasks can not be matched to the triggering function.
+
+  The default is `True`.
+
+- `monitor_beat_tasks`:
+
+  Turn auto-instrumentation for Celery Beat tasks using Sentry Crons on or off.
+
+  See <PlatformLink to="/crons/#celery-beat-auto-discovery">Celery Beat Auto Discovery</PlatformLink> to learn more.
+
+  The default is `False`.
+
+- `exclude_beat_tasks`:
+
+  A list of Celery Beat tasks that should be excluded from auto-instrumentation using Sentry Crons. Only applied if `monitor_beat_tasks` is set to `True`.
+
+  The list can contain simple strings. In this case the task with the same name in the Celery Beat schedule will be excluded. It can also include regular expressions to match multiple tasks. If you for example give `"payment-check-.*"` every task starting with `payment-check-` will be excluded from auto-instrumentation.
+
+  See <PlatformLink to="/crons/#celery-beat-auto-discovery">Celery Beat Auto Discovery</PlatformLink> to learn more.
+
+  The default is `None`.

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -98,7 +98,7 @@ You can pass the following keyword arguments to `CeleryIntegration()`:
 
 - `monitor_beat_tasks`:
 
-  Turn auto-instrumentation for Celery Beat tasks using Sentry Crons on or off.
+  Turn auto-instrumentation on or off for Celery Beat tasks using Sentry Crons.
 
   See <PlatformLink to="/crons/#celery-beat-auto-discovery">Celery Beat Auto Discovery</PlatformLink> to learn more.
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -70,7 +70,7 @@ The fix for the custom headers propagation issue was introduced to Celery projec
 
 ## Options
 
-By adding `CeleryIntegration` explictly to your `sentry_sdk.init()` call you can set options for `CeleryIntegration` to change its behavior:
+To set options on `CeleryIntegration` to change its behavior, add it explicitly to your `sentry_sdk.init()`:
 
 ```python
 import sentry_sdk


### PR DESCRIPTION
Documentation of the new `exclude_beat_tasks` option for the Celery Beat auto-instrumentation of Sentry Crons.

Related to https://github.com/getsentry/sentry-python/pull/2130