### PR TITLE
SSL: add `DigiCert Global Root G2` to the list of root certificates

### DIFF
--- a/src/docs/product/security/ssl.mdx
+++ b/src/docs/product/security/ssl.mdx
@@ -87,6 +87,12 @@ Valid until: 10/Nov/2031
 Serial Number: 08:3B:E0:56:90:42:46:B1:A1:75:6A:C9:59:91:C7:4A
 SHA1 Fingerprint: A8:98:5D:3A:65:E5:E5:C4:B2:D7:D6:6D:40:C6:DD:2F:B1:9C:54:36
 SHA256 Fingerprint: 43:48:A0:E9:44:4C:78:CB:26:5E:05:8D:5E:89:44:B4:D8:4F:96:62:BD:26:DB:25:7F:89:34:A4:43:C7:01:61
+
+DigiCert Global Root G2
+Valid until: 15/Jan/2038
+Serial Number: 03:3A:F1:E6:A7:11:A9:A0:BB:28:64:B1:1D:09:FA:E5
+SHA1 Fingerprint: DF:3C:24:F9:BF:D6:66:76:1B:26:80:73:FE:06:D1:CC:8D:4F:82:A4
+SHA256 Fingerprint: CB:3C:CB:B7:60:31:E5:E0:13:8F:8D:D3:9A:23:F9:DE:47:FF:C3:5E:43:C1:14:4C:EA:27:D4:6A:5A:B1:CB:5F
 ```
 
 - [Let's Encrypt](https://letsencrypt.org/certificates/)


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

From [DigiCert root and intermediate CA certificate updates 2023][1]:
> On March 8, 2023, at 10:00 MST (17:00 UTC), DigiCert will begin updating the default public issuance of TLS/SSL certificate to our public, second-generation (G2) root, and intermediate CA (ICA) certificate hierarchies.

We are going to have new certificates issued from the new G2 certificate hierarchy soon. Likely beginning of August, but certainly not later than August 20, when our old certificates will start to expire.

## Extra resources

[DigiCert root and intermediate CA certificate updates 2023][1]

[1]: https://knowledge.digicert.com/generalinformation/digicert-root-and-intermediate-ca-certificate-updates-2023.html
