### PR TITLE
Change Maven plugin to execution phase generate-resources

### DIFF
--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -225,7 +225,7 @@ Add the [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) 
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>

--- a/src/wizard/java/index.md
+++ b/src/wizard/java/index.md
@@ -97,7 +97,7 @@ To upload your source code to Sentry so it can be shown in stack traces, use our
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>

--- a/src/wizard/java/log4j2.md
+++ b/src/wizard/java/log4j2.md
@@ -54,7 +54,7 @@ To upload your source code to Sentry so it can be shown in stack traces, use our
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>

--- a/src/wizard/java/logback.md
+++ b/src/wizard/java/logback.md
@@ -54,7 +54,7 @@ To upload your source code to Sentry so it can be shown in stack traces, use our
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>

--- a/src/wizard/java/spring-boot.md
+++ b/src/wizard/java/spring-boot.md
@@ -119,7 +119,7 @@ To upload your source code to Sentry so it can be shown in stack traces, use our
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>

--- a/src/wizard/java/spring.md
+++ b/src/wizard/java/spring.md
@@ -72,7 +72,7 @@ To upload your source code to Sentry so it can be shown in stack traces, use our
             </configuration>
             <executions>
                 <execution>
-                    <phase>install</phase>
+                    <phase>generate-resources</phase>
                     <goals>
                         <goal>uploadSourceBundle</goal>
                     </goals>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/7241

Also updating our sample https://github.com/getsentry/sentry-maven-plugin/pull/6

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
