### PR TITLE
Tiny language tweak to "assigned" filter description

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties/issues.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties/issues.mdx
@@ -32,7 +32,7 @@ Returns issues assigned to the defined user(s) or team(s). Values can be a user 
 
 ### `assigned_or_suggested`
 
-Returns issues that are assigned to or suggested to be assigned to the defined user(s) or team(s). Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` for `#team-name` for teams you belong to.
+Returns issues that are assigned to or suggested to be assigned to the defined user(s) or team(s). Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.
 
 - **Type:** team or org user
 


### PR DESCRIPTION
changed "for" to "or"

Updated: `none` for no assignee/suggestion, `my_teams` for `#team-name` for teams you belong to.
To: `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.