### PR TITLE
docs(nextjs): Replace withSentry with wrapApiHandlerWithSentry

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -312,7 +312,7 @@ If the automatic instrumentation doesn't work for your use case, you can turn it
 For API routes, use the `wrapApiHandlerWithSentry` function:
 
 ```javascript {filename:pages/api/*}
-import { withSentry } from "@sentry/nextjs";
+import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
 
 const handler = (req, res) => {
   res.status(200).json({ name: "John Doe" });
@@ -323,7 +323,7 @@ export default wrapApiHandlerWithSentry(handler, "/api/myRoute");
 
 ```typescript {filename:pages/api/*}
 import type { NextApiRequest, NextApiResponse } from "next";
-import { withSentry } from "@sentry/nextjs";
+import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
 
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
   res.status(200).json({ name: "John Doe" });


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Imported names are wrong. They should be `wrapApiHandlerWithSentry`.