### PR TITLE
Add sign in notes to code samples containing placeholders

### DIFF
--- a/src/docs/clients/cocoa/advanced.mdx
+++ b/src/docs/clients/cocoa/advanced.mdx
@@ -73,6 +73,8 @@ Client.shared?.enabled = false
 
 You can also `init` the client with options:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 Client.shared = try Client(options: [
     "dsn": "___PUBLIC_DSN___",

--- a/src/docs/clients/cocoa/dsym.mdx
+++ b/src/docs/clients/cocoa/dsym.mdx
@@ -109,6 +109,8 @@ You need to have an Auth Token for this to work. You can [create an Auth Token h
 1.  Download and install [sentry-cli](https://github.com/getsentry/sentry-cli/releases) — The best place to put this is in the _/usr/local/bin/_ directory
 2.  You will need to copy the script below into a new _Run Script_ and set your _AUTH_TOKEN_, _ORG_SLUG_, and _PROJECT_SLUG_
 
+<SignInNote />
+
 ```bash
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___

--- a/src/docs/clients/cocoa/index.mdx
+++ b/src/docs/clients/cocoa/index.mdx
@@ -73,6 +73,8 @@ Version tags or branches need to have the Package.swift file in it or Xcode won'
 
 To use the client, change your AppDelegate’s _application_ method to instantiate the Sentry client:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -92,6 +94,9 @@ func application(_ application: UIApplication,
 ```
 
 If you prefer to use Objective-C you can do so like this:
+
+
+<SignInNote />
 
 ```objc {tabTitle:Objective-C}
 @import Sentry;

--- a/src/docs/clients/cocoa/index.mdx
+++ b/src/docs/clients/cocoa/index.mdx
@@ -95,7 +95,6 @@ func application(_ application: UIApplication,
 
 If you prefer to use Objective-C you can do so like this:
 
-
 <SignInNote />
 
 ```objc {tabTitle:Objective-C}

--- a/src/docs/clients/react-native/expo.mdx
+++ b/src/docs/clients/react-native/expo.mdx
@@ -21,6 +21,8 @@ npm i sentry-expo --save
 
 In your `main.js` or `app.js`:
 
+<SignInNote />
+
 ```javascript
 import Sentry from "sentry-expo";
 // import { SentrySeverity, SentryLog } from 'react-native-sentry';

--- a/src/docs/clients/react-native/index.mdx
+++ b/src/docs/clients/react-native/index.mdx
@@ -75,6 +75,8 @@ For Android we hook into gradle for the source map build process. When you run `
 
 When you run `react-native link` we will automatically update your _index.ios.js_ / _index.android.js_ with the following changes:
 
+<SignInNote />
+
 ```javascript
 import { Sentry } from "react-native-sentry";
 Sentry.config("___PUBLIC_DSN___").install();

--- a/src/docs/clients/ruby/configuration/options.mdx
+++ b/src/docs/clients/ruby/configuration/options.mdx
@@ -14,6 +14,8 @@ A new Ruby SDK has superseded this deprecated version. Sentry preserves this doc
 
 Configuration is passed as part of the client initialization:
 
+<SignInNote />
+
 ```ruby
 Raven.configure do |config|
   config.dsn = '___PUBLIC_DSN___'
@@ -288,6 +290,8 @@ config.transport_failure_callback = lambda { |event, error|
 : After you complete setting up a project, you’ll be given a value which we call a DSN, or Data Source Name. It looks a lot like a standard URL, but it’s actually just a representation of the configuration required by Raven (the Sentry client). It consists of a few pieces, including the protocol, public and secret keys, the server address, and the project identifier.
 
 With Raven, you may either set the SENTRY_DSN environment variable (recommended), or set your DSN manually in a config block:
+
+<SignInNote />
 
 ```ruby
 # in Rails, this might be in config/initializers/sentry.rb

--- a/src/docs/clients/ruby/usage.mdx
+++ b/src/docs/clients/ruby/usage.mdx
@@ -6,6 +6,8 @@ description: "Learn about reporting failures, messages, referencing events, opti
 
 To use Raven Ruby all you need is your DSN. Like most Sentry libraries it will honor the `SENTRY_DSN` environment variable. You can find it on the project settings page under API Keys. You can either export it as environment variable or manually configure it with `Raven.configure`:
 
+<SignInNote />
+
 ```ruby
 Raven.configure do |config|
   config.dsn = '___PUBLIC_DSN___'
@@ -13,6 +15,8 @@ end
 ```
 
 If you only want to send events to Sentry in certain environments, you should set `config.environments` too:
+
+<SignInNote />
 
 ```ruby
 Raven.configure do |config|

--- a/src/docs/clients/unity-lite/index.mdx
+++ b/src/docs/clients/unity-lite/index.mdx
@@ -31,6 +31,8 @@ Configuration should happen as early as possible in your application's lifecycle
 
 You can attach Sentry to a Game Object and initialize it with the DSN programatically:
 
+<SignInNote />
+
 ```csharp
 var sentry = gameObject.AddComponent<SentrySdk>();
 sentry.Dsn = "___PUBLIC_DSN___";

--- a/src/docs/product/cli/send-event.mdx
+++ b/src/docs/product/cli/send-event.mdx
@@ -6,6 +6,8 @@ description: "Learn how Sentry's command line interface can be used for sending 
 
 The `sentry-cli` tool can also be used for sending events. If you want to use it, you need to export the `SENTRY_DSN` environment variable and point it to the DSN of a project of yours:
 
+<SignInNote />
+
 ```bash
 export SENTRY_DSN='___PUBLIC_DSN___'
 ```
@@ -100,6 +102,8 @@ The limitations for this are:
 - sentry-cli registers an `EXIT` and `ERR` trap.
 
 Usage:
+
+<SignInNote />
 
 ```bash
 #!/bin/bash

--- a/src/docs/product/crons/getting-started/cli.mdx
+++ b/src/docs/product/crons/getting-started/cli.mdx
@@ -24,11 +24,15 @@ To begin monitoring your recurring, scheduled job:
 
 The Sentry CLI uses your Monitor's project DSN to authorize check-ins. To set it up, export the `SENTRY_DSN` environment variable:
 
+<SignInNote />
+
 ```bash
 export SENTRY_DSN=___PUBLIC_DSN___
 ```
 
 Alternatively, you can add it to your `~/.sentryclirc` config:
+
+<SignInNote />
 
 ```ini {filename:~/.sentryclirc}
 [auth]

--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -26,7 +26,6 @@ Content-Security-Policy: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___
 
 Alternatively you can setup CSP reports to simply send reports rather than actually enforcing the policy:
 
-
 <SignInNote />
 
 ```

--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -18,11 +18,16 @@ The integration process consists of configuring the appropriate header with your
 
 To configure CSP reports in Sentry, you’ll need to send a header from your server describing your policy, as well specifying the authenticated Sentry endpoint:
 
+<SignInNote />
+
 ```
 Content-Security-Policy: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
 ```
 
 Alternatively you can setup CSP reports to simply send reports rather than actually enforcing the policy:
+
+
+<SignInNote />
 
 ```
 Content-Security-Policy-Report-Only: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
@@ -38,6 +43,8 @@ For more information, see the article on [MDN](https://developer.mozilla.org/en-
 
 To configure reports in Sentry, you’ll need to configure the Expect-CT a header from your server:
 
+<SignInNote />
+
 ```
 Expect-CT: ..., report-uri="https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"
 ```
@@ -49,6 +56,8 @@ For more information, see the article on [MDN](https://developer.mozilla.org/en-
 [HTTP Public Key Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) (HPKP) is a security feature that tells a web client to associate a specific cryptographic public key with a certain web server to decrease the risk of MITM attacks with forged certificates. It’s enforced by browser vendors, and Sentry supports capturing violations using the standard reporting hooks.
 
 To configure HPKP reports in Sentry, you’ll need to send a header from your server describing your policy, as well specifying the authenticated Sentry endpoint:
+
+<SignInNote />
 
 ```
 Public-Key-Pins: ...; report-uri="https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"

--- a/src/includes/platforms/configuration/integrations/default.mdx
+++ b/src/includes/platforms/configuration/integrations/default.mdx
@@ -177,6 +177,8 @@ To disable system integrations, set `defaultIntegrations: false` when calling `i
 
 To override their settings, provide a new instance with your config to the `integrations` option. For example, to turn off browser capturing console calls:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -19,6 +19,8 @@ Because Sentry uses a redux **enhancer**, you should pass it as indicated above 
 
 By default, Sentry SDKs normalize any context to a depth of 3. You may want to increase this for sending Redux states by passing `normalizeDepth` to the `Sentry.init` call:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/includes/sentry-cli-sourcemaps.mdx
+++ b/src/includes/sentry-cli-sourcemaps.mdx
@@ -16,6 +16,8 @@ Visit the [auth token user settings page](https://sentry.io/settings/account/api
 
 </Note>
 
+<SignInNote />
+
 ```bash {filename:.env.local}
 SENTRY_AUTH_TOKEN=your-auth-token
 SENTRY_ORG=___ORG_SLUG___

--- a/src/platform-includes/configuration/auto-session-tracking/apple.mdx
+++ b/src/platform-includes/configuration/auto-session-tracking/apple.mdx
@@ -24,7 +24,6 @@ SentrySDK.start { options in
 
 If you'd like to opt out of this feature, you can do so using options:
 
-
 <SignInNote />
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/configuration/auto-session-tracking/apple.mdx
+++ b/src/platform-includes/configuration/auto-session-tracking/apple.mdx
@@ -2,6 +2,8 @@ To benefit from the health data, you must use _at least_ version 5.0.0 of the Co
 
 By default, the session is terminated once the application is in the background for more than 30 seconds. You can change the time out with the option named `sessionTrackingIntervalMillis`. It takes the amount in milliseconds. For example, to configure it to be 60 seconds:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -21,6 +23,9 @@ SentrySDK.start { options in
 ```
 
 If you'd like to opt out of this feature, you can do so using options:
+
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platform-includes/configuration/auto-session-tracking/react-native.mdx
+++ b/src/platform-includes/configuration/auto-session-tracking/react-native.mdx
@@ -12,6 +12,8 @@ Sentry.init({
 
 The session terminates once the application is in the background for more than 30 seconds. To change the timeout, use the option `sessionTrackingIntervalMillis`. For example:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/configuration/before-send-fingerprint/apple.mdx
+++ b/src/platform-includes/configuration/before-send-fingerprint/apple.mdx
@@ -1,4 +1,3 @@
-
 <SignInNote />
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/configuration/before-send-fingerprint/apple.mdx
+++ b/src/platform-includes/configuration/before-send-fingerprint/apple.mdx
@@ -1,3 +1,6 @@
+
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/configuration/before-send-fingerprint/php.mdx
+++ b/src/platform-includes/configuration/before-send-fingerprint/php.mdx
@@ -1,4 +1,3 @@
-
 <SignInNote />
 
 ```php

--- a/src/platform-includes/configuration/before-send-fingerprint/php.mdx
+++ b/src/platform-includes/configuration/before-send-fingerprint/php.mdx
@@ -1,3 +1,6 @@
+
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/configuration/before-send-hint/php.mdx
+++ b/src/platform-includes/configuration/before-send-hint/php.mdx
@@ -1,4 +1,3 @@
-
 <SignInNote />
 
 ```php

--- a/src/platform-includes/configuration/before-send-hint/php.mdx
+++ b/src/platform-includes/configuration/before-send-hint/php.mdx
@@ -1,3 +1,6 @@
+
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/configuration/before-send-transaction/javascript.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/before-send-transaction/php.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/php.mdx
@@ -1,5 +1,8 @@
 In PHP, a closure can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
 
+
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/configuration/before-send-transaction/php.mdx
+++ b/src/platform-includes/configuration/before-send-transaction/php.mdx
@@ -1,6 +1,5 @@
 In PHP, a closure can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
 
-
 <SignInNote />
 
 ```php

--- a/src/platform-includes/configuration/before-send/apple.mdx
+++ b/src/platform-includes/configuration/before-send/apple.mdx
@@ -1,4 +1,3 @@
-
 <SignInNote />
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/configuration/before-send/apple.mdx
+++ b/src/platform-includes/configuration/before-send/apple.mdx
@@ -1,3 +1,6 @@
+
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/configuration/before-send/javascript.mdx
+++ b/src/platform-includes/configuration/before-send/javascript.mdx
@@ -2,6 +2,8 @@ In JavaScript, you can use a function to modify the event or return a completely
 You can either return `null` or an event payload - no other return value (including `void`) is allowed.
 If you return `null`, the event will be discarded.
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/before-send/php.mdx
+++ b/src/platform-includes/configuration/before-send/php.mdx
@@ -1,5 +1,7 @@
 In PHP, a closure can be used to modify the event or return a completely new one. If you return `null`, the event will be discarded.
 
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/configuration/capture-console/javascript.mdx
+++ b/src/platform-includes/configuration/capture-console/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { CaptureConsole as CaptureConsoleIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/capture-console/node.mdx
+++ b/src/platform-includes/configuration/capture-console/node.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
 import { CaptureConsole as CaptureConsoleIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/config-intro/android.mdx
+++ b/src/platform-includes/configuration/config-intro/android.mdx
@@ -1,5 +1,7 @@
 Options on Android can be set by setting the values on the `AndroidManifest.xml` file:
 
+<SignInNote />
+
 ```xml
 <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
 ```

--- a/src/platform-includes/configuration/config-intro/apple.mdx
+++ b/src/platform-includes/configuration/config-intro/apple.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 

--- a/src/platform-includes/configuration/config-intro/dart.mdx
+++ b/src/platform-includes/configuration/config-intro/dart.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `Sentry.init` method:
 
+<SignInNote />
+
 ```dart
 import 'package:sentry/sentry.dart';
 

--- a/src/platform-includes/configuration/config-intro/dotnet.aspnetcore.mdx
+++ b/src/platform-includes/configuration/config-intro/dotnet.aspnetcore.mdx
@@ -3,6 +3,8 @@ pass the option object along for modifications:
 
 ASP.NET Core 2.x:
 
+<SignInNote />
+
 ```csharp
 public static IWebHost BuildWebHost(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
@@ -16,6 +18,8 @@ public static IWebHost BuildWebHost(string[] args) =>
 ```
 
 ASP.NET Core 3.0:
+
+<SignInNote />
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -33,6 +37,8 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 ```
 
 Additionally, you can set your options on `appsettings.json` when using `UseSentry()`:
+
+<SignInNote />
 
 ```json {filename:appsettings.json}
   "Sentry": {

--- a/src/platform-includes/configuration/config-intro/dotnet.google-cloud-functions.mdx
+++ b/src/platform-includes/configuration/config-intro/dotnet.google-cloud-functions.mdx
@@ -19,6 +19,8 @@ With that in mind, you'll be able to configure your options using two options: u
 
 See both methods below:
 
+<SignInNote />
+
 ```json {tabTitle:appsettings.json}
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/config-intro/dotnet.mdx
+++ b/src/platform-includes/configuration/config-intro/dotnet.mdx
@@ -1,5 +1,7 @@
 Options can be set from a function provided to the `SentrySdk.Init` method. For example:
 
+<SignInNote />
+
 ```csharp
 using Sentry;
 

--- a/src/platform-includes/configuration/config-intro/dotnet.nlog.mdx
+++ b/src/platform-includes/configuration/config-intro/dotnet.nlog.mdx
@@ -6,6 +6,8 @@ For more information on how to dynamically set event data via `NLog.config`, see
 
 You can configure the Sentry NLog target via `NLog.config` or by code as follows:
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"

--- a/src/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
+++ b/src/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
@@ -1,6 +1,8 @@
 Options can be set by passing a callback to the `Init()` method which will
 pass the option object along for modifications:
 
+<SignInNote />
+
 ```csharp
 using Sentry;
 

--- a/src/platform-includes/configuration/config-intro/flutter.mdx
+++ b/src/platform-includes/configuration/config-intro/flutter.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `SentryFlutter.init` method:
 
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platform-includes/configuration/config-intro/go.mdx
+++ b/src/platform-includes/configuration/config-intro/go.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `Init()` method as an instance of `sentry.ClientOptions`:
 
+<SignInNote />
+
 ```go
 sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/config-intro/java.mdx
+++ b/src/platform-includes/configuration/config-intro/java.mdx
@@ -1,6 +1,8 @@
 Options can be set by passing a callback to the `init()` method which will
 pass the option object along for modifications:
 
+<SignInNote />
+
 ```java {tabTitle:Java}
 import io.sentry.Sentry;
 

--- a/src/platform-includes/configuration/config-intro/java.spring-boot.mdx
+++ b/src/platform-includes/configuration/config-intro/java.spring-boot.mdx
@@ -1,5 +1,7 @@
 Basic options properties can be set in `application.properties` using `sentry` prefix:
 
+<SignInNote />
+
 ```properties {tabTitle: application.properties}
 sentry.dsn=___PUBLIC_DSN___
 sentry.release=io.sentry.samples.console@3.0.0+1

--- a/src/platform-includes/configuration/config-intro/javascript.ember.mdx
+++ b/src/platform-includes/configuration/config-intro/javascript.ember.mdx
@@ -1,5 +1,7 @@
 Options are passed to `sentry` inside your environment:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/ember";
 

--- a/src/platform-includes/configuration/config-intro/javascript.mdx
+++ b/src/platform-includes/configuration/config-intro/javascript.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `init()` function as object:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/config-intro/kotlin-multiplatform.mdx
+++ b/src/platform-includes/configuration/config-intro/kotlin-multiplatform.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 

--- a/src/platform-includes/configuration/config-intro/native.mdx
+++ b/src/platform-includes/configuration/config-intro/native.mdx
@@ -2,6 +2,8 @@ Options are passed into `sentry_init` as a pointer to an options object created
 via `sentry_options_new()`. There are functions that allow to set all options
 individually.
 
+<SignInNote />
+
 ```c
 #include <sentry.h>
 

--- a/src/platform-includes/configuration/config-intro/php.mdx
+++ b/src/platform-includes/configuration/config-intro/php.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `init()` method as an array:
 
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/configuration/config-intro/python.mdx
+++ b/src/platform-includes/configuration/config-intro/python.mdx
@@ -1,5 +1,7 @@
 Options are passed to the `init()` function as optional keyword arguments:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platform-includes/configuration/config-intro/ruby.mdx
+++ b/src/platform-includes/configuration/config-intro/ruby.mdx
@@ -1,5 +1,7 @@
 Options are passed within the `init` block:
 
+<SignInNote />
+
 ```ruby
 Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'

--- a/src/platform-includes/configuration/config-intro/rust.mdx
+++ b/src/platform-includes/configuration/config-intro/rust.mdx
@@ -2,6 +2,8 @@ Options are passed to the `init()` function as tuple where the first argument is
 
 Additionally, the `release_name` macro automatically generates the expected release based on the cargo metadata.
 
+<SignInNote />
+
 ```rust
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),

--- a/src/platform-includes/configuration/debug/javascript.mdx
+++ b/src/platform-includes/configuration/debug/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { Debug as DebugIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/dedupe/javascript.mdx
+++ b/src/platform-includes/configuration/dedupe/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { Dedupe as DedupeIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/dedupe/react-native.mdx
+++ b/src/platform-includes/configuration/dedupe/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 import { Dedupe as DedupeIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/diagnostic-logger/dotnet.mdx
+++ b/src/platform-includes/configuration/diagnostic-logger/dotnet.mdx
@@ -1,5 +1,7 @@
 Sentry's SDK includes its own internal logger to report diagnostics that may be useful when troubleshooting your Sentry configuration. To enable logging, set the `Debug` option to `true`:
 
+<SignInNote />
+
 ```csharp
 options =>
 {

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver as ReportingObserverIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver as ReportingObserverIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/enable-pluggable-integrations/react-native.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 import { Dedupe as DedupeIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/src/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { ExtraErrorData as ExtraErrorDataIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/http-client/javascript.mdx
+++ b/src/platform-includes/configuration/http-client/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { HttpClient as HttpClientIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/http-client/react-native.mdx
+++ b/src/platform-includes/configuration/http-client/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 import { HttpClient as HttpClientIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/ignore-errors/javascript.mdx
+++ b/src/platform-includes/configuration/ignore-errors/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/ignore-transactions/javascript.mdx
+++ b/src/platform-includes/configuration/ignore-transactions/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/configuration/offline/javascript.mdx
+++ b/src/platform-includes/configuration/offline/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/browser";
 

--- a/src/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/src/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver as ReportingObserverIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/browser";
 import { RewriteFrames as RewriteFramesIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/rewrite-frames/node.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/node.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
 import { RewriteFrames as RewriteFramesIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/rewrite-frames/react-native.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 import { RewriteFrames as RewriteFramesIntegration } from "@sentry/integrations";

--- a/src/platform-includes/configuration/sample-rate/php.mdx
+++ b/src/platform-includes/configuration/sample-rate/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/crons/setup/python.celery.mdx
+++ b/src/platform-includes/crons/setup/python.celery.mdx
@@ -22,6 +22,8 @@ app.conf.beat_schedule = {
 
 Initialize Sentry in the `celeryd_init` or `beat_init` signal. Make sure to set `monitor_beat_tasks=True` in `CeleryIntegration`:
 
+<SignInNote />
+
 ```python
 # tasks.py
 from celery import signals
@@ -55,6 +57,8 @@ You don't need to create Cron Monitors for your tasks on Sentry.io, we'll do it 
 
 You can exclude Celery Beat tasks from being auto-instrumented. To do this, add a list of tasks you want to exclude as option `exclude_beat_tasks` when creating `CeleryIntegration`. The list can contain simple strings with the full task name, as specified in the Celery Beat schedule, or regular expressions to match multiple tasks.
 
+<SignInNote />
+
 ```python
     exclude_beat_tasks = [
         "some-task-a",
@@ -86,6 +90,8 @@ We provide a lightweight decorator to make monitoring individual tasks easier. T
 Make sure the Sentry `@sentry_sdk.monitor` decorator is below Celery's `@app.task` decorator.
 
 </Note>
+
+<SignInNote />
 
 ```python
 # tasks.py

--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -25,6 +25,8 @@ Sentry can display snippets of your code next to the event stacktraces. This fea
 
 For this to work, your project settings for `DEBUG_INFORMATION_FORMAT` must be set to `DWARF with dSYM File`, which is the default for release builds but not for debug builds.
 
+<SignInNote />
+
 ```bash
 sentry-cli debug-files upload --auth-token YOUR_AUTH_TOKEN \
   --include-sources \
@@ -41,6 +43,8 @@ If you're already using Fastlane, you can use the [Sentry Fastlane plugin](https
 to upload your dSYMs to Sentry.
 
 Sentry can display snippets of your code next to event stacktraces. This feature is called <PlatformLink to="/data-management/debug-files/source-context/">source context</PlatformLink>. When setting the `include_sources` parameter to `true`, the Fastlane plugin will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
+
+<SignInNote />
 
 ```ruby
 sentry_upload_dif(
@@ -81,6 +85,8 @@ Depending on your needs, you may want to emit warnings to the Xcode build log to
 Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` to `YES` in build settings for configurations you use to deploy to production.
 
 </Alert>
+
+<SignInNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
 if which sentry-cli >/dev/null; then

--- a/src/platform-includes/distributed-tracing/how-to-use/node.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/node.mdx
@@ -1,5 +1,7 @@
 If you're using version `7.58.0` or above of our Node SDK and have the HTTP integration set up, distributed tracing will work out of the box.
 
+<SignInNote />
+
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/limiting-traces/javascript.mdx
+++ b/src/platform-includes/distributed-tracing/limiting-traces/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/limiting-traces/node.mdx
+++ b/src/platform-includes/distributed-tracing/limiting-traces/node.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/limiting-traces/python.mdx
+++ b/src/platform-includes/distributed-tracing/limiting-traces/python.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platform-includes/enriching-events/add-attachment/javascript.mdx
+++ b/src/platform-includes/enriching-events/add-attachment/javascript.mdx
@@ -34,6 +34,8 @@ It's possible to add, remove, or modify attachments before an event is sent by w
 the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>
 hook or a global event processor.
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/enriching-events/attach-screenshots/dotnet.xamarin.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/dotnet.xamarin.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```csharp
 SentryXamarin.Init(options =>
 {

--- a/src/platform-includes/enriching-events/attach-screenshots/flutter.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/flutter.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platform-includes/enriching-events/attach-screenshots/javascript.electron.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/javascript.electron.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 

--- a/src/platform-includes/enriching-events/attach-screenshots/react-native.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/enriching-events/attach-viewhierarchy/flutter.mdx
+++ b/src/platform-includes/enriching-events/attach-viewhierarchy/flutter.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platform-includes/enriching-events/attach-viewhierarchy/kotlin-multiplatform.mdx
+++ b/src/platform-includes/enriching-events/attach-viewhierarchy/kotlin-multiplatform.mdx
@@ -4,6 +4,8 @@ Currently only available on iOS and Android.
 
 </Note>
 
+<SignInNote />
+
 ```kotlin
 import io.sentry.kotlin.multiplatform.sentry
 

--- a/src/platform-includes/enriching-events/attach-viewhierarchy/react-native.mdx
+++ b/src/platform-includes/enriching-events/attach-viewhierarchy/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/enriching-events/scopes/configure-scope/react-native.mdx
+++ b/src/platform-includes/enriching-events/scopes/configure-scope/react-native.mdx
@@ -12,6 +12,8 @@ Sentry.configureScope(function (scope) {
 
 If you want to set context data in the JS layer and then receive that context data when a native (C/C++) crash happens, you need to synchronize the JS `Scope` with the native `Scope`. This feature was introduced in version `2.0.0` of the React-Native SDK and requires an opt-in:
 
+<SignInNote />
+
 ```javascript {filename:App.js}
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
+++ b/src/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
@@ -4,6 +4,8 @@ For more information on how to dynamically set event tags via `NLog.config`, see
 
 </Alert>
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"

--- a/src/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
+++ b/src/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
@@ -5,6 +5,8 @@
 
 </Alert>
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/_default.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/_default.mdx
@@ -14,6 +14,8 @@ name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
 There is also a function called <PlatformIdentifier name="last-event-id" />
 that returns the ID of the most recently sent event.
 
+<SignInNote />
+
 ```html
 <script>
   Sentry.init({ dsn: "___PUBLIC_DSN___" });

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/dotnet.aspnet.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/dotnet.aspnet.mdx
@@ -10,6 +10,8 @@ Make sure you've got the JavaScript SDK available:
 
 If you are rendering the page from the server, for example on ASP.NET MVC, the `Error.cshtml` razor page can be:
 
+<SignInNote />
+
 ```cshtml
 @if (SentrySdk.LastEventId != SentryId.Empty) {
   <script>

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/dotnet.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/dotnet.mdx
@@ -14,6 +14,8 @@ name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
 There is also a function called <PlatformIdentifier name="last-event-id" />
 that returns the ID of the most recently sent event.
 
+<SignInNote />
+
 ```html
 <script>
   Sentry.init({ dsn: "___PUBLIC_DSN___" });

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/javascript.electron.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/javascript.electron.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 const { init, showReportDialog } = require("@sentry/electron");
 

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/javascript.mdx
@@ -1,5 +1,7 @@
 If you're using a framework like [React](/platforms/javascript/guides/react/) or [Angular](/platforms/javascript/guides/angular/), the best place to collect user feedback is in your error-handling component. (Please see platform-specific docs for examples.) If you're not using a framework, you can collect feedback right before the event is sent, using `beforeSend`:
 
+<SignInNote />
+
 ```html
 <script>
   Sentry.init({

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/php.laravel.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/php.laravel.mdx
@@ -10,6 +10,8 @@ Make sure you've got the JavaScript SDK available:
 
 Next, create `resources/views/errors/500.blade.php`, and embed the feedback code:
 
+<SignInNote />
+
 ```html {filename:resources/views/errors/500.blade.php}
 <div class="content">
   <div class="title">Something went wrong.</div>

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/php.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/php.mdx
@@ -16,6 +16,8 @@ Make sure you've got the JavaScript SDK available:
 
 Depending on how you render your templates, the example would be in a simple php file:
 
+<SignInNote />
+
 ```html
 <?php if (\Sentry\SentrySdk::getCurrentHub()->getLastEventId()) { ?>
 <script>

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/python.django.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/python.django.mdx
@@ -22,6 +22,8 @@ Make sure you've got the JavaScript SDK available:
 
 And the template that brings up the dialog
 
+<SignInNote />
+
 ```html
 {% if sentry_event_id %}
 <script>

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/python.flask.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/python.flask.mdx
@@ -21,6 +21,8 @@ Make sure you've got the JavaScript SDK available:
 
 And the template that brings up the dialog:
 
+<SignInNote />
+
 ```html
 {% if sentry_event_id %}
 <script>

--- a/src/platform-includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget/ruby.rails.mdx
@@ -14,6 +14,8 @@ Make sure you've got the JavaScript SDK available:
 
 Additionally, you need the template that brings up the dialog:
 
+<SignInNote />
+
 ```ERB
 <% sentry_id = request.env["sentry.error_event_id"] %>
 <% if sentry_id.present? %>

--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/apple.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/apple.mdx
@@ -26,6 +26,8 @@ To capture user feedback regarding a crash, use the `SentryOptions.onCrashedLast
 This callback gets called shortly after the initialization of the SDK when the last
 program execution terminated with a crash. It is not guaranteed that this is called on the main thread.
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/sdk-api-example/javascript.mdx
@@ -17,6 +17,8 @@ Sentry.captureUserFeedback(userFeedback);
 
 You could also collect feedback and send it when an error occurs via the SDK's `beforeSend` callback:
 
+<SignInNote />
+
 ```js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',

--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -1,5 +1,7 @@
 Configuration is done via the application `AndroidManifest.xml` Here's an example config which should get you started:
 
+<SignInNote />
+
 ```xml {filename:AndroidManifest.xml}
 <application>
   <!-- Required: set your sentry.io project identifier (DSN) -->

--- a/src/platform-includes/getting-started-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/apple.mdx
@@ -1,5 +1,7 @@
 We recommend initializing the SDK on the main thread as soon as possible, such as in your AppDelegate `application:didFinishLaunchingWithOptions` method:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry // Make sure you import Sentry
 
@@ -37,6 +39,8 @@ func application(_ application: UIApplication,
 ```
 
 When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
+
+<SignInNote />
 
 ```swift
 import Sentry

--- a/src/platform-includes/getting-started-config/dart.mdx
+++ b/src/platform-includes/getting-started-config/dart.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:sentry/sentry.dart';
 

--- a/src/platform-includes/getting-started-config/dotnet.aspnetcore.mdx
+++ b/src/platform-includes/getting-started-config/dotnet.aspnetcore.mdx
@@ -2,6 +2,8 @@ Add Sentry to `Program.cs` through the `WebHostBuilder`:
 
 ASP.NET Core 2.x:
 
+<SignInNote />
+
 ```csharp
 public static IWebHost BuildWebHost(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
@@ -17,6 +19,8 @@ let BuildWebHost args =
 ```
 
 ASP.NET Core 3.0:
+
+<SignInNote />
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/src/platform-includes/getting-started-config/dotnet.mdx
+++ b/src/platform-includes/getting-started-config/dotnet.mdx
@@ -1,5 +1,7 @@
 For example, initialize with `SentrySdk.Init` in your `Program.cs` file:
 
+<SignInNote />
+
 ```csharp
 using Sentry;
 

--- a/src/platform-includes/getting-started-config/dotnet.xamarin.mdx
+++ b/src/platform-includes/getting-started-config/dotnet.xamarin.mdx
@@ -1,6 +1,8 @@
 You should initialize the SDK as early as possible, for an example, the start of OnCreate
 on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate for iOS).
 
+<SignInNote />
+
 ```csharp
 using Sentry;
 

--- a/src/platform-includes/getting-started-config/flutter.mdx
+++ b/src/platform-includes/getting-started-config/flutter.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platform-includes/getting-started-config/go.mdx
+++ b/src/platform-includes/getting-started-config/go.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platform-includes/getting-started-config/java.jul.mdx
+++ b/src/platform-includes/getting-started-config/java.jul.mdx
@@ -29,6 +29,8 @@ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 
 Sentry reads the DSN from the system property `sentry.dsn`, environment variable `SENTRY_DSN` or the `dsn` property in `sentry.properties` file. [See the configuration page](/platforms/java/configuration/) for more details on external configuration.
 
+<SignInNote />
+
 ```properties {tabTitle:sentry.properties}
 dsn=___PUBLIC_DSN___
 ```

--- a/src/platform-includes/getting-started-config/java.log4j2.mdx
+++ b/src/platform-includes/getting-started-config/java.log4j2.mdx
@@ -6,6 +6,8 @@ The `ConsoleAppender` is provided only as an example of a non-Sentry appender se
 
 </Note>
 
+<SignInNote />
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="warn" packages="org.apache.logging.log4j.core,io.sentry.log4j2">
@@ -31,6 +33,8 @@ The `ConsoleAppender` is provided only as an example of a non-Sentry appender se
 
 Note that **you need to configure your DSN** (client key) only if you wish to initialize the SDK through the log4j2 integration. If you're planning to use `Sentry.init` to provide configuration, such as by using the `beforeSend` callback, you **should not** provide the DSN in both `Sentry.init` and the appender configuration; just leave it out of the appender configuration in this case.
 
+<SignInNote />
+
 ```xml
 <Sentry name="Sentry"
         dsn="___PUBLIC_DSN___" />
@@ -52,6 +56,8 @@ Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `log4j2.xml` only aff
 </Note>
 
 Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.info` or `logger.warn`, no event is sent to Sentry. If you then log with `logger.error`, an event is sent to Sentry that includes those 100 `info` or `warn` messages. For this to work, `SentryAppender` needs to receive **all** log entries to decide what to keep as breadcrumb or send as event. Set the `SentryAppender` log level configuration to a value lower than what is set for the `minimumBreadcrumbLevel` and `minimumEventLevel` so that `SentryAppender` receives these log messages.
+
+<SignInNote />
 
 ```xml
 <!-- Setting minimumBreadcrumbLevel modifies the default minimum level to add breadcrumbs from INFO to DEBUG  -->

--- a/src/platform-includes/getting-started-config/java.logback.mdx
+++ b/src/platform-includes/getting-started-config/java.logback.mdx
@@ -6,6 +6,8 @@ The `ConsoleAppender` is provided only as an example of a non-Sentry appender se
 
 </Note>
 
+<SignInNote />
+
 ```xml
 <configuration>
     <!-- Configure the Console appender -->
@@ -36,6 +38,8 @@ The `ConsoleAppender` is provided only as an example of a non-Sentry appender se
 
 Note that **you need to configure your DSN** (client key).
 
+<SignInNote />
+
 ```xml
 <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <options>
@@ -61,6 +65,8 @@ Setting `minimumEventLevel` or `minimumBreadcrumbLevel` in `logback.xml` only af
 </Note>
 
 Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.info` or `logger.warn`, no event is sent to Sentry. If you then log with `logger.error`, an event is sent to Sentry which includes those 100 `info` or `warn` messages. For this to work, `SentryAppender` needs to receive **all** log entries to decide what to keep as breadcrumb or sent as event. Set the `SentryAppender` log level configuration to a value lower than what is set for the `minimumBreadcrumbLevel` and `minimumEventLevel` so that `SentryAppender` receives these log messages.
+
+<SignInNote />
 
 ```xml
 <appender name="Sentry" class="io.sentry.logback.SentryAppender">

--- a/src/platform-includes/getting-started-config/java.mdx
+++ b/src/platform-includes/getting-started-config/java.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```java {tabTitle: Java}
 import io.sentry.Sentry;
 

--- a/src/platform-includes/getting-started-config/java.servlet.mdx
+++ b/src/platform-includes/getting-started-config/java.servlet.mdx
@@ -1,5 +1,7 @@
 The following example configures a `SentryInitializer` servlet container initializer that initializes Sentry on application startup.
 
+<SignInNote />
+
 ```java
 package sentry.sample;
 
@@ -37,6 +39,8 @@ class SentryInitializer : ServletContainerInitializer {
 ```
 
 Create a file in `src/main/resources/META-INF/services` named `javax.servlet.ServletContainerInitializer`, with a full name of your custom `SentryInitializer` class as a content:
+
+<SignInNote />
 
 ```properties
 sentry.sample.SentryInitializer

--- a/src/platform-includes/getting-started-config/java.spring-boot.mdx
+++ b/src/platform-includes/getting-started-config/java.spring-boot.mdx
@@ -2,6 +2,8 @@ Sentry's Spring Boot integration auto-configures `sentry.in-app-packages` proper
 
 Provide a `sentry.dsn` property using either `application.properties` or `application.yml`:
 
+<SignInNote />
+
 ```properties {filename:application.properties}
 sentry.dsn=___PUBLIC_DSN___
 

--- a/src/platform-includes/getting-started-config/java.spring.mdx
+++ b/src/platform-includes/getting-started-config/java.spring.mdx
@@ -1,5 +1,7 @@
 The `sentry-spring` and `sentry-spring-jakarta` libraries provide an `@EnableSentry` annotation that registers all required Spring beans. `@EnableSentry` can be placed on any class annotated with [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html) including the main entry class in Spring Boot applications annotated with [@SpringBootApplication](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html).
 
+<SignInNote />
+
 ```java {tabTitle:Java (Spring 5)}
 import io.sentry.spring.EnableSentry;
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
@@ -43,6 +45,8 @@ The DSN can be also provided through the system property `sentry.dsn`, environme
 Once this integration is configured you can _also_ use Sentry’s static API, [as shown on the usage page](usage/), to record breadcrumbs, set the current user, or manually send events, for example.
 
 By default, only unhandled exceptions are sent to Sentry. This behavior can be tuned through configuring the `exceptionResolverOrder` property. For example, setting it to `Ordered#HIGHEST_PRECEDENCE` ensures exceptions that have been handled by exception resolvers with higher order are sent to Sentry - including ones handled by `@ExceptionHandler` annotated methods.
+
+<SignInNote />
 
 ```java {tabTitle:Java (Spring 5)}
 import io.sentry.spring.EnableSentry;

--- a/src/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/src/platform-includes/getting-started-config/javascript.angular.mdx
@@ -1,5 +1,7 @@
 Once this is done, Sentry's Angular SDK captures all unhandled exceptions and transactions.
 
+<SignInNote />
+
 ```javascript{tabTitle: Angular 12+}{filename: main.ts}
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";

--- a/src/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/src/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -1,5 +1,7 @@
 Then forward the `init` method from the sibling Sentry SDK for the framework you use, such as Angular in this example:
 
+<SignInNote />
+
 ```typescript {tabTitle: Angular} {filename: app.module.ts}
 import * as Sentry from "@sentry/capacitor";
 // Use @sentry/angular-ivy for Angular 12+ or `@sentry/angular` from Angular 10 and 11

--- a/src/platform-includes/getting-started-config/javascript.cordova.mdx
+++ b/src/platform-includes/getting-started-config/javascript.cordova.mdx
@@ -1,5 +1,7 @@
 You should `init` the SDK in the `deviceReady` function, to make sure the native integrations runs.
 
+<SignInNote />
+
 ```javascript
 onDeviceReady: function() {
   var Sentry = cordova.require("sentry-cordova.Sentry");

--- a/src/platform-includes/getting-started-config/javascript.electron.mdx
+++ b/src/platform-includes/getting-started-config/javascript.electron.mdx
@@ -1,5 +1,7 @@
 You need to call `init` in the `main` process and every `renderer` process you spawn.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 

--- a/src/platform-includes/getting-started-config/javascript.ember.mdx
+++ b/src/platform-includes/getting-started-config/javascript.ember.mdx
@@ -1,5 +1,7 @@
 This snippet includes automatic instrumentation to monitor the performance of your application, which registers and configures the Tracing integration, including custom [Ember instrumentation](./configuration/ember-options/).
 
+<SignInNote />
+
 ```javascript
 import Application from "@ember/application";
 import Resolver from "ember-resolver";

--- a/src/platform-includes/getting-started-config/javascript.mdx
+++ b/src/platform-includes/getting-started-config/javascript.mdx
@@ -1,5 +1,7 @@
 Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions, transactions, and Session Replays, based on the sample rates set.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/browser";
 

--- a/src/platform-includes/getting-started-config/javascript.react.mdx
+++ b/src/platform-includes/getting-started-config/javascript.react.mdx
@@ -1,3 +1,6 @@
+
+<SignInNote />
+
 ```javascript
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router-dom";

--- a/src/platform-includes/getting-started-config/javascript.react.mdx
+++ b/src/platform-includes/getting-started-config/javascript.react.mdx
@@ -1,4 +1,3 @@
-
 <SignInNote />
 
 ```javascript

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -57,7 +57,6 @@ Sentry.init({
 
 Initialize Sentry in your entry point for the server to capture exceptions and get performance metrics for your [`action`](https://remix.run/docs/en/v1/api/conventions#action) and [`loader`](https://remix.run/docs/en/v1/api/conventions#loader) functions. You can also initialize Sentry's database integrations, such as Prisma, to get spans for your database calls.
 
-
 <SignInNote />
 
 ```typescript {filename: entry.server.tsx}

--- a/src/platform-includes/getting-started-config/javascript.remix.mdx
+++ b/src/platform-includes/getting-started-config/javascript.remix.mdx
@@ -4,6 +4,8 @@ Create two files in the root directory of your project, `entry.client.tsx` and `
 
 The two configuration types are mostly the same, except that some configuration features, like Session Replay, only work in `entry.client.tsx`.
 
+<SignInNote />
+
 ```typescript {tabTitle:Client} {filename: entry.client.tsx}
 import { useLocation, useMatches } from "@remix-run/react";
 import * as Sentry from "@sentry/remix";
@@ -54,6 +56,9 @@ Sentry.init({
 ```
 
 Initialize Sentry in your entry point for the server to capture exceptions and get performance metrics for your [`action`](https://remix.run/docs/en/v1/api/conventions#action) and [`loader`](https://remix.run/docs/en/v1/api/conventions#loader) functions. You can also initialize Sentry's database integrations, such as Prisma, to get spans for your database calls.
+
+
+<SignInNote />
 
 ```typescript {filename: entry.server.tsx}
 import { prisma } from "~/db.server";

--- a/src/platform-includes/getting-started-config/javascript.svelte.mdx
+++ b/src/platform-includes/getting-started-config/javascript.svelte.mdx
@@ -1,5 +1,7 @@
 To use the SDK, initialize it in your Svelte entry point before bootstrapping your app. In a typical Svelte project, that is your `main.js` or `main.ts` file.
 
+<SignInNote />
+
 ```javascript {filename: main.js}
 import "./app.css";
 import App from "./App.svelte";

--- a/src/platform-includes/getting-started-config/javascript.vue.mdx
+++ b/src/platform-includes/getting-started-config/javascript.vue.mdx
@@ -2,6 +2,8 @@ To initialize Sentry in your Vue application, add the following code snippet to 
 
 ### Vue 3
 
+<SignInNote />
+
 ```javascript {filename:main.js}
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
@@ -43,6 +45,8 @@ app.mount("#app");
 ```
 
 ### Vue 2
+
+<SignInNote />
 
 ```javascript {filename:main.js}
 import Vue from "vue";

--- a/src/platform-includes/getting-started-config/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-config/kotlin-multiplatform.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 

--- a/src/platform-includes/getting-started-config/native.mdx
+++ b/src/platform-includes/getting-started-config/native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```c
 #include <sentry.h>
 

--- a/src/platform-includes/getting-started-config/native.qt.mdx
+++ b/src/platform-includes/getting-started-config/native.qt.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```cpp
 #include <QtWidgets>
 #include <sentry.h>

--- a/src/platform-includes/getting-started-config/node.mdx
+++ b/src/platform-includes/getting-started-config/node.mdx
@@ -1,5 +1,7 @@
 Once this is done, Sentry's Node SDK captures all transactions and unhandled exceptions.
 
+<SignInNote />
+
 ```javascript {tabTitle:ESM}
 import * as Sentry from "@sentry/node";
 

--- a/src/platform-includes/getting-started-config/php.mdx
+++ b/src/platform-includes/getting-started-config/php.mdx
@@ -1,5 +1,7 @@
 To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.
 
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/getting-started-config/python.flask.mdx
+++ b/src/platform-includes/getting-started-config/python.flask.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```python
 import sentry_sdk
 from flask import Flask

--- a/src/platform-includes/getting-started-config/python.mdx
+++ b/src/platform-includes/getting-started-config/python.mdx
@@ -1,5 +1,7 @@
 Once this is done, Sentry's Python SDK captures all unhandled exceptions and transactions.
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platform-includes/getting-started-config/react-native.mdx
+++ b/src/platform-includes/getting-started-config/react-native.mdx
@@ -2,6 +2,8 @@
 
 To initialize the SDK, you need to call:
 
+<SignInNote />
+
 ```javascript {filename:App.js}
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/getting-started-config/ruby.mdx
+++ b/src/platform-includes/getting-started-config/ruby.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```ruby
 require 'sentry-ruby'
 

--- a/src/platform-includes/getting-started-config/ruby.rack.mdx
+++ b/src/platform-includes/getting-started-config/ruby.rack.mdx
@@ -1,5 +1,7 @@
 Add `use Sentry::Rack::CaptureExceptions` to your `config.ru` or other rackup file:
 
+<SignInNote />
+
 ```ruby {filename:config.ru}
 require 'sentry-ruby'
 

--- a/src/platform-includes/getting-started-config/ruby.rails.mdx
+++ b/src/platform-includes/getting-started-config/ruby.rails.mdx
@@ -1,5 +1,7 @@
 Initialize the SDK within your `config/initializers/sentry.rb`:
 
+<SignInNote />
+
 ```ruby {filename:config/initializers/sentry.rb}
 Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'

--- a/src/platform-includes/getting-started-config/rust.mdx
+++ b/src/platform-includes/getting-started-config/rust.mdx
@@ -1,5 +1,7 @@
 `sentry.init()` will return you a guard that when freed, will prevent process exit until all events have been sent (within a timeout):
 
+<SignInNote />
+
 ```rust
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),

--- a/src/platform-includes/getting-started-config/unity.mdx
+++ b/src/platform-includes/getting-started-config/unity.mdx
@@ -1,5 +1,7 @@
 The minimum configuration required is the [DSN](/product/sentry-basics/dsn-explainer/) to your project.
 
+<SignInNote />
+
 ```
 ___PUBLIC_DSN___
 ```

--- a/src/platform-includes/getting-started-config/unreal.mdx
+++ b/src/platform-includes/getting-started-config/unreal.mdx
@@ -1,5 +1,7 @@
 The minimum configuration required is the [DSN](/product/sentry-basics/dsn-explainer/) of your project:
 
+<SignInNote />
+
 ```
 ___PUBLIC_DSN___
 ```

--- a/src/platform-includes/getting-started-verify/go.mdx
+++ b/src/platform-includes/getting-started-verify/go.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platform-includes/getting-started-verify/rust.mdx
+++ b/src/platform-includes/getting-started-verify/rust.mdx
@@ -1,5 +1,7 @@
 The quickest way to verify Sentry in your Rust application is to cause a panic:
 
+<SignInNote />
+
 ```rust
 fn main() {
     let _guard = sentry::init("___PUBLIC_DSN___");

--- a/src/platform-includes/in-app-frames/apple.mdx
+++ b/src/platform-includes/in-app-frames/apple.mdx
@@ -7,6 +7,8 @@ The `sentry-cocoa` SDK always marks public frameworks such as UIKitCore, CoreFou
 
 If you use dynamic frameworks, such as, for example, Sentry, the SDK marks these as `not inApp`. In case you have a private framework that should be `inApp`, you can use [`inAppInclude`](/platforms/apple/configuration/options/#in-app-include) or [`inAppExclude`](/platforms/apple/configuration/options/#in-app-exclude) of the SentryOptions.
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/performance/always-inherit-sampling-decision/php.mdx
+++ b/src/platform-includes/performance/always-inherit-sampling-decision/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/performance/configure-sample-rate/android.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/android.mdx
@@ -8,6 +8,8 @@ Or alternatively:
 
 Or, if you are manually instrumenting Sentry:
 
+<SignInNote />
+
 ```java {tabTitle:Java}
 import io.sentry.android.core.SentryAndroid;
 

--- a/src/platform-includes/performance/configure-sample-rate/apple.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/apple.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/performance/configure-sample-rate/dart.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/dart.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:sentry/sentry.dart';
 

--- a/src/platform-includes/performance/configure-sample-rate/flutter.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/flutter.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platform-includes/performance/configure-sample-rate/java.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/java.mdx
@@ -6,6 +6,8 @@ If you are using either our [Spring](/platforms/java/guides/spring/performance/)
 
 </Note>
 
+<SignInNote />
+
 ```java {tabTitle:Java}
 import io.sentry.Sentry;
 

--- a/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 // BrowserTracing should only be configured in Electron renderer processes
 import * as Sentry from "@sentry/electron/renderer";

--- a/src/platform-includes/performance/configure-sample-rate/javascript.ember.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.ember.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/ember";
 

--- a/src/platform-includes/performance/configure-sample-rate/javascript.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 // If you're using one of our framework SDK packages, like `@sentry/react`,
 // substitute its name for `@sentry/browser` here

--- a/src/platform-includes/performance/configure-sample-rate/javascript.nextjs.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.nextjs.mdx
@@ -1,5 +1,7 @@
 In both, `sentry.server.config.js` and `sentry.client.config.js`, set:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/nextjs";
 

--- a/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.react.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import { createBrowserRouter } from "react-router-dom";
 import * as Sentry from "@sentry/react";

--- a/src/platform-includes/performance/configure-sample-rate/javascript.sveltekit.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.sveltekit.mdx
@@ -1,5 +1,7 @@
 In both, `hooks.client.js` and `hooks.server.js`, set:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/sveltekit";
 

--- a/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import Vue from "vue";
 import * as Sentry from "@sentry/vue";

--- a/src/platform-includes/performance/configure-sample-rate/node.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/node.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
 

--- a/src/platform-includes/performance/configure-sample-rate/php.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/performance/configure-sample-rate/python.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/python.mdx
@@ -1,5 +1,7 @@
 Performance Monitoring is available for the Sentry Python SDK version ≥ 0.11.2.
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platform-includes/performance/configure-sample-rate/react-native.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/react-native.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/performance/custom-performance-metrics/python.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/python.mdx
@@ -1,5 +1,7 @@
 Adding custom metrics is supported in Sentry's Python SDK version `1.16.0` and above.
 
+<SignInNote />
+
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
@@ -24,6 +26,8 @@ set_measurement('cache_read_count', 4);
 The feature was marked experimental between versions `1.5.12` and `1.16.0`.
 To enable the capturing of custom metrics before `1.16.0`, you'll need to enable the `custom_measurements` experiment option
 and fetch the transaction manually.
+
+<SignInNote />
 
 ```python
 sentry_sdk.init(

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
@@ -2,6 +2,8 @@ To enable tracing, include the `BrowserTracing` integration in your SDK configur
 
 After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
 
+<SignInNote />
+
 ```javascript
 // BrowserTracing should only be configured in Electron renderer processes
 import * as Sentry from "@sentry/electron/renderer";

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.ember.mdx
@@ -2,6 +2,8 @@ The Ember add-on automatically adds the tracing integration for you with additio
 
 After configuration, you will see both `pageload` and `navigation` transactions in sentry.io.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/ember";
 

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.mdx
@@ -2,6 +2,8 @@ To enable tracing, include the `BrowserTracing` integration in your SDK configur
 
 After configuration, you will see both `pageload` and `navigation` transactions in the Sentry UI.
 
+<SignInNote />
+
 ```javascript
 // If you're using one of our framework SDK packages, like `@sentry/react`,
 // substitute its name for `@sentry/browser` here

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.react.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.react.mdx
@@ -2,6 +2,8 @@ To enable tracing, include the `BrowserTracing` integration in your SDK configur
 
 To use `react-router` integration, import and set a custom routing instrumentation using a custom history. Make sure you use a `Router` component combined with `createBrowserHistory` (or equivalent).
 
+<SignInNote />
+
 ```javascript
 import { Router } from "react-router-dom";
 import { createBrowserHistory } from "history";

--- a/src/platform-includes/performance/enable-tracing/react-native.mdx
+++ b/src/platform-includes/performance/enable-tracing/react-native.mdx
@@ -4,6 +4,8 @@ If you use a version of our SDK prior to version `3.0.0`, you will need to inclu
 
 </Alert>
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 

--- a/src/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -1,5 +1,7 @@
 You need to register the Sentry-provided SpanProcessor and Propagator as shown below:
 
+<SignInNote />
+
 ```go
 import (
 	"go.opentelemetry.io/otel"

--- a/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/javascript.nextjs.mdx
@@ -4,6 +4,8 @@
 
 3. Enable your `sentry.server.config.js` file to be able to use the OpenTelemetry instrumenter option.
 
+<SignInNote />
+
 ```javascript {filename:sentry.server.config.js}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -1,5 +1,7 @@
 You need to register `SentrySpanProcessor` and `SentryPropagator` with your OpenTelemetry installation:
 
+<SignInNote />
+
 ```js
 const Sentry = require("@sentry/node");
 const {

--- a/src/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -1,5 +1,7 @@
 Initialize Sentry for tracing and set the `instrumenter` to `otel`:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -1,5 +1,7 @@
 Initialize Sentry for tracing and set the `instrumenter` to `:otel`:
 
+<SignInNote />
+
 ```ruby {filename:config/initializers/sentry.rb}
 Sentry.init do |config|
   config.dsn = "___PUBLIC_DSN___"

--- a/src/platform-includes/performance/opentelemetry-setup/with-java-agent/with-auto-init/java.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/with-java-agent/with-auto-init/java.mdx
@@ -1,5 +1,7 @@
 This `java` command shows how to run your application using `sentry-opentelemetry-agent`:
 
+<SignInNote />
+
 ```bash
 SENTRY_PROPERTIES_FILE=sentry.properties java -javaagent:sentry-opentelemetry-agent-{{@inject packages.version('sentry.java.opentelemetry-agent') }}.jar -jar your-application.jar
 ```

--- a/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.mdx
@@ -1,5 +1,7 @@
 If you're not using the auto initialization provided by `sentry-opentelemetry-agent` (`SENTRY_AUTO_INIT=false`), you have to set the `instrumenter` option to `otel`. This disables all Sentry instrumentation and uses the chosen OpenTelemetry tracers for creating spans instead. To ensure errors are properly linked to transactions that were created by the OpenTelemetry integration, add the `OpenTelemetryLinkErrorEventProcessor`:
 
+<SignInNote />
+
 ```java {tabTitle: Java}
 import io.sentry.Instrumenter;
 import io.sentry.Sentry;

--- a/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.spring-boot.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/with-java-agent/without-auto-init/java.spring-boot.mdx
@@ -1,6 +1,8 @@
 If you're not using the auto initialization provided by `sentry-opentelemetry-agent` (`SENTRY_AUTO_INIT=false`), you have to
 set the `instrumenter` option to `otel`. This disables all Sentry instrumentation and uses the chosen OpenTelemetry tracers for creating spans instead:
 
+<SignInNote />
+
 ```properties {filename:application.properties}
 sentry.dsn=___PUBLIC_DSN___
 sentry.traces-sample-rate=1.0

--- a/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.mdx
@@ -47,6 +47,8 @@ You have to set the `instrumenter` option to `otel`. This disables all Sentry in
 
 To ensure errors are properly linked to transactions that were created by the OpenTelemetry integration, add the `OpenTelemetryLinkErrorEventProcessor`:
 
+<SignInNote />
+
 ```java {tabTitle: Java}
 import io.sentry.Instrumenter;
 import io.sentry.Sentry;

--- a/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.spring-boot.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/without-java-agent/java.spring-boot.mdx
@@ -45,6 +45,8 @@ val openTelemetry = OpenTelemetrySdk.builder()
 
 You have to set the `instrumenter` option to `otel`. This disables all Sentry instrumentation and uses the chosen OpenTelemetry tracers for creating spans instead.
 
+<SignInNote />
+
 ```properties {filename:application.properties}
 sentry.dsn=___PUBLIC_DSN___
 sentry.traces-sample-rate=1.0

--- a/src/platform-includes/performance/tracePropagationTargets-example/javascript.ember.mdx
+++ b/src/platform-includes/performance/tracePropagationTargets-example/javascript.ember.mdx
@@ -6,6 +6,8 @@ For example:
 - The option can be configured for the built-in ember browser tracing: `browserTracingOptions: { tracePropagationTargets: ['api.example.com'] }}`
 - Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/ember";
 

--- a/src/platform-includes/performance/tracePropagationTargets-example/react-native.mdx
+++ b/src/platform-includes/performance/tracePropagationTargets-example/react-native.mdx
@@ -6,6 +6,8 @@ For example:
 - Therefore, the option needs to be configured like this: `new Sentry.ReactNativeTracing({tracePropagationTargets: ['api.example.com']})`
 - Now outgoing XHR/fetch requests to `api.example.com` will get the `sentry-trace` header attached
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/performance/traces-sample-rate/php.mdx
+++ b/src/platform-includes/performance/traces-sample-rate/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/performance/traces-sampler-as-filter/php.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-filter/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/performance/traces-sampler-as-sampler/android.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-sampler/android.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```java
 import io.sentry.CustomSamplingContext;
 import io.sentry.android.core.SentryAndroid;

--- a/src/platform-includes/performance/traces-sampler-as-sampler/apple.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-sampler/apple.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/performance/traces-sampler-as-sampler/java.mdx
+++ b/src/platform-includes/performance/traces-sampler-as-sampler/java.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```java
 import io.sentry.CustomSamplingContext;
 import io.sentry.Sentry;

--- a/src/platform-includes/session-replay/setup/javascript.capacitor.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.capacitor.mdx
@@ -4,6 +4,8 @@ Several options are supported and passable using the integration constructor. Se
   The minimal supported version of Sentry's SDK for Capacitor is 0.11.1.
 </Note>
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/capacitor";
 import { Replay } from "@sentry/replay";

--- a/src/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -4,6 +4,8 @@ constructor. See the [configuration
 documentation](/platforms/javascript/session-replay/configuration/) for more
 details.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron/renderer";
 

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -1,5 +1,7 @@
 To set up the integration, add the following to your Sentry initialization. Several options are supported and passable using the integration constructor. See the [configuration documentation](/platforms/javascript/session-replay/configuration/) for more details.
 
+<SignInNote />
+
 ```javascript
 // import Sentry from your framework SDK (e.g. @sentry/react) instead of @sentry/browser
 import * as Sentry from "@sentry/browser";

--- a/src/platform-includes/set-environment/apple.mdx
+++ b/src/platform-includes/set-environment/apple.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platform-includes/set-environment/dotnet.nlog.mdx
+++ b/src/platform-includes/set-environment/dotnet.nlog.mdx
@@ -4,6 +4,8 @@ For more information on how to dynamically set event data via `NLog.config`, see
 
 </Alert>
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 
 <?xml version="1.0" encoding="utf-8" ?>

--- a/src/platform-includes/set-environment/php.mdx
+++ b/src/platform-includes/set-environment/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/set-release/dotnet.nlog.mdx
+++ b/src/platform-includes/set-release/dotnet.nlog.mdx
@@ -4,6 +4,8 @@ For more information on how to dynamically set event data via `NLog.config`, see
 
 </Alert>
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"

--- a/src/platform-includes/set-release/php.mdx
+++ b/src/platform-includes/set-release/php.mdx
@@ -1,3 +1,5 @@
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',

--- a/src/platform-includes/set-release/rust.mdx
+++ b/src/platform-includes/set-release/rust.mdx
@@ -1,5 +1,7 @@
 The `release_name` macro automatically infers the release from the cargo metadata and is the preferred way to set a release.
 
+<SignInNote />
+
 ```rust
 use sentry;
 

--- a/src/platform-includes/source-context/apple.mdx
+++ b/src/platform-includes/source-context/apple.mdx
@@ -6,6 +6,8 @@ There are three options for setting up source context:
 
 If you add the `--include-sources` flag to the sentry-cli `debug-files upload` command, sentry-cli will scan your debug files to find references to the source code files, resolve them in the local file system, bundle them up, and upload them to Sentry.
 
+<SignInNote />
+
 ```bash
 sentry-cli debug-files upload --auth-token YOUR_AUTH_TOKEN \
   --include-sources \
@@ -19,6 +21,8 @@ sentry-cli debug-files upload --auth-token YOUR_AUTH_TOKEN \
 If you're already using Fastlane, you can use the [Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin)
 to upload your source to Sentry by adding `include_sources: true` to the plugin call.
 
+<SignInNote />
+
 ```ruby
 sentry_upload_dif(
   auth_token: 'YOUR_AUTH_TOKEN',
@@ -31,6 +35,8 @@ sentry_upload_dif(
 ### 3. Xcode Build Phase
 
 You can upload your sources to Sentry after every build through Xcode. To do this, add the `--include-sources` flag to the sentry-cli `debug-files upload` command in the [Upload Debug Symbols](#xcode-build-phase) Xcode build phase script.
+
+<SignInNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
 if which sentry-cli >/dev/null; then

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -46,6 +46,8 @@ Add the Sentry Gradle plugin to your project by adding the following lines:
 
 <PlatformSection supported={["android"]}>
 
+<SignInNote />
+
 ```groovy
 buildscript {
     repositories {
@@ -119,6 +121,8 @@ sentry {
 <PlatformSection notSupported={["android"]}>
 
 Make sure the `assemble` task is executed.
+
+<SignInNote />
 
 ```groovy
 buildscript {
@@ -195,6 +199,8 @@ sentry {
 ## Using the Maven Build Tool Plugin
 
 Add the [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) to your project by adding the following lines to your `pom.xml` file:
+
+<SignInNote />
 
 ```xml
 <build>

--- a/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -59,6 +59,8 @@ Assuming you have the `@sentry/webpack` package installed on version `1.x`, you 
 
 Example:
 
+<SignInNote />
+
 ```javascript {filename:webpack.config.js}
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
@@ -87,6 +89,8 @@ module.exports = {
 
 The Sentry Webpack plugin will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release` option exactly:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -110,6 +114,8 @@ This applies when using the following packages on version `2.x` and above:
 - `@sentry/rollup-plugin`
 
 Example of using the `release.uploadLegacySourcemaps` option:
+
+<SignInNote />
 
 ```javascript {filename:webpack.config.js} {tabTitle:Webpack}
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
@@ -224,6 +230,8 @@ export default {
 ```
 
 The Sentry bundler plugins will automatically inject a release value into the SDK so you must either omit the `release` option from `Sentry.init` or make sure `Sentry.init`'s `release` option matches the plugin's `release.name` option exactly:
+
+<SignInNote />
 
 ```javascript
 Sentry.init({

--- a/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -22,6 +22,8 @@ Visit the [auth token user settings page](https://sentry.io/settings/account/api
 
 </Note>
 
+<SignInNote />
+
 ```ìni {filename:.sentryclirc}
 [auth]
 token=your-auth-token

--- a/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -47,6 +47,8 @@ yarn add @sentry/vite-plugin --dev
 
 Configure Vite to emit source maps and use the Sentry Vite plugin:
 
+<SignInNote />
+
 ```JavaScript {filename:vite.config.js}
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";

--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -27,6 +27,8 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 
 Example:
 
+<SignInNote />
+
 ```javascript {filename:vite.config.js}
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";

--- a/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -34,6 +34,8 @@ Learn more about configuring the plugin in our [Sentry esbuild Plugin documentat
 
 Example:
 
+<SignInNote />
+
 ```javascript {filename:esbuild.config.js}
 const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 

--- a/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -34,6 +34,8 @@ Learn more about configuring the plugin in our [Sentry Rollup Plugin documentati
 
 Example:
 
+<SignInNote />
+
 ```javascript {filename:rollup.config.js}
 import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 

--- a/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -34,6 +34,8 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 
 Example:
 
+<SignInNote />
+
 ```javascript {filename:vite.config.js}
 import { defineConfig } from "vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -36,6 +36,8 @@ Learn more about configuring the plugin in our [Sentry Webpack Plugin documentat
 
 You'll have to setup your environment variables first. In most cases, you'll either want to add the env. variables to a `.env` file (e.g. when deploying locally), or you'll have to add them to your CI/CD environment.
 
+<SignInNote />
+
 <OrgAuthTokenNote />
 
 ```bash {filename:.env}
@@ -68,6 +70,8 @@ module.exports = {
 </PlatformSection>
 
 <PlatformSection supported={["javascript.gatsby"]}>
+
+<SignInNote />
 
 ```javascript {filename:gatsby-node.js}
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");

--- a/src/platform-includes/troubleshooting/dotnet.mdx
+++ b/src/platform-includes/troubleshooting/dotnet.mdx
@@ -24,6 +24,8 @@ The above error could have two meanings:
 
 Your debug window will have following messages:
 
+<SignInNote />
+
 ```
 Debug: Logging enabled with ConsoleDiagnosticLogger and min level: Debug
 Debug: Initializing Hub for Dsn: '___PUBLIC_DSN___'.

--- a/src/platforms/android/configuration/manual-init.mdx
+++ b/src/platforms/android/configuration/manual-init.mdx
@@ -62,6 +62,8 @@ The SDK can catch errors and crashes only after you've initialized it. So, we re
 
 Configuration options will be loaded from the manifest so that you don't need to have the static properties in your code. In the `init` method, you can provide a callback that will modify the configuration and also register new options.
 
+<SignInNote />
+
 ```java
 import io.sentry.SentryLevel;
 import io.sentry.android.core.SentryAndroid;

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -390,17 +390,17 @@ To initialize the SDK manually:
 
 <SignInNote />
 
-  ```java
-  SentryAndroid.init(this, options -> {
-    options.setDsn("___PUBLIC_DSN___");
-  });
-  ```
+```java
+SentryAndroid.init(this, options -> {
+  options.setDsn("___PUBLIC_DSN___");
+});
+```
 
-  ```kotlin
-  SentryAndroid.init(this) { options ->
-    options.dsn = "___PUBLIC_DSN___"
-  }
-  ```
+```kotlin
+SentryAndroid.init(this) { options ->
+  options.dsn = "___PUBLIC_DSN___"
+}
+```
 
 ### Releases
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -357,6 +357,8 @@ The file `sentry.properties` used by the previous version of the SDK has been di
 
 Example of the configuration in the Manifest:
 
+<SignInNote />
+
 ```xml
 <application>
     <!-- Example of the Sentry DSN setting -->
@@ -385,6 +387,8 @@ To initialize the SDK manually:
   ```
 
 - Initialize the SDK directly in your application:
+
+<SignInNote />
 
   ```java
   SentryAndroid.init(this, options -> {

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -22,6 +22,8 @@ Because the app hang detection integration uses SentryCrashIntegration to captur
 
 Starting with version 8.0.0, this feature has been enabled by default. To disable it:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -42,6 +44,8 @@ SentrySDK.start { options in
 ```
 
 You can change the timeout by changing the `appHangTimeoutInterval` option:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/apple/common/configuration/http-client-errors.mdx
+++ b/src/platforms/apple/common/configuration/http-client-errors.mdx
@@ -8,6 +8,8 @@ Once enabled, this feature automatically captures HTTP client errors, like bad r
 
 Since 8.0.0, this feature has been enabled by default. To disable it:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -27,6 +29,8 @@ SentrySDK.start { options in
 ```
 
 By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -50,6 +54,8 @@ SentrySDK.start { options in
 ```
 
 HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -76,6 +82,8 @@ These events are searchable and you can set alerts on them if you use the `http.
 ### Customize or Drop the Error Event
 
 The captured error event can be customized or dropped with a `beforeSend`:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/apple/common/configuration/metric-kit.mdx
+++ b/src/platforms/apple/common/configuration/metric-kit.mdx
@@ -18,6 +18,8 @@ The SDK supports this feature from iOS 15 and up and macOS 12 and up because in 
 
 This is an experimental feature requiring opt-in, and can be enabled by setting the `enableMetricKit` option to `true`:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platforms/apple/common/configuration/out-of-memory.mdx
+++ b/src/platforms/apple/common/configuration/out-of-memory.mdx
@@ -8,6 +8,8 @@ We renamed this integration to <PlatformLink to="/configuration/watchdog-termina
 
 If you'd like to opt out of this feature, you can do so using options:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platforms/apple/common/configuration/swizzling.mdx
+++ b/src/platforms/apple/common/configuration/swizzling.mdx
@@ -60,6 +60,8 @@ The Cocoa SDK uses [swizzling](https://nshipster.com/method-swizzling/) to provi
 
 Since Cocoa 7.5.0, you can opt out of swizzling using options. When you disable swizzling, the SDK disables the features above:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platforms/apple/common/configuration/watchdog-terminations.mdx
+++ b/src/platforms/apple/common/configuration/watchdog-terminations.mdx
@@ -32,6 +32,8 @@ If you're interested in the implementation details, you can check out [the code]
 
 If you'd like to opt out of this feature, you can do so using options:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platforms/apple/common/migration.mdx
+++ b/src/platforms/apple/common/migration.mdx
@@ -84,6 +84,8 @@ We cleaned up our public classes by removing a few functions and properties, tha
 
 We removed the version of `SentrySDK.startWithOptions` that took a dictionary, and renamed `SentrySDK.startWithOptionsObject` to `SentrySDK.startWithOptions`. The recommended way to initialize Sentry has not changed:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -197,6 +199,8 @@ This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelop
 #### SDK Inits
 
 We removed the [deprecated SDK inits](https://github.com/getsentry/sentry-cocoa/blob/5.2.2/Sources/Sentry/include/SentrySDK.h#L35-L47). The recommended way to initialize Sentry is now:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -322,6 +326,8 @@ The samples below illustrate how the SDK works:
 
 Example in 4.x:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 do {
     Client.shared = try Client(dsn: "___PUBLIC_DSN___")
@@ -342,6 +348,8 @@ if (nil != error) {
 ```
 
 Example in 5.x:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 SentrySDK.start(options: [

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -31,6 +31,8 @@ The SDK creates spans to provide insight into the time consumed by each of the m
 
 To disable the `UIViewController` Tracing:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -98,6 +100,8 @@ You can filter for different app start types in [Discover](/product/discover-que
 
 To enable prewarmed app start tracing:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -140,6 +144,8 @@ Network Tracking is enabled by default once you <PlatformLink to="/performance/"
 
 To disable the HTTP instrumentation:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -168,6 +174,8 @@ Sentry adds an extra header with the trace id in the outgoing HTTP requests to c
 You can set the `tracePropagationTarget` option to filter which requests Sentry adds the extra header to.
 For example, to ensure that only your app backend will receive the trace id.
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -195,6 +203,8 @@ If `tracePropagationTargets` is not provided, trace data is attached to every ou
 The Sentry SDK adds spans for file I/O operations to ongoing transactions bound to the scope. Currently, the SDK supports operations with [NSData][NSData], but many other APIs like [NSFileManager][NSFileManager], [NSString][NSString] and [NSBundle][NSBundle] uses [NSData][NSData].
 
 Since 8.0.0, this feature has been enabled by default. To disable it:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -230,6 +240,8 @@ SentrySDK.start { options in
 The Sentry SDK adds spans for Core Data operations to ongoing transactions bound to the scope. Currently, the SDK supports fetch and save operations with [NSManagedObjectContext](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext).
 Since 8.0.0, this feature has been enabled by default. To disable it:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -257,6 +269,8 @@ SentrySDK.start { options in
 ## User Interaction Tracing
 
 User interaction tracing, once enabled, captures transactions for clicks. This feature is unavailable for SwiftUI. Since 8.0.0, this feature has been enabled by default. To disable it:
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -314,6 +328,8 @@ When the user interaction transaction is not finished yet, but the user makes a 
 
 You can opt out of all automatic instrumentations using the options:
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -360,6 +376,8 @@ Time to full display provides insight into how long it takes your view controlle
 The span starts when the view of a view controller is loaded, and there is no other view controller transaction happening at the moment.
 
 _Time to full display is disabled by default, but you can enable it by setting:_
+
+<SignInNote />
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -411,6 +411,8 @@ Data to be set to the initial scope. Initial scope can be defined either as an o
 
 Object:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -440,6 +442,8 @@ Sentry.init({
 <ConfigKey name="initial-scope" supported={["apple"]}>
 
 A block that configures the initial scope when starting the SDK.
+
+<SignInNote />
 
 ```swift
 import Sentry

--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -46,6 +46,8 @@ Optionally, you can skip the first step and [create or update (upsert) a monitor
 
 Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
 
+<SignInNote />
+
 ```bash {tabTitle: cURL}
 # 🟡 Notify Sentry your job is running:
 curl -X POST \
@@ -85,6 +87,8 @@ Content-Type: application/json
 ```
 
 If your job execution fails:
+
+<SignInNote />
 
 ```bash {tabTitle: cURL}
 # 🔴 Notify Sentry your job has failed:
@@ -130,6 +134,8 @@ In the future it will be possible to delete environments for a specified monitor
 
 </Alert>
 
+<SignInNote />
+
 ```bash {tabTitle: cURL}
 # 🟡 Notify Sentry your job is running in the dev environment:
 curl -X POST \
@@ -151,6 +157,8 @@ curl -X PUT \
 ### Creating or Updating a Monitor Through a Check-In (Optional)
 
 Sentry enables the automatic creation or update of a monitor (upsert) through the check-in payload. This can be useful if you have many scheduled tasks or need to create them dynamically.
+
+<SignInNote />
 
 ```bash {tabTitle: cURL}
 # Upsert monitor with a check-in
@@ -220,6 +228,8 @@ It's important to provide a timezone for non-repeating crontab schedules, such a
 
 Sentry Crons can help you better understand your job check-ins by storing a file, such as a log output. You'll be able to use this to debug check-in failures or track job statuses. To upload your attachment, execute the following `HTTP POST (multipart/form-data)` request:
 
+<SignInNote />
+
 ```bash {tabTitle: curl}
 # Perform a POST request to attach a file to a check-in
 curl -X POST \
@@ -264,6 +274,8 @@ If this happens, you have to provide a check-in ID with the second check-in requ
 
 Usage example:
 
+<SignInNote />
+
 ```bash {tabTitle: cURL}
 # 🟡 Notify Sentry your job is running:
 curl -X POST \
@@ -287,6 +299,8 @@ curl -X PUT \
 
 Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
 
+<SignInNote />
+
 ```bash {tabTitle: cURL}
 # 🟢 Notify Sentry your job has completed successfully:
 curl -X POST \
@@ -308,6 +322,8 @@ Content-Type: application/json
 ```
 
 If your job execution fails:
+
+<SignInNote />
 
 ```bash {tabTitle: cURL}
 # 🔴 Notify Sentry your job has failed:

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -57,6 +57,8 @@ Profiling depends on Sentry’s performance monitoring product being enabled bef
 
 <PlatformSection supported={["apple"]}>
 
+<SignInNote />
+
 ```swift {tabTitle:Swift}
 import Sentry
 
@@ -92,6 +94,8 @@ In `AndroidManifest.xml`:
 
 <PlatformSection supported={["go"]}>
 
+<SignInNote />
+
 ```go
 err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
@@ -105,6 +109,8 @@ err := sentry.Init(sentry.ClientOptions{
 
 <PlatformSection supported={["python"]}>
 
+<SignInNote />
+
 ```python
 sentry_sdk.init(
   dsn="___PUBLIC_DSN___",
@@ -115,6 +121,8 @@ sentry_sdk.init(
 </PlatformSection>
 
 <PlatformSection supported={["ruby"]}>
+
+<SignInNote />
 
 ```ruby
 Sentry.init do |config|
@@ -142,6 +150,9 @@ By default, some transactions will be created automatically for common operation
 iOS profiling is available starting in SDK version `8.3.1`.
 
 </Note>
+
+<SignInNote />
+
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -181,6 +192,8 @@ Android profiling is available starting in SDK version `6.16.0`.
 
 In `AndroidManifest.xml`:
 
+<SignInNote />
+
 ```xml
 <application>
     <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
@@ -204,6 +217,8 @@ The `io.sentry.traces.profiling.sample-rate` setting is _relative_ to the `io.se
 Python profiling is available starting in SDK version `1.18.0`.
 
 </Note>
+
+<SignInNote />
 
 ```python
 import sentry_sdk
@@ -237,6 +252,8 @@ The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to 
 
 The feature was experimental prior to version `1.17.0`. To update to the latest SDK, remove `profiles_sample_rate` from `_experiments` and set it in the top-level options.
 
+<SignInNote />
+
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
@@ -258,6 +275,8 @@ Go Profiling alpha is available since SDK version `0.22.0`.
 </Note>
 
 To enable profiling, set the `ProfilesSampleRate`:
+
+<SignInNote />
 
 ```go
 err := sentry.Init(sentry.ClientOptions{
@@ -292,6 +311,8 @@ gem 'sentry-ruby'
 ```
 
 Then, make sure both `traces_sample_rate` and `profiles_sample_rate` are set and non-zero in your sentry initializer.
+
+<SignInNote />
 
 ```ruby
 # config/initializers/sentry.rb

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -153,7 +153,6 @@ iOS profiling is available starting in SDK version `8.3.1`.
 
 <SignInNote />
 
-
 ```swift {tabTitle:Swift}
 import Sentry
 

--- a/src/platforms/dart/configuration/integrations/dio.mdx
+++ b/src/platforms/dart/configuration/integrations/dio.mdx
@@ -23,6 +23,8 @@ dependencies:
 
 Configuration should happen as early as possible in your application's lifecycle.
 
+<SignInNote />
+
 ```dart
 import 'package:sentry_dio/sentry_dio.dart';
 import 'package:sentry/sentry.dart';
@@ -57,6 +59,8 @@ final response = await dio.get<String>('https://wrong-url.dev/');
 ```
 
 This is an opt-out feature. The following example shows how to disable it:
+
+<SignInNote />
 
 ```dart
 import 'package:sentry/sentry.dart';

--- a/src/platforms/dart/configuration/integrations/http-integration.mdx
+++ b/src/platforms/dart/configuration/integrations/http-integration.mdx
@@ -25,6 +25,8 @@ var uriResponse = await client.post('https://example.com/whatsit/create',
 
 This is an opt-out feature. The following example shows how to disable it:
 
+<SignInNote />
+
 ```dart
 import 'package:sentry/sentry.dart';
 

--- a/src/platforms/dart/configuration/integrations/logging.mdx
+++ b/src/platforms/dart/configuration/integrations/logging.mdx
@@ -25,6 +25,8 @@ dependencies:
 
 Configuration should happen as early as possible in your application's lifecycle.
 
+<SignInNote />
+
 ```dart
 import 'package:sentry_logging/sentry_logging.dart';
 import 'package:sentry/sentry.dart';

--- a/src/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/src/platforms/dotnet/common/configuration/msbuild.mdx
@@ -87,6 +87,8 @@ can slow down your development workflow.
 Alternatively, you could control this using any MSBuild property or environment variable you like. For example,
 if you only want these features enabled in a GitHub Actions CI workflow, you could use `Condition="'$(GITHUB_ACTIONS)' == 'true'"`.
 
+<SignInNote />
+
 ```xml
 <!-- We recommend only using these features for release builds. -->
 <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -111,6 +113,8 @@ if you only want these features enabled in a GitHub Actions CI workflow, you cou
 ```
 
 Alternatively, they could be passed as parameters when building your project. For example:
+
+<SignInNote />
 
 ```shell
 dotnet build YourProject.csproj -c Release -p:SentryOrg=___ORG_SLUG___ -p:SentryProject=___PROJECT_SLUG___ -p:SentryUploadSymbols=true -p:SentryUploadSources=true

--- a/src/platforms/dotnet/guides/aspnet/index.mdx
+++ b/src/platforms/dotnet/guides/aspnet/index.mdx
@@ -24,6 +24,8 @@ as well as your logs as breadcrumbs. The logging integrations also capture event
 
 You configure the SDK in the `Global.asax.cs`:
 
+<SignInNote />
+
 ```csharp
 using System;
 using System.Web;
@@ -80,6 +82,8 @@ public class MvcApplication : HttpApplication
 ### Capturing the affected user
 
 When opting-in to [SendDefaultPii](#senddefaultpii), the SDK will automatically read the user from the request by inspecting `HttpContext.User`. Default claim values like `NameIdentifier` for the _Id_ will be used.
+
+<SignInNote />
 
 ```csharp
 SentrySdk.Init(o =>

--- a/src/platforms/dotnet/guides/aspnet/performance/included-instrumentation.mdx
+++ b/src/platforms/dotnet/guides/aspnet/performance/included-instrumentation.mdx
@@ -12,6 +12,8 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 ASP.NET integration, once enabled, captures each incoming HTTP request and turns it into a transaction with the help of a custom middleware. To enable tracing on ASP.NET, you need to update your `Global.asax.cs` file like this:
 
+<SignInNote />
+
 ```csharp
 using System;
 using System.Configuration;

--- a/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
+++ b/src/platforms/dotnet/guides/aspnet/troubleshooting.mdx
@@ -65,6 +65,8 @@ You can find more information about the problem [in this GitHub issue](https://g
 This happens because the `scope` from `requests` will be different from the one executed during the execution of Application_Start.
 To apply `Tags` globally, it's recommended that you set them in `SentryOptions`, as shown in the example below:
 
+<SignInNote />
+
 ```csharp
 SentrySdk.Init(options =>
 {

--- a/src/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/src/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -68,6 +68,8 @@ When using `WebHost.CreateDefaultBuilder`, the framework automatically loads `ap
 
 For example:
 
+<SignInNote />
+
 ```json {filename:appsettings.json}
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",
@@ -296,6 +298,8 @@ A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your applic
 - Add to the container by calling `AddSentryTunneling();` on `IServiceCollection`.
 - Add the web app by calling `UseSentryTunneling();` on `IApplicationBuilder`.
 - In the client-side JavaScript configuration, ensure the tunnel option is used:
+
+<SignInNote />
 
 ```javascript
 Sentry.init({

--- a/src/platforms/dotnet/guides/aws-lambda/index.mdx
+++ b/src/platforms/dotnet/guides/aws-lambda/index.mdx
@@ -25,6 +25,8 @@ All `ASP.NET Core` configurations are valid here. But one configuration in parti
 
 `FlushOnCompletedRequest` ensures all events are flushed out. This is because the general ASP.NET Core hooks for when the process is exiting are not guaranteed to run in a serverless environment. This setting ensures that no event is lost if AWS recycles the process.
 
+<SignInNote />
+
 ```csharp
 public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
 {

--- a/src/platforms/dotnet/guides/azure-functions-worker/index.mdx
+++ b/src/platforms/dotnet/guides/azure-functions-worker/index.mdx
@@ -24,6 +24,8 @@ This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extens
 
 Sentry integration with Azure Functions (when using the Isolated Worker Process execution mode) is done by calling `.UseSentry()` and specifying the options. E.g.:
 
+<SignInNote />
+
 ```csharp
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults((host, builder) =>

--- a/src/platforms/dotnet/guides/extensions-logging/index.mdx
+++ b/src/platforms/dotnet/guides/extensions-logging/index.mdx
@@ -82,6 +82,8 @@ With this approach, options like `Dsn`, `SendDefaultPii`, `MinimumBreadcrumbLeve
 
 Example using `appsettings.json`:
 
+<SignInNote />
+
 ```json
 {
   "Logging": {
@@ -101,6 +103,8 @@ Example using `appsettings.json`:
 Above we set the application wide minimum log level to `Debug`. Sentry specific settings are set under the `Sentry` property. Options are documented below.
 
 #### Through `ILoggerFactory`
+
+<SignInNote />
 
 ```csharp
 using (var loggerFactory = new LoggerFactory()

--- a/src/platforms/dotnet/guides/google-cloud-functions/index.mdx
+++ b/src/platforms/dotnet/guides/google-cloud-functions/index.mdx
@@ -65,6 +65,8 @@ using the assembly method `FunctionsStartup` to include the type `SentryStartup`
 
 For example:
 
+<SignInNote />
+
 ```json {filename:appsettings.json}
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",

--- a/src/platforms/dotnet/guides/log4net/index.mdx
+++ b/src/platforms/dotnet/guides/log4net/index.mdx
@@ -28,6 +28,8 @@ This package extends `Sentry` main SDK. That means besides the log4net `Appender
 Once the log4net integration package is installed in your project, you can modify your configuration file to add the appender.
 This can be done, for example, via the `app.config` for console and desktop apps or `web.config` in case of ASP.NET.
 
+<SignInNote />
+
 ```xml {filename:app.config}
   <appender name="SentryAppender" type="Sentry.Log4Net.SentryAppender, Sentry.Log4Net">
     <Dsn value="___PUBLIC_DSN___"/>

--- a/src/platforms/dotnet/guides/maui/index.mdx
+++ b/src/platforms/dotnet/guides/maui/index.mdx
@@ -37,6 +37,8 @@ This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extens
 
 In your `MauiProgram.cs` file, call `UseSentry` on your `MauiAppBuilder`, and include any options you would like to set. The `Dsn` is the only required parameter.
 
+<SignInNote />
+
 ```csharp
 public static MauiApp CreateMauiApp()
 {

--- a/src/platforms/dotnet/guides/nlog/configuration/advanced-configuration-example.mdx
+++ b/src/platforms/dotnet/guides/nlog/configuration/advanced-configuration-example.mdx
@@ -12,6 +12,8 @@ For more information on how to dynamically set event data via `NLog.config`, see
 
 The SDK can be configured via `NLog.config` XML file:
 
+<SignInNote />
+
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"

--- a/src/platforms/dotnet/guides/nlog/index.mdx
+++ b/src/platforms/dotnet/guides/nlog/index.mdx
@@ -75,6 +75,8 @@ LogManager.Configuration
 It's also possible to initialize the SDK through the NLog integration (as opposed to using `SentrySdk.Init`).
 This is useful when NLog is the only integration being used in your application. To initialize the Sentry SDK through the NLog integration, provide it with the DSN:
 
+<SignInNote />
+
 ```csharp
 LogManager.Configuration = new LoggingConfiguration();
 LogManager.Configuration
@@ -96,6 +98,8 @@ The SDK needs to be initialized only once. If a `DSN` is made available to this 
 Two log levels are used to configure this integration (see options below). One will configure the lowest level required for a log message to become an event (`MinimumEventLevel`) sent to Sentry. The other option (`MinimumBreadcrumbLevel`) configures the lowest level a message has to be to become a breadcrumb. Breadcrumbs are kept in memory (by default the last 100 records) and are sent with events. For example, by default, if you log 100 entries with `logger.Info` or `logger.Warn`, no event is sent to Sentry. If you then log with `logger.Error`, an event is sent to Sentry which includes those 100 `Info` or `Warn` messages. For this to work, `SentryTarget` needs to receive **all** log entries in order to decide what to keep as breadcrumb or sent as event. Make sure to set the `NLog` `LogLevel` configuration to a value lower than what you set for the `MinimumBreadcrumbLevel` and `MinimumEventLevel` to make sure `SentryTarget` receives these log messages.
 
 The SDK can also be configured via `NLog.config` XML file:
+
+<SignInNote />
 
 ```xml {tabTitle:NLog.config}
 <?xml version="1.0" encoding="utf-8" ?>

--- a/src/platforms/dotnet/guides/serilog/index.mdx
+++ b/src/platforms/dotnet/guides/serilog/index.mdx
@@ -58,6 +58,8 @@ Log.Logger = new LoggerConfiguration()
 
 It's also possible to initialize the SDK through the Serilog integration. This is useful when the Serilog is the only integration being used in your application. To initialize the Sentry SDK through the Serilog integration, provide it with the DSN:
 
+<SignInNote />
+
 ```csharp
 Log.Logger = new LoggerConfiguration()
   .WriteTo.Sentry(o => o.Dsn = "___PUBLIC_DSN___")

--- a/src/platforms/dotnet/guides/uwp/index.mdx
+++ b/src/platforms/dotnet/guides/uwp/index.mdx
@@ -17,6 +17,8 @@ The SDK should be initialized in the constructor of your application class (usua
 
 </Note>
 
+<SignInNote />
+
 ```csharp
 // Add these to your existing using statements.
 using Sentry;

--- a/src/platforms/dotnet/guides/winforms/index.mdx
+++ b/src/platforms/dotnet/guides/winforms/index.mdx
@@ -21,6 +21,8 @@ You should also set `Application.SetUnhandledExceptionMode(UnhandledExceptionMod
 
 A complete example of the recommended startup is as follows:
 
+<SignInNote />
+
 ```csharp
 using System;
 using System.Windows.Forms;
@@ -90,6 +92,8 @@ First, modify the settings on the project properties page as follows:
 
 Then, add the following file as `Program.vb`:
 
+<SignInNote />
+
 ```vb
 Imports Sentry
 
@@ -152,6 +156,8 @@ Once you have the file created:
 - Use the `UnhandledException` event to send unhandled exceptions to sentry.
 
 See the following complete example:
+
+<SignInNote />
 
 ```vb
 Imports Microsoft.VisualBasic.ApplicationServices

--- a/src/platforms/dotnet/guides/wpf/index.mdx
+++ b/src/platforms/dotnet/guides/wpf/index.mdx
@@ -19,6 +19,8 @@ The SDK should be initialized in the constructor of your application class (usua
 
 The SDK automatically handles `AppDomain.UnhandledException`. On WPF, for production apps (when no debugger is attached), WPF catches exception to show the dialog to the user. You can also configure your app to capture those exceptions before the dialog shows up:
 
+<SignInNote />
+
 ```csharp
 using System.Windows;
 

--- a/src/platforms/dotnet/legacy-sdk/index.mdx
+++ b/src/platforms/dotnet/legacy-sdk/index.mdx
@@ -21,6 +21,8 @@ A [NuGet Package](https://www.nuget.org/packages/SharpRaven) is available for Sh
 
 Instantiate the client with your DSN:
 
+<SignInNote />
+
 ```csharp
 var ravenClient = new RavenClient("___PUBLIC_DSN___");
 ```
@@ -82,6 +84,8 @@ async Task<string> CaptureAsync(SentryEvent @event);
 You can install the [SharpRaven.Nancy](https://www.nuget.org/packages/SharpRaven.Nancy) package to capture the HTTP context in [Nancy](https://nancyfx.org/) applications. It will auto-register on the `IPipelines.OnError` event, so all unhandled exceptions will be sent to Sentry.
 
 The only thing you have to do is provide a DSN, either by registering an instance of the `Dsn` class in your container:
+
+<SignInNote />
 
 ```csharp
 protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)

--- a/src/platforms/dotnet/migration.mdx
+++ b/src/platforms/dotnet/migration.mdx
@@ -252,6 +252,8 @@ If your project is targeting .NET Framework, it will need to be using at least v
 
 Changed how to initialize Sentry:
 
+<SignInNote />
+
 ```csharp
 using Sentry;
 
@@ -266,6 +268,8 @@ SentrySdk.Init(o =>
 ```
 
 For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `o.AddAspNet()`:
+
+<SignInNote />
 
 ```csharp
 using Sentry;
@@ -303,6 +307,8 @@ await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
 ```
 
 You can close the SDK, which will also flush the event queue, by invoking the `IDisposable` returned by `SentrySdk.Init(...)`:
+
+<SignInNote />
 
 ```csharp
 var sentryInitialization = SentrySdk.Init("___PUBLIC_DSN___");

--- a/src/platforms/elixir/configuration/options.mdx
+++ b/src/platforms/elixir/configuration/options.mdx
@@ -10,6 +10,8 @@ Configuration is handled using the standard Elixir configuration.
 
 Simply add configuration to the `:sentry` key in the file `config/prod.exs`:
 
+<SignInNote />
+
 ```elixir
 config :sentry,
   dsn: "___PUBLIC_DSN___"

--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -35,6 +35,8 @@ end
 
 Setup the application production environment in your `config/prod.exs`
 
+<SignInNote />
+
 ```elixir {filename:config/prod.exs}
 config :sentry,
   dsn: "___PUBLIC_DSN___",
@@ -51,6 +53,8 @@ The `environment_name` and `included_environments` work together to determine if
 
 An alternative is to use `Mix.env` in your general configuration file:
 
+<SignInNote />
+
 ```elixir
 config :sentry, dsn: "___PUBLIC_DSN___",
    included_environments: [:prod],
@@ -60,6 +64,8 @@ config :sentry, dsn: "___PUBLIC_DSN___",
 This will set the environment name to whatever the current Mix environment atom is, but it will only send events if the current environment is `:prod`, since that is the only entry in the `included_environments` key.
 
 You can even rely on more custom determinations of the environment name. It's not uncommon for most applications to have a "staging" environment. In order to handle this without adding an additional Mix environment, you can set an environment variable that determines the release level.
+
+<SignInNote />
 
 ```elixir
 config :sentry, dsn: "___PUBLIC_DSN___",

--- a/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/flutter/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -181,6 +181,8 @@ Slow and frozen frames are Mobile Vitals, which you can learn about in the [full
 
 The [AssetBundle](https://api.flutter.dev/flutter/services/AssetBundle-class.html) instrumentation provides insight into how long your app takes to load its assets, such as files. It can be enabled by wrapping the `runApp` method with a `DefaultAssetBundle` and `SentryAssetBundle`.
 
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platforms/flutter/migration.mdx
+++ b/src/platforms/flutter/migration.mdx
@@ -45,6 +45,8 @@ You may remove `android:extractNativeLibs="true"` meta-data in the `AndroidManif
 A random generated installationId replaces [Settings.Secure.ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID), which has been removed. This may affect the number of unique users displayed on the the Issues page and Alerts. If you always set a custom user using Sentry.setUser(customUser), the behavior has not changed. While you don't have to make any update, if you want to maintain the old behavior, use the following code snippet.
 It makes use of the [device_info_plus](https://pub.dev/packages/device_info_plus) plugin:
 
+<SignInNote />
+
 ```dart
 import 'package:flutter/foundation.dart';
 import 'package:device_info_plus/device_info_plus.dart';

--- a/src/platforms/flutter/native-init.mdx
+++ b/src/platforms/flutter/native-init.mdx
@@ -8,6 +8,8 @@ By default, the Flutter SDK initializes the native SDK underneath the `init` met
 
 To do this, set [autoInitializeNativeSdk](/platforms/flutter/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
+<SignInNote />
+
 ```dart
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';

--- a/src/platforms/go/common/configuration/options.mdx
+++ b/src/platforms/go/common/configuration/options.mdx
@@ -126,6 +126,8 @@ type ClientOptions struct {
 
 By default, TLS uses the host's root CA set. If you don't have `ca-certificates` (which should be your go-to way of fixing the issue of the missing certificates) and want to use `gocertifi` instead, you can provide pre-loaded cert files as one of the options to the `sentry.Init` call:
 
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platforms/go/common/configuration/transports.mdx
+++ b/src/platforms/go/common/configuration/transports.mdx
@@ -12,6 +12,8 @@ The Sentry Go SDK itself, provides two built-in transports. `HTTPTransport`, whi
 
 To configure transport, provide an instance of `sentry.Transport` interface to `ClientOptions`
 
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platforms/go/common/migration.mdx
+++ b/src/platforms/go/common/migration.mdx
@@ -24,6 +24,8 @@ go get github.com/getsentry/sentry-go
 
 raven-go
 
+<SignInNote />
+
 ```go
 import "github.com/getsentry/raven-go"
 
@@ -66,6 +68,8 @@ SetIncludePaths()
 
 sentry-go
 
+<SignInNote />
+
 ```go
 sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
@@ -84,6 +88,8 @@ Available options: see [Configuration](/platforms/go/configuration/options/) sec
 #### Providing SSL Certificates
 
 By default, TLS uses the host's root CA set. If you don't have `ca-certificates` (which should be your go-to way of fixing the missing certificates issue) and want to use `gocertifi` instead, you can provide pre-loaded cert files as one of the options to `sentry.Init` call:
+
+<SignInNote />
 
 ```go
 package main

--- a/src/platforms/go/common/panics.mdx
+++ b/src/platforms/go/common/panics.mdx
@@ -46,6 +46,8 @@ The first one being extracting the `Hub` instance from the context and using it 
 
 And the second feature, an access to the `context.Context` itself inside the `beforeSend` method, which can be used to extract any additional information about what happened during the panic:
 
+<SignInNote />
+
 ```go
 type contextKey int
 const SomeContextKey = contextKey(1)

--- a/src/platforms/go/guides/echo/index.mdx
+++ b/src/platforms/go/guides/echo/index.mdx
@@ -23,6 +23,8 @@ go get github.com/getsentry/sentry-go/echo
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -128,6 +130,8 @@ app.Logger.Fatal(app.Start(":3000"))
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/fasthttp/index.mdx
+++ b/src/platforms/go/guides/fasthttp/index.mdx
@@ -24,6 +24,8 @@ go get github.com/getsentry/sentry-go/fasthttp
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -134,6 +136,8 @@ if err := fasthttp.ListenAndServe(":3000", sentryHandler.Handle(fastHTTPHandler)
 ```
 
 ### Accessing Context in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/gin/index.mdx
+++ b/src/platforms/go/guides/gin/index.mdx
@@ -23,6 +23,8 @@ go get github.com/getsentry/sentry-go/gin
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -120,6 +122,8 @@ app.Run(":3000")
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/http/index.mdx
+++ b/src/platforms/go/guides/http/index.mdx
@@ -25,6 +25,8 @@ go get github.com/getsentry/sentry-go/http
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -131,6 +133,8 @@ if err := http.ListenAndServe(":3000", nil); err != nil {
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/iris/index.mdx
+++ b/src/platforms/go/guides/iris/index.mdx
@@ -23,6 +23,8 @@ go get github.com/getsentry/sentry-go/iris
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -118,6 +120,8 @@ app.Run(iris.Addr(":3000"))
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/martini/index.mdx
+++ b/src/platforms/go/guides/martini/index.mdx
@@ -23,6 +23,8 @@ go get github.com/getsentry/sentry-go/martini
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -116,6 +118,8 @@ app.Run()
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/guides/negroni/index.mdx
+++ b/src/platforms/go/guides/negroni/index.mdx
@@ -23,6 +23,8 @@ go get github.com/getsentry/sentry-go/negroni
 
 <Break />
 
+<SignInNote />
+
 ```go
 import (
 	"fmt"
@@ -126,6 +128,8 @@ http.ListenAndServe(":3000", app)
 ```
 
 ### Accessing Request in `BeforeSend` callback
+
+<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/src/platforms/go/legacy-sdk/config.mdx
+++ b/src/platforms/go/legacy-sdk/config.mdx
@@ -26,6 +26,8 @@ and the Sentry Go SDKs can pick this up from an environment variable (`SENTRY_DS
 When set to an empty string, SDK won't send any events to Sentry, and all `Capture*` methods
 will effectively act as no-ops.
 
+<SignInNote />
+
 ```go
 raven.SetDSN("___PUBLIC_DSN___")
 ```

--- a/src/platforms/go/legacy-sdk/index.mdx
+++ b/src/platforms/go/legacy-sdk/index.mdx
@@ -36,6 +36,8 @@ go get github.com/getsentry/raven-go
 To use `raven-go`, you’ll need to import the `raven` package, then initialize your DSN globally. If you specify the `SENTRY_DSN` environment variable, this will be done automatically for you. The release and environment can also be specified in the environment variables `SENTRY_RELEASE` and `SENTRY_ENVIRONMENT` respectively.
 More on this in [Configuration](/platforms/go/legacy-sdk/config/) section.
 
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platforms/go/legacy-sdk/integrations.mdx
+++ b/src/platforms/go/legacy-sdk/integrations.mdx
@@ -35,6 +35,8 @@ go get github.com/getsentry/raven-go
 
 Make sure that you’ve set configured `raven` with your DSN, typically inside the `init()` in your `main` package is a good place.
 
+<SignInNote />
+
 ```go
 package main
 

--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -10,6 +10,8 @@ The DSN is the first and most important thing to configure because it tells the 
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
+<SignInNote />
+
 ```text {tabTitle:Properties File} {filename:sentry.properties}
 dsn=___PUBLIC_DSN___
 ```
@@ -27,6 +29,8 @@ SENTRY_DSN=___PUBLIC_DSN___ java -jar app.jar
 ```
 
 In code:
+
+<SignInNote />
 
 ```java {tabTitle:Java}
 import io.sentry.Sentry;

--- a/src/platforms/java/common/legacy/configuration/index.mdx
+++ b/src/platforms/java/common/legacy/configuration/index.mdx
@@ -16,6 +16,8 @@ The DSN is the first and most important thing to configure because it tells the 
 
 In a properties file on your filesystem or classpath (defaults to `sentry.properties`):
 
+<SignInNote />
+
 ```text {tabTitle:Properties File} {filename:sentry.properties}
 dsn=___PUBLIC_DSN___
 ```
@@ -33,6 +35,8 @@ SENTRY_DSN=___PUBLIC_DSN___ java -jar app.jar
 ```
 
 In code:
+
+<SignInNote />
 
 ```java
 import io.sentry.Sentry;
@@ -83,6 +87,8 @@ SENTRY_SAMPLE_RATE=0.75 java -jar app.jar
 ### Configuration via code
 
 The DSN itself can also be configured directly in code:
+
+<SignInNote />
 
 ```java
 import io.sentry.Sentry;

--- a/src/platforms/java/common/legacy/usage.mdx
+++ b/src/platforms/java/common/legacy/usage.mdx
@@ -29,6 +29,8 @@ For other dependency managers see the [central Maven repository](https://search.
 
 To report an event manually you need to initialize a `SentryClient`. It is recommended that you use the static API via the `Sentry` class, but you can also construct and manage your own `SentryClient` instance. An example of each style is shown below:
 
+<SignInNote />
+
 ```java
 import io.sentry.context.Context;
 import io.sentry.event.BreadcrumbBuilder;

--- a/src/platforms/java/guides/jul/usage/advanced-usage.mdx
+++ b/src/platforms/java/guides/jul/usage/advanced-usage.mdx
@@ -160,6 +160,8 @@ class MyClass {
 
 Starting with Sentry version 6.0.0 and up, you can define a list of `MDC tags` that will be viewable as `Tags` in the Sentry UI. `MDC Tags` not in this list will be viewable as `Context Data`. To define tags, add a `context-tags` entry with the tags as comma-separated items to the `sentry.properties` file.
 
+<SignInNote />
+
 ```properties {tabTitle:Properties}
 dsn=___PUBLIC_DSN___
 context-tags=userId,requestId

--- a/src/platforms/java/guides/log4j2/advanced_usage.mdx
+++ b/src/platforms/java/guides/log4j2/advanced_usage.mdx
@@ -143,6 +143,8 @@ class MyClass {
 
 Starting with Sentry version 6.0.0 and up, you can define a list of `MDC tags` that will be viewable as `Tags` in the Sentry UI. `MDC Tags` not in this list will be viewable as `Context Data`. To define tags, add a `contextTags` attribute to the `<Sentry>` tag in your `log4j2.xml` with the tags as comma-separated items.
 
+<SignInNote />
+
 ```xml {tabTitle:XML}
 <Sentry name="Sentry"
   dsn="___PUBLIC_DSN___"

--- a/src/platforms/java/guides/logback/configuration/configuration-example.mdx
+++ b/src/platforms/java/guides/logback/configuration/configuration-example.mdx
@@ -8,6 +8,8 @@ description: "Review an example of configuration for Logback."
 
 You can configure values such as `environment` and `release`. [See the configuration page](../options) for an in-depth explanation of each property.
 
+<SignInNote />
+
 ```xml
 <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <options>

--- a/src/platforms/java/guides/logback/usage/advanced-usage.mdx
+++ b/src/platforms/java/guides/logback/usage/advanced-usage.mdx
@@ -142,6 +142,8 @@ class MyClass {
 
 Starting with Sentry version 6.0.0 and up, you can define a list of `MDC tags` that will be viewable as `Tags` in the Sentry UI. `MDC Tags` not in this list will be viewable as `Context Data`. To define a tag, add a `<contextTag>` entry inside the `<options>` of the Sentry appender configuration in `logback.xml`
 
+<SignInNote />
+
 ```xml {tabTitle:XML}
   <appender name="sentry" class="io.sentry.logback.SentryAppender">
     <options>

--- a/src/platforms/java/guides/spring/advanced-usage.mdx
+++ b/src/platforms/java/guides/spring/advanced-usage.mdx
@@ -12,6 +12,8 @@ To record the user's IP address and `Principal#name` as the username so you can 
 
 1. Set the personal information flag on `@EnableSentry` to `true`.
 
+<SignInNote />
+
 ```Java {tabTitle:Java (Spring 5)}
 import org.springframework.context.annotation.Configuration;
 import io.sentry.spring.EnableSentry;

--- a/src/platforms/java/usage.mdx
+++ b/src/platforms/java/usage.mdx
@@ -153,7 +153,6 @@ Find more configuration options in the [Configuration](/platforms/java/configura
 
 To report an event manually you need to initialize a `Sentry` class. It is recommended that you use the static API via the `Sentry` class, but you can also construct and manage your own `IHub` instance. An example of each style is shown below:
 
-
 <SignInNote />
 
 ```java

--- a/src/platforms/java/usage.mdx
+++ b/src/platforms/java/usage.mdx
@@ -34,6 +34,8 @@ For other dependency managers see the [central Maven repository](https://search.
 
 When Sentry is used in manual way, configuration options must be passed to a static `Sentry#init` method:
 
+<SignInNote />
+
 ```java {tabTitle:Java}
 import io.sentry.Sentry;
 
@@ -150,6 +152,9 @@ Find more configuration options in the [Configuration](/platforms/java/configura
 ## Capture an Error
 
 To report an event manually you need to initialize a `Sentry` class. It is recommended that you use the static API via the `Sentry` class, but you can also construct and manage your own `IHub` instance. An example of each style is shown below:
+
+
+<SignInNote />
 
 ```java
 import io.sentry.IHub;
@@ -344,6 +349,8 @@ class MyClass {
 ### Building More Complex Events
 
 For more complex messages, you’ll need to build an `SentryEvent` object:
+
+<SignInNote />
 
 ```java
 import io.sentry.Sentry;

--- a/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
+++ b/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
@@ -20,6 +20,8 @@ yarn add sentry-testkit --dev
 
 ### Using in tests
 
+<SignInNote />
+
 ```javascript
 import sentryTestkit from "sentry-testkit";
 

--- a/src/platforms/javascript/common/configuration/webworkers/index.mdx
+++ b/src/platforms/javascript/common/configuration/webworkers/index.mdx
@@ -31,6 +31,8 @@ yarn add @sentry/browser
 
 Then you can use it:
 
+<SignInNote />
+
 ```javascript {filename:index.js}
 import * as Sentry from "@sentry/browser";
 
@@ -66,6 +68,8 @@ self.onmessage = (message) => {
 ```
 
 #### Usage With Worker-Level Initialization
+
+<SignInNote />
 
 ```javascript {filename:worker.js}
 import * as Sentry from "@sentry/browser";

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -14,6 +14,8 @@ The Loader Script is the easiest way to initialize the Sentry SDK. The Loader Sc
 
 To use the loader, go in the Sentry UI to **Settings > Projects > (select project) > Client Keys (DSN)**, and then press the "Configure" button. Copy the script tag from the "JavaScript Loader" section and include it as the first script on your page. By including it first, you allow it to catch and buffer events from any subsequent scripts, while still ensuring the full SDK doesn't load until after everything else has run.
 
+<SignInNote />
+
 ```html
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"

--- a/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -30,6 +30,8 @@ Capturing transactions requires that you first <PlatformLink to="/performance/">
 
 Though the `BrowserTracing` integration is automatically enabled in `@sentry/nextjs`, in order to customize its options you must include it in your `Sentry.init` in `sentry.client.config.js`:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/nextjs";
 

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -62,6 +62,8 @@ If you are on an older version and you want to upload source maps we recommend u
 
 Register the Sentry Webpack plugin in your `webpack.config.js`:
 
+<SignInNote />
+
 ```javascript {filename:webpack.config.js}
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 

--- a/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -79,6 +79,8 @@ If you are on an older version and you want to upload source maps we recommend u
 
 Register the Sentry Webpack plugin in your `webpack.config.js`:
 
+<SignInNote />
+
 ```javascript {filename:webpack.config.js}
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -94,6 +94,8 @@ Starting with version `6.7.0` of the JavaScript SDK, you can use the `tunnel` op
 
 To enable the `tunnel` option, provide either a relative or an absolute URL in your `Sentry.init` call. When you use a relative URL, it's relative to the current origin, and this is the form that we recommend. Using a relative URL will not trigger a preflight CORS request, so no events will be blocked, because the ad-blocker will not treat these events as third-party requests.
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -269,6 +271,8 @@ To be able to manage several Sentry instances without any conflicts between them
 This also helps to prevent tracking of any parent application errors in case your application is integrated
 inside of it. In this example we use `@sentry/browser` but it's also applicable to `@sentry/node`.
 
+<SignInNote />
+
 ```javascript
 import {
   BrowserClient,
@@ -288,6 +292,8 @@ client.captureException(new Error("example"));
 ```
 
 While the above sample should work perfectly fine, some methods like `configureScope` and `withScope` are missing on the `Client` because the `Hub` takes care of the state management. That's why it may be easier to create a new `Hub` and bind your `Client` to it. The result is the same but you will also get state management with it.
+
+<SignInNote />
 
 ```javascript
 import {
@@ -329,6 +335,8 @@ hub.withScope(function (scope) {
 
 Integrations are setup on the `Client`, if you need to deal with multiple clients and hubs you have to make sure to also do the integration handling correctly.
 Here is a working example of how to use multiple clients with multiple hubs running global integrations.
+
+<SignInNote />
 
 ```javascript
 import * as Sentry from "@sentry/browser";

--- a/src/platforms/javascript/guides/angular/angular1.mdx
+++ b/src/platforms/javascript/guides/angular/angular1.mdx
@@ -27,6 +27,8 @@ yarn add @sentry/browser@6 @sentry/integrations@6
 
 and afterwards using it like this:
 
+<SignInNote />
+
 ```javascript
 import angular from "angular";
 import * as Sentry from "@sentry/browser";
@@ -44,6 +46,8 @@ angular.module("yourApplicationModule", ["ngSentry"]);
 ```
 
 If you're using the CDN version of the SDK, Sentry provides a standalone file for every integration:
+
+<SignInNote />
 
 ```html
 <script

--- a/src/platforms/javascript/guides/cordova/ionic.mdx
+++ b/src/platforms/javascript/guides/cordova/ionic.mdx
@@ -50,6 +50,8 @@ If you want to skip the automatic release version and set the release completely
 
 To setup Sentry in your codebase, add this to your `app.module.ts`:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "sentry-cordova";
 

--- a/src/platforms/javascript/guides/electron/configuration/integrations/default.mdx
+++ b/src/platforms/javascript/guides/electron/configuration/integrations/default.mdx
@@ -30,6 +30,8 @@ Captures breadcrumbs for events for many of Electrons built-in modules. The brea
 
 The defaults for this integration are effectively:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 
@@ -72,6 +74,8 @@ Captures minidumps and sends them with full context to the Sentry Envelope endpo
 
 Injects a preload script via the Electron [`session.setPreloads(preloads)`](https://www.electronjs.org/docs/latest/api/session#sessetpreloadspreloads) API. By default sessions are only injected into the `defaultSession`. If you are using other sessions, you can pass a function as `getSessions` to `init`.
 
+<SignInNote />
+
 ```javascript
 import { session } from "electron";
 import * as Sentry from "@sentry/electron";
@@ -101,6 +105,8 @@ interface AdditionalContextOptions {
 ```
 
 To disable specific context items, set them as `false`:
+
+<SignInNote />
 
 ```javascript
 import * as Sentry from "@sentry/electron";
@@ -146,6 +152,8 @@ interface NetOptions {
 
 For example, to disable breadcrumb capture and addition of `sentry-trace` headers and only capture spans for `POST` requests:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 
@@ -185,6 +193,8 @@ interface ChildProcessOptions {
 
 For example, to disable capture of breadcrumbs and only capture events for Out-Of-Memory crashes:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 
@@ -204,6 +214,8 @@ Sentry.init({
 Captures sessions linked to the lifetime of the Electron main process. These sessions result in [release health](/product/releases/health/) statistics being displayed in Sentry.
 
 Unless `autoSessionTracking` is set to `false`, this integration will be automatically added.
+
+<SignInNote />
 
 ```javascript
 import * as Sentry from "@sentry/electron";

--- a/src/platforms/javascript/guides/electron/configuration/integrations/optional.mdx
+++ b/src/platforms/javascript/guides/electron/configuration/integrations/optional.mdx
@@ -9,6 +9,8 @@ Captures and sends minidumps via Electrons built in `crashReporter` uploader. Re
 
 If you add the `ElectronMinidump` integration, the `SentryMinidump` integration will be automatically removed to avoid duplicate crashes being reported.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron";
 

--- a/src/platforms/javascript/guides/electron/index.mdx
+++ b/src/platforms/javascript/guides/electron/index.mdx
@@ -46,6 +46,8 @@ If you are using preload scripts, have `contextIsolation` enabled and want to ca
 
 If you change the `userData` directory used by your app, ensure this change is made before you configure the SDK as this path is used to cache scope and events between application restarts.
 
+<SignInNote />
+
 ```javascript
 import { app } from "electron";
 import * as Sentry from "@sentry/electron";
@@ -92,6 +94,8 @@ init(
 The default transport automatically handles offline events caching. Following, are a
 number of options that allow you to customize queueing behavior:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/electron/main";
 
@@ -120,6 +124,8 @@ To give detailed information for all events including native crashes, the SDK me
 
 By default, the SDK attempts to establish communication from `renderer` to `main` via Electron IPC API's and if that fails, falls back to using a custom HTTP protocol. You can change this default via the `ipcMode` option which can be one of `Classic`, `Protocol` or `Both`.
 
+<SignInNote />
+
 ```javascript
 const { init, IPCMode } = require("@sentry/electron");
 
@@ -133,6 +139,8 @@ init({
 ### Preload Injection
 
 The SDK attempts to inject a preload script via [`session.setPreloads(preloads)`](https://www.electronjs.org/docs/latest/api/session#sessetpreloadspreloads) and by default only does this for the `defaultSession`. If you are using other sessions, you can pass custom sessions via the `getSessions` option in the `main` process:
+
+<SignInNote />
 
 ```javascript
 import { session } from "electron";

--- a/src/platforms/javascript/guides/ember/configuration/ember-options.mdx
+++ b/src/platforms/javascript/guides/ember/configuration/ember-options.mdx
@@ -6,6 +6,8 @@ sidebar_order: 1
 
 All Sentry SDK options can be passed to `init`:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/ember";
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -36,6 +36,8 @@ module.exports = {
 
 Then, configure your `Sentry.init`:
 
+<SignInNote />
+
 ```javascript {filename:sentry.config.(js|ts)}
 import * as Sentry from "@sentry/gatsby";
 

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -28,6 +28,8 @@ Create three files in the root directory of your project, `sentry.client.config.
 
 Please note that there are slight differences between these files since they run in different places (browser, server, edge), so copy them carefully!
 
+<SignInNote />
+
 ```javascript {tabTitle:Client} {filename:sentry.client.config.(js|ts)}
 import * as Sentry from "@sentry/nextjs";
 
@@ -54,6 +56,8 @@ Sentry.init({
 });
 ```
 
+<SignInNote />
+
 ```javascript {tabTitle:Server} {filename:sentry.server.config.(js|ts)}
 import * as Sentry from "@sentry/nextjs";
 
@@ -72,6 +76,8 @@ Sentry.init({
   // that it will also get attached to your source maps
 });
 ```
+
+<SignInNote />
 
 ```javascript {tabTitle:Edge} {filename:sentry.edge.config.(js|ts)}
 import * as Sentry from "@sentry/nextjs";
@@ -102,6 +108,8 @@ Use `withSentryConfig` to extend the default Next.js usage of Webpack. This will
 - Generate and upload source maps to Sentry, so that your stacktraces contain readable code.
 
 Include the following in your `next.config.js` or `next.config.mjs`:
+
+<SignInNote />
 
 ```JavaScript {filename:next.config.(js|mjs)}
 // This file sets a custom webpack configuration to use your Next.js app

--- a/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
+++ b/src/platforms/javascript/guides/react/configuration/integrations/react-router.mdx
@@ -43,6 +43,8 @@ _(Available in version 7.21.0 and above)_
 
 If you choose to create your router instance with [`createBrowserRouter`](https://reactrouter.com/en/main/routers/create-browser-router) from the `react-router-dom` package, you can use `Sentry.wrapCreateBrowserRouter` to wrap it with the instrumentation:
 
+<SignInNote />
+
 ```javascript
 import { createBrowserRouter } from "react-router-dom";
 import * as Sentry from "@sentry/react";
@@ -80,6 +82,8 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 ### Usage With `<Routes />` Component
 
 If you're using the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/docs/en/v6/api#routes-and-route) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context. You can also use `Sentry.withSentryReactRouterV6Routing` for `Routes` inside `BrowserRouter`. `MemoryRouter`, and `HashRouter` components:
+
+<SignInNote />
 
 ```javascript
 import React from "react";
@@ -136,6 +140,8 @@ If you specify your route definitions as an object to the [`useRoutes` hook](htt
 
 </Alert>
 
+<SignInNote />
+
 ```javascript
 import {
   createRoutesFromChildren,
@@ -191,6 +197,8 @@ To get parameterized transaction names (for example, `/teams/:teamid/user/:useri
 
 We recommend you use the `withSentryRouting` higher order component to create a `SentryRoute` component that will update the match path on render.
 
+<SignInNote />
+
 ```javascript
 import {Route, Router, Switch } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
@@ -229,6 +237,8 @@ render() {
 ```
 
 If you don't want to wrap individual routes, you can still specify parameterized routes manually by passing an array of route config objects, per [react-router-config](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config), to the instrumentation function call. You'll also need to provide the `matchPath` function exported from the `react-router-dom` or `react-router` packages.
+
+<SignInNote />
 
 ```javascript
 import { Route, Router, Switch, matchPath } from 'react-router-dom';
@@ -272,6 +282,8 @@ render() {
 ## React Router v3
 
 To use the router integration, import and set a custom routing instrumentation and pass it the history, your routes and a match function. React Router v3 support is maintained for React Router >= 3.2.0 and < 4.0.0.
+
+<SignInNote />
 
 ```javascript
 import * as Router from "react-router";

--- a/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -28,6 +28,8 @@ If you're updating your Sentry SDK to the latest version, check out our [migrati
 
 2. At the top of your client hooks file, initialize the Sentry SDK as shown in the snippet below. See the [Basic Options](../configuration/options/) page to view other SDK configuration options.
 
+<SignInNote />
+
 ```javascript {filename:hooks.client.js}
 import * as Sentry from "@sentry/sveltekit";
 
@@ -91,6 +93,8 @@ export const handleError = Sentry.handleErrorWithSentry(myErrorHandler);
 1. If you don't already have a [server hooks](https://kit.svelte.dev/docs/hooks#server-hooks) file, create a new one in `src/hooks.server.(js|ts)`.
 
 2. At the top of your server hooks file, initialize the Sentry SDK as shown in the snippet below. See the [Basic Options](../configuration/options/) page to view other SDK configuration options.
+
+<SignInNote />
 
 ```javascript {filename:hooks.server.js}
 import * as Sentry from "@sentry/sveltekit";

--- a/src/platforms/javascript/guides/vue/configuration/integrations/vue-router.mdx
+++ b/src/platforms/javascript/guides/vue/configuration/integrations/vue-router.mdx
@@ -11,6 +11,8 @@ Our routing instrumentation supports `vue-router` v2, v3, and v4.
 
 Here is a full example of how to use it:
 
+<SignInNote />
+
 ```javascript {filename:main.js}
 import Vue from "vue";
 import App from "./App";

--- a/src/platforms/javascript/guides/wasm/index.mdx
+++ b/src/platforms/javascript/guides/wasm/index.mdx
@@ -21,6 +21,8 @@ yarn add @sentry/browser @sentry/wasm
 
 and afterwards use it like this:
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/browser";
 import { Wasm as WasmIntegration } from "@sentry/wasm";

--- a/src/platforms/javascript/legacy-sdk/config.mdx
+++ b/src/platforms/javascript/legacy-sdk/config.mdx
@@ -12,6 +12,8 @@ redirect_from:
 
 To get started, you need to configure Raven.js to use your Sentry DSN:
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___").install();
 ```
@@ -21,6 +23,8 @@ At this point, Raven is ready to capture any uncaught exception.
 ## Optional settings
 
 `Raven.config()` can optionally be passed an additional argument for extra configuration:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
@@ -351,6 +355,8 @@ instrument: {
 ```
 
 ## Putting it all together
+
+<SignInNote />
 
 ```html
 <!DOCTYPE html>

--- a/src/platforms/javascript/legacy-sdk/index.mdx
+++ b/src/platforms/javascript/legacy-sdk/index.mdx
@@ -39,6 +39,8 @@ For installation using npm or other package managers, see [_Installation_](/plat
 
 Next you need to configure Raven.js to use your Sentry DSN:
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___").install();
 ```

--- a/src/platforms/javascript/legacy-sdk/install.mdx
+++ b/src/platforms/javascript/legacy-sdk/install.mdx
@@ -13,6 +13,8 @@ Raven is distributed in a few different methods, and should get included after a
 
 So for example:
 
+<SignInNote />
+
 ```html
 <script src="jquery.js"></script>
 <script
@@ -78,6 +80,8 @@ If you intend to use Raven with Node, [raven-node](https://github.com/getsentry/
 
 To use Raven with CommonJS imports:
 
+<SignInNote />
+
 ```javascript
 var Raven = require("raven-js");
 Raven.config("___PUBLIC_DSN___").install();
@@ -86,6 +90,8 @@ Raven.config("___PUBLIC_DSN___").install();
 ## ES2015 (ES6)
 
 To use Raven with ES2015 (ES6) imports:
+
+<SignInNote />
 
 ```javascript
 import Raven from "raven-js";
@@ -97,6 +103,8 @@ Raven.config("___PUBLIC_DSN___").install();
 To load Sentry JS SDK asynchronously, you need to do two things.
 
 Provide global `SENTRY_SDK` variable with SDK’s URL (for example from our CDN), your DSN and SDK’s configuration. And place the snippet below as soon as possible in your HTML code. For example:
+
+<SignInNote />
 
 ```html
 <script>

--- a/src/platforms/javascript/legacy-sdk/integrations.mdx
+++ b/src/platforms/javascript/legacy-sdk/integrations.mdx
@@ -59,6 +59,8 @@ For convenience, our CDN serves a single, minified JavaScript file containing bo
 
 Example:
 
+<SignInNote />
+
 ```html
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
 <script
@@ -78,6 +80,8 @@ Pre-built distributions of Raven.js and the Raven.js AngularJS plugin are availa
 
 ##### Bower
 
+<SignInNote />
+
 ```shell
 bower install raven-js --save
 ```
@@ -92,6 +96,8 @@ bower install raven-js --save
 ```
 
 ##### npm
+
+<SignInNote />
 
 ```shell
 npm install raven-js --save
@@ -115,6 +121,8 @@ Raven.addPlugin(Raven.Plugins.Angular, angular);
 #### Module loaders (CommonJS)
 
 Raven and the Raven AngularJS plugin can be loaded using a module loader like Browserify or Webpack.
+
+<SignInNote />
 
 ```javascript
 var angular = require("angular");
@@ -207,6 +215,8 @@ System.config({
 
 Then, in your main module file (where `@NgModule` is called, e.g. app.module.ts):
 
+<SignInNote />
+
 ```javascript
 import Raven = require('raven-js');
 import { BrowserModule } from '@angular/platform-browser';
@@ -241,6 +251,8 @@ Once you’ve completed these two steps, you are done.
 #### Angular CLI
 
 Angular CLI now uses Webpack to build instead of SystemJS. All you need to do is modify your main module file (where `@NgModule` is called, e.g. app.module.ts):
+
+<SignInNote />
 
 ```javascript
 import * as Raven from "raven-js";
@@ -288,6 +300,8 @@ Start by adding the `raven.js` script tag to your page. It should be loaded as e
 
 Next configure Raven.js to use your Sentry DSN:
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___").install();
 ```
@@ -316,6 +330,8 @@ For convenience, our CDN serves a single, minified JavaScript file containing bo
 
 Example:
 
+<SignInNote />
+
 ```html
 <script src="http://builds.emberjs.com/tags/v2.3.1/ember.prod.js"></script>
 <script
@@ -335,6 +351,8 @@ Pre-built distributions of Raven.js and the Raven.js Ember plugin are available 
 
 ##### Bower
 
+<SignInNote />
+
 ```shell
 bower install raven-js --save
 ```
@@ -353,6 +371,8 @@ app.import("bower_components/raven-js/dist/plugins/ember.js");
 ```
 
 ##### npm
+
+<SignInNote />
 
 ```shell
 npm install raven-js --save
@@ -395,6 +415,8 @@ Start by adding the `raven.js` script tag to your page. It should be loaded as e
 ### Configuring the Client
 
 Next configure Raven.js to use your Sentry DSN:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___").install();
@@ -492,6 +514,8 @@ For convenience, our CDN serves a single, minified JavaScript file containing bo
 
 Example:
 
+<SignInNote />
+
 ```html
 <script src="https://cdn.jsdelivr.net/vue/2.0.0-rc/vue.min.js"></script>
 <script
@@ -511,6 +535,8 @@ Both Raven.js and the Raven.js Vue plugin can be installed via npm and Bower.
 
 ##### npm
 
+<SignInNote />
+
 ```shell
 npm install raven-js --save
 ```
@@ -525,6 +551,8 @@ npm install raven-js --save
 ```
 
 ##### Bower
+
+<SignInNote />
 
 ```shell
 bower install raven-js --save
@@ -548,6 +576,8 @@ Raven.addPlugin(Raven.Plugins.Vue, Vue);
 #### Module loaders
 
 In your main application file, import and configure both Raven.js and the Raven.js Vue plugin as follows:
+
+<SignInNote />
 
 ```javascript
 import Vue from "vue";
@@ -589,6 +619,8 @@ require("raven-js/plugins/react-native")(Raven);
 ### Configuring the Client
 
 Now we need to set up Raven.js to use your Sentry DSN:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___", { release: RELEASE_ID }).install();

--- a/src/platforms/javascript/legacy-sdk/usage.mdx
+++ b/src/platforms/javascript/legacy-sdk/usage.mdx
@@ -205,6 +205,8 @@ To learn more about what types of data can be collected via breadcrumbs, see the
 
 Note that you can also disable automatic breadcrumb collection entirely or disable specific collectors:
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
   autoBreadcrumbs: {

--- a/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
+++ b/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
@@ -18,6 +18,8 @@ Using a shared initializer provides a single source of truth for your SDK's conf
 
 To initialize the SDK, create a Kotlin file in your `commonMain` e.g. `AppSetup.kt`, (or whatever you decide to call it), and create an initialization function. You'll then be able to call it in an early lifecycle stage in your platforms.
 
+<SignInNote />
+
 ```kotlin {filename:AppSetup.kt}
 import io.sentry.kotlin.multiplatform.Context
 import io.sentry.kotlin.multiplatform.Sentry
@@ -79,6 +81,8 @@ expect fun initializeSentry(context: Context? = null)
 
 ### androidMain
 
+<SignInNote />
+
 ```kotlin {filename:androidMain/AppSetup.kt}
 import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.Context
@@ -94,6 +98,8 @@ actual fun initializeSentry(context: Context?) {
 ```
 
 ### iosMain
+
+<SignInNote />
 
 ```kotlin {filename:iosMain/AppSetup.kt}
 import io.sentry.kotlin.multiplatform.Sentry

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -170,6 +170,8 @@ JavaScript modules (ESM).
 You can work around this issue by wrapping your code in try/catch and
 enabling the `captureAllExceptions` option:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -235,6 +237,8 @@ Available options:
 To disable system integrations, set `defaultIntegrations: false` when calling `init()`.
 
 To override an integration's settings, provide a new instance to the `integrations` option when calling `init()`. For example, to change the fatal error handler:
+
+<SignInNote />
 
 ```javascript
 Sentry.init({

--- a/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/pluggable-integrations.mdx
@@ -24,6 +24,8 @@ yarn add @sentry/integrations
 
 After installation, you can import the integration and provide a new instance with your config to the `integrations` option.
 
+<SignInNote />
+
 ```javascript
 import { CaptureConsole } from "@sentry/integrations";
 

--- a/src/platforms/node/common/performance/database/auto-instrument.mdx
+++ b/src/platforms/node/common/performance/database/auto-instrument.mdx
@@ -12,6 +12,8 @@ will need to manually add the required integrations.
 
 </Note>
 
+<SignInNote />
+
 ```javascript
 const Sentry = require("@sentry/node");
 
@@ -37,6 +39,8 @@ Supported packages and their integration name:
 If you need to add a specific database integration manually (for example, when using multiple client instances), you can import them from the `Integrations` namespace.
 
 For example:
+
+<SignInNote />
 
 ```javascript{tabTitle: MongoDB}
 const Sentry = require("@sentry/node");

--- a/src/platforms/node/common/performance/database/opt-in.mdx
+++ b/src/platforms/node/common/performance/database/opt-in.mdx
@@ -12,6 +12,8 @@ Prisma integration creates a `db.prisma` span for each query and reports to Sent
 
 For example:
 
+<SignInNote />
+
 ```javascript
 import { PrismaClient } from "@prisma/client";
 import * as Sentry from "@sentry/node";

--- a/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -23,6 +23,8 @@ We recommend manually adding <PlatformLink to="/performance/database" >database 
 
 </Note>
 
+<SignInNote />
+
 ```javascript
 const Sentry = require("@sentry/node");
 

--- a/src/platforms/node/common/profiling/index.mdx
+++ b/src/platforms/node/common/profiling/index.mdx
@@ -32,6 +32,8 @@ yarn add @sentry/node @sentry/profiling-node
 
 To enable profiling, import @sentry/profiling-node, add ProfilingIntegration to your integrations, and set the profilesSampleRate.
 
+<SignInNote />
+
 ```javascript
 const Sentry = require("@sentry/node");
 const { ProfilingIntegration } = require("@sentry/profiling-node");

--- a/src/platforms/node/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/container-image/index.mdx
@@ -21,6 +21,8 @@ Set the following environment variables in AWS:
 
 Alternatively, you can also set the environment variables in the Dockerfile:
 
+<SignInNote />
+
 ```{tabTitle: Dockerfile}
 ENV NODE_OPTIONS="-r @sentry/serverless/dist/awslambda-auto"
 ENV SENTRY_DSN="___PUBLIC_DSN___"

--- a/src/platforms/node/guides/aws-lambda/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/index.mdx
@@ -35,6 +35,8 @@ We also support [installing Sentry as a Container Image](/platforms/node/guides/
 
 You can use the AWS Lambda integration for the Node like this:
 
+<SignInNote />
+
 ```javascript {tabTitle:async}
 const Sentry = require("@sentry/serverless");
 

--- a/src/platforms/node/guides/azure-functions/index.mdx
+++ b/src/platforms/node/guides/azure-functions/index.mdx
@@ -17,6 +17,8 @@ yarn add @sentry/node
 
 To set up Sentry error logging for an Azure Function:
 
+<SignInNote />
+
 ```javascript
 "use strict";
 

--- a/src/platforms/node/guides/connect/index.mdx
+++ b/src/platforms/node/guides/connect/index.mdx
@@ -20,6 +20,8 @@ yarn add @sentry/node
 
 Configure Sentry as a middleware:
 
+<SignInNote />
+
 ```javascript
 import connect from "connect";
 import * as Sentry from "@sentry/node";

--- a/src/platforms/node/guides/express/index.mdx
+++ b/src/platforms/node/guides/express/index.mdx
@@ -18,6 +18,8 @@ yarn add @sentry/node
 
 Sentry should be initialized as early in your app as possible:
 
+<SignInNote />
+
 ```javascript
 import express from "express";
 import * as Sentry from "@sentry/node";
@@ -142,6 +144,8 @@ app.use(Sentry.Handlers.errorHandler() as express.ErrorRequestHandler);
 ## Monitor Performance
 
 It’s possible to add tracing to all popular frameworks; however, we only provide pre-written handlers for Express.
+
+<SignInNote />
 
 ```javascript
 const Sentry = require("@sentry/node");

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -11,6 +11,8 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 </Note>
 
+<SignInNote />
+
 ```javascript
 const Sentry = require("@sentry/node");
 const express = require("express");

--- a/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/node/guides/express/performance/instrumentation/automatic-instrumentation.mdx
@@ -11,6 +11,8 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 </Note>
 
+<SignInNote />
+
 ```javascript
 const Sentry = require("@sentry/node");
 const express = require("express");

--- a/src/platforms/node/guides/gcp-functions/index.mdx
+++ b/src/platforms/node/guides/gcp-functions/index.mdx
@@ -15,6 +15,8 @@ Add `@sentry/serverless` as a dependency to `package.json`:
 
 To set up Sentry for a Google Cloud Function:
 
+<SignInNote />
+
 ```javascript {tabTitle:Http functions}
 const Sentry = require("@sentry/serverless");
 

--- a/src/platforms/node/guides/koa/index.mdx
+++ b/src/platforms/node/guides/koa/index.mdx
@@ -18,6 +18,8 @@ yarn add @sentry/node @sentry/utils
 
 Initialize the Sentry SDK and install the on error hook:
 
+<SignInNote />
+
 ```javascript
 import Koa from "koa";
 import * as Sentry from "@sentry/node";
@@ -43,6 +45,8 @@ app.listen(3000);
 ## Monitor Performance
 
 Create and attach a transaction to each request:
+
+<SignInNote />
 
 ```javascript
 const Sentry = require("@sentry/node");

--- a/src/platforms/node/guides/serverless-cloud/index.mdx
+++ b/src/platforms/node/guides/serverless-cloud/index.mdx
@@ -11,6 +11,8 @@ cloud install @sentry/node
 
 Sentry should be initialized as early in your app as possible:
 
+<SignInNote />
+
 ```javascript
 import api from "@serverless/cloud";
 import * as Sentry from "@sentry/node";
@@ -112,6 +114,8 @@ api.use(
 ```
 
 ## Monitor Performance
+
+<SignInNote />
 
 ```javascript
 const Sentry = require("@sentry/node");

--- a/src/platforms/node/legacy-sdk/coffeescript.mdx
+++ b/src/platforms/node/legacy-sdk/coffeescript.mdx
@@ -20,6 +20,8 @@ In order to use raven-node with coffee-script or another library which overwrite
 
 In order to not have raven-node (and the underlying raw stack trace library) require Traceback you can pass your own stackFunction in the options. For example:
 
+<SignInNote />
+
 ```coffeescript
 client = new raven.Client('___PUBLIC_DSN___', {
     stackFunction: {{ Your stack function }}

--- a/src/platforms/node/legacy-sdk/config.mdx
+++ b/src/platforms/node/legacy-sdk/config.mdx
@@ -17,6 +17,8 @@ A new Node SDK has superseded this deprecated version. Sentry preserves this doc
 
 To get started, you need to configure Raven to use your Sentry DSN:
 
+<SignInNote />
+
 ```javascript
 var Raven = require("raven");
 Raven.config("___PUBLIC_DSN___").install();
@@ -25,6 +27,8 @@ Raven.config("___PUBLIC_DSN___").install();
 At this point, Raven is ready to capture any uncaught exceptions.
 
 Note that the `install` method can optionally take a callback function that is invoked if a fatal, non-recoverable error occurs. You can use this callback to perform any cleanup that should occur before the Node process exits.
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___").install(function (err, initialErr, eventId) {
@@ -36,6 +40,8 @@ Raven.config("___PUBLIC_DSN___").install(function (err, initialErr, eventId) {
 ## Optional settings
 
 `Raven.config()` can optionally be passed an additional argument for extra configuration:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___", {

--- a/src/platforms/node/legacy-sdk/index.mdx
+++ b/src/platforms/node/legacy-sdk/index.mdx
@@ -36,6 +36,8 @@ npm install raven --save
 
 Next you need to initialize the Raven client and configure it to use your Sentry DSN:
 
+<SignInNote />
+
 ```javascript
 var Raven = require("raven");
 Raven.config("___PUBLIC_DSN___").install();

--- a/src/platforms/node/legacy-sdk/integrations.mdx
+++ b/src/platforms/node/legacy-sdk/integrations.mdx
@@ -17,6 +17,8 @@ A new Node SDK has superseded this deprecated version. Sentry preserves this doc
 
 ## Connect
 
+<SignInNote />
+
 ```javascript
 var connect = require("connect");
 var Raven = require("raven");
@@ -82,6 +84,8 @@ app.listen(3000);
 ```
 
 ## Koa
+
+<SignInNote />
 
 ```javascript
 var koa = require("koa");

--- a/src/platforms/node/legacy-sdk/usage.mdx
+++ b/src/platforms/node/legacy-sdk/usage.mdx
@@ -38,6 +38,8 @@ try {
 
 The recommended usage pattern, though, is to run your entire program inside a Raven context:
 
+<SignInNote />
+
 ```javascript
 var Raven = require("raven");
 
@@ -235,6 +237,8 @@ Raven can be configured to automatically capture breadcrubs for certain events i
 
 Automatic breadcrumb collection is disabled by default. You can enable it with a config option:
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
   autoBreadcrumbs: true,
@@ -242,6 +246,8 @@ Raven.config("___PUBLIC_DSN___", {
 ```
 
 Or just enable specific types of automatic breadcrumbs:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
@@ -266,6 +272,8 @@ var eventId = Raven.captureException(e, function (sendErr, eventId2) {
 ## Promises
 
 By default, Raven does not capture unhandled promise rejections. You can have it do so automatically:
+
+<SignInNote />
 
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
@@ -319,6 +327,8 @@ Raven.captureMessage("Boom");
 
 ## Configuring the HTTP Transport
 
+<SignInNote />
+
 ```javascript
 Raven.config("___PUBLIC_DSN___", {
   transport: new raven.transports.HTTPSTransport({ rejectUnauthorized: false }),
@@ -328,6 +338,8 @@ Raven.config("___PUBLIC_DSN___", {
 ## Disable Raven
 
 Passing any falsey value as the DSN will disable sending events upstream:
+
+<SignInNote />
 
 ```javascript
 Raven.config(process.env.NODE_ENV === "production" && "___PUBLIC_DSN___");

--- a/src/platforms/php/common/configuration/transports.mdx
+++ b/src/platforms/php/common/configuration/transports.mdx
@@ -49,6 +49,8 @@ Although not so common there could be cases in which you don't want to send
 events at all. The `NullTransport` transport does this: it simply ignores
 the events, but report them as sent.
 
+<SignInNote />
+
 ```php
 use Sentry\ClientBuilder;
 use Sentry\Transport\NullTransport;
@@ -80,6 +82,8 @@ SentrySdk::getCurrentHub()->bindClient($builder->getClient());
 The `HttpTransport` sends events over the HTTP protocol using [Httplug](https://httplug.io/).
 The best adapter available is automatically selected when creating a client instance
 through the client builder, but you can override it using the appropriate methods.
+
+<SignInNote />
 
 ```php
 use Http\Discovery\HttpAsyncClientDiscovery;

--- a/src/platforms/php/common/integrations.mdx
+++ b/src/platforms/php/common/integrations.mdx
@@ -71,6 +71,8 @@ You can enable these integrations by passing them to the `integrations` option w
 
 In this example, the optional `IgnoreErrorsIntegration` is added:
 
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',
@@ -91,6 +93,8 @@ This integration decides whether an event should not be captured according to a 
 You can customize the list of integration without disabling the default integration using the `integrations` option. You can pass a callable for advanced needs, though a fixed list of integrations will work in most use cases.
 
 In the example below, all integrations are enabled except the `ExceptionListenerIntegration`. In addition, the `ModulesIntegration` is added.
+
+<SignInNote />
 
 ```php
 \Sentry\init([

--- a/src/platforms/php/common/profiling/index.mdx
+++ b/src/platforms/php/common/profiling/index.mdx
@@ -63,6 +63,8 @@ Sentry's performance monitoring product has to be enabled in order for Profiling
 To begin capturing profiling data, you first need to start a transaction.
 Check out the <PlatformLink to="/performance/">performance setup</PlatformLink> and <PlatformLink to="/performance/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink> documentation for more detailed information.
 
+<SignInNote />
+
 ```php
 \Sentry\init([
     'dsn' => '___PUBLIC_DSN___',
@@ -71,6 +73,8 @@ Check out the <PlatformLink to="/performance/">performance setup</PlatformLink> 
 ```
 
 ## Enabling Profiling
+
+<SignInNote />
 
 ```php
 \Sentry\init([

--- a/src/platforms/php/guides/laravel/index.mdx
+++ b/src/platforms/php/guides/laravel/index.mdx
@@ -43,11 +43,15 @@ Alternatively, you can configure Sentry in your [Laravel Log Channel](usage/#log
 
 Configure the Sentry DSN with this command:
 
+<SignInNote />
+
 ```shell
 php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
 It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
+
+<SignInNote />
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/src/platforms/php/guides/laravel/other-versions/laravel4.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel4.mdx
@@ -47,6 +47,8 @@ php artisan config:publish sentry/sentry-laravel
 
 Add your DSN to `config/sentry.php`:
 
+<SignInNote />
+
 ```php {filename:config/sentry.php}
 <?php
 

--- a/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel5.mdx
@@ -52,11 +52,15 @@ public function report(Exception $exception)
 
 Configure the Sentry DSN with this command:
 
+<SignInNote />
+
 ```shell
 php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
 It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
+
+<SignInNote />
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/src/platforms/php/guides/laravel/other-versions/laravel6-7.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/laravel6-7.mdx
@@ -46,11 +46,15 @@ public function report(Exception $exception)
 
 Configure the Sentry DSN with this command:
 
+<SignInNote />
+
 ```shell
 php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
 It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
+
+<SignInNote />
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/src/platforms/php/guides/laravel/other-versions/lumen.mdx
+++ b/src/platforms/php/guides/laravel/other-versions/lumen.mdx
@@ -53,6 +53,8 @@ cp vendor/sentry/sentry-laravel/config/sentry.php config/sentry.php
 
 Afterwards, add your DSN to `.env`:
 
+<SignInNote />
+
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
 ```

--- a/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/src/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -10,6 +10,8 @@ In addition to the [configuration available in the PHP SDK](../options/), there 
 
 All configuration for Symfony is done in `config/packages/sentry.yaml`.
 
+<SignInNote />
+
 <!-- prettier-ignore -->
 ```yaml {filename:config/packages/sentry.yaml}
 sentry:

--- a/src/platforms/php/guides/symfony/index.mdx
+++ b/src/platforms/php/guides/symfony/index.mdx
@@ -44,6 +44,8 @@ sentry:
 
 And in your `.env` file:
 
+<SignInNote />
+
 ```plain {filename:.env}
 ###> sentry/sentry-symfony ###
 SENTRY_DSN="___PUBLIC_DSN___"

--- a/src/platforms/php/index.mdx
+++ b/src/platforms/php/index.mdx
@@ -37,6 +37,8 @@ After you’ve completed setting up a project in Sentry, Sentry will give you a 
 
 To capture all errors, even the one during the startup of your application, you should initialize the Sentry PHP SDK as soon as possible.
 
+<SignInNote />
+
 ```php
 \Sentry\init(['dsn' => '___PUBLIC_DSN___' ]);
 ```

--- a/src/platforms/php/legacy-sdk/index.mdx
+++ b/src/platforms/php/legacy-sdk/index.mdx
@@ -52,6 +52,8 @@ Alternatively you can manually install it:
 
 The most important part is the creation of the raven client. Create it once and reference it from anywhere you want to interface with Sentry:
 
+<SignInNote />
+
 ```php
 $client = new Raven_Client('___PUBLIC_DSN___');
 ```

--- a/src/platforms/php/legacy-sdk/integrations.mdx
+++ b/src/platforms/php/legacy-sdk/integrations.mdx
@@ -62,6 +62,8 @@ php artisan vendor:publish --provider="Sentry\SentryLaravel\SentryLaravelService
 
 Add your DSN to `.env`:
 
+<SignInNote />
+
 ```bash
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
 ```
@@ -101,6 +103,8 @@ class Handler extends ExceptionHandler
 ```
 
 Next, create `resources/views/errors/500.blade.php`, and embed the feedback code:
+
+<SignInNote />
 
 ```html
 <div class="content">
@@ -161,6 +165,8 @@ php artisan config:publish sentry/sentry-laravel
 
 Add your DSN to `config/sentry.php`:
 
+<SignInNote />
+
 ```php
 <?php
 
@@ -208,6 +214,8 @@ public function report(Exception $e)
 ```
 
 Create the Sentry configuration file (`config/sentry.php`):
+
+<SignInNote />
 
 ```php
 <?php
@@ -286,6 +294,8 @@ The following settings are available for the client:
 
 : The DSN to authenticate with Sentry.
 
+<SignInNote />
+
 ```php
 'dsn' => '___PUBLIC_DSN___',
 ```
@@ -326,6 +336,8 @@ Defaults to `true`.
 
 Monolog supports Sentry out of the box, so you’ll just need to configure a handler:
 
+<SignInNote />
+
 ```php
 $client = new Raven_Client('___PUBLIC_DSN___');
 
@@ -362,6 +374,8 @@ $monolog->pushProcessor(function ($record) {
 ### Breadcrumbs
 
 Sentry provides a breadcrumb handler to automatically send logs along as crumbs:
+
+<SignInNote />
 
 ```php
 $client = new Raven_Client('___PUBLIC_DSN___');
@@ -409,6 +423,8 @@ public function registerBundles()
 ```
 
 Add your DSN to `app/config/config.yml`:
+
+<SignInNote />
 
 ```yaml
 sentry:

--- a/src/platforms/php/legacy-sdk/usage.mdx
+++ b/src/platforms/php/legacy-sdk/usage.mdx
@@ -22,6 +22,8 @@ Using Sentry with PHP is straightforward. After installation of the library you 
 
 The most important part is the creation of the raven client. Create it once and reference it from anywhere you want to interface with Sentry:
 
+<SignInNote />
+
 ```php
 $sentryClient = new Raven_Client('___PUBLIC_DSN___');
 ```
@@ -173,6 +175,8 @@ $sentryClient->getLastEventID();
 
 To enable user feedback for crash reports, you will need to create an error handler which is aware of the last event ID.
 
+<SignInNote />
+
 ```php
 <?php
 
@@ -190,6 +194,8 @@ public class App {
 ```
 
 Then in your template you can load up the feedback widget:
+
+<SignInNote />
 
 ```html
 <!-- Sentry JS SDK 2.1.+ required -->
@@ -274,6 +280,8 @@ if (!$my_file) {
 ## Testing Your Connection
 
 The PHP client includes a simple helper script to test your connection and credentials with the Sentry master server:
+
+<SignInNote />
 
 ```bash
 bin/sentry test ___PUBLIC_DSN___

--- a/src/platforms/python/common/configuration/integrations/asgi.mdx
+++ b/src/platforms/python/common/configuration/integrations/asgi.mdx
@@ -22,6 +22,8 @@ pip install --upgrade 'sentry-sdk'
 
 ## Configure
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

--- a/src/platforms/python/common/configuration/integrations/asyncio.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncio.mdx
@@ -16,6 +16,8 @@ pip install --upgrade 'sentry-sdk'
 
 Add `AsyncioIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.asyncio import AsyncioIntegration

--- a/src/platforms/python/common/configuration/integrations/cloudresourcecontext.mdx
+++ b/src/platforms/python/common/configuration/integrations/cloudresourcecontext.mdx
@@ -18,6 +18,8 @@ pip install --upgrade 'sentry-sdk'
 
 Add `CloudResourceContextIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.cloud_resource_context import CloudResourceContextIntegration

--- a/src/platforms/python/common/configuration/integrations/gnu_backtrace.mdx
+++ b/src/platforms/python/common/configuration/integrations/gnu_backtrace.mdx
@@ -26,6 +26,8 @@ pip install --upgrade 'sentry-sdk'
 
 Add `GnuBacktraceIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[httpx]'
 
 Add `HttpxIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.httpx import HttpxIntegration

--- a/src/platforms/python/common/configuration/integrations/loguru.mdx
+++ b/src/platforms/python/common/configuration/integrations/loguru.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[loguru]'
 
 Add `LoguruIntegration()` to your integrations list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.loguru import LoguruIntegration
@@ -83,6 +85,8 @@ You can also use `before-send` and `before-breadcrumb` to ignore only certain me
 ## Options
 
 You can pass the following keyword arguments to `LoguruIntegration()`:
+
+<SignInNote />
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/configuration/integrations/pure_eval.mdx
+++ b/src/platforms/python/common/configuration/integrations/pure_eval.mdx
@@ -26,6 +26,8 @@ pip install --upgrade 'sentry-sdk[pure_eval]'
 
 Add `PureEvalIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.pure_eval import PureEvalIntegration

--- a/src/platforms/python/common/configuration/integrations/pymongo.mdx
+++ b/src/platforms/python/common/configuration/integrations/pymongo.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[pymongo]'
 
 To configure the SDK, initialize it before creating any of PyMongo's MongoClient instances:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.pymongo import PyMongoIntegration

--- a/src/platforms/python/common/configuration/integrations/redis.mdx
+++ b/src/platforms/python/common/configuration/integrations/redis.mdx
@@ -18,6 +18,8 @@ pip install --upgrade 'sentry-sdk'
 
 If you have the `redis` Python package in your dependencies, the Redis integration will be enabled automatically. There is nothing to do for you except initializing the Sentry SDK.
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -49,6 +51,8 @@ By default `RedisIntegration()` will trim data collected after `1024` characters
 
 Example for disabling data trimming, the whole Redis command will be recorded:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -62,6 +66,8 @@ sentry_sdk.init(
 ```
 
 Example of keeping just a maximum of 50 characters of Redis commands:
+
+<SignInNote />
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/configuration/integrations/socket.mdx
+++ b/src/platforms/python/common/configuration/integrations/socket.mdx
@@ -14,6 +14,8 @@ Use this integration to create spans for dns resolves and connection creations.
 
 Add `SocketIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.socket import SocketIntegration

--- a/src/platforms/python/common/configuration/integrations/sqlalchemy.mdx
+++ b/src/platforms/python/common/configuration/integrations/sqlalchemy.mdx
@@ -27,6 +27,8 @@ pip install --upgrade 'sentry-sdk[sqlalchemy]'
 
 Add `SqlalchemyIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration

--- a/src/platforms/python/common/configuration/integrations/wsgi.mdx
+++ b/src/platforms/python/common/configuration/integrations/wsgi.mdx
@@ -22,6 +22,8 @@ pip install --upgrade 'sentry-sdk'
 
 ## Configure
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware

--- a/src/platforms/python/common/migration.mdx
+++ b/src/platforms/python/common/migration.mdx
@@ -12,12 +12,16 @@ The installation is now the same regardless of framework or library you integrat
 
 **Old**:
 
+<SignInNote />
+
 ```python
 import raven
 client = raven.Client("___PUBLIC_DSN___", release="1.3.0")
 ```
 
 **New**:
+
+<SignInNote />
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -110,6 +110,8 @@ def eat_slice(slice):
 
 To avoid having custom performance instrumentation code scattered all over your code base, pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -25,6 +25,8 @@ pip install --upgrade aiocontextvars
 
 ## Configure
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration

--- a/src/platforms/python/guides/airflow/index.mdx
+++ b/src/platforms/python/guides/airflow/index.mdx
@@ -17,6 +17,8 @@ pip install 'apache-airflow[sentry]'
 
 Then, add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.
 
+<SignInNote />
+
 ```ini {filename:airflow.cfg}
 [sentry]
 sentry_dsn = ___PUBLIC_DSN___

--- a/src/platforms/python/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/container-image/index.mdx
@@ -27,6 +27,8 @@ Also, set the following environment variables in AWS:
 
 Alternatively, you can also set the environment variables in the Dockerfile:
 
+<SignInNote />
+
 ```{tabTitle: Dockerfile}
 ENV SENTRY_INITIAL_HANDLER="<PATH_TO_FUNCTION_HANDLER>"
 ENV SENTRY_DSN="___PUBLIC_DSN___"

--- a/src/platforms/python/guides/aws-lambda/index.mdx
+++ b/src/platforms/python/guides/aws-lambda/index.mdx
@@ -25,6 +25,8 @@ We also support [installing Sentry as a Container Image](/platforms/python/guide
 
 You can use the AWS Lambda integration for the Python SDK like this:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
@@ -60,6 +62,8 @@ the [configured timeout](https://docs.aws.amazon.com/lambda/latest/dg/configurat
 
 To enable the warning, update the SDK initialization to set `timeout_warning` to
 `true`:
+
+<SignInNote />
 
 ```python
 sentry_sdk.init(

--- a/src/platforms/python/guides/beam/index.mdx
+++ b/src/platforms/python/guides/beam/index.mdx
@@ -13,6 +13,8 @@ A Beam version of 2.12 or later is required.
 
 Add `BeamIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.beam import BeamIntegration

--- a/src/platforms/python/guides/bottle/index.mdx
+++ b/src/platforms/python/guides/bottle/index.mdx
@@ -22,6 +22,8 @@ pip install --upgrade 'sentry-sdk[bottle]==0.16.2'
 
 To configure the SDK, initialize it with the integration before your app has been initialized:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platforms/python/guides/celery/index.mdx
+++ b/src/platforms/python/guides/celery/index.mdx
@@ -10,6 +10,8 @@ The Celery integration adds support for the [Celery Task Queue System](https://d
 
 Just add `CeleryIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration

--- a/src/platforms/python/guides/chalice/index.mdx
+++ b/src/platforms/python/guides/chalice/index.mdx
@@ -15,6 +15,8 @@ pip install --upgrade sentry-sdk[chalice]
 
 ## Configure
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from chalice import Chalice

--- a/src/platforms/python/guides/django/index.mdx
+++ b/src/platforms/python/guides/django/index.mdx
@@ -29,6 +29,8 @@ pip install --upgrade 'sentry-sdk[django]'
 
 To configure the Sentry SDK, initialize it in your `settings.py` file:
 
+<SignInNote />
+
 ```python {filename:settings.py}
 import sentry_sdk
 
@@ -85,6 +87,8 @@ The parameter `traces_sample_rate` needs to be set when initializing the Sentry 
 ## Options
 
 By adding `DjangoIntegration` explicitly to your `sentry_sdk.init()` call you can set options for `DjangoIntegration` to change its behavior:
+
+<SignInNote />
 
 ```python
 import sentry_sdk

--- a/src/platforms/python/guides/falcon/index.mdx
+++ b/src/platforms/python/guides/falcon/index.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[falcon]==0.16.2'
 
 To configure the SDK, initialize it with the integration before your app has been initialized:
 
+<SignInNote />
+
 ```python
 import falcon
 import sentry_sdk

--- a/src/platforms/python/guides/fastapi/index.mdx
+++ b/src/platforms/python/guides/fastapi/index.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[fastapi]'
 
 To configure the Sentry SDK, initialize it before your app has been initialized:
 
+<SignInNote />
+
 ```python
 from fastapi import FastAPI
 

--- a/src/platforms/python/guides/gcp-functions/index.mdx
+++ b/src/platforms/python/guides/gcp-functions/index.mdx
@@ -23,6 +23,8 @@ The GCP integration currently supports only the Python `3.7` runtime environment
 
 You can use the Google Cloud Functions integration for the Python SDK like this:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.gcp import GcpIntegration
@@ -58,6 +60,8 @@ the [configured timeout](https://cloud.google.com/functions/docs/concepts/exec#t
 
 To enable the warning, update the SDK initialization to set `timeout_warning` to
 `true`:
+
+<SignInNote />
 
 ```python
 sentry_sdk.init(

--- a/src/platforms/python/guides/logging/index.mdx
+++ b/src/platforms/python/guides/logging/index.mdx
@@ -9,6 +9,8 @@ description: "Learn about logging with Python."
 Calling `sentry_sdk.init()` already integrates with the logging module. It is
 equivalent to this explicit configuration:
 
+<SignInNote />
+
 ```python
 import logging
 import sentry_sdk

--- a/src/platforms/python/guides/pyramid/index.mdx
+++ b/src/platforms/python/guides/pyramid/index.mdx
@@ -20,6 +20,8 @@ pip install --upgrade sentry-sdk
 
 To configure the SDK, initialize it with the integration before or after your app has been created:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 

--- a/src/platforms/python/guides/pyspark/index.mdx
+++ b/src/platforms/python/guides/pyspark/index.mdx
@@ -15,6 +15,8 @@ The spark driver integration is supported for Spark 2 and above.
 
 To configure the SDK, initialize it with the integration before you create a `SparkContext` or `SparkSession`.
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.spark import SparkIntegration
@@ -44,6 +46,8 @@ if __name__ == "__main__":
 The spark worker integration is supported for Spark versions 2.4.x and 3.1.x.
 
 Create a file called `sentry-daemon.py` with the following content:
+
+<SignInNote />
 
 ```python {filename:sentry-daemon.py}
 import sentry_sdk

--- a/src/platforms/python/guides/quart/index.mdx
+++ b/src/platforms/python/guides/quart/index.mdx
@@ -21,6 +21,8 @@ pip install --upgrade sentry-sdk
 
 To configure the SDK, initialize it with the integration before or after your app has been initialized:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.quart import QuartIntegration

--- a/src/platforms/python/guides/rq/index.mdx
+++ b/src/platforms/python/guides/rq/index.mdx
@@ -10,6 +10,8 @@ The RQ integration adds support for the [RQ Job Queue System](https://python-rq.
 
 Create a file called `mysettings.py` with the following content:
 
+<SignInNote />
+
 ```python {filename:mysettings.py}
 import sentry_sdk
 from sentry_sdk.integrations.rq import RqIntegration
@@ -40,6 +42,8 @@ The integration will automatically report errors from all RQ jobs.
 Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.
 
 In addition, make sure that **`init` is called only once** in your app. For example, if you have a Flask app and a worker that depends on the app, we recommend initializing Sentry with a single configuration that is suitable for Flask and RQ, as in:
+
+<SignInNote />
 
 ```python {filename:app.py}
 import sentry_sdk

--- a/src/platforms/python/guides/sanic/index.mdx
+++ b/src/platforms/python/guides/sanic/index.mdx
@@ -37,6 +37,8 @@ pip install --upgrade aiocontextvars
 
 To configure the SDK, initialize it with the integration before or after your app has been initialized:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.sanic import SanicIntegration

--- a/src/platforms/python/guides/serverless/index.mdx
+++ b/src/platforms/python/guides/serverless/index.mdx
@@ -16,6 +16,8 @@ If you use a serverless provider not directly supported by the SDK, you can use 
 
 Apply the `serverless_function` decorator to each function that might throw errors:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function

--- a/src/platforms/python/guides/starlette/index.mdx
+++ b/src/platforms/python/guides/starlette/index.mdx
@@ -22,6 +22,8 @@ pip install --upgrade 'sentry-sdk[starlette]'
 
 To configure the SDK, initialize it with the integration before your app has been initialized:
 
+<SignInNote />
+
 ```python
 from starlette.applications import Starlette
 

--- a/src/platforms/python/guides/tornado/index.mdx
+++ b/src/platforms/python/guides/tornado/index.mdx
@@ -26,6 +26,8 @@ pip install --upgrade aiocontextvars
 
 Initialize the SDK before starting the server:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.tornado import TornadoIntegration

--- a/src/platforms/python/guides/tryton/index.mdx
+++ b/src/platforms/python/guides/tryton/index.mdx
@@ -9,6 +9,8 @@ The Tryton integration adds support for the [Tryton Framework Server](https://ww
 
 To configure the SDK, initialize it with the integration in a custom wsgi.py script:
 
+<SignInNote />
+
 ```python
 # wsgi.py
 import sentry_sdk

--- a/src/platforms/python/legacy-sdk/integrations.mdx
+++ b/src/platforms/python/legacy-sdk/integrations.mdx
@@ -373,6 +373,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 By default Django will render `500.html`, so simply drop the following snippet into your template:
 
+<SignInNote />
+
 ```html
 <!-- Sentry JS SDK 2.1.+ required -->
 <script src="https://cdn.ravenjs.com/2.3.0/raven.min.js"></script>

--- a/src/platforms/python/legacy-sdk/usage.mdx
+++ b/src/platforms/python/legacy-sdk/usage.mdx
@@ -102,6 +102,8 @@ raven test
 
 You should get something like the following, assuming you’re configured everything correctly:
 
+<SignInNote />
+
 ```bash
 raven test sync+___DSN___
 Using DSN configuration:

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -134,6 +134,8 @@ When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is
 
 To upload generated sourcemaps using Fastlane, use the `sentry_upload_sourcemap` action. See how to install Sentry Fastlane Plugin [here](https://github.com/getsentry/sentry-fastlane-plugin).
 
+<SignInNote />
+
 ```ruby {tabTitle:Android}
 sentry_upload_sourcemap(
   auth_token: 'YOUR_AUTH_TOKEN',

--- a/src/platforms/react-native/manual-setup/native-init.mdx
+++ b/src/platforms/react-native/manual-setup/native-init.mdx
@@ -8,6 +8,8 @@ By default, the React Native SDK initializes the native SDK underneath the `init
 
 To do this, set [autoInitializeNativeSdk](/platforms/react-native/configuration/options/#autoInitializeNativeSdk) to `false` in the init options:
 
+<SignInNote />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/automatic-instrumentation.mdx
@@ -346,6 +346,8 @@ The tracing integration creates a child span for every `XMLHttpRequest` or `fetc
 
 To configure the automatic performance instrumentation, you will need to add the `ReactNativeTracing` integration yourself. We provide many options by default, so for the majority of apps you won't need to configure the integration yourself.
 
+<SignInNote />
+
 ```javascript
 import * as Sentry from "@sentry/react-native";
 
@@ -361,6 +363,8 @@ For all possible options, see [ReactNativeTracingOptions](https://github.com/get
 ### beforeNavigate
 
 You can use `beforeNavigate` to modify the transaction from routing instrumentation before the transaction is created. If you prefer not to send the transaction, set `sampled = false`.
+
+<SignInNote />
 
 ```javascript
 Sentry.init({
@@ -486,6 +490,8 @@ When bundling for production, React Native will minify class and function names 
 ## Opt Out
 
 If you want to use tracing without our automatic instrumentation, you can disable it by setting `enableAutoPerformanceTracking` in your Sentry options and removing the `ReactNativeTracing` integration, if you added it:
+
+<SignInNote />
 
 ```javascript
 import * as Sentry from "@sentry/react-native";

--- a/src/platforms/react-native/troubleshooting.mdx
+++ b/src/platforms/react-native/troubleshooting.mdx
@@ -29,6 +29,8 @@ By default we will patch the global `Promise` instance to ensure it matches exac
 
 If you use a polyfilling library that patches the global `Promise` instance, you'll need to make sure you run the polyfill **after** `Sentry.init` is called.
 
+<SignInNote />
+
 ```js
 import allSettled from "promise.allsettled";
 

--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -9,6 +9,8 @@ description: "Learn more about how to configure the SDK."
 
 Configuration is passed as part of the client initialization:
 
+<SignInNote />
+
 ```ruby
 Sentry.init do |config|
   config.dsn = '___PUBLIC_DSN___'
@@ -256,6 +258,8 @@ config.transport.transport_class = MyTransportClass
 : After you complete setting up a project, you’ll be given a value which we call a DSN, or Data Source Name. It looks a lot like a standard URL, but it’s actually just a representation of the configuration required by Sentry (the Sentry client). It consists of a few pieces, including the protocol, public and secret keys, the server address, and the project identifier.
 
 With Sentry, you may either set the SENTRY_DSN environment variable (recommended), or set your DSN manually in a config block:
+
+<SignInNote />
 
 ```ruby
 # in Rails, this might be in config/initializers/sentry.rb

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -21,6 +21,8 @@ sentry-actix = "{{@inject packages.version('sentry.rust') }}"
 
 And your Rust code:
 
+<SignInNote />
+
 ```rust {filename:main.rs}
 use std::io;
 

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -34,6 +34,8 @@ The most convenient way to use this library is the `sentry::init` function, whic
 
 The `sentry::init` function returns a guard that, when dropped, will flush Events that were not yet sent to the Sentry service. It has a two second deadline for this, so shutdown of applications might slightly delay as a result. Keeping the guard around or sending events will not work.
 
+<SignInNote />
+
 ```rust {filename:main.rs}
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),
@@ -46,6 +48,8 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 ## Verify Setup
 
 The quickest way to verify Sentry in your Rust application is to cause a panic:
+
+<SignInNote />
 
 ```rust {filename:main.rs}
 fn main() {

--- a/src/platforms/unity/configuration/event-debouncing.mdx
+++ b/src/platforms/unity/configuration/event-debouncing.mdx
@@ -14,6 +14,8 @@ The time that needs to pass after an event has been triggered to be captured aga
 - `LogType.Warning` - one second
 - `LogType.Error`, `LogType.Exception`, `LogType.Assert` and actual exceptions - one second
 
+<SignInNote />
+
 ```csharp
 using UnityEngine;
 

--- a/src/platforms/unity/migration.mdx
+++ b/src/platforms/unity/migration.mdx
@@ -51,6 +51,8 @@ The updated Sentry Unity SDK requires Unity version 2019.4 or higher with .NET S
 
 </Note>
 
+<SignInNote />
+
 1. Remove the old `Sentry.cs` and `SentrySdk.cs` files from your project.
 2. Remove the old initialization code `gameObject.AddComponent<SentrySdk>().Dsn = "___PUBLIC_DSN___";`.
 3. Install the new [Sentry Unity SDK](/platforms/unity/).

--- a/src/platforms/unity/native-support/index.mdx
+++ b/src/platforms/unity/native-support/index.mdx
@@ -65,6 +65,8 @@ The automated symbol upload will take care of the `BCSymbolMap` files by process
 
 If you don't want to rely on the automated symbol upload, you can run `sentry-cli` through the commandline. For that, you can use the provided executables from within the package or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols, run it with:
 
+<SignInNote />
+
 ```bash
 sentry-cli --auth-token YOUR_AUTH_TOKEN debug-files upload --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_SYMBOLS
 ```

--- a/src/platforms/unreal/debug-symbols.mdx
+++ b/src/platforms/unreal/debug-symbols.mdx
@@ -19,6 +19,8 @@ The automated debug symbols upload is disabled by default and requires configura
 
 To upload debug symbols to Sentry manually, run `sentry-cli` through the command line. You can either use the provided executables from within the package, or follow the [sentry-cli documentation](/product/cli/installation/) to make it available globally. To upload debug symbols run the following command:
 
+<SignInNote />
+
 ```bash
 sentry-cli --auth-token YOUR_AUTH_TOKEN debug-files upload --org ___ORG_SLUG___ --project ___PROJECT_SLUG___ PATH_TO_SYMBOLS
 ```


### PR DESCRIPTION
We developed a "sign in note", that directs users to the Sentry login page, and redirects them back to that exact page, once successfully registered/logged in.

It is only shown when users aren't logged in to Sentry.io. We've placed it above code sections, that contain the following placeholders:
- `___PUBLIC_DSN___`
- `___PROJECT_ID___`
- `___PROJECT_SLUG___`
- `___ORG_SLUG___`

When users are logged out, this is how the note looks like:

> ![Screenshot 2023-07-18 at 15 22 35](https://github.com/getsentry/sentry-docs/assets/7096858/ad34b322-8a00-42f0-b493-83fac6bb3afe)



And when there is no placeholder in the code section, we of course haven't added the note:

> ![Screenshot 2023-07-18 at 15 22 41](https://github.com/getsentry/sentry-docs/assets/7096858/59f438f7-01f3-4294-ac89-728b55bca19e)
