### PR TITLE
fix(native): Update notes on Native perf support

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -116,7 +116,7 @@ If you leave your sample rate at `1.0`, a transaction will be sent every time a 
 
 <Alert level="info">
 
-The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
+The Native SDK doesn't currently support sampling functions (<PlatformIdentifier name="traces-sampler" />).
 
 </Alert>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -74,6 +74,17 @@ First, enable tracing and configure the sampling rate for transactions. Set the 
 
 The two options are meant to be mutually exclusive. If you set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.
 
+<PlatformSection supported={["native"]}>
+
+<Alert level="info">
+
+The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
+
+</Alert>
+
+</PlatformSection>
+
+
 <PlatformContent includePath="performance/configure-sample-rate" />
 
 Learn more about how the options work in <PlatformLink to="/configuration/sampling/">Sampling Transactions</PlatformLink>.
@@ -99,6 +110,16 @@ Once testing is complete, you may want to set a lower <PlatformIdentifier name="
 <PlatformSection supported={["javascript"]} notSupported={["react-native"]}>
 
 If you leave your sample rate at `1.0`, a transaction will be sent every time a user loads a page or navigates within your app. Depending on the amount of traffic your application gets, this may mean a lot of transactions. If you have a high-load, backend application, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
+
+</PlatformSection>
+
+<PlatformSection supported={["native"]}>
+
+<Alert level="info">
+
+The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
+
+</Alert>
 
 </PlatformSection>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -78,7 +78,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <Alert level="info">
 
-The Native SDK currently does not support sampling functions (<PlatformIdentifier name="traces-sampler" />).
+The Native SDK doesn't currently support sampling functions (<PlatformIdentifier name="traces-sampler" />).
 
 </Alert>
 

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -84,7 +84,6 @@ The Native SDK currently does not support sampling functions (<PlatformIdentifie
 
 </PlatformSection>
 
-
 <PlatformContent includePath="performance/configure-sample-rate" />
 
 Learn more about how the options work in <PlatformLink to="/configuration/sampling/">Sampling Transactions</PlatformLink>.

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -37,16 +37,6 @@ To capture transactions customized to your organization's needs, you must first 
 
 </Note>
 
-<PlatformSection supported={["native"]}>
-
-<Note>
-
-Performance monitoring is still an experimental, work-in-progress feature, and its API may be unstable. It may also have bugs. Feedback is appreciated, and should be submitted as an issue in the repository linked on the right side of this page.
-
-</Note>
-
-</PlatformSection>
-
 To instrument certain regions of your code, you can create transactions to capture them.
 
 <PlatformContent includePath="performance/enable-manual-instrumentation" />


### PR DESCRIPTION
- removes `experimental` note on Native perf page for custom instrumentation
- adds alerts on Sampling page that `tracesSampler` is not available for Native