### PR TITLE
Add browser profiling to profiling getting started

### DIFF
--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -17,7 +17,7 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 
 </Alert>
 
-- [Browser JavaScript](/platforms/javascript/profiling/)
+- [Browser JavaScript](/platforms/javascript/profiling/) [experimental]
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)

--- a/src/docs/product/profiling/getting-started.mdx
+++ b/src/docs/product/profiling/getting-started.mdx
@@ -17,6 +17,7 @@ Profiling depends on Sentry's performance monitoring product being enabled befor
 
 </Alert>
 
+- [Browser JavaScript](/platforms/javascript/profiling/)
 - Mobile
   - [Android](/platforms/android/profiling/)
   - [iOS](/platforms/apple/guides/ios/profiling/)


### PR DESCRIPTION
Noticed this when clicking docs link in https://blog.sentry.io/profiling-to-speed-up-your-apps/ but didn't see browser profiling 😢.

I wonder if we should add custom instructions for Next.js (setting it up for both server and client)

