### PR TITLE
Fix code sample for functions_to_trace

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -114,11 +114,11 @@ To avoid having custom performance instrumentation code scattered all over your 
 import sentry_sdk
 
 functions_to_trace = [
-    "myrootmodule.eat_slice",
-    "myrootmodule.swallow",
-    "myrootmodule.chew",
-    "myrootmodule.someothermodule.another.some_function",
-    "myrootmodule.SomePizzaClass.some_method",
+    {"qualified_name": "myrootmodule.eat_slice"},
+    {"qualified_name": "myrootmodule.swallow"},
+    {"qualified_name": "myrootmodule.chew"},
+    {"qualified_name": "myrootmodule.someothermodule.another.some_function"},
+    {"qualified_name": "myrootmodule.SomePizzaClass.some_method"},
 ]
 
 sentry_sdk.init(


### PR DESCRIPTION
Documentation says functions_to_trace is list[str], but is actually list[dict[str, str]] #7051
