### PR TITLE
fix(a11y): add more contrast to sidebar links

### DIFF
--- a/src/css/_includes/sidebar.scss
+++ b/src/css/_includes/sidebar.scss
@@ -106,7 +106,7 @@
     line-height: 1.5;
     display: block;
     border-radius: 0.125em;
-    color: $desatPurple6;
+    color: $desatPurple3;
     padding: 0.25em 0;
     opacity: 0.8;
     text-decoration: none;


### PR DESCRIPTION
darker text, higher contrast -- fixes accessibility constrast minimum on sidebar links https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
<img width="253" alt="Screenshot 2023-08-29 at 4 35 48 PM" src="https://github.com/getsentry/sentry-docs/assets/1976777/b4887d17-8a38-48e1-9625-cdd60ba804e7">
<img width="276" alt="Screenshot 2023-08-29 at 4 35 38 PM" src="https://github.com/getsentry/sentry-docs/assets/1976777/316f2ca2-e9c7-491c-aafc-9ac4e5975409">

before and after. 


