### PR TITLE
feat(alerts): Add new common tags

### DIFF
--- a/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -86,7 +86,7 @@ For some metric alerts, you can set the event type that you want to be alerted a
 Add filters in the provided input to narrow down what you'll be alerted about, such as URL tags or other event properties. Available properties depend on your alert's event type:
 
 - for **error** events, all error properties are available. See [Searchable Properties](/product/sentry-basics/search/searchable-properties/#event-properties) for a full list
-- for **transaction** events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, and `http.method`.
+- for **transaction** events, only five properties are available: `release`, `transaction`, `transaction.status`, `transaction.op`, `browser.name`, `os.name`, `geo.country_code`, `http.status_code`, and `http.method`.
 
 #### Invalid Filters
 


### PR DESCRIPTION
Add new common tags to the metric alerts. 

This adds:
- `os.name`
- `browser.name`
- `geo.country_code`
- `http.status_code`