### PR TITLE
Remove critical level

### DIFF
--- a/src/platform-includes/set-level/ruby.mdx
+++ b/src/platform-includes/set-level/ruby.mdx
@@ -2,4 +2,4 @@
 Sentry.capture_message("this is not important", level: :info)
 ```
 
-Available levels are `:fatal`, `:critical`, `:error`, `:warning`, `:log`, `:info`, and `:debug`. The default, if not specified, is `:error`.
+Available levels are `:fatal`, `:error`, `:warning`, `:log`, `:info`, and `:debug`. The default, if not specified, is `:error`.


### PR DESCRIPTION
As per dev docs, critical level is not supported: https://develop.sentry.dev/sdk/event-payloads/#optional-attributes

An event sent with level:critical has the level changed to fatal during server side processing

