### PR TITLE
fix(replay): Incorrect code snippet for "Manually Starting Replay"

### DIFF
--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -57,11 +57,11 @@ You can manually start a Replay session with:
 const replay = new Sentry.Replay();
 
 Sentry.init({
-  dsn: '...',
+  dsn: "...",
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 0,
   integrations: [replay],
-})
+});
 
 // This starts in `session` mode, regardless of sample rates
 replay.start();

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -54,10 +54,14 @@ You can manually start a Replay session with:
 
 ```javascript
 // This initializes Replay without starting any session
-const replay = new Sentry.Replay({
+const replay = new Sentry.Replay();
+
+Sentry.init({
+  dsn: '...',
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 0,
-});
+  integrations: [replay],
+})
 
 // This starts in `session` mode, regardless of sample rates
 replay.start();


### PR DESCRIPTION
This code snippet is incorrct.

Closes https://github.com/getsentry/sentry-docs/issues/6983
