### PR TITLE
[Perf at Scale] Warning about quota

### DIFF
--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -102,7 +102,7 @@ To send 100% of your transaction events, set your [tracesSampleRate](/platform-r
 
 <Note>
 
-Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](product/accounts/quotas/manage-transaction-quota/).
+Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](/product/accounts/quotas/manage-transaction-quota/).
 
 </Note>
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -102,7 +102,7 @@ To send 100% of your transaction events, set your [tracesSampleRate](/platform-r
 
 <Note>
 
-Please note that Performance at Scale doesn't automatically mange your quota. If you increase your SDK sampling rate, you'll also need to increase the volume of transactions you send to Sentry. This may require that you adjust your [transactions quota](/product/accounts/quotas/manage-transaction-quota/).
+Please note that Performance at Scale doesn't automatically mange your quota. If you increase your SDK sampling rate, you'll also increase the volume of transactions you send to Sentry. This may require that you adjust your [transactions quota](/product/accounts/quotas/manage-transaction-quota/).
 
 </Note>
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -102,7 +102,7 @@ To send 100% of your transaction events, set your [tracesSampleRate](/platform-r
 
 <Note>
 
-Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](product/accounts/quotas/manage-transaction-quota/).  
+Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](product/accounts/quotas/manage-transaction-quota/).
 
 </Note>
 

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -100,6 +100,12 @@ Retention priorities and your SDK sampling configuration act independently of ea
 
 To send 100% of your transaction events, set your [tracesSampleRate](/platform-redirect/?next=/performance/) in the SDK to 1.0. If you want to offset overhead, (with high-volume back-end applications, for example), set a lower value, or switch to sampling selectively by using the <PlatformIdentifier name="traces-sampler" /> to filter your transactions based on contextual data.
 
+<Note>
+
+Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](product/accounts/quotas/manage-transaction-quota/).  
+
+</Note>
+
 As your transaction volume goes up, the per-transaction pricing will go down accordingly, making it possible to scale affordably. Learn more in [Benefits of Performance at Scale](/product/performance/performance-at-scale/benefits-performance-at-scale/).
 
 ## Next Steps

--- a/src/docs/product/performance/performance-at-scale/index.mdx
+++ b/src/docs/product/performance/performance-at-scale/index.mdx
@@ -102,7 +102,7 @@ To send 100% of your transaction events, set your [tracesSampleRate](/platform-r
 
 <Note>
 
-Please note that Performance at scale does not perform any quota management. Increasing your SDK sampling rate, will increase the volume of transactions you send to Sentry and require you to adjust your [transactions quota](/product/accounts/quotas/manage-transaction-quota/).
+Please note that Performance at Scale doesn't automatically mange your quota. If you increase your SDK sampling rate, you'll also need to increase the volume of transactions you send to Sentry. This may require that you adjust your [transactions quota](/product/accounts/quotas/manage-transaction-quota/).
 
 </Note>
 


### PR DESCRIPTION
Adding note to call out the need to adjust your transactions quota when increasing the SDK sampling rate.