### PR TITLE
chore(android): Mention sdk 7.0.0 will capture failed HTTP requests by default

### DIFF
--- a/src/platforms/android/configuration/integrations/okhttp.mdx
+++ b/src/platforms/android/configuration/integrations/okhttp.mdx
@@ -288,9 +288,9 @@ private final OkHttpClient client = new OkHttpClient.Builder()
 
 ## HTTP Client Errors
 
-This feature, once enabled, automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
+This feature automatically captures HTTP client errors, like bad response codes, as error events and reports them to Sentry. The error event will contain the `request` and `response` data, such as `url`, `status_code`, and so on.
 
-This feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
+Starting with SDK version `7.0.0` HTTP client error capturing is enabled by default. For prior versions of the SDK this feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
 
 ```kotlin
 import okhttp3.OkHttpClient


### PR DESCRIPTION
Relevant code change: https://github.com/getsentry/sentry-java/pull/2794

To be merged once `sentry-java` `7.0.0` is released.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
