### PR TITLE
Changing parent sampled flag breaks distributed traces. 

### DIFF
--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -109,7 +109,7 @@ In its simplest form, used just for filtering the transaction, it looks like thi
 
 It also allows you to sample different transactions at different rates.
 
-If the transaction currently being processed is has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.)
+If the transaction currently being processed has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.) See <PlatformLink to="/configuration/sampling/#inheritance">Inheriting the parent sampling decision</PlatformLink> to learn more.
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -109,6 +109,8 @@ In its simplest form, used just for filtering the transaction, it looks like thi
 
 It also allows you to sample different transactions at different rates.
 
+If the transaction currently being processed is has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.)
+
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 
 <PlatformSection supported={["node", "javascript", "php", "go", "python", "java", "ruby"]}>

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -109,7 +109,7 @@ In its simplest form, used just for filtering the transaction, it looks like thi
 
 It also allows you to sample different transactions at different rates.
 
-If the transaction currently being processed has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.) See <PlatformLink to="/configuration/sampling/#inheritance">Inheriting the parent sampling decision</PlatformLink> to learn more.
+If the transaction currently being processed has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. Resulting in not all your services showing up in the trace. See <PlatformLink to="/configuration/sampling/#inheritance">Inheriting the parent sampling decision</PlatformLink> to learn more.
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 

--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -109,7 +109,7 @@ In its simplest form, used just for filtering the transaction, it looks like thi
 
 It also allows you to sample different transactions at different rates.
 
-If the transaction currently being processed has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. Resulting in not all your services showing up in the trace. See <PlatformLink to="/configuration/sampling/#inheritance">Inheriting the parent sampling decision</PlatformLink> to learn more.
+If the transaction currently being processed has a parent transaction (from an upstream service calling this service), the parent (upstream) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. A broken trace will not include all your services. See <PlatformLink to="/configuration/sampling/#inheritance">Inheriting the parent sampling decision</PlatformLink> to learn more.
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -121,7 +121,7 @@ Whatever a transaction's sampling decision, that decision will be passed to its 
 
 </PlatformSection>
 
-If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will be included in the sampling context data. Your <PlatformIdentifier name="traces-sampler" /> can use this information to choose whether to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. Resulting in not all your services showing up in the trace.
+If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will be included in the sampling context data. Your <PlatformIdentifier name="traces-sampler" /> can use this information to choose whether to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. A broken trace will not include all your services.
 
 <PlatformContent includePath="performance/always-inherit-sampling-decision">
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -121,7 +121,7 @@ Whatever a transaction's sampling decision, that decision will be passed to its 
 
 </PlatformSection>
 
-If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid partial traces.)
+If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.)
 
 <PlatformContent includePath="performance/always-inherit-sampling-decision">
 
@@ -154,7 +154,7 @@ There are multiple ways for a transaction to end up with a sampling decision.
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
 1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" />, that decision will be used, overriding everything else.
-1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction.
+1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction. (We adive against overriding the parent sampling decision, because it will break distirbuted traces.)
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -121,7 +121,7 @@ Whatever a transaction's sampling decision, that decision will be passed to its 
 
 </PlatformSection>
 
-If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will be included in the sampling context data. Your <PlatformIdentifier name="traces-sampler" /> can use this information to choose whether to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces.
+If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will be included in the sampling context data. Your <PlatformIdentifier name="traces-sampler" /> can use this information to choose whether to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces. Resulting in not all your services showing up in the trace.
 
 <PlatformContent includePath="performance/always-inherit-sampling-decision">
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -121,7 +121,7 @@ Whatever a transaction's sampling decision, that decision will be passed to its 
 
 </PlatformSection>
 
-If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will always be included in the sampling context data, so that your <PlatformIdentifier name="traces-sampler" /> can choose whether and when to inherit that decision. (In most cases, inheritance is the right choice, to avoid breaking distributed traces.)
+If the transaction currently being created is one of those subsequent transactions (in other words, if it has a parent transaction), the upstream (parent) sampling decision will be included in the sampling context data. Your <PlatformIdentifier name="traces-sampler" /> can use this information to choose whether to inherit that decision. In most cases, inheritance is the right choice, to avoid breaking distributed traces.
 
 <PlatformContent includePath="performance/always-inherit-sampling-decision">
 

--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -154,7 +154,7 @@ There are multiple ways for a transaction to end up with a sampling decision.
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
 1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" />, that decision will be used, overriding everything else.
-1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, or use the sampling context data to make its own decision or choose a sample rate for the transaction. (We adive against overriding the parent sampling decision, because it will break distirbuted traces.)
+1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, use the sampling context data to make its own decision, or choose a sample rate for the transaction. We advise against overriding the parent sampling decision because it will break distributed traces)
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 


### PR DESCRIPTION
Make it explicit, that if the parent sample decision is overridden, then distributed traces break.
