### PR TITLE
ref(ts): Prefer component return types to be inferred

### DIFF
--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -8,13 +8,7 @@ type Props = {
   title?: string;
 };
 
-export function Alert({
-  title,
-  children,
-  level,
-  deepLink,
-  dismiss = false,
-}: Props): JSX.Element {
+export function Alert({title, children, level, deepLink, dismiss = false}: Props) {
   let className = 'alert';
   if (level) {
     className += ` alert-${level}`;

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -56,7 +56,7 @@ export function BasePage({
   sidebar,
   children,
   prependToc,
-}: Props): JSX.Element {
+}: Props) {
   const tx = getCurrentTransaction();
   if (tx) {
     tx.setStatus('ok');

--- a/src/components/cliChecksumTable.tsx
+++ b/src/components/cliChecksumTable.tsx
@@ -22,7 +22,7 @@ const ChecksumValue = styled.code`
   white-space: nowrap;
 `;
 
-export function CliChecksumTable(): JSX.Element {
+export function CliChecksumTable() {
   const {
     app: {files, version},
   } = useStaticQuery(query);

--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -317,7 +317,7 @@ const ItemButton = styled('button')<{isActive: boolean}>`
   `}
 `;
 
-function CodeWrapper(props): JSX.Element {
+function CodeWrapper(props) {
   const {children, class: className, ...rest} = props;
 
   return (
@@ -327,7 +327,7 @@ function CodeWrapper(props): JSX.Element {
   );
 }
 
-function SpanWrapper(props): JSX.Element {
+function SpanWrapper(props) {
   const {children, class: className, ...rest} = props;
   return (
     <span className={className} {...rest}>
@@ -343,7 +343,7 @@ type Props = {
   title?: string;
 };
 
-export function CodeBlock({filename, language, children}: Props): JSX.Element {
+export function CodeBlock({filename, language, children}: Props) {
   const [showCopied, setShowCopied] = useState(false);
   const codeRef = useRef(null);
 

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -24,7 +24,7 @@ type Props = {
   children: JSX.Element | JSX.Element[];
 };
 
-export function CodeTabs({children}: Props): JSX.Element {
+export function CodeTabs({children}: Props) {
   if (!Array.isArray(children)) {
     children = [children];
   } else {

--- a/src/components/configKey.tsx
+++ b/src/components/configKey.tsx
@@ -17,7 +17,7 @@ export function ConfigKey({
   notSupported = [],
   children,
   platform,
-}: Props): JSX.Element {
+}: Props) {
   // This is a literal copypaste of the HTML Gatsby outputs for regular
   // Markdown headings because we can't figure out how to make Gatsby
   // render component content like regular markdown/MDX content. We tried

--- a/src/components/content.tsx
+++ b/src/components/content.tsx
@@ -20,7 +20,7 @@ function RawHtml({html}) {
   return <div dangerouslySetInnerHTML={{__html: html}} />;
 }
 
-export function Content({file}: Props): JSX.Element | null {
+export function Content({file}: Props) {
   if (!file) {
     return null;
   }

--- a/src/components/definitionList.tsx
+++ b/src/components/definitionList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export function DefinitionList({children}: {children: React.ReactNode}): JSX.Element {
+export function DefinitionList({children}: {children: React.ReactNode}) {
   return <div className="large-definition-list">{children}</div>;
 }

--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -84,11 +84,7 @@ type ChildrenProps = {
   showDepth?: number;
 };
 
-export function Children({
-  tree,
-  exclude = [],
-  showDepth = 0,
-}: ChildrenProps): JSX.Element {
+export function Children({tree, exclude = [], showDepth = 0}: ChildrenProps) {
   return <React.Fragment>{renderChildren(tree, exclude, showDepth)}</React.Fragment>;
 }
 
@@ -114,7 +110,7 @@ export function DynamicNav({
   prependLinks = [],
   suppressMissing = false,
   noHeadingLink = false,
-}: Props): JSX.Element | null {
+}: Props) {
   const location = useLocation();
 
   if (root.startsWith('/')) {

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -22,7 +22,7 @@ const ExpandableBody = styled.div<ExpandedProps>`
   display: ${props => (props.isExpanded ? 'block' : 'none')};
 `;
 
-export function Expandable({title, children}: Props): JSX.Element {
+export function Expandable({title, children}: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <div className="note">

--- a/src/components/externalLink.tsx
+++ b/src/components/externalLink.tsx
@@ -6,7 +6,7 @@ type Props =
     }
   | React.HTMLProps<HTMLAnchorElement>;
 
-export function ExternalLink({children, ...props}: Props): JSX.Element {
+export function ExternalLink({children, ...props}: Props) {
   return (
     <a {...props}>
       {children}

--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -7,10 +7,7 @@ type GitHubCTAProps = {
   sourceInstanceName: string;
 };
 
-export function GitHubCTA({
-  sourceInstanceName,
-  relativePath,
-}: GitHubCTAProps): JSX.Element {
+export function GitHubCTA({sourceInstanceName, relativePath}: GitHubCTAProps) {
   return (
     <div className="github-cta">
       <small>Help improve this content</small>

--- a/src/components/guideGrid.tsx
+++ b/src/components/guideGrid.tsx
@@ -9,7 +9,7 @@ type Props = {
   platform?: string;
 };
 
-export function GuideGrid({platform, className}: Props): JSX.Element {
+export function GuideGrid({platform, className}: Props) {
   const [currentPlatform] = usePlatform(platform);
   // platform might actually not be a platform, so lets handle that case gracefully
   if (!(currentPlatform as Platform).guides) {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {SmartLink} from './smartLink';
 
-export function Header(): JSX.Element {
+export function Header() {
   return (
     <div className="navbar navbar-expand-md navbar-light bg-white global-header">
       <SmartLink to="/" title="Sentry error monitoring" className="navbar-brand pb-0">

--- a/src/components/include.tsx
+++ b/src/components/include.tsx
@@ -22,7 +22,7 @@ type Props = {
   name: string;
 };
 
-export function Include({name}: Props): JSX.Element {
+export function Include({name}: Props) {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includeQuery);

--- a/src/components/includePlatformContent.tsx
+++ b/src/components/includePlatformContent.tsx
@@ -22,7 +22,7 @@ type Props = {
   name: string;
 };
 
-export function IncludePlatformContent({name}: Props): JSX.Element {
+export function IncludePlatformContent({name}: Props) {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includePlatformContentQuery);

--- a/src/components/internalDocsSidebar.tsx
+++ b/src/components/internalDocsSidebar.tsx
@@ -18,7 +18,7 @@ const query = graphql`
   }
 `;
 
-export function InternalDocsSidebar(): JSX.Element {
+export function InternalDocsSidebar() {
   const data = useStaticQuery(query);
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
   return (

--- a/src/components/jsBundleList.tsx
+++ b/src/components/jsBundleList.tsx
@@ -21,7 +21,7 @@ const ChecksumValue = styled.code`
   white-space: nowrap;
 `;
 
-export function JsBundleList(): JSX.Element {
+export function JsBundleList() {
   const {
     package: {files},
   } = useStaticQuery(query);

--- a/src/components/jsCdnTag.tsx
+++ b/src/components/jsCdnTag.tsx
@@ -24,7 +24,7 @@ const query = graphql`
   }
 `;
 
-export function JsCdnTag({tracing = false, name = ''}: Props): JSX.Element {
+export function JsCdnTag({tracing = false, name = ''}: Props) {
   const {package: packageData} = useStaticQuery(query);
 
   const bundleName = tracing ? 'bundle.tracing.min.js' : name || 'bundle.min.js';

--- a/src/components/lambdaLayerDetail.tsx
+++ b/src/components/lambdaLayerDetail.tsx
@@ -35,7 +35,7 @@ const toOption = ({region}: RegionData) => {
   };
 };
 
-export function LambdaLayerDetail({canonical}: {canonical: string}): JSX.Element {
+export function LambdaLayerDetail({canonical}: {canonical: string}) {
   const {
     allLayer: {nodes: layerList},
   }: {allLayer: {nodes: LayerData[]}} = useStaticQuery(query);

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -26,7 +26,7 @@ type Props = {
   sidebar?: JSX.Element;
 };
 
-export function Layout({children, sidebar, pageContext = {}}: Props): JSX.Element {
+export function Layout({children, sidebar, pageContext = {}}: Props) {
   const searchPlatforms = [pageContext.platform?.name, pageContext.guide?.name].filter(
     Boolean
   );

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -4,7 +4,7 @@ type Props = {
   loading?: boolean;
 };
 
-export function Logo({loading}: Props): JSX.Element {
+export function Logo({loading}: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,7 +11,7 @@ type Props = {
   platforms?: string[];
 };
 
-export function Navbar({platforms}: Props): JSX.Element {
+export function Navbar({platforms}: Props) {
   const location = useLocation();
 
   return (

--- a/src/components/note.tsx
+++ b/src/components/note.tsx
@@ -4,7 +4,7 @@ type Props = {
   children?: any;
 };
 
-export function Note({children}: Props): JSX.Element {
+export function Note({children}: Props) {
   //   let className = "";
   //   if (children.props && typeof children.props.children === "string") {
   //     className += " markdown-text-only";

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -31,7 +31,7 @@ type Props = {
   header?: string;
 };
 
-export function PageGrid({nextPages = false, header, exclude}: Props): JSX.Element {
+export function PageGrid({nextPages = false, header, exclude}: Props) {
   const data = useStaticQuery(query);
   const location = useLocation();
 

--- a/src/components/paramTable.tsx
+++ b/src/components/paramTable.tsx
@@ -12,7 +12,7 @@ type Props = {
   fields: Field[];
 };
 
-export function ParamTable({fields}: Props): JSX.Element {
+export function ParamTable({fields}: Props) {
   return (
     <table className="table">
       {fields.map(([name, paramList]) => (

--- a/src/components/platformContent.tsx
+++ b/src/components/platformContent.tsx
@@ -64,7 +64,7 @@ const getFileForPlatform = (
   return contentMatch;
 };
 
-export function PlatformContent({includePath, platform, children}: Props): JSX.Element {
+export function PlatformContent({includePath, platform, children}: Props) {
   const {
     allFile: {nodes: files},
   } = useStaticQuery(includeQuery);

--- a/src/components/platformGrid.tsx
+++ b/src/components/platformGrid.tsx
@@ -61,7 +61,7 @@ type Props = {
   noGuides: boolean;
 };
 
-export function PlatformGrid({noGuides = false}: Props): JSX.Element {
+export function PlatformGrid({noGuides = false}: Props) {
   const platformList = usePlatformList();
   return (
     <div className="row">

--- a/src/components/platformIdentifier.tsx
+++ b/src/components/platformIdentifier.tsx
@@ -7,7 +7,7 @@ type Props = {
   platform?: string;
 };
 
-export function PlatformIdentifier({name, platform}: Props): JSX.Element {
+export function PlatformIdentifier({name, platform}: Props) {
   const [currentPlatform] = usePlatform(platform);
   return <code>{formatCaseStyle(currentPlatform.caseStyle, name)}</code>;
 }

--- a/src/components/platformLink.tsx
+++ b/src/components/platformLink.tsx
@@ -8,7 +8,7 @@ type Props = {
   to?: string;
 };
 
-export function PlatformLink({children, to}: Props): JSX.Element {
+export function PlatformLink({children, to}: Props) {
   const [currentPlatform] = usePlatform(null);
   let path = currentPlatform ? currentPlatform.url : `/platform-redirect/`;
   if (to) {

--- a/src/components/platformLinkWithLogo.tsx
+++ b/src/components/platformLinkWithLogo.tsx
@@ -10,7 +10,7 @@ type Props = {
   url?: string;
 };
 
-export function PlatformLinkWithLogo({platform, label, url}: Props): JSX.Element {
+export function PlatformLinkWithLogo({platform, label, url}: Props) {
   const [currentPlatform] = usePlatform(platform);
   let linkText = currentPlatform.title;
 

--- a/src/components/platformSdkDetail.tsx
+++ b/src/components/platformSdkDetail.tsx
@@ -45,7 +45,7 @@ const PackageDetail = styled.div`
   }
 `;
 
-export function PlatformSdkDetail(): JSX.Element {
+export function PlatformSdkDetail() {
   const [platform] = usePlatform();
 
   const {

--- a/src/components/platformSection.tsx
+++ b/src/components/platformSection.tsx
@@ -30,7 +30,7 @@ export function PlatformSection({
   platform,
   noGuides,
   children,
-}: Props): JSX.Element {
+}: Props) {
   const [currentPlatform] = usePlatform(platform);
   if (noGuides && !(currentPlatform as Platform).guides) {
     return null;

--- a/src/components/platformSidebar.tsx
+++ b/src/components/platformSidebar.tsx
@@ -54,7 +54,7 @@ type ChildProps = Props & {
   };
 };
 
-export function SidebarContent({platform, guide, data}: ChildProps): JSX.Element {
+export function SidebarContent({platform, guide, data}: ChildProps) {
   const platformName = platform.name;
   const guideName = guide ? guide.name : null;
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
@@ -132,7 +132,7 @@ export function SidebarContent({platform, guide, data}: ChildProps): JSX.Element
   );
 }
 
-export function PlatformSidebar(props: Props): JSX.Element {
+export function PlatformSidebar(props: Props) {
   return (
     <StaticQuery
       query={navQuery}

--- a/src/components/relayMetrics.tsx
+++ b/src/components/relayMetrics.tsx
@@ -62,7 +62,7 @@ function Metric({metric}) {
   );
 }
 
-export function RelayMetrics(): JSX.Element {
+export function RelayMetrics() {
   const data = useStaticQuery(query);
   const metrics = data.allRelayMetric.nodes;
 

--- a/src/components/relayPiifields.tsx
+++ b/src/components/relayPiifields.tsx
@@ -33,7 +33,7 @@ function PiiField({field}) {
   );
 }
 
-export function PiiFields(): JSX.Element {
+export function PiiFields() {
   const data = useStaticQuery(query);
   const fields = data.allPiiFieldPath.nodes;
 

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -82,7 +82,7 @@ type Props = {
   platforms?: string[];
 };
 
-export function Search({path, autoFocus, platforms = []}: Props): JSX.Element {
+export function Search({path, autoFocus, platforms = []}: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState(``);
   const [results, setResults] = useState([] as Result[]);

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -45,7 +45,7 @@ export function BaseSEO({
   keywords = [],
   title,
   noindex,
-}: ChildProps): JSX.Element {
+}: ChildProps) {
   const metaDescription = description || data.site.siteMetadata.description;
 
   return (
@@ -127,7 +127,7 @@ export function BaseSEO({
   );
 }
 
-export function SEO(props: Props): JSX.Element {
+export function SEO(props: Props) {
   return (
     <StaticQuery
       query={detailsQuery}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -38,7 +38,7 @@ type ChildProps = {
   };
 };
 
-export function BaseSidebar({data}: ChildProps): JSX.Element {
+export function BaseSidebar({data}: ChildProps) {
   const tree = toTree(data.allSitePage.nodes.filter(n => !!n.context));
   return (
     <ul className="list-unstyled" data-sidebar-tree>

--- a/src/components/signInNote.tsx
+++ b/src/components/signInNote.tsx
@@ -16,7 +16,7 @@ const siteMetaQuery = graphql`
   }
 `;
 
-export function SignInNote(): JSX.Element {
+export function SignInNote() {
   const location = useLocation();
 
   const {codeKeywords} = useContext(CodeContext);

--- a/src/components/smartLink.tsx
+++ b/src/components/smartLink.tsx
@@ -26,7 +26,7 @@ export function SmartLink({
   className = '',
   isActive,
   ...props
-}: Props): JSX.Element {
+}: Props) {
   const realTo = to || href || '';
 
   const [forcedUrl, setForcedUrl] = useState(realTo);


### PR DESCRIPTION
JSX.Element isn't always quite the right return type for components. We
can simplify this and just let typescript infer the return type for
components (which is inline with what we do in sentry)