### PR TITLE
Added max_string_lengthj option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -360,6 +360,15 @@ This parameter controls if integrations should capture HTTP request bodies. It c
 
 </ConfigKey>
 
+<ConfigKey name="max-string-length" supported={["python"]}>
+
+This parameter controls to what maximum lengths strings in events (errors, transactions, etc) are trimmed before they are sent to Sentry. The default is `1024`. If a string in an event is longer than this value, it will be truncated.
+
+**Note:** If you set this to a very big value, it can happen that the event as a whole becomes bigger that 1 MiB. When this threshold is reached the event will be dropped by Sentry.
+
+</ConfigKey>
+
+
 <ConfigKey name="max-request-body-size" supported={["php", "dotnet.aspnet", "dotnet.aspnetcore", "java"]}>
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:


### PR DESCRIPTION
Adds new option in Python SDK `max_string_length` that lets the users configure the maximum lengths a string can have in events.