### PR TITLE
[sentry-cli] use debug-files instead of difutil

### DIFF
--- a/src/docs/product/cli/dif.mdx
+++ b/src/docs/product/cli/dif.mdx
@@ -23,10 +23,10 @@ differently in Sentry. For more information see [Source Maps in sentry-cli](/pro
 ## Checking Files
 
 Not all debug information files can be used by Sentry. To see if they are usable
-or not, you can use the `sentry-cli difutil check` command:
+or not, you can use the `sentry-cli debug-files check` command:
 
 ```bash
-sentry-cli difutil check mylibrary.so.debug
+sentry-cli debug-files check mylibrary.so.debug
 
 Debug Info File Check
   Type: elf debug companion
@@ -43,11 +43,11 @@ if it passes basic requirements for Sentry.
 ## Finding Files
 
 If you see in Sentry's UI that debug information files are missing, but you are
-not sure how to locate them, you can use the `sentry-cli difutil find` command
+not sure how to locate them, you can use the `sentry-cli debug-files find` command
 to look for them:
 
 ```bash
-sentry-cli difutil find <identifier>
+sentry-cli debug-files find <identifier>
 ```
 
 Additionally, `sentry-cli debug-files upload` can automatically search for files in a
@@ -64,12 +64,12 @@ This is particularly useful when building and uploading debug information files
 are detached. In this case, a source bundle can be created when building and can
 be uploaded at any later point in time with `sentry-cli debug-files upload`.
 
-To create a source bundle, use the `difutil bundle-sources` command on a list of
+To create a source bundle, use the `debug-files bundle-sources` command on a list of
 debug information files:
 
 ```bash
 # on the build machine:
-sentry-cli difutil bundle-sources /path/to/files...
+sentry-cli debug-files bundle-sources /path/to/files...
 
 # at any later time:
 sentry-cli debug-files upload --type sourcebundle /path/to/bundles...
@@ -175,7 +175,7 @@ information.
 are available on the local file system, they are bundled and uploaded as a
 source archive. This allows Sentry to resolve source context. Only specify
 this command when uploading from the same machine as the build. Otherwise, use
-`difutil bundle-sources` to generate the bundle ahead of time.
+`debug-files bundle-sources` to generate the bundle ahead of time.
 
 `--derived-data`
 

--- a/src/platforms/common/data-management/debug-files/identifiers.mdx
+++ b/src/platforms/common/data-management/debug-files/identifiers.mdx
@@ -101,7 +101,7 @@ tool can do this for you automatically.
 
 Unlike other debug information files, ProGuard files do not have an intrinsic
 unique identifier. Sentry CLI assigns them a SHA1 UUID based on the checksum of
-the file. You can use `sentry-cli difutil check` on a ProGuard file to see the
+the file. You can use `sentry-cli debug-files check` on a ProGuard file to see the
 generated UUID.
 
 If you need to generate the UUID yourself, you can do so with the following


### PR DESCRIPTION
While `difutil` still exists as an alias, `debug-files` seems to be the preferred sub-command name for uploading debug-files. Now, the docs inconsistently present both, which confuses users. This PR replaces all uses with the new preference.

CC @Swatinem, @bitsandfoxes, @markushi 