### PR TITLE
Adjust needed self-hosted version for debug ID sourcemap upload

### DIFF
--- a/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -9,7 +9,7 @@ Use the guide on this page if you're using one of the following:
 - JavaScript SDK version `7.46.0` or lower
 - `@sentry/webpack-plugin` package version `1.x` or lower
 - `sentry-cli` version `2.16.1` or lower
-- Sentry self-hosted or single-tenant on version `23.4.0` or lower
+- Sentry self-hosted or single-tenant on version `23.6.1` or lower
 
 If all of your Sentry dependencies are on more up-to-date versions than in the list above, we recommend using the regular <PlatformLink to="/sourcemaps">Source Maps</PlatformLink> guide.
 
@@ -104,7 +104,7 @@ Sentry.init({
 
 ## Uploading using Sentry Bundler Plugins on Version `2.x`
 
-If you are using a Sentry self-hosted or single-tenant on version `23.4.0` or lower, or you are using the Sentry JavaScript SDK on version `7.46.0` you will need to configure the bundler plugins with the `release.uploadLegacySourcemaps` option.
+If you are using a Sentry self-hosted or single-tenant on version `23.6.1` or lower, or you are using the Sentry JavaScript SDK on version `7.46.0` you will need to configure the bundler plugins with the `release.uploadLegacySourcemaps` option.
 
 This applies when using the following packages on version `2.x` and above:
 

--- a/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/src/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -24,7 +24,7 @@ Dependency versions that require the legacy method of uploading source maps incl
     <code>sentry-cli</code> version <code>2.16.1</code> or lower
   </li>
   <li>
-    Sentry self-hosted or single-tenant on version <code>23.4.0</code> or lower
+    Sentry self-hosted or single-tenant on version <code>23.6.1</code> or lower
   </li>
 </ul>
 


### PR DESCRIPTION
We had a bug/wrong feature flag in Sentry that caused the new source-map upload to be weird in self-hosted Sentry.

This bug was fixed in https://github.com/getsentry/sentry/pull/52102 which was first part of 23.6.2 so we need to adjust the docs to reflect that version as the minimum version for debug IDs.

Ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/360