### PR TITLE
THOUGHT EXPERIMENT: new performance api

### DIFF
--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -31,86 +31,114 @@ redirect_from:
   - /performance/custom-instrumentation
 ---
 
+
 <Note>
 
-To capture transactions and spans customized to your organization's needs, you must first <PlatformLink to="/performance/">set up performance monitoring.</PlatformLink>
+This is just a THOUGHT experiment and should not be merged!
 
 </Note>
 
-<PlatformSection notSupported={["javascript", "node"]}>
 
-<PlatformContent includePath="performance/enable-manual-instrumentation" />
 
-<PlatformContent includePath="performance/add-spans-example" />
+## Creating Spans
 
-</PlatformSection>
+```javascript
+function doWork() {
+  const result = Sentry.startSpan({ name: "Important Function" }, () => {
+    return expensiveFunction();
+  });
+}
+```
 
-<PlatformSection supported={["javascript", "node"]}>
+## Creacting Nested Spans
 
-To add custom performance data to your application, you need to create and use spans. Spans are a way to measure the time it takes for a specific action to occur. For example, you can create a span to measure the time it takes for a function to execute.
+If you have a distinct sub-operation you’d like to track as a part of another one, you can create spans to represent the relationship:
 
-To start measuring timing data, you first need to import the SDK.
+```javascript
+function doWork() {
+  const result = Sentry.startSpan({ name: "Parent Span" }, () => {
+    return expensiveParentFunction();
 
-<PlatformContent includePath="enriching-events/import" />
+    const res = Sentry.startSpan({ name: "Child Span" }, () => {
+      return expensiveChildFunction();
+    });
+  });
+}
+```
 
-<PlatformContent includePath="performance/span-api-version" />
 
-## Create Active Span
+## Creating Spans with Decorators
 
-By default created spans are considered active, which means they are put on the Sentry scope. This allows child spans and Sentry errors to be associated with that span. This is the recommended way to create spans.
+It’s common to have a single span track the execution of an entire function. In that scenario, there is a decorator you can use to reduce code:
 
-<PlatformContent includePath="performance/add-active-span" />
+```javascript
+???
 
-## Get Active Span
+// TBD
+```
 
-You can also get the current active span, which is useful for when you need to add new child spans.
+Use of the decorator is equivalent to creating the span inside do_work() and ending it when do_work() is finished.
 
-<PlatformContent includePath="performance/get-span" />
+The function name will be used as the spans name.
 
-## Start Independent Spans
 
-If you want to add a span that is not active, you can create a independent spans. This is useful for when you have work that is grouped together under a single parent span, but is independent from the current active span. In most cases you'll want to create and use active spans.
+## Creating Spans That Need Manual Finishing
 
-<PlatformContent includePath="performance/add-independent-span" />
+Sometimes you do not want to use context managers, and do want to finish spans on your own. You can do this:
 
-## Start Transaction
+```javascript
+const parentSpan = Sentry.startSpan({ name: "Parent Span" });
 
-The root span (the span that is the parent of all other spans) is known as a transaction in Sentry. This can be accessed and created separately if you need more control over the timing data or if you use a version of the SDK that does not support the top level span APIs.
+parentWork();
 
-<PlatformContent includePath="performance/enable-manual-instrumentation" />
+const childSpan = Sentry.startSpan({ name: "Child Span" });
 
-<PlatformContent includePath="performance/add-spans-example" />
+childWork();
 
-## Adding Span operations
+childSpan.finish();
+parentSpan.finish();
+```
 
-Spans can have an operation associated with them, which help activate Sentry identify additional context about the span. For example database related spans have the `db` span operation associated with them. The Sentry product offers additional controls, visualizations and filters for spans with known operations.
+If you want to create independend spans that are not in a parent/child relation ship a as above you can create them like this:
 
