### PR TITLE
ref: Add that auto-assignment is turned off after manual assignment

### DIFF
--- a/src/docs/product/issues/ownership-rules/index.mdx
+++ b/src/docs/product/issues/ownership-rules/index.mdx
@@ -16,6 +16,8 @@ description: "Learn how to automatically assign issues to their respective owner
 
 Sentry offers multiple ways to define the "ownership" of an issue. With ownership defined, we can automatically assign issues and send alerts to the owner. Sentry defines ownership with _code owners_ and _ownership rules_. Code owners functionality lets you import your [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) or [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) CODEOWNERS file, and then we assign issues according to those file paths. Ownership rules allow you to override the assignments based on code owners and provide advanced matcher types (for example, urls and tags). These rules can also match on the file paths of files in the stack trace, URL of the request, or event tags.
 
+If a user manually assigns an issue after it has been automatically assigned by Sentry, future auto-assignment will be turned off for that issue.
+
 ## Methods
 
 Ownership rules and code owners are matched against individual events in an issue. This matching is relied upon in other areas of [sentry.io](https://sentry.io), as described in the following sections.


### PR DESCRIPTION
Add that auto assignment of an issue is turned off after manual assignment

closes https://github.com/getsentry/sentry/issues/51612