### PR TITLE
feat(angular): Add guide for uploading source maps with `@nx/angular` CLI

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
@@ -28,12 +28,14 @@ To generate source maps, you need to add the `sourceMap` option to your `angular
 }
 ```
 
-### Two Ways to Upload Source Maps
+### Three Ways to Upload Source Maps
 
 You can either set releases and upload source maps automatically using the Angular CLI, or upload source maps manually using the Sentry-CLI.
 
 - [**Angular CLI and Sentry Webpack Plugin**](./uploading/angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.
+- [**Nx Angular CLI and Sentry Webpack Plugin**](./uploading/angular-nx/) <br/>
+  If you're using Nx, Use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
 - [**Sentry CLI**](./uploading/cli/)<br/>
   Upload source maps manually using the Sentry-CLI.
 

--- a/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
@@ -30,7 +30,7 @@ To generate source maps, you need to add the `sourceMap` option to your `angular
 
 ### Ways to Upload Source Maps
 
-You can either set releases and upload source maps automatically using the Angular CLI, or upload source maps manually using the Sentry-CLI.
+To upload your Angular project's source maps to Sentry, we recommend one of these options:
 
 - [**Angular CLI and Sentry Webpack Plugin**](./uploading/angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.

--- a/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
@@ -28,15 +28,15 @@ To generate source maps, you need to add the `sourceMap` option to your `angular
 }
 ```
 
-### Three Ways to Upload Source Maps
+### Ways to Upload Source Maps
 
 You can either set releases and upload source maps automatically using the Angular CLI, or upload source maps manually using the Sentry-CLI.
 
 - [**Angular CLI and Sentry Webpack Plugin**](./uploading/angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.
 - [**Nx Angular CLI and Sentry Webpack Plugin**](./uploading/angular-nx/) <br/>
-  If you're using Nx, Use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
+  If you're using Nx, use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
 - [**Sentry CLI**](./uploading/cli/)<br/>
-  Upload source maps manually using the Sentry-CLI.
+  Upload source maps manually using the Sentry CLI.
 
 Take a look at this [guide for further options to upload source maps](./uploading/).

--- a/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
@@ -1,4 +1,4 @@
-To upload your Angular project's source maps to Sentry, we recommend one of these two options:
+To upload your Angular project's source maps to Sentry, we recommend one of these options:
 
 - [**Angular CLI and Sentry Webpack Plugin**](./angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.

--- a/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
@@ -2,9 +2,11 @@ To upload your Angular project's source maps to Sentry, we recommend one of thes
 
 - [**Angular CLI and Sentry Webpack Plugin**](./angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.
+- [**Nx Angular CLI and Sentry Webpack Plugin**](./angular-nx/) <br/>
+  If you're using Nx, Use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
 - [**Sentry CLI**](./cli/)<br/>
   Upload source maps manually using Sentry-CLI.
 
 These options work well with Angular projects out of the box. For other bundlers or more advanced projects and configurations, take a look at the following guides and options for uploading sourcemaps:
 
-<PageGrid exclude={["angular-webpack", "cli"]} />
+<PageGrid exclude={["angular-webpack", "angular-nx", "cli"]} />

--- a/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
@@ -5,7 +5,7 @@ To upload your Angular project's source maps to Sentry, we recommend one of thes
 - [**Nx Angular CLI and Sentry Webpack Plugin**](./angular-nx/) <br/>
   If you're using Nx, use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
 - [**Sentry CLI**](./cli/)<br/>
-  Upload source maps manually using Sentry-CLI.
+  Upload source maps manually using Sentry CLI.
 
 These options work well with Angular projects out of the box. For other bundlers or more advanced projects and configurations, take a look at the following guides and options for uploading sourcemaps:
 

--- a/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/upload/primer/javascript.angular.mdx
@@ -3,7 +3,7 @@ To upload your Angular project's source maps to Sentry, we recommend one of thes
 - [**Angular CLI and Sentry Webpack Plugin**](./angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry Webpack plugin to set releases and upload source maps automatically when running `ng build`.
 - [**Nx Angular CLI and Sentry Webpack Plugin**](./angular-nx/) <br/>
-  If you're using Nx, Use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
+  If you're using Nx, use `@nx/angular` CLI and the Sentry Webpack plugin to set releases and upload source maps automatically when running `nx build`.
 - [**Sentry CLI**](./cli/)<br/>
   Upload source maps manually using Sentry-CLI.
 

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -1,0 +1,93 @@
+---
+title: Nx Angular CLI
+description: "Upload your source maps using the Nx Angular CLI and the Sentry Webpack plugin."
+sidebar_order: 0
+supported:
+  - javascript.angular
+---
+
+If you're using [`@nx/angular`](https://nx.dev/packages/angular), you can use the Nx CLI together with our Sentry Webpack plugin to automatically create releases and upload source maps to Sentry when building your app (with `nx build`, for example).
+Due to `@nx/angular`'s architecture, to register the Webpack plugin, you'll first need to configure the [`@nx/angular:webpack-browser` executor](https://nx.dev/packages/angular/executors/webpack-browser).
+In the end, you'll be able to automatically upload source maps whenever you're creating a production build of your app.
+
+## Install
+
+Install the Sentry Webpack plugin:
+
+```shell {tabTitle:npm}
+npm install --save-dev @sentry/webpack-plugin
+```
+
+```shell {tabTitle:Yarn}
+yarn add --dev  @sentry/webpack-plugin
+```
+
+## Configure
+
+Configure your app to upload source maps in three steps.
+
+### 1. Configure `project.json`
+
+In your `project.json`, replace the default executor (`@angular-devkit/build-angular:browser`) with `@nx/angular:webpack-browser`:
+
+```javascript {filename:project.json}
+{
+  "targets": {
+    "build": {
+      "builder": "@nx/angular:webpack-browser",
+      "options": {
+        "customWebpackConfig": {
+          "path": "./webpack.config.js" // path to your webpack.config.js
+        },
+        "sourceMap": { // enable source maps generation
+            "scripts": true,
+         }
+        // ... other options
+      },
+      // ... other options
+    }
+  }
+}
+```
+
+### 2. Register the Sentry Webpack Plugin
+
+<Note>
+
+This guide assumes you are using a Sentry SDK on version `7.47.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
+Register the Sentry Webpack plugin in your `webpack.config.js`:
+
+```javascript {filename:webpack.config.js}
+const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
+
+module.exports = {
+  // ... other config above ...
+
+  devtool: "source-map", // Source map generation must be turned on
+  plugins: [
+    sentryWebpackPlugin({
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+
+      // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
+      // and need the `project:releases` and `org:read` scopes
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+};
+```
+
+Learn more about configuring the plugin in our [Sentry Webpack Plugin documentation](https://www.npmjs.com/package/@sentry/webpack-plugin).
+
+### 3. Upload
+
+To upload the source maps, build your Angular application:
+
+```bash
+nx build
+```


### PR DESCRIPTION
Based on our findings from https://github.com/getsentry/sentry-javascript/issues/8267 let's bring this guide to our docs. 

Verified the steps with a simple Nx Angular test app: https://github.com/Lms24/nx-angular-sentry
