### PR TITLE
feat(sentry-go): Document Crons support

### DIFF
--- a/src/docs/product/crons/getting-started/index.mdx
+++ b/src/docs/product/crons/getting-started/index.mdx
@@ -18,6 +18,8 @@ To set up Sentry Crons, use the links below for supported SDKs or the Sentry CLI
   - [Next.js](/platforms/javascript/guides/nextjs/crons/)
   - [SvelteKit](/platforms/javascript/guides/sveltekit/crons/)
   - [Remix](/platforms/javascript/guides/remix/crons/)
+- [Go](/platforms/go/crons/)
+
 
 <Alert level="note" title="Don't see your platform?">
 

--- a/src/docs/product/crons/getting-started/index.mdx
+++ b/src/docs/product/crons/getting-started/index.mdx
@@ -20,7 +20,6 @@ To set up Sentry Crons, use the links below for supported SDKs or the Sentry CLI
   - [Remix](/platforms/javascript/guides/remix/crons/)
 - [Go](/platforms/go/crons/)
 
-
 <Alert level="note" title="Don't see your platform?">
 
 We're working on enabling additional platforms for Crons. In the meantime, you can use the Sentry CLI or HTTP to set up monitoring for your jobs.

--- a/src/platform-includes/crons/connect-errors/go.mdx
+++ b/src/platform-includes/crons/connect-errors/go.mdx
@@ -1,0 +1,5 @@
+```go
+sentry.ConfigureScope(func(scope *sentry.Scope) {
+	scope.SetContext("monitor", sentry.Context{"slug": "<monitor-slug>"})
+})
+```

--- a/src/platform-includes/crons/requirements/go.mdx
+++ b/src/platform-includes/crons/requirements/go.mdx
@@ -1,0 +1,2 @@
+- Use our <PlatformLink to="/">getting started</PlatformLink> guide to install and configure the Sentry Go SDK (version `0.23.0` or newer) for your recurring job.
+- [Create and configure](https://sentry.io/crons/create/) your first Monitor.

--- a/src/platform-includes/crons/setup/go.mdx
+++ b/src/platform-includes/crons/setup/go.mdx
@@ -119,3 +119,5 @@ sentry.CaptureCheckIn(
 	monitorConfig,
 )
 ```
+
+A full end-to-end example can be found [in the `sentry-go` repository](https://github.com/getsentry/sentry-go/blob/dde4d360660838f3c2e0ced8205bc8f7a8d312d9/_examples/crons/main.go).

--- a/src/platform-includes/crons/setup/go.mdx
+++ b/src/platform-includes/crons/setup/go.mdx
@@ -1,0 +1,121 @@
+## Check-Ins (Recommended)
+
+Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+```go
+// 🟡 Notify Sentry your job is running:
+checkinId := sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusInProgress,
+	},
+	nil,
+)
+
+// Execute your scheduled task here...
+
+// 🟢 Notify Sentry your job has completed successfully:
+sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		ID:          *checkinId,
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusOK,
+	},
+	nil,
+)
+```
+
+If your job execution fails, you can notify Sentry about the failure:
+
+```go
+// 🔴 Notify Sentry your job has failed:
+sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		ID:          *checkinId,
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusError,
+	},
+	nil,
+)
+```
+
+## Heartbeat
+
+Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
+
+```go
+// Execute your scheduled task...
+
+// 🟢 Notify Sentry your job completed successfully:
+sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusOK,
+	},
+	nil,
+)
+```
+
+If your job execution fails, you can:
+
+```go
+// 🔴 Notify Sentry your job has failed:
+sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusError,
+	},
+	nil,
+)
+```
+
+## Upserting Cron Monitors
+
+You can create and update your Monitors programmatically with code
+rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/).
+
+```go
+// Create a crontab schedule object (every 10 minutes)
+monitorSchedule := sentry.CrontabSchedule("*/10 * * * *")
+
+// Or create an interval schedule object (every 10 minutes)
+monitorSchedule := sentry.IntervalSchedule(10, sentry.MonitorScheduleUnitMinute)
+```
+
+Supported units are:
+
+- MonitorScheduleUnitMinute
+- MonitorScheduleUnitHour
+- MonitorScheduleUnitDay
+- MonitorScheduleUnitWeek
+- MonitorScheduleUnitMonth
+- MonitorScheduleUnitYear
+
+```go
+// Create a monitor config object
+monitorConfig := &sentry.MonitorConfig{
+	Schedule:      monitorSchedule,
+	MaxRuntime:    2,
+	CheckInMargin: 1,
+}
+
+// 🟡 Notify Sentry your job is running:
+checkinId := sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusInProgress,
+	},
+	monitorConfig,
+)
+
+// Execute your scheduled task here...
+
+// 🟢 Notify Sentry your job has completed successfully:
+sentry.CaptureCheckIn(
+	&sentry.CheckIn{
+		MonitorSlug: "<monitor-slug>",
+		Status:      sentry.CheckInStatusOK,
+	},
+	monitorConfig,
+)
+```

--- a/src/platform-includes/crons/setup/go.mdx
+++ b/src/platform-includes/crons/setup/go.mdx
@@ -51,6 +51,8 @@ sentry.CaptureCheckIn(
 	&sentry.CheckIn{
 		MonitorSlug: "<monitor-slug>",
 		Status:      sentry.CheckInStatusOK,
+		// Specify the duration of the job.
+		Duration:    time.Second * 10,
 	},
 	nil,
 )
@@ -64,6 +66,7 @@ sentry.CaptureCheckIn(
 	&sentry.CheckIn{
 		MonitorSlug: "<monitor-slug>",
 		Status:      sentry.CheckInStatusError,
+		Duration:    time.Second * 10,
 	},
 	nil,
 )

--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -8,6 +8,7 @@ supported:
   - javascript.nextjs
   - javascript.sveltekit
   - javascript.remix
+  - go
 description: "Learn how to enable Cron Monitoring in your app"
 ---
 
@@ -15,7 +16,7 @@ description: "Learn how to enable Cron Monitoring in your app"
 
 Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.
 
-<PlatformSection supported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix"]}>
+<PlatformSection supported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go"]}>
 
 ## Requirements
 
@@ -31,7 +32,7 @@ To link any exceptions captured during your job's lifecycle, use <PlatformLink t
 
 </PlatformSection>
 
-<PlatformSection notSupported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix"]}>
+<PlatformSection notSupported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go"]}>
 
 ## Requirements
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Starting from `sentry-go` version 0.23.0, we'll have initial support for Cron check-ins. This change documents the current API. 
Also linked the full E2E example from here: https://github.com/getsentry/sentry-go/blob/dde4d360660838f3c2e0ced8205bc8f7a8d312d9/_examples/crons/main.go

Closes https://github.com/getsentry/sentry-go/issues/671
