### PR TITLE
Add spans.ui to searchable properties

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties/events.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties/events.mdx
@@ -552,6 +552,12 @@ Cumulative resource time for a transaction, based on span operations.
 
 - **Type:** duration
 
+### `spans.ui`
+
+Cumulative ui time for a transaction, based on span operations.
+
+- **Type:** duration
+
 ### `stack.abs_path`
 
 The absolute path to the source file. In events, this is an array; in issues, this is a single value.

--- a/src/docs/product/sentry-basics/search/searchable-properties/events.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties/events.mdx
@@ -554,7 +554,7 @@ Cumulative resource time for a transaction, based on span operations.
 
 ### `spans.ui`
 
-Cumulative ui time for a transaction, based on span operations.
+Cumulative UI time for a transaction, based on span operations.
 
 - **Type:** duration
 


### PR DESCRIPTION
`spans.ui` is a supported, searchable property, so it should be listed in the docs.

Fixes #7406