### PR TITLE
ref(js): Add `tracePropagationTargets` to onboarding wizard snippets

### DIFF
--- a/src/wizard/javascript/angular/index.md
+++ b/src/wizard/javascript/angular/index.md
@@ -38,7 +38,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
-      tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
   ],

--- a/src/wizard/javascript/angular/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/angular/with-error-monitoring-and-performance.md
@@ -42,6 +42,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
   ],

--- a/src/wizard/javascript/angular/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/angular/with-error-monitoring-performance-and-replay.md
@@ -42,6 +42,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
     new Sentry.Replay(),

--- a/src/wizard/javascript/ember/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/ember/with-error-monitoring-and-performance.md
@@ -28,12 +28,7 @@ import * as Sentry from "@sentry/ember";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-    }),
-  ],
+
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/ember/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/ember/with-error-monitoring-and-performance.md
@@ -28,7 +28,12 @@ import * as Sentry from "@sentry/ember";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/ember/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/ember/with-error-monitoring-performance-and-replay.md
@@ -28,13 +28,7 @@ import * as Sentry from "@sentry/ember";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-    }),
-    new Sentry.Replay(),
-  ],
+  integrations: [new Sentry.Replay()],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/ember/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/ember/with-error-monitoring-performance-and-replay.md
@@ -28,7 +28,13 @@ import * as Sentry from "@sentry/ember";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/gatsby/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/gatsby/with-error-monitoring-and-performance.md
@@ -38,7 +38,12 @@ import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/gatsby/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/gatsby/with-error-monitoring-performance-and-replay.md
@@ -38,7 +38,13 @@ import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/index.md
+++ b/src/wizard/javascript/index.md
@@ -23,7 +23,12 @@ import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-and-performance.md
@@ -36,7 +36,12 @@ npm install --save @sentry/nextjs
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
@@ -36,7 +36,13 @@ npm install --save @sentry/nextjs
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay()
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/nextjs/with-error-monitoring-performance-and-replay.md
@@ -41,7 +41,7 @@ Sentry.init({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
     }),
-    new Sentry.Replay()
+    new Sentry.Replay(),
   ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
+++ b/src/wizard/javascript/performance-onboarding/javascript/2.configure.md
@@ -16,7 +16,12 @@ import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/wizard/javascript/performance-onboarding/react/2.configure.md
+++ b/src/wizard/javascript/performance-onboarding/react/2.configure.md
@@ -17,7 +17,12 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/wizard/javascript/react/index.md
+++ b/src/wizard/javascript/react/index.md
@@ -33,7 +33,12 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   tracesSampleRate: 1.0,
 });
 

