### PR TITLE
clarify watchdog thread with apphang disabled

### DIFF
--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -10,15 +10,13 @@ Trying to use an unresponsive app is extremely frustrating for users. There are 
 
 The app hang detection integration has a default timeout of two (2) seconds, but with version 7.24.0, we’ve improved the algorithm to detect app hangs sooner, decreasing from `appHangTimeoutInterval * 2` to `appHangTimeoutInterval * 1.2`.
 
-To detect app hangs, the SDK launches a dedicated watchdog thread, periodically enqueues work items on the main thread, and checks if the main thread is executing them within the timeout. If the app is unresponsive for two seconds or more, it creates an error event.
+To detect app hangs, the SDK launches a dedicated watchdog thread called `io.sentry.AppHangTracker`, which periodically enqueues work items on the main thread, and checks if the main thread is executing them within the timeout. If the app is unresponsive for two seconds or more, it creates an error event. Note that this thread is also used by <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink> and will be launched even if `enableAppHangTracking` is disabled.
 
 Recording the stack trace precisely when the app hang occurs works reliably if the app is completely stuck, but if the main thread is extremely busy with different code spots, the app hang detection might fire a bit too late. If this happens, the SDK may record a stack trace that isn’t 100% related to the code, causing the app to hang. Each event has a stack trace of all running threads so you can easily detect where the problem occurred.
 
 The SDK reports an app hang immediately, but doesn’t report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app anytime if it's blocking the main thread.
 
-When watchdog termination tracking is enabled, the app hang code runs in the background, even if `enableAppHangTracking` is disabled, and won’t report app hangs. This minimizes the number of false errors reported by watchdog termination tracking, for example, if the OS kills an app causing an app hang.
-
-Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, SentryCrashIntegration has to be enabled for the integration to work.
+Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, SentryCrashIntegration has to be enabled for the integration to work. 
 
 Starting with version 8.0.0, this feature has been enabled by default. To disable it:
 

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -16,7 +16,7 @@ Recording the stack trace precisely when the app hang occurs works reliably if t
 
 The SDK reports an app hang immediately, but doesn’t report the exact duration because the [watchdog](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) could kill the app anytime if it's blocking the main thread.
 
-Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, SentryCrashIntegration has to be enabled for the integration to work. 
+Because the app hang detection integration uses SentryCrashIntegration to capture the stack trace when creating app hang events, SentryCrashIntegration has to be enabled for the integration to work.
 
 Starting with version 8.0.0, this feature has been enabled by default. To disable it:
 

--- a/src/platforms/apple/common/configuration/app-hangs.mdx
+++ b/src/platforms/apple/common/configuration/app-hangs.mdx
@@ -10,7 +10,7 @@ Trying to use an unresponsive app is extremely frustrating for users. There are 
 
 The app hang detection integration has a default timeout of two (2) seconds, but with version 7.24.0, we’ve improved the algorithm to detect app hangs sooner, decreasing from `appHangTimeoutInterval * 2` to `appHangTimeoutInterval * 1.2`.
 
-To detect app hangs, the SDK launches a dedicated watchdog thread called `io.sentry.AppHangTracker`, which periodically enqueues work items on the main thread, and checks if the main thread is executing them within the timeout. If the app is unresponsive for two seconds or more, it creates an error event. Note that this thread is also used by <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink> and will be launched even if `enableAppHangTracking` is disabled.
+To detect app hangs, the SDK launches a dedicated watchdog thread called `io.sentry.AppHangTracker`, which periodically enqueues work items on the main thread, and checks if the main thread is executing them within the timeout. If the app is unresponsive for two seconds or more, it creates an error event. This thread is also used by <PlatformLink to="/configuration/watchdog-terminations/">Watchdog Terminations</PlatformLink> and will be launched even if `enableAppHangTracking` is disabled.
 
 Recording the stack trace precisely when the app hang occurs works reliably if the app is completely stuck, but if the main thread is extremely busy with different code spots, the app hang detection might fire a bit too late. If this happens, the SDK may record a stack trace that isn’t 100% related to the code, causing the app to hang. Each event has a stack trace of all running threads so you can easily detect where the problem occurred.
 


### PR DESCRIPTION
fixes/improves wording around app hang detection thread also running when app hang feature is disabled

the [previous change](https://github.com/getsentry/sentry-docs/pull/7681/files) still left some confusion - this removes the old paragraph completely and adds a clear message regarding the thread. the necessary information about watchdog terminations not being reported in case of app hangs is already captured on the [watchdog termination page](https://docs.sentry.io/platforms/apple/guides/ios/configuration/watchdog-terminations/), which is a better place to point this out.