### PR TITLE
Clean up bundler plugin instructions 

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -1,5 +1,13 @@
 ## Upload Source Maps for a Svelte Project
 
+<Note>
+
+This guide assumes you are using the `@sentry/svelte` SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 This page is a guide on how to create releases and upload source maps to Sentry when bundling your Svelte app.
 
 To generate source maps with your Svelte project, you need to set the source map [compiler options](https://svelte.dev/docs#compile-time-svelte-compile) in your Svelte config:
@@ -51,17 +59,6 @@ export default defineConfig({
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./dist/**",
-      },
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // include: "./dist",
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
 });

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -1,5 +1,13 @@
 ## Uploading Source Maps using Vite
 
+<Note>
+
+This guide assumes you are using the `@sentry/vue` SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 If you are using Vue, chances are good you are using Vite to bundle your project.
 You can use the Sentry Vite plugin to automatically create [releases](/product/releases/) and upload source maps to Sentry when bundling your app.
 
@@ -40,27 +48,6 @@ export default defineConfig({
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
 });

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -1,3 +1,11 @@
+<Note>
+
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 You can use the Sentry esbuild plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Install
@@ -30,27 +38,6 @@ require("esbuild").build({
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
 });

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -1,3 +1,11 @@
+<Note>
+
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 You can use the Sentry Rollup plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Installation
@@ -29,27 +37,6 @@ export default {
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
   output: {

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -1,3 +1,11 @@
+<Note>
+
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 You can use the Sentry Vite plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Installation
@@ -17,13 +25,10 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 Example:
 
 ```javascript {filename:vite.config.js}
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 
-export default defineConfig(({ command, mode }) => {
-  // Load env file based on `mode` in the current working directory.
-  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-  const env = loadEnv(mode, process.cwd(), "");
+export default defineConfig({
   return {
     build: {
       sourcemap: true, // Source map generation must be turned on
@@ -37,27 +42,6 @@ export default defineConfig(({ command, mode }) => {
         // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
         // and need `project:releases` and `org:read` scopes
         authToken: env.SENTRY_AUTH_TOKEN,
-
-        sourcemaps: {
-          // Specify the directory containing build artifacts
-          assets: "./**",
-          // Don't upload the source maps of dependencies
-          ignore: ["./node_modules/**"],
-        },
-
-        // Helps troubleshooting - set to false to make plugin less noisy
-        debug: true,
-
-        // Use the following option if you're on an SDK version lower than 7.47.0:
-        // release: {
-        //   uploadLegacySourcemaps: {
-        //     include: ".",
-        //     ignore: ["node_modules"],
-        //   },
-        // },
-
-        // Optionally uncomment the line below to override automatic release name detection
-        // release: env.RELEASE,
       }),
     ],
   };

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -1,12 +1,12 @@
-You can use the Sentry Webpack plugin to automatically create releases and upload source maps to Sentry when bundling your app.
-
 <Note>
 
-This guide for the Sentry Webpack plugin is for version `2.x` of the plugin.
-If you are using version `1.x` of `@sentry/webpack-plugin` please see the migration guide on how to update:
-https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/MIGRATION.md
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
 
 </Note>
+
+You can use the Sentry Webpack plugin to automatically create releases and upload source maps to Sentry when bundling your app.
 
 ## Installation
 
@@ -41,27 +41,6 @@ module.exports = {
       // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
       // and need `project:releases` and `org:read` scopes
       authToken: process.env.SENTRY_AUTH_TOKEN,
-
-      sourcemaps: {
-        // Specify the directory containing build artifacts
-        assets: "./**",
-        // Don't upload the source maps of dependencies
-        ignore: ["./node_modules/**"],
-      },
-
-      // Helps troubleshooting - set to false to make plugin less noisy
-      debug: true,
-
-      // Use the following option if you're on an SDK version lower than 7.47.0:
-      // release: {
-      //   uploadLegacySourcemaps: {
-      //     include: ".",
-      //     ignore: ["node_modules"],
-      //   },
-      // },
-
-      // Optionally uncomment the line below to override automatic release name detection
-      // release: process.env.RELEASE,
     }),
   ],
 };
@@ -91,15 +70,6 @@ exports.onCreateWebpackConfig = ({ actions }) => {
           // Don't upload the source maps of dependencies
           ignore: ["./node_modules/**"],
         },
-
-        // Helps troubleshooting - set to false to make plugin less noisy
-        debug: true,
-
-        // Use the following option if you're on an SDK version lower than 7.47.0:
-        // include: "./dist",
-
-        // Optionally uncomment the line below to override automatic release name detection
-        // release: process.env.RELEASE,
       }),
     ],
   });

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -63,13 +63,6 @@ exports.onCreateWebpackConfig = ({ actions }) => {
         // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
         // and need `project:releases` and `org:read` scopes
         authToken: process.env.SENTRY_AUTH_TOKEN,
-
-        sourcemaps: {
-          // Specify the directory containing build artifacts
-          assets: "./**",
-          // Don't upload the source maps of dependencies
-          ignore: ["./node_modules/**"],
-        },
       }),
     ],
   });

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -69,6 +69,14 @@ If you're using an Angular version below 13, only `ng build --prod` will leverag
 
 ### 2. Register the Sentry Webpack Plugin
 
+<Note>
+
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 Register the Sentry Webpack plugin in your `webpack.config.js`:
 
 ```javascript {filename:webpack.config.js}


### PR DESCRIPTION
- Add notes that you need SDK version 7.47.0 or higher to use the guide.
- Remove everything except for the absolute necessary options for the bundler plugins.