### PR TITLE
[Python] Add template meta helper docs for Django/Fastapi/Starlette/Flask.

### DIFF
--- a/src/platform-includes/distributed-tracing/custom-instrumentation/python.mdx
+++ b/src/platform-includes/distributed-tracing/custom-instrumentation/python.mdx
@@ -50,6 +50,8 @@ In this example, tracing information is propagated to the project running at `ht
 
 The two services are now connected with your custom distributed tracing implementation.
 
+<PlatformSection supported={["python"]}  notSupported={["python.django", "python.flask", "python.fastapi", "python.starlette"]}>
+
 ### Inject Tracing Information Into Rendered HTML
 
 To propagate tracing information into JavaScript running in rendered HTML you have to inject HTML `meta` tags for `sentry-trace` and `baggage` data into your rendered HTML. Here's an example:
@@ -78,6 +80,159 @@ html = """
 render(html)
 
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={["python.django"]}>
+
+### Inject Tracing Information Into Rendered HTML
+
+To propagate tracing information into JavaScript running in rendered HTML you have to inject HTML `meta` tags in your rendered HTML. For Django Sentry provides a variable `sentry_trace_meta` to your template context:
+
+```html {filename: myproject/templates/mydjangoapp/index.html}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    {{ sentry_trace_meta }}
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+The rendered template will then look something like this:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="sentry-trace" content="98e5de1c09e444469475855d313e22c3-b995922394e8433d" />
+    <meta name="baggage" content="sentry-trace_id=98e5de1c09e444469475855d313e22c3,sentry-environment=prod,sentry-public_key=..." />
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+</PlatformSection>
+
+<PlatformSection supported={["python.flask"]}>
+
+### Inject Tracing Information Into Rendered HTML
+
+To propagate tracing information into JavaScript running in rendered HTML you have to inject HTML `meta` tags in your rendered HTML. For Flask Sentry provides a variable `sentry_trace_meta` to your template context:
+
+```html {filename: templates/index.html}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    {{ sentry_trace_meta }}
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+The rendered template will then look something like this:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="sentry-trace" content="98e5de1c09e444469475855d313e22c3-b995922394e8433d" />
+    <meta name="baggage" content="sentry-trace_id=98e5de1c09e444469475855d313e22c3,sentry-environment=prod,sentry-public_key=..." />
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+
+
+</PlatformSection>
+
+<PlatformSection supported={["python.fastapi"]}>
+
+### Inject Tracing Information Into Rendered HTML
+
+To propagate tracing information into JavaScript running in rendered HTML you have to inject HTML `meta` tags in your rendered HTML. For FastAPI Sentry provides a variable `sentry_trace_meta` to your Jinja2 template context:
+
+```html {filename: templates/index.html}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    {{ sentry_trace_meta }}
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+The rendered template will then look something like this:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="sentry-trace" content="98e5de1c09e444469475855d313e22c3-b995922394e8433d" />
+    <meta name="baggage" content="sentry-trace_id=98e5de1c09e444469475855d313e22c3,sentry-environment=prod,sentry-public_key=..." />
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+</PlatformSection>
+
+<PlatformSection supported={["python.starlette"]}>
+
+### Inject Tracing Information Into Rendered HTML
+
+To propagate tracing information into JavaScript running in rendered HTML you have to inject HTML `meta` tags in your rendered HTML. For Starlette Sentry provides a variable `sentry_trace_meta` to your Jinja2 template context:
+
+```html {filename: templates/index.html}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    {{ sentry_trace_meta }}
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+The rendered template will then look something like this:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="sentry-trace" content="98e5de1c09e444469475855d313e22c3-b995922394e8433d" />
+    <meta name="baggage" content="sentry-trace_id=98e5de1c09e444469475855d313e22c3,sentry-environment=prod,sentry-public_key=..." />
+  </head>
+  <body>
+    <p>This is a website.</p>
+  </body>
+</html>
+```
+
+
+</PlatformSection>
 
 ## Verification
 


### PR DESCRIPTION
We have a new feature to make it easier for Python users to inject tracing information into rendered HTML. (This helps when users want to connect the Python backend to a JS frontend)

PR of the feature: https://github.com/getsentry/sentry-python/issues/2186