### PR TITLE
CI: Update setup-volta action to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       JEKYLL_ENABLE_PLATFORM_API: false
     steps:
       - uses: actions/checkout@v2
-      - uses: getsentry/action-setup-volta@d6f6ebfc4046feb3cfb6049e885185a01afd82b7 # v1.0.0
+      - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb # v1.1.0
       - uses: actions/cache@v2
         id: cache
         with:
@@ -48,7 +48,7 @@ jobs:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      - uses: getsentry/action-setup-volta@d6f6ebfc4046feb3cfb6049e885185a01afd82b7 # v1.0.0
+      - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb # v1.1.0
 
       - uses: actions/cache@v2
         id: cache
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: getsentry/action-setup-volta@d6f6ebfc4046feb3cfb6049e885185a01afd82b7 # v1.0.0
+      - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb # v1.1.0
       - uses: actions/cache@v2
         id: cache
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: getsentry/action-setup-volta@d6f6ebfc4046feb3cfb6049e885185a01afd82b7 # v1.0.0
+      - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb # v1.1.0
       - uses: actions/cache@v2
         id: cache
         with:


### PR DESCRIPTION
Updating to the latest version of [action-setup-volta](https://github.com/getsentry/action-setup-volta) to address GitHub action deprecation warnings.