### PR TITLE
Fix min version for sourec code context on Flutter ios

### DIFF
--- a/src/platforms/flutter/troubleshooting.mdx
+++ b/src/platforms/flutter/troubleshooting.mdx
@@ -36,4 +36,4 @@ Flutter `split-debug-info` and `obfuscate` flags are supported on iOS/macOS. The
 
 ## Source Context
 
-Source Context support requires compiling your app using the `split-debug-info` build parameter and the latest Flutter (`master` channel), you must also upload [debug symbols](/platforms/flutter/upload-debug/).
+Source Context support requires compiling your app using the `split-debug-info` build parameter and compiling your app using Flutter, version `3.10.0` and above, you must also upload [debug symbols](/platforms/flutter/upload-debug/) with the `upload_sources` option enabled.

--- a/src/platforms/flutter/troubleshooting.mdx
+++ b/src/platforms/flutter/troubleshooting.mdx
@@ -36,4 +36,4 @@ Flutter `split-debug-info` and `obfuscate` flags are supported on iOS/macOS. The
 
 ## Source Context
 
-Source Context support requires compiling your app using the `split-debug-info` build parameter and compiling your app using Flutter, version `3.10.0` and above, you must also upload [debug symbols](/platforms/flutter/upload-debug/) with the `upload_sources` option enabled.
+Source Context support requires compiling your app using the `split-debug-info` build parameter using Flutter, version `3.10.0` and above, you must also upload [debug symbols](/platforms/flutter/upload-debug/) with the `upload_sources` option enabled.

--- a/src/platforms/flutter/troubleshooting.mdx
+++ b/src/platforms/flutter/troubleshooting.mdx
@@ -36,4 +36,4 @@ Flutter `split-debug-info` and `obfuscate` flags are supported on iOS/macOS. The
 
 ## Source Context
 
-Source Context support requires compiling your app using the `split-debug-info` build parameter using Flutter, version `3.10.0` and above, you must also upload [debug symbols](/platforms/flutter/upload-debug/) with the `upload_sources` option enabled.
+Source Context support requires compiling your app using the `split-debug-info` build parameter on Flutter `3.10.0` and above. You must also upload [debug symbols](/platforms/flutter/upload-debug/) with the `upload_sources` option enabled.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
