### PR TITLE
Document Debug File Retention Policy

### DIFF
--- a/src/platform-includes/sourcemaps/artifact-bundles/javascript.mdx
+++ b/src/platform-includes/sourcemaps/artifact-bundles/javascript.mdx
@@ -25,3 +25,10 @@ Since you might still want to know to which release a specific artifact bundle i
 The new Artifact Bundle format supports a new kind of association to a `release` and optionally `dist`, known as weak release association. This type of association **will not require the creation of a `release`** before uploading sourcemaps and will consequentely allow the creation of a `release` as a separate step down the pipeline.
 
 With an associated `release` and optionally `dist` you will be able to quickly go to the Artifact Bundle from your `release` in Sentry, without having to worry about which artifact bundle was used for your errors.
+
+## Retention Policy
+
+Artifact Bundles have a retention period of _90 days_, using a _time to idle_ expiration mechanism.
+This means that uploaded artifact bundles are retained for as long as they are actively being used for event processing.
+Once an artifact bundle has not been used to process incoming events for at least 90 days,
+it will automatically expire and be eligible for deletion.

--- a/src/platforms/common/data-management/debug-files/index.mdx
+++ b/src/platforms/common/data-management/debug-files/index.mdx
@@ -69,6 +69,13 @@ ProGuard files are listed separately, in the _ProGuard_ section of the project s
 
 </Note>
 
+## Retention Policy
+
+Debug Files have a retention period of _90 days_, using a _time to idle_ expiration mechanism.
+This means that uploaded debug files are retained for as long as they are actively being used for event processing.
+Once a debug file has not been used to process incoming events for at least 90 days,
+it will automatically expire and be eligible for deletion.
+
 ## Learn More
 
 <PageGrid />


### PR DESCRIPTION
This documents the time-to-idle retention policy of debug files. After 90 days of being idle, we will delete them.