### PR TITLE
ref(js): Add note about react error boundary and CaptureConsole

### DIFF
--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -36,11 +36,15 @@ _Import name: `Sentry.Integrations.CaptureConsole`_
 
 This integration captures all `Console API` calls and redirects them to Sentry using the SDK's `captureMessage` or `captureException` call, depending on the log level. It then re-triggers to preserve default native behavior.
 
+<PlatformSection supported={["javascript.react"]}>
+
 <Alert level="warning" title="Note">
 
-By default React [logs all errors to the console](https://github.com/facebook/react/blob/493f72b0a7111b601c16b8ad8bc2649d82c184a0/packages/react-reconciler/src/ReactFiberErrorLogger.js#L85), even if you are using an React error boundary. This means that Sentry will capture the error through the `CaptureConsole` integration and not through the error boundary.
+By default React [logs all errors to the console](https://github.com/facebook/react/blob/493f72b0a7111b601c16b8ad8bc2649d82c184a0/packages/react-reconciler/src/ReactFiberErrorLogger.js#L85), even if you are using an React error boundary. This means that Sentry will capture the error through the `CaptureConsole` integration and not through the error boundary. We recommend disabling logging the `error` level if using React error boundaries and the `CaptureConsole` integration.
 
 </Alert>
+
+</PlatformSection>
 
 <PlatformContent includePath="configuration/capture-console" />
 

--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -34,7 +34,13 @@ Available options:
 
 _Import name: `Sentry.Integrations.CaptureConsole`_
 
-This integration captures all `Console API` calls and redirects them to Sentry using the SDK's `captureMessage` or `captureException` call, depending on the log level. It then re-triggers to preserve default native behavior:
+This integration captures all `Console API` calls and redirects them to Sentry using the SDK's `captureMessage` or `captureException` call, depending on the log level. It then re-triggers to preserve default native behavior.
+
+<Alert level="warning" title="Note">
+
+By default React [logs all errors to the console](https://github.com/facebook/react/blob/493f72b0a7111b601c16b8ad8bc2649d82c184a0/packages/react-reconciler/src/ReactFiberErrorLogger.js#L85), even if you are using an React error boundary. This means that Sentry will capture the error through the `CaptureConsole` integration and not through the error boundary.
+
+</Alert>
 
 <PlatformContent includePath="configuration/capture-console" />
 

--- a/src/platforms/javascript/guides/react/features/error-boundary.mdx
+++ b/src/platforms/javascript/guides/react/features/error-boundary.mdx
@@ -59,6 +59,12 @@ class App extends React.Component {
 export default App;
 ```
 
+<Alert level="warning" title="Note">
+
+By default React [logs all errors to the console](https://github.com/facebook/react/blob/493f72b0a7111b601c16b8ad8bc2649d82c184a0/packages/react-reconciler/src/ReactFiberErrorLogger.js#L85), even if you are using a React error boundary. If you are using the `CaptureConsole` integration this means that Sentry will capture the error through the `CaptureConsole` integration and not through the error boundary.
+
+</Alert>
+
 ## Options
 
 The ErrorBoundary component exposes a variety of props that can be passed in for extra configuration. There are no required options, but we highly recommend that you set a fallback component.


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8689

Add note about interaction between react error boundary and the `CaptureConsole` integration. This is duplicated, once in the react docs and once in the `CaptureConsole` docs so that it can be discovered easily.