### PR TITLE
chore(android): Add troubleshooting section to NDK docs

### DIFF
--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -122,3 +122,14 @@ To support the devices on the API level lower than 16, update your `AndroidManif
 ```
 
 With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
+
+## Troubleshooting
+
+### Missing debug images / unsymbolicated stack traces
+
+When parts of your native stack traces are not symbolicated, then this could be caused due to module caching on the SDK side. In case a module gets loaded dynamically ensure to clear any existing module cache the following way:
+
+```cpp
+// load a new module
+sentry_clear_modulecache();
+```

--- a/src/platforms/android/using-ndk.mdx
+++ b/src/platforms/android/using-ndk.mdx
@@ -125,9 +125,9 @@ With these changes the SDK will be enabled on all devices with API level ≥ 14 
 
 ## Troubleshooting
 
-### Missing debug images / unsymbolicated stack traces
+### Missing Debug Images or Unsymbolicated Stack Traces
 
-When parts of your native stack traces are not symbolicated, then this could be caused due to module caching on the SDK side. In case a module gets loaded dynamically ensure to clear any existing module cache the following way:
+Unsymbolicated stack traces may be caused by module-caching on the SDK side. Be sure to clear any existing module cache if your modules are loaded dynamically:
 
 ```cpp
 // load a new module


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-java/issues/2586

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
