### PR TITLE
Fix `functions_to_trace` example

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -114,11 +114,11 @@ To avoid having custom performance instrumentation code scattered all over your 
 import sentry_sdk
 
 functions_to_trace = [
-    "myrootmodule.eat_slice",
-    "myrootmodule.swallow",
-    "myrootmodule.chew",
-    "myrootmodule.someothermodule.another.some_function",
-    "myrootmodule.SomePizzaClass.some_method",
+    {"qualified_name": "myrootmodule.eat_slice"},
+    {"qualified_name": "myrootmodule.swallow"},
+    {"qualified_name": "myrootmodule.chew"},
+    {"qualified_name": "myrootmodule.someothermodule.another.some_function"},
+    {"qualified_name": "myrootmodule.SomePizzaClass.some_method"},
 ]
 
 sentry_sdk.init(


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

`functions_to_trace` has to be a list of dictionaries with a certain structure (https://github.com/getsentry/sentry-python/pull/1960#issue-1627368894, https://github.com/getsentry/sentry-python/pull/1960#issuecomment-1553410650), the example in the docs uses a different format.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
