### PR TITLE
Update react-router - why tho?

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,7 +15,7 @@ The React Router integration is designed to work with Sentry Performance Monitor
 
 </Alert>
 
-The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
+The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests. 
 
 We support integrations for React Router 3, 4, 5, and 6.
 
@@ -181,6 +181,8 @@ ReactDOM.render(
 Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (for example, `/teams/:teamid/user/:userid`), where applicable. This is only needed at the top level of your app, rather than how v4/v5 required wrapping every `<Route/>` you wanted parametrized.
 
 ## React Router v4/v5
+
+Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
 ### Parameterized Transaction Names
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,6 +15,8 @@ The React Router integration is designed to work with Sentry Performance Monitor
 
 </Alert>
 
+The React router instrumentation uses the React router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
+
 We support integrations for React Router 3, 4, 5, and 6.
 
 ## React Router v6
@@ -179,8 +181,6 @@ ReactDOM.render(
 Now, Sentry should generate `pageload`/`navigation` transactions with parameterized transaction names (for example, `/teams/:teamid/user/:userid`), where applicable. This is only needed at the top level of your app, rather than how v4/v5 required wrapping every `<Route/>` you wanted parametrized.
 
 ## React Router v4/v5
-
-The React router instrumentation uses the React router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
 ### Parameterized Transaction Names
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,7 +15,7 @@ The React Router integration is designed to work with Sentry Performance Monitor
 
 </Alert>
 
-The React router instrumentation uses the React router library to create `pageload/navigation` transactions and paramaterize transaction names. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
+The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
 We support integrations for React Router 3, 4, 5, and 6.
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,7 +15,7 @@ The React Router integration is designed to work with Sentry Performance Monitor
 
 </Alert>
 
-The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests.
+The React Router instrumentation uses the React Router library to create `pageload/navigation` transactions to ensure you collect meaningful performance data about the health of your page loads and associated requests.
 
 We support integrations for React Router 3, 4, 5, and 6.
 

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -15,7 +15,7 @@ The React Router integration is designed to work with Sentry Performance Monitor
 
 </Alert>
 
-The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests. 
+The React router instrumentation uses the React router library to create `pageload/navigation` transactions to ensure you collect meaninful performance data about the health of your page loads and assoicated requests.
 
 We support integrations for React Router 3, 4, 5, and 6.
 


### PR DESCRIPTION
Just noticing the description of why to setup react router is more halfway down the page. The version specifics are still relevant but generally i think this statement should be at the top and is applicable across

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
