### PR TITLE
Use correct license identifer in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git+https://github.com/getsentry/sentry-docs.git"
   },
   "author": "getsentry",
-  "license": "BSL-1.1",
+  "license": "BUSL-1.1",
   "bugs": {
     "url": "https://github.com/getsentry/sentry-docs/issues"
   },


### PR DESCRIPTION
I was trying to get rid of 

```sh
warning package.json: License should be a valid SPDX license expression
```

when running the docs locally. While I didn't achieve this, the change still makes sense.

`BSL-1.1` does not exists, the closest match is the [Boost Software License 1.0](https://spdx.org/licenses/BSL-1.0.html).
In our case, this repo is licensed under the [Business Source License 1.1](https://spdx.org/licenses/BUSL-1.1.html), which short identifier is `BUSL-1.1`.