### PR TITLE
Add Docs for enabled option for Java SDK

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -575,7 +575,7 @@ If the callback is not set, or it returns `undefined`, the default naming scheme
 
 </PlatformSection>
 
-<ConfigKey name="enabled" supported={["javascript", "node"]}>
+<ConfigKey name="enabled" supported={["javascript", "node", "java"]}>
 
 Specifies whether this SDK should send events to Sentry. Defaults to `true`. Setting this to `enabled: false` doesn't prevent all overhead from Sentry instrumentation. To disable Sentry completely, depending on environment, call `Sentry.init` conditionally.
 

--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -299,7 +299,7 @@ sentry.debug=true
 
 ### Disable Sentry
 
-To disable Sentry in the debug mode, use the `enabled` option:
+To disable Sentry, use the `enabled` option:
 
 ```properties {tabTitle:sentry.properties}
 enabled=false

--- a/src/platforms/java/common/configuration/index.mdx
+++ b/src/platforms/java/common/configuration/index.mdx
@@ -297,6 +297,22 @@ SENTRY_DEBUG=true
 sentry.debug=true
 ```
 
+### Disable Sentry
+
+To disable Sentry in the debug mode, use the `enabled` option:
+
+```properties {tabTitle:sentry.properties}
+enabled=false
+```
+
+```properties {tabTitle:environment variable}
+SENTRY_ENABLED=false
+```
+
+```properties {tabTitle:system property}
+sentry.enabled=false
+```
+
 ## Configuring Timeouts
 
 It’s possible to manually set the connection timeouts length with `connectionTimeoutMillis` and `readTimeoutMillis`:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Documents changes done in https://github.com/getsentry/sentry-java/pull/2840

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
