### PR TITLE
Updated asyncio code snippet

### DIFF
--- a/src/platforms/python/common/configuration/integrations/asyncio.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncio.mdx
@@ -14,20 +14,28 @@ pip install --upgrade 'sentry-sdk'
 
 ## Configure
 
-Add `AsyncioIntegration()` to your `integrations` list:
+Add `AsyncioIntegration()` to your `integrations` list. Make sure that you call `sentry_sdk.init()` at the beginning of your async loop:
 
 <SignInNote />
 
-```python
+```python {filename:main.py}
 import sentry_sdk
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 
-sentry_sdk.init(
-    dsn="___PUBLIC_DSN___",
-    integrations=[
-        AsyncioIntegration(),
-    ],
-)
+
+async def main():
+    sentry_sdk.init(
+        dsn="___PUBLIC_DSN___",
+        integrations=[
+            AsyncioIntegration(),
+        ],
+    )
+
+    # your code goes here.
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Behavior

--- a/src/platforms/python/common/configuration/integrations/asyncio.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncio.mdx
@@ -14,7 +14,7 @@ pip install --upgrade 'sentry-sdk'
 
 ## Configure
 
-Add `AsyncioIntegration()` to your `integrations` list. Make sure that you call `sentry_sdk.init()` at the beginning of your async loop:
+Add `AsyncioIntegration()` to your list of `integrations` and be sure to call `sentry_sdk.init()` at the beginning of your async loop:
 
 <SignInNote />
 


### PR DESCRIPTION
Updated the code snippet for AsyncioIntegration in Python to make clear where the call to `sentry_sdk.init()` should go.

See the preview here:
https://sentry-docs-git-antonpirker-python-integration-asyncio.sentry.dev/platforms/python/configuration/integrations/asyncio/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F7662