### PR TITLE
chore(relay): Remove TLS mentions from getting started guide

### DIFF
--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -69,8 +69,6 @@ _"create custom config"_ and customizing these parameters:
 - The `port` and `host` settings configure the TCP port at which Relay will
   listen. This is the address to which SDKs send events.
 
-- The `tls` settings configure TLS support (HTTPS support), used when communication between the SDK and Relay needs to be secured.
-
 Settings are recorded in `.relay/config.yml`. Note that all configuration values
 are optional and default to these settings:
 
@@ -82,9 +80,6 @@ relay:
   upstream: https://___ORG_INGEST_DOMAIN___.
   host: 0.0.0.0
   port: 3000
-  tls_port: ~
-  tls_identity_path: ~
-  tls_identity_password: ~
 ```
 
 ```yaml {tabTitle:Run Executable}
@@ -95,9 +90,6 @@ relay:
   upstream: https://___ORG_INGEST_DOMAIN___.
   host: 127.0.0.1
   port: 3000
-  tls_port: ~
-  tls_identity_path: ~
-  tls_identity_password: ~
 ```
 
 Configurations are fully documented in [Configuration Options](../options/).


### PR DESCRIPTION
Relay does not support TLS configuration anymore and rather required reverse proxy to do the SSL offloading. 
Let's remove it from the docs altogether. 