### PR TITLE
Fix link to Apple debug symbols

### DIFF
--- a/src/docs/clients/react-native/manual-setup.mdx
+++ b/src/docs/clients/react-native/manual-setup.mdx
@@ -83,10 +83,6 @@ export SENTRY_PROPERTIES=../sentry.properties
 ../node_modules/@sentry/cli/bin/sentry-cli debug-files upload "$DWARF_DSYM_FOLDER_PATH"
 ```
 
-For bitcode enabled builds via iTunes Connect, additional steps are required.
-Follow the instructions at [With Bitcode](/clients/cocoa/dsym/#dsym-with-bitcode) to set up uploads of
-symbols for all build variants.
-
 Note that uploading of debug simulator builds by default is disabled for speed reasons. If you do want to also generate debug symbols for debug builds you can pass `--allow-fetch` as a parameter to `react-native-xcode` in the above mentioned build phase.
 
 ### Using node with nvm or notion

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -78,7 +78,7 @@ $SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 ```
 
 For bitcode enabled builds via iTunes Connect, additional steps are required.
-Follow the instructions in [Sentry's bitcode documentation](/clients/cocoa/dsym/#dsym-with-bitcode) to set up uploads of symbols for all build variants.
+Follow the instructions in [Sentry's bitcode documentation](/platforms/apple/dsym/) to set up uploads of symbols for all build variants.
 
 By default, uploading of debug simulator builds is disabled for speed reasons. If you want to generate debug symbols for debug builds, you can pass `--allow-fetch` as a parameter to `react-native-xcode` in the above mentioned build phase.
 

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -77,9 +77,6 @@ SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
 $SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 ```
 
-For bitcode enabled builds via iTunes Connect, additional steps are required.
-Follow the instructions in [Sentry's bitcode documentation](/platforms/apple/dsym/) to set up uploads of symbols for all build variants.
-
 By default, uploading of debug simulator builds is disabled for speed reasons. If you want to generate debug symbols for debug builds, you can pass `--allow-fetch` as a parameter to `react-native-xcode` in the above mentioned build phase.
 
 ### Using node with nvm or Volta


### PR DESCRIPTION
Fix link to Apple debug symbols page from the RN manual setup docs. This is the only remaining reference to a `/client` page from a non-`/client` page that I could find.

EDIT: since the section was specific to bitcode, and bitcode has been deprecated months ago, we decided to remove the section