### PR TITLE
Add documentation for python clickhouse-driver integration

### DIFF
--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -1,5 +1,5 @@
 ---
-title: Clickhouse Driver
+title: clickhouse-driver
 description: "Learn about importing the Clickhouse Driver integration and how it captures queries from clickhouse-driver as breadcrumbs."
 sidebar_order: 27
 ---

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -4,7 +4,7 @@ description: "Learn about importing the clickhouse-driver integration and how it
 sidebar_order: 27
 ---
 
-The Clickhouse Driver integration captures queries from
+The clickhouse-driver integration captures queries from
 [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) as breadcrumbs and spans.
 The integration is available for clickhouse-driver 0.2.0 or later.
 

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -1,7 +1,7 @@
 ---
 title: Clickhouse Driver
 description: "Learn about importing the Clickhouse Driver integration and how it captures queries from clickhouse-driver as breadcrumbs."
-sidebar_order: 120
+sidebar_order: 27
 ---
 
 The Clickhouse Driver integration captures queries from

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -32,7 +32,7 @@ sentry_sdk.init(
 )
 ```
 
-By default the parameters of the query are not retrieved. If you want to see the query parameters in Sentry you need to enable `send_default_pii`. See <PlatformLink to="/configuration/options/#send-default-pii">Basic Options</PlatformLink> for details.
+By default, the parameters of the query are not retrieved. To see the query parameters in Sentry, enable `send_default_pii`. See <PlatformLink to="/configuration/options/#send-default-pii">Basic Options</PlatformLink> for details.
 
 ## Supported Versions
 

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -1,0 +1,38 @@
+---
+title: Clickhouse Driver
+description: "Learn about importing the Clickhouse Driver integration and how it captures queries from clickhouse-driver as breadcrumbs."
+sidebar_order: 120
+---
+
+The Clickhouse Driver integration captures queries from
+[clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) as breadcrumbs.
+The integration is available for clickhouse-driver 0.2.0 or later.
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `clickhouse-driver` extra.
+
+```bash
+pip install --upgrade 'sentry-sdk[clickhouse-driver]'
+```
+
+## Configure
+
+Add `ClickhouseDriverIntegration()` to your `integrations` list:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.clickhouse_driver import ClickhouseDriverIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        ClickhouseDriverIntegration(),
+    ],
+)
+```
+
+## Supported Versions
+
+- clickhouse-driver >= 0.2.0
+- python >= 3.8

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -32,6 +32,8 @@ sentry_sdk.init(
 )
 ```
 
+By default the parameters of the query are not retrieved. If you want to see the query parameters in Sentry you need to enable `send_default_pii`. See <PlatformLink to="/configuration/options/#send-default-pii">Basic Options</PlatformLink> for details.
+
 ## Supported Versions
 
 - clickhouse-driver >= 0.2.0

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -1,6 +1,6 @@
 ---
 title: clickhouse-driver
-description: "Learn about importing the Clickhouse Driver integration and how it captures queries from clickhouse-driver as breadcrumbs."
+description: "Learn about importing the clickhouse-driver integration and how it captures queries from clickhouse-driver as breadcrumbs."
 sidebar_order: 27
 ---
 

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -10,7 +10,7 @@ The integration is available for clickhouse-driver 0.2.0 or later.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `clickhouse-driver` extra.
+Install `sentry-sdk` with the `clickhouse-driver` extra.
 
 ```bash
 pip install --upgrade 'sentry-sdk[clickhouse-driver]'

--- a/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
+++ b/src/platforms/python/common/configuration/integrations/clickhouse-driver.mdx
@@ -5,7 +5,7 @@ sidebar_order: 120
 ---
 
 The Clickhouse Driver integration captures queries from
-[clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) as breadcrumbs.
+[clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) as breadcrumbs and spans.
 The integration is available for clickhouse-driver 0.2.0 or later.
 
 ## Install

--- a/src/platforms/python/common/configuration/integrations/index.mdx
+++ b/src/platforms/python/common/configuration/integrations/index.mdx
@@ -18,6 +18,7 @@ If you don't want integrations to be enabled automatically, set the `default_int
 
 - [ASGI](asgi/)
 - [asyncio](asyncio/)
+- [Clikchouse Driver](clickhouse-driver/)
 - [Cloud Resource Context](cloudresourcecontext/)
 - [Enhanced Locals](pure_eval/)
 - [GNU Backtrace](gnu_backtrace/)

--- a/src/platforms/python/common/configuration/integrations/index.mdx
+++ b/src/platforms/python/common/configuration/integrations/index.mdx
@@ -18,7 +18,7 @@ If you don't want integrations to be enabled automatically, set the `default_int
 
 - [ASGI](asgi/)
 - [asyncio](asyncio/)
-- [Clikchouse Driver](clickhouse-driver/)
+- [clickhouse-driver](clickhouse-driver/)
 - [Cloud Resource Context](cloudresourcecontext/)
 - [Enhanced Locals](pure_eval/)
 - [GNU Backtrace](gnu_backtrace/)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This adds the documentation for a new python integration for `clickhouse-driver`.

See https://github.com/getsentry/sentry-python/issues/2154.
Companion PR: https://github.com/getsentry/sentry-python/pull/2167

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
