### PR TITLE
Remove note for muting metric alerts 

### DIFF
--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -60,12 +60,6 @@ Issue alerts can be muted on the **Alerts** details page by clicking the "Mute" 
 
 ### Muting Metric Alerts
 
-<Note>
-
-This feature is only available if you're in the [Early Adopter](/product/accounts/early-adopter/) program. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-</Note>
-
 Metric alerts work in the same way as Issue alerts and can be muted on the **Alerts** details page by clicking the "Mute" button.
 
 ## Notifications


### PR DESCRIPTION
this pr removes the note that says muting metric alerts is only available for ea users , now that we have ga'ed the feature