### PR TITLE
docs: add missing getCurrentHub import

### DIFF
--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -45,6 +45,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { Replay } = await import("@sentry/browser");
+const { getCurrentHub, Replay } = await import("@sentry/browser");
 getCurrentHub().getClient().addIntegration(new Replay());
 ```


### PR DESCRIPTION
This PR will fix the missing `getCurrentHub` import in the `src/platform-includes/session-replay/setup/javascript.mdx` docs.