### PR TITLE
feat(replay): Add troubleshooting doc for Apollo Client response capture

### DIFF
--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -72,7 +72,7 @@ This is not a supported use-case. The replay package is built to work on a websi
 
 ## Response data for Apollo GraphQL Client network requests is not captured
 
-Apollo Client sends an abort signal via `AbortController` whenever a query completes, in order to clean up & cancel all in-flight queries. 
+Apollo Client sends an abort signal via `AbortController` whenever a query completes, in order to clean up & cancel all in-flight queries.
 This leads to the Replay not being able to capture the response body, because the request is handled as aborted before Replay can access the response.
 
 In order to avoid this, you have to disable this behavior of Apollo Client by configuring your own abort signal:

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -72,10 +72,10 @@ This is not a supported use-case. The replay package is built to work on a websi
 
 ## Response data for Apollo GraphQL Client network requests is not captured
 
-Apollo Client sends an abort signal via `AbortController` whenever a query completes, in order to clean up & cancel all in-flight queries.
-This leads to the Replay not being able to capture the response body, because the request is handled as aborted before Replay can access the response.
+Apollo Client sends an abort signal via `AbortController` whenever a query completes, to clean up and cancel all in-flight queries.
+When this happens, the Replay can't capture the response body because the request is handled as aborted before Replay can access the response.
 
-In order to avoid this, you have to disable this behavior of Apollo Client by configuring your own abort signal:
+To avoid this, disable this behavior of Apollo Client by configuring your own abort signal:
 
 ```js
 const abortController = new AbortController();

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -69,3 +69,23 @@ To hide this content, block the iframe, as described in our Session Replay <Plat
 ## Replay on My Browser Extension Doesn't Work
 
 This is not a supported use-case. The replay package is built to work on a website and not as an externally-loaded script via browser extension or other mechanism. In fact, Sentry's Session Replay product can help developers find out when a third-party Chrome extension causes otherwise hard to debug or reproduce issues with their website.
+
+## Response data for Apollo GraphQL Client network requests is not captured
+
+Apollo Client sends an abort signal via `AbortController` whenever a query completes, in order to clean up & cancel all in-flight queries. 
+This leads to the Replay not being able to capture the response body, because the request is handled as aborted before Replay can access the response.
+
+In order to avoid this, you have to disable this behavior of Apollo Client by configuring your own abort signal:
+
+```js
+const abortController = new AbortController();
+
+const httpLink = createHttpLink({
+  // ... other options
+  fetchOptions: {
+    signal: abortController.signal, // overwrite the default abort signal
+  },
+});
+```
+
+With this configuration, Replay is able to capture response bodies from Apollo Client requests.


### PR DESCRIPTION
This adds a replay troubleshooting section to explain how to get apollo client responses captured. I think it makes sense to have this as a troubleshooting section?

Closes https://github.com/getsentry/sentry-javascript/issues/8345