### PR TITLE
Async option removal was delayed til 6.0

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -133,7 +133,7 @@ config.timeout #=> config.transport.timeout
 config.open_timeout #=> config.transport.open_timeout
 config.proxy #=> config.transport.proxy
 
-# These options are present in sentry-ruby 4.* but has been removed in 5.0 with the faraday removal
+# These options are present in sentry-ruby 4.* but were removed in 5.0 with the faraday removal
 config.http_adapter #=> config.transport.http_adapter
 config.faraday_builder #=> config.transport.faraday_builder
 ```
@@ -281,7 +281,7 @@ config.before_send = lambda do |event, hint|
   if exception = hint[:exception]
     exception.raven_context.each do |key, value|
       # here I assume the event would be a Sentry::Event object
-      # it'll be a hash if you use the async callback though (which will be removed in version 5.0)
+      # however, it'll be a hash if you use the async callback (which will be removed in version 6.0)
       event.send("#{key}=", value)
     end
   end


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

* https://github.com/getsentry/sentry-ruby/issues/1522

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
