### PR TITLE
Update index.mdx

### DIFF
--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -22,7 +22,7 @@ description: "Profiling offers a deeper level of visibility on top of traditiona
 
 </Note>
 
-Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. Profiling provides context at a deeper level than traditional tracing, enabling you to visualize the precise details of the call stack without the need for custom instrumentation. With Profiilng you can quickly identify hot paths in your code and understand potential performance bottlenecks, enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one. 
+Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. Profiling provides context at a deeper level than traditional tracing, enabling you to visualize the precise details of the call stack without the need for custom instrumentation. With Profiilng you can quickly identify hot paths in your code and understand potential performance bottlenecks, enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one.
 
 Sentry profiling supports common platforms for both Mobile and Backend applications:
 

--- a/src/docs/product/profiling/index.mdx
+++ b/src/docs/product/profiling/index.mdx
@@ -17,12 +17,12 @@ description: "Profiling offers a deeper level of visibility on top of traditiona
 - [PHP (including Laravel and Symfony)](/platforms/php/profiling/)
 - [Browser JavaScript [beta]](/platforms/javascript/profiling/)
 - [Go [experimental]](/platforms/go/profiling/)
-- [Ruby [experimental]](/platforms/ruby/profiling/)
-- [React Native [experimental]](/platforms/react-native/profiling/)
+- [Ruby [beta]](/platforms/ruby/profiling/)
+- [React Native [beta]](/platforms/react-native/profiling/)
 
 </Note>
 
-Profiling offers a deeper level of visibility on top of traditional tracing, removing the need for custom instrumentation and enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one. Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. This allows you to quickly identify potential performance bottlenecks and visualize the call stack to find hot paths in your code.
+Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. Profiling provides context at a deeper level than traditional tracing, enabling you to visualize the precise details of the call stack without the need for custom instrumentation. With Profiilng you can quickly identify hot paths in your code and understand potential performance bottlenecks, enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one. 
 
 Sentry profiling supports common platforms for both Mobile and Backend applications:
 
@@ -39,15 +39,15 @@ This will take you to the **Transaction Summary** page where you'll see a list o
 
 ![Transaction Summary page](transaction-summary-page.png)
 
-Transaction events that have a profile contain a link in the "Profile" column which will take you to a flame chart with details about that event. Learn how to read [Flame Charts and Flame Graphs](/product/profiling/flame-charts-graphs).
+Transaction events that have a profile contain a link in the "Profile" column which will take you to a flame graph with details about that event. Learn how to read [Flame Graphs and Aggregated Flame Graphs](/product/profiling/flame-charts-graphs).
 
-![Profile details page showing a flame chart](profile-details-flame-chart.png)
+![Profile details page showing a flame graph](profile-details-flame-chart.png)
 
 Alternatively, if you click on the "Event ID" for a transaction, you'll see a span waterfall where you'll can identify suspect spans - operations that may be impacting performance, including slow DB queries and HTTP requests. You can click on a span to see profile information, including the most frequently occurring code path (call stack with with exact line numbers), along with the approximate percentage of time required for that code path.
 
 ![Transaction showing call stack data from a profile](call-stack-transaction.png)
 
-From this view, you can also click "View Profile" to zoom in on the flame chart.
+From this view, you can also click "View Profile" to zoom in on the flame graph.
 
 ## Profiling Page
 
@@ -61,12 +61,12 @@ The "Suspect Functions" widget shows you a list of the functions that took the m
 
 Using the Profiling page is typically an advanced workflow, enabling you to directly select transactions of interest and examine detailed profiling data.
 
-Selecting one of the transactions will take you to the **Profile Summary** page below. On this page, you can examine the consolidated [flame graph](/product/profiling/flame-charts-graphs) that presents aggregated sample data for the selected transaction.
+Selecting one of the transactions will take you to the **Profile Summary** page below. On this page, you can examine the aggregated [flame graph](/product/profiling/flame-charts-graphs) that presents aggregated sample data for the selected transaction.
 
 ![Transaction Profile summary page](transaction-profile-view.png)
 
 ## Learn More
 
-To learn more about profiling tools, read the docs about [Flame Charts and Flame Graphs](/product/profiling/flame-charts-graphs).
+To learn more about profiling tools, read the docs about [Flame Graphs and Aggregated Flame Graphs](/product/profiling/flame-charts-graphs).
 
 <PageGrid />


### PR DESCRIPTION
Profiling team is retiring the "flame chart" term

Instead will use Flame Graph and Aggregated Flame Graph in our docs - This should make the terminology more intuitive.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
