### PR TITLE
fix: typo (rate-imited -> rate-limited)

### DIFF
--- a/src/platforms/javascript/common/session-replay/index.mdx
+++ b/src/platforms/javascript/common/session-replay/index.mdx
@@ -107,7 +107,7 @@ Sampling begins as soon as a session starts. <PlatformIdentifier name="replays-s
 
 Errors that happen on the page while a replay is running will be linked to the replay, making it possible to jump between related issues and replays. However, it's **possible** that in some cases the error count reported on the **Replays Details** page won't match the actual errors that have been captured. That's because errors can be lost, and while this is uncommon, there are a few reasons why it could happen:
 
-- The replay was rate-imited and couldn't be accepted.
+- The replay was rate-limited and couldn't be accepted.
 - The replay was deleted by a member of your org.
 - There were network errors and the replay wasn't saved.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Hi, Team.
There's a little typo as below.
Please kindly reveiw this change :)
Thank you.

- as-is
`rate-imited`  

- to-be
`rate-limited`

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
