### PR TITLE
fix(releases): Add note about repo name when associating commits

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -74,6 +74,11 @@ In case you are deploying without access to the git repository, you can manually
 sentry-cli releases set-commits "$VERSION" --commit "my-repo@deadbeef"
 ```
 
+<Note>
+  The repository name `my-repo` should match the name you entered when linking
+  the repo, and should be in the form `owner-name/repo-name`.
+</Note>
+
 To see which repos are available for the organization, you can run `sentry-cli repos list` which will return a list of configured repositories.
 
 Note that you need to refer to releases you need to use the actual full commit SHA. If you want to refer to tags or references (like _HEAD_), the repository needs to be checked out and reachable from the path where you invoke _sentry-cli_.

--- a/src/docs/product/releases/associate-commits/index.mdx
+++ b/src/docs/product/releases/associate-commits/index.mdx
@@ -55,11 +55,16 @@ sentry-cli releases set-commits --local $VERSION
 
 For more control over which commits to associate, or if you're unable to execute the command inside the repository, you can manually specify a repository and range.
 
-The following example associates commits (or refs) between `from` and `to` with the current release, where `from` is the previous release’s commit. The repository name `my-repo` should match the name you entered when linking the repo using the form `owner-name/repo-name`. The `from` commit is optional; we’ll use the previous release’s commit as the baseline if it is excluded:
+The following example associates commits (or refs) between `from` and `to` with the current release, where `from` is the previous release’s commit. The `from` commit is optional; we’ll use the previous release’s commit as the baseline if it is excluded:
 
 ```bash
 sentry-cli releases set-commits --commit "my-repo@from..to" $VERSION
 ```
+
+<Note>
+  The repository name `my-repo` should match the name you entered when linking
+  the repo, and should be in the form `owner-name/repo-name`.
+</Note>
 
 ### Using the API
 


### PR DESCRIPTION
A customer recently ran into trouble because they were trying to associate commits using the form `some-repo@123abc` rather than the form `some-org/some-repo@123abc`. Though we do have a note about this in the docs, in the section on releases, it's easy to miss. We also don't mention it at all in the CLI docs.

This fixes that by pulling it out into a highlighted note in both places.