### PR TITLE
ref: Add more details to ownership rules evaluation flow

### DIFF
--- a/src/docs/product/issues/ownership-rules/index.mdx
+++ b/src/docs/product/issues/ownership-rules/index.mdx
@@ -113,12 +113,12 @@ Create external team/user mappings for your GitHub/GitLab teams and users by nav
 
 ## Evaluation Flow
 
-If you have both ownership rules and code owners, Sentry evaluates an event against the rules in the following order:
+If you have both ownership rules and code owners, Sentry evaluates an event’s in-app frames against the rules in the following order:
 
 1. Code owners, top-to-bottom
 2. Ownership rules, top-to-bottom
 
-After evaluation, the last rule matching returns the assignment.
+After evaluation, the last rule matching returns the assignment. The order of the event’s stacktrace filepaths is irrelevant in determining the rule assignment.
 
 ### Example
 


### PR DESCRIPTION
Add the fact that the stacktrace paths order is irrelevant and that we only check the in-app frames to evaluation flow
