### PR TITLE
ref(ts): Prefer ReactNode over JSX.Element

### DIFF
--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -31,7 +31,7 @@ const WrappedTOC = forwardRef(
 );
 
 type Props = {
-  children?: JSX.Element;
+  children?: React.ReactNode;
   data?: {
     file?: {
       [key: string]: any;
@@ -44,9 +44,9 @@ type Props = {
     notoc?: boolean;
     title?: string;
   };
-  prependToc?: JSX.Element;
+  prependToc?: React.ReactNode;
   seoTitle?: string;
-  sidebar?: JSX.Element;
+  sidebar?: React.ReactNode;
 };
 
 export function BasePage({

--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -339,7 +339,7 @@ function SpanWrapper(props) {
 }
 
 type Props = {
-  children: JSX.Element;
+  children: React.ReactNode;
   filename?: string;
   language?: string;
   title?: string;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -12,7 +12,7 @@ import {Sidebar} from './sidebar';
 import {SmartLink} from './smartLink';
 
 type Props = {
-  children: JSX.Element | JSX.Element[];
+  children: React.ReactNode;
   pageContext?: {
     guide?: {
       [key: string]: any;
@@ -23,7 +23,7 @@ type Props = {
       name?: string;
     };
   };
-  sidebar?: JSX.Element;
+  sidebar?: React.ReactNode;
 };
 
 export function Layout({children, sidebar, pageContext = {}}: Props) {

--- a/src/components/platformLink.tsx
+++ b/src/components/platformLink.tsx
@@ -4,7 +4,7 @@ import {usePlatform} from './hooks/usePlatform';
 import {SmartLink} from './smartLink';
 
 type Props = {
-  children: JSX.Element;
+  children: React.ReactNode;
   to?: string;
 };
 

--- a/src/components/signedInCheck.tsx
+++ b/src/components/signedInCheck.tsx
@@ -8,7 +8,7 @@ export function SignedInCheck({
 }: {
   children: React.ReactNode;
   isUserAuthenticated: boolean;
-}): JSX.Element {
+}) {
   const {codeKeywords, status} = useContext(CodeContext);
 
   // Never render until loaded


### PR DESCRIPTION
This type is more lenient and is typically what we want in these cases.