### PR TITLE
feat(wizard): Simplify iOS wizard and align with best-converting platforms

### DIFF
--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -7,18 +7,17 @@ type: language
 
 ## Install
 
-We recommend installing the SDK with CocoaPods, but we also support [alternate installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your Podfile:
+We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternate installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the Git repo url in the top right search field:
 
-```ruby
-platform :ios, '11.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
+```text
+https://github.com/getsentry/sentry-cocoa.git
 ```
 
-Afterwards run `pod install`.
+Alternatively, when your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
+
+```swift {tabTitle:Swift}
+.package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{@inject packages.version('sentry.cocoa') }}"),
+```:
 
 ## Configure
 
@@ -106,7 +105,7 @@ SentrySDK.start { options in
 
 ## Next Steps
 
-- [SPM/Carthage](/platforms/apple/install/): Learn about integrating Sentry into your project using Swift Package Manager or Carthage.
+- [CocoaPods/Carthage](/platforms/apple/install/): Learn about integrating Sentry into your project using CocoaPods or Carthage.
 - [Debug Symbols](/platforms/apple/dsym/): Symbolicate and get readable stacktraces in your Sentry errors.
 - [SwiftUI](/platforms/apple/performance/instrumentation/swiftui-instrumentation/): Learn about our first class integration with SwiftUI.
 - [Profiling](/platforms/apple/profiling/): Collect and analyze performance profiles from real user devices in production.

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -67,7 +67,7 @@ struct SwiftUIApp: App {
 
 ## Verify
 
-This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your main `ViewController`.
+This snippet contains an intentional error you can use to test that errors are uploaded to Sentry correctly. You can add it to your main `ViewController`.
 
 ```swift
 let button = UIButton(type: .roundedRect)

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -17,7 +17,7 @@ Alternatively, when your project uses a `Package.swift` file to manage dependenc
 
 ````swift {tabTitle:Swift}
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{@inject packages.version('sentry.cocoa') }}"),
-```:
+```
 
 ## Configure
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -15,7 +15,7 @@ https://github.com/getsentry/sentry-cocoa.git
 
 Alternatively, when your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
 
-````swift {tabTitle:Swift}
+```swift {tabTitle:Swift}
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{@inject packages.version('sentry.cocoa') }}"),
 ```
 
@@ -42,7 +42,7 @@ func application(_ application: UIApplication,
 
     return true
 }
-````
+```
 
 When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -15,7 +15,7 @@ https://github.com/getsentry/sentry-cocoa.git
 
 Alternatively, when your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
 
-```swift {tabTitle:Swift}
+````swift {tabTitle:Swift}
 .package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{@inject packages.version('sentry.cocoa') }}"),
 ```:
 
@@ -42,7 +42,7 @@ func application(_ application: UIApplication,
 
     return true
 }
-```
+````
 
 When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
 

--- a/src/wizard/apple/ios.md
+++ b/src/wizard/apple/ios.md
@@ -5,11 +5,9 @@ support_level: production
 type: language
 ---
 
-We support installing the SDK with [CocoaPods](/platforms/apple/install/cocoapods/), [Swift Package Manager](/platforms/apple/install/swift-package-manager/), and [Carthage](/platforms/apple/install/carthage/).
+## Install
 
-### CocoaPods
-
-To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with CocoaPods, but we also support [alternate installation methods](/platforms/apple/install/). To integrate Sentry into your Xcode project, specify it in your Podfile:
 
 ```ruby
 platform :ios, '11.0'
@@ -20,35 +18,9 @@ target 'YourApp' do
 end
 ```
 
-Afterwards run `pod install`. For more information visit the [docs](/platforms/apple/install/cocoapods/).
+Afterwards run `pod install`.
 
