### PR TITLE
docs(api): Clarify team contributor abilities

### DIFF
--- a/src/docs/product/accounts/membership.mdx
+++ b/src/docs/product/accounts/membership.mdx
@@ -64,7 +64,7 @@ All members of a specific team and their team-level roles are listed in **Settin
 
 Only Org Admins, Managers, and Owners can add new teams to an organization. Users can join a team with one of the following team-level roles:
 
-- **Team Contributors** can view and act on issues and, depending on org rules, can add members and projects to the team.
+- **Team Contributors** can view and act on issues. Depending on the organization rules, they can also add members to the team.
 - **Team Admins** have additional permissions to manage their team's membership and projects. These permissions are granted at the team-level, and don't apply to teams where they're not a Team Admin.
 
 Org Members can be Team Admins for specific teams, but they can't add new teams. Org Admins automatically become Team Admins when they join a team. Org Managers and Owners can perform Team Admin actions for all teams without needing to join.


### PR DESCRIPTION
Team contributors cannot add projects to teams, even if `Open Membership` is turned on. I tested and verified this on my test organization, but let me know if there's some other way to do it that I missed.