### PR TITLE
feat(mute alerts): Add mention of muting metric alerts for EA

### DIFF
--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -52,15 +52,9 @@ By default all users can mute alerts for everyone. Sentry users with manager or 
 
 </Note>
 
-Issue alerts can be muted on the alert rule details page by clicking the "Mute" button. This will mute the alert from notifying you until you click "Unmute". If you want to mute the alert from firing entirely, select "Mute for everyone" from the dropdown. If the only alert action is set to notify an integration, the only option available will be "Mute for everyone". If there are multiple alert actions which notify an integration and notify a user or team and you select "Mute for me", the integration alert will still fire.
+Both [Issue](/product/alerts/alert-types/#issue-alerts) and [Metric](/product/alerts/alert-types/#metric-alerts) alerts can be muted on the alert rule details page by clicking the "Mute" button. This will mute the alert from notifying you until you click "Unmute". If you want to mute the alert from firing entirely, select "Mute for everyone" from the dropdown. If the only alert action is set to notify an integration, the only option available will be "Mute for everyone". If there are multiple alert actions which notify an integration and notify a user or team and you select "Mute for me", the integration alert will still fire.
 
-<Note>
 
-Muting metric alerts is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
-
-</Note>
-
-Metric alerts can also be muted in the same way as issue alerts. Click [here](/product/alerts/alert-types/) to learn about the differences between issue alert and metric alerts.
 
 ## Notifications
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -54,8 +54,6 @@ By default all users can mute alerts for everyone. Sentry users with manager or 
 
 Both [Issue](/product/alerts/alert-types/#issue-alerts) and [Metric](/product/alerts/alert-types/#metric-alerts) alerts can be muted on the alert rule details page by clicking the "Mute" button. This will mute the alert from notifying you until you click "Unmute". If you want to mute the alert from firing entirely, select "Mute for everyone" from the dropdown. If the only alert action is set to notify an integration, the only option available will be "Mute for everyone". If there are multiple alert actions which notify an integration and notify a user or team and you select "Mute for me", the integration alert will still fire.
 
-
-
 ## Notifications
 
 Besides alerts, Sentry sends you notifications about various things like [issue state changes](/product/issues/states-triage/), [release deploys](/product/releases/), and [quota usage](/product/accounts/quotas/). You can fine tune these notifications, as well as your personal alert settings, in **User Settings > Notifications**. Learn more about notifications and adjusting their associated settings in [the full documentation](/product/alerts/notifications/).

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -54,6 +54,14 @@ By default all users can mute alerts for everyone. Sentry users with manager or 
 
 Issue alerts can be muted on the alert rule details page by clicking the "Mute" button. This will mute the alert from notifying you until you click "Unmute". If you want to mute the alert from firing entirely, select "Mute for everyone" from the dropdown. If the only alert action is set to notify an integration, the only option available will be "Mute for everyone". If there are multiple alert actions which notify an integration and notify a user or team and you select "Mute for me", the integration alert will still fire.
 
+<Note>
+
+Muting metric alerts is available only if you're in the Early Adopter program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony. If you’re interested in being an Early Adopter, you can turn your organization’s Early Adopter status on/off in General Settings. This will affect all users in your organization and can be turned back off just as easily.
+
+</Note>
+
+Metric alerts can also be muted in the same way as issue alerts. Click [here](/product/alerts/alert-types/) to learn about the differences between issue alert and metric alerts.
+
 ## Notifications
 
 Besides alerts, Sentry sends you notifications about various things like [issue state changes](/product/issues/states-triage/), [release deploys](/product/releases/), and [quota usage](/product/accounts/quotas/). You can fine tune these notifications, as well as your personal alert settings, in **User Settings > Notifications**. Learn more about notifications and adjusting their associated settings in [the full documentation](/product/alerts/notifications/).


### PR DESCRIPTION
Add a mention of muting metric alerts just for EA. Do not merge until EA is live.

To save you a click:
<img width="774" alt="Screenshot 2023-06-15 at 10 54 46 AM" src="https://github.com/getsentry/sentry-docs/assets/29959063/ceddb63f-6b8b-445f-94f3-31fed3d523e1">
