### PR TITLE
ref: Update ownership rule evaluation flow for multiple owners in rule

### DIFF
--- a/src/docs/product/issues/ownership-rules/index.mdx
+++ b/src/docs/product/issues/ownership-rules/index.mdx
@@ -121,7 +121,7 @@ If you have both ownership rules and code owners, Sentry evaluates an event’s 
 
 2. Ownership rules, top-to-bottom
 
-    a. If there are multiple owners in the rule, left-to-right
+   a. If there are multiple owners in the rule, left-to-right
 
 After evaluation, the last rule matching returns the assignment. The order of the event’s stacktrace filepaths is irrelevant in determining the rule assignment.
 

--- a/src/docs/product/issues/ownership-rules/index.mdx
+++ b/src/docs/product/issues/ownership-rules/index.mdx
@@ -116,7 +116,12 @@ Create external team/user mappings for your GitHub/GitLab teams and users by nav
 If you have both ownership rules and code owners, Sentry evaluates an event’s in-app frames against the rules in the following order:
 
 1. Code owners, top-to-bottom
+
+   a. If there are multiple owners in the rule, left-to-right
+
 2. Ownership rules, top-to-bottom
+
+    a. If there are multiple owners in the rule, left-to-right
 
 After evaluation, the last rule matching returns the assignment. The order of the event’s stacktrace filepaths is irrelevant in determining the rule assignment.
 
@@ -131,7 +136,7 @@ codeowners:*.js                    #ecosystem
 **Ownership Rules:**
 
 ```
-path:*.js                          #ecosystem
+path:*.js                          #ecosystem #frontend
 path:sentry/api/*                  #api
 url:*subscription*                 #billing
 path:dist/frontend/components/*               #frontend
@@ -139,7 +144,10 @@ path:dist/frontend/components/*               #frontend
 
 When Sentry receives an event with a stacktrace filepath: `dist/frontend/components/sidebar.js`, we:
 
-1. Evaluate against the code owners top-to-bottom; we get one match.
+1. Evaluate against the code owners top-to-bottom; we get one match with two owners in the rule.
+
+   a. Evaluate the rule left-to-right; we choose the first owner.
+
 2. Evaluate against the ownership rules top-to-bottom; we get two matches.
 
 The matches, in order, are:


### PR DESCRIPTION
Update the ownership rule evaluation flow docs to state that the first owner in the rule will be assigned

closes https://github.com/getsentry/sentry/issues/53337