--- a/src/wizard/javascript/react/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/react/with-error-monitoring-and-performance.md
@@ -29,7 +29,12 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/react/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/react/with-error-monitoring-performance-and-replay.md
@@ -29,7 +29,13 @@ import App from "./App";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/remix/index.md
+++ b/src/wizard/javascript/remix/index.md
@@ -27,6 +27,8 @@ Sentry.init({
   tracesSampleRate: 1,
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,

--- a/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
@@ -30,6 +30,8 @@ Sentry.init({
   dsn: "___DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,

--- a/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
@@ -30,6 +30,8 @@ Sentry.init({
   dsn: "___DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.remixRouterInstrumentation(
         useEffect,
         useLocation,

--- a/src/wizard/javascript/svelte/index.md
+++ b/src/wizard/javascript/svelte/index.md
@@ -26,7 +26,12 @@ import * as Sentry from "@sentry/svelte";
 // Initialize the Sentry SDK here
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/src/wizard/javascript/svelte/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/svelte/with-error-monitoring-and-performance.md
@@ -29,7 +29,12 @@ import * as Sentry from "@sentry/svelte";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/svelte/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/svelte/with-error-monitoring-performance-and-replay.md
@@ -29,7 +29,13 @@ import * as Sentry from "@sentry/svelte";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/src/wizard/javascript/vue/index.md
+++ b/src/wizard/javascript/vue/index.md
@@ -23,41 +23,6 @@ npm install --save @sentry/vue
 
 Next, initialize Sentry in your app entry point before you initialize your root component.
 
-#### Vue 2
-
-```javascript
-import Vue from "vue";
-import Router from "vue-router";
-import * as Sentry from "@sentry/vue";
-
-Vue.use(Router);
-
-const router = new Router({
-  // ...
-});
-
-Sentry.init({
-  Vue,
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-    }),
-  ],
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-});
-
-// ...
-
-new Vue({
-  router,
-  render: (h) => h(App),
-}).$mount("#app");
-```
-
 #### Vue 3
 
 ```javascript
@@ -77,6 +42,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
     }),
   ],
@@ -88,6 +55,43 @@ Sentry.init({
 
 app.use(router);
 app.mount("#app");
+```
+
+#### Vue 2
+
+```javascript
+import Vue from "vue";
+import Router from "vue-router";
+import * as Sentry from "@sentry/vue";
+
+Vue.use(Router);
+
+const router = new Router({
+  // ...
+});
+
+Sentry.init({
+  Vue,
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+    }),
+  ],
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+
+// ...
+
+new Vue({
+  router,
+  render: (h) => h(App),
+}).$mount("#app");
 ```
 
 We recommend adjusting the value of `tracesSampleRate` in production. Learn more about configuring sampling in our [full documentation](https://docs.sentry.io/platforms/javascript/configuration/sampling/).

--- a/src/wizard/javascript/vue/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/vue/with-error-monitoring-and-performance.md
@@ -21,39 +21,6 @@ npm install --save @sentry/vue
 
 Initialize Sentry as early as possible in your application's lifecycle.
 
-#### Vue 2
-
-```javascript
-import Vue from "vue";
-import Router from "vue-router";
-import * as Sentry from "@sentry/vue";
-
-Vue.use(Router);
-
-const router = new Router({
-  // ...
-});
-
-Sentry.init({
-  Vue,
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-    }),
-  ],
-  // Performance Monitoring
-  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
-});
-
-// ...
-
-new Vue({
-  router,
-  render: (h) => h(App),
-}).$mount("#app");
-```
-
 #### Vue 3
 
 ```javascript
@@ -73,6 +40,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
     }),
   ],
@@ -82,6 +51,41 @@ Sentry.init({
 
 app.use(router);
 app.mount("#app");
+```
+
+#### Vue 2
+
+```javascript
+import Vue from "vue";
+import Router from "vue-router";
+import * as Sentry from "@sentry/vue";
+
+Vue.use(Router);
+
+const router = new Router({
+  // ...
+});
+
+Sentry.init({
+  Vue,
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+    }),
+  ],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+});
+
+// ...
+
+new Vue({
+  router,
+  render: (h) => h(App),
+}).$mount("#app");
 ```
 
 ## Verify

--- a/src/wizard/javascript/vue/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/vue/with-error-monitoring-performance-and-replay.md
@@ -21,43 +21,6 @@ npm install --save @sentry/vue
 
 Initialize Sentry as early as possible in your application's lifecycle.
 
-#### Vue 2
-
-```javascript
-import Vue from "vue";
-import Router from "vue-router";
-import * as Sentry from "@sentry/vue";
-
-Vue.use(Router);
-
-const router = new Router({
-  // ...
-});
-
-Sentry.init({
-  Vue,
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    new Sentry.BrowserTracing({
-      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-    }),
-    new Sentry.Replay(),
-  ],
-  // Performance Monitoring
-  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
-  // Session Replay
-  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-});
-
-// ...
-
-new Vue({
-  router,
-  render: (h) => h(App),
-}).$mount("#app");
-```
-
 #### Vue 3
 
 ```javascript
@@ -77,6 +40,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       routingInstrumentation: Sentry.vueRouterInstrumentation(router),
     }),
     new Sentry.Replay(),
@@ -90,6 +55,45 @@ Sentry.init({
 
 app.use(router);
 app.mount("#app");
+```
+
+#### Vue 2
+
+```javascript
+import Vue from "vue";
+import Router from "vue-router";
+import * as Sentry from "@sentry/vue";
+
+Vue.use(Router);
+
+const router = new Router({
+  // ...
+});
+
+Sentry.init({
+  Vue,
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+    }),
+    new Sentry.Replay(),
+  ],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+});
+
+// ...
+
+new Vue({
+  router,
+  render: (h) => h(App),
+}).$mount("#app");
 ```
 
 ## Verify

--- a/src/wizard/javascript/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/with-error-monitoring-and-performance.md
@@ -25,7 +25,12 @@ import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });

--- a/src/wizard/javascript/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/with-error-monitoring-performance-and-replay.md
@@ -25,7 +25,13 @@ import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+    new Sentry.Replay(),
+  ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay


### PR DESCRIPTION
Following #7013, this PR now also adds `tracePropagationTargets` to the onboarding wizard code snippets.