### PR TITLE
Python crons monitor is now also a contextmanager

### DIFF
--- a/src/platform-includes/crons/setup/python.mdx
+++ b/src/platform-includes/crons/setup/python.mdx
@@ -18,7 +18,7 @@ def tell_the_world(msg):
     # Scheduled task here...
     print(msg)
 
-# monitor can also equivalently be used as a context manager, like so
+# monitor can also be used as a context manager
 def tell_the_world_contextmanager(msg):
     with monitor(monitor_slug='<monitor-slug>'):
         # Scheduled task here...

--- a/src/platform-includes/crons/setup/python.mdx
+++ b/src/platform-includes/crons/setup/python.mdx
@@ -17,4 +17,10 @@ from sentry_sdk.crons import monitor
 def tell_the_world(msg):
     # Scheduled task here...
     print(msg)
+
+# monitor can also equivalently be used as a context manager, like so
+def tell_the_world_contextmanager(msg):
+    with monitor(monitor_slug='<monitor-slug>'):
+        # Scheduled task here...
+        print(msg)
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Updated Python crons monitor setup instructions to reflect that `monitor` can now be used as a context manager, in addition to remaining usable as a decorator. This change to the documentation is necessary due to [PR #2290](https://github.com/getsentry/sentry-python/pull/2290) in the sentry-python repo. 

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