-### Swift Package Manager
-
-To integrate Sentry into your Xcode project using Swift Package Manager (SPM), open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the Git repo url in the top right search field:
-
-```text
-https://github.com/getsentry/sentry-cocoa.git
-```
-
-Alternatively, when your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
-
-```swift {tabTitle:Swift}
-.package(url: "https://github.com/getsentry/sentry-cocoa", from: "{{@inject packages.version('sentry.cocoa') }}"),
-```
-
-For more information visit the [docs](/platforms/apple/install/swift-package-manager/).
-
-### Carthage
-
-To integrate Sentry into your Xcode project using Carthage, specify it in your `Cartfile`:
-
-```ruby
-github "getsentry/sentry-cocoa" "{{@inject packages.version('sentry.cocoa') }}"
-```
-
-Run `carthage update` to download the framework and drag the built `Sentry.framework` into your Xcode project. For more information visit the [docs](/platforms/apple/install/carthage/).
-
-## Configuration
+## Configure
 
 Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
@@ -93,33 +65,23 @@ struct SwiftUIApp: App {
 }
 ```
 
-## Debug Symbols
+## Verify
 
-To capture crashes, you need to provide debug information to Sentry. You can also use our source context feature to display code snippets next to the event stack traces by enabling the `include-sources` option when uploading your debug information files. Debug information is provided by [uploading dSYM files](/platforms/apple/dsym/).
+This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your main `ViewController`.
 
-## Performance Monitoring
+```swift
+let button = UIButton(type: .roundedRect)
+button.frame = CGRect(x: 20, y: 50, width: 100, height: 30)
+button.setTitle("Break the world", for: [])
+button.addTarget(self, action: #selector(self.breakTheWorld(_:)), for: .touchUpInside)
+view.addSubview(button)
 
-After [setting up performance monitoring](/platforms/apple/guides/ios/performance), the Cocoa SDK [automatically instruments](/platforms/apple/performance/instrumentation/automatic-instrumentation/) UIViewControllers, HTTP requests, app start, and slow and frozen frames.
-
-You can manually measure the performance of your code by capturing transactions and spans.
-
-```swift {tabTitle:Swift}
-import Sentry // Make sure you import Sentry
-
-// Transaction can be started by providing, at minimum, the name and the operation
-let transaction = SentrySDK.startTransaction(name: "Update Repos", operation: "db")
-// Transactions can have child spans (and those spans can have child spans as well)
-let span = transaction.startChild(operation: "db", description: "Update first repo")
-
-// ...
-// (Perform the operation represented by the span/transaction)
-// ...
-
-span.finish() // Mark the span as finished
-transaction.finish() // Mark the transaction as finished and send it to Sentry
+@IBAction func breakTheWorld(_ sender: AnyObject) {
+    fatalError("Break the world")
+}
 ```
 
-Check out [the documentation](https://docs.sentry.io/platforms/apple/performance/instrumentation/) to learn more about the API and automatic instrumentations.
+### Experimental Features
 
 > Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stacktraces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
 >
@@ -140,6 +102,11 @@ SentrySDK.start { options in
 }
 ```
 
-## Performance Monitoring for SwiftUI
+---
 
-If you want to find out the performance of your Views in a SwiftUI project, [try the SentrySwiftUI library](/platforms/apple/performance/instrumentation/swiftui-instrumentation).
+## Next Steps
+
+- [SPM/Carthage](/platforms/apple/install/): Learn about integrating Sentry into your project using Swift Package Manager or Carthage.
+- [Debug Symbols](/platforms/apple/dsym/): Symbolicate and get readable stacktraces in your Sentry errors.
+- [SwiftUI](/platforms/apple/performance/instrumentation/swiftui-instrumentation/): Learn about our first class integration with SwiftUI.
+- [Profiling](/platforms/apple/profiling/): Collect and analyze performance profiles from real user devices in production.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We'd like to improve the Create Project -> Sent First Error conversion for native mobile platforms, therefore refining the wizard docs and aligning them with the best-converting platforms like react/django/nextjs.

I'm focusing on iOS only for now, but let me know if I should do the same changes for macos/apple generic wizard.

Rendered version:
![image](https://github.com/getsentry/sentry-docs/assets/4999776/9da859ce-9a31-47f5-bdee-7c5385413752)
![image](https://github.com/getsentry/sentry-docs/assets/4999776/d8cb0a64-56ae-4fdc-9343-78211d8e7a56)
![image](https://github.com/getsentry/sentry-docs/assets/4999776/2f4ff54a-8092-45c8-a3bf-5d8f7abf75f1)

