### PR TITLE
fix(alerts): Add current assignee to issue alert suggested assignees

### DIFF
--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -88,7 +88,7 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 Suggested Assignees include people or teams currently assigned the issue, issue owners defined in [ownership rules](/product/issues/ownership-rules/), and anyone who has been identified as author of a [suspect commit](/product/issues/suspect-commits/). When an alert is triggered, they can choose to be notified via email or Slack (depending on their [notification settings](/product/alerts/notifications/notification-settings/)).
 
-If a suggested assignee hasn't been assigned, configured or found, the notification will be sent to the teams or members specified in the fallback notification setting, as shown below:
+If no suggested assignees are found, the notification will be sent to the teams or members specified in the fallback notification setting, as shown below:
 
 ![Suggested Assignees with notify all project members selected.](suggested_assignee_all_members.png)
 

--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -86,9 +86,9 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Suggested Assignees
 
-Suggested Assignees are people who have either been assigned as [owners of an issue](/product/issues/ownership-rules/) or have been identified as authors of the commit and pull request in which a [suspect commit](/product/issues/suspect-commits/) was made. When an alert is triggered, they can choose to be notified via email or Slack, (depending on their [notification settings](/product/alerts/notifications/notification-settings/).
+Suggested Assignees are people or teams that are currently assigned the issue, assigned as [owners of an issue](/product/issues/ownership-rules/) or have been identified as authors of the commit and pull request in which a [suspect commit](/product/issues/suspect-commits/) was made. When an alert is triggered, they can choose to be notified via email or Slack, (depending on their [notification settings](/product/alerts/notifications/notification-settings/).
 
-If a suggested assignee hasn't been configured or found, the notification will be sent to the teams or members specified in the fallback notification setting, as shown below:
+If a suggested assignee hasn't been assigned, configured or found, the notification will be sent to the teams or members specified in the fallback notification setting, as shown below:
 
 ![Suggested Assignees with notify all project members selected.](suggested_assignee_all_members.png)
 

--- a/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/src/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -86,7 +86,7 @@ Learn more about [routing alerts with integrations](/product/alerts/create-alert
 
 ### Suggested Assignees
 
-Suggested Assignees are people or teams that are currently assigned the issue, assigned as [owners of an issue](/product/issues/ownership-rules/) or have been identified as authors of the commit and pull request in which a [suspect commit](/product/issues/suspect-commits/) was made. When an alert is triggered, they can choose to be notified via email or Slack, (depending on their [notification settings](/product/alerts/notifications/notification-settings/).
+Suggested Assignees include people or teams currently assigned the issue, issue owners defined in [ownership rules](/product/issues/ownership-rules/), and anyone who has been identified as author of a [suspect commit](/product/issues/suspect-commits/). When an alert is triggered, they can choose to be notified via email or Slack (depending on their [notification settings](/product/alerts/notifications/notification-settings/)).
 
 If a suggested assignee hasn't been assigned, configured or found, the notification will be sent to the teams or members specified in the fallback notification setting, as shown below:
 


### PR DESCRIPTION
issue alerts using "Suggested Assignee" are now alerting the current assignee

more docs https://www.notion.so/sentry/Suggested-Assignees-Issue-Owners-Issue-alert-fallback-settings-91e6dfdbe8b4494886d360893443b0bf?pvs=4