### PR TITLE
ref(js): Update BrowserTracing and Angular SDK usage in capacitor and ionic docs

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -2,7 +2,8 @@ Then forward the `init` method from the sibling Sentry SDK for the framework you
 
 ```typescript {tabTitle: Angular} {filename: app.module.ts}
 import * as Sentry from "@sentry/capacitor";
-import * as SentryAngular from "@sentry/angular";
+// Use @sentry/angular-ivy for Angular 12+ or `@sentry/angular` from Angular 10 and 11
+import * as SentryAngular from "@sentry/angular-ivy";
 
 Sentry.init(
   {
@@ -36,6 +37,16 @@ Sentry.init(
       provide: ErrorHandler,
       // Attach the Sentry ErrorHandler
       useValue: SentryAngular.createErrorHandler(),
+    },
+    {
+      provide: SentryAngular.TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [SentryAngular.TraceService],
+      multi: true,
     },
   ],
 })

--- a/src/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -18,7 +18,7 @@ Sentry.init(
       // performance, including custom Angular routing instrumentation
       new SentryAngular.BrowserTracing({
         tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
-        routingInstrumentation: Sentry.routingInstrumentation,
+        routingInstrumentation: SentryAngular.routingInstrumentation,
       }),
     ],
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/src/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -11,7 +11,20 @@ Sentry.init(
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
-    dist: "<dist>"
+    dist: "<dist>",
+    integrations: [
+      // Registers and configures the Tracing integration,
+      // which automatically instruments your application to monitor its
+      // performance, including custom Angular routing instrumentation
+      new SentryAngular.BrowserTracing({
+        tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
+        routingInstrumentation: Sentry.routingInstrumentation,
+      }),
+    ],
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
   },
   // Forward the init method from @sentry/angular
   SentryAngular.init

--- a/src/platform-includes/getting-started-install/javascript.capacitor.mdx
+++ b/src/platform-includes/getting-started-install/javascript.capacitor.mdx
@@ -2,10 +2,10 @@ Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the 
 
 ```bash {tabTitle:Angular}
 # npm
-npm install --save @sentry/capacitor @sentry/angular
+npm install --save @sentry/capacitor @sentry/angular-ivy
 
 # yarn
-yarn add @sentry/capacitor @sentry/angular
+yarn add @sentry/capacitor @sentry/angular-ivy
 ```
 
 ```bash {tabTitle:Other Frameworks}

--- a/src/wizard/capacitor/index.md
+++ b/src/wizard/capacitor/index.md
@@ -9,7 +9,7 @@ Install the Sentry Capacitor SDK alongside the sibling Sentry Angular SDK:
 
 ```bash
 # npm
-npm install --save @sentry/capacitor @sentry/angular
+npm install --save @sentry/capacitor @sentry/angular-ivy
 
 # yarn
 yarn add @sentry/capacitor @sentry/angular @sentry/tracing --exact
@@ -108,6 +108,7 @@ Sentry.init(
       new SentryAngular.BrowserTracing({
         // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
         tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+        routingInstrumentation: SentryAngular.routingInstrumentation,
       }),
     ]
   },
@@ -121,6 +122,16 @@ Sentry.init(
       provide: ErrorHandler,
       // Attach the Sentry ErrorHandler
       useValue: SentryAngular.createErrorHandler(),
+    },
+    {
+      provide: SentryAngular.TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [SentryAngular.TraceService],
+      multi: true,
     },
   ],
 })

--- a/src/wizard/capacitor/index.md
+++ b/src/wizard/capacitor/index.md
@@ -91,12 +91,9 @@ With Ionic/Angular:
 ```typescript
 // app.module.ts
 import * as Sentry from '@sentry/capacitor';
