### PR TITLE
Fix filename in TypeScript version of code snippet of manual-setup.mdx

### DIFF
--- a/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -75,7 +75,7 @@ export const handleError = Sentry.handleErrorWithSentry(myErrorHandler);
 // export const handleError = handleErrorWithSentry();
 ```
 
-```typescript {filename:hooks.server.ts}
+```typescript {filename:hooks.client.ts}
 const myErrorHandler = ({ error, event }) => {
   console.error("An error occurred on the client side:", error, event);
 };


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

In the code snippet for the third step of the client-side setup when manually setting up the SvelteKit SDK, the filename is incorrectly set as `hooks.server.ts`. This PR fixes this.

<details>
<summary>Toggle screenshots</summary>
JavaScript:
 
<img width="782" alt="image" src="https://github.com/getsentry/sentry-docs/assets/11270438/db2e1cae-4a8a-4876-b7f1-d91e4e271a2f">

---

TypeScript:

<img width="781" alt="image" src="https://github.com/getsentry/sentry-docs/assets/11270438/e9677b53-c1e2-4358-8711-00578c57f22c">

</details>





## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
