### PR TITLE
chore(large-http): Update docs for GA

### DIFF
--- a/src/docs/product/accounts/early-adopter.mdx
+++ b/src/docs/product/accounts/early-adopter.mdx
@@ -21,5 +21,4 @@ Limitations:
 - [Issue Reprocessing](/product/issues/reprocessing/)
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
 - Organization Domains - Instead of being a path segment, organization slugs are used as a subdomain for [sentry.io](https://sentry.io). For example, `https://acme.sentry.io/issues/` replaces `https://sentry.io/organizations/acme/issues/`. API URLs are unchanged.
-- [Large HTTP Payload](/product/issues/issue-details/performance-issues/large-http-payload/)
 - [Team-level Roles](https://sentry-docs-git-update-org-and-user-managment-page.sentry.dev/product/accounts/membership/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F6934#team-level-roles)

--- a/src/docs/product/issues/issue-details/performance-issues/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/index.mdx
@@ -48,10 +48,10 @@ The following is a list of available performance issues:
     <td>
       <ul>
         <li>
-          <a href="./consecutive-http/">Consecutive HTTP*</a>
+          <a href="./consecutive-http/">Consecutive HTTP</a>
         </li>
         <li>
-          <a href="./large-http-payload/">Large HTTP Payload*</a>
+          <a href="./large-http-payload/">Large HTTP Payload</a>
         </li>
         <li>
           <a href="./large-render-blocking-asset/">
@@ -126,8 +126,6 @@ The following is a list of available performance issues:
     </td>
   </tr>
 </table>
-
-<Note>* Currently only available to Early Adopters.</Note>
 
 ## Performance Issue Limitations
 

--- a/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
@@ -6,19 +6,17 @@ redirect_from:
 description: "Learn more about Large HTTP Payload issues, how to diagnose and fix them."
 ---
 
-<Include name="early-adopter-note.mdx" />
-
 Large HTTP payload issues are created when an http span has an encoded body size that exceeds a threshold.
 
 ## Detection Criteria
 
 The detector for this performance issue looks for a single http span that meets the following criteria:
 
-- The HTTP method must be a GET, POST, DELETE, PUT, PATCH
 - The HTTP url must not begin with \_next/static/ or \_next/data/
-- The HTTP url must not end with the extensions .js, .css, .svg, .png, .mp3, .jpg, .jpeg
+- The HTTP url must not end with an extension (e.g. .js, .css, .png, .jpg, .jpeg, .mp3), unless the extension is .json
+- The HTTP span must have a body size that exceeds 500kb
 
-Once an HTTP span that meets this criteria is found, the encoded body size is checked against a threshold. If Sentry isn't detecting a Large HTTP Payload issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
+If Sentry isn't detecting a Large HTTP Payload issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
 
 ## Span Evidence
 

--- a/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
@@ -14,7 +14,7 @@ The detector for this performance issue looks for a single http span that meets 
 
 - The HTTP url must not begin with \_next/static/ or \_next/data/
 - The HTTP url must not end with an extension (e.g. .js, .css, .png, .jpg, .jpeg, .mp3), unless the extension is .json
-- The HTTP span must have a body size that exceeds 500kb
+- The HTTP span must have an `http.response_content_length` that exceeds 500kb
 
 If Sentry isn't detecting a Large HTTP Payload issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
 

--- a/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
@@ -15,6 +15,7 @@ The detector for this performance issue looks for a single http span that meets 
 - The HTTP url must not begin with \_next/static/ or \_next/data/
 - The HTTP url must not end with an extension (e.g. .js, .css, .png, .jpg, .jpeg, .mp3), unless the extension is .json
 - The HTTP span must have an `http.response_content_length` that exceeds 500kb
+- The HTTP span duration must exceed 100ms
 
 If Sentry isn't detecting a Large HTTP Payload issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.
 

--- a/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/large-http-payload/index.mdx
@@ -14,7 +14,7 @@ The detector for this performance issue looks for a single http span that meets 
 
 - The HTTP url must not begin with \_next/static/ or \_next/data/
 - The HTTP url must not end with an extension (e.g. .js, .css, .png, .jpg, .jpeg, .mp3), unless the extension is .json
-- The HTTP span must have an `http.response_content_length` that exceeds 500kb
+- The HTTP span must have an `http.response_content_length` (added by the `@sentry/browser` SDK, version `7.53.0`) that exceeds 500kb
 - The HTTP span duration must exceed 100ms
 
 If Sentry isn't detecting a Large HTTP Payload issue where you expect one, it's probably because the transaction didn't meet one of the above criteria.


### PR DESCRIPTION
Removes EA notes around large http detector and adds the threshold to the detection criteria