### PR TITLE
fix: remove semicolons from some python statements

### DIFF
--- a/src/platform-includes/performance/custom-performance-metrics/python.mdx
+++ b/src/platform-includes/performance/custom-performance-metrics/python.mdx
@@ -14,13 +14,13 @@ To capture in the SDK:
 from sentry_sdk import set_measurement
 
 # Record amount of memory used
-set_measurement('memory_used', 123, 'byte');
+set_measurement('memory_used', 123, 'byte')
 
 # Record time when job was started
-set_measurement('job_start_time', 1.3, 'second');
+set_measurement('job_start_time', 1.3, 'second')
 
 # Record amount of times cache was read
-set_measurement('cache_read_count', 4);
+set_measurement('cache_read_count', 4)
 ```
 
 The feature was marked experimental between versions `1.5.12` and `1.16.0`.
@@ -41,5 +41,5 @@ sentry_sdk.init(
 transaction = Hub.current.scope.transaction
 
 if transaction:
-    transaction.set_measurement('memory_used', 123, 'byte');
+    transaction.set_measurement('memory_used', 123, 'byte')
 ```


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This page (and maybe others) ends Python statements with semicolons. The code will still work, but I used to get flamed for doing that on IRC so we should probably tidy it up.

If anyone knows `awk` they could maybe search for other Python blocks that have semicolons in them.

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
