### PR TITLE
Mention react-router instrumentation's `HashRouter` and `MemoryRouter` support.

### DIFF
--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -79,7 +79,7 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 
 ### Usage With `<Routes />` Component
 
-If you use the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context, as in the example below:
+If you use the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context. You can use `Sentry.withSentryReactRouterV6Routing` for `Routes` inside `BrowserRouter`. `MemoryRouter`, and `HashRouter` components:
 
 ```javascript
 import React from "react";


### PR DESCRIPTION
`Sentry.withSentryReactRouterV6Routing` also works when `HashRouter` or `MemoryRouter` is used.