### PR TITLE
ref(sveltekit): Update SvelteKit SDK compatibility note

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.sveltekit.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.sveltekit.mdx
@@ -1,16 +1,21 @@
 Sentry's SvelteKit SDK enables automatic reporting of errors and performance data.
 
-<Note>
+## Compatibility
 
 The minimum supported **SvelteKit version is `1.0.0`**. This SDK works best with **Vite 4.2** and newer.
 Older Vite versions might not generate source maps correctly.
 
-</Note>
-
 <Note>
 
-The SvelteKit SDK is designed to work with SvelteKit's [Node adapter](https://kit.svelte.dev/docs/adapter-node).
+The SvelteKit SDK is designed to work out of the box with the following SvelteKit adapters:
+
+- [Adapter-auto](https://kit.svelte.dev/docs/adapter-auto) - for Vercel; other platforms might work but we don't guarantee compatiblity at this time.
+- [Adapter-vercel](https://kit.svelte.dev/docs/adapter-vercel) - only for Node (Lambda) runtimes, not yet Vercel's edge runtime.
+- [Adapter-node](https://kit.svelte.dev/docs/adapter-node).
+
 Other adapters may work but aren't currently supported.
 We're looking into extending first-class support to [more adapters](https://kit.svelte.dev/docs/adapters) in the future.
+
+The SvelteKit SDK does not yet work with non-node server runtimes, such as Vercel's edge runtime or Cloudflare Workers.
 
 </Note>

--- a/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -240,7 +240,42 @@ export default {
 };
 ```
 
-Using the `sourceMapsUploadOptions` object is useful if the default source maps upload doesn't work out of the box, for instance, if you have a customized build setup or if you're using the SDK with a SvelteKit adapter other than the Node adapter.
+Using the `sourceMapsUploadOptions` object is useful if the default source maps upload doesn't work out of the box, for instance, if you have a customized build setup or if you're using the SDK with a SvelteKit adapter other than the [supported adapters](../#compatibility).
+
+### Overriding SvelteKit Adapter detection
+
+By default, `sentrySvelteKit` will try to detect the used SvelteKit adapter to configure source maps upload correctly for the respective adapter.
+If we detect the wrong adapter our you're using another adapter than the [supported adapters](../#compatibility), you can override the adapter detection by passing the `adapter` option to `sentrySvelteKit`:
+
+```javascript {filename:vite.config.js}
+import { sveltekit } from "@sveltejs/kit/vite";
+import { sentrySvelteKit } from "@sentry/sveltekit";
+
+export default {
+  plugins: [
+    sentrySvelteKit({
+      adapter: "vercel",
+    }),
+    sveltekit(),
+  ],
+  // ... rest of your Vite config
+};
+```
+
+```typescript {filename:vite.config.ts}
+import { sveltekit } from "@sveltejs/kit/vite";
+import { sentrySvelteKit } from "@sentry/sveltekit";
+
+export default {
+  plugins: [
+    sentrySvelteKit({
+      adapter: "vercel",
+    }),
+    sveltekit(),
+  ],
+  // ... rest of your Vite config
+};
+```
 
 ### Disable Source Maps Upload
 

--- a/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -244,8 +244,8 @@ Using the `sourceMapsUploadOptions` object is useful if the default source maps 
 
 ### Overriding SvelteKit Adapter detection
 
-By default, `sentrySvelteKit` will try to detect the used SvelteKit adapter to configure source maps upload correctly for the respective adapter.
-If we detect the wrong adapter our you're using another adapter than the [supported adapters](../#compatibility), you can override the adapter detection by passing the `adapter` option to `sentrySvelteKit`:
+By default, `sentrySvelteKit` will try to detect your SvelteKit adapter to configure source maps upload correctly.
+If you're not using one of the [supported adapters](../#compatibility) or the wrong one is detected, you can override the adapter detection by passing the `adapter` option to `sentrySvelteKit`:
 
 ```javascript {filename:vite.config.js}
 import { sveltekit } from "@sveltejs/kit/vite";


### PR DESCRIPTION
Now that we support more adapters, we should update the compatibility note accordingly

ref https://github.com/getsentry/sentry-javascript/issues/8085