### PR TITLE
feat(docs): add replay onboarding for electron platform

### DIFF
--- a/src/wizard/electron/1.install.md
+++ b/src/wizard/electron/1.install.md
@@ -1,0 +1,18 @@
+---
+name: Electron
+doc_link: https://docs.sentry.io/platforms/javascript/guides/electron/session-replay/
+support_level: production
+type: language
+---
+
+#### Install
+
+For the Session Replay to work, you must have the framework SDK (e.g. @sentry/electron) installed, minimum version 4.2.0.
+
+```bash
+# Using yarn
+yarn add @sentry/electron
+
+# Using npm
+npm install --save @sentry/electron
+```

--- a/src/wizard/electron/2.configure.md
+++ b/src/wizard/electron/2.configure.md
@@ -1,0 +1,27 @@
+---
+name: Electron
+doc_link: https://docs.sentry.io/platforms/javascript/guides/electron/session-replay/
+support_level: production
+type: language
+---
+
+#### Configure
+
+Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the `integrations` constructor. Learn more about configuring Session Replay by reading the [configuration docs](https://docs.sentry.io/platforms/javascript/session-replay/).
+
+```javascript
+import * as Sentry from "@sentry/electron";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [new Sentry.Replay()],
+});
+```


### PR DESCRIPTION
I needed to add the same replay onboarding docs under the `electron` platform (rather than `javascript-electron`). 
Same onboarding content as seen here: https://github.com/getsentry/sentry-docs/pull/7635