### PR TITLE
docs: Rename python configuration options and add deprecation alerts

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -349,18 +349,7 @@ A list of exception types that will be filtered out before sending to Sentry.
 
 </ConfigKey>
 
-<ConfigKey name="request-bodies" supported={["python"]}>
-
-This parameter controls if integrations should capture HTTP request bodies. It can be set to one of the following values:
-
-- `never`: request bodies are never sent
-- `small`: only small request bodies will be captured where the cutoff for small depends on the SDK (typically 4KB)
-- `medium`: medium and small requests will be captured (typically 10KB)
-- `always`: the SDK will always capture the request body for as long as Sentry can make sense of it
-
-</ConfigKey>
-
-<ConfigKey name="max-request-body-size" supported={["php", "dotnet.aspnet", "dotnet.aspnetcore", "java"]}>
+<ConfigKey name="max-request-body-size" supported={["php", "dotnet.aspnet", "dotnet.aspnetcore", "java", "python"]}>
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
@@ -374,12 +363,6 @@ This parameter controls whether integrations should capture HTTP request bodies.
 <ConfigKey name="max-value-length" supported={["php"]}>
 
 The number of characters after which the values containing text in the event payload will be truncated (defaults to `1024`).
-
-</ConfigKey>
-
-<ConfigKey name="with-locals" supported={["python"]}>
-
-When enabled, local variables are sent along with stackframes. This can have a performance and PII impact. Enabled by default on platforms where this is available.
 
 </ConfigKey>
 
@@ -402,6 +385,22 @@ The number of context lines for each frame when loading a file.
 #### Deprecated
 
 `frameContextLines` has moved to the <PlatformLink to="/configuration/integrations/default-integrations/#contextlines">`ContextLines` integration</PlatformLink>.
+
+</ConfigKey>
+
+<ConfigKey name="request-bodies" supported={["python"]}>
+
+#### Deprecated
+
+Has been renamed to [max_request_body_size](/platforms/python/configuration/options/#max-request-body-size).
+
+</ConfigKey>
+
+<ConfigKey name="with-locals" supported={["python"]}>
+
+#### Deprecated
+
+Has been renamed to [include_local_variables](/platforms/python/configuration/options/#include-local-variables).
 
 </ConfigKey>
 

--- a/src/platforms/python/common/data-collected.mdx
+++ b/src/platforms/python/common/data-collected.mdx
@@ -48,9 +48,9 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
   -JSON and form bodies are sent
   -Raw request bodies are always removed
   -Uploaded files in the request bodies are never sent to Sentry
-- **The size of the request body:** There's a ["request_bodies"](/platforms/python/configuration/options/#request-bodies) option that's set to `medium` by default. This means that larger request bodies aren't sent to Sentry.
+- **The size of the request body:** There's a ["max_request_body_size"](/platforms/python/configuration/options/#max-request-body-size) option that's set to `medium` by default. This means that larger request bodies aren't sent to Sentry.
 
-If you want to prevent bodies from being sent to Sentry altogether, set `request_bodies` to `"never"`.
+If you want to prevent bodies from being sent to Sentry altogether, set `max_request_body_size` to `"never"`.
 
 ## Source Context
 


### PR DESCRIPTION
Rename `request_bodies` to `max_request_body_size` and add deprecation alert.
Add deprecation alert also for `with_locals`.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds the documentation for the changes made in https://github.com/getsentry/sentry-python/pull/2247 for ticket https://github.com/getsentry/sentry-python/issues/926.

A preview of how it looks like:

<img width="369" alt="image" src="https://github.com/getsentry/sentry-docs/assets/16822952/df054004-a2a9-41a0-a2c3-41dea2b63de8">

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
