### PR TITLE
[Python] Added deprecation message to `propagate_traces` in CeleryIntegration

### DIFF
--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -90,7 +90,15 @@ sentry_sdk.init(
 
 You can pass the following keyword arguments to `CeleryIntegration()`:
 
-- `propagate_traces`
+- `propagate_traces` [DEPRECATED]
+
+  <Alert>
+
+  **This option is deprecated and will be removed in the future!**
+
+  Please see <PlatformLink to="/configuration/filtering/">Filtering</PlatformLink> to learn how to filter events or information in events.
+
+  </Alert>
 
   Propagate Sentry tracing information to the Celery task. This makes it possible to link errors in Celery tasks to the function that triggered the Celery task. If this is set to `False`, errors in Celery tasks can't be matched to the triggering function.
 


### PR DESCRIPTION
The option `propagate_traces` in `CeleryIntegration` is deprecated. 

This adds a message plus a link to the documentation where one can learn how to replace the option.