### PR TITLE
Remove decorator mentioning from custom-instrumentation.mdx

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -158,12 +158,9 @@ def eat_pizza(pizza):
 
 To change data in the current span, use `sentry_sdk.Hub.current.scope.span`. This property will return a span if there's one running, otherwise it will return `None`.
 
-In this example, we'll set a tag in the span created by the `@sentry_sdk.trace` decorator.
-
 ```python
 import sentry_sdk
 
-@sentry_sdk.trace
 def eat_slice(slice):
     span = sentry_sdk.Hub.current.scope.span
 


### PR DESCRIPTION
sentry_sdk.trace decorator doesn't exist in Python sdk, so let's remove it from docs

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Current Python SDK doesn't have a decorator sentry_sdk.trace mentioned on the page 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