-import * as SentryAngular from '@sentry/angular';
-// If taking advantage of automatic instrumentation (highly recommended)
-import { BrowserTracing } from '@sentry/tracing';
-// Or, if only manually tracing
-// import "@sentry/tracing";
-// Note: You MUST import the package in some way for tracing to work
+// Use `@sentry/angular-ivy` for Angular 12+ or `@sentry/angular` for Angular 10 or 11
+import * as SentryAngular from '@sentry/angular-ivy';
+
 
 Sentry.init(
   {
@@ -108,8 +105,9 @@ Sentry.init(
     // We recommend adjusting this value in production.
     tracesSampleRate: 1.0,
     integrations: [
-      new BrowserTracing({
-        tracingOrigins: ['localhost', 'https://yourserver.io/api'],
+      new SentryAngular.BrowserTracing({
+        // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+        tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       }),
     ]
   },

--- a/src/wizard/ionic/index.md
+++ b/src/wizard/ionic/index.md
@@ -98,6 +98,7 @@ Sentry.init(
           "localhost",
           /^https:\/\/yourserver\.io\/api/,
         ],
+        routingInstrumentation: SentrySibling.routingInstrumentation,
       }),
     ],
   },

--- a/src/wizard/ionic/index.md
+++ b/src/wizard/ionic/index.md
@@ -79,10 +79,8 @@ You must initialize the Sentry SDK as early as you can:
 
 ```javascript
 import * as Sentry from "@sentry/capacitor";
-// The example is using Angular, Import '@sentry/vue' or '@sentry/react' when using a Sibling different than Angular.
-import * as SentrySibling from "@sentry/angular";
-// For automatic instrumentation (highly recommended)
-import { BrowserTracing } from "@sentry/tracing";
+// The example is using Angular 12+. Import '@sentry/angular' for Angular 10 and 11. Import '@sentry/vue' or '@sentry/react' when using a Sibling different than Angular.
+import * as SentrySibling from "@sentry/angular-ivy";
 
 Sentry.init(
   {
@@ -94,8 +92,9 @@ Sentry.init(
     // We recommend adjusting this value in production.
     tracesSampleRate: 1.0,
     integrations: [
-      new BrowserTracing({
-        tracingOrigins: ["localhost", "https://yourserver.io/api"],
+      new SentrySibling.BrowserTracing({
+        // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+        tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
       }),
     ],
   },

--- a/src/wizard/ionic/index.md
+++ b/src/wizard/ionic/index.md
@@ -94,7 +94,10 @@ Sentry.init(
     integrations: [
       new SentrySibling.BrowserTracing({
         // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-        tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+        tracePropagationTargets: [
+          "localhost",
+          /^https:\/\/yourserver\.io\/api/,
+        ],
       }),
     ],
   },

--- a/src/wizard/ionic/index.md
+++ b/src/wizard/ionic/index.md
@@ -6,7 +6,7 @@ type: framework
 ---
 
 To use Sentry in your Ionic app, install the Sentry Capacitor SDK alongside the sibling Sentry SDK related to the Web framework you're using with Ionic.
-The supported siblings are: Angular `@sentry/angular`, React `@sentry/react` and Vue `@sentry/vue`.
+The supported siblings are: Angular `@sentry/angular-ivy`, React `@sentry/react` and Vue `@sentry/vue`.
 
 Heres an example of installing Sentry Capacitor along with Sentry Angular:
 
@@ -20,7 +20,7 @@ or
 yarn add @sentry/capacitor @sentry/angular
 ```
 
-The same installation process applies to the other siblings, all you need to do is to replace `@sentry/angular` by the desired sibling.
+The same installation process applies to the other siblings, all you need to do is to replace `@sentry/angular-ivy` by the desired sibling.
 
 ## Capacitor 2 - Android Installation
 
@@ -107,7 +107,7 @@ Sentry.init(
 );
 ```
 
-Additionally for Angular, you will also need to alter NgModule (same code doesn't apply to other siblings)
+Additionally for Angular, you will also need to configure your root `app.module.ts` (same code doesn't apply to other siblings):
 
 ```javascript
 @NgModule({
@@ -116,6 +116,16 @@ Additionally for Angular, you will also need to alter NgModule (same code doesn'
       provide: ErrorHandler,
       // Attach the Sentry ErrorHandler
       useValue: SentrySibling.createErrorHandler(),
+    },
+    {
+      provide: SentrySibling.TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [SentrySibling.TraceService],
+      multi: true,
     },
   ],
 })


### PR DESCRIPTION
This PR updates the usage of `BrowserTracing` in capacitor and ionic docs:
- replace `tracingOrigins` (which is deprecated) with `tracePropagationTargets`
- update `tracePropagationTargets` values as in #7013 
- add notes around `@sentry/angular` vs `@sentry/angular-ivy`
- add `BrowserTracing` and `tracesSampleRate` in Getting Started page 
- add the `TraceService` provider snippets as well as it's required for proper routing instrumentation in Angular. 

I have no context around capacitor/ionic so I'd appreciate a review from the mobile team before this is merged. For instance, I'm not sure if `BrowserTracing` is also exported from the capacitor SDK which is why I used the sibling SDK. Furthermore, I don't know if capacitor depends on any custom logic around `tracingOrigins` that hasn't yet been updated for `tracePropagationTargets`. 