### PR TITLE
fix(apple): Replace references to master with main

### DIFF
--- a/src/platform-includes/capture-error/apple.mdx
+++ b/src/platform-includes/capture-error/apple.mdx
@@ -44,7 +44,7 @@ For the Swift error above Sentry displays:
 
 ### Customizing Error Descriptions
 
-This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7250) and above.
+This feature is available on [sentry-cocoa 7.25.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#7250) and above.
 
 You may want to provide a custom description to make identifying the error in the **Issues** page easier. For `NSError` values, you can do this by adding a description to the `userInfo` dictionary with the key `NSDebugDescriptionErrorKey`.
 

--- a/src/platform-includes/performance/default-sampling-context-platform/apple.mdx
+++ b/src/platform-includes/performance/default-sampling-context-platform/apple.mdx
@@ -1,1 +1,1 @@
-For Apple SDKs, it includes a [Transaction Context](https://github.com/getsentry/sentry-cocoa/blob/master/Sources/Sentry/Public/SentryTransactionContext.h) and a custom sampling context (`string` to `object` dictionary).
+For Apple SDKs, it includes a [Transaction Context](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/Public/SentryTransactionContext.h) and a custom sampling context (`string` to `object` dictionary).

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -312,7 +312,7 @@ event.message = [SentryMessage messageWithFormatted:"Hello World"];
 
 In 5.x, you could pass a nullable scope to capture methods of the SDK, Hub, and Client, such as `SentrySdk.captureMessage()`. In 6.x, we changed the Scope to nonnull and provide overloads for the Hub and the Client.
 
-Please see the [Changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md) for a complete list of changes.
+Please see the [Changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md) for a complete list of changes.
 
 ## Upgrading From 4.x to 5.x
 


### PR DESCRIPTION



## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Replace all links pointing to master with main. Related to #7261.
