### PR TITLE
Clarify Azure DevOps installation process

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -9,21 +9,19 @@ redirect_from:
 description: "Learn more about Sentry's Azure DevOps integration and how it can track and resolve bugs faster by using data from your Azure DevOps commits."
 ---
 
-Track and resolve bugs faster by using data from your Azure DevOps (formerly known as Visual Studio Team Services, VSTS) commits.
+Track and resolve bugs faster by using data from your Azure DevOps commits. (Azure DevOps was formerly known as Visual Studio Team Services, VSTS.)
 
 ## Install
 
-<Note>
+1. To install this integration, you need to have Sentry organization owner, manager, or admin permissions, as well as Azure organization owner permissions, or be a user in the Project Collections Administrators group.
 
-To install this integration, Sentry organization owner, manager, or admin permissions and Azure organization owner permissions or being a user in the Project Collections Administrators group are required.
+2. Go to your Azure Org's settings to make sure third-party access via OAuth is enabled.
 
-</Note>
-
-1. Navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
+3. In Sentry.io, navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
 
    ![Install Azure DevOps integration](azure-devops-install.png)
 
-2. An Azure DevOps install window should pop up. Select the Azure DevOps account you'd like to link with Sentry, and press **Submit**.
+4. An Azure DevOps install window should pop up. Select the Azure DevOps account you'd like to link with Sentry, and press **Submit**.
 
    ![Configure Azure DevOps](azure-global-installed.png)
 

--- a/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -17,7 +17,7 @@ Track and resolve bugs faster by using data from your Azure DevOps commits. (Azu
 
 2. Go to your Azure Org's settings to make sure third-party access via OAuth is enabled.
 
-3. In Sentry.io, navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
+3. In [Sentry.io](https://sentry.sentry.io/settings/organization/), navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
 
    ![Install Azure DevOps integration](azure-devops-install.png)
 


### PR DESCRIPTION
Clarify that the organization needs to allow Third-party application access via Oauth in their Azure Org's settings.

