### PR TITLE
Update IP address for apex domain and app.getsentry.com

### DIFF
--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -9,7 +9,7 @@ description: "Learn how Sentry's SaaS product uses IP Ranges for API usage, even
 <Alert title="Note" level="warning">
 
 The contents of this page apply only to Sentry's SaaS product. It **does not**
-apply to self-hosted or single tenant instances.
+apply to self-hosted or single tenant.
 
 </Alert>
 

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -9,7 +9,7 @@ description: "Learn how Sentry's SaaS product uses IP Ranges for API usage, even
 <Alert title="Note" level="warning">
 
 The contents of this page apply only to Sentry's SaaS product. It **does not**
-apply to Self-hosted or Single Tenant.
+apply to self-hosted or single tenant.
 
 </Alert>
 
@@ -21,7 +21,7 @@ Sentry's dashboard and API are both served from a single IP address for all web 
 35.188.42.15/32
 ```
 
-Starting 1 August 2023, Sentry's dashboard and API will both be served from a new IP address:
+Starting on 1 August 2023, Sentry's dashboard and API will both be served from a new IP address:
 
 ```
 35.186.247.156/32
@@ -40,7 +40,7 @@ Sentry's apex domain (`sentry.io`) accepts events from the same IP address as th
 35.188.42.15/32
 ```
 
-Starting 1 August 2023, Sentry's apex domain (`sentry.io`) will migrate to the same new IP address as the dashboard and API:
+Starting on 1 August 2023, Sentry's apex domain (`sentry.io`) will migrate to the same new IP address as the dashboard and API:
 
 ```
 35.186.247.156/32
@@ -52,7 +52,7 @@ Sentry's organization subdomains (`o<number>.ingest.sentry.io`) accept events fr
 34.120.195.249/32
 ```
 
-Starting 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also migrate to a new IP address:
+Starting on 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also migrate to a new IP address:
 
 ```
 34.96.102.34/32

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -21,7 +21,7 @@ Sentry's dashboard and API are both served from a single IP address for all web 
 35.188.42.15/32
 ```
 
-Starting on 1 August 2023, Sentry's dashboard and API will both be served from a new IP address:
+Starting on August 1, 2023, Sentry's dashboard and API will both be served from a new IP address:
 
 ```
 35.186.247.156/32
@@ -40,7 +40,7 @@ Sentry's apex domain (`sentry.io`) accepts events from the same IP address as th
 35.188.42.15/32
 ```
 
-Starting on 1 August 2023, Sentry's apex domain (`sentry.io`) will migrate to the same new IP address as the dashboard and API:
+Starting on August 1, 2023, Sentry's apex domain (`sentry.io`) will migrate to the same new IP address as the dashboard and API:
 
 ```
 35.186.247.156/32
@@ -52,7 +52,7 @@ Sentry's organization subdomains (`o<number>.ingest.sentry.io`) accept events fr
 34.120.195.249/32
 ```
 
-Starting on 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also migrate to a new IP address:
+Starting on August 1, 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also migrate to a new IP address:
 
 ```
 34.96.102.34/32

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -9,7 +9,7 @@ description: "Learn how Sentry's SaaS product uses IP Ranges for API usage, even
 <Alert title="Note" level="warning">
 
 The contents of this page apply only to Sentry's SaaS product. It **does not**
-apply to self-hosted or single tenant.
+apply to self-hosted or single tenant instances.
 
 </Alert>
 

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -40,7 +40,7 @@ Sentry's apex domain (`sentry.io`) accepts events from the same IP address as th
 35.188.42.15/32
 ```
 
-Starting 1 August 2023, Sentry's apex domain (`sentry.io`) will accept events from the same new IP address as the dashboard and API:
+Starting 1 August 2023, Sentry's apex domain (`sentry.io`) will migrate to the same new IP address as the dashboard and API:
 
 ```
 35.186.247.156/32
@@ -52,10 +52,10 @@ Sentry's organization subdomains (`o<number>.ingest.sentry.io`) accept events fr
 34.120.195.249/32
 ```
 
-Starting 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also use the organization subdomain IP address:
+Starting 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also migrate to a new IP address:
 
 ```
-34.120.195.249/32
+34.96.102.34/32
 ```
 
 ## Outbound Requests

--- a/src/docs/product/security/ip-ranges.mdx
+++ b/src/docs/product/security/ip-ranges.mdx
@@ -21,6 +21,12 @@ Sentry's dashboard and API are both served from a single IP address for all web 
 35.188.42.15/32
 ```
 
+Starting 1 August 2023, Sentry's dashboard and API will both be served from a new IP address:
+
+```
+35.186.247.156/32
+```
+
 ## Event Ingestion
 
 Sentry's Event Ingestion respects two domains within a Data Source Name (DSN):
@@ -34,7 +40,19 @@ Sentry's apex domain (`sentry.io`) accepts events from the same IP address as th
 35.188.42.15/32
 ```
 
-Starting December 1st, 2020, Sentry's organization subdomains (`o<number>.ingest.sentry.io`) will migrate from the prior IP address to the following single address:
+Starting 1 August 2023, Sentry's apex domain (`sentry.io`) will accept events from the same new IP address as the dashboard and API:
+
+```
+35.186.247.156/32
+```
+
+Sentry's organization subdomains (`o<number>.ingest.sentry.io`) accept events from a separate IP address:
+
+```
+34.120.195.249/32
+```
+
+Starting 1 August 2023, Sentry's legacy ingestion hostname (`app.getsentry.com`) will also use the organization subdomain IP address:
 
 ```
 34.120.195.249/32


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We'll be changing the DNS A records for `sentry.io` and `app.getsentry.com` in August 2023. This PR will update https://docs.sentry.io/product/security/ip-ranges/ to reflect the new addresses for each of those hosts, so that anyone who needs to update a firewall configuration can make the necessary changes. This also removes the effective date from the organizational subdomain text.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
