### PR TITLE
ref(escalating): Add merge/unmerge limitation

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/merging-issues/index.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/merging-issues/index.mdx
@@ -5,6 +5,7 @@ description: "Learn about merging similar issues that aren't automatically group
 ---
 
 <Include name="only-error-issues-note.mdx" />
+<Include name="merge-escalating-note.mdx" />
 
 If you have similar-looking issues that have not been grouped together automatically and you want to reduce noise, you can do so by merging them.
 

--- a/src/docs/product/issues/states-triage/escalating-issues/index.mdx
+++ b/src/docs/product/issues/states-triage/escalating-issues/index.mdx
@@ -4,6 +4,8 @@ sidebar_order: 40
 description: "Learn how the escalating issues algorithm works."
 ---
 
+<Include name="merge-escalating-note.mdx" />
+
 Sentry defines an issue as `Escalating` when the number of events is significantly higher than the previous week.
 
 The escalating issues algorithm uses historical data from the previous week to calculate thresholds for the next week on a per-issue basis. If an issue exceeds its predetermined threshold, it gets tagged as "escalating." An escalating issue is automatically surfaced in the "Unresolved" and "Escalating" tabs, even if the issue was previously archived.

--- a/src/docs/product/issues/states-triage/index.mdx
+++ b/src/docs/product/issues/states-triage/index.mdx
@@ -12,7 +12,7 @@ Here's a list of all statuses, how they're assigned to an issue, and their custo
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | **New**        | An issue that was created in the last 7 days.                                                                                 | is:new             |
 | **Ongoing**    | An issue that was created more than 7 days ago or has manually been marked as reviewed.                                       | is:ongoing         |
-| **Escalating** | An issue that's exceeded its forecasted event volume. For more details, see [Escalating Issues Algorithm](escalating-issues). | is:escalating      |
+| **Escalating** | An issue that's exceeded its forecasted event volume. For more details, see [Escalating Issues Algorithm](escalating-issues). Please note that escalating issues does not work for merged/unmerged issues. We are working on fixing it [here](https://github.com/getsentry/snuba/issues/4558). | is:escalating      |
 | **Regressed**  | A resolved issue that's come up again.                                                                                        | is:regressed       |
 | **Archived**   | An issue that's been marked as archived.                                                                                      | is:archived        |
 | **Resolved**   | An issue that's been marked as fixed.                                                                                         | is:resolved        |

--- a/src/includes/merge-escalating-note.mdx
+++ b/src/includes/merge-escalating-note.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+Escalating issues does not work for merged/unmerged issues. We are working on fixing it [here](https://github.com/getsentry/snuba/issues/4558).
+
+</Note>


### PR DESCRIPTION
Escalating issues does not work for merged/unmerged issues due to this [bug](https://github.com/getsentry/snuba/issues/4558).

This PR adds this limitation to the docs so users are aware of this issue.

closes https://github.com/getsentry/sentry/issues/53375
