### PR TITLE
chore: Remove suggestion to use Bitcode

### DIFF
--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -174,6 +174,7 @@ When using Fastlane's _upload_to_testflight_ action, it's recommended to pass th
 <Note>
 
 As of April 25th, 2023, the [App Store](https://developer.apple.com/news/?id=jd9wcyov) no longer accepts submissions with bitcode enabled.
+The instructions below will only work retroactively for apps that were submitted before this date and that included bitcode.
 
 </Note>
 

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -168,3 +168,23 @@ If your App Store Connect API key is revoked on the Apple side, the Sentry custo
 ![Warning to update credentials in Custom Repositories](custom-repositories-warning.png)
 
 When using Fastlane's _upload_to_testflight_ action, it's recommended to pass the _skip_waiting_for_build_processing_ parameter to speed up the action.
+
+## Bitcode {#dsym-with-bitcode}
+
+<Note>
+
+As of April 25th, 2023, the [App Store](https://developer.apple.com/news/?id=jd9wcyov) no longer accepts submissions with bitcode enabled.
+
+</Note>
+
+If you’re using Xcode 13, you’ll need to download the dSYMs from App Store Connect after it finishes processing your build, and then upload them to Sentry using one of the methods below:
+
+- Download Fastlane's [download_dsyms](https://docs.fastlane.tools/actions/download_dsyms/) action and then upload the dSYMs with the [Sentry Fastlane plugin](#fastlane).
+- Use the [Sentry App Store Connect integration](#appstore-connect), which fetches the dSYMS directly from App Store Connect.
+- Download manually from App Store Connect:
+  - Open Xcode Organizer, go to your app, and click _Download dSYMs..._
+  - Log in to App Store Connect, go to your app > “Activity".
+  - Click the build number to go into the "detail" page, and click _Download dSYM_.
+  - Manually upload the dSYMs with [sentry-cli](#sentry-cli).
+
+These dSYMs contain obfuscated symbol names and paths. You must upload the BCSymbolMap file stored in your xcarchive so Sentry can properly symbolicate your crash reports. You can do this by using the `debug-files upload` command of either [sentry-cli](#sentry-cli) or the [Sentry Fastlane plugin](#fastlane), which will automatically find and upload all BCSymbolMap files when specifying the path to the app's xcarchive.

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -168,23 +168,3 @@ If your App Store Connect API key is revoked on the Apple side, the Sentry custo
 ![Warning to update credentials in Custom Repositories](custom-repositories-warning.png)
 
 When using Fastlane's _upload_to_testflight_ action, it's recommended to pass the _skip_waiting_for_build_processing_ parameter to speed up the action.
-
-## Bitcode {#dsym-with-bitcode}
-
-<Note>
-
-As of April 25th, 2023, the [App Store](https://developer.apple.com/news/?id=jd9wcyov) no longer accepts submissions with bitcode enabled.
-
-</Note>
-
-If you’re using Xcode 13, you’ll need to download the dSYMs from App Store Connect after it finishes processing your build, and then upload them to Sentry using one of the methods below:
-
-- Download Fastlane's [download_dsyms](https://docs.fastlane.tools/actions/download_dsyms/) action and then upload the dSYMs with the [Sentry Fastlane plugin](#fastlane).
-- Use the [Sentry App Store Connect integration](#appstore-connect), which fetches the dSYMS directly from App Store Connect.
-- Download manually from App Store Connect:
-  - Open Xcode Organizer, go to your app, and click _Download dSYMs..._
-  - Log in to App Store Connect, go to your app > “Activity".
-  - Click the build number to go into the "detail" page, and click _Download dSYM_.
-  - Manually upload the dSYMs with [sentry-cli](#sentry-cli).
-
-These dSYMs contain obfuscated symbol names and paths. You must upload the BCSymbolMap file stored in your xcarchive so Sentry can properly symbolicate your crash reports. You can do this by using the `debug-files upload` command of either [sentry-cli](#sentry-cli) or the [Sentry Fastlane plugin](#fastlane), which will automatically find and upload all BCSymbolMap files when specifying the path to the app's xcarchive.

--- a/src/platform-includes/getting-started-install/javascript.cordova.mdx
+++ b/src/platform-includes/getting-started-install/javascript.cordova.mdx
@@ -8,4 +8,4 @@ The [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your 
 
 ### iOS Specifics
 
-When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However, if you are using bitcode, you will need to disable the “Upload Debug Symbols to Sentry” build phase and then separately upload debug symbols from iTunes Connect to Sentry.
+When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps.

--- a/src/platform-includes/getting-started-install/react-native.mdx
+++ b/src/platform-includes/getting-started-install/react-native.mdx
@@ -39,7 +39,7 @@ Make sure that the version of `@sentry/react-native` matches what `sentry-expo` 
 
 ### iOS Specifics
 
-When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However, if you are using bitcode, you will need to disable the “Upload Debug Symbols to Sentry” build phase and then separately upload debug symbols from iTunes Connect to Sentry.
+When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps.
 
 ### Android Specifics
 

--- a/src/platforms/unity/native-support/index.mdx
+++ b/src/platforms/unity/native-support/index.mdx
@@ -50,18 +50,16 @@ Sentry requires [debug information files](/platforms/unity/data-management/debug
 
 The automated debug symbols upload is enabled by default but requires configuration. Go to **Tools > Sentry > Editor** to enter the [Auth Token](https://sentry.io/api/), Organization Slug, and the Project Name. Note that the Unity SDK creates a file at `Assets/Plugins/Sentry/SentryCliOptions.asset` to store the configuration, that should **not** be made publicly available.
 
-### iOS - dSYM and Bitcode
+### iOS - dSYM
 
-Debug information files on the iOS platform are called dSYM, and the way to obtain them differs depending on whether `Enable Bitcode` is set to `true` in your Xcode project.
+Debug information files on the iOS platform are called dSYM.
 
-For Sentry to symbolicate your crash logs and with `bitcode` enabled, we need two types of files:
+For Sentry to symbolicate your crash logs we need two types of files:
 
-1. `dSYM` files available only **after** App Store Connect finishes processing the build
+1. `dSYM` that the automated symbols upload will pick up at the end of the build process without further action required.
 2. `BCSymbolMap` files that are created during the archiving process
 
-The automated symbol upload will take care of the `BCSymbolMap` files by processing them during the archiving process. To provide the dSYM files to Sentry, you can either set up the [Sentry App Store Connect Integration](/platforms/apple/guides/ios/dsym/#appstore-connect) so Sentry can fetch them for you, or download them from Apple and then upload them [manually using sentry-cli](/platforms/apple/guides/ios/dsym/#sentry-cli).
-
-With `bitcode` disabled, the automated symbols upload will pick up the `dSYM` files at the end of the build process without further action required.
+The automated symbol upload will take care of the `BCSymbolMap` files by processing them during the archiving process.
 
 ### Manual Upload Using sentry-cli
 

--- a/src/wizard/react-native/index.md
+++ b/src/wizard/react-native/index.md
@@ -17,7 +17,7 @@ npx @sentry/wizard -s -i reactNative
 
 [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [setup manually](/platforms/react-native/manual-setup/manual-setup/) if you prefer.
 
-- iOS Specifics: When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However.
+- iOS Specifics: When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. ```
 - Android Specifics: We hook into Gradle for the source map build process. When you run `./gradlew assembleRelease`, source maps are automatically built and uploaded to Sentry. If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build by setting `org.gradle.configureondemand=false` or remove it.
 
 ### Initialize the SDK

--- a/src/wizard/react-native/index.md
+++ b/src/wizard/react-native/index.md
@@ -17,7 +17,7 @@ npx @sentry/wizard -s -i reactNative
 
 [Sentry Wizard](https://github.com/getsentry/sentry-wizard) will patch your project accordingly, though you can [setup manually](/platforms/react-native/manual-setup/manual-setup/) if you prefer.
 
-- iOS Specifics: When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However, if you are using bitcode, you will need to disable the “Upload Debug Symbols to Sentry” build phase and then separately upload debug symbols from iTunes Connect to Sentry.
+- iOS Specifics: When you use Xcode, you can hook directly into the build process to upload debug symbols and source maps. However.
 - Android Specifics: We hook into Gradle for the source map build process. When you run `./gradlew assembleRelease`, source maps are automatically built and uploaded to Sentry. If you have enabled Gradle's `org.gradle.configureondemand` feature, you'll need a clean build, or you'll need to disable this feature to upload the source map on every build by setting `org.gradle.configureondemand=false` or remove it.
 
 ### Initialize the SDK


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes
Apple don't support Bitcode anymore, so we remove the suggestions to use Bitcode to extract symbols.

Related to https://github.com/getsentry/sentry-docs/issues/6756