### PR TITLE
feat(proguard): release association docs

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -288,6 +288,18 @@ sentry-cli upload-proguard \
     app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 
+Additionally, you can associate the proguard mapping file to a specific release:
+
+```bash
+# Additionally create an association to the release my.app.id@1.0.0+1
+sentry-cli upload-proguard \
+    --uuid A_VALID_UUID \
+    app/build/outputs/mapping/{BuildVariant}/mapping.txt \
+    --app-id my.app.id \
+    --version 1.0.0 \
+    --version-code 1
+```
+
 After the upload, Sentry deobfuscates future events.
 To make sure that it worked, you can check _Project Settings > ProGuard_ and see if the upload mapping files are listed.
 


### PR DESCRIPTION
Adds docs on how to associate a proguard mapping file to a release