### PR TITLE
feat(apple): Add tracePropagationTarget to automatic instrumentation

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -163,9 +163,10 @@ SentrySDK.start { options in
 
 ### Trace Propagation Targets
 
-Sentry addes an extra header with the trace id in the outgoing HTTP requests in order to continue the transaction in the backend.
+Sentry adds an extra header with the trace id in the outgoing HTTP requests to continue the transaction in the backend.
 
-It's possible to filter out which requests Sentry should add the extra header by setting the `tracePropagationTarget` option, this way, only the app backend will receive the trace id.
+You can set the `tracePropagationTarget` option to filter which requests Sentry adds the extra header to.
+For example, to ensure that only the app backend will receive the trace id.
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -187,7 +188,7 @@ SentrySDK.start { options in
 
 The option may contain a list of NSString or NSRegularExpression against which the URLs of outgoing requests are matched. If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request. String entries do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
 
-If tracePropagationTargets is not provided, trace data is attached to every outgoing request from the instrumented client.
+If `tracePropagationTargets` is not provided, trace data is attached to every outgoing request from the instrumented client.
 
 ## File I/O Tracing
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -166,7 +166,7 @@ SentrySDK.start { options in
 Sentry adds an extra header with the trace id in the outgoing HTTP requests to continue the transaction in the backend.
 
 You can set the `tracePropagationTarget` option to filter which requests Sentry adds the extra header to.
-For example, to ensure that only the app backend will receive the trace id.
+For example, to ensure that only your app backend will receive the trace id.
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -186,7 +186,7 @@ SentrySDK.start { options in
 }];
 ```
 
-The option may contain a list of NSString or NSRegularExpression against which the URLs of outgoing requests are matched. If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request. String entries do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+The option may contain a list of `NSString` or `NSRegularExpression` against which the URLs of outgoing requests are matched. If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request. String entries do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
 
 If `tracePropagationTargets` is not provided, trace data is attached to every outgoing request from the instrumented client.
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -161,6 +161,34 @@ SentrySDK.start { options in
 [NSURLSession]: https://developer.apple.com/documentation/foundation/nsurlsession
 [NSURLConnection]: https://developer.apple.com/documentation/foundation/nsurlconnection
 
+### Trace Propagation Targets
+
+Sentry addes an extra header with the trace id in the outgoing HTTP requests in order to continue the transaction in the backend.
+
+It's possible to filter out which requests Sentry should add the extra header by setting the `tracePropagationTarget` option, this way, only the app backend will receive the trace id.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.tracePropagationTargets = ["MyAppDomain.com"]
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.tracePropagationTargets = @[@"MyAppDomain.com"]
+}];
+```
+
+The option may contain a list of NSString or NSRegularExpression against which the URLs of outgoing requests are matched. If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request. String entries do not have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+
+If tracePropagationTargets is not provided, trace data is attached to every outgoing request from the instrumented client.
+
 ## File I/O Tracing
 
 The Sentry SDK adds spans for file I/O operations to ongoing transactions bound to the scope. Currently, the SDK supports operations with [NSData][NSData], but many other APIs like [NSFileManager][NSFileManager], [NSString][NSString] and [NSBundle][NSBundle] uses [NSData][NSData].


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Added an explanation on how to filter out requests that will contain the trace id by using 'tracePropagationTarget' option.

In response to #7110 