### PR TITLE
feat: Do not show sign in note while loading user

### DIFF
--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, useEffect, useState} from 'react';
 
-type CodeContextStatus = 'LOADING' | 'LOADED';
+type CodeContextStatus = 'loading' | 'loaded';
 
 type ProjectCodeKeywords = {
   API_URL: string;
@@ -180,16 +180,16 @@ export function useCodeContextState(fetcher = fetchCodeKeywords): CodeContextTyp
   const [codeKeywords, setCodeKeywords] = useState(cachedCodeKeywords ?? DEFAULTS);
 
   const [status, setStatus] = useState<CodeContextStatus>(
-    cachedCodeKeywords ? 'LOADED' : 'LOADING'
+    cachedCodeKeywords ? 'loaded' : 'loading'
   );
 
   useEffect(() => {
     if (cachedCodeKeywords === null) {
-      setStatus('LOADING');
+      setStatus('loaded');
       fetcher().then((config: CodeKeywords) => {
         cachedCodeKeywords = config;
         setCodeKeywords(config);
-        setStatus('LOADED');
+        setStatus('loading');
       });
     }
   }, [setStatus, setCodeKeywords, fetcher]);

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -1,5 +1,7 @@
 import {createContext, useEffect, useState} from 'react';
 
+type CodeContextStatus = 'LOADING' | 'LOADED';
+
 type ProjectCodeKeywords = {
   API_URL: string;
   DSN: string;
@@ -80,6 +82,7 @@ type CodeContextType = {
   codeKeywords: CodeKeywords;
   sharedCodeSelection: any;
   sharedKeywordSelection: any;
+  status: CodeContextStatus;
 };
 
 export const CodeContext = createContext<CodeContextType | null>(null);
@@ -173,21 +176,28 @@ export async function fetchCodeKeywords(): Promise<CodeKeywords> {
   };
 }
 
-export function useCodeContextState(fetcher = fetchCodeKeywords) {
+export function useCodeContextState(fetcher = fetchCodeKeywords): CodeContextType {
   const [codeKeywords, setCodeKeywords] = useState(cachedCodeKeywords ?? DEFAULTS);
+
+  const [status, setStatus] = useState<CodeContextStatus>(
+    cachedCodeKeywords ? 'LOADED' : 'LOADING'
+  );
 
   useEffect(() => {
     if (cachedCodeKeywords === null) {
+      setStatus('LOADING');
       fetcher().then((config: CodeKeywords) => {
         cachedCodeKeywords = config;
         setCodeKeywords(config);
+        setStatus('LOADED');
       });
     }
-  });
+  }, [setStatus, setCodeKeywords, fetcher]);
 
   return {
     codeKeywords,
     sharedCodeSelection: useState(null),
     sharedKeywordSelection: useState({}),
+    status,
   };
 }

--- a/src/components/signInNote.tsx
+++ b/src/components/signInNote.tsx
@@ -20,7 +20,7 @@ export function SignInNote(): JSX.Element {
   const location = useLocation();
 
   return (
-    <SignedInCheck ifIsAuthenticated={false}>
+    <SignedInCheck isUserAuthenticated={false}>
       <StaticQuery
         query={siteMetaQuery}
         render={data => {

--- a/src/components/signInNote.tsx
+++ b/src/components/signInNote.tsx
@@ -1,10 +1,10 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import {useLocation} from '@reach/router';
 import {graphql, StaticQuery} from 'gatsby';
 
-import {CodeContext} from './codeContext';
 import {ExternalLink} from './externalLink';
 import {Note} from './note';
+import {SignedInCheck} from './signedInCheck';
 
 const siteMetaQuery = graphql`
   query SignInNoteQuery {
@@ -19,34 +19,24 @@ const siteMetaQuery = graphql`
 export function SignInNote(): JSX.Element {
   const location = useLocation();
 
-  const {codeKeywords} = useContext(CodeContext);
-
-  const user = codeKeywords.USER;
-
-  // This means the user is signed in
-  if (user) {
-    return null;
-  }
-
   return (
-    <StaticQuery
-      query={siteMetaQuery}
-      render={data => {
-        const url = data.site.siteMetadata.siteUrl + location.pathname;
-        return (
-          <Note>
-            The following code sample will let you choose your personal config from the
-            dropdown, once you're{' '}
-            <ExternalLink
-              href={`https://sentry.io/auth/login/?next=${url}`}
-              target="_blank"
-            >
-              logged in
-            </ExternalLink>
-            .
-          </Note>
-        );
-      }}
-    />
+    <SignedInCheck ifIsAuthenticated={false}>
+      <StaticQuery
+        query={siteMetaQuery}
+        render={data => {
+          const url = data.site.siteMetadata.siteUrl + location.pathname;
+          return (
+            <Note>
+              The following code sample will let you choose your personal config from the
+              dropdown, once you're{' '}
+              <ExternalLink href={`https://sentry.io/auth/login/?next=${url}`}>
+                logged in
+              </ExternalLink>
+              .
+            </Note>
+          );
+        }}
+      />
+    </SignedInCheck>
   );
 }

--- a/src/components/signedInCheck.tsx
+++ b/src/components/signedInCheck.tsx
@@ -4,19 +4,19 @@ import {CodeContext} from './codeContext';
 
 export function SignedInCheck({
   children,
-  ifIsAuthenticated,
+  isUserAuthenticated,
 }: {
-  children: any;
+  children: React.ReactNode;
   ifIsAuthenticated: boolean;
 }): JSX.Element {
   const {codeKeywords, status} = useContext(CodeContext);
-
-  const user = codeKeywords.USER;
 
   // Never render until loaded
   if (status !== 'LOADED') {
     return null;
   }
+  
+   const user = codeKeywords.USER;
 
   const hasUser = !!user;
   if (hasUser !== ifIsAuthenticated) {

--- a/src/components/signedInCheck.tsx
+++ b/src/components/signedInCheck.tsx
@@ -1,0 +1,27 @@
+import React, {Fragment, useContext} from 'react';
+
+import {CodeContext} from './codeContext';
+
+export function SignedInCheck({
+  children,
+  ifIsAuthenticated,
+}: {
+  children: any;
+  ifIsAuthenticated: boolean;
+}): JSX.Element {
+  const {codeKeywords, status} = useContext(CodeContext);
+
+  const user = codeKeywords.USER;
+
+  // Never render until loaded
+  if (status !== 'LOADED') {
+    return null;
+  }
+
+  const hasUser = !!user;
+  if (hasUser !== ifIsAuthenticated) {
+    return null;
+  }
+
+  return <Fragment>{children}</Fragment>;
+}

--- a/src/components/signedInCheck.tsx
+++ b/src/components/signedInCheck.tsx
@@ -7,19 +7,19 @@ export function SignedInCheck({
   isUserAuthenticated,
 }: {
   children: React.ReactNode;
-  ifIsAuthenticated: boolean;
+  isUserAuthenticated: boolean;
 }): JSX.Element {
   const {codeKeywords, status} = useContext(CodeContext);
 
   // Never render until loaded
-  if (status !== 'LOADED') {
+  if (status !== 'loaded') {
     return null;
   }
-  
-   const user = codeKeywords.USER;
+
+  const user = codeKeywords.USER;
 
   const hasUser = !!user;
-  if (hasUser !== ifIsAuthenticated) {
+  if (hasUser !== isUserAuthenticated) {
     return null;
   }
 


### PR DESCRIPTION
* Do not show signed in note until the user has loaded (or not).
* Extract the signed in check out (we'll need it for the org auth tokens as well)
* Make sure the sign in link does not open in a new tab, as the redirect back to docs already works 🎉 