### PR TITLE
Update early-adopter.mdx

### DIFF
--- a/src/docs/product/accounts/early-adopter.mdx
+++ b/src/docs/product/accounts/early-adopter.mdx
@@ -20,5 +20,3 @@ Limitations:
 - [Grouping Breakdown](/product/data-management-settings/event-grouping/grouping-breakdown/)
 - [Issue Reprocessing](/product/issues/reprocessing/)
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
-- Organization Domains - Instead of being a path segment, organization slugs are used as a subdomain for [sentry.io](https://sentry.io). For example, `https://acme.sentry.io/issues/` replaces `https://sentry.io/organizations/acme/issues/`. API URLs are unchanged.
-- [Team-level Roles](https://sentry-docs-git-update-org-and-user-managment-page.sentry.dev/product/accounts/membership/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F6934#team-level-roles)


### PR DESCRIPTION
Remove team roles and org slug from list of EA features, since they are now in GA
