### PR TITLE
fix(rn): RN Profiling is available from version 5.8.0

### DIFF
--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -290,7 +290,7 @@ sentry_sdk.init(
 
 <Note>
 
-Profiling for React Native is available in alpha in SDK versions `5.7.0` and above.
+Profiling for React Native is available in alpha in SDK versions `5.8.0` and above.
 
 </Note>
 

--- a/src/wizard/react-native/profiling-onboarding/react-native/1.install.md
+++ b/src/wizard/react-native/profiling-onboarding/react-native/1.install.md
@@ -7,4 +7,4 @@ type: language
 
 #### Install
 
-For the Profiling integration to work, you must have the Sentry React Native SDK (minimum version v5.7.0). Learn more about installation methods in our [full documentation](https://docs.sentry.io/platforms/react-native/#install).
+For the Profiling integration to work, you must have the Sentry React Native SDK (minimum version v5.8.0). Learn more about installation methods in our [full documentation](https://docs.sentry.io/platforms/react-native/#install).


### PR DESCRIPTION
fix rn sdk version

https://github.com/getsentry/sentry-react-native/releases/tag/5.8.0