### PR TITLE
Mention traces sample rate and set it to 1.0

### DIFF
--- a/src/platform-includes/getting-started-config/java.mdx
+++ b/src/platform-includes/getting-started-config/java.mdx
@@ -3,6 +3,11 @@ import io.sentry.Sentry;
 
 Sentry.init(options -> {
   options.setDsn("___PUBLIC_DSN___");
+
+  // Set traces_sample_rate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production.
+  options.setTracesSampleRate(1.0);
 });
 ```
 
@@ -11,5 +16,10 @@ import io.sentry.Sentry
 
 Sentry.init { options ->
   options.dsn = "___PUBLIC_DSN___"
+
+  // Set traces_sample_rate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production.
+  options.tracesSampleRate = 1.0
 }
 ```

--- a/src/platform-includes/getting-started-config/java.spring-boot.mdx
+++ b/src/platform-includes/getting-started-config/java.spring-boot.mdx
@@ -4,11 +4,21 @@ Provide a `sentry.dsn` property using either `application.properties` or `applic
 
 ```properties {filename:application.properties}
 sentry.dsn=___PUBLIC_DSN___
+
+# Set traces_sample_rate to 1.0 to capture 100%
+# of transactions for performance monitoring.
+# We recommend adjusting this value in production.
+sentry.traces-sample-rate=1.0
 ```
 
 ```yaml {filename:application.yml}
 sentry:
   dsn: ___PUBLIC_DSN___
+
+  # Set traces_sample_rate to 1.0 to capture 100%
+  # of transactions for performance monitoring.
+  # We recommend adjusting this value in production.
+  tracesSampleRate: 1.0
 ```
 
 By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring the `sentry.exception-resolver-order` property. For example, setting it to `-2147483647` (the value of `org.springframework.core.Ordered#HIGHEST_PRECEDENCE`) ensures exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.

--- a/src/platform-includes/performance/configure-sample-rate/java.spring-boot.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/java.spring-boot.mdx
@@ -3,7 +3,10 @@ Or alternatively:
 Configure sample rate in `application.properties` or `application.yml` file:
 
 ```properties
-sentry.traces-sample-rate=0.3
+# Set traces_sample_rate to 1.0 to capture 100%
+# of transactions for performance monitoring.
+# We recommend adjusting this value in production.
+sentry.traces-sample-rate=1.0
 ```
 
 Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:

--- a/src/platform-includes/performance/configure-sample-rate/java.spring.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/java.spring.mdx
@@ -3,7 +3,10 @@ Or alternatively:
 Configure sample rate in `sentry.properties`:
 
 ```properties
-traces-sample-rate=0.3
+# Set traces_sample_rate to 1.0 to capture 100%
+# of transactions for performance monitoring.
+# We recommend adjusting this value in production.
+traces-sample-rate=1.0
 ```
 
 Or through providing a bean of type `SentryOptions#TracesSamplerCallback`:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Some getting started pages didn't set `tracesSampleRate` yet. Also it was set to < `1.0` in some places.

I presume it's fine to leave https://docs.sentry.io/platforms/java/configuration/sampling/#setting-a-uniform-sample-rate and similar as they are. Please let me know otherwise.