### PR TITLE
Document new issue details event dropdown and the recommended event

### DIFF
--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -16,6 +16,7 @@ In the right hand sidebar, [sentry.io](https://sentry.io) reflects a summary tha
 
 There are two categories of issues: [error issues](/product/issues/issue-details/error-issues/) and [performance issues](/product/issues/issue-details/performance-issues/). Depending on the issue category and available event data, the **Issue Details** page displays some combination of the following sections:
 
+- **Event Dropdown** - Allows you to select a specific event from the issue to view.
 - **Trace Navigator** - An abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction.
 - **Suspect Commits** - A commit that's been identified as potentially having caused an error event.
 - **Tags** - Searchable key/value string pairs providing information such as the browser or device.
@@ -28,6 +29,16 @@ There are two categories of issues: [error issues](/product/issues/issue-details
 
 Learn more about what's included an issue detail for each of these in [Error Issues](/product/issues/issue-details/error-issues/) and [Performance Issues](/product/issues/issue-details/performance-issues/).
 In addition, this page provides several other key pieces of information.
+
+## Event Dropdown
+
+By default, the issues page will display the "Recommended" event. To view other events, you can used the dropdown to skip to the latest or oldest event, or view the full list of events. If you wish to change the default event, you may do so in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
+
+What is the "Recommended" event? The recommended event is the event that gives you the greatest context in solving the issue. Sentry uses the following criteria in determining the recommended event:
+
+- **Recency**: The recommended event is never more than 7 days older than the lastest event.
+- **Relevence**: The recommended event takes into account what terms you've searched for on your way to the issue.
+- **Content**: The recommended event prioritizes events that contain debugging tools such as replays, profiles, and traces.
 
 ## Trace Navigator
 

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -40,6 +40,8 @@ By default, the **Issue Details** page displays the "Recommended" event with the
 - **Relevence**: The recommended event takes into account what terms you've searched for on your way to the issue.
 - **Content**: The recommended event prioritizes events that contain debugging tools such as replays, profiles, and traces.
 
+To view other events, you can use the dropdown to skip to the latest or oldest event, or view the full list of events. You can change the default event in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
+ 
 ## Trace Navigator
 
 The trace navigator (which displays below the date) is an abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction. It displays up to six nodes, each representing different groups of the event's trace:

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -34,7 +34,7 @@ In addition, this page provides several other key pieces of information.
 
 By default, the issues page will display the "Recommended" event. To view other events, you can used the dropdown to skip to the latest or oldest event, or view the full list of events. If you wish to change the default event, you may do so in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
 
-What is the "Recommended" event? The recommended event is the event that gives you the greatest context in solving the issue. Sentry uses the following criteria in determining the recommended event:
+By default, the **Issue Details** page displays the "Recommended" event with the most context to help you solve the issue. Sentry uses the following criteria in determining the recommended event:
 
 - **Recency**: The recommended event is never more than 7 days older than the lastest event.
 - **Relevence**: The recommended event takes into account what terms you've searched for on your way to the issue.

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -32,8 +32,6 @@ In addition, this page provides several other key pieces of information.
 
 ## Event Dropdown
 
-By default, the issues page will display the "Recommended" event. To view other events, you can used the dropdown to skip to the latest or oldest event, or view the full list of events. If you wish to change the default event, you may do so in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
-
 By default, the **Issue Details** page displays the "Recommended" event with the most context to help you solve the issue. Sentry uses the following criteria in determining the recommended event:
 
 - **Recency**: The recommended event is never more than 7 days older than the lastest event.

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -34,7 +34,7 @@ In addition, this page provides several other key pieces of information.
 
 By default, the **Issue Details** page displays the "Recommended" event with the most context to help you solve the issue. Sentry uses the following criteria in determining the recommended event:
 
-- **Recency**: The recommended event is never more than 7 days older than the lastest event.
+- **Recency**: The recommended event is never more than 7 days older than the latest event.
 - **Relevence**: The recommended event takes into account what terms you've searched for on your way to the issue.
 - **Content**: The recommended event prioritizes events that contain debugging tools such as replays, profiles, and traces.
 

--- a/src/docs/product/issues/issue-details/index.mdx
+++ b/src/docs/product/issues/issue-details/index.mdx
@@ -32,14 +32,16 @@ In addition, this page provides several other key pieces of information.
 
 ## Event Dropdown
 
+By default, the issues page will display the "Recommended" event. To view other events, you can used the dropdown to skip to the latest or oldest event, or view the full list of events. If you wish to change the default event, you may do so in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
+
 By default, the **Issue Details** page displays the "Recommended" event with the most context to help you solve the issue. Sentry uses the following criteria in determining the recommended event:
 
-- **Recency**: The recommended event is never more than 7 days older than the latest event.
+- **Recency**: The recommended event is never more than 7 days older than the lastest event.
 - **Relevence**: The recommended event takes into account what terms you've searched for on your way to the issue.
 - **Content**: The recommended event prioritizes events that contain debugging tools such as replays, profiles, and traces.
 
 To view other events, you can use the dropdown to skip to the latest or oldest event, or view the full list of events. You can change the default event in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
- 
+
 ## Trace Navigator
 
 The trace navigator (which displays below the date) is an abbreviated view of the related [trace](/product/sentry-basics/tracing/distributed-tracing) for the current transaction. It displays up to six nodes, each representing different groups of the event's trace:


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adds information about the new event dropdown and the new Recommended event. This feature is currently in EA, but will GA tomorrow on 8/17.

![CleanShot 2023-08-16 at 12 47 21](https://github.com/getsentry/sentry-docs/assets/10888943/4a468f9b-0123-445c-98d6-527b73026f03)
