### PR TITLE
adding responses section explaining timeout

### DIFF
--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -130,6 +130,10 @@ All webhook requests have some common elements.
 }
 ```
 
+## Responses
+
+Webhooks should respond within 1 second otherwise the response is considered a timeout. If the webhook has 1000 timeouts within 24 hours, the webhook will be unsubscribed from receiving events.
+
 ## Event Types
 
 - [Installation](/product/integrations/integration-platform/webhooks/installation/)

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -130,7 +130,7 @@ All webhook requests have some common elements.
 }
 ```
 
-## Responses
+## Response
 
 Webhooks should respond within 1 second. Otherwise, the response is considered a timeout. If a webhook has 1000 timeouts within 24 hours, the webhook will be unsubscribed from receiving events.
 

--- a/src/docs/product/integrations/integration-platform/webhooks.mdx
+++ b/src/docs/product/integrations/integration-platform/webhooks.mdx
@@ -132,7 +132,7 @@ All webhook requests have some common elements.
 
 ## Responses
 
-Webhooks should respond within 1 second otherwise the response is considered a timeout. If the webhook has 1000 timeouts within 24 hours, the webhook will be unsubscribed from receiving events.
+Webhooks should respond within 1 second. Otherwise, the response is considered a timeout. If a webhook has 1000 timeouts within 24 hours, the webhook will be unsubscribed from receiving events.
 
 ## Event Types
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

We have been slowly lowering the timeout from 5 seconds to 3 seconds https://github.com/getsentry/sentry/pull/54645  then 3 seconds to 1 seconds: https://github.com/getsentry/sentry/pull/54879 and want to reflect this in docs 




## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
