### PR TITLE
Add `capture_graphql_errors` option to Python HTTP client integrations

### DIFF
--- a/src/platforms/python/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/python/common/configuration/integrations/default-integrations.mdx
@@ -71,8 +71,6 @@ You can pass the following keyword arguments to `StdlibIntegration()`:
   error event will have both the request and the response content if the SDK has
   been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
-  
-
 ## Modules
 
 _Import name: `sentry_sdk.integrations.modules.ModulesIntegration`_

--- a/src/platforms/python/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/python/common/configuration/integrations/default-integrations.mdx
@@ -60,6 +60,19 @@ The stdlib integration instruments certain modules in the standard library to em
 
 - Subprocesses spawned with the `subprocess` module will result in a <PlatformLink to="/enriching-events/breadcrumbs/">breadcrumb</PlatformLink> being logged.
 
+### Options
+
+You can pass the following keyword arguments to `StdlibIntegration()`:
+
+- `capture_graphql_errors`:
+
+  If enabled, the SDK will automatically create an error event whenever the response
+  to a request to an endpoint called `/graphql` contains an `errors` array. The
+  error event will contain the request as well as response content if the SDK has
+  been set up with `send_default_pii=True`.
+
+  The default is `True`. Set to `False` to stop capturing client GraphQL errors.
+
 ## Modules
 
 _Import name: `sentry_sdk.integrations.modules.ModulesIntegration`_

--- a/src/platforms/python/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/python/common/configuration/integrations/default-integrations.mdx
@@ -68,8 +68,8 @@ You can pass the following keyword arguments to `StdlibIntegration()`:
 
   If enabled, the SDK will automatically create an error event whenever the response
   to a request to an endpoint called `/graphql` contains an `errors` array. The
-  error event will contain the request as well as response content if the SDK has
-  been set up with `send_default_pii=True`.
+  error event will have both the request and the response content if the SDK has
+  been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
   The default is `True`. Set to `False` to stop capturing client GraphQL errors.
 

--- a/src/platforms/python/common/configuration/integrations/default-integrations.mdx
+++ b/src/platforms/python/common/configuration/integrations/default-integrations.mdx
@@ -71,7 +71,7 @@ You can pass the following keyword arguments to `StdlibIntegration()`:
   error event will have both the request and the response content if the SDK has
   been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
-  The default is `True`. Set to `False` to stop capturing client GraphQL errors.
+  
 
 ## Modules
 

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -45,8 +45,6 @@ to a request to an endpoint called `/graphql` contains an `errors` array. The
 error event will have both the request and the response content if the SDK has
 been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
-The default is `True`. Set to `False` to stop capturing client GraphQL errors.
-
 ## Supported Versions
 
 - HTTPX: 0.16+

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -20,6 +20,8 @@ pip install --upgrade 'sentry-sdk[httpx]'
 
 Add `HttpxIntegration()` to your `integrations` list:
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.httpx import HttpxIntegration
@@ -44,7 +46,6 @@ You can pass the following keyword arguments to `HttpxIntegration()`:
   been set up with `send_default_pii=True`.
 
   The default is `True`. Set to `False` to stop capturing client GraphQL errors.
