### PR TITLE
Remove suggestion that OTEL is needed for Spring WebFlux performance

### DIFF
--- a/src/platforms/java/guides/spring-boot/webflux.mdx
+++ b/src/platforms/java/guides/spring-boot/webflux.mdx
@@ -4,4 +4,4 @@ sidebar_order: 6
 description: "Learn more about using Spring WebFlux with Sentry."
 ---
 
-Similar to Spring MVC, Sentry offers support for Spring WebFlux. When developing a reactive web application, Sentry Spring Boot Starter creates the infrastructure required for capturing errors triggered during HTTP request processing. If you would like to use [performance monitoring](/product/performance/) with WebFlux, please take a look at our <PlatformLink to="/performance/instrumentation/opentelemetry/">OpenTelemetry integration</PlatformLink>.
+Similar to Spring MVC, Sentry offers support for Spring WebFlux. When developing a reactive web application, Sentry Spring Boot Starter creates the infrastructure required for capturing errors triggered during HTTP request processing.


### PR DESCRIPTION
Came up in https://github.com/getsentry/sentry-java/issues/2907

This is no longer true as of `6.16.0` of the Java SDK.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
