### PR TITLE
fix(rust): Add warning about #[tokio::main]

### DIFF
--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -43,7 +43,7 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 }));
 ```
 
-**Important:** Note your DSN. The DSN (Data Source Name) tells the SDK where to send events. If you forget it, view Settings -> Projects -> Client Keys (DSN) in sentry.io.
+**Important:** Remember your DSN. The DSN (Data Source Name) tells the SDK where to send events. If you forget it you can find it be going to: Settings -> Projects -> Client Keys (DSN) in sentry.io.
 
 ### Async Main Function
 

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -62,7 +62,7 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 }
 ```
 
-do this:
+Do this instead:
 
 ```rust {filename:main.rs}
 // RIGHT

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -45,7 +45,7 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 
 **Important:** Note your DSN. The DSN (Data Source Name) tells the SDK where to send events. If you forget it, view Settings -> Projects -> Client Keys (DSN) in sentry.io.
 
-### Async main function
+### Async Main Function
 
 The Sentry client must be initialized before any async runtime is started or threads are spawned. Unfortunately, this makes it impossible to use macros such as `#[tokio::main]` or `#[actix_web::main]`, because they start the runtime first. Thus, instead of
 

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -32,7 +32,7 @@ sentry = "{{@inject packages.version('sentry.rust') }}"
 
 The most convenient way to use this library is the `sentry::init` function, which starts a Sentry client with a default set of integrations, and binds it to the current Hub.
 
-The `sentry::init` function returns a guard that, when dropped, will flush Events that were not yet sent to the Sentry service. It has a two second deadline for this, so shutdown of applications might slightly delay as a result. Keeping the guard around or sending events will not work.
+The `sentry::init` function returns a guard that, when dropped, will flush Events that were not yet sent to the Sentry service. It has a two second deadline for this, so shutdown of applications might slightly delay as a result. Keep the guard around or sending events will not work.
 
 <SignInNote />
 
@@ -44,6 +44,44 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 ```
 
 **Important:** Note your DSN. The DSN (Data Source Name) tells the SDK where to send events. If you forget it, view Settings -> Projects -> Client Keys (DSN) in sentry.io.
+
+### Async main function
+
+The Sentry client must be initialized before any async runtime is started or threads are spawned. Unfortunately, this makes it impossible to use macros such as `#[tokio::main]` or `#[actix_web::main]`, because they start the runtime first. Thus, instead of
+
+```rust {filename:main.rs}
+// WRONG
+#[tokio::main]
+async fn main() {
+let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+    release: sentry::release_name!(),
+    ..Default::default()
+}));
+
+// implementation of main
+}
+```
+
+do this:
+
+```rust {filename:main.rs}
+// RIGHT
+fn main() {
+let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
+    release: sentry::release_name!(),
+    ..Default::default()
+}));
+
+tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            // implementation of main
+        });
+}
+```
+
 
 ## Verify Setup
 

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -32,7 +32,7 @@ sentry = "{{@inject packages.version('sentry.rust') }}"
 
 The most convenient way to use this library is the `sentry::init` function, which starts a Sentry client with a default set of integrations, and binds it to the current Hub.
 
-The `sentry::init` function returns a guard that, when dropped, will flush Events that were not yet sent to the Sentry service. It has a two second deadline for this, so shutdown of applications might slightly delay as a result. Keep the guard around or sending events will not work.
+The `sentry::init` function returns a guard that when dropped, will flush Events that weren't yet sent to Sentry. It has a two-second deadline, so application shutdown may be slightly delayed as a result. Be sure to keep the guard or you won't be able to send events.
 
 <SignInNote />
 

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -47,7 +47,7 @@ let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
 
 ### Async Main Function
 
-The Sentry client must be initialized before any async runtime is started or threads are spawned. Unfortunately, this makes it impossible to use macros such as `#[tokio::main]` or `#[actix_web::main]`, because they start the runtime first. Thus, instead of
+In a multithreaded application, spawned threads should inherit the Hub from the main thread. In order for that to happen, the Sentry client must be initialized before starting an async runtime or spawning threads. This means you'll have to avoid using macros such as `#[tokio::main]` or `#[actix_web::main]`, because they start the runtime first. So rather than doing this:
 
 ```rust {filename:main.rs}
 // WRONG

--- a/src/platforms/rust/index.mdx
+++ b/src/platforms/rust/index.mdx
@@ -82,7 +82,6 @@ tokio::runtime::Builder::new_multi_thread()
 }
 ```
 
-
 ## Verify Setup
 
 The quickest way to verify Sentry in your Rust application is to cause a panic:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This warns users not to use macros like `#[tokio::main]` or `#[actix_web::main]` and explains how to manually write an "async" main function.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
