### PR TITLE
ref: Fix issue triage docs for escalating

### DIFF
--- a/src/docs/product/issues/index.mdx
+++ b/src/docs/product/issues/index.mdx
@@ -46,7 +46,9 @@ From the **Issues** page, you can begin to triage. The page is organized into ta
 
 - All Unresolved (`is:unresolved`): All unresolved issues, including issues that need review.
 - For Review (`is:unresolved is:for_review`): Also called **Review List**. Issues that need to be reviewed; for-review issues are a sub-set of all unresolved issues.
-- Ignored (`is:ignored`): All ignored issues.
+- Regressed (`is:regressed`): All regressed issues; resolved issues that have come up again.
+- Archived (`is:archived`): All archived issues.
+- Escalating (`is:escalating`): All escalating issues; previously archived issues that have exceeded their forecasted event volume.
 
 Learn more about triaging issues and their different states in [Issue States and Triage](/product/issues/states-triage/).
 


### PR DESCRIPTION
On https://docs.sentry.io/product/issues/#issue-triage:
- Add Regressed, Escalating (and their search terms)
- Update Ignored to Archived
