### PR TITLE
feat(js): Update Micro frontends docs to include new bundler plugins support

### DIFF
--- a/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
+++ b/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
@@ -1,6 +1,7 @@
 ---
 title: Micro Frontend Support
 sidebar_order: 200
+description: Learn how to identify the source of errors and route events to different Sentry projects when using micro frontend or module federation.
 keywords:
   [
     "micro frontend",
@@ -15,9 +16,12 @@ different release cycles, you may want to identify these or route events to spec
 
 ## Identifying the source of errors
 
-To identify the source of an error, you must inject metadata that helps identify which bundles were responsible for an error. You can do this with the `@sentry/webpack-plugin` by enabling the `_experiments.moduleMetadata` option.
+To identify the source of an error, you must inject metadata that helps identify
+which bundles were responsible for the error. You can do this with any of the
+Sentry bundler plugins by enabling the `_experiments.moduleMetadata` option.
 
-Requires version `2.5.0` or higher of `@sentry/webpack-plugin`.
+Requires version `2.5.0` or higher of `@sentry/webpack-plugin` or version
+`2.7.0` or higher of `@sentry/rollup-plugin`, `@sentry/vite-plugin` or `@sentry/esbuild-plugin`.
 
 `moduleMetadata` can be any serializable data or alternatively a function that
 returns serializable data. If you supply a function, it will be passed an object


### PR DESCRIPTION
This PR updates the docs for micro-frontend support since metadata injection is now supported by all bundler plugins.

I also added a description since I noticed one was missing: 

<img width="495" alt="image" src="https://github.com/getsentry/sentry-docs/assets/1150298/c8a8234b-f49d-477a-aa9e-a4748932742e">
