### PR TITLE
Add source maps wizard instructions to Getting Started pages

### DIFF
--- a/src/platform-includes/getting-started-sourcemaps/javascript.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.mdx
@@ -6,4 +6,4 @@ To fix this, upload your source maps to Sentry. The easiest way to do this is to
 
 <Include name="sourcemaps-wizard-instructions.mdx" />
 
-For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.
+For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">Source Maps</PlatformLink> documentation.

--- a/src/platform-includes/getting-started-sourcemaps/javascript.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.mdx
@@ -4,6 +4,6 @@ Depending on how you've set up your JavaScript project, the stack traces in your
 
 To fix this, upload your source maps to Sentry. The easiest way to do this is to use the Sentry Wizard:
 
-<Include name="sourcemaps-wizard-instructions.mdx"/>
+<Include name="sourcemaps-wizard-instructions.mdx" />
 
 For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.

--- a/src/platform-includes/getting-started-sourcemaps/javascript.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.mdx
@@ -2,4 +2,8 @@
 
 Depending on how you've set up your JavaScript project, the stack traces in your Sentry errors probably don't look like your actual code.
 
-To fix this, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink> where you'll learn how to upload source maps, so you can make sense of your stack traces.
+To fix this, upload your source maps to Sentry. The easiest way to do this is to use the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx"/>
+
+For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.

--- a/src/platform-includes/getting-started-sourcemaps/node.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/node.mdx
@@ -1,5 +1,9 @@
 ## Add Readable Stack Traces to Errors
 
-Depending on how you've set up your JavaScript project, the stack traces in your Sentry errors probably don't look like your actual code.
+Depending on how you've set up your Node project, the stack traces in your Sentry errors probably don't look like your actual code.
 
-To fix this, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink> where you'll learn how to upload source maps, so you can make sense of your stack traces.
+To fix this, upload your source maps to Sentry. The easiest way to do this is to use the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx"/>
+
+For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.

--- a/src/platform-includes/getting-started-sourcemaps/node.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/node.mdx
@@ -6,4 +6,4 @@ To fix this, upload your source maps to Sentry. The easiest way to do this is to
 
 <Include name="sourcemaps-wizard-instructions.mdx" />
 
-For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.
+For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">Source Maps</PlatformLink> documentation.

--- a/src/platform-includes/getting-started-sourcemaps/node.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/node.mdx
@@ -4,6 +4,6 @@ Depending on how you've set up your Node project, the stack traces in your Sentr
 
 To fix this, upload your source maps to Sentry. The easiest way to do this is to use the Sentry Wizard:
 
-<Include name="sourcemaps-wizard-instructions.mdx"/>
+<Include name="sourcemaps-wizard-instructions.mdx" />
 
 For more information on source maps or for more options to upload them, head over to our <PlatformLink to="/sourcemaps/">source maps documentation</PlatformLink>.

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -36,6 +36,12 @@ Sentry supports multiple versions of React Router. See the <PlatformLink to="/co
 
 <PlatformContent includePath="getting-started-config" />
 
+<PlatformSection supported={["javascript", "node"]}>
+
+<PlatformContent includePath="getting-started-sourcemaps" />
+
+</PlatformSection>
+
 ## Verify
 
 <PlatformSection notSupported={["unreal"]}>
@@ -53,11 +59,5 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 </Note>
 
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
-
-<PlatformSection supported={["javascript", "node"]}>
-
-<PlatformContent includePath="getting-started-sourcemaps" />
-
-</PlatformSection>
 
 <PageGrid header="Next Steps" nextSteps />


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR is Part 2 of #7304. It adds instructions for the new source maps wizard to the "Getting Started" pages of all JS/Node frameworks that don't come with automatic source maps upload included.

closes #7300 