### PR TITLE
ref(js): Add note about ad-blocking behaviour of Brave browser

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -80,7 +80,9 @@ When you are using our CDN, ad-blocking or script-blocking extensions may preven
 
 Additionally, even when the SDK is downloaded and initialized correctly, Sentry endpoints that need to receive captured data may be blocked as well. This prevents any error reports, sessions health, or performance data from being delivered, making it effectively unavailable in [sentry.io](https://sentry.io).
 
-You can work around the first issue in multiple ways explained above. However, the endpoint blockage can be only resolved using the tunnel.
+Furthermore, some Browsers, like [Brave](https://brave.com/), have built-in ad-blockers that may block requests sent to our endpoint. Even if users deactivate your domain from blocking, Brave might continue to block [requests made from service workers](https://github.com/getsentry/sentry/issues/47912#issuecomment-1573714875).
+
+You can work around our CDN bundles being blocked by [using our NPM packages](#using-the-npm-package) and bundling our SDK with your app. However, the endpoint blockage can be only resolved by using a tunnel as explained below.
 
 ### Using the `tunnel` Option
 
@@ -205,7 +207,7 @@ Check out our [examples repository](https://github.com/getsentry/examples/tree/m
 
 If your use-case is related to the SDK package itself being blocked, any of the following solutions will help you resolve this issue.
 
-### Using Package Directly
+### Using the NPM Package
 
 The best way to deal with script-blocking extensions is to use the SDK package directly through the `npm` and bundle it with your application. This way, you can be sure that the code will be always be there as you expect it to be.
 

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -211,6 +211,8 @@ If your use-case is related to the SDK package itself being blocked, any of the 
 
 The best way to deal with script-blocking extensions is to use the SDK package directly through the `npm` and bundle it with your application. This way, you can be sure that the code will be always be there as you expect it to be.
 
+### Self-hosting CDN bundles
+
 The second way is to download the SDK from our CDN and host it yourself. This way, the SDK will still be separated from the rest of your code, but you'll be certain that it won't be blocked since its origin will be the same as the origin of your website.
 
 You can easily fetch it using `curl` or any other similar tool:

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -80,9 +80,9 @@ When you are using our CDN, ad-blocking or script-blocking extensions may preven
 
 Additionally, even when the SDK is downloaded and initialized correctly, Sentry endpoints that need to receive captured data may be blocked as well. This prevents any error reports, sessions health, or performance data from being delivered, making it effectively unavailable in [sentry.io](https://sentry.io).
 
-Furthermore, some Browsers, like [Brave](https://brave.com/), have built-in ad-blockers that may block requests sent to our endpoint. Even if users deactivate your domain from blocking, Brave might continue to block [requests made from service workers](https://github.com/getsentry/sentry/issues/47912#issuecomment-1573714875).
+Furthermore, some browsers, like [Brave](https://brave.com/), have built-in ad-blockers that may block requests sent to our endpoint. Even if users deactivate your domain from blocking, Brave might continue to block [requests made from service workers](https://github.com/getsentry/sentry/issues/47912#issuecomment-1573714875).
 
-You can work around our CDN bundles being blocked by [using our NPM packages](#using-the-npm-package) and bundling our SDK with your app. However, the endpoint blockage can be only resolved by using a tunnel as explained below.
+You can work around our CDN bundles being blocked by [using our NPM packages](#using-the-npm-package) and bundling our SDK with your app. However, the endpoint blockage can only be resolved by using a tunnel as explained below.
 
 ### Using the `tunnel` Option
 


### PR DESCRIPTION
As we recently found out, Brave blocks [Sentry requests that are passed through service workers](https://github.com/getsentry/sentry/issues/47912#issuecomment-1573714875), even if users deactivated the domain from being blocked. While this might be a bug in the browser we should nevertheless include this information to avoid confusion. Also it's one more reason to set up a tunnel and using the SDK's `tunnel` option. 

(I'm on vacation for the next two weeks. Please feel free to take this PR over and merge it as you see fit). 