### PR TITLE
fix: Use `___PUBLIC_DSN___` instead of `___DSN___` for all current SDKs

### DIFF
--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -11,7 +11,7 @@ const store = createStore(
 
 <Alert level="info" title="Note">
 
-Because Sentry uses a redux **enhancer**, you should pass it as indicated above rather than passing it to`applyMiddleware`. Don't call the method when you pass it to `createStore`.
+Because Sentry uses a redux **enhancer**, you should pass it as indicated above rather than passing it to `applyMiddleware`. Don't call the method when you pass it to `createStore`.
 
 </Alert>
 
@@ -21,7 +21,7 @@ By default, Sentry SDKs normalize any context to a depth of 3. You may want to i
 
 ```javascript
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   normalizeDepth: 10, // Or however deep you want your state context to be.
 });
 ```

--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
@@ -19,7 +19,7 @@ You could also collect feedback and send it when an error occurs via the SDK's `
 
 ```js
 Sentry.init({
-  dsn: '__DSN__',
+  dsn: '___PUBLIC_DSN___',
   beforeSend: event => {
     const userFeedback = collectYourUserFeedback();
     const feedback = {

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -10,7 +10,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
@@ -43,7 +43,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
@@ -60,7 +60,7 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1,
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
   // ...

--- a/src/platform-includes/performance/custom-performance-metrics/python.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/python.mdx
@@ -2,7 +2,7 @@ Adding custom metrics is supported in Sentry's Python SDK version `1.16.0` and a
 
 ```python
 sentry_sdk.init(
-    dsn="___DSN___",
+    dsn="___PUBLIC_DSN___",
 )
 ```
 
@@ -27,7 +27,7 @@ and fetch the transaction manually.
 
 ```python
 sentry_sdk.init(
-    dsn="___DSN___",
+    dsn="___PUBLIC_DSN___",
     _experiments={
         "custom_measurements": True,  # for versions before 1.16.0
     },

--- a/src/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -11,7 +11,7 @@ import (
 )
 
 sentry.Init(sentry.ClientOptions{
-	Dsn:              "__DSN__",
+	Dsn:              "___PUBLIC_DSN___",
 	EnableTracing:    true,
 	TracesSampleRate: 1.0,
 	Debug:            true,

--- a/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
@@ -6,7 +6,7 @@
 
 ```javascript {filename:sentry.server.config.js}
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
   // set the instrumenter to use OpenTelemetry instead of Sentry
   instrumenter: "otel",

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -18,7 +18,7 @@ const {
 
 // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
 Sentry.init({
-  dsn: "__DSN__",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
   // set the instrumenter to use OpenTelemetry instead of Sentry
   instrumenter: "otel",

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -2,7 +2,7 @@ Initialize Sentry for tracing and set the `instrumenter` to `:otel`:
 
 ```ruby {filename:config/initializers/sentry.rb}
 Sentry.init do |config|
-  config.dsn = "__DSN__"
+  config.dsn = "___PUBLIC_DSN___"
   config.traces_sample_rate = 1.0
   # set the instrumenter to use OpenTelemetry instead of Sentry
   config.instrumenter = :otel

--- a/src/platform-includes/performance/opentelemetry-setup/with-java-agent/with-auto-init/java.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/with-java-agent/with-auto-init/java.mdx
@@ -7,6 +7,6 @@ SENTRY_PROPERTIES_FILE=sentry.properties java -javaagent:sentry-opentelemetry-ag
 Here's the `sentry.properties` file that goes with it:
 
 ```properties {filename:sentry.properties}
-dsn=___DSN___
+dsn=___PUBLIC_DSN___
 traces-sample-rate=1.0
 ```

--- a/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.spring-boot.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.spring-boot.mdx
@@ -2,7 +2,7 @@ If you're not using the auto initialization provided by `sentry-opentelemetry-ag
 set the `instrumenter` option to `otel`. This disables all Sentry instrumentation and uses the chosen OpenTelemetry tracers for creating spans instead:
 
 ```properties {filename:application.properties}
-sentry.dsn=___DSN___
+sentry.dsn=___PUBLIC_DSN___
 sentry.traces-sample-rate=1.0
 # enable this to see more logs
 sentry.debug=false

--- a/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.spring-boot.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.spring-boot.mdx
@@ -46,7 +46,7 @@ val openTelemetry = OpenTelemetrySdk.builder()
 You have to set the `instrumenter` option to `otel`. This disables all Sentry instrumentation and uses the chosen OpenTelemetry tracers for creating spans instead.
 
 ```properties {filename:application.properties}
-sentry.dsn=___DSN___
+sentry.dsn=___PUBLIC_DSN___
 sentry.traces-sample-rate=1.0
 # enable this to see more logs
 sentry.debug=false

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -61,7 +61,7 @@ Profiling depends on Sentry’s performance monitoring product being enabled bef
 import Sentry
 
 SentrySDK.start { options in
-    options.dsn = "___DSN___"
+    options.dsn = "___PUBLIC_DSN___"
     options.tracesSampleRate = 1.0
 }
 ```
@@ -70,7 +70,7 @@ SentrySDK.start { options in
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___DSN___";
+    options.dsn = @"___PUBLIC_DSN___";
     options.tracesSampleRate = @1.0;
 }];
 ```
@@ -83,7 +83,7 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="___DSN___" />
+    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
     <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
 </application>
 ```
@@ -107,7 +107,7 @@ err := sentry.Init(sentry.ClientOptions{
 
 ```python
 sentry_sdk.init(
-  dsn="___DSN___",
+  dsn="___PUBLIC_DSN___",
   traces_sample_rate=1.0,
 )
 ```
@@ -147,7 +147,7 @@ iOS profiling is available starting in SDK version `8.3.1`.
 import Sentry
 
 SentrySDK.start { options in
-    options.dsn = "___DSN___"
+    options.dsn = "___PUBLIC_DSN___"
     options.tracesSampleRate = 1.0 // tracing must be enabled for profiling
     options.profilesSampleRate = 1.0 // see also `profilesSampler` if you need custom sampling logic
 }
@@ -157,7 +157,7 @@ SentrySDK.start { options in
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___DSN___";
+    options.dsn = @"___PUBLIC_DSN___";
     options.tracesSampleRate = @1.0; // tracing must be enabled for profiling
     options.profilesSampleRate = @1.0; // see also `profilesSampler` if you need custom sampling logic
 }];
@@ -183,7 +183,7 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="___DSN___" />
+    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
     <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
     <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 </application>
@@ -213,7 +213,7 @@ def profiles_sampler(sampling_context):
     # return a number between 0 and 1 or a boolean
 
 sentry_sdk.init(
-    dsn="___DSN___",
+    dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
 
     # To set a uniform sample rate
@@ -239,7 +239,7 @@ The feature was experimental prior to version `1.17.0`. To update to the latest 
 
 ```python
 sentry_sdk.init(
-    dsn="___DSN___",
+    dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
     _experiments={
       "profiles_sample_rate": 1.0,  # for versions before 1.17.0
@@ -297,7 +297,7 @@ Then, make sure both `traces_sample_rate` and `profiles_sample_rate` are set and
 # config/initializers/sentry.rb
 
 Sentry.init do |config|
-  config.dsn = "___DSN___"
+  config.dsn = "___PUBLIC_DSN___"
   config.traces_sample_rate = 1.0
   config.profiles_sample_rate = 1.0
 end

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -147,7 +147,7 @@ import { wrapUseRoutes } from "@sentry/react";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV6Instrumentation(

--- a/src/platforms/php/common/profiling/index.mdx
+++ b/src/platforms/php/common/profiling/index.mdx
@@ -65,7 +65,7 @@ Check out the <PlatformLink to="/performance/">performance setup</PlatformLink> 
 
 ```php
 \Sentry\init([
-    'dsn' => '___DSN___',
+    'dsn' => '___PUBLIC_DSN___',
     'traces_sample_rate' => 1.0,
 ]);
 ```
@@ -74,7 +74,7 @@ Check out the <PlatformLink to="/performance/">performance setup</PlatformLink> 
 
 ```php
 \Sentry\init([
-    'dsn' => '___DSN___',
+    'dsn' => '___PUBLIC_DSN___',
     'traces_sample_rate' => 1.0,
     // Set a sampling rate for profiling - this is relative to traces_sample_rate
     'profiles_sample_rate' => 1.0,

--- a/src/wizard/javascript/remix/index.md
+++ b/src/wizard/javascript/remix/index.md
@@ -23,7 +23,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1,
   integrations: [
     new Sentry.BrowserTracing({
@@ -47,7 +47,7 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1,
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
 });

--- a/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-and-performance.md
@@ -27,7 +27,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
@@ -52,7 +52,7 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/src/wizard/javascript/remix/with-error-monitoring-and-replay.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-and-replay.md
@@ -27,7 +27,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.Replay()],
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
@@ -41,7 +41,7 @@ Initialize Sentry in your entry point for the server to capture exceptions and g
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
 });
 ```
 

--- a/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
+++ b/src/wizard/javascript/remix/with-error-monitoring-performance-and-replay.md
@@ -27,7 +27,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
@@ -56,7 +56,7 @@ import { prisma } from "~/db.server";
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.Integrations.Prisma({ client: prisma })],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/src/wizard/javascript/remix/with-error-monitoring.md
+++ b/src/wizard/javascript/remix/with-error-monitoring.md
@@ -27,7 +27,7 @@ import * as Sentry from "@sentry/remix";
 import { useEffect } from "react";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
 });
 ```
 
@@ -37,7 +37,7 @@ Initialize Sentry in your entry point for the server to capture exceptions and g
 import * as Sentry from "@sentry/remix";
 
 Sentry.init({
-  dsn: "___DSN___",
+  dsn: "___PUBLIC_DSN___",
 });
 ```
 

--- a/src/wizard/python/pylons.md
+++ b/src/wizard/python/pylons.md
@@ -27,7 +27,7 @@ Configuration is handled via the sentry namespace:
 
 ```ini
 [sentry]
-dsn=___DSN___
+dsn=___PUBLIC_DSN___
 include_paths=my.package,my.other.package,
 exclude_paths=my.package.crud
 ```


### PR DESCRIPTION
Based on a discussion on Slack, we noticed that in a bunch of places we were using `___DSN___`, which includes a private part, instead of `___PUBLIC_DSN___`. I updated places except for legacy SDK places I found.

There were also some places where we've been using `__DSN__` (with two `_`), which is not replaced at all.

For the future, make sure to use the public dsn placeholder.