### PR TITLE
ref(js): Add `tracePropagationTargets` to SDK init code snippets

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/src/platform-includes/getting-started-config/javascript.angular.mdx
@@ -13,7 +13,8 @@ Sentry.init({
     // which automatically instruments your application to monitor its
     // performance, including custom Angular routing instrumentation
     new Sentry.BrowserTracing({
-      tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
     // Registers the Replay integration,
@@ -51,7 +52,8 @@ Sentry.init({
     // which automatically instruments your application to monitor its
     // performance, including custom Angular routing instrumentation
     new Sentry.BrowserTracing({
-      tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
   ],

--- a/src/platform-includes/getting-started-config/javascript.mdx
+++ b/src/platform-includes/getting-started-config/javascript.mdx
@@ -9,7 +9,13 @@ Sentry.init({
   // Alternatively, use `process.env.npm_package_version` for a dynamic release version
   // if your build tool supports it.
   release: "my-project-name@2.3.12",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/platform-includes/getting-started-config/javascript.react.mdx
+++ b/src/platform-includes/getting-started-config/javascript.react.mdx
@@ -6,7 +6,13 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay()
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -13,6 +13,8 @@ Sentry.init({
   dsn: "___DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,

--- a/src/platform-includes/getting-started-config/javascript.svelte.mdx
+++ b/src/platform-includes/getting-started-config/javascript.svelte.mdx
@@ -1,6 +1,6 @@
 To use the SDK, initialize it in your Svelte entry point before bootstrapping your app. In a typical Svelte project, that is your `main.js` or `main.ts` file.
 
-```typescript {filename: main.ts}
+```javascript {filename: main.js}
 import "./app.css";
 import App from "./App.svelte";
 
@@ -9,7 +9,13 @@ import * as Sentry from "@sentry/svelte";
 // Initialize the Sentry SDK here
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
@@ -20,30 +26,6 @@ Sentry.init({
   // plus for 100% of sessions with an error
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-});
-
-const app = new App({
-  target: document.getElementById("app"),
-});
-
-export default app;
-```
-
-```javascript {filename: main.js}
-import "./app.css";
-import App from "./App.svelte";
-
-import * as Sentry from "@sentry/svelte";
-
-// Initialize the Sentry SDK here
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
 });
 
 const app = new App({

--- a/src/platform-includes/getting-started-config/javascript.vue.mdx
+++ b/src/platform-includes/getting-started-config/javascript.vue.mdx
@@ -19,6 +19,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
     }),
     new Sentry.Replay(),
@@ -57,6 +59,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
     }),
     new Sentry.Replay(),

--- a/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
@@ -10,7 +10,12 @@ Sentry.init({
 
   // This enables automatic instrumentation (highly recommended), but is not
   // necessary for purely manual usage
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platform-includes/performance/configure-sample-rate/javascript.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.mdx
@@ -11,7 +11,12 @@ Sentry.init({
   // If you only want to use manual instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
@@ -9,7 +9,12 @@ Sentry.init({
   // If you only want to use manual instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -12,7 +12,12 @@ Sentry.init({
   // If you only want to use manual instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platform-includes/performance/tracePropagationTargets-example/javascript.mdx
+++ b/src/platform-includes/performance/tracePropagationTargets-example/javascript.mdx
@@ -2,16 +2,17 @@ For example:
 
 - A frontend application is served from `example.com`.
 - A backend service is served from `api.example.com`.
+- During development, the backend service is served from `localhost`.
 - The frontend application makes API calls to the backend.
-- Set the `tracePropagationTargets` option to `['api.example.com']`.
-- Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached.
+- Set the `tracePropagationTargets` option to `["localhost", /^https:\/\/api\.example\.com/]`.
+- Now outgoing XHR/fetch requests to your backend service will get the `sentry-trace` and `baggage` headers attached.
 
 ```javascript
 Sentry.init({
   // ...
   integrations: [
     new Sentry.BrowserTracing({
-      tracePropagationTargets: ["api.example.com"],
+      tracePropagationTargets: ["localhost", /^https:\/\/api\.example\.com/],
     }),
   ],
 });

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -184,7 +184,15 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // this assumes your build process replaces `process.env.npm_package_version` with a value
   release: "my-project-name@" + process.env.npm_package_version,
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    // If you use a bundle with performance monitoring enabled, add the BrowserTracing integration
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    // If you use a bundle with session replay enabled, add the SessionReplay integration
+    new Sentry.Replay(),
+  ],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -38,7 +38,13 @@ Sentry.init({
 
   integrations: [
     new Sentry.BrowserTracing({
-      // custom options
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: [
+        "localhost",
+        /^\//,
+        /^https:\/\/yourserver\.io\/api/,
+      ],
+      // Add additional custom options here
     }),
   ],
 


### PR DESCRIPTION
This PR updates all JS SDK Sentry.init snippets that include `BrowserTracing` to also include the `tracePropagationTargets` options. The purpose of this change is to point out to users that `tracePropagationTargets` is necessary to control to which urls of outgoing requests, our distributed tracing headers should be added. 

This does not yet address the onboarding wizard snippets. Will update them in a separate PR

cc @cleptric 
