### PR TITLE
Add NDK references to source context setup

### DIFF
--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -198,7 +198,7 @@ sentry {
 
 ### Include NDK Source Context with Gradle Plugin
 
-By default the native code is not uploaded with the Java/Kotlin code. Add the following options to enable Source Context for native code:
+By default native code (C/C++) is not uploaded with the Java/Kotlin code. Add the following options to enable Source Context for native code:
 
 ```groovy
 sentry {

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -355,7 +355,7 @@ options.addBundleId("A_VALID_UUID");
 
 <PlatformSection supported={["android"]}>
 
-## Manual Uploading Native Symbols and Source Code
+## Manually Uploading Native Symbols and Source Code
 
 Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
 

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -311,18 +311,6 @@ First, create the source bundle containing your source files:
 sentry-cli debug-files bundle-jvm --output path/to/store/bundle --debug-id A_VALID_UUID path/to/source-code
 ```
 
-<PlatformSection supported={["android"]}>
-
-### Creating the Native Source Bundle
-
-If you're using NDK, create the native source bundle containing your source files:
-
-```
-sentry-cli difutil bundle-sources /path/to/files
-```
-
-</PlatformSection>
-
 ### Uploading the Source Bundle
 
 Next, upload that source bundle to Sentry:
@@ -333,12 +321,18 @@ sentry-cli debug-files upload --type jvm path/to/bundle
 
 <PlatformSection supported={["android"]}>
 
-### Uploading including the Native Source Bundle
+### Uploading Native Symbols and Source Code
 
-Include the native source bundle with `--include-sources` and upload it to Sentry:
+Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
 
 ```
-sentry-cli debug-files upload --include-sources /path/to/files --type jvm path/to/bundle
+sentry-cli debug-files upload app/build/intermediates/merged_native_libs/
+```
+
+In order to upload the native source files as well, you can use the `--include-sources` flag. Using this flag sentry-cli will automatically generate source bundles on the fly during the upload.
+
+```
+sentry-cli debug-files upload app/build/intermediates/merged_native_libs/ --include-sources
 ```
 
 </PlatformSection>

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -194,6 +194,49 @@ sentry {
 
 </PlatformSection>
 
+
+<PlatformSection supported={["android"]}>
+
+### Include NDK Source Context with Gradle Plugin
+
+By default the native code is not uploaded with the Java/Kotlin code. Add the following options to enable Source Context for native code:
+
+```groovy
+sentry {
+    // Includes the source code of native code when uploading native symbols for Sentry.
+    // This executes sentry-cli with the --include-sources param. automatically so
+    // you don't need to do it manually. This only works with uploadNativeSymbols enabled.
+    //
+    // Default is disabled.
+    includeNativeSources = true
+
+    // Enables the automatic configuration of Native Symbols for Sentry.
+    // This executes sentry-cli automatically so you don't need to do it manually.
+    //
+    // Default is disabled.
+    uploadNativeSymbols = true
+}
+```
+
+```kotlin
+sentry {
+    // Includes the source code of native code when uploading native symbols for Sentry.
+    // This executes sentry-cli with the --include-sources param. automatically so
+    // you don't need to do it manually. This only works with uploadNativeSymbols enabled.
+    //
+    // Default is disabled.
+    includeNativeSources.set(true)
+
+    // Enables the automatic configuration of Native Symbols for Sentry.
+    // This executes sentry-cli automatically so you don't need to do it manually.
+    //
+    // Default is disabled.
+    uploadNativeSymbols.set(true)
+}
+```
+
+</PlatformSection>
+
 <PlatformSection notSupported={["android"]}>
 
 ## Using the Maven Build Tool Plugin
@@ -269,6 +312,18 @@ First, create the source bundle containing your source files:
 sentry-cli debug-files bundle-jvm --output path/to/store/bundle --debug-id A_VALID_UUID path/to/source-code
 ```
 
+<PlatformSection supported={["android"]}>
+
+### Creating the Native Source Bundle
+
+If you're using NDK, create the native source bundle containing your source files:
+
+```
+sentry-cli difutil bundle-sources /path/to/files
+```
+
+</PlatformSection>
+
 ### Uploading the Source Bundle
 
 Next, upload that source bundle to Sentry:
@@ -276,6 +331,18 @@ Next, upload that source bundle to Sentry:
 ```
 sentry-cli debug-files upload --type jvm path/to/bundle
 ```
+
+<PlatformSection supported={["android"]}>
+
+### Uploading including the Native Source Bundle
+
+Include the native source bundle with `--include-sources` and upload it to Sentry:
+
+```
+sentry-cli debug-files upload --include-sources /path/to/files --type jvm path/to/bundle
+```
+
+</PlatformSection>
 
 ### Configuring the SDK
 

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -355,7 +355,7 @@ options.addBundleId("A_VALID_UUID");
 
 <PlatformSection supported={["android"]}>
 
-## Manual Upload of Native Symbols and Source Code
+## Manual Uploading Native Symbols and Source Code
 
 Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
 

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -319,24 +319,6 @@ Next, upload that source bundle to Sentry:
 sentry-cli debug-files upload --type jvm path/to/bundle
 ```
 
-<PlatformSection supported={["android"]}>
-
-### Uploading Native Symbols and Source Code
-
-Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
-
-```
-sentry-cli debug-files upload app/build/intermediates/merged_native_libs/
-```
-
-In order to upload the native source files as well, you can use the `--include-sources` flag. Using this flag sentry-cli will automatically generate source bundles on the fly during the upload.
-
-```
-sentry-cli debug-files upload app/build/intermediates/merged_native_libs/ --include-sources
-```
-
-</PlatformSection>
-
 ### Configuring the SDK
 
 You'll need to tell the SDK which source bundle it should use for providing Source Context via one of the following options:
@@ -370,3 +352,21 @@ sentry.bundle-ids=A_VALID_UUID`
 ```Java
 options.addBundleId("A_VALID_UUID");
 ```
+
+<PlatformSection supported={["android"]}>
+
+## Manual Upload of Native Symbols and Source Code
+
+Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
+
+```
+sentry-cli debug-files upload app/build/intermediates/merged_native_libs/
+```
+
+In order to upload the native source files as well, you can use the `--include-sources` flag. Using this flag sentry-cli will automatically generate source bundles on the fly during the upload.
+
+```
+sentry-cli debug-files upload app/build/intermediates/merged_native_libs/ --include-sources
+```
+
+</PlatformSection>

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -194,7 +194,6 @@ sentry {
 
 </PlatformSection>
 
-
 <PlatformSection supported={["android"]}>
 
 ### Include NDK Source Context with Gradle Plugin

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -355,15 +355,9 @@ options.addBundleId("A_VALID_UUID");
 
 <PlatformSection supported={["android"]}>
 
-## Manually Uploading Native Symbols and Source Code
+## Manually Uploading Debug Symbols and Native Source Code
 
-Upload the native symbols manually using the `debug-files upload command`, here's a typical example for Android:
-
-```
-sentry-cli debug-files upload app/build/intermediates/merged_native_libs/
-```
-
-In order to upload the native source files as well, you can use the `--include-sources` flag. Using this flag sentry-cli will automatically generate source bundles on the fly during the upload.
+Upload the native debug symbols manually using the `debug-files upload command`. Adding the `--include-sources` flag, sentry-cli will automatically generate source bundles on the fly and upload them. Here's a typical example for Android:
 
 ```
 sentry-cli debug-files upload app/build/intermediates/merged_native_libs/ --include-sources


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes
Fixes https://github.com/getsentry/sentry-docs/issues/6677

Added NDK references to source context setup
