### PR TITLE
fix: replace 'Sentry Plugin Support' with 'Sentry Bundler Support'

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.mdx
@@ -16,7 +16,7 @@ We've compiled a list of guides on how to upload source maps to Sentry for the m
   </PlatformLink>
   <Note>
     If you're using one of Webpack, Vite, Rollup or Esbuild, use the
-    corresponding Sentry plugin instead (see section "Sentry Plugin Support").
+    corresponding Sentry plugin instead (see section "Sentry Bundler Support").
   </Note>
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Replaced 'Sentry Plugin Support' with 'Sentry Bundler Support'

Issue #7213

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
