### PR TITLE
Update `createHashRouter` usage.

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -71,7 +71,7 @@ const router = sentryCreateBrowserRouter([
 
 <Alert level="warning" title="Note">
 
-While [`createHashRouter`](https://reactrouter.com/en/main/routers/create-hash-router) isn't supported by Sentry yet, you can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/routers/create-memory-router) using the `wrapCreateBrowserRouter` function.
+You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/routers/create-memory-router) and [`createHashRouter`](https://reactrouter.com/en/main/routers/create-hash-router) using the `wrapCreateBrowserRouter` function.
 
 </Alert>
 


### PR DESCRIPTION
It looks like `createHashRouter` can be wrapped by `wrapCreateBrowserRouter`.

https://github.com/getsentry/sentry-javascript/issues/8317#issuecomment-1591045500
https://github.com/getsentry/sentry-javascript/pull/8362