### PR TITLE
Remove node primer

### DIFF
--- a/src/platform-includes/getting-started-primer/node.mdx
+++ b/src/platform-includes/getting-started-primer/node.mdx
@@ -1,9 +1,0 @@
-<Note>
-
-Sentry's Node SDK enables automatic reporting of errors, exceptions, and transactions.
-
-Our Node SDK supports all recent versions, and integrates well with a variety of popular frameworks and packages. It gives developers the ability to see Node source code at each frame instead and get proper asynchronous context tracking in a way that fits Node’s concurrency model.
-
-If you are using our previous Node SDK, you can access the <Link rel={`nofollow`} to={`/platforms/node/legacy-sdk/`}>legacy SDK documentation</Link>, until further notice.
-
-</Note>


### PR DESCRIPTION
I believe we should not immediately confront people landing on the getting started page with asynchronous context, which is a very advanced concept + we're already mentioning errors right below the note anyhow.

I would also like to remove the note about the legacy SDK documentation because the legacy sdk is REALLY old and doesn't deserve a spot on this page. The legacy SDK docs should really only be accessible via external links.