### PR TITLE
Fixed typo

### DIFF
--- a/src/docs/product/issues/issue-details/ai-suggested-solution/index.mdx
+++ b/src/docs/product/issues/issue-details/ai-suggested-solution/index.mdx
@@ -32,14 +32,14 @@ user will receive a prompt to confirm that data will be sent to a third party.
 
 Under all circumstance we will not send any event data to OpenAI without an
 explicit instruction to do so. Only by clicking the "View Suggestion" button
-will selected event data be shared with a third party. we sent the following data from an event:
+will selected event data be shared with a third party. We send the following data from an event:
 
 - message
 - platform
 - exception type
 - exception mechanism
 - exception value
-- exception’s stack trace
+- exception stack trace
 
 This feature uses the OpenAI API and the event data shared via this feature will not be used to train their AI models.
 


### PR DESCRIPTION
Fixed typo - lower case "we" after "."
