### PR TITLE
feat(apple): Renaming enableTimeToFullDisplay to enableTimeToFullDisplayTracing

### DIFF
--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -65,7 +65,7 @@ SentrySDK.start { options in
     options.attachViewHierarchy = true
     options.enablePreWarmedAppStartTracing = true
     options.enableMetricKit = true
-    options.enableTimeToFullDisplay = true
+    options.enableTimeToFullDisplayTracing = true
     options.swiftAsyncStacktraces = true
 }
 ```
@@ -80,7 +80,7 @@ SentrySDK.start { options in
     options.attachViewHierarchy = YES;
     options.enablePreWarmedAppStartTracing = YES;
     options.enableMetricKit = YES;
-    options.enableTimeToFullDisplay = YES;
+    options.enableTimeToFullDisplayTracing = YES;
 }];
 ```
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -366,7 +366,7 @@ import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableTimeToFullDisplay = true
+    options.enableTimeToFullDisplayTracing = true
 }
 ```
 
@@ -375,7 +375,7 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableTimeToFullDisplay = YES;
+    options.enableTimeToFullDisplayTracing = YES;
 }];
 ```
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -135,7 +135,7 @@ SentrySDK.start { options in
     options.attachViewHierarchy = true
     options.enablePreWarmedAppStartTracing = true
     options.enableMetricKit = true
-    options.enableTimeToFullDisplay = true
+    options.enableTimeToFullDisplayTracing = true
     options.swiftAsyncStacktraces = true
 }
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Renaming `enableTimeToFullDisplay` to `enableTimeToFullDisplayTracing` to reflect latest changes.