### PR TITLE
Add sourcemaps wizard to angular source map guide

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.angular.mdx
@@ -1,9 +1,16 @@
 ## Uploading Source Maps in an Angular project
 
-Sentry uses [releases](/product/releases/) to match the correct source maps to your events.
-This page explains how to generate source maps, set releases, and upload source maps to Sentry either manually or automatically when bundling your Angular app.
+### Automatic Setup
 
-### Generating Source Maps
+The easiest way to configure uploading source maps is by using the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx" />
+
+### Manual Setup
+
+If you want to configure source maps upload with Angular manually, follow the steps below.
+
+#### Generating Source Maps
 
 To generate source maps, you need to add the `sourceMap` option to your `angular.json` build configuration:
 
@@ -28,7 +35,7 @@ To generate source maps, you need to add the `sourceMap` option to your `angular
 }
 ```
 
-### Ways to Upload Source Maps
+#### Uploading Source Maps
 
 To upload your Angular project's source maps to Sentry, we recommend one of these options:
 


### PR DESCRIPTION
Seems like we missed this.