### PR TITLE
Add electron as performance at scale supported SDK

### DIFF
--- a/src/includes/sampling-supported-sdks.mdx
+++ b/src/includes/sampling-supported-sdks.mdx
@@ -11,3 +11,4 @@
 - Java: 6.5.0 or later
 - .NET: 3.22.0 or later
 - Go: 0.16.0 or later
+- Electron: 4.9.0 or later


### PR DESCRIPTION
https://github.com/getsentry/sentry-electron/pull/710 fixes a bug with baggage propagation that existed for a while, so making `4.9.0` the min version required.