-
 
 ## Supported Versions
 

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -32,6 +32,20 @@ sentry_sdk.init(
 )
 ```
 
+## Options
+
+You can pass the following keyword arguments to `HttpxIntegration()`:
+
+- `capture_graphql_errors`:
+
+  If enabled, the SDK will automatically create an error event whenever the response
+  to a request to an endpoint called `/graphql` contains an `errors` array. The
+  error event will contain the request as well as response content if the SDK has
+  been set up with `send_default_pii=True`.
+
+  The default is `True`. Set to `False` to stop capturing client GraphQL errors.
+
+
 ## Supported Versions
 
 - HTTPX: 0.16+

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -40,10 +40,10 @@ You can pass the following keyword arguments to `HttpxIntegration()`:
 
 - `capture_graphql_errors`:
 
-  If enabled, the SDK will automatically create an error event whenever the response
+If enabled, the SDK will automatically create an error event whenever the response
   to a request to an endpoint called `/graphql` contains an `errors` array. The
-  error event will contain the request as well as response content if the SDK has
-  been set up with `send_default_pii=True`.
+  error event will have both the request and the response content if the SDK has
+  been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
   The default is `True`. Set to `False` to stop capturing client GraphQL errors.
 

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -41,10 +41,11 @@ You can pass the following keyword arguments to `HttpxIntegration()`:
 - `capture_graphql_errors`:
 
 If enabled, the SDK will automatically create an error event whenever the response
-  to a request to an endpoint called `/graphql` contains an `errors` array. The
-  error event will have both the request and the response content if the SDK has
-  been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
+to a request to an endpoint called `/graphql` contains an `errors` array. The
+error event will have both the request and the response content if the SDK has
+been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
+The default is `True`. Set to `False` to stop capturing client GraphQL errors.
 
 ## Supported Versions
 

--- a/src/platforms/python/common/configuration/integrations/httpx.mdx
+++ b/src/platforms/python/common/configuration/integrations/httpx.mdx
@@ -45,7 +45,6 @@ If enabled, the SDK will automatically create an error event whenever the respon
   error event will have both the request and the response content if the SDK has
   been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
-  The default is `True`. Set to `False` to stop capturing client GraphQL errors.
 
 ## Supported Versions
 

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -58,6 +58,8 @@ web.run_app(app)
 
 - All exceptions leading to an Internal Server Error are reported.
 
+- AIOHTTP client requests will be instrumented.
+
 - _The AIOHTTP integration currently does not attach the request body._ See
   [the relevant GitHub
   issue](https://github.com/getsentry/sentry-python/issues/220).
@@ -65,6 +67,8 @@ web.run_app(app)
 - Logging with any logger will create breadcrumbs when
   the [Logging](/platforms/python/guides/logging/)
   integration is enabled (done by default).
+
+- GraphQL errors encountered when using the AIOHTTP client will be captured.
 
 ## Options
 
@@ -82,3 +86,12 @@ You can pass the following keyword arguments to `AioHttpIntegration()`:
   - `<module_name>.hello` if you set `transaction_style="handler_name"`
 
   The default is `"handler_name"`.
+
+- `capture_graphql_errors`:
+
+  If enabled, the SDK will automatically create an error event whenever the response
+  to a request to an endpoint called `/graphql` contains an `errors` array. The
+  error event will contain the request as well as response content if the SDK has
+  been set up with `send_default_pii=True`.
+
+  The default is `True`. Set to `False` to stop capturing client GraphQL errors.

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -89,9 +89,9 @@ You can pass the following keyword arguments to `AioHttpIntegration()`:
 
 - `capture_graphql_errors`:
 
-  If enabled, the SDK will automatically create an error event whenever the response
+If enabled, the SDK will automatically create an error event whenever the response
   to a request to an endpoint called `/graphql` contains an `errors` array. The
-  error event will contain the request as well as response content if the SDK has
-  been set up with `send_default_pii=True`.
+  error event will have both the request and the response content if the SDK has
+  been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
   The default is `True`. Set to `False` to stop capturing client GraphQL errors.

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -25,6 +25,8 @@ pip install --upgrade aiocontextvars
 
 ## Configure
 
+<SignInNote />
+
 ```python
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -90,7 +92,6 @@ You can pass the following keyword arguments to `AioHttpIntegration()`:
 - `capture_graphql_errors`:
 
 If enabled, the SDK will automatically create an error event whenever the response
-  to a request to an endpoint called `/graphql` contains an `errors` array. The
-  error event will have both the request and the response content if the SDK has
-  been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
-
+to a request to an endpoint called `/graphql` contains an `errors` array. The
+error event will have both the request and the response content if the SDK has
+been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.

--- a/src/platforms/python/guides/aiohttp/index.mdx
+++ b/src/platforms/python/guides/aiohttp/index.mdx
@@ -94,4 +94,3 @@ If enabled, the SDK will automatically create an error event whenever the respon
   error event will have both the request and the response content if the SDK has
   been set up with `send_default_pii=True` (which is the default). If you don't want to capture client GraphQL errors, set `send_default_pii=False`.
 
-  The default is `True`. Set to `False` to stop capturing client GraphQL errors.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We just released a new version of the Python SDK that supports [creating events from GraphQL errors](https://github.com/getsentry/sentry-python/issues/2198). We also added an option to opt out of this to the three affected integrations (aiohttp, httpx, stdlib).

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
