### PR TITLE
unify wording for custom integration (manual vs. custom)

### DIFF
--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -3,7 +3,7 @@ title: "Profiling"
 sidebar_order: 50
 redirect_from:
   - /profiling/
-description: "Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for manual instrumentation and enabling precise code-level visibility into your application in a production environment."
+description: "Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for custom instrumentation and enabling precise code-level visibility into your application in a production environment."
 ---
 
 <Note>
@@ -20,7 +20,7 @@ description: "Profiling offers a deeper level of visibility on top of traditiona
 
 </Note>
 
-Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for manual instrumentation and enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one. Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. This allows you to quickly identify potential performance bottlenecks and visualize the call stack to find hot paths in your code.
+Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for custom instrumentation and enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one. Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. This allows you to quickly identify potential performance bottlenecks and visualize the call stack to find hot paths in your code.
 
 Sentry profiling supports common platforms for both Mobile and Backend applications:
 

--- a/src/platform-includes/performance/configure-sample-rate/javascript.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.mdx
@@ -8,7 +8,7 @@ Sentry.init({
 
   // This enables automatic instrumentation (highly recommended),
   // but is not necessary for purely manual usage
-  // If you only want to use manual instrumentation:
+  // If you only want to use custom instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
   integrations: [

--- a/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
   // This enables automatic instrumentation (highly recommended)
-  // If you only want to use manual instrumentation:
+  // If you only want to use custom instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
   integrations: [

--- a/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -9,7 +9,7 @@ Sentry.init({
 
   // This enables automatic instrumentation (highly recommended),
   // but is not necessary for purely manual usage
-  // If you only want to use manual instrumentation:
+  // If you only want to use custom instrumentation:
   // * Remove the `BrowserTracing` integration
   // * add `Sentry.addTracingExtensions()` above your Sentry.init() call
   integrations: [

--- a/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -58,7 +58,7 @@ span?.finish()
 
 In case that the user left this Activity before you've finished the transaction manually, the SDK finishes the transaction automatically when the `onDestroy` method is called.
 
-Transactions are always bound to the Scope automatically if there's none set. Because of that, you may create spans using manual instrumentation, and those spans will be automatically associated with the Activity's running transaction.
+Transactions are always bound to the Scope automatically if there's none set. Because of that, you may create spans using custom instrumentation, and those spans will be automatically associated with the Activity's running transaction.
 
 ```java
 import java.lang.Exception;
@@ -329,7 +329,7 @@ span?.finish()
 
 If the host `Activity` transitions into a non-interactive state (for example, `onPause`), the UI transaction will be scheduled to finish automatically (as soon as all of its child spans are finished).
 
-Transactions are always bound to the `Scope` automatically if there's none set. Because of that, you can create spans using manual instrumentation, and those spans will be automatically associated with the running UI transaction.
+Transactions are always bound to the `Scope` automatically if there's none set. Because of that, you can create spans using custom instrumentation, and those spans will be automatically associated with the running UI transaction.
 
 ```java
 import java.lang.Exception;

--- a/src/platforms/android/configuration/integrations/file-io.mdx
+++ b/src/platforms/android/configuration/integrations/file-io.mdx
@@ -133,7 +133,7 @@ At the moment, we only support `java.io.FileInputStream`, `java.io.FileOutputStr
 
 </Note>
 
-## (Optional) Manual Instrumentation
+## (Optional) Custom Instrumentation
 
 Alternatively, if you are not using our Gradle Plugin, the Android SDK provides the capability to manually instrument file I/O operations through the custom Sentry-specific implementations.
 

--- a/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
+++ b/src/platforms/android/configuration/integrations/room-and-sqlite.mdx
@@ -14,7 +14,7 @@ Supported in Sentry's Android SDK version `4.0.0` and above.
 
 Supported in Sentry Android Gradle Plugin version `3.0.0` and above.
 
-Manual instrumentation is supported in Sentry's Android SDK, version `6.21.0` and above.
+Custom instrumentation is supported in Sentry's Android SDK, version `6.21.0` and above.
 
 </Note>
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -284,7 +284,7 @@ If the UI transaction has idled but didn't have any child spans added, the SDK w
 
 </Note>
 
-The SDK binds user interaction transactions to the `Scope` automatically if there's no other transaction set. Because of that, you can create spans using manual instrumentation, and those spans will be automatically associated with the running UI transaction.
+The SDK binds user interaction transactions to the `Scope` automatically if there's no other transaction set. Because of that, you can create spans using custom instrumentation, and those spans will be automatically associated with the running UI transaction.
 
 ```Swift
 import Sentry

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -877,7 +877,7 @@ If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trac
 An optional list of functions that should be set up for performance monitoring. For each function in the list, a span will be created when the function is executed.
 Functions in the list are represented as strings containing the fully qualified name of the function.
 
-This is a convenient option, making it possible to have one central place for configuring what functions to trace, instead of having manual instrumentation scattered all over your code base.
+This is a convenient option, making it possible to have one central place for configuring what functions to trace, instead of having custom instrumentation scattered all over your code base.
 
 To learn more, see the [Custom Instrumentation](/platforms/python/performance/instrumentation/custom-instrumentation/#define-span-creation-in-a-central-place) documentation.
 

--- a/src/platforms/flutter/common/configuration/integrations/user-interaction-instrumentation.mdx
+++ b/src/platforms/flutter/common/configuration/integrations/user-interaction-instrumentation.mdx
@@ -57,7 +57,7 @@ final span = Sentry.getSpan()
 await span?.finish();
 ```
 
-Transactions are always bound to the `Scope` automatically if there's none set. Because of that, you can create spans using manual instrumentation, and those spans will be automatically associated with the running UI transaction.
+Transactions are always bound to the `Scope` automatically if there's none set. Because of that, you can create spans using custom instrumentation, and those spans will be automatically associated with the running UI transaction.
 
 ```dart
 import 'package:sentry/sentry.dart';

--- a/src/platforms/react-native/performance/instrumentation/user-interaction-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/user-interaction-instrumentation.mdx
@@ -54,7 +54,7 @@ export default Sentry.wrap(App, {
   dropped.
 </Note>
 
-Because transactions are automatically bound to scope, you can create child spans using [manual instrumentation](/platforms/react-native/performance/instrumentation/custom-instrumentation/#retrieve-a-transaction). Note, that the `idleTimeoout` for running UI transactions defaults to `1000` milliseconds (one second).
+Because transactions are automatically bound to scope, you can create child spans using [custom instrumentation](/platforms/react-native/performance/instrumentation/custom-instrumentation/#retrieve-a-transaction). Note, that the `idleTimeoout` for running UI transactions defaults to `1000` milliseconds (one second).
 
 ## Gesture Events
 


### PR DESCRIPTION
Use ubiquitous terms across docs