### PR TITLE
Update options.mdx to remove information about TLS support in sentry relay

### DIFF
--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -51,29 +51,6 @@ The host to which Relay should bind (network interface). Example: `0.0.0.0`
 
 The port to bind for the unencrypted Relay HTTP server. Example: `3000`
 
-`relay.tls_port`
-
-: _Integer, optional_
-
-Optional port to bind for the encrypted Relay HTTPS server. Example: `3001`
-
-This is in addition to the `port` option: If you set up a HTTPS server at
-`tls_port`, the HTTP server at `port` still exists.
-
-`relay.tls_identity_path`
-
-: _String, optional_
-
-The filesystem path to the identity (DER-encoded PKCS12) to use for the HTTPS
-server. Relative paths are evaluated in the current working directory.
-Example: `relay_dev.pfx`
-
-`relay.tls_identity_password`
-
-: _String, optional_
-
-Password for the PKCS12 archive in `relay.tls_identity_path`.
-
 `relay.override_project_ids`
 
 : _Boolean, optional_


### PR DESCRIPTION
Remove no longer supported TLS configuration options

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Remove no longer available TLS configuration options that were removed in sentry relay in https://github.com/getsentry/relay/pull/1938.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
