### PR TITLE
fix(js): Correctly load `type` in usePlatform graphQL query

### DIFF
--- a/src/components/hooks/usePlatform.tsx
+++ b/src/components/hooks/usePlatform.tsx
@@ -20,6 +20,7 @@ const query = graphql`
         caseStyle
         supportLevel
         fallbackPlatform
+        type
         guides {
           key
           name
@@ -29,6 +30,7 @@ const query = graphql`
           caseStyle
           supportLevel
           fallbackPlatform
+          type
         }
       }
     }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Fixes missing `type` param from @evanpurkhiser 's refactor PR: https://github.com/getsentry/sentry-docs/pull/7505

Fixes messed up formatting on this page which uses the `PlatformLinkWithLogo` component:

![image](https://github.com/getsentry/sentry-docs/assets/3520671/52536b32-ef15-4560-80d5-56ed1fa58116)


