### PR TITLE
Add hint to run production build when trying to upload source maps locally

### DIFF
--- a/src/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
@@ -183,6 +183,12 @@ We maintain an online validation tool that can be used to test your source maps 
 
 Alternatively, if you are using Sentry CLI to upload source maps to Sentry, you can use the `--validate` command line option to verify your source maps are correct.
 
+## Verify You Are Running A Production Build
+
+When running JavaScript build tools (like Webpack, Vite, ...) in development-mode/watch-mode, the generated code is sometimes incompatible with our source map uploading processes.
+
+We recommend, especially when testing locally, to run a production build to verify your source maps uploading setup.
+
 ## Verify your source maps work locally
 
 If you find that Sentry is not mapping filename, line, or column mappings correctly, you should verify that your source maps are functioning locally. To do so, you can use Node.js coupled with Mozilla's [source-map library](https://github.com/mozilla/source-map).

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -66,7 +66,7 @@ export default defineConfig({
 
 <Note>
 
-The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Vite plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -64,6 +64,13 @@ export default defineConfig({
 });
 ```
 
+<Note>
+
+The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>
+
 ### Other Bundlers
 
 If you're using a bundler other than Vite, check out our general guide on how to <PlatformLink to="/sourcemaps/uploading/">upload source maps</PlatformLink>, or refer to your bundler's documentation.

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -53,6 +53,13 @@ export default defineConfig({
 });
 ```
 
+<Note>
+
+The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>
+
 ## Other Bundlers
 
 In case you are using a bundler other than Vite to build your Vue project, we've compiled a list of guides on how to upload source maps to Sentry for the most popular JavaScript bundlers:

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 
 <Note>
 
-The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Vite plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -101,6 +101,12 @@ We maintain an online validation tool that can be used to test your source maps 
 
 Alternatively, if you are using Sentry CLI to upload source maps to Sentry, you can use the `--validate` command line option to verify your source maps are correct.
 
+## Verify You Are Running A Production Build
+
+When running JavaScript build tools (like Webpack, Vite, ...) in development-mode/watch-mode, the generated code is sometimes incompatible with our source map uploading processes.
+
+We recommend, especially when testing locally, to run a production build to verify your source maps uploading setup.
+
 ## Verify your source maps work locally
 
 If you find that Sentry is not mapping filename, line, or column mappings correctly, you should verify that your source maps are functioning locally. To do so, you can use Node.js coupled with Mozilla's [source-map library](https://github.com/mozilla/source-map).

--- a/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -63,6 +63,12 @@ Bundlers and tools (like `tsc`) that generate code, often require you to manuall
 
 If you followed one of our tool-specific guides, verify you configured your tool to emit source maps and that the source maps contain your original source code in the `sourcesContent` field.
 
+## Verify You Are Running A Production Build
+
+When running JavaScript build tools (like Webpack, Vite, ...) in development-mode/watch-mode, the generated code is sometimes incompatible with our source map uploading processes.
+
+We recommend, especially when testing locally, to run a production build to verify your source maps uploading setup.
+
 ## Verify Your Source Files Contain Debug ID Injection Snippets
 
 In the JavaScript files you uploaded to Sentry, search for code that roughly looks like `e._sentryDebugIds=e._sentryDebugIds||{}`. This code snippet might look different depending on how you process your code.

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -42,3 +42,10 @@ require("esbuild").build({
   ],
 });
 ```
+
+<Note>
+
+The Sentry esbuild plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -45,7 +45,7 @@ require("esbuild").build({
 
 <Note>
 
-The Sentry esbuild plugin does not upload source maps in watch-mode/development-mode.
+The Sentry esbuild plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -45,3 +45,10 @@ export default defineConfig({
   ],
 });
 ```
+
+<Note>
+
+The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -48,7 +48,7 @@ export default defineConfig({
 
 <Note>
 
-The Sentry Vite plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Vite plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -73,6 +73,13 @@ exports.onCreateWebpackConfig = ({ actions }) => {
 
 <Note>
 
+The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>
+
+<Note>
+
 If you use [SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin) for more fine-grained control of source map generation, turn off `noSources` so Sentry can display proper source code context in event stack traces.
 
 </Note>

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -73,7 +73,7 @@ exports.onCreateWebpackConfig = ({ actions }) => {
 
 <Note>
 
-The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Webpack plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -94,7 +94,7 @@ nx build
 
 <Note>
 
-The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Webpack plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -91,3 +91,10 @@ To upload the source maps, build your Angular application:
 ```bash
 nx build
 ```
+
+<Note>
+
+The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -111,7 +111,7 @@ ng build # add --prod for Angular versions below 13
 
 <Note>
 
-The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+The Sentry Webpack plugin doesn't upload source maps in watch-mode/development-mode.
 We recommend running a production build to test your implementation.
 
 </Note>

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -108,3 +108,10 @@ To upload the source maps, build your Angular application:
 ```bash
 ng build # add --prod for Angular versions below 13
 ```
+
+<Note>
+
+The Sentry Webpack plugin does not upload source maps in watch-mode/development-mode.
+We recommend running a production build to test your implementation.
+
+</Note>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-docs/issues/7229

When uploading source maps, it is not recommended to do it with a dev build or in watch mode. This PR adds hints in the bundler plugin sections and troubleshooting guides about this.