### PR TITLE
Remove beta label for Apollo 3 GraphQL Client Errors

### DIFF
--- a/src/platforms/android/configuration/integrations/apollo3.mdx
+++ b/src/platforms/android/configuration/integrations/apollo3.mdx
@@ -124,8 +124,6 @@ val apollo = ApolloClient.builder()
 
 ## GraphQL Client Errors
 
-<Include name="feature-stage-beta.mdx" />
-
 Once enabled, this feature will automatically capture GraphQL client errors such as bad operations and response codes, and report them to Sentry as error events. Each error event will contain the `request` and `response` data, including the `url`, `status_code`, and `data` (stringified `query`).
 
 Sentry will group GraphQL client errors by the `operationName`, `operationType`, and `statusCode`, so that you can easily see the number of errors that happened for each.


### PR DESCRIPTION
Remove beta label for Apollo 3 GraphQL Client Errors