### PR TITLE
Update DSN in react-router.mdx

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -96,6 +96,7 @@ import {
 import * as Sentry from "@sentry/react";
 
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV6Instrumentation(
@@ -202,6 +203,7 @@ const SentryRoute = Sentry.withSentryRouting(Route);
 const history = createBrowserHistory();
 
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
@@ -241,6 +243,7 @@ const history = createBrowserHistory();
 const routes = [{ path: '/users/:userid' }, { path: '/users' }, { path: '/' }];
 
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV5Instrumentation(history, routes, matchPath),
@@ -286,6 +289,7 @@ const routes = (
 );
 
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     new Sentry.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV3Instrumentation(


### PR DESCRIPTION
## Description of changes

Was referencing the Javascript docs for configuring Sentry with React and noticed that the DSN client key did not appear in some of the example router configurations. Modified the examples so that each one has a DSN. (https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/)