### PR TITLE
Documentation Update: Unmerging and Deleting Events.

### DIFF
--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -128,7 +128,7 @@ By default, the **Let Members Delete Events** option in **Settings > General Set
 
 When this option is enabled, members are granted the `event:admin` scope and allowed to delete and unmerge events, including the delete and discard actions.
 
-If the "Let Members Delete Events" option is toggled off, members will still be able to merge events, but they will not have the ability to unmerge them.
+If the "Let Members Delete Events" option is disabled, members will still be able to merge events, but they will not have the ability to unmerge them.
 
 ## Transfer a Project
 

--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -126,7 +126,7 @@ If "Open Membership" is toggled off, team access is on an invite-only basis. Use
 
 By default, the **Let Members Delete Events** option in **Settings > General Settings** is enabled.
 
-When this option is enabled, members with the event:admin scope are granted permission to delete and unmerge events, including the delete and discard actions.
+When this option is enabled, members are granted the `event:admin` scope and allowed to delete and unmerge events, including the delete and discard actions.
 
 If the "Let Members Delete Events" option is toggled off, members will still be able to merge events, but they will not have the ability to unmerge them.
 

--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -122,6 +122,14 @@ To restrict access to teams and projects, turn off "Open Membership" for the org
 
 If "Open Membership" is toggled off, team access is on an invite-only basis. Users can request to join a team and invite others to join their teams, but access requests and invitations must be approved by an Org Manager, Org Owner, or a Team Admin for that team. Org Admins who aren't part of the team also need to follow this process to join. Once they join, they automatically become a Team Admin.
 
+### Unmerge and Delete Events
+
+By default, the **Let Members Delete Events** option in **Settings > General Settings** is enabled.
+
+When this option is enabled, members with the event:admin scope are granted permission to delete and unmerge events, including the delete and discard actions.
+
+If the "Let Members Delete Events" option is toggled off, members will still be able to merge events, but they will not have the ability to unmerge them.
+
 ## Transfer a Project
 
 Only Org Owners can transfer a project to another organization. To do so, go to the target project's **Project Settings > General Settings** and click "Transfer Project". Enter the new Org Owner's email. The Owner for the receiving organization then receives an email to approve the transfer.


### PR DESCRIPTION
Alerting users on the downside of having "Let Members Delete Events" switched off.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
