### PR TITLE
feat(profiling): add browser profiling docs

### DIFF
--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -12,9 +12,10 @@ description: "Profiling offers a deeper level of visibility on top of traditiona
 
 - [Android (Java and Kotlin only)](/platforms/android/profiling/)
 - [iOS (Swift and Objective-C only)](/platforms/apple/profiling/)
-- [Node.js](/platforms/node/profiling/)
 - [Python](/platforms/python/profiling/)
+- [Node.js](/platforms/node/profiling/)
 - [PHP (including Laravel and Symfony)](/platforms/php/profiling/)
+- [Browser JavaScript [beta]](/platforms/javascript/profiling/)
 - [Go [experimental]](/platforms/go/profiling/)
 - [Ruby [experimental]](/platforms/ruby/profiling/)
 

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -28,7 +28,7 @@ yarn add @sentry/browser
 npm install --save @sentry/browser
 ```
 
-#### Add Document-Policy:js-profiling header
+## Add Document-Policy: js-profiling header
 
 In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -8,7 +8,7 @@ description: "Learn what transactions are captured after tracing is enabled."
 
 Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
 
-Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
 In order to get started with browser profiling, you will need to:
 

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -1,0 +1,76 @@
+---
+title: Profiling
+sidebar_order: 1
+supported:
+  - javascript
+description: "Learn what transactions are captured after tracing is enabled."
+---
+
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
+
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
+
+
+In order to get started with browser profiling, you will need to:
+- Install the @sentry/browser SDK
+- Configure document response header to include `Document-Policy: js-profiling`
+- Configure the SDK to use the BrowserProfilingIntegration and set profilesSampleRate
+
+#### Installation
+
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+
+# Using npm
+npm install --save @sentry/browser
+```
+
+#### Add Document-Policy:js-profiling header
+
+In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
+
+How you do this will depend on your server. If you're using a server like express, you'll be able to use the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
+
+```js
+app.get("/", (request, response) => {
+  response.set("Document-Policy", "js-profiling");
+  response.sendFile("index.html");
+});
+```
+
+#### Configure
+
+Configuration should happen as early as possible in your application's lifecycle.
+
+Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
+
+```javascript
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    new Sentry.BrowserProfilingIntegration(),
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    }),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set profilesSampleRate to 1.0 to profile every transaction.
+  // Since profilesSampleRate is relative to tracesSampleRate,
+  // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+  // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
+  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  profilesSampleRate: 1.0,
+});
+```

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -41,11 +41,9 @@ app.get("/", (request, response) => {
 });
 ```
 
-#### Configure
+## Configure
 
-Configuration should happen as early as possible in your application's lifecycle.
-
-Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
+Configuration should happen as early as possible in your application's lifecycle. Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
 
 ```javascript
 import * as Sentry from "@sentry/browser";

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -10,10 +10,10 @@ Because our browser profiling integration is built on top of the profiler expose
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-In order to get started with browser profiling, you will need to:
+In order to get started with browser profiling, you'll need to:
 
 - Install the @sentry/browser SDK
-- Configure document response header to include `Document-Policy: js-profiling`
+- Configure the document response header to include `Document-Policy: js-profiling`
 - Configure the SDK to use the BrowserProfilingIntegration and set profilesSampleRate
 
 #### Installation

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -16,7 +16,7 @@ In order to get started with browser profiling, you'll need to:
 - Configure the document response header to include `Document-Policy: js-profiling`
 - Configure the SDK to use the BrowserProfilingIntegration and set profilesSampleRate
 
-#### Installation
+## Install
 
 Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**.
 

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -10,8 +10,8 @@ Because our browser profiling integration is built on top of the profiler expose
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-
 In order to get started with browser profiling, you will need to:
+
 - Install the @sentry/browser SDK
 - Configure document response header to include `Document-Policy: js-profiling`
 - Configure the SDK to use the BrowserProfilingIntegration and set profilesSampleRate

--- a/src/platforms/javascript/common/profiling/index.mdx
+++ b/src/platforms/javascript/common/profiling/index.mdx
@@ -18,7 +18,7 @@ In order to get started with browser profiling, you will need to:
 
 #### Installation
 
-Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**.
 
 ```bash
 # Using yarn

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -1,0 +1,22 @@
+---
+name: Browser (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/profiling/
+support_level: beta
+type: framework
+---
+
+#### Install
+
+Our browser profiling integration is built upon the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it is therefor in beta stage and is likely to only to move out as the official spec progresses. There are obviously risks with using a beta package - we've made sure that the SDK gracefully degrades in unsupported environments.
+
+Please note that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherintly be biased towards that demographic - this is something you need to be aware of when making decisions.
+
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
+
+```bash
+# Using yarn
+yarn add @sentry/browser
+
+# Using npm
+npm install --save @sentry/browser
+```

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -5,7 +5,7 @@ support_level: beta
 type: framework
 ---
 
-#### Install
+## Install
 
 Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -9,7 +9,7 @@ type: framework
 
 Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses. There are some risks involved with using a beta package. We've made sure that the SDK gracefully degrades in unsupported environments.
 
-Please note that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherintly be biased towards that demographic - this is something you need to be aware of when making decisions.
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic.
 
 Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -7,7 +7,7 @@ type: framework
 
 #### Install
 
-Our browser profiling integration is built upon the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it is therefor in beta stage and is likely to only to move out as the official spec progresses. There are obviously risks with using a beta package - we've made sure that the SDK gracefully degrades in unsupported environments.
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses. There are some risks involved with using a beta package. We've made sure that the SDK gracefully degrades in unsupported environments.
 
 Please note that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherintly be biased towards that demographic - this is something you need to be aware of when making decisions.
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -7,11 +7,11 @@ type: framework
 
 #### Install
 
-Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses. There are some risks involved with using a beta package. We've made sure that the SDK gracefully degrades in unsupported environments.
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
 
-Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic.
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
 
 ```bash
 # Using yarn

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -9,7 +9,7 @@ type: framework
 
 Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
 
-Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
 Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/1.install.md
@@ -11,7 +11,7 @@ Because our browser profiling integration is built on top of the profiler expose
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**.
 
 ```bash
 # Using yarn

--- a/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
@@ -1,0 +1,19 @@
+---
+name: Browser (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/profiling/
+support_level: beta
+type: framework
+---
+
+#### Add Document-Policy:js-profiling header
+
+In order to enable the profiler to start, the document response header has to include a  header key `Document-Policy` with value of `js-profiling`.
+
+Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
+
+```js
+app.get('/', (request, response) => {
+  response.set('Document-Policy', 'js-profiling')
+  response.sendFile('index.html');
+});
+```

--- a/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
@@ -5,7 +5,7 @@ support_level: beta
 type: framework
 ---
 
-#### Add Document-Policy:js-profiling header
+## Add Document-Policy: js-profiling header
 
 In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
@@ -9,7 +9,7 @@ type: framework
 
 In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 
-Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
+How you do this will depend on your server. If you're using a server like express, you'll be able to use the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 
 ```js
 app.get("/", (request, response) => {

--- a/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
@@ -7,7 +7,7 @@ type: framework
 
 #### Add Document-Policy:js-profiling header
 
-In order to enable the profiler to start, the document response header has to include a header key `Document-Policy` with value of `js-profiling`.
+In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 
 Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 

--- a/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/2.configure-document-policy.md
@@ -7,13 +7,13 @@ type: framework
 
 #### Add Document-Policy:js-profiling header
 
-In order to enable the profiler to start, the document response header has to include a  header key `Document-Policy` with value of `js-profiling`.
+In order to enable the profiler to start, the document response header has to include a header key `Document-Policy` with value of `js-profiling`.
 
 Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 
 ```js
-app.get('/', (request, response) => {
-  response.set('Document-Policy', 'js-profiling')
-  response.sendFile('index.html');
+app.get("/", (request, response) => {
+  response.set("Document-Policy", "js-profiling");
+  response.sendFile("index.html");
 });
 ```

--- a/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
@@ -5,11 +5,9 @@ support_level: beta
 type: framework
 ---
 
-#### Configure
+## Configure
 
-Configuration should happen as early as possible in your application's lifecycle.
-
-Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
+Configuration should happen as early as possible in your application's lifecycle. Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
 
 ```javascript
 import * as Sentry from "@sentry/browser";

--- a/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
@@ -1,0 +1,40 @@
+---
+name: Browser (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/profiling/
+support_level: beta
+type: framework
+------
+
+#### Configure
+
+Configuration should happen as early as possible in your application's lifecycle.
+
+Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions and transactions.
+
+```javascript
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    new Sentry.BrowserProfilingIntegration(),
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    })
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set profilesSampleRate to 1.0 to profile every transaction.
+  // Since profilesSampleRate is relative to tracesSampleRate,
+  // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+  // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
+  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  profilesSampleRate: 1.0
+});
+```

--- a/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
@@ -1,9 +1,11 @@
 ---
+
 name: Browser (JS Self Profiling)
 doc_link: https://docs.sentry.io/platforms/javascript/profiling/
 support_level: beta
 type: framework
-------
+
+---
 
 #### Configure
 
@@ -22,7 +24,7 @@ Sentry.init({
     new Sentry.BrowserTracing({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-    })
+    }),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -35,6 +37,6 @@ Sentry.init({
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
   // results in 25% of transactions being profiled (0.5*0.5=0.25)
-  profilesSampleRate: 1.0
+  profilesSampleRate: 1.0,
 });
 ```

--- a/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
@@ -1,10 +1,8 @@
 ---
-
 name: Browser (JS Self Profiling)
 doc_link: https://docs.sentry.io/platforms/javascript/profiling/
 support_level: beta
 type: framework
-
 ---
 
 #### Configure

--- a/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/javascript/3.configure.md
@@ -9,7 +9,7 @@ type: framework
 
 Configuration should happen as early as possible in your application's lifecycle.
 
-Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions and transactions.
+Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
 
 ```javascript
 import * as Sentry from "@sentry/browser";

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -9,7 +9,7 @@ type: framework
 
 Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992).
 
-Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
 Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
 

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -7,7 +7,7 @@ type: framework
 
 #### Install
 
-Our browser profiling integration is built upon the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it is therefor in beta stage and is likely to only to move out as the official spec progresses. There are obviously risks with using a beta package - we've made sure that the SDK gracefully degrades in unsupported environments.
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses. There are some risks involved with using a beta package. We've made sure that the SDK gracefully degrades in unsupported environments.
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic.
 

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -7,11 +7,11 @@ type: framework
 
 #### Install
 
-Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses. There are some risks involved with using a beta package. We've made sure that the SDK gracefully degrades in unsupported environments.
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
 
-Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic.
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
 
 ```bash
 # Using yarn

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -9,7 +9,7 @@ type: framework
 
 Our browser profiling integration is built upon the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it is therefor in beta stage and is likely to only to move out as the official spec progresses. There are obviously risks with using a beta package - we've made sure that the SDK gracefully degrades in unsupported environments.
 
-Please note that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherintly be biased towards that demographic - this is something you need to be aware of when making decisions.
+Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic.
 
 Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
 

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -5,9 +5,9 @@ support_level: beta
 type: framework
 ---
 
-#### Install
+## Install
 
-Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992)
+Because our browser profiling integration is built on top of the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it's in beta and will likely only move out once the official spec progresses and gains adoption. As with any beta package, there are risks involved in using it - see platform [status](https://chromestatus.com/feature/5170190448852992).
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic - this is something you need consider if you are basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -11,7 +11,7 @@ Because our browser profiling integration is built on top of the profiler expose
 
 Please note, that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherently be biased towards that demographic. This is something you'll need to consider if you're basing your decisions on the data collected. We hope that as the API gains adoption, other browsers will implement it as well. If you find browser profiling feature helpful and would like to see it gain further adoption, please consider supporting the spec at the official [WICG repository](https://github.com/WICG/js-self-profiling).
 
-Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is **7.60.0**.
 
 ```bash
 # Using yarn

--- a/src/wizard/javascript/profiling-onboarding/react/1.install.md
+++ b/src/wizard/javascript/profiling-onboarding/react/1.install.md
@@ -1,0 +1,22 @@
+---
+name: React (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/profiling/
+support_level: beta
+type: framework
+---
+
+#### Install
+
+Our browser profiling integration is built upon the profiler exposed by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/), it is therefor in beta stage and is likely to only to move out as the official spec progresses. There are obviously risks with using a beta package - we've made sure that the SDK gracefully degrades in unsupported environments.
+
+Please note that since profiling API is currently only implemented in Chromium based browsers, the profiles collected will inherintly be biased towards that demographic - this is something you need to be aware of when making decisions.
+
+Install our JavaScript browser SDK using either `yarn` or `npm`, the minimum version that supports profiling is @TODO
+
+```bash
+# Using yarn
+yarn add @sentry/react
+
+# Using npm
+npm install --save @sentry/react
+```

--- a/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
@@ -7,7 +7,7 @@ type: framework
 
 #### Add Document-Policy:js-profiling header
 
-In order to enable the profiler to start, the document response header has to include a header key `Document-Policy` with value of `js-profiling`.
+In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 
 How you do this will depend on your server. If you're using a server like express, you'll be able to use the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 

--- a/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
@@ -5,7 +5,7 @@ support_level: beta
 type: framework
 ---
 
-#### Add Document-Policy:js-profiling header
+## Add Document-Policy: js-profiling header
 
 In order for the profiler to start, the document response header has to include a `Document-Policy` header key with the `js-profiling` value.
 

--- a/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
@@ -9,7 +9,7 @@ type: framework
 
 In order to enable the profiler to start, the document response header has to include a header key `Document-Policy` with value of `js-profiling`.
 
-Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
+How you do this will depend on your server. If you're using a server like express, you'll be able to use the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 
 ```js
 app.get("/", (request, response) => {

--- a/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
@@ -1,0 +1,19 @@
+---
+name: React (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/profiling/
+support_level: beta
+type: framework
+---
+
+#### Add Document-Policy:js-profiling header
+
+In order to enable the profiler to start, the document response header has to include a  header key `Document-Policy` with value of `js-profiling`.
+
+Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
+
+```js
+app.get('/', (request, response) => {
+  response.set('Document-Policy', 'js-profiling')
+  response.sendFile('index.html');
+});
+```

--- a/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
+++ b/src/wizard/javascript/profiling-onboarding/react/2.configure-document-policy.md
@@ -7,13 +7,13 @@ type: framework
 
 #### Add Document-Policy:js-profiling header
 
-In order to enable the profiler to start, the document response header has to include a  header key `Document-Policy` with value of `js-profiling`.
+In order to enable the profiler to start, the document response header has to include a header key `Document-Policy` with value of `js-profiling`.
 
 Depending on your server, how you do this will vary. If you are using a server like express, you can do this like via the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 
 ```js
-app.get('/', (request, response) => {
-  response.set('Document-Policy', 'js-profiling')
-  response.sendFile('index.html');
+app.get("/", (request, response) => {
+  response.set("Document-Policy", "js-profiling");
+  response.sendFile("index.html");
 });
 ```

--- a/src/wizard/javascript/profiling-onboarding/react/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/react/3.configure.md
@@ -1,0 +1,40 @@
+---
+name: React (JS Self Profiling)
+doc_link: https://docs.sentry.io/platforms/javascript/guides/react/profiling/
+support_level: beta
+type: framework
+---
+
+#### Configure
+
+Configuration should happen as early as possible in your application's lifecycle.
+
+Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions and transactions.
+
+```javascript
+import * as Sentry from "@sentry/react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    new Sentry.BrowserProfilingIntegration(),
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+    })
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set profilesSampleRate to 1.0 to profile every transaction.
+  // Since profilesSampleRate is relative to tracesSampleRate,
+  // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+  // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
+  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  profilesSampleRate: 1.0
+});
+```

--- a/src/wizard/javascript/profiling-onboarding/react/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/react/3.configure.md
@@ -9,7 +9,7 @@ type: framework
 
 Configuration should happen as early as possible in your application's lifecycle.
 
-Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions and transactions.
+Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
 
 ```javascript
 import * as Sentry from "@sentry/react";

--- a/src/wizard/javascript/profiling-onboarding/react/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/react/3.configure.md
@@ -22,7 +22,7 @@ Sentry.init({
     new Sentry.BrowserTracing({
       // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-    })
+    }),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -35,6 +35,6 @@ Sentry.init({
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
   // results in 25% of transactions being profiled (0.5*0.5=0.25)
-  profilesSampleRate: 1.0
+  profilesSampleRate: 1.0,
 });
 ```

--- a/src/wizard/javascript/profiling-onboarding/react/3.configure.md
+++ b/src/wizard/javascript/profiling-onboarding/react/3.configure.md
@@ -5,11 +5,9 @@ support_level: beta
 type: framework
 ---
 
-#### Configure
+## Configure
 
-Configuration should happen as early as possible in your application's lifecycle.
-
-Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
+Configuration should happen as early as possible in your application's lifecycle. Once this is done, Sentry's JavaScript SDK will capture all unhandled exceptions and transactions.
 
 ```javascript
 import * as Sentry from "@sentry/react";


### PR DESCRIPTION
Will require the latest release of browser SDK hence why the @TODO for version number. @indragiek lmk if the docs are too conservative, I tried leaving the disclaimer which I think is fair and something folks should be aware of. 

We are also not adding other JS SDK docs yet, I think starting with plain javascript and react is a good step.