### PR TITLE
Improve org auth token usage for Java source context

### DIFF
--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -41,6 +41,16 @@ You can create an auth token by visiting the
 
 ## Using the Gradle Build Tool Plugin
 
+We have a [Sentry Gradle Plugin](https://github.com/getsentry/sentry-android-gradle-plugin) available.
+
+Set the auth token as an environment variable to be used when running your release build.
+
+<OrgAuthTokenNote />
+
+```bash
+export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
 Add the Sentry Gradle plugin to your project by adding the following lines:
 
 <PlatformSection supported={["android"]}>
@@ -77,7 +87,7 @@ sentry {
 
     org = "___ORG_SLUG___"
     projectName = "___PROJECT_SLUG___"
-    authToken = "your-sentry-auth-token"
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
 ```
 
@@ -111,7 +121,7 @@ sentry {
 
     org.set("___ORG_SLUG___")
     projectName.set("___PROJECT_SLUG___")
-    authToken.set("your-sentry-auth-token")
+    authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
 }
 ```
 
@@ -153,7 +163,7 @@ sentry {
 
     org = "___ORG_SLUG___"
     projectName = "___PROJECT_SLUG___"
-    authToken = "your-sentry-auth-token"
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
 ```
 
@@ -187,7 +197,7 @@ sentry {
 
     org.set("___ORG_SLUG___")
     projectName.set("___PROJECT_SLUG___")
-    authToken.set("your-sentry-auth-token")
+    authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
 }
 ```
 
@@ -239,7 +249,17 @@ sentry {
 
 ## Using the Maven Build Tool Plugin
 
-Add the [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) to your project by adding the following lines to your `pom.xml` file:
+We have a [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) available.
+
+Set the auth token as an environment variable to be used when running your release build.
+
+<OrgAuthTokenNote />
+
+```bash
+export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+Add the Sentry Maven Plugin to your project by adding the following lines to your `pom.xml` file:
 
 <SignInNote />
 
@@ -267,7 +287,6 @@ Add the [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) 
                 <!--<url>http://localhost:8000/</url>-->
 
                 <!-- provide your auth token via SENTRY_AUTH_TOKEN environment variable -->
-                <!-- you can find it in Sentry UI: Settings > Account > API > Auth Tokens -->
                 <authToken>${env.SENTRY_AUTH_TOKEN}</authToken>
             </configuration>
             <executions>


### PR DESCRIPTION
Improves upon https://github.com/getsentry/sentry-docs/pull/7733 by using the org auth token placeholder and providing snippets that can be pasted using the generated token.


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
