### PR TITLE
Add docs for AggregateErrors in Node.js and Browser

### DIFF
--- a/src/includes/platforms/configuration/integrations/default.mdx
+++ b/src/includes/platforms/configuration/integrations/default.mdx
@@ -91,7 +91,7 @@ _Import name: `Sentry.Integrations.LinkedErrors`_
 
 This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
-Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
+This integration also enhances captured error events with data from an [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) where applicable, by recursively iterating over the `errors` property on Error objects.
 
 Available options:
 

--- a/src/includes/platforms/configuration/integrations/default.mdx
+++ b/src/includes/platforms/configuration/integrations/default.mdx
@@ -89,20 +89,22 @@ Available options:
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows you to configure linked errors. They’ll be recursively read up to a specified limit, and lookup will be performed by a specific key. By default, the Sentry SDK sets the limit to five and the key used is `"cause"`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recurstion is `"cause"`.
 
 Available options:
 
 ```javascript
 {
-  key: string;
-  limit: number;
+  key: string; // default: "cause"
+  limit: number; // default: 5
 }
 ```
 
 Here is a code example of how this could be implemented:
 
 <PlatformContent includePath="configuration/linked-errors" />
+
+Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
 
 ### HttpContext
 

--- a/src/includes/platforms/configuration/integrations/default.mdx
+++ b/src/includes/platforms/configuration/integrations/default.mdx
@@ -91,6 +91,8 @@ _Import name: `Sentry.Integrations.LinkedErrors`_
 
 This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
+Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
+
 Available options:
 
 ```javascript
@@ -103,8 +105,6 @@ Available options:
 Here is a code example of how this could be implemented:
 
 <PlatformContent includePath="configuration/linked-errors" />
-
-Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
 
 ### HttpContext
 

--- a/src/includes/platforms/configuration/integrations/default.mdx
+++ b/src/includes/platforms/configuration/integrations/default.mdx
@@ -89,7 +89,7 @@ Available options:
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recurstion is `"cause"`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
 Available options:
 

--- a/src/platforms/apple/common/install/carthage.mdx
+++ b/src/platforms/apple/common/install/carthage.mdx
@@ -9,7 +9,15 @@ To integrate Sentry into your Xcode project using Carthage, specify it in your _
 github "getsentry/sentry-cocoa" "{{@inject packages.version('sentry.cocoa') }}"
 ```
 
-Run `carthage update` to download the framework and drag the built _Sentry.framework_ into your Xcode project. We also provide a pre-built version for every release, which can be downloaded at [releases on GitHub](https://github.com/getsentry/sentry-cocoa/releases).
+Run `carthage update` to download the framework and drag the built _Sentry.xcframework_ into your Xcode project. We also provide a pre-built version for every release, which can be downloaded at [releases on GitHub](https://github.com/getsentry/sentry-cocoa/releases).
+
+Sentry's Carthage setup generates 3 different frameworks:
+
+- Sentry
+- SentryPrivate
+- SentrySwiftUI
+
+_Sentry_ is required for all projects. _SentrySwiftUI_ is required to measure the performance of your SwiftUI views. _SentryPrivate_ is only needed if you changed the carthage build process to generate static frameworks.
 
 ## Macs with Apple Silicon and XCFrameworks
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -33,7 +33,7 @@ _Import name: `Sentry.Integrations.LinkedErrors`_
 
 This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
-Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
+This integration also enhances captured error events with data from an [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) where applicable, by recursively iterating over the `errors` property on Error objects.
 
 Available options:
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -31,7 +31,7 @@ are wrapped by our error or breadcrumb handlers.
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and lookup will be performed by a specific key. By default, the limit is set to `5` and the key used is `"cause"`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recurstion is `"cause"`.
 
 Available options:
 
@@ -41,6 +41,8 @@ Available options:
   limit: number; // default: 5
 }
 ```
+
+Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
 
 ## Node-specific
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -33,6 +33,8 @@ _Import name: `Sentry.Integrations.LinkedErrors`_
 
 This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
+Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
+
 Available options:
 
 ```javascript
@@ -41,8 +43,6 @@ Available options:
   limit: number; // default: 5
 }
 ```
-
-Additionally, the `LinkedErrors` integration enhances the capturing of [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) by recursively iterating over the `errors` property on Error objects.
 
 ## Node-specific
 

--- a/src/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -31,7 +31,7 @@ are wrapped by our error or breadcrumb handlers.
 
 _Import name: `Sentry.Integrations.LinkedErrors`_
 
-This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recurstion is `"cause"`.
+This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, and a lookup will be performed by a specific key on the captured Error object. By default, the integration records up to five errors and the key used for recursion is `"cause"`.
 
 Available options:
 


### PR DESCRIPTION
Documents changes from https://github.com/getsentry/sentry-javascript/pull/8463 where we implemented support for AggregateErrors in the JS SDK.