### PR TITLE
Add missing options to Basic Options

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -248,6 +248,22 @@ If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event pay
 
 </ConfigKey>
 
+<ConfigKey name="include-source-context" supported={["python"]}>
+
+You can opt out of source context being included in events sent to Sentry by disabling this option.
+
+The option is enabled by default.
+
+</ConfigKey>
+
+<ConfigKey name="include-local-variables" supported={["python"]}>
+
+If this option is disabled, the SDK will not capture a snapshot of local variables to send with the event.
+
+This option is on by default, i.e., local variables will be included.
+
+</ConfigKey>
+
 <ConfigKey name="server-name" supported={["python", "node", "ruby", "php", "java", "dart", "dotnet"]} notSupported={["android"]}>
 
 This option can be used to supply a "server name." When provided, the name of the server is sent along and persisted in the event. For many integrations, the server name actually corresponds to the device hostname, even in situations where the machine is not actually a server.

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -250,7 +250,7 @@ If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event pay
 
 <ConfigKey name="include-source-context" supported={["python"]}>
 
-If the source context is being included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening.
+If this option is enabled, the source context will be included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening.
 
 The option is enabled by default.
 
@@ -258,9 +258,9 @@ The option is enabled by default.
 
 <ConfigKey name="include-local-variables" supported={["python"]}>
 
-If this option is enabled, the SDK will capture a snapshot of local variables to send with the event.
+If this option is enabled, the SDK will capture a snapshot of local variables to send with the event to help with debugging.
 
-This option is on by default, i.e., local variables will be included.
+This option is on by default.
 
 </ConfigKey>
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -258,7 +258,7 @@ The option is enabled by default.
 
 <ConfigKey name="include-local-variables" supported={["python"]}>
 
-If this option is disabled, the SDK will not capture a snapshot of local variables to send with the event.
+If this option is enabled, the SDK will capture a snapshot of local variables to send with the event.
 
 This option is on by default, i.e., local variables will be included.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -250,7 +250,7 @@ If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event pay
 
 <ConfigKey name="include-source-context" supported={["python"]}>
 
-If this option is enabled, the source context will be included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening.
+When enabled, source context will be included in events sent to Sentry. This source context includes the five lines of code above and below the line of code where an error happened.
 
 The option is enabled by default.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -258,7 +258,7 @@ The option is enabled by default.
 
 <ConfigKey name="include-local-variables" supported={["python"]}>
 
-If this option is enabled, the SDK will capture a snapshot of local variables to send with the event to help with debugging.
+When enabled, the SDK will capture a snapshot of local variables to send with the event to help with debugging.
 
 This option is on by default.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -250,7 +250,7 @@ If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event pay
 
 <ConfigKey name="include-source-context" supported={["python"]}>
 
-If the source context is being included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening. 
+If the source context is being included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening.
 
 The option is enabled by default.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -250,7 +250,7 @@ If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event pay
 
 <ConfigKey name="include-source-context" supported={["python"]}>
 
-You can opt out of source context being included in events sent to Sentry by disabling this option.
+If the source context is being included in events sent to Sentry. The source context are the five lines of code above and below the line of code where an error was happening. 
 
 The option is enabled by default.
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

`include_source_context` and `include_local_variables` were missing from the Basic Options page.


## Preview

- https://sentry-docs-f5f6onk55.sentry.dev/platforms/python/configuration/options/#include-source-context
