### PR TITLE
ref(node/serverless): Add note about performance impact of auto discovery of integrations

### DIFF
--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -15,7 +15,9 @@ Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn 
 
 <Note>
 
-If you’re adopting Performance in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
+If you're adopting Performance in a high-throughput environment, we recommend testing prior to deployment to ensure that your service's performance characteristics maintain expectations.
+
+Note that calling `Sentry.autoDiscoverNodePerformanceMonitoringIntegrations` might degrade startup performance of your app. This is especially a concern in Serverless functions. If you're experiencing this, manually add [database integrations](../../database/) of your choice instead (see example below).
 
 </Note>
 
@@ -28,7 +30,11 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // Automatically instrument Node.js libraries and frameworks
+    // (This might degrade startup performance)
     ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+    // Or manually add integrations of your choice. For example:
+    Sentry.Integrations.Apollo(),
+    Sentry.Integraionts.Postgres(),
   ],
 
   // We recommend adjusting this value in production, or using tracesSampler

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -17,7 +17,7 @@ Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn 
 
 If you're adopting Performance in a high-throughput environment, we recommend testing prior to deployment to ensure that your service's performance characteristics maintain expectations.
 
-Note that calling `Sentry.autoDiscoverNodePerformanceMonitoringIntegrations` might degrade startup performance of your app. This is especially a concern in Serverless functions. If you're experiencing this, manually add [database integrations](../../database/) of your choice instead (see example below).
+Note, that calling `Sentry.autoDiscoverNodePerformanceMonitoringIntegrations` might degrade startup performance of your app. This is especially a concern for Serverless functions. If you're experiencing this, add [database integrations](../../database/) of your choice manually (see example below).
 
 </Note>
 
@@ -30,7 +30,7 @@ Sentry.init({
     // enable HTTP calls tracing
     new Sentry.Integrations.Http({ tracing: true }),
     // Automatically instrument Node.js libraries and frameworks
-    // (This might degrade startup performance)
+    // (This function is slow because of file I/O, consider manually adding additional integrations instead)
     ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
     // Or manually add integrations of your choice. For example:
     Sentry.Integrations.Apollo(),

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -17,7 +17,9 @@ Read more about [Custom Instrumentation](./../custom-instrumentation/) to learn 
 
 If you're adopting Performance in a high-throughput environment, we recommend testing prior to deployment to ensure that your service's performance characteristics maintain expectations.
 
-Note, that calling `Sentry.autoDiscoverNodePerformanceMonitoringIntegrations` might degrade startup performance of your app. This is especially a concern for Serverless functions. If you're experiencing this, add [database integrations](../../database/) of your choice manually (see example below).
+Note, that calling `Sentry.autoDiscoverNodePerformanceMonitoringIntegrations` will degrade startup performance of your app due to file I/O operations.
+This is especially a concern in Serverless functions.
+We recommend manually adding <PlatformLink to="/performance/database" >database integrations</PlatformLink> of your choice manually (see example below).
 
 </Note>
 


### PR DESCRIPTION
This PR adds a note about the performance impact of `autoDiscoverNodePerformanceMonitoringIntegrations`. 

closes: https://github.com/getsentry/sentry-docs/issues/7221