### PR TITLE
fix(actix-web): Manually start runtime in actix-web example

### DIFF
--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -34,22 +34,26 @@ async fn failing(_req: HttpRequest) -> Result<String, Error> {
     Err(io::Error::new(io::ErrorKind::Other, "An error happens here").into())
 }
 
-#[actix_web::main]
-async fn main() -> io::Result<()> {
-    let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
-        release: sentry::release_name!(),
-        ..Default::default()
-    }));
+fn main() -> io::Result<()> {
+    let _guard = sentry::init((
+        "___PUBLIC_DSN___",
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            ..Default::default()
+        },
+    ));
     std::env::set_var("RUST_BACKTRACE", "1");
 
-    HttpServer::new(|| {
-        App::new()
-            .wrap(sentry_actix::Sentry::new())
-            .service(failing)
-    })
-    .bind("127.0.0.1:3001")?
-    .run()
-    .await?;
+    actix_web::rt::System::new().block_on(async {
+        HttpServer::new(|| {
+            App::new()
+                .wrap(sentry_actix::Sentry::new())
+                .service(failing)
+        })
+        .bind("127.0.0.1:3001")?
+        .run()
+        .await
+    })?;
 
     Ok(())
 }

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -15,6 +15,7 @@ In your `Cargo.toml`:
 
 ```toml {filename:Cargo.toml}
 [dependencies]
+actix-web = "4.3.1"
 sentry = "{{@inject packages.version('sentry.rust') }}"
 sentry-actix = "{{@inject packages.version('sentry.rust') }}"
 ```

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -9,6 +9,7 @@ The `sentry-actix` crate adds a middleware for [`actix-web`](https://actix.rs/) 
 
 To use this middleware, configure Sentry then add it to your actix web app as a middleware. Because actix is generally working with non sendable objects and is highly concurrent, this middleware creates a new hub per request. As a result, many of the Sentry integrations, such as breadcrumbs, do not work unless you bind the actix hub.
 
+NB: Macros like `#[tokio::main]` and `#[actix_web::main]` are not supported. The Sentry client must be initialized before the async runtime is started so that all threads are correctly connected to the Hub.
 ## Example
 
 In your `Cargo.toml`:

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -10,6 +10,7 @@ The `sentry-actix` crate adds a middleware for [`actix-web`](https://actix.rs/) 
 To use this middleware, configure Sentry then add it to your actix web app as a middleware. Because actix is generally working with non sendable objects and is highly concurrent, this middleware creates a new hub per request. As a result, many of the Sentry integrations, such as breadcrumbs, do not work unless you bind the actix hub.
 
 NB: Macros like `#[tokio::main]` and `#[actix_web::main]` are not supported. The Sentry client must be initialized before the async runtime is started so that all threads are correctly connected to the Hub.
+
 ## Example
 
 In your `Cargo.toml`:

--- a/src/platforms/rust/guides/actix-web/index.mdx
+++ b/src/platforms/rust/guides/actix-web/index.mdx
@@ -9,7 +9,7 @@ The `sentry-actix` crate adds a middleware for [`actix-web`](https://actix.rs/) 
 
 To use this middleware, configure Sentry then add it to your actix web app as a middleware. Because actix is generally working with non sendable objects and is highly concurrent, this middleware creates a new hub per request. As a result, many of the Sentry integrations, such as breadcrumbs, do not work unless you bind the actix hub.
 
-NB: Macros like `#[tokio::main]` and `#[actix_web::main]` are not supported. The Sentry client must be initialized before the async runtime is started so that all threads are correctly connected to the Hub.
+Note: Macros like `#[tokio::main]` and `#[actix_web::main]` are not supported. The Sentry client must be initialized before the async runtime is started so that all threads are correctly connected to the Hub.
 
 ## Example
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This removes the use of `#[actix_web::main]` and correctly initializes Sentry before the async runtime is started.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
