### PR TITLE
Remove duplicated sourcemaps troubleshooting content

### DIFF
--- a/src/platform-includes/sourcemaps/validating/javascript.mdx
+++ b/src/platform-includes/sourcemaps/validating/javascript.mdx
@@ -1,9 +1,0 @@
-It can be quite challenging to ensure that source maps are actually valid themselves and uploaded correctly. To help with this, we maintain an online validation tool that can be used to test your source maps against your **hosted** source: [sourcemaps.io](https://sourcemaps.io).
-
-Additionally, you can use the `--validate` flag within when uploading source maps with [sentry-cli](/product/cli/), which will attempt to locally parse the source map and look up the references. Note that there are known cases where the validate flag will indicate failures when the setup is correct (if you have references to external source maps, then the validation tool will indicate a failure).
-
-You can also check these, in addition to the validation step:
-
-- Ensure that the URL prefix is correct for your files. This is easy to get wrong.
-- Upload the matching source maps for your minimized files.
-- Ensure that the minified files you have on your servers actually have references to your `.map` files.

--- a/src/platforms/javascript/common/sourcemaps/validating.mdx
+++ b/src/platforms/javascript/common/sourcemaps/validating.mdx
@@ -1,7 +1,0 @@
----
-title: Validating Files
-description: "Learn about Sentry's online validation tool that can be used to test your source maps against your hosted source."
-sidebar_order: 2
----
-
-<PlatformContent includePath="sourcemaps/validating" />

--- a/src/platforms/node/common/sourcemaps/validating.mdx
+++ b/src/platforms/node/common/sourcemaps/validating.mdx
@@ -1,7 +1,0 @@
----
-title: Validating Files
-description: "Learn about Sentry's online validation tool that can be used to test your source maps against your hosted source."
-sidebar_order: 6
----
-
-<PlatformContent includePath="sourcemaps/troubleshooting" />


### PR DESCRIPTION
The "Validating Files" section only contains outdated information or information that is already part of the troubleshooting guide:

- https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-your-source-maps-work-locally
- https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-your-source-maps-are-built-correctly