### PR TITLE
design: tweak sidebar font color to have higher contrast ratio

### DIFF
--- a/src/css/_includes/sidebar.scss
+++ b/src/css/_includes/sidebar.scss
@@ -75,7 +75,7 @@
   position: relative;
   line-height: 1.5;
   border-radius: 0.125em;
-  color: $desatPurple6;
+  color: $desatPurple0;
   padding: 0.25em 0.5em;
   opacity: 0.8;
   text-decoration: none;


### PR DESCRIPTION
<img width="292" alt="Screenshot 2023-08-23 at 5 27 19 PM" src="https://github.com/getsentry/sentry-docs/assets/1976777/734a4039-3787-40c9-a1d7-07705befed80">
<img width="313" alt="Screenshot 2023-08-23 at 5 27 27 PM" src="https://github.com/getsentry/sentry-docs/assets/1976777/ba48b190-7cdf-4a09-aa2c-8bd647bcbf86">

Before and after. Our current sidebar text-to-background contrast ratio is 3.54, while 4.5 is the recommended ratio for text. This should make the sidebar text a bit easier to read https://www.w3.org/TR/WCAG20-TECHS/G18.html

lmk thoughts on if color should be tweaked.

part of replays-accessibility hackweek project