### PR TITLE
Add org role requirement note

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
@@ -23,6 +23,12 @@ You can configure detector thresholds for slow DB queries issues in **Project Se
 
 ![Slow DB Query detector threshold settings](slow-db-queries-detector-settings.png)
 
+<Note>
+
+These settings can only be edited by users with the organization-level owner, manager, or team-level admin roles.
+
+</Note
+
 ## Span Evidence
 
 You can get additional information about your slow DB query by looking at the following fields in the "Span Evidence":

--- a/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
@@ -27,7 +27,7 @@ You can configure detector thresholds for slow DB queries issues in **Project Se
 
 These settings can only be edited by users with the organization-level owner, manager, or team-level admin roles.
 
-</Note
+</Note>
 
 ## Span Evidence
 

--- a/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/slow-db-queries/index.mdx
@@ -25,7 +25,7 @@ You can configure detector thresholds for slow DB queries issues in **Project Se
 
 <Note>
 
-These settings can only be edited by users with the organization-level owner, manager, or team-level admin roles.
+These settings can only be edited by users with owner, manager, or team-level admin roles.
 
 </Note>
 


### PR DESCRIPTION
It looks like the missing information caused confusion to a customer, even though they got the same message in the Sentry Web UI:
![image](https://github.com/getsentry/sentry-docs/assets/81985895/59a48470-c892-4110-925a-94ad1366a50e)

For completeness, it would be better to add it in our documentation too.