### PR TITLE
Add RN SAGP app dependency and disable auto install option examples

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -99,7 +99,7 @@ apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 
 ### Enable Sentry AGP
 
-You can enable native symbol upload and other features by adding [Sentry Android Gradle Plugin (SAGP)](/platforms/android/configuration/gradle) dependency to `android/build.gradle`.
+You can enable native symbol upload and other features by adding the [Sentry Android Gradle Plugin (AGP)](/platforms/android/configuration/gradle) dependency to `android/build.gradle`.
 
 ```groovy {filename:android/build.gradle}
 buildscript {
@@ -110,7 +110,7 @@ buildscript {
 }
 ```
 
-And configure the plugin options in `android/app/build.gradle`.
+You can configure the plugin options in `android/app/build.gradle`, as shown below:
 
 ```groovy {filename:android/app/build.gradle}
 apply plugin: "io.sentry.android.gradle"

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -101,6 +101,15 @@ apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 
 You can enable native symbol upload and other features by adding [Sentry Android Gradle Plugin (SAGP)](/platforms/android/configuration/gradle) to `android/app/build.gradle`.
 
+```groovy {filename:android/build.gradle}
+buildscript {
+    dependencies {
+        // Other dependencies ...
+        classpath("io.sentry:sentry-android-gradle-plugin:{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}")
+    }
+}
+```
+
 ```groovy {filename:android/app/build.gradle}
 apply plugin: "io.sentry.android.gradle"
 
@@ -117,6 +126,15 @@ sentry {
     // This option has an effect only when [uploadNativeSymbols] is enabled.
     // Default is disabled.
     includeNativeSources = true
+
+    // `@sentry/react-native` ships with compatible `sentry-android`
+    // This option would install the latest version that ships with the SDK or SAGP (Sentry Android Gradle Plugin)
+    // which might be incompatible with the React Native SDK
+    // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
+    // Default is enabled.
+    autoInstallation {
+      enabled = false
+    }
 }
 ```
 

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -99,7 +99,7 @@ apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 
 ### Enable Sentry AGP
 
-You can enable native symbol upload and other features by adding [Sentry Android Gradle Plugin (SAGP)](/platforms/android/configuration/gradle) to `android/app/build.gradle`.
+You can enable native symbol upload and other features by adding [Sentry Android Gradle Plugin (SAGP)](/platforms/android/configuration/gradle) dependency to `android/build.gradle`.
 
 ```groovy {filename:android/build.gradle}
 buildscript {
@@ -109,6 +109,8 @@ buildscript {
     }
 }
 ```
+
+And configure the plugin options in `android/app/build.gradle`.
 
 ```groovy {filename:android/app/build.gradle}
 apply plugin: "io.sentry.android.gradle"


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The Sentry Android Gradle Plugin auto installation can potentially break the RN SDK by installing a newer version of the Android SDK which can be potentially incompatible. RN SDK shipped with a comparable version of sentry-android.

- related rn sample update https://github.com/getsentry/sentry-react-native/pull/3136
