### PR TITLE
ref: Reword `CaptureMessage` behaviour sentence

### DIFF
--- a/src/platforms/common/usage/index.mdx
+++ b/src/platforms/common/usage/index.mdx
@@ -38,6 +38,6 @@ While capturing an event, you can also record the breadcrumbs that lead up to th
 
 ## Capturing Messages
 
-Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically messages are not emitted, but they can be useful for some teams.
+Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically, our SDKs don't automatically capture messages, but you can capture them manually.
 
 <PlatformContent includePath="capture-message" />

--- a/src/platforms/php/guides/laravel/usage/index.mdx
+++ b/src/platforms/php/guides/laravel/usage/index.mdx
@@ -19,7 +19,7 @@ In Laravel, you can pass an error object to `captureException()` to get it captu
 
 ## Capturing Messages
 
-Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically messages are not emitted, but they can be useful for some teams.
+Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically, our SDKs don't automatically capture messages, but you can capture them manually.
 
 <PlatformContent includePath="capture-message" />
 


### PR DESCRIPTION
We were notified that the description about the SDK's behaviour around `captureMessage` is a big confusing. I agree, so let's reword this sentence.

ref #7443 