### PR TITLE
Add Fastlane Plugin option to RN Hermes sourcemaps page

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -129,3 +129,21 @@ You will upload the `index.android.bundle` and `index.android.bundle.map` for An
 When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
 
 </Note>
+
+### Upload using Sentry Fastlane Plugin
+
+To upload generated sourcemaps using Fashlane you can use `sentry_upload_sourcemap` action. See how to install Sentry Fastlane Plguin [here](https://github.com/getsentry/sentry-fastlane-plugin).
+
+```ruby
+sentry_upload_sourcemap(
+  auth_token: 'YOUR_AUTH_TOKEN',
+  org_slug: '___ORG_SLUG___',
+  project_slug: '___PROJECT_SLUG___',
+  version: '...',
+  app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
+  dist: '...', # optional distribution of the release usually the buildnumber
+  sourcemap: ['main.jsbundle', 'main.jsbundle.map'], # Sourcemap(s) to upload. Path(s) can be a comma-separated string or an array of strings.
+  rewrite: true
+)
+```

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -130,9 +130,9 @@ When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is
 
 </Note>
 
-### Upload using Sentry Fastlane Plugin
+### Upload Using Sentry Fastlane Plugin
 
-To upload generated sourcemaps using Fashlane you can use `sentry_upload_sourcemap` action. See how to install Sentry Fastlane Plguin [here](https://github.com/getsentry/sentry-fastlane-plugin).
+To upload generated sourcemaps using Fastlane, use the `sentry_upload_sourcemap` action. See how to install Sentry Fastlane Plugin [here](https://github.com/getsentry/sentry-fastlane-plugin).
 
 ```ruby {tabTitle:Android}
 sentry_upload_sourcemap(

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -134,16 +134,30 @@ When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is
 
 To upload generated sourcemaps using Fashlane you can use `sentry_upload_sourcemap` action. See how to install Sentry Fastlane Plguin [here](https://github.com/getsentry/sentry-fastlane-plugin).
 
-```ruby
+```ruby {tabTitle:Android}
 sentry_upload_sourcemap(
   auth_token: 'YOUR_AUTH_TOKEN',
   org_slug: '___ORG_SLUG___',
   project_slug: '___PROJECT_SLUG___',
   version: '...',
-  app_identifier: '...', # pass in the bundle_identifer of your app
-  build: '...', # Optionally pass in the build number of your app
+  app_identifier: '...', # bundle_identifer of your app
+  build: '...', # optional build number of your app
   dist: '...', # optional distribution of the release usually the buildnumber
-  sourcemap: ['main.jsbundle', 'main.jsbundle.map'], # Sourcemap(s) to upload. Path(s) can be a comma-separated string or an array of strings.
+  sourcemap: ['index.android.bundle', 'index.android.bundle.map'],
+  rewrite: true
+)
+```
+
+```ruby {tabTitle:iOS}
+sentry_upload_sourcemap(
+  auth_token: 'YOUR_AUTH_TOKEN',
+  org_slug: '___ORG_SLUG___',
+  project_slug: '___PROJECT_SLUG___',
+  version: '...',
+  app_identifier: '...', # bundle_identifer of your app
+  build: '...', # optional build number of your app
+  dist: '...', # optional distribution of the release usually the buildnumber
+  sourcemap: ['main.jsbundle', 'main.jsbundle.map'],
   rewrite: true
 )
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Related to https://github.com/getsentry/sentry-fastlane-plugin/pull/195

Adding the Fastlane example to show that Hermes source map and bundle have to be uploaded in one action together.

That is a difference compared to JSC.


