### PR TITLE
feat(js): Add documentation for new `ContextLines` integration

### DIFF
--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -112,12 +112,13 @@ Available options:
 
 ### ContextLines
 
-_Import name: `Sentry.Integrations.ReportingObserver`_
+_Import name: `Sentry.Integrations.ContextLines`_
 
-This integration collects code lines at and around the stack frames of an error that point to code in the current page's html (for example in `<script>` tags).
-Note that this integration _cannot_ collect code lines from other files that are loaded by the browser.
-Generally, context line collection is already taken care of by the Sentry backend which will try to fetch the JavaScript file from your server when an error is reported to Sentry.
-However, in some cases, our backend might not be able to fetch the JavaScript file, for example if the file is only available for logged in users.
+This integration attaches source code of inline JavaScript inside the page's HTML (e.g. JS in `<script>` tags) to errors captured by the SDK.
+Note that this integration _cannot_ collect source code from assets referenced by your HTML (e.g. `<script src="..." />`).
+
+Generally, the Sentry backend tries to attach source code to these errors by fetching the page and extracting the respective lines.
+However, in some cases, our backend might not be able to fetch the JavaScript file, for example if the file is only available for authenticated users.
 
 Use this integration if you have inline JS code in HTML pages that can't be accessed by our backend, for example due to a login-protected page.
 

--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -107,3 +107,20 @@ Available options:
 <PlatformContent includePath="configuration/reporting-observer" />
 
 </PlatformSection>
+
+<PlatformSection supported={["javascript"]}>
+
+### ContextLines
+
+_Import name: `Sentry.Integrations.ReportingObserver`_
+
+This integration collects code lines at and around the stack frames of an error that point to code in the current page's html (for example in `<script>` tags).
+Note that this integration _cannot_ collect code lines from other files that are loaded by the browser.
+Generally, context line collection is already taken care of by the Sentry backend which will try to fetch the JavaScript file from your server when an error is reported to Sentry.
+However, in some cases, our backend might not be able to fetch the JavaScript file, for example if the file is only available for logged in users.
+
+Use this integration if you have inline JS code in HTML pages that can't be accessed by our backend, for example due to a login-protected page.
+
+<PlatformContent includePath="configuration/contextlines" />
+
+</PlatformSection>

--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -114,13 +114,10 @@ Available options:
 
 _Import name: `Sentry.Integrations.ContextLines`_
 
-This integration attaches source code of inline JavaScript inside the page's HTML (e.g. JS in `<script>` tags) to errors captured by the SDK.
-Note that this integration _cannot_ collect source code from assets referenced by your HTML (e.g. `<script src="..." />`).
+This integration adds source code from inline JavaScript of the current page's HTML (e.g. JS in `<script>` tags) to stack traces of captured errors.
+It _can't_ collect source code from assets referenced by your HTML (e.g. `<script src="..." />`).
 
-Generally, the Sentry backend tries to attach source code to these errors by fetching the page and extracting the respective lines.
-However, in some cases, our backend might not be able to fetch the JavaScript file, for example if the file is only available for authenticated users.
-
-Use this integration if you have inline JS code in HTML pages that can't be accessed by our backend, for example due to a login-protected page.
+The `ContextLines` integration is useful when you have inline JS code in HTML pages that can't be accessed by Sentry's backend, for example, due to a login-protected page.
 
 <PlatformContent includePath="configuration/contextlines" />
 

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     new ContextLines({
-      // The number of lines to collect for each stack frame
+      // The number of lines to collect around each stack frame's line number
       // Defaults to 7
       frameContextLines: 7,
     }),
@@ -32,7 +32,7 @@ Sentry.init({
     Sentry.init({
       integrations: [
         new Sentry.Integrations.ContextLines({
-          // The number of lines to collect for each stack frame
+          // The number of lines to collect around each stack frame's line number
           // Defaults to 7
           frameContextLines: 7,
         }),
@@ -59,7 +59,7 @@ Sentry.init({
     dsn: "___PUBLIC_DSN___",
     integrations: [
       new Sentry.Integrations.ContextLines({
-        // The number of lines to collect for each stack frame
+        // The number of lines to collect around each stack frame's line number
         // Defaults to 7
         frameContextLines: 7,
       }),

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -32,7 +32,7 @@ Sentry.init({
     Sentry.init({
       integrations: [
         new Sentry.Integrations.ContextLines({
-          // The number of lines to collect around each stack frame's line number
+          // The number of lines to collect before and after each stack frame's line number
           // Defaults to 7
           frameContextLines: 7,
         }),

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -1,0 +1,69 @@
+<SignInNote />
+
+```javascript {tabTitle: ESM}
+import * as Sentry from "@sentry/browser";
+import { ContextLines } from "@sentry/integrations";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new ContextLines({
+      // The number of lines to collect for each stack frame
+      // Defaults to 7
+      frameContextLines: 7,
+    }),
+  ],
+});
+```
+
+```html {tabTitle: Loader}
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/contextlines.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'contextlines.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<script>
+  Sentry.onLoad(function () {
+    Sentry.init({
+      integrations: [
+        new Sentry.Integrations.ContextLines({
+          // The number of lines to collect for each stack frame
+          // Defaults to 7
+          frameContextLines: 7,
+        }),
+      ],
+    });
+  });
+</script>
+```
+
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'bundle.tracing.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/contextlines.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'contextlines.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<script>
+  Sentry.init({
+    dsn: "___PUBLIC_DSN___",
+    integrations: [
+      new Sentry.Integrations.ContextLines({
+        // The number of lines to collect for each stack frame
+        // Defaults to 7
+        frameContextLines: 7,
+      }),
+    ],
+  });
+</script>
+```


### PR DESCRIPTION
Adds documentation for the new `ContextLines` integration which we're going to ship soon (https://github.com/getsentry/sentry-javascript/pull/8699)

ref https://github.com/getsentry/sentry-javascript/issues/8656