### PR TITLE
ref(js-loader): Reword source maps sentence

### DIFF
--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -25,7 +25,7 @@ By default, Performance Monitoring and Session Replay is enabled.
 
 ## Source Maps
 
-To have correct stack traces for minified asset files when using the Loader Script, you will have to [upload & host your Source Maps publicly](/platforms/javascript/sourcemaps/uploading/hosting-publicly/).
+To have correct stack traces for minified asset files when using the Loader Script, you will have to either [host your Source Maps publicly](/platforms/javascript/sourcemaps/uploading/hosting-publicly/) or [upload them to Sentry](/platforms/javascript/sourcemaps/).
 
 ## Loader Configuration
 


### PR DESCRIPTION
As brought up in #7443, the sentence around source maps and the JS loader conveys that users have to host source maps publicly. While this is probably the easiest method of making source maps available for loader users, it is not the only one. So let's change the sentence to reflect this.

closes #7443 