### PR TITLE
Added asyncpg docs

### DIFF
--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -12,7 +12,7 @@ The asyncpg integration captures queries from
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash
-pip install --upgrade sentry-sdk
+pip install --upgrade sentry-sdk[asyncpg]
 ```
 
 ## Configure

--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -9,7 +9,7 @@ The asyncpg integration captures queries from
 
 ## Install
 
-Install `sentry-sdk` from PyPI.
+To get started, install `sentry-sdk` from PyPI.
 
 ```bash
 pip install --upgrade sentry-sdk

--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -1,0 +1,39 @@
+---
+title: asyncpg
+description: "Learn about importing the asyncpg integration and how it captures queries from asyncpg."
+sidebar_order: 120
+---
+
+The asyncpg integration captures queries from
+[asyncpg](https://magicstack.github.io/asyncpg/current/) and shows them in the "Performance" seciton of Sentry.
+
+## Install
+
+Install `sentry-sdk` from PyPI.
+
+```bash
+pip install --upgrade sentry-sdk
+```
+
+## Configure
+
+Add `AsyncPGIntegration()` to your `integrations` list:
+
+<SignInNote />
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.asyncpg import AsyncPGIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        AsyncPGIntegration(),
+    ],
+)
+```
+
+## Supported Versions
+
+- asyncpg: 0.23+
+- Python: 3.7+

--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -5,7 +5,7 @@ sidebar_order: 25
 ---
 
 The asyncpg integration captures queries from
-[asyncpg](https://github.com/MagicStack/asyncpg) and shows them in the "Performance" seciton of Sentry.
+[asyncpg](https://github.com/MagicStack/asyncpg), which can be viewed in Sentry's **Performance** page.
 
 ## Install
 

--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -5,7 +5,7 @@ sidebar_order: 25
 ---
 
 The asyncpg integration captures queries from
-[asyncpg](https://magicstack.github.io/asyncpg/current/) and shows them in the "Performance" seciton of Sentry.
+[asyncpg](https://github.com/MagicStack/asyncpg) and shows them in the "Performance" seciton of Sentry.
 
 ## Install
 

--- a/src/platforms/python/common/configuration/integrations/asyncpg.mdx
+++ b/src/platforms/python/common/configuration/integrations/asyncpg.mdx
@@ -1,7 +1,7 @@
 ---
 title: asyncpg
 description: "Learn about importing the asyncpg integration and how it captures queries from asyncpg."
-sidebar_order: 120
+sidebar_order: 25
 ---
 
 The asyncpg integration captures queries from


### PR DESCRIPTION
New Python integration for the `asyncpg` library (asynchronous postgres client)

Preview: https://sentry-docs-git-antonpirker-python-asyncpg.sentry.dev/platforms/python/configuration/integrations/asyncpg/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-docs%2Fpull%2F7756

Integration PR is here: https://github.com/getsentry/sentry-python/pull/2314