### PR TITLE
 Add auth token to manual Next.js setup snippet

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -135,11 +135,16 @@ const sentryWebpackPluginOptions = {
   // Additional config options for the Sentry Webpack plugin. Keep in mind that
   // the following options are set automatically, and overriding them is not
   // recommended:
-  //   release, url, authToken, configFile, stripPrefix,
+  //   release, url, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
   org: "___ORG_SLUG___",
   project: "___PROJECT_SLUG___",
+
+  // An auth token is necessary for uploading source maps and can be obtained
+  // from https://sentry.io/settings/account/api/auth-tokens/
+  // You need the `project:releases` and `org:read` scopes for uploading source maps
+  authToken: process.env.SENTRY_AUTH_TOKEN,
 
   silent: true, // Suppresses all logs
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -135,8 +135,7 @@ const sentryWebpackPluginOptions = {
   // Additional config options for the Sentry Webpack plugin. Keep in mind that
   // the following options are set automatically, and overriding them is not
   // recommended:
-  //   release, url, configFile, stripPrefix,
-  //   urlPrefix, include, ignore
+  //   release, url, configFile, stripPrefix, urlPrefix, include, ignore
 
   org: "___ORG_SLUG___",
   project: "___PROJECT_SLUG___",

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -140,9 +140,9 @@ const sentryWebpackPluginOptions = {
   org: "___ORG_SLUG___",
   project: "___PROJECT_SLUG___",
 
-  // An auth token is necessary for uploading source maps and can be obtained
-  // from https://sentry.io/settings/account/api/auth-tokens/
-  // You need the `project:releases` and `org:read` scopes for uploading source maps
+  // An auth token is required for uploading source maps.
+  // You can get an auth token from https://sentry.io/settings/account/api/auth-tokens/
+  // The token must have `project:releases` and `org:read` scopes for uploading source maps
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
   silent: true, // Suppresses all logs


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/7206#issuecomment-1602174581

The SDK will scream at you if you don't provide an auth token so we should add it to the manual setup guide.