### PR TITLE
Fix: Move team plan banner for metric alerts

### DIFF
--- a/src/docs/product/alerts/alert-types.mdx
+++ b/src/docs/product/alerts/alert-types.mdx
@@ -40,6 +40,8 @@ The **Alert Details** page also includes a list of issues that triggered the ale
 
 ## Metric Alerts
 
+<Include name="feature-available-for-plan-team.mdx" />
+
 Metric alerts tell you when a [metric](/product/performance/metrics/) crosses a threshold, such as a spike in the number of errors in a project, or a change in a performance metric, like [latency](/product/performance/metrics/#latency), [Apdex](/product/performance/metrics/#apdex), [failure rate](/product/performance/metrics/#failure-rate), or [throughput](/product/performance/metrics/#throughput-total-tpm-tps).
 
 Metric alerts monitor macro-level metrics for both error and transaction events. A metric takes a set of events and computes an aggregate value using a function, such as `count()` or `avg()`, applied to the event properties over a period of time. When you create a metric alert, you can filter events by attributes and <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, which is particularly useful for aggregating across events that aren't grouped into single issues.
@@ -60,8 +62,6 @@ When you create an alert, all the displayed alert types (except “Issues”) ma
 - Users Experiencing Errors
 
 ### Sessions (Crash Rate Alerts)
-
-<Include name="feature-available-for-plan-team.mdx" />
 
 Crash rate alerts tell you when the crash free percentage for either [sessions or users](/product/releases/health/#active-sessionsusers) falls below a specific threshold. This could happen because of a spike in the number of session or user [crashes](/product/releases/health/#crash). Use crash rate alerts to monitor the health of your application per project, or in a specific release
 


### PR DESCRIPTION
Move banner about team plan from sessions to metric alerts for clarity
