### PR TITLE
Add Android v7 requirement API 19

### DIFF
--- a/src/platforms/android/configuration/using-ndk.mdx
+++ b/src/platforms/android/configuration/using-ndk.mdx
@@ -9,9 +9,9 @@ description: "Learn how to configure the NDK integration."
 
 The Android Native Development Kit (NDK) allows you to implement parts of your app in native code, using languages such as C and C++.
 
-NDK integration is packed with the SDK and requires API level 16. The package `sentry-android-ndk` works by bundling Sentry's native SDK, [`sentry-native`](/platforms/native/). As a result, even if a native library in your app causes the crash, Sentry is able to capture it.
+NDK integration is packed with the SDK. The package `sentry-android-ndk` works by bundling Sentry's native SDK, [`sentry-native`](/platforms/native/). As a result, even if a native library in your app causes the crash, Sentry is able to capture it.
 
-You can [disable the NDK integration](#disable-ndk-integration), use our Sentry Android SDK [without the NDK](#using-the-sdk-without-the-ndk), and support devices on [API levels lower than 16](#api-level-lower-than-16).
+You can [disable the NDK integration](#disable-ndk-integration), use our Sentry Android SDK [without the NDK](#using-the-sdk-without-the-ndk).
 
 ## Symbolicate Stack Traces
 
@@ -110,19 +110,6 @@ configurations.configureEach {
   exclude(group = "io.sentry", module = "sentry-android-ndk")
 }
 ```
-
-## API Level Lower Than 16
-
-To support the devices on the API level lower than 16, update your `AndroidManifest.xml`:
-
-```xml {filename:AndroidManifest.xml}
-<manifest>
-    <!-- Merging strategy for the imported manifests -->
-    <uses-sdk tools:overrideLibrary="io.sentry.android" />
-</manifest>
-```
-
-With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
 
 ## Troubleshooting
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -6,6 +6,22 @@ redirect_from:
 description: "Migrating between versions of Sentry's SDK for Android."
 ---
 
+## Migrating from `io.sentry:sentry-android 6.x` to `io.sentry:sentry-android 7.0.0`
+
+- This version requires API level 19.
+  - Older versions with NDK integration support API level 16.
+    To support the devices on the API level lower than 16, update your `AndroidManifest.xml`:
+```xml {filename:AndroidManifest.xml}
+<manifest>
+    <!-- Merging strategy for the imported manifests -->
+    <uses-sdk tools:overrideLibrary="io.sentry.android" />
+</manifest>
+```
+    With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
+  - Older versions without NDK integration support API level 14.
+
+
+
 ## Migrating from `io.sentry:sentry-android 6.14.x` to `io.sentry:sentry-android 6.15.0`
 
 The `sentry-compose-android` and `sentry-compose` integrations now declare their upstream dependencies as `compileOnly`. Make sure to have the `androidx.navigation:navigation-compose`, `androidx.compose.runtime:runtime`, and `androidx.compose.ui:ui` dependencies on the classpath if you're using those integrations. Otherwise, the application will crash with a `NoClassDefFoundError` exception.

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -8,20 +8,20 @@ description: "Migrating between versions of Sentry's SDK for Android."
 
 ## Migrating from `io.sentry:sentry-android 6.x` to `io.sentry:sentry-android 7.0.0`
 
-- This version requires API level 19.
-  - Older versions with NDK integration support API level 16.
-    To support the devices on the API level lower than 16, update your `AndroidManifest.xml`:
+- `io.sentry:sentry-android 7.0.0` requires API level 19.
 
-```xml {filename:AndroidManifest.xml}
-<manifest>
-    <!-- Merging strategy for the imported manifests -->
-    <uses-sdk tools:overrideLibrary="io.sentry.android" />
-</manifest>
-```
+    Older versions with the NDK integration support API level 16. To support devices on an API level lower than 16, update your `AndroidManifest.xml`:
+
+    ```xml {filename:AndroidManifest.xml}
+    <manifest>
+        <!-- Merging strategy for the imported manifests -->
+        <uses-sdk tools:overrideLibrary="io.sentry.android" />
+    </manifest>
+    ```
 
     With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
 
-- Older versions without NDK integration support API level 14.
+- Older versions without the NDK integration support API level 14.
 
 ## Migrating from `io.sentry:sentry-android 6.14.x` to `io.sentry:sentry-android 6.15.0`
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -10,16 +10,16 @@ description: "Migrating between versions of Sentry's SDK for Android."
 
 - `io.sentry:sentry-android 7.0.0` requires API level 19.
 
-    Older versions with the NDK integration support API level 16. To support devices on an API level lower than 16, update your `AndroidManifest.xml`:
+  Older versions with the NDK integration support API level 16. To support devices on an API level lower than 16, update your `AndroidManifest.xml`:
 
-    ```xml {filename:AndroidManifest.xml}
-    <manifest>
-        <!-- Merging strategy for the imported manifests -->
-        <uses-sdk tools:overrideLibrary="io.sentry.android" />
-    </manifest>
-    ```
+  ```xml {filename:AndroidManifest.xml}
+  <manifest>
+      <!-- Merging strategy for the imported manifests -->
+      <uses-sdk tools:overrideLibrary="io.sentry.android" />
+  </manifest>
+  ```
 
-    With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
+  With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
 
 - Older versions without the NDK integration support API level 14.
 

--- a/src/platforms/android/migration.mdx
+++ b/src/platforms/android/migration.mdx
@@ -11,16 +11,17 @@ description: "Migrating between versions of Sentry's SDK for Android."
 - This version requires API level 19.
   - Older versions with NDK integration support API level 16.
     To support the devices on the API level lower than 16, update your `AndroidManifest.xml`:
+
 ```xml {filename:AndroidManifest.xml}
 <manifest>
     <!-- Merging strategy for the imported manifests -->
     <uses-sdk tools:overrideLibrary="io.sentry.android" />
 </manifest>
 ```
+
     With these changes the SDK will be enabled on all devices with API level ≥ 14 and the SDK with NDK will be enabled on all devices with API level ≥ 16.
-  - Older versions without NDK integration support API level 14.
 
-
+- Older versions without NDK integration support API level 14.
 
 ## Migrating from `io.sentry:sentry-android 6.14.x` to `io.sentry:sentry-android 6.15.0`
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

SDK v7 requires Android API level 19+.
This info has been added to the migration guide. Also, previous workaround for NDK on API 14 has been removed.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