-Sentry maintains a [list of well known span operations](https://develop.sentry.dev/sdk/performance/span-operations/#list-of-operations) and it is recommended that you use one of those operations if it is applicable to your span.
+```javascript
+const span1 = Sentry.startSpan({ name: "first-step", independend: true });
 
-<PlatformContent includePath="performance/span-operations" />
+firstStep();
 
-</PlatformSection>
+const span2 = Sentry.startSpan({ name: "second-step", independend: true });
 
-<PlatformSection supported={["java", "apple"]}>
+secondStep();
 
-<PlatformContent includePath="performance/create-transaction-bound-to-scope" />
+const span3 = Sentry.startSpan({ name: "third-step", independend: true });
 
-</PlatformSection>
+thirdStep();
 
-<PlatformSection notSupported={["java", "native", "apple", "javascript", "node"]}>
+span1.finish();
+span2.finish();
+span3.finish();
+```
 
-<PlatformContent includePath="performance/retrieve-transaction" />
+Now there will be no child relation between the spans, they will be siblings in the span tree.
 
-</PlatformSection>
 
-<PlatformSection supported={["rust", "native"]}>
+## Accessing the Current Span
 
-<PlatformContent includePath="performance/concurrency" />
+Sometimes it’s helpful to access whatever the current span is at a point in time so that you can enrich it with more information.
 
-</PlatformSection>
+```javascript
+const currentSpan = Sentry.getActiveSpan();
+// enrich 'currentSpan' with some information
+```
 
-<PlatformSection supported={["java", "dart", "flutter", "rust", "native", "apple"]}>
+## Add Data to a Span
 
-<PlatformContent includePath="performance/connect-errors-spans" />
+You can add additional data to a span so it carries more information about the current operation that it’s tracking.
 
-</PlatformSection>
+```javascript
+const currentSpan = Sentry.getActiveSpan();
+
+currentSpan?.setData("operation.value", 1);
+currentSpan?.setData("operation.name", "Saying hello!");
+currentSpan?.setData("operation.other-stuff", [1, 2, 3]);
+```

--- a/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/common/performance/instrumentation/custom-instrumentation.mdx
@@ -31,14 +31,11 @@ redirect_from:
   - /performance/custom-instrumentation
 ---
 
-
 <Note>
 
 This is just a THOUGHT experiment and should not be merged!
 
 </Note>
-
-
 
 ## Creating Spans
 
@@ -66,7 +63,6 @@ function doWork() {
 }
 ```
 
-
 ## Creating Spans with Decorators
 
 It’s common to have a single span track the execution of an entire function. In that scenario, there is a decorator you can use to reduce code:
@@ -80,7 +76,6 @@ It’s common to have a single span track the execution of an entire function. I
 Use of the decorator is equivalent to creating the span inside do_work() and ending it when do_work() is finished.
 
 The function name will be used as the spans name.
-
 
 ## Creating Spans That Need Manual Finishing
 
@@ -120,7 +115,6 @@ span3.finish();
 ```
 
 Now there will be no child relation between the spans, they will be siblings in the span tree.
-
 
 ## Accessing the Current Span
 

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation-old.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation-old.mdx
@@ -1,0 +1,182 @@
+---
+title: Custom Instrumentation
+sidebar_order: 20
+description: "Learn how to capture performance data on any action in your app."
+---
+
+The Sentry SDK for Python does a very good job of auto instrumenting your application. If you use one of the popular frameworks, we've got you covered because everything is instrumented out of the box. The Sentry SDK will check your installed Python packages and auto enable the matching SDK integrations.
+
+## Add a Transaction
+
+Adding transactions will allow you to instrument and capture certain regions of your code.
+
+<Note>
+
+If you're using one of Sentry's SDK integrations, transactions will be created for you automatically.
+
+</Note>
+
+The following example creates a transaction for an expensive operation (in this case,`eat_pizza`), and then sends the result to Sentry:
+
+```python
+import sentry_sdk
+
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
+```
+
+## Add Spans to a Transaction
+
+If you want to have more fine-grained performance monitoring, you can add child spans to your transaction, which can be done by either:
+
+- Using a context manager or
+- Using a decorator, (this works on sync and `async` functions)
+
+Calling a `sentry_sdk.start_span()` will find the current active transaction and attach the span to it.
+
+### Using a Context Manager
+
+```python
+import sentry_sdk
+
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            with sentry_sdk.start_span(description="Eat Slice"):
+                eat_slice(pizza.slices.pop())
+
+```
+
+### Using a Decorator
+
+```python
+import sentry_sdk
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    ...
+
+def eat_pizza(pizza):
+    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
+        while pizza.slices > 0:
+            eat_slice(pizza.slices.pop())
+
+```
+
+## Nested Spans
+
+Spans can be nested to form a span tree. If you'd like to learn more, read our [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.
+
+### Using a Context Manager
+
+```python
+import sentry_sdk
+
+def chew():
+    ...
+
+def swallow():
+    ...
+
+def eat_slice(slice):
+    with sentry_sdk.start_span(description="Eat Slice"):
+        with sentry_sdk.start_span(description="Chew"):
+            chew()
+        with sentry_sdk.start_span(description="Swallow"):
+            swallow()
+
+```
+
+### Using a Decorator
+
+```python
+import sentry_sdk
+
+@sentry_sdk.trace
+def chew():
+    ...
+
+@sentry_sdk.trace
+def swallow():
+    ...
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    chew()
+    swallow()
+```
+
+## Define Span Creation in a Central Place
+
+To avoid having custom performance instrumentation code scattered all over your code base, pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
+
+<SignInNote />
+
+```python
+import sentry_sdk
+
+functions_to_trace = [
+    {"qualified_name": "myrootmodule.eat_slice"},
+    {"qualified_name": "myrootmodule.swallow"},
+    {"qualified_name": "myrootmodule.chew"},
+    {"qualified_name": "myrootmodule.someothermodule.another.some_function"},
+    {"qualified_name": "myrootmodule.SomePizzaClass.some_method"},
+]
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    functions_to_trace=functions_to_trace,
+)
+```
+
+Now, whenever a function specified in `functions_to_trace` will be executed, a span will be created and attached as a child to the currently running span.
+
+<Alert level="warning" title="Important">
+
+To enable performance monitoring for the functions specified in `functions_to_trace`, the SDK needs to load the function modules. Be aware, there may be code being executed in modules during module loading. To avoid this, use the method described above to trace your functions.
+
+</Alert>
+
+## Accessing the Current Transaction
+
+To change data in an already ongoing transaction, use `Hub.current.scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
+
+```python
+import sentry_sdk
+
+def eat_pizza(pizza):
+    transaction = sentry_sdk.Hub.current.scope.transaction
+
+    if transaction is not None:
+        transaction.set_tag("num_of_slices", len(pizza.slices))
+
+    while pizza.slices > 0:
+        eat_slice(pizza.slices.pop())
+```
+
+## Accessing the Current Span
+
+To change data in the current span, use `sentry_sdk.Hub.current.scope.span`. This property will return a span if there's one running, otherwise it will return `None`.
+
+In this example, we'll set a tag in the span created by the `@sentry_sdk.trace` decorator.
+
+```python
+import sentry_sdk
+
+@sentry_sdk.trace
+def eat_slice(slice):
+    span = sentry_sdk.Hub.current.scope.span
+
+    if span is not None:
+        span.set_tag("slice_id", slice.id)
+
+    ...
+```

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -4,179 +4,133 @@ sidebar_order: 20
 description: "Learn how to capture performance data on any action in your app."
 ---
 
-The Sentry SDK for Python does a very good job of auto instrumenting your application. If you use one of the popular frameworks, we've got you covered because everything is instrumented out of the box. The Sentry SDK will check your installed Python packages and auto enable the matching SDK integrations.
-
-## Add a Transaction
-
-Adding transactions will allow you to instrument and capture certain regions of your code.
-
 <Note>
 
-If you're using one of Sentry's SDK integrations, transactions will be created for you automatically.
+This is just a THOUGHT experiment and should not be merged!
 
 </Note>
 
-The following example creates a transaction for an expensive operation (in this case,`eat_pizza`), and then sends the result to Sentry:
+The Sentry SDK for Python does a very good job of auto instrumenting your application. If you use one of the popular frameworks, we've got you covered because everything is instrumented out of the box. The Sentry SDK will check your installed Python packages and auto enable the matching SDK integrations.
+
+
+## Creating Spans
 
 ```python
 import sentry_sdk
 
-def eat_slice(slice):
-    ...
-
-def eat_pizza(pizza):
-    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
-        while pizza.slices > 0:
-            eat_slice(pizza.slices.pop())
+def do_work():
+    with sentry_sdk.start_span(op="function", name="my-span-name"):
+        # do some work that 'span' will track
+        print("doing some work...")
+        # When the 'with' block goes out of scope, 'span' is finished for you
 ```
 
-## Add Spans to a Transaction
+## Creacting Nested Spans
 
-If you want to have more fine-grained performance monitoring, you can add child spans to your transaction, which can be done by either:
-
-- Using a context manager or
-- Using a decorator, (this works on sync and `async` functions)
-
-Calling a `sentry_sdk.start_span()` will find the current active transaction and attach the span to it.
-
-### Using a Context Manager
+If you have a distinct sub-operation you’d like to track as a part of another one, you can create spans to represent the relationship:
 
 ```python
 import sentry_sdk
 
-def eat_slice(slice):
-    ...
+def do_work():
+    with sentry_sdk.start_span(name="parent") as parent:
+        # do some work that 'parent' tracks
+        print("doing some work...")
+        # Create a nested span to track nested work
+        with sentry_sdk.start_span(name="child") as child:
+            # do some work that 'child' tracks
+            print("doing some nested work...")
+            # the nested span is closed when it's out of scope
 
-def eat_pizza(pizza):
-    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
-        while pizza.slices > 0:
-            with sentry_sdk.start_span(description="Eat Slice"):
-                eat_slice(pizza.slices.pop())
-
+        # This span is also closed when it goes out of scope
 ```
 
-### Using a Decorator
+
+## Creating Spans with Decorators
+
+It’s common to have a single span track the execution of an entire function. In that scenario, there is a decorator you can use to reduce code:
 
 ```python
 import sentry_sdk
 
-@sentry_sdk.trace
-def eat_slice(slice):
-    ...
-
-def eat_pizza(pizza):
-    with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
-        while pizza.slices > 0:
-            eat_slice(pizza.slices.pop())
+@sentry_sdk.start_span
+def do_work():
+    print("doing some work...")
 
 ```
 
-## Nested Spans
+Use of the decorator is equivalent to creating the span inside do_work() and ending it when do_work() is finished.
 
-Spans can be nested to form a span tree. If you'd like to learn more, read our [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.
+The function name will be used as the spans name.
 
-### Using a Context Manager
+
+## Creating Spans That Need Manual Finishing
+
+Sometimes you do not want to use context managers, and do want to finish spans on your own. You can do this:
 
 ```python
 import sentry_sdk
 
-def chew():
-    ...
 
-def swallow():
-    ...
+parent_span = sentry_sdk.start_span(name="parent")
+do_work_parent()
 
-def eat_slice(slice):
-    with sentry_sdk.start_span(description="Eat Slice"):
-        with sentry_sdk.start_span(description="Chew"):
-            chew()
-        with sentry_sdk.start_span(description="Swallow"):
-            swallow()
+child_span = sentry_sdk.start_span(name="child")
+do_work_child()
+
+child_span.finish()
+parent_span.finish()
 
 ```
 
-### Using a Decorator
+If you want to create independend spans that are not in a parent/child relation ship a as above you can create them like this:
 
 ```python
 import sentry_sdk
 
-@sentry_sdk.trace
-def chew():
-    ...
 
-@sentry_sdk.trace
-def swallow():
-    ...
+span1 = sentry_sdk.start_span(name="step1", independent=True)
 
-@sentry_sdk.trace
-def eat_slice(slice):
-    chew()
-    swallow()
+step1()
+
+span2 = sentry_sdk.start_span(name="step1", independent=True)
+
+step2()
+
+span3 = sentry_sdk.start_span(name="step1", independent=True)
+
+step3()
+
+span1.finish()
+span2.finish()
+span3.finish()
 ```
 
-## Define Span Creation in a Central Place
+Now there will be no child relation between the spans, they will be siblings in the span tree.
 
-To avoid having custom performance instrumentation code scattered all over your code base, pass a parameter <PlatformIdentifier name="functions-to-trace" /> to your `sentry_sdk.init()` call.
-
-<SignInNote />
-
-```python
-import sentry_sdk
-
-functions_to_trace = [
-    {"qualified_name": "myrootmodule.eat_slice"},
-    {"qualified_name": "myrootmodule.swallow"},
-    {"qualified_name": "myrootmodule.chew"},
-    {"qualified_name": "myrootmodule.someothermodule.another.some_function"},
-    {"qualified_name": "myrootmodule.SomePizzaClass.some_method"},
-]
-
-sentry_sdk.init(
-    dsn="___PUBLIC_DSN___",
-    functions_to_trace=functions_to_trace,
-)
-```
-
-Now, whenever a function specified in `functions_to_trace` will be executed, a span will be created and attached as a child to the currently running span.
-
-<Alert level="warning" title="Important">
-
-To enable performance monitoring for the functions specified in `functions_to_trace`, the SDK needs to load the function modules. Be aware, there may be code being executed in modules during module loading. To avoid this, use the method described above to trace your functions.
-
-</Alert>
-
-## Accessing the Current Transaction
-
-To change data in an already ongoing transaction, use `Hub.current.scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
-
-```python
-import sentry_sdk
-
-def eat_pizza(pizza):
-    transaction = sentry_sdk.Hub.current.scope.transaction
-
-    if transaction is not None:
-        transaction.set_tag("num_of_slices", len(pizza.slices))
-
-    while pizza.slices > 0:
-        eat_slice(pizza.slices.pop())
-```
 
 ## Accessing the Current Span
 
-To change data in the current span, use `sentry_sdk.Hub.current.scope.span`. This property will return a span if there's one running, otherwise it will return `None`.
-
-In this example, we'll set a tag in the span created by the `@sentry_sdk.trace` decorator.
+Sometimes it’s helpful to access whatever the current span is at a point in time so that you can enrich it with more information.
 
 ```python
 import sentry_sdk
 
-@sentry_sdk.trace
-def eat_slice(slice):
-    span = sentry_sdk.Hub.current.scope.span
+current_span = sentry_sdk.get_current_span()
+# enrich 'current_span' with some information
+```
 
-    if span is not None:
-        span.set_tag("slice_id", slice.id)
+## Add Data to a Span
 
-    ...
+You can add additional data to a span so it carries more information about the current operation that it’s tracking.
+
+```python
+import sentry_sdk
+
+current_span = sentry_sdk.get_current_span()
+
+if current_span is not None:
+    current_span.set_data("operation.value", 1)
+    current_span.set_data("operation.name", "Saying hello!")
+    current_span.set_data("operation.other-stuff", [1, 2, 3])
 ```

--- a/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/common/performance/instrumentation/custom-instrumentation.mdx
@@ -12,7 +12,6 @@ This is just a THOUGHT experiment and should not be merged!
 
 The Sentry SDK for Python does a very good job of auto instrumenting your application. If you use one of the popular frameworks, we've got you covered because everything is instrumented out of the box. The Sentry SDK will check your installed Python packages and auto enable the matching SDK integrations.
 
-
 ## Creating Spans
 
 ```python
@@ -45,7 +44,6 @@ def do_work():
         # This span is also closed when it goes out of scope
 ```
 
-
 ## Creating Spans with Decorators
 
 It’s common to have a single span track the execution of an entire function. In that scenario, there is a decorator you can use to reduce code:
@@ -62,7 +60,6 @@ def do_work():
 Use of the decorator is equivalent to creating the span inside do_work() and ending it when do_work() is finished.
 
 The function name will be used as the spans name.
-
 
 ## Creating Spans That Need Manual Finishing
 
@@ -107,7 +104,6 @@ span3.finish()
 ```
 
 Now there will be no child relation between the spans, they will be siblings in the span tree.
-
 
 ## Accessing the Current Span
 


### PR DESCRIPTION
This is just an experiment how the new performance api could look like. 

In Python: https://sentry-docs-git-antonpirker-python-new-performance-api.sentry.dev/platforms/python/performance/instrumentation/custom-instrumentation/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F7732

In Javascript: https://sentry-docs-git-antonpirker-python-new-performance-api.sentry.dev/platforms/node/performance/instrumentation/custom-instrumentation/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F7732
