### PR TITLE
fix: Github > GitHub

### DIFF
--- a/src/docs/product/accounts/getting-started/index.mdx
+++ b/src/docs/product/accounts/getting-started/index.mdx
@@ -19,7 +19,7 @@ Of course, you're welcome to go through all the steps, even if you're a team of 
 
 ## 1. Enable Single Sign-On Access
 
-[Single sign-on (SSO)](/product/accounts/sso/) allows your team to log in quickly, streamlines the on/off-boarding process for member accounts, and strengthens your login with secure credentials. Sentry provides out-of-the-box configuration for integrating SSO providers like [Okta](/product/accounts/sso/#okta) and [Azure Active Directory](/product/accounts/sso/#azure-active-directory) (SAML) or [Google](/product/accounts/sso/#google-business-app) and [Github](/product/accounts/sso/#github-organizations) (Oauth). In addition, we provide a generic configuration option for any other [SAML2 Identity Provider](/product/accounts/sso/saml2/).
+[Single sign-on (SSO)](/product/accounts/sso/) allows your team to log in quickly, streamlines the on/off-boarding process for member accounts, and strengthens your login with secure credentials. Sentry provides out-of-the-box configuration for integrating SSO providers like [Okta](/product/accounts/sso/#okta) and [Azure Active Directory](/product/accounts/sso/#azure-active-directory) (SAML) or [Google](/product/accounts/sso/#google-business-app) and [GitHub](/product/accounts/sso/#github-organizations) (Oauth). In addition, we provide a generic configuration option for any other [SAML2 Identity Provider](/product/accounts/sso/saml2/).
 
 Sentry also supports a subset of the specification for System for Cross-Domain Identity Management (SCIM) for [Okta](/product/accounts/sso/okta-sso/okta-scim/) and [Azure AD](/product/accounts/sso/azure-sso/#scim-integration).
 

--- a/src/docs/product/codecov/set-up.mdx
+++ b/src/docs/product/codecov/set-up.mdx
@@ -10,11 +10,11 @@ If you're a user of both Codecov and Sentry, you can enable the Codecov integrat
 There are a few prerequisites that have to be fulfilled in order for Codecov to work in Sentry. You have to have:
 
 - Owner or manager-level permissions in Sentry.io.
-- The [Github Integration](/product/integrations/source-code-mgmt/github/) installed in Sentry with [Code Mappings](/product/integrations/source-code-mgmt/github/#stack-trace-linking) enabled.
+- The [GitHub Integration](/product/integrations/source-code-mgmt/github/) installed in Sentry with [Code Mappings](/product/integrations/source-code-mgmt/github/#stack-trace-linking) enabled.
 
   <Note>
-    If you have the Github integration set up correctly, your stack traces will
-    show an “Open this line in Github” prompt that will take you to your app's
+    If you have the GitHub integration set up correctly, your stack traces will
+    show an “Open this line in GitHub” prompt that will take you to your app's
     code.
   </Note>
 

--- a/src/docs/product/issues/ownership-rules/index.mdx
+++ b/src/docs/product/issues/ownership-rules/index.mdx
@@ -115,9 +115,9 @@ Let us know if you have feedback: [ecosystem-feedback@sentry.io](mailto:ecosyste
 
 </Note>
 
-![External team mappings for Github/Gitlab](external_team_mappings.png)
+![External team mappings for GitHub/Gitlab](external_team_mappings.png)
 
-![External user mappings for Github/Gitlab](external_user_mappings.png)
+![External user mappings for GitHub/Gitlab](external_user_mappings.png)
 
 Create external team/user mappings for your GitHub/GitLab teams and users by navigating to **Settings > Integrations > GitHub/GitLab > [Configuration] > Team Mappings/User Mappings**. Suggestions will come from any CODEOWNERS files on projects for the organization.
 

--- a/src/docs/product/issues/suspect-commits/index.mdx
+++ b/src/docs/product/issues/suspect-commits/index.mdx
@@ -71,7 +71,7 @@ You can send us your commit data [manually](/product/releases/associate-commits/
 - Your organization doesn't have a GitHub or Gitlab integration.
 - Your integration has gotten disconnected.
 
-Sentry will attempt to find suspect commits via your Github or Gitlab integration by default. If this fails and you've set up the manual process, Sentry will fall back to using the release commit data to find suspect commits.
+Sentry will attempt to find suspect commits via your GitHub or Gitlab integration by default. If this fails and you've set up the manual process, Sentry will fall back to using the release commit data to find suspect commits.
 
 ## Missing Suspect Commits
 

--- a/src/docs/product/releases/setup/release-automation/github-deployment-gates/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/github-deployment-gates/index.mdx
@@ -13,4 +13,4 @@ If you make changes to your organization slug, you'll need to update your config
 
 The [Sentry GitHub Deployment Gates](https://github.com/apps/sentry-deployment-gate) allows Sentry to interact with GitHub releases via deployment protection rules. After sending Sentry release information, you can watch a release for errors and reject a canary release before it is fully deployed.
 
-For more details about Sentry Deployment Gate, see the [Github Application](https://github.com/apps/sentry-deployment-gate).
+For more details about Sentry Deployment Gate, see the [GitHub Application](https://github.com/apps/sentry-deployment-gate).

--- a/src/gatsby/utils/resolveOpenAPI.ts
+++ b/src/gatsby/utils/resolveOpenAPI.ts
@@ -18,7 +18,7 @@ async function main() {
       return data;
     } catch (error) {
       console.log(
-        `Failed to connect to  ${process.env.OPENAPI_LOCAL_PATH}. Continuing to fetch versioned schema from Github.
+        `Failed to connect to  ${process.env.OPENAPI_LOCAL_PATH}. Continuing to fetch versioned schema from GitHub.
         ${error}`
       );
     }

--- a/src/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.mdx
@@ -20,7 +20,7 @@ We've compiled a list of guides on how to upload source maps to Sentry for the m
   </Note>
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
-- [Github Actions](/product/releases/setup/release-automation/github-actions/)
+- [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
 
 ### Other Tools
 

--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -330,7 +330,7 @@ import retrofit2.HttpException
 
 try {
   // If this API call returns 500, it will be captured as an error event by the `SentryOkHttpInterceptor`.
-  return GithubAPI.service.listReposAsync("getsentry")
+  return GitHubAPI.service.listReposAsync("getsentry")
 } catch (e: HttpException) {
   // Do not manually capture this exception to avoid duplicated error events.
   // Sentry.captureException(e)

--- a/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
+++ b/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
@@ -151,7 +151,7 @@ To view the recorded transaction, log into [sentry.io](https://sentry.io) and op
 
 <Note>
 
-At the moment, we only support standard `androidx.room` usage. That is, the SDK will not report SQL queries for any `SupportSQLiteOpenHelper.Factory` other than [androidx.sqlite](https://github.com/androidx/androidx/tree/androidx-main/sqlite). However, if you are using a different `SupportSQLiteOpenHelper.Factory`, please report any [issues on Github](https://github.com/getsentry/sentry-android-gradle-plugin/issues), so we are aware and can possibly work on them.
+At the moment, we only support standard `androidx.room` usage. That is, the SDK will not report SQL queries for any `SupportSQLiteOpenHelper.Factory` other than [androidx.sqlite](https://github.com/androidx/androidx/tree/androidx-main/sqlite). However, if you are using a different `SupportSQLiteOpenHelper.Factory`, please report any [issues on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/issues), so we are aware and can possibly work on them.
 
 </Note>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

Changes all instances of `Github` to `GitHub` which is the correct case.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
