### PR TITLE
[DRAFT] Add redirects for top 404s

### DIFF
--- a/src/platforms/node/legacy-sdk/typescript.mdx
+++ b/src/platforms/node/legacy-sdk/typescript.mdx
@@ -8,6 +8,7 @@ noindex: true
 tags: []
 redirect_from:
   - /clients/node/typescript/
+  - /platforms/node/typescript/
 ---
 
 <Alert level="warning" title="Deprecation Warning">

--- a/vercel.json
+++ b/vercel.json
@@ -112,6 +112,10 @@
       "destination": "/platforms/$1/guides/$2/enriching-events/$3"
     },
     {
+      "source": "/enriching-error-data/(.*)",
+      "destination": "/platforms/javascript/enriching-events/$1"
+    },
+    {
       "source": "/platforms/javascript/config/sourcemaps/",
       "destination": "/platforms/javascript/sourcemaps/"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -381,6 +381,10 @@
       "destination": "/platforms/java/"
     },
     {
+      "source": "/clients/java/modules/android/",
+      "destination": "/platforms/java/android"
+    },
+    {
       "source": "/clients/javascript/integrations/angular2/",
       "destination": "/platforms/javascript/guides/angular/"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -113,7 +113,7 @@
     },
     {
       "source": "/enriching-error-data/(.*)",
-      "destination": "/platforms/javascript/enriching-events/$1"
+      "destination": "/platforms/javascript/enriching-events/"
     },
     {
       "source": "/platforms/javascript/config/sourcemaps/",

--- a/vercel.json
+++ b/vercel.json
@@ -382,7 +382,7 @@
     },
     {
       "source": "/clients/java/modules/android/",
-      "destination": "/platforms/java/android"
+      "destination": "/platforms/android"
     },
     {
       "source": "/clients/javascript/integrations/angular2/",


### PR DESCRIPTION
# Added redirects for top 404s from last 90 days

Details on the 404s

1. https://docs.sentry.io/enriching-error-data/scopes/
  - Preview link to test redirect fix: https://sentry-docs-q8ottlbhj.sentry.dev/enriching-error-data/scopes/
  - How many hits is this getting (last 90 days)
    - 191 hits
    - 161 unique users
  - Where are they coming from?
    - Linked from a [popular GitHub issue](https://github.com/getsentry/sentry-javascript/issues/1607)
    - and somewhere on our forums
  - These links use the old query string method for selecting a platform (https://docs.sentry.io/enriching-error-data/scopes/?platform=browser)
    - those platform names to match 1:1 to what we use now
    - often the url doesn't have a platform query string on it
    - this all makes it hard to navigate users to the right framework page
    - we also don't have a non-SDK specific page for this
    - since most 404 links that DO have a query string are for the browser, I'm just going to set up a redirect to the browser page
  
2. https://docs.sentry.io/clients/java/modules/android/
  - Preview link to test redirect fix: https://sentry-docs-q8ottlbhj.sentry.dev/clients/java/modules/android/
  - How many hits is this getting (last 90 days)
    - 176 hits
    - 93 unique users
  - Where are they coming from?
    - [in-product onboarding for super out of date instances of Sentry](https://github.com/getsentry/sentry/blob/6f8c3a79c534ae911a6e9ed35ca4951181a146be/fixtures/integration-docs/_platforms.json#L78)
    - [GitHub Issue](https://github.com/getsentry/sentry-java/issues/643)

3. https://docs.sentry.io/enriching-error-data/context/
  - Preview link to test redirect fix: https://sentry-docs-q8ottlbhj.sentry.dev/enriching-error-data/context/
  - How many hits is this getting (last 90 days)
    - 174 hits
    - 135 unique users
  - Where are they coming from?
    - [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/1794)
    - somewhere on our forums
    - Links on [this dude's repo](https://github.com/aandrewww/winston-transport-sentry-node/blob/5b466b42b3b7ea9c1983fd7ce5e463311ac9c072/README.md?plain=1#L87)
  - Same major issues as 1, fixed with same solution as 1.

4. https://docs.sentry.io/enriching-error-data/additional-data/
  - Preview link to test redirect fix: https://sentry-docs-q8ottlbhj.sentry.dev/enriching-error-data/additional-data/
  - How many hits is this getting (last 90 days)
    - 154 hits
    - 125 unique users
  - Where are they coming from?
    - somewhere on our forums
    - [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/2791)
    - https://thehub.github.com/ - no idea what this is
    - Some self hosted Sentry instances, but the URL doesn't appear in the repo anymore, so no concerns
  - Same major issues as 1, fixed with same solution as 1.
 
5. https://docs.sentry.io/platforms/node/typescript/
  - Preview link to test redirect fix: https://sentry-docs-q8ottlbhj.sentry.dev/platforms/node/typescript/
  - How many hits is this getting (last 90 days)
    - 129 hits
    - 98 unique users
  - Where are they coming from?
    - Somewhere on https://blog.sentry.io/
    - https://itnext.io/how-to-monitor-and-track-errors-in-your-apps-with-sentry-angular-7ef9d9b73a2a
    - [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/1857)
  - Easy fix with normal redirect in md header