### PR TITLE
Make decorator code snippet more visible

### DIFF
--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -39,7 +39,9 @@ If you want to have more fine-grained performance monitoring, you can add child 
 
 Calling a `sentry_sdk.start_span()` will find the current active transaction and attach the span to it.
 
-```python {tabTitle:Context Manager}
+### Using a Context Manager
+
+```python
 import sentry_sdk
 
 def eat_slice(slice):
@@ -53,7 +55,9 @@ def eat_pizza(pizza):
 
 ```
 
-```python {tabTitle:Decorator}
+### Using a Decorator
+
+```python
 import sentry_sdk
 
 @sentry_sdk.trace
@@ -71,7 +75,9 @@ def eat_pizza(pizza):
 
 Spans can be nested to form a span tree. If you'd like to learn more, read our [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.
 
-```python {tabTitle:Context Manager}
+### Using a Context Manager
+
+```python
 import sentry_sdk
 
 def chew():
@@ -89,7 +95,9 @@ def eat_slice(slice):
 
 ```
 
-```python {tabTitle:Decorator}
+### Using a Decorator
+
+```python
 import sentry_sdk
 
 @sentry_sdk.trace


### PR DESCRIPTION
People do not find the code snippet hidden in a tab in a code block. Now we have two blocks.
