### PR TITLE
Add wrong Kotlin inline function number to Android Troubleshooting

### DIFF
--- a/src/platforms/android/troubleshooting.mdx
+++ b/src/platforms/android/troubleshooting.mdx
@@ -73,6 +73,13 @@ For example, the following stack traces:
   at io.sentry.HubAdapter.captureEvent (HubAdapter.java:29)
 ```
 
+## Kotlin
+
+Stack trace elements referring to Kotlin inline functions from files different than the call site are incorrect, due to how they are compiled.
+A .class file with inline functions contains code from many source files. When the JVM generates a stacktrace, it will contain a different line number, because it doesn't substitute the class and line in which the error occurred with the original file and line number.
+As a result, if an exception is thrown inside an inline function, the line number of the stack trace of the Exception could be wrong.
+This is a missing feature in the JVM itself, so "Sentry can't fix this".
+
 ## NDK
 
 If you're using a version of `sentry-android` before 5.0, due to current limitations in how `sentry-native` works, it cannot identify native libraries loaded directly from `.apk` files. Instead, it needs to have access to the extracted libraries on the file system.

--- a/src/platforms/android/troubleshooting.mdx
+++ b/src/platforms/android/troubleshooting.mdx
@@ -73,12 +73,11 @@ For example, the following stack traces:
   at io.sentry.HubAdapter.captureEvent (HubAdapter.java:29)
 ```
 
-## Kotlin
+## Incorrect Line Numbers in Kotlin
 
-Stack trace elements referring to Kotlin inline functions from files different than the call site are incorrect, due to how they are compiled.
-A .class file with inline functions contains code from many source files. When the JVM generates a stacktrace, it will contain a different line number, because it doesn't substitute the class and line in which the error occurred with the original file and line number.
-As a result, if an exception is thrown inside an inline function, the line number of the stack trace of the Exception could be wrong.
-This is a missing feature in the JVM itself, so "Sentry can't fix this".
+Stack trace elements referring to Kotlin inline functions from files different than the call site may refer to the wrong line numbers.
+
+This is due to a missing feature in the JVM. `.class` files with inline functions contain code from many source files, and when the JVM generates a stacktrace, it doesn't replace the class and line where the error occurred with the original file and line number. So, when an exception is thrown in an inline function, the line number for the stack trace of the Exception may be wrong.
 
 ## NDK
 

--- a/src/platforms/android/troubleshooting.mdx
+++ b/src/platforms/android/troubleshooting.mdx
@@ -77,7 +77,47 @@ For example, the following stack traces:
 
 Stack trace elements referring to Kotlin inline functions from files different than the call site may refer to the wrong line numbers.
 
-This is due to a missing feature in the JVM. `.class` files with inline functions contain code from many source files, and when the JVM generates a stacktrace, it doesn't replace the class and line where the error occurred with the original file and line number. So, when an exception is thrown in an inline function, the line number for the stack trace of the Exception may be wrong.
+This is due to a [missing feature in the JVM](https://youtrack.jetbrains.com/issue/KT-8628/Line-numbers-are-incorrect-in-exception-stack-trace). `.class` files with inline functions contain code from many source files, and when the JVM generates a stacktrace, it doesn't replace the class and line where the error occurred with the original file and line number. So, when an exception is thrown in an inline function, the line number for the stack trace of the Exception may be wrong.
+
+Let's show an example. Here is an Activity with an inline function throwing an Exception.
+
+```
+class MyActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        erroringFunction() // Line 10
+    }
+
+    inline fun erroringFunction() {
+        throw RuntimeException() // Line 14
+    }
+}
+ // Line 17
+```
+
+The stacktrace of the Exception points to the line 18 of the `MyActivity.kt` class.
+
+```
+java.lang.RuntimeException
+	at io.sentry.samples.android.MyActivity.onCreate(MyActivity.kt:18)
+	at android.app.Activity.performCreate(Activity.java:8305)
+	at android.app.Activity.performCreate(Activity.java:8284)
+	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1417)
+	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3626)
+	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3782)
+	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
+	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
+	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
+	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
+	at android.os.Handler.dispatchMessage(Handler.java:106)
+	at android.os.Looper.loopOnce(Looper.java:201)
+	at android.os.Looper.loop(Looper.java:288)
+	at android.app.ActivityThread.main(ActivityThread.java:7872)
+	at java.lang.reflect.Method.invoke(Native Method)
+	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
+	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
+```
 
 ## NDK
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

added a `Kotlin` section to Android Troubleshooting regarding kotlin inline function reported with wrong line numbers
Relates to https://github.com/getsentry/sentry-java/issues/2763