### PR TITLE
fix(a11y): add lang attribute to site config

### DIFF
--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -216,6 +216,7 @@ const config = {
     homeUrl: 'https://docs.sentry.io',
     siteUrl: 'https://docs.sentry.io',
     sitePath: 'docs.sentry.io',
+    lang: 'en',
     description: 'Product documentation for Sentry.io and its SDKs',
     author: '@getsentry',
   },


### PR DESCRIPTION
We weren't setting a lang attribute previously. fixes https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html on our docs site.