### PR TITLE
Add missing integrations to Python index

### DIFF
--- a/src/platforms/python/common/configuration/integrations/index.mdx
+++ b/src/platforms/python/common/configuration/integrations/index.mdx
@@ -21,11 +21,14 @@ If you don't want integrations to be enabled automatically, set the `default_int
 - [Cloud Resource Context](cloudresourcecontext/)
 - [Enhanced Locals](pure_eval/)
 - [GNU Backtrace](gnu_backtrace/)
+- [GRPC](grpc/)
 - [HTTPX](httpx/)
+- [Loguru](loguru/)
 - [PyMongo](pymongo/)
 - [Redis](redis/)
 - [SQLAlchemy](sqlalchemy/)
-- [WSGI](wsgi)
+- [SOCKET](socket/)
+- [WSGI](wsgi/)
 
 ## Web Frameworks
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This is just a small update of the index page for Python integrations, where the list of available integrations is not up-to-date with actually available integrations that you can find in the menu.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
