### PR TITLE
feat(org-tokens): Update link & docs for org token creation

### DIFF
--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -113,8 +113,7 @@ function OrgAuthTokenCreator() {
   );
   const [token, setToken] = useState(null);
   const [sharedSelection] = codeContext.sharedKeywordSelection;
-
-  const {codeKeywords} = useContext(CodeContext);
+  const {codeKeywords} = codeContext;
 
   const choices = codeKeywords?.PROJECT;
 

--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -24,7 +24,7 @@ export function OrgAuthTokenNote() {
 
   const url = data.site.siteMetadata.siteUrl + location.pathname;
 
-  const orgAuthTokenUrl = OrgAuthTokenUrl();
+  const orgAuthTokenUrl = useOrgAuthTokenUrl();
 
   return (
     <Fragment>
@@ -56,19 +56,16 @@ export function OrgAuthTokenNote() {
   );
 }
 
-export function OrgAuthTokenUrl() {
-  const codeContext = useContext(CodeContext);
-
-  const [sharedSelection] = codeContext.sharedKeywordSelection;
-  const {codeKeywords} = codeContext;
-
-  const choices = codeKeywords?.PROJECT;
+export function useOrgAuthTokenUrl() {
+  const {codeKeywords, sharedKeywordSelection} = useContext(CodeContext);
+  const [sharedSelection] = sharedKeywordSelection
 
   // When not signed in, we use a redirect URL that uses the last org the user visited
   if (!codeKeywords.USER) {
     return 'https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/';
   }
 
+  const choices = codeKeywords?.PROJECT;
   const currentSelectionIdx = sharedSelection.PROJECT ?? 0;
   const currentSelection = choices[currentSelectionIdx];
 

--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -58,7 +58,7 @@ export function OrgAuthTokenNote() {
 
 export function useOrgAuthTokenUrl() {
   const {codeKeywords, sharedKeywordSelection} = useContext(CodeContext);
-  const [sharedSelection] = sharedKeywordSelection
+  const [sharedSelection] = sharedKeywordSelection;
 
   // When not signed in, we use a redirect URL that uses the last org the user visited
   if (!codeKeywords.USER) {

--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -1,8 +1,9 @@
-import React, {Fragment} from 'react';
+import React, {Fragment, useContext} from 'react';
 import {useLocation} from '@reach/router';
 import {graphql, useStaticQuery} from 'gatsby';
 
 import {Alert} from './alert';
+import {CodeContext} from './codeContext';
 import {ExternalLink} from './externalLink';
 import {Note} from './note';
 import {SignedInCheck} from './signedInCheck';
@@ -23,12 +24,14 @@ export function OrgAuthTokenNote() {
 
   const url = data.site.siteMetadata.siteUrl + location.pathname;
 
+  const orgAuthTokenUrl = OrgAuthTokenUrl();
+
   return (
     <Fragment>
       <SignedInCheck isUserAuthenticated={false}>
         <Note>
           You can{' '}
-          <ExternalLink href="https://sentry.io/settings/auth-tokens/" target="_blank">
+          <ExternalLink href={orgAuthTokenUrl} target="_blank">
             manually create an Auth Token
           </ExternalLink>{' '}
           or{' '}
@@ -41,10 +44,35 @@ export function OrgAuthTokenNote() {
 
       <SignedInCheck isUserAuthenticated>
         <Alert level="warning">
-          A created token will only be visible once right after creation - make sure to
-          copy it!
+          You can{' '}
+          <ExternalLink href={orgAuthTokenUrl} target="_blank">
+            manually create an Auth Token
+          </ExternalLink>{' '}
+          or create a token directly from the docs. A created token will only be visible
+          once right after creation - make sure to copy it!
         </Alert>
       </SignedInCheck>
     </Fragment>
   );
+}
+
+export function OrgAuthTokenUrl() {
+  const codeContext = useContext(CodeContext);
+
+  const [sharedSelection] = codeContext.sharedKeywordSelection;
+  const {codeKeywords} = codeContext;
+
+  const choices = codeKeywords?.PROJECT;
+
+  // When not signed in, we use a redirect URL that uses the last org the user visited
+  if (!codeKeywords.USER) {
+    return 'https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/';
+  }
+
+  const currentSelectionIdx = sharedSelection.PROJECT ?? 0;
+  const currentSelection = choices[currentSelectionIdx];
+
+  const org = currentSelection.ORG_SLUG;
+
+  return `https://sentry.io/settings/${org}/auth-tokens/`;
 }

--- a/src/includes/sourcemaps-create-react-app.mdx
+++ b/src/includes/sourcemaps-create-react-app.mdx
@@ -43,15 +43,11 @@ For more info on `sentry-cli` configuration visit the [Sentry CLI configuration 
 
 Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
 
-<SignInNote />
-
 <OrgAuthTokenNote />
 
 ```bash {filename:.env}
 SENTRY_ORG=___ORG_SLUG___
 SENTRY_PROJECT=___PROJECT_SLUG___
-# Auth tokens can be obtained from
-# https://sentry.io/settings/auth-tokens/
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 

--- a/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/src/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -36,15 +36,11 @@ Learn more about configuring the plugin in our [Sentry webpack plugin documentat
 
 You'll have to setup your environment variables first. In most cases, you'll either want to add the env. variables to a `.env` file (e.g. when deploying locally), or you'll have to add them to your CI/CD environment.
 
-<SignInNote />
-
 <OrgAuthTokenNote />
 
 ```bash {filename:.env}
 SENTRY_ORG=___ORG_SLUG___
 SENTRY_PROJECT=___PROJECT_SLUG___
-# Auth tokens can be obtained from
-# https://sentry.io/settings/auth-tokens/
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 


### PR DESCRIPTION
When signed in:

![Screenshot 2023-08-29 at 11 46 54](https://github.com/getsentry/sentry-docs/assets/2411343/f8faf53b-448a-4add-84da-8e8ab7da3901)

When not signed in:

![Screenshot 2023-08-29 at 11 46 30](https://github.com/getsentry/sentry-docs/assets/2411343/9969e483-7487-4b16-9e88-acd5cbf10ffb)

The link for the org token creation should be the correct one, either using a redirect or the actual org in the URL.