### PR TITLE
ref(node): Streamline note about error-catching behaviour in `withScope`

### DIFF
--- a/src/platforms/common/enriching-events/scopes.mdx
+++ b/src/platforms/common/enriching-events/scopes.mdx
@@ -132,8 +132,7 @@ even call <PlatformIdentifier name="clear" /> to briefly remove all context info
 <PlatformSection notSupported={["ruby"]}>
 <Alert level="info" title="Important">
 
-Any exceptions that occur within the callback function for <PlatformIdentifier name="with-scope" /> will not be
-caught, and all errors that occur will be silently ignored and **not** reported.
+Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
 
 </Alert>
 </PlatformSection>


### PR DESCRIPTION
This streamlines the note about errors happening within the callback `withScope` being ignored by the SDK. We previously used "Error" and "Exception" quite interchangeably in this note which seems to cause confusion. 

closes https://github.com/getsentry/sentry-docs/issues/7557