### PR TITLE
Add hint about electron SDK version in source maps troubleshooting docs

### DIFF
--- a/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -7,10 +7,26 @@ For information on the legacy method of uploading source maps, please see the gu
 
 Dependency versions that require the legacy method of uploading source maps include:
 
-- JavaScript SDK version `7.46.0` or lower
-- `@sentry/webpack-plugin` package version `1.x` or lower
-- `sentry-cli` version `2.16.1` or lower
-- Sentry self-hosted or single-tenant on version `23.4.0` or lower
+<ul>
+  <PlatformSection supported={["javascript.electron"]}>
+    <li>
+      Electron SDK version <code>4.5.0</code> or lower
+    </li>
+  </PlatformSection>
+  <li>
+    JavaScript SDK version <code>7.46.0</code> or lower
+  </li>
+  <li>
+    <code>@sentry/webpack-plugin</code> package version <code>1.x</code> or
+    lower
+  </li>
+  <li>
+    <code>sentry-cli</code> version <code>2.16.1</code> or lower
+  </li>
+  <li>
+    Sentry self-hosted or single-tenant on version <code>23.4.0</code> or lower
+  </li>
+</ul>
 
 </Note>
 


### PR DESCRIPTION
Adds a hint about the required SDK version for debug IDs for the electron SDK.