### PR TITLE
Add Troubleshooting section to Discord docs

### DIFF
--- a/src/docs/product/accounts/early-adopter-features/discord/index.mdx
+++ b/src/docs/product/accounts/early-adopter-features/discord/index.mdx
@@ -82,3 +82,13 @@ All users in any Discord server with the Sentry bot can use the `/link` command 
 ![Discord identity linking page](discord-identity-link-page.png)
 
 To unlink your accounts, use the `/unlink` command. Follow the link and click "Unlink from Discord"
+
+### Troubleshooting
+
+#### Your channel ID isn't working in the alert creation wizard
+
+If you're trying to create an alert with a Discord action and we're telling you that we can't access the channel you've provided, please double check the following:
+
+- You are giving us a channel ID and not a channel name or something else. See [Configure](#configure) for more details.
+- The channel your trying to add is in the same server that is selected in the alert action.
+- The bot has access to the channel you're trying to use. A quick way to verify this is to check whether you can find the bot in the list of users on the right hand side of Discord while currently in the desired channel. If you do not see the bot in the list of users, you will need to update your Discord role and/or channel permissions to allow the bot access.

--- a/src/docs/product/accounts/early-adopter-features/discord/index.mdx
+++ b/src/docs/product/accounts/early-adopter-features/discord/index.mdx
@@ -87,8 +87,8 @@ To unlink your accounts, use the `/unlink` command. Follow the link and click "U
 
 #### Your channel ID isn't working in the alert creation wizard
 
-If you're trying to create an alert with a Discord action and we're telling you that we can't access the channel you've provided, please double check the following:
+If you're trying to create an alert with a Discord action and Sentry can't access the channel you've provided, please double-check the following:
 
 - You are giving us a channel ID and not a channel name or something else. See [Configure](#configure) for more details.
-- The channel your trying to add is in the same server that is selected in the alert action.
-- The bot has access to the channel you're trying to use. A quick way to verify this is to check whether you can find the bot in the list of users on the right hand side of Discord while currently in the desired channel. If you do not see the bot in the list of users, you will need to update your Discord role and/or channel permissions to allow the bot access.
+- The channel you're trying to add is in the same server that is selected in the alert action.
+- The bot has access to the channel you're trying to use. A quick way to verify this is to check whether you can find the bot in the desired channel's member list. If you do not see the bot in the list of users, you may need to update your Discord role and/or channel permissions to allow the bot access. See [Install](#install) for more details.


### PR DESCRIPTION
Just mimicking the Slack integration docs. We wanted somewhere to put Q & A/troubleshooting info based on our experiences with user issues.