### PR TITLE
fix(apple): App hanging when Watchdog termination is enabled

### DIFF
--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -16,7 +16,7 @@ Recording the stack trace precisely when the app hang occurs works reliably if t
 
 The SDK reports an app hang immediately, but doesn’t report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app anytime if it's blocking the main thread.
 
-When watchdog termination tracking is enabled, the app hang code is disabled, runs in the background, and won’t report app hangs. This is done to minimize the number of false errors being reported by watchdog termination tracking, (such as if the OS kills an app causing an app hang).
+When watchdog termination tracking is enabled, the app hang code even if disabled, runs in the background, and won’t report app hangs. This is done to minimize the number of false errors being reported by watchdog termination tracking, (such as if the OS kills an app causing an app hang).
 
 Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, SentryCrashIntegration has to be enabled for the integration to work.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Description of app hanging code running when watchdog termination is enabled was wrong.
