### PR TITLE
chore(relay): Add a new configuration option: `geoip.path`

### DIFF
--- a/src/docs/product/relay/options.mdx
+++ b/src/docs/product/relay/options.mdx
@@ -127,8 +127,10 @@ default.
 | sentry.enabled | Boolean | default: `false` | Determines whether to report internal errors to a separate DSN. `false` means that no internal errors will be sent, but will still be logged.                                        |
 | sentry.dsn     | String  | optional: `true` | Sentry DSN to which you can report internal Relay failures. We recommend setting this to a value that sends Relay errors directly to Sentry instead of sending them to itself first. |
 
-## Geoip
+## GeoIP
+
+By default, Relay does not include geographical location information in events. Set the MaxMind database file path to add GeoIP info in events.
 
 | key        | type   | value           | description                                                                                                              |
 | ---------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| geoip.path | String | default: `null` | The path to the MaxMind GeoIP City database file. When set the additional GeoIp information will be added to the events. |
+| geoip.path | String | default: `null` | The path to the MaxMind GeoIP City database file. When set the additional GeoIP information will be added to the events. |


### PR DESCRIPTION
Adds new Relay config option.

Related to https://github.com/getsentry/relay/issues/2225 and https://github.com/getsentry/relay/pull/2229

Closes https://github.com/getsentry/relay/issues/2231.