### PR TITLE
ref(js): Switch components to named exports

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import PageContext from 'sentry-docs/components/pageContext';
+import {PageContext} from 'sentry-docs/components/pageContext';
 
 const sentryEnvironment = process.env.GATSBY_ENV || process.env.NODE_ENV || 'development';
 const sentryLoaderUrl = process.env.SENTRY_LOADER_URL;

--- a/src/components/__tests__/configKey.test.js
+++ b/src/components/__tests__/configKey.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import ConfigKey from '../configKey';
-import usePlatform, {getPlatformsWithFallback} from '../hooks/usePlatform';
+import {ConfigKey} from '../configKey';
+import {getPlatformsWithFallback, usePlatform} from '../hooks/usePlatform';
 
 jest.mock('../hooks/usePlatform');
 

--- a/src/components/__tests__/header.test.js
+++ b/src/components/__tests__/header.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import Header from '../header';
+import {Header} from '../header';
 
 describe('Header', () => {
   it('renders correctly', () => {

--- a/src/components/__tests__/platformLink.test.js
+++ b/src/components/__tests__/platformLink.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import usePlatform from '../hooks/usePlatform';
-import PlatformLink from '../platformLink';
+import {usePlatform} from '../hooks/usePlatform';
+import {PlatformLink} from '../platformLink';
 
 jest.mock('../hooks/usePlatform');
 

--- a/src/components/__tests__/platformSection.test.js
+++ b/src/components/__tests__/platformSection.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import usePlatform, {getPlatformsWithFallback} from '../hooks/usePlatform';
-import PlatformSection from '../platformSection';
+import {getPlatformsWithFallback, usePlatform} from '../hooks/usePlatform';
+import {PlatformSection} from '../platformSection';
 
 jest.mock('../hooks/usePlatform');
 

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -8,7 +8,7 @@ type Props = {
   title?: string;
 };
 
-export default function Alert({
+export function Alert({
   title,
   children,
   level,

--- a/src/components/apiSidebar.tsx
+++ b/src/components/apiSidebar.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from 'react';
 import {useLocation} from '@reach/router';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import {toTree, DynamicNav} from './dynamicNav';
+import {DynamicNav, toTree} from './dynamicNav';
 import {SidebarLink} from './sidebarLink';
 
 const query = graphql`

--- a/src/components/apiSidebar.tsx
+++ b/src/components/apiSidebar.tsx
@@ -2,8 +2,8 @@ import React, {Fragment} from 'react';
 import {useLocation} from '@reach/router';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import DynamicNav, {toTree} from './dynamicNav';
-import SidebarLink from './sidebarLink';
+import {toTree, DynamicNav} from './dynamicNav';
+import {SidebarLink} from './sidebarLink';
 
 const query = graphql`
   query ApiNavQuery {
@@ -18,7 +18,7 @@ const query = graphql`
   }
 `;
 
-export default function ApiSidebar() {
+export function ApiSidebar() {
   const data = useStaticQuery(query);
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
   const endpoints = tree[0].children.filter(curr => curr.children.length > 1);

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -47,7 +47,7 @@ const readOrResetLocalStorage = () => {
   }
 };
 
-function Banner({isModule = false}) {
+export function Banner({isModule = false}) {
   const [isVisible, setIsVisible] = useState(false);
   const hash = fastHash(`${BANNER_TEXT}:${BANNER_LINK_URL}`).toString();
 
@@ -99,5 +99,3 @@ function Banner({isModule = false}) {
       )
     : null;
 }
-
-export default Banner;

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -2,12 +2,12 @@ import React, {forwardRef, Fragment, useRef} from 'react';
 
 import {getCurrentTransaction} from '../utils';
 
-import Banner from './banner';
-import CodeContext, {useCodeContextState} from './codeContext';
+import {Banner} from './banner';
+import {CodeContext, useCodeContextState} from './codeContext';
 import {GitHubCTA} from './githubCta';
-import Layout from './layout';
-import SEO from './seo';
-import TableOfContents from './tableOfContents';
+import {Layout} from './layout';
+import {SEO} from './seo';
+import {TableOfContents} from './tableOfContents';
 
 export type PageContext = {
   description?: string;
@@ -49,7 +49,7 @@ type Props = {
   sidebar?: JSX.Element;
 };
 
-export default function BasePage({
+export function BasePage({
   data: {file} = {},
   pageContext = {},
   seoTitle,

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useLocation} from '@reach/router';
 import {graphql, StaticQuery} from 'gatsby';
 
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
 const query = graphql`
   query BreadcrumbsQuery {
@@ -79,7 +79,7 @@ export function BaseBreadcrumbs({
   );
 }
 
-export default function breadcrumb() {
+export function breadcrumb() {
   return (
     <StaticQuery
       query={query}

--- a/src/components/break.tsx
+++ b/src/components/break.tsx
@@ -1,3 +1,3 @@
-export default function Break() {
+export function Break() {
   return null;
 }

--- a/src/components/cliChecksumTable.tsx
+++ b/src/components/cliChecksumTable.tsx
@@ -22,7 +22,7 @@ const ChecksumValue = styled.code`
   white-space: nowrap;
 `;
 
-export default function CliChecksumTable(): JSX.Element {
+export function CliChecksumTable(): JSX.Element {
   const {
     app: {files, version},
   } = useStaticQuery(query);

--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -9,7 +9,7 @@ import memoize from 'lodash/memoize';
 
 import {useOnClickOutside} from 'sentry-docs/utils';
 
-import CodeContext from './codeContext';
+import {CodeContext} from './codeContext';
 
 const KEYWORDS_REGEX = /\b___(?:([A-Z_][A-Z0-9_]*)\.)?([A-Z_][A-Z0-9_]*)___\b/g;
 
@@ -338,7 +338,7 @@ type Props = {
   title?: string;
 };
 
-export default function CodeBlock({filename, language, children}: Props): JSX.Element {
+export function CodeBlock({filename, language, children}: Props): JSX.Element {
   const [showCopied, setShowCopied] = useState(false);
   const codeRef = useRef(null);
 

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -68,7 +68,7 @@ type CodeContextType = {
   sharedKeywordSelection: any;
 };
 
-const CodeContext = createContext<CodeContextType | null>(null);
+export const CodeContext = createContext<CodeContextType | null>(null);
 
 const parseDsn = function (dsn: string): Dsn {
   const match = dsn.match(/^(.*?\/\/)(.*?):(.*?)@(.*?)(\/.*?)$/);
@@ -152,8 +152,6 @@ export async function fetchCodeKeywords() {
     }),
   };
 }
-
-export default CodeContext;
 
 export function useCodeContextState(fetcher = fetchCodeKeywords) {
   const [codeKeywords, setCodeKeywords] = useState(cachedCodeKeywords ?? DEFAULTS);

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
-import CodeContext from './codeContext';
+import {CodeContext} from './codeContext';
 
 // human readable versions of names
 const LANGUAGES = {
@@ -24,7 +24,7 @@ type Props = {
   children: JSX.Element | JSX.Element[];
 };
 
-export default function CodeTabs({children}: Props): JSX.Element {
+export function CodeTabs({children}: Props): JSX.Element {
   if (!Array.isArray(children)) {
     children = [children];
   } else {

--- a/src/components/configKey.tsx
+++ b/src/components/configKey.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import PlatformIdentifier from './platformIdentifier';
-import PlatformSection from './platformSection';
+import {PlatformIdentifier} from './platformIdentifier';
+import {PlatformSection} from './platformSection';
 
 type Props = {
   name: string;
@@ -11,7 +11,7 @@ type Props = {
   supported?: string[];
 };
 
-export default function ConfigKey({
+export function ConfigKey({
   name,
   supported = [],
   notSupported = [],

--- a/src/components/content.tsx
+++ b/src/components/content.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Markdown from './markdown';
+import {Markdown} from './markdown';
 
 type FileNode = {
   childMarkdownRemark?: {
@@ -20,7 +20,7 @@ function RawHtml({html}) {
   return <div dangerouslySetInnerHTML={{__html: html}} />;
 }
 
-export default function Content({file}: Props): JSX.Element | null {
+export function Content({file}: Props): JSX.Element | null {
   if (!file) {
     return null;
   }

--- a/src/components/definitionList.tsx
+++ b/src/components/definitionList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export default function DefinitionList({children}: React.Props<{}>): JSX.Element {
+export function DefinitionList({children}: React.Props<{}>): JSX.Element {
   return <div className="large-definition-list">{children}</div>;
 }

--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -4,8 +4,8 @@ import {withPrefix} from 'gatsby';
 
 import {sortPages} from 'sentry-docs/utils';
 
-import SidebarLink from './sidebarLink';
-import SmartLink from './smartLink';
+import {SidebarLink} from './sidebarLink';
+import {SmartLink} from './smartLink';
 
 type Node = {
   [key: string]: any;
@@ -104,7 +104,7 @@ type Props = {
   title?: string;
 };
 
-export default function DynamicNav({
+export function DynamicNav({
   root,
   title,
   tree,

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -22,7 +22,7 @@ const ExpandableBody = styled.div<ExpandedProps>`
   display: ${props => (props.isExpanded ? 'block' : 'none')};
 `;
 
-export default function Expandable({title, children}: Props): JSX.Element {
+export function Expandable({title, children}: Props): JSX.Element {
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <div className="note">

--- a/src/components/externalLink.tsx
+++ b/src/components/externalLink.tsx
@@ -6,7 +6,7 @@ type Props =
     }
   | React.HTMLProps<HTMLAnchorElement>;
 
-export default function ExternalLink({children, ...props}: Props): JSX.Element {
+export function ExternalLink({children, ...props}: Props): JSX.Element {
   return (
     <a {...props}>
       {children}

--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
 type GitHubCTAProps = {
   relativePath: string;

--- a/src/components/guideGrid.tsx
+++ b/src/components/guideGrid.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import {PlatformIcon} from 'platformicons';
 
-import usePlatform, {Platform} from './hooks/usePlatform';
-import SmartLink from './smartLink';
+import {Platform, usePlatform} from './hooks/usePlatform';
+import {SmartLink} from './smartLink';
 
 type Props = {
   className?: string;
   platform?: string;
 };
 
-export default function GuideGrid({platform, className}: Props): JSX.Element {
+export function GuideGrid({platform, className}: Props): JSX.Element {
   const [currentPlatform] = usePlatform(platform);
   // platform might actually not be a platform, so lets handle that case gracefully
   if (!(currentPlatform as Platform).guides) {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
-export default function Header(): JSX.Element {
+export function Header(): JSX.Element {
   return (
     <div className="navbar navbar-expand-md navbar-light bg-white global-header">
       <SmartLink to="/" title="Sentry error monitoring" className="navbar-brand pb-0">

--- a/src/components/hooks/__tests__/usePlatform.test.js
+++ b/src/components/hooks/__tests__/usePlatform.test.js
@@ -6,9 +6,9 @@ import {useLocation, useNavigate} from '@reach/router';
 import {act, renderHook} from '@testing-library/react-hooks';
 import {useStaticQuery} from 'gatsby';
 
-import PageContext from '../../pageContext';
-import useLocalStorage from '../useLocalStorage';
-import usePlatform from '../usePlatform';
+import {PageContext} from '../../pageContext';
+import {useLocalStorage} from '../useLocalStorage';
+import {usePlatform} from '../usePlatform';
 
 const PLATFORMS = [
   {

--- a/src/components/hooks/useKeyboardNavigate.tsx
+++ b/src/components/hooks/useKeyboardNavigate.tsx
@@ -92,4 +92,4 @@ function useKeyboardNavigate<T>({list, onSelect}: Props<T>) {
   return {focused, setFocus};
 }
 
-export default useKeyboardNavigate;
+export {useKeyboardNavigate};

--- a/src/components/hooks/useLocalStorage.ts
+++ b/src/components/hooks/useLocalStorage.ts
@@ -2,7 +2,7 @@ import {useState} from 'react';
 
 type Callback<T> = (value: T) => T;
 
-function useLocalStorage<T>(
+export function useLocalStorage<T>(
   key: string,
   defaultValue: T
 ): [T, (value: T | Callback<T>) => void] {
@@ -36,5 +36,3 @@ function useLocalStorage<T>(
 
   return [storedValue, setValue];
 }
-
-export default useLocalStorage;

--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -3,9 +3,9 @@ import {useLocation, useNavigate, WindowLocation} from '@reach/router';
 import {graphql, useStaticQuery} from 'gatsby';
 import {parse} from 'query-string';
 
-import PageContext from 'sentry-docs/components/pageContext';
+import {PageContext} from 'sentry-docs/components/pageContext';
 
-import useLocalStorage from './useLocalStorage';
+import {useLocalStorage} from './useLocalStorage';
 
 const query = graphql`
   query UsePlatformQuery {
@@ -236,7 +236,7 @@ export const getPlatformsWithFallback = (platform: Platform | Guide): string[] =
  * If you're operating in a context that is _only_ for a specific platform, you
  * want to pass `defaultValue` with the effective platform to avoid fallbacks.
  */
-export default function usePlatform(
+export function usePlatform(
   value: string = null,
   useStoredValue: boolean = true,
   useDefault: boolean = true,

--- a/src/components/include.tsx
+++ b/src/components/include.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import Content from './content';
+import {Content} from './content';
 
 const includeQuery = graphql`
   query IncludeQuery {
@@ -22,7 +22,7 @@ type Props = {
   name: string;
 };
 
-export default function Include({name}: Props): JSX.Element {
+export function Include({name}: Props): JSX.Element {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includeQuery);

--- a/src/components/includePlatformContent.tsx
+++ b/src/components/includePlatformContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import Content from './content';
+import {Content} from './content';
 
 const includePlatformContentQuery = graphql`
   query IncludePlatformContentQuery {
@@ -22,7 +22,7 @@ type Props = {
   name: string;
 };
 
-export default function IncludePlatformContent({name}: Props): JSX.Element {
+export function IncludePlatformContent({name}: Props): JSX.Element {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includePlatformContentQuery);

--- a/src/components/internalDocsSidebar.tsx
+++ b/src/components/internalDocsSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import DynamicNav, {toTree} from './dynamicNav';
+import {toTree, DynamicNav} from './dynamicNav';
 
 const query = graphql`
   query InternalDocsSidebarQuery {
@@ -18,7 +18,7 @@ const query = graphql`
   }
 `;
 
-export default function InternalDocsSidebar(): JSX.Element {
+export function InternalDocsSidebar(): JSX.Element {
   const data = useStaticQuery(query);
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
   return (

--- a/src/components/internalDocsSidebar.tsx
+++ b/src/components/internalDocsSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import {toTree, DynamicNav} from './dynamicNav';
+import {DynamicNav, toTree} from './dynamicNav';
 
 const query = graphql`
   query InternalDocsSidebarQuery {

--- a/src/components/jsBundleList.tsx
+++ b/src/components/jsBundleList.tsx
@@ -21,7 +21,7 @@ const ChecksumValue = styled.code`
   white-space: nowrap;
 `;
 
-export default function JsBundleList(): JSX.Element {
+export function JsBundleList(): JSX.Element {
   const {
     package: {files},
   } = useStaticQuery(query);

--- a/src/components/jsCdnTag.tsx
+++ b/src/components/jsCdnTag.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import CodeBlock from './codeBlock';
-import CodeTabs from './codeTabs';
+import {CodeBlock} from './codeBlock';
+import {CodeTabs} from './codeTabs';
 
 type Props = {
   name?: string;
@@ -24,7 +24,7 @@ const query = graphql`
   }
 `;
 
-export default function JsCdnTag({tracing = false, name = ''}: Props): JSX.Element {
+export function JsCdnTag({tracing = false, name = ''}: Props): JSX.Element {
   const {package: packageData} = useStaticQuery(query);
 
   const bundleName = tracing ? 'bundle.tracing.min.js' : name || 'bundle.min.js';

--- a/src/components/lambdaLayerDetail.tsx
+++ b/src/components/lambdaLayerDetail.tsx
@@ -35,7 +35,7 @@ const toOption = ({region}: RegionData) => {
   };
 };
 
-export default function LambdaLayerDetail({canonical}: {canonical: string}): JSX.Element {
+export function LambdaLayerDetail({canonical}: {canonical: string}): JSX.Element {
   const {
     allLayer: {nodes: layerList},
   }: {allLayer: {nodes: LayerData[]}} = useStaticQuery(query);

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -3,13 +3,13 @@ import {Nav} from 'react-bootstrap';
 
 import 'sentry-docs/css/screen.scss';
 
-import Breadcrumbs from './breadcrumbs';
-import Header from './header';
-import Navbar from './navbar';
-import NavbarPlatformDropdown from './navbarPlatformDropdown';
+import {breadcrumb as Breadcrumbs} from './breadcrumbs';
+import {Header} from './header';
+import {Navbar} from './navbar';
+import {NavbarPlatformDropdown} from './navbarPlatformDropdown';
 import {getSandboxURL, SandboxOnly} from './sandboxLink';
-import Sidebar from './sidebar';
-import SmartLink from './smartLink';
+import {Sidebar} from './sidebar';
+import {SmartLink} from './smartLink';
 
 type Props = {
   children: JSX.Element | JSX.Element[];
@@ -26,11 +26,7 @@ type Props = {
   sidebar?: JSX.Element;
 };
 
-export default function Layout({
-  children,
-  sidebar,
-  pageContext = {},
-}: Props): JSX.Element {
+export function Layout({children, sidebar, pageContext = {}}: Props): JSX.Element {
   const searchPlatforms = [pageContext.platform?.name, pageContext.guide?.name].filter(
     Boolean
   );

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -4,7 +4,7 @@ type Props = {
   loading?: boolean;
 };
 
-export default function Logo({loading}: Props): JSX.Element {
+export function Logo({loading}: Props): JSX.Element {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -4,28 +4,28 @@ import React from 'react';
 import {MDXProvider} from '@mdx-js/react';
 import {MDXRenderer} from 'gatsby-plugin-mdx';
 
-import Alert from './alert';
-import Break from './break';
-import CodeBlock from './codeBlock';
-import CodeTabs from './codeTabs';
-import ConfigKey from './configKey';
-import DefinitionList from './definitionList';
-import Expandable from './expandable';
-import GuideGrid from './guideGrid';
-import Include from './include';
-import IncludePlatformContent from './includePlatformContent';
-import JsCdnTag from './jsCdnTag';
-import LambdaLayerDetail from './lambdaLayerDetail';
-import Note from './note';
-import PageGrid from './pageGrid';
-import ParamTable from './paramTable';
-import PlatformContent from './platformContent';
-import PlatformIdentifier from './platformIdentifier';
-import PlatformLink from './platformLink';
-import PlatformSection from './platformSection';
-import RelayMetrics from './relayMetrics';
-import SandboxLink, {SandboxOnly} from './sandboxLink';
-import SmartLink from './smartLink';
+import {Alert} from './alert';
+import {Break} from './break';
+import {CodeBlock} from './codeBlock';
+import {CodeTabs} from './codeTabs';
+import {ConfigKey} from './configKey';
+import {DefinitionList} from './definitionList';
+import {Expandable} from './expandable';
+import {GuideGrid} from './guideGrid';
+import {Include} from './include';
+import {IncludePlatformContent} from './includePlatformContent';
+import {JsCdnTag} from './jsCdnTag';
+import {LambdaLayerDetail} from './lambdaLayerDetail';
+import {Note} from './note';
+import {PageGrid} from './pageGrid';
+import {ParamTable} from './paramTable';
+import {PlatformContent} from './platformContent';
+import {PlatformIdentifier} from './platformIdentifier';
+import {PlatformLink} from './platformLink';
+import {PlatformSection} from './platformSection';
+import {RelayMetrics} from './relayMetrics';
+import {SandboxLink, SandboxOnly} from './sandboxLink';
+import {SmartLink} from './smartLink';
 import {VimeoEmbed, YouTubeEmbed} from './video';
 
 const mdxComponents = {
@@ -57,7 +57,7 @@ const mdxComponents = {
   SandboxOnly,
 };
 
-export default function Markdown({value}) {
+export function Markdown({value}) {
   return (
     <MDXProvider components={mdxComponents}>
       <MDXRenderer>{value}</MDXRenderer>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import {Nav} from 'react-bootstrap';
 import {useLocation} from '@reach/router';
 
-import NavbarPlatformDropdown from './navbarPlatformDropdown';
+import {NavbarPlatformDropdown} from './navbarPlatformDropdown';
 import {getSandboxURL, SandboxOnly} from './sandboxLink';
-import Search from './search';
-import SmartLink from './smartLink';
+import {Search} from './search';
+import {SmartLink} from './smartLink';
 
 type Props = {
   platforms?: string[];
 };
 
-export default function Navbar({platforms}: Props): JSX.Element {
+export function Navbar({platforms}: Props): JSX.Element {
   const location = useLocation();
 
   return (

--- a/src/components/navbarPlatformDropdown.tsx
+++ b/src/components/navbarPlatformDropdown.tsx
@@ -2,10 +2,10 @@ import React, {Fragment} from 'react';
 import {NavDropdown} from 'react-bootstrap';
 import {PlatformIcon} from 'platformicons';
 
-import usePlatform, {usePlatformList} from './hooks/usePlatform';
-import SmartLink from './smartLink';
+import {usePlatformList, usePlatform} from './hooks/usePlatform';
+import {SmartLink} from './smartLink';
 
-export default function NavbarPlatformDropdown() {
+export function NavbarPlatformDropdown() {
   const platformList = usePlatformList();
   const [currentPlatform] = usePlatform(null, false, false);
   return (

--- a/src/components/navbarPlatformDropdown.tsx
+++ b/src/components/navbarPlatformDropdown.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from 'react';
 import {NavDropdown} from 'react-bootstrap';
 import {PlatformIcon} from 'platformicons';
 
-import {usePlatformList, usePlatform} from './hooks/usePlatform';
+import {usePlatform, usePlatformList} from './hooks/usePlatform';
 import {SmartLink} from './smartLink';
 
 export function NavbarPlatformDropdown() {

--- a/src/components/note.tsx
+++ b/src/components/note.tsx
@@ -4,7 +4,7 @@ type Props = {
   children?: any;
 };
 
-export default function Note({children}: Props): JSX.Element {
+export function Note({children}: Props): JSX.Element {
   //   let className = "";
   //   if (children.props && typeof children.props.children === "string") {
   //     className += " markdown-text-only";

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -4,7 +4,7 @@ import {graphql, useStaticQuery} from 'gatsby';
 
 import {sortPages} from 'sentry-docs/utils';
 
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
 const query = graphql`
   query PageGridQuery {
@@ -31,11 +31,7 @@ type Props = {
   header?: string;
 };
 
-export default function PageGrid({
-  nextPages = false,
-  header,
-  exclude,
-}: Props): JSX.Element {
+export function PageGrid({nextPages = false, header, exclude}: Props): JSX.Element {
   const data = useStaticQuery(query);
   const location = useLocation();
 

--- a/src/components/paramTable.tsx
+++ b/src/components/paramTable.tsx
@@ -12,7 +12,7 @@ type Props = {
   fields: Field[];
 };
 
-export default function ParamTable({fields}: Props): JSX.Element {
+export function ParamTable({fields}: Props): JSX.Element {
   return (
     <table className="table">
       {fields.map(([name, paramList]) => (

--- a/src/components/platformContent.tsx
+++ b/src/components/platformContent.tsx
@@ -1,13 +1,14 @@
 import React, {Fragment, useState} from 'react';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import usePlatform, {
+import {
   getPlatform,
   getPlatformsWithFallback,
   Platform,
+  usePlatform,
 } from './hooks/usePlatform';
-import Content from './content';
-import SmartLink from './smartLink';
+import {Content} from './content';
+import {SmartLink} from './smartLink';
 
 const includeQuery = graphql`
   query PlatformContentQuery {
@@ -63,11 +64,7 @@ const getFileForPlatform = (
   return contentMatch;
 };
 
-export default function PlatformContent({
-  includePath,
-  platform,
-  children,
-}: Props): JSX.Element {
+export function PlatformContent({includePath, platform, children}: Props): JSX.Element {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includeQuery);

--- a/src/components/platformGrid.tsx
+++ b/src/components/platformGrid.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
 import {usePlatformList} from './hooks/usePlatform';
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
 const PlatformCell = styled.div`
   display: flex;
@@ -61,7 +61,7 @@ type Props = {
   noGuides: boolean;
 };
 
-export default function PlatformGrid({noGuides = false}: Props): JSX.Element {
+export function PlatformGrid({noGuides = false}: Props): JSX.Element {
   const platformList = usePlatformList();
   return (
     <div className="row">

--- a/src/components/platformIdentifier.tsx
+++ b/src/components/platformIdentifier.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import usePlatform, {formatCaseStyle} from './hooks/usePlatform';
+import {formatCaseStyle, usePlatform} from './hooks/usePlatform';
 
 type Props = {
   name: string;
   platform?: string;
 };
 
-export default function PlatformIdentifier({name, platform}: Props): JSX.Element {
+export function PlatformIdentifier({name, platform}: Props): JSX.Element {
   const [currentPlatform] = usePlatform(platform);
   return <code>{formatCaseStyle(currentPlatform.caseStyle, name)}</code>;
 }

--- a/src/components/platformLink.tsx
+++ b/src/components/platformLink.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import usePlatform from './hooks/usePlatform';
-import SmartLink from './smartLink';
+import {usePlatform} from './hooks/usePlatform';
+import {SmartLink} from './smartLink';
 
 type Props = {
   children: JSX.Element;
   to?: string;
 };
 
-export default function PlatformLink({children, to}: Props): JSX.Element {
+export function PlatformLink({children, to}: Props): JSX.Element {
   const [currentPlatform] = usePlatform(null);
   let path = currentPlatform ? currentPlatform.url : `/platform-redirect/`;
   if (to) {

--- a/src/components/platformSdkDetail.tsx
+++ b/src/components/platformSdkDetail.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import usePlatform from './hooks/usePlatform';
-import SmartLink from './smartLink';
+import {usePlatform} from './hooks/usePlatform';
+import {SmartLink} from './smartLink';
 
 const query = graphql`
   query PlatformSdkDetail {
@@ -45,7 +45,7 @@ const PackageDetail = styled.div`
   }
 `;
 
-export default function PlatformSdkDetail(): JSX.Element {
+export function PlatformSdkDetail(): JSX.Element {
   const [platform] = usePlatform();
 
   const {

--- a/src/components/platformSection.tsx
+++ b/src/components/platformSection.tsx
@@ -1,6 +1,6 @@
 import React, {Fragment} from 'react';
 
-import usePlatform, {getPlatformsWithFallback, Platform} from './hooks/usePlatform';
+import {getPlatformsWithFallback, Platform, usePlatform} from './hooks/usePlatform';
 
 type Props = {
   children?: React.ReactNode;
@@ -24,7 +24,7 @@ const isSupported = (
   return null;
 };
 
-export default function PlatformSection({
+export function PlatformSection({
   supported = [],
   notSupported = [],
   platform,

--- a/src/components/platformSelector.tsx
+++ b/src/components/platformSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Select from 'react-select';
 import {graphql, StaticQuery} from 'gatsby';
 
-import usePlatform from './hooks/usePlatform';
+import {usePlatform} from './hooks/usePlatform';
 
 const query = graphql`
   query PlatformSelectorQuery {
@@ -73,7 +73,7 @@ export function BasePlatformSelector({
   );
 }
 
-export default function PlatformSelector(): JSX.Element {
+export function PlatformSelector(): JSX.Element {
   return (
     <StaticQuery query={query} render={data => <BasePlatformSelector data={data} />} />
   );

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, StaticQuery} from 'gatsby';
 
-import DynamicNav, {toTree} from './dynamicNav';
+import {toTree, DynamicNav} from './dynamicNav';
 
 const navQuery = graphql`
   query PlatformNavQuery {
@@ -132,7 +132,7 @@ export function SidebarContent({platform, guide, data}: ChildProps): JSX.Element
   );
 }
 
-export default function PlatformSidebar(props: Props): JSX.Element {
+export function PlatformSidebar(props: Props): JSX.Element {
   return (
     <StaticQuery
       query={navQuery}

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, StaticQuery} from 'gatsby';
 
-import {toTree, DynamicNav} from './dynamicNav';
+import {DynamicNav, toTree} from './dynamicNav';
 
 const navQuery = graphql`
   query PlatformNavQuery {

--- a/src/components/relayMetrics.tsx
+++ b/src/components/relayMetrics.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {graphql, useStaticQuery} from 'gatsby';
 
-import Alert from './alert';
+import {Alert} from './alert';
 
 const query = graphql`
   query RelayMetricsQuery {
@@ -62,7 +62,7 @@ function Metric({metric}) {
   );
 }
 
-export default function RelayMetrics(): JSX.Element {
+export function RelayMetrics(): JSX.Element {
   const data = useStaticQuery(query);
   const metrics = data.allRelayMetric.nodes;
 

--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import usePlatform from './hooks/usePlatform';
-import ExternalLink from './externalLink';
+import {usePlatform} from './hooks/usePlatform';
+import {ExternalLink} from './externalLink';
 
 const scenarios = [
   'performance',
@@ -75,7 +75,7 @@ const SANDBOX_PLATFORM_MAP: {[key: string]: string} = {
   node: 'react',
 };
 
-export default function SandboxLink({children, platform, target, ...params}: Props) {
+export function SandboxLink({children, platform, target, ...params}: Props) {
   const [currentPlatform] = usePlatform(platform);
 
   if (isSandboxHidden()) {

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -9,8 +9,8 @@ import DOMPurify from 'dompurify';
 import {Link, navigate} from 'gatsby';
 import algoliaInsights from 'search-insights';
 
-import useKeyboardNavigate from './hooks/useKeyboardNavigate';
-import Logo from './logo';
+import {useKeyboardNavigate} from './hooks/useKeyboardNavigate';
+import {Logo} from './logo';
 
 // https://stackoverflow.com/a/2117523/115146
 function uuidv4() {
@@ -82,7 +82,7 @@ type Props = {
   platforms?: string[];
 };
 
-function Search({path, autoFocus, platforms = []}: Props): JSX.Element {
+export function Search({path, autoFocus, platforms = []}: Props): JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState(``);
   const [results, setResults] = useState([] as Result[]);
@@ -282,5 +282,3 @@ function Search({path, autoFocus, platforms = []}: Props): JSX.Element {
     </div>
   );
 }
-
-export default Search;

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -127,7 +127,7 @@ export function BaseSEO({
   );
 }
 
-export default function SEO(props: Props): JSX.Element {
+export function SEO(props: Props): JSX.Element {
   return (
     <StaticQuery
       query={detailsQuery}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql, StaticQuery} from 'gatsby';
 
-import {toTree, DynamicNav} from './dynamicNav';
+import {DynamicNav, toTree} from './dynamicNav';
 import {SidebarLink} from './sidebarLink';
 
 const navQuery = graphql`

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {graphql, StaticQuery} from 'gatsby';
 
-import DynamicNav, {toTree} from './dynamicNav';
-import SidebarLink from './sidebarLink';
+import {toTree, DynamicNav} from './dynamicNav';
+import {SidebarLink} from './sidebarLink';
 
 const navQuery = graphql`
   query NavQuery {
@@ -88,6 +88,6 @@ export function BaseSidebar({data}: ChildProps): JSX.Element {
   );
 }
 
-export default function Sidebar() {
+export function Sidebar() {
   return <StaticQuery query={navQuery} render={data => <BaseSidebar data={data} />} />;
 }

--- a/src/components/sidebarLink.tsx
+++ b/src/components/sidebarLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useLocation} from '@reach/router';
 import {withPrefix} from 'gatsby';
 
-import SmartLink from './smartLink';
+import {SmartLink} from './smartLink';
 
 type Props = {
   /**
@@ -20,12 +20,7 @@ type Props = {
   collapsed?: boolean | null;
 };
 
-export default function SidebarLink({
-  to,
-  title,
-  children,
-  collapsed = null,
-}: Props): JSX.Element {
+export function SidebarLink({to, title, children, collapsed = null}: Props): JSX.Element {
   const location = useLocation();
   const isActive = location && location.pathname.indexOf(withPrefix(to)) === 0;
 

--- a/src/components/smartLink.tsx
+++ b/src/components/smartLink.tsx
@@ -3,7 +3,7 @@ import {Link} from 'gatsby';
 
 import {marketingUrlParams} from 'sentry-docs/utils';
 
-import ExternalLink from './externalLink';
+import {ExternalLink} from './externalLink';
 
 type Props = {
   activeClassName?: string;
@@ -17,7 +17,7 @@ type Props = {
   to?: string;
 };
 
-export default function SmartLink({
+export function SmartLink({
   to,
   href,
   children,

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -3,7 +3,7 @@ import React, {Fragment, useEffect, useState} from 'react';
 import {captureException} from '../utils';
 
 import {PageContext} from './basePage';
-import GuideGrid from './guideGrid';
+import {GuideGrid} from './guideGrid';
 
 type Item = {
   items: Item[];
@@ -77,7 +77,7 @@ function recursiveRender(items) {
   });
 }
 
-export default function TableOfContents({contentRef, pageContext}: Props) {
+export function TableOfContents({contentRef, pageContext}: Props) {
   const [items, setItems] = useState<Item[]>(null);
   const {platform} = pageContext;
 

--- a/src/docs/product/cli/installation.mdx
+++ b/src/docs/product/cli/installation.mdx
@@ -4,7 +4,7 @@ sidebar_order: 0
 description: "Learn about the different methods available to install `sentry-cli`."
 ---
 
-import CliChecksumTable from "sentry-docs/components/cliChecksumTable";
+import { CliChecksumTable } from "sentry-docs/components/cliChecksumTable";
 
 Depending on your platform, there are different methods available to install `sentry-cli`.
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import Layout from 'sentry-docs/components/layout';
-import SEO from 'sentry-docs/components/seo';
+import {Layout} from 'sentry-docs/components/layout';
+import {SEO} from 'sentry-docs/components/seo';
 
 import {getCurrentTransaction} from '../utils';
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {Nav} from 'react-bootstrap';
 import {PlatformIcon} from 'platformicons';
 
-import Banner from 'sentry-docs/components/banner';
+import {Banner} from 'sentry-docs/components/banner';
 import {usePlatformList} from 'sentry-docs/components/hooks/usePlatform';
-import NavbarPlatformDropdown from 'sentry-docs/components/navbarPlatformDropdown';
+import {NavbarPlatformDropdown} from 'sentry-docs/components/navbarPlatformDropdown';
 import {getSandboxURL, SandboxOnly} from 'sentry-docs/components/sandboxLink';
-import Search from 'sentry-docs/components/search';
-import SEO from 'sentry-docs/components/seo';
-import SmartLink from 'sentry-docs/components/smartLink';
+import {Search} from 'sentry-docs/components/search';
+import {SEO} from 'sentry-docs/components/seo';
+import {SmartLink} from 'sentry-docs/components/smartLink';
 import SentryWordmarkSVG from 'sentry-docs/logos/sentry-wordmark-dark.svg';
 
 import 'sentry-docs/css/screen.scss';

--- a/src/pages/platform-redirect.tsx
+++ b/src/pages/platform-redirect.tsx
@@ -4,8 +4,8 @@ import {PlatformIcon} from 'platformicons';
 import {parse} from 'query-string';
 
 import {usePlatformList} from 'sentry-docs/components/hooks/usePlatform';
-import Layout from 'sentry-docs/components/layout';
-import SmartLink from 'sentry-docs/components/smartLink';
+import {Layout} from 'sentry-docs/components/layout';
+import {SmartLink} from 'sentry-docs/components/smartLink';
 
 type Props = {
   path?: string;

--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -7,7 +7,7 @@ redirect_from:
   - /clients/
 ---
 
-import PlatformGrid from "sentry-docs/components/platformGrid";
+import { PlatformGrid } from "sentry-docs/components/platformGrid";
 
 To report to Sentry you’ll need to use a language-specific SDK. The Sentry team builds and maintains these for most popular languages, but there’s also a large ecosystem supported by the community.
 

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -123,7 +123,7 @@ If you want to understand the inner workings of the loader itself, you can read 
 
 ## CDN
 
-import JsBundleList from "sentry-docs/components/jsBundleList";
+import { JsBundleList } from "sentry-docs/components/jsBundleList";
 
 Sentry supports loading the JavaScript SDK from a CDN. Generally we suggest using our Loader instead. If you _must_ use a CDN, see [Available Bundles](#available-bundles) below.
 

--- a/src/templates/apiDoc.tsx
+++ b/src/templates/apiDoc.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 
-import ApiSidebar from 'sentry-docs/components/apiSidebar';
-import BasePage from 'sentry-docs/components/basePage';
-import Content from 'sentry-docs/components/content';
-import SmartLink from 'sentry-docs/components/smartLink';
+import {ApiSidebar} from 'sentry-docs/components/apiSidebar';
+import {BasePage} from 'sentry-docs/components/basePage';
+import {Content} from 'sentry-docs/components/content';
+import {SmartLink} from 'sentry-docs/components/smartLink';
 
 export default function ApiDoc(props) {
   const {

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -6,10 +6,10 @@ import 'prismjs/components/prism-json';
 import React, {Fragment, useEffect, useState} from 'react';
 import {graphql} from 'gatsby';
 
-import ApiSidebar from 'sentry-docs/components/apiSidebar';
-import BasePage from 'sentry-docs/components/basePage';
-import Content from 'sentry-docs/components/content';
-import SmartLink from 'sentry-docs/components/smartLink';
+import {ApiSidebar} from 'sentry-docs/components/apiSidebar';
+import {BasePage} from 'sentry-docs/components/basePage';
+import {Content} from 'sentry-docs/components/content';
+import {SmartLink} from 'sentry-docs/components/smartLink';
 import {
   OpenAPI,
   OpenApiPath,

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 
-import ApiSidebar from 'sentry-docs/components/apiSidebar';
-import BasePage from 'sentry-docs/components/basePage';
-import Content from 'sentry-docs/components/content';
-import InternalDocsSidebar from 'sentry-docs/components/internalDocsSidebar';
+import {ApiSidebar} from 'sentry-docs/components/apiSidebar';
+import {BasePage} from 'sentry-docs/components/basePage';
+import {Content} from 'sentry-docs/components/content';
+import {InternalDocsSidebar} from 'sentry-docs/components/internalDocsSidebar';
 
 export default function Doc(props: any) {
   let sidebar = null;

--- a/src/templates/platform.tsx
+++ b/src/templates/platform.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 
-import BasePage from 'sentry-docs/components/basePage';
-import Content from 'sentry-docs/components/content';
-import PlatformSdkDetail from 'sentry-docs/components/platformSdkDetail';
-import PlatformSidebar from 'sentry-docs/components/platformSidebar';
+import {BasePage} from 'sentry-docs/components/basePage';
+import {Content} from 'sentry-docs/components/content';
+import {PlatformSdkDetail} from 'sentry-docs/components/platformSdkDetail';
+import {PlatformSidebar} from 'sentry-docs/components/platformSidebar';
 
 type Props = {
   data: {

--- a/src/templates/wizardDebug.tsx
+++ b/src/templates/wizardDebug.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 
-import Content from 'sentry-docs/components/content';
+import {Content} from 'sentry-docs/components/content';
 
 export default function WizardDebug({data: {file}}) {
   const {frontmatter} = file.childMarkdownRemark;

--- a/src/templates/wizardDebugIndex.tsx
+++ b/src/templates/wizardDebugIndex.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {graphql} from 'gatsby';
 
-import BasePage from 'sentry-docs/components/basePage';
-import SmartLink from 'sentry-docs/components/smartLink';
+import {BasePage} from 'sentry-docs/components/basePage';
+import {SmartLink} from 'sentry-docs/components/smartLink';
 
 export default function WizardDebug({
   data: {


### PR DESCRIPTION
Using this as a bit of a testing ground for doing something similar in
sentry.

We would like to restrict default exports and make the choice easy
"always use named exports"