### PR TITLE
Revert "feat(sdk): Upgrade `@sentry/gatsby` to v7.64.0-alpha.0 (#7644)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mdx-js/mdx": "^1.6.18",
     "@mdx-js/react": "^1.6.18",
     "@sentry-internal/global-search": "^0.5.7",
-    "@sentry/browser": "7.64.0-alpha.0",
+    "@sentry/browser": "7.55.2",
     "@sentry/webpack-plugin": "2.2.2",
     "@types/dompurify": "^3.0.2",
     "@types/js-cookie": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,27 +2582,27 @@
     "@sentry/utils" "7.53.1"
     tslib "^1.9.3"
 
-"@sentry-internal/tracing@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.64.0-alpha.0.tgz#f3a197d09a27332afaf6cc6134b2011dffb921b1"
-  integrity sha512-ZXMB/9j0r4AUysxXiNe9zqQvVVvUBPi36MalrsKItcUa06O09Ef4uQmTtvALrJ/F81fpZcg03PP24YwLk/eHCQ==
+"@sentry-internal/tracing@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.55.2.tgz#29687b8327cc9d980695603d451316706f2630ed"
+  integrity sha512-yBW+R7NfwLrOjpwOJHoOSvGDDoM3ZKod5OKXi7Gd5tYqVm1mCaL0n2/wlNMcGTbPbulLBtgzjoTU1bPJAGhmYw==
   dependencies:
-    "@sentry/core" "7.64.0-alpha.0"
-    "@sentry/types" "7.64.0-alpha.0"
-    "@sentry/utils" "7.64.0-alpha.0"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/core" "7.55.2"
+    "@sentry/types" "7.55.2"
+    "@sentry/utils" "7.55.2"
+    tslib "^1.9.3"
 
-"@sentry/browser@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.64.0-alpha.0.tgz#a531c4980879341c895c60f8dd74dc29151199e4"
-  integrity sha512-nObPVtzNY7c4GUoGGk8EyfOPEEGoLpfrh/553YQ5+Pk40/DC02dNtwOcwJB6KkPUHiLm8ftTPzMJXWuVQT4eWQ==
+"@sentry/browser@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.55.2.tgz#32a5cf7cc2af14b83926ea04ea140e1024f000a6"
+  integrity sha512-RgA4KOD6t8XHVLm6D2oTh9KW19g3DoQ0QsrUmAq4+giSj2AyDW67VP2V4E72mCZ9Ln9AkNhY0Eh3XuD3opiFQA==
   dependencies:
-    "@sentry-internal/tracing" "7.64.0-alpha.0"
-    "@sentry/core" "7.64.0-alpha.0"
-    "@sentry/replay" "7.64.0-alpha.0"
-    "@sentry/types" "7.64.0-alpha.0"
-    "@sentry/utils" "7.64.0-alpha.0"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry-internal/tracing" "7.55.2"
+    "@sentry/core" "7.55.2"
+    "@sentry/replay" "7.55.2"
+    "@sentry/types" "7.55.2"
+    "@sentry/utils" "7.55.2"
+    tslib "^1.9.3"
 
 "@sentry/bundler-plugin-core@2.2.2":
   version "2.2.2"
@@ -2637,14 +2637,14 @@
     "@sentry/utils" "7.53.1"
     tslib "^1.9.3"
 
-"@sentry/core@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.64.0-alpha.0.tgz#dc3aa4e586c5082b7ab65279fa9dd0fe8ba1042b"
-  integrity sha512-WaI6Oofk49XNqWLe/u5XDKmYPxRm0rnFAMIXcAFJjzEFNGjJxJxizOodKVxhryGj0+NYwgu8hC2GaPsj8X3WEw==
+"@sentry/core@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.55.2.tgz#a3988393ab791eba5d7fe735dfecea5a615e9e50"
+  integrity sha512-clzQirownxqADv9+fopyMJTHzaoWedkN2+mi4ro1LxjLgROdXBFurMCC1nT+7cH/xvQ5gMIRkM/y/4gRtKy2Ew==
   dependencies:
-    "@sentry/types" "7.64.0-alpha.0"
-    "@sentry/utils" "7.64.0-alpha.0"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/types" "7.55.2"
+    "@sentry/utils" "7.55.2"
+    tslib "^1.9.3"
 
 "@sentry/node@7.53.1":
   version "7.53.1"
@@ -2660,24 +2660,24 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/replay@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.64.0-alpha.0.tgz#c401092cf7845dc4898fed3b43ba89d8626ef4e5"
-  integrity sha512-x+VgF5yBE+lV9ZM0XeKNP8xT2WZfcrCfVUAJ0joOtWiMDjrBoV/OnB00jY0nL3S5iSh71Lja86DKrjF+TQHq7Q==
+"@sentry/replay@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.55.2.tgz#001eeb4d0dd900630ddfcea99185556b0699c12a"
+  integrity sha512-G9iAcI9bvy5X8fvdz0QxF3LJ8oGB0Vxt0iOPdRZYhjIcPbNpE3NaeT6xZlNX1pCcHLroE6BMRF/6TTalcl5Erw==
   dependencies:
-    "@sentry/core" "7.64.0-alpha.0"
-    "@sentry/types" "7.64.0-alpha.0"
-    "@sentry/utils" "7.64.0-alpha.0"
+    "@sentry/core" "7.55.2"
+    "@sentry/types" "7.55.2"
+    "@sentry/utils" "7.55.2"
 
 "@sentry/types@7.53.1":
   version "7.53.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.53.1.tgz#3eefbad851f2d0deff67285d7e976d23d7d06a41"
   integrity sha512-/ijchRIu+jz3+j/zY+7KRPfLSCY14fTx5xujjbOdmEKjmIHQmwPBdszcQm40uwofrR8taV4hbt5MFN+WnjCkCw==
 
-"@sentry/types@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.64.0-alpha.0.tgz#50cefca17b49da9514804907d1fa8ee4678a31c3"
-  integrity sha512-iSI6S4lkWU1R4rpwMs4QP5Xu/jdv9L9hWYT4fPqotEOJfDaUWsuo+qn/2jol5NGnyrjcV3NY7KKzWYxKABtyfw==
+"@sentry/types@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.55.2.tgz#1abd2e02308fcd9ff3e0ac0a56c6d67e36764964"
+  integrity sha512-mAtkA8wvUDrLjAAmy9tjn+NiXcxVz/ltbslTKaIW6JNgVRz5kMt1Ny8RJsgqaZqa4LFP8q+IvWw4Vd91kb57rA==
 
 "@sentry/utils@7.53.1":
   version "7.53.1"
@@ -2687,13 +2687,13 @@
     "@sentry/types" "7.53.1"
     tslib "^1.9.3"
 
-"@sentry/utils@7.64.0-alpha.0":
-  version "7.64.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.64.0-alpha.0.tgz#e2b189ca58f71ac2d91bc23be27730fd46afb9b4"
-  integrity sha512-mNBTI0iUg/pLr6RNSi1r7K16k2DwqYLhdLcH3KSNBSoiqRBz9JX4+r4BGt7seU3YmFOWpt+6nh8tQt5H/LVTuA==
+"@sentry/utils@7.55.2":
+  version "7.55.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.55.2.tgz#6a214c867c73305faac0997bdef4581f3bee0128"
+  integrity sha512-Yv9XtbOESdN7bkK2AMrKsmKMF5OOVv5v5hVcOqXtSTw1t2oMAtRjXXqGpUo+TkdTOjeoX6dr19ozVFHaGvqHkw==
   dependencies:
-    "@sentry/types" "7.64.0-alpha.0"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/types" "7.55.2"
+    tslib "^1.9.3"
 
 "@sentry/webpack-plugin@2.2.2":
   version "2.2.2"
@@ -14821,11 +14821,6 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
-
-"tslib@^2.4.1 || ^1.9.3":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tslib@~2.4.0:
   version "2.4.1"


### PR DESCRIPTION
This reverts commit c721c5b3a550f5af9fa9c1d9256d3de7f84aa847.

Noticed we are using the SDK Loader here, so this upgrade does nothing.
The package was imported for types only.
