### PR TITLE
fix: Clarify string vs regex usage of `ignoreErrors`/`ignoreTransactions`

### DIFF
--- a/src/platforms/common/configuration/filtering.mdx
+++ b/src/platforms/common/configuration/filtering.mdx
@@ -79,7 +79,7 @@ In this example, the fingerprint is forced to a common value if an exception of 
 
 ### Using <PlatformIdentifier name="ignore-errors" />
 
-You can use the <PlatformIdentifier name="ignore-errors" /> option to filter out errors that match a certain pattern. This option receives a list of strings and regular expressions to match against the error message.
+You can use the <PlatformIdentifier name="ignore-errors" /> option to filter out errors that match a certain pattern. This option receives a list of strings and regular expressions to match against the error message. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead.
 
 <PlatformContent includePath="configuration/ignore-errors" />
 </PlatformSection>
@@ -124,7 +124,7 @@ Learn more about <PlatformLink to="/configuration/sampling/">configuring the sam
 
 ### Using <PlatformIdentifier name="ignore-transactions" />
 
-You can use the <PlatformIdentifier name="ignore-transactions" /> option to filter out transactions that match a certain pattern. This option receives a list of strings and regular expressions to match against the transaction name.
+You can use the <PlatformIdentifier name="ignore-transactions" /> option to filter out transactions that match a certain pattern. This option receives a list of strings and regular expressions to match against the transaction name. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead.
 
 <PlatformContent includePath="configuration/ignore-transactions" />
 </PlatformSection>


### PR DESCRIPTION
Small tweak to the "Filtering" page to clarify usage of `ignoreErrors` / `ignoreTransactions` based on this comment https://github.com/getsentry/sentry-javascript/issues/1013#issuecomment-1681145227.