### PR TITLE
Adapt docs sidebars to senty.io UI navigation order

### DIFF
--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -86,6 +86,13 @@ export function SidebarContent({platform, guide, data}: ChildProps): JSX.Element
         tree={tree}
       />
       <DynamicNav
+        root={`/${pathRoot}/profiling`}
+        title="Profiling"
+        prependLinks={[[`/${pathRoot}/profiling/`, 'Set Up Profiling']]}
+        suppressMissing
+        tree={tree}
+      />
+      <DynamicNav
         root={`/${pathRoot}/session-replay`}
         title="Session Replay"
         prependLinks={[[`/${pathRoot}/session-replay/`, 'Set Up Session Replay']]}
@@ -96,13 +103,6 @@ export function SidebarContent({platform, guide, data}: ChildProps): JSX.Element
         root={`/${pathRoot}/crons`}
         title="Crons"
         prependLinks={[[`/${pathRoot}/crons/`, 'Set Up Crons']]}
-        suppressMissing
-        tree={tree}
-      />
-      <DynamicNav
-        root={`/${pathRoot}/profiling`}
-        title="Profiling"
-        prependLinks={[[`/${pathRoot}/profiling/`, 'Set Up Profiling']]}
         suppressMissing
         tree={tree}
       />

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Alerts
-sidebar_order: 2
+sidebar_order: 80
 redirect_from:
   - /workflow/alerts-notifications/
   - /product/alerts-notifications/

--- a/src/docs/product/codecov/index.mdx
+++ b/src/docs/product/codecov/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Codecov
-sidebar_order: 3
+sidebar_order: 140
 description: “Learn about Sentry's integration with Codecov.”
 ---
 

--- a/src/docs/product/crons/index.mdx
+++ b/src/docs/product/crons/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Crons"
-sidebar_order: 2
+sidebar_order: 70
 description: "Cron Monitoring helps you maintain your jobs' uptime and performance, delivering alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service."
 support_level: alpha
 ---

--- a/src/docs/product/dashboards/index.mdx
+++ b/src/docs/product/dashboards/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dashboards
-sidebar_order: 6
+sidebar_order: 100
 redirect_from:
   - /workflow/visibility/
   - /workflow/dashboards/

--- a/src/docs/product/discover-queries/index.mdx
+++ b/src/docs/product/discover-queries/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Discover"
-sidebar_order: 5
+sidebar_order: 90
 redirect_from:
   - /product/discover/
   - /workflow/discover/

--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Issues
-sidebar_order: 1
+sidebar_order: 20
 redirect_from:
   - /product/error-monitoring/
 description: "Learn more about the Issues page and how you can use it to efficiently triage issues."

--- a/src/docs/product/performance/index.mdx
+++ b/src/docs/product/performance/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Performance Monitoring"
-sidebar_order: 2
+sidebar_order: 40
 redirect_from:
   - /performance/
   - /performance/display/

--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Profiling"
-sidebar_order: 1
+sidebar_order: 50
 redirect_from:
   - /profiling/
 description: "Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for manual instrumentation and enabling precise code-level visibility into your application in a production environment."

--- a/src/docs/product/projects/index.mdx
+++ b/src/docs/product/projects/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Projects
-sidebar_order: 1
+sidebar_order: 30
 description: "View all the projects associated with teams that you're a member of, then dive into their details quickly."
 ---
 

--- a/src/docs/product/releases/index.mdx
+++ b/src/docs/product/releases/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Releases
-sidebar_order: 4
+sidebar_order: 110
 redirect_from:
   - /learn/releases/
   - /workflow/releases/

--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Security Policy Reporting
-sidebar_order: 80
+sidebar_order: 150
 redirect_from:
   - /learn/security-policy-reporting/
   - /error-reporting/security-policy-reporting/

--- a/src/docs/product/sentry-basics/index.mdx
+++ b/src/docs/product/sentry-basics/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sentry Basics
-sidebar_order: 0
+sidebar_order: 10
 description: "Welcome to Sentry Basics, our primer on using tools available in sentry.io to help you resolve issues quickly."
 redirect_from:
   - /basics/

--- a/src/docs/product/session-replay/index.mdx
+++ b/src/docs/product/session-replay/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Session Replay"
-sidebar_order: 3
+sidebar_order: 60
 description: "Learn about Sentry's Session Replay, which provides video-like reproductions of user interactions on a site or web app."
 ---
 

--- a/src/docs/product/stats/index.mdx
+++ b/src/docs/product/stats/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stats
-sidebar_order: 20
+sidebar_order: 130
 redirect_from:
   - /product/accounts/quotas/org-stats/
 description: "Learn about projects and teams across your organization."

--- a/src/docs/product/user-feedback/index.mdx
+++ b/src/docs/product/user-feedback/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: User Feedback
-sidebar_order: 70
+sidebar_order: 120
 description: "Learn how you can view user feedback submissions which, paired with the original event, give you additional insight into issues."
 ---
 


### PR DESCRIPTION
Mini adjustment, so that the docs sidebars are in-sync with the in-product navigation

**SDK sidebar**
![Screenshot 2023-06-12 at 21 09 53](https://github.com/getsentry/sentry-docs/assets/7096858/3cdbbc62-2b11-4e8d-bfd6-9aa2a9852d25)

**Product sidebar**
![Screenshot 2023-06-12 at 21 15 54](https://github.com/getsentry/sentry-docs/assets/7096858/16418128-2180-490a-b165-5a835b166396)

**Product page**

before 
![screencapture-docs-sentry-io-product-2023-06-12-21_23_38](https://github.com/getsentry/sentry-docs/assets/7096858/94c6049f-35d6-44c4-beea-e1b115b2754f)

after
![screencapture-localhost-3000-product-2023-06-12-21_23_27](https://github.com/getsentry/sentry-docs/assets/7096858/89f7c8cc-828a-4946-953a-cf984472b710)