### PR TITLE
ref: Specify that only archived issues escalate

### DIFF
--- a/src/docs/product/issues/states-triage/escalating-issues/index.mdx
+++ b/src/docs/product/issues/states-triage/escalating-issues/index.mdx
@@ -8,7 +8,7 @@ description: "Learn how the escalating issues algorithm works."
 
 Sentry defines an issue as `Escalating` when the number of events is significantly higher than the previous week.
 
-The escalating issues algorithm uses historical data from the previous week to calculate thresholds for the next week on a per-issue basis. If an issue exceeds its predetermined threshold, it gets tagged as `Escalating`, unless it was "[Archived Forever](/product/issues/states-triage/#archive)". An escalating issue is automatically surfaced in the "Unresolved" and "Escalating" tabs.
+The escalating issues algorithm uses historical data from the previous week to calculate thresholds for the next week on a per-issue basis. If an archived issue exceeds its predetermined threshold, it gets tagged as `Escalating`, unless it was "[Archived Forever](/product/issues/states-triage/#archive)". An escalating issue is automatically surfaced in the "Unresolved" and "Escalating" tabs.
 
 ## Escalating Limit Calculation
 


### PR DESCRIPTION
Follow up to this [conversation](https://github.com/getsentry/sentry-docs/pull/6980#discussion_r1312180871):
- Currently, only archived issues escalate so we should specify this