### PR TITLE
Adjust wording for nextjs set release

### DIFF
--- a/src/platform-includes/set-release/javascript.nextjs.mdx
+++ b/src/platform-includes/set-release/javascript.nextjs.mdx
@@ -1,1 +1,1 @@
-For the Next.js SDK, set the `SENTRY_RELEASE` environmental variable so your sourcemaps also get associated to the correct release.
+To make sure that your sourcemaps are associated with the right release, set the SENTRY_RELEASE environmental variable in Sentry’s Next.js SDK.


### PR DESCRIPTION
Originally added here: https://github.com/getsentry/sentry-docs/pull/7549

wording change after docs team review.