### PR TITLE
feat(getting-started): Switch from manual setup to sentry-wizard for Android and iOS in getting started

### DIFF
--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -1,3 +1,3 @@
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 
-Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>,  <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
+Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.

--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -1,28 +1,3 @@
-Configuration is done via the application `AndroidManifest.xml` Here's an example config which should get you started:
-
-<SignInNote />
-
-```xml {filename:AndroidManifest.xml}
-<application>
-  <!-- Required: set your sentry.io project identifier (DSN) -->
-  <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
-
-  <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
-  <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
-  <!-- enable screenshot for crashes -->
-  <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
-  <!-- enable view hierarchy for crashes -->
-  <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
-
-  <!-- enable the performance API by setting a sample-rate, adjust in production env -->
-  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-  <!-- enable profiling when starting transactions, adjust in production env -->
-  <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
-</application>
-```
-
-Under the hood Sentry uses a `ContentProvider` to initialize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
-
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 
-If you want to customize the SDK init behaviour, you can still use the <PlatformLink to="/configuration/manual-init/">Manual Initialization method</PlatformLink>.
+Here you can also set context data - data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, for example, or <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink> - which will be added to every event sent to Sentry.

--- a/src/platform-includes/getting-started-config/android.mdx
+++ b/src/platform-includes/getting-started-config/android.mdx
@@ -1,3 +1,3 @@
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 
-Here you can also set context data - data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, for example, or <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink> - which will be added to every event sent to Sentry.
+Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>,  <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -41,8 +41,8 @@ SentrySDK.start { options in
 
 <Note>This feature is experimental and may have bugs.</Note>
 
-If you use Swift concurrency, this feature will stitch your stack traces together. That means you will be able to see the full stack trace of your async code.
-For this to happen you need to enable the `swiftAsyncStacktraces` option.
+If you use Swift concurrency, this feature will stitch your stack traces together. That means you'll be able to see the full stack trace of your async code.
+For this to happen, you'll need to enable the `swiftAsyncStacktraces` option.
 You can also enable this in your Objective-C project, however, only async code written in Swift will be stitched together.
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -37,32 +37,6 @@ SentrySDK.start { options in
 }];
 ```
 
-## Stitch Together Swift Concurrency Stack Traces
-
-<Note>This feature is experimental and may have bugs.</Note>
-
-If you use Swift concurrency, this feature will stitch your stack traces together. That means you'll be able to see the full stack trace of your async code.
-For this to happen, you'll need to enable the `swiftAsyncStacktraces` option.
-You can also enable this in your Objective-C project, however, only async code written in Swift will be stitched together.
-
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    // ...
-    options.swiftAsyncStacktraces = true
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    // ...
-    options.swiftAsyncStacktraces = YES;
-}];
-```
-
 ## Use Sentry with SwiftUI
 
 If you want to find out the performance of your Views in a SwiftUI project, [try the SentrySwiftUI library](/platforms/apple/performance/instrumentation/swiftui-instrumentation).

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -2,7 +2,7 @@ Additional options can be found <PlatformLink to="/configuration/options/">on ou
 
 Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>,  <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
 
-## Experimental features
+## Experimental Features
 
 > Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
 >

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -1,10 +1,10 @@
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 
-Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>,  <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
+Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
 
-## Experimental Features
+## Experimental features
 
-> Want to play with something new? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
+> Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
 >
 > Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-cocoa/issues).
 
@@ -41,8 +41,8 @@ SentrySDK.start { options in
 
 <Note>This feature is experimental and may have bugs.</Note>
 
-If you use Swift concurrency, this feature will stitch your stack traces together. That means you'll be able to see the full stack trace of your async code.
-For this to happen, you'll need to enable the `swiftAsyncStacktraces` option.
+If you use Swift concurrency, this feature will stitch your stack traces together. That means you will be able to see the full stack trace of your async code.
+For this to happen you need to enable the `swiftAsyncStacktraces` option.
 You can also enable this in your Objective-C project, however, only async code written in Swift will be stitched together.
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -2,9 +2,9 @@ Additional options can be found <PlatformLink to="/configuration/options/">on ou
 
 Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
 
-## Experimental features
+## Experimental Features
 
-> Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
+> Want to play with something new? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
 >
 > Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-cocoa/issues).
 
@@ -41,8 +41,8 @@ SentrySDK.start { options in
 
 <Note>This feature is experimental and may have bugs.</Note>
 
-If you use Swift concurrency, this feature will stitch your stack traces together. That means you will be able to see the full stack trace of your async code.
-For this to happen you need to enable the `swiftAsyncStacktraces` option.
+If you use Swift concurrency, this feature will stitch your stack traces together. That means you'll be able to see the full stack trace of your async code.
+For this to happen, you'll need to enable the `swiftAsyncStacktraces` option.
 You can also enable this in your Objective-C project, however, only async code written in Swift will be stitched together.
 
 ```swift {tabTitle:Swift}

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -4,7 +4,7 @@ Here, you'll also be able to set context data, which includes data about the <Pl
 
 ## Experimental Features
 
-> Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
+> Want to play with something new? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
 >
 > Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-cocoa/issues).
 

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -1,6 +1,6 @@
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 
-Here you can also set context data - data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, for example, or <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink> - which will be added to every event sent to Sentry.
+Here, you'll also be able to set context data, which includes data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>,  <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink>, all of which will be added to every event sent to Sentry.
 
 ## Experimental features
 

--- a/src/platform-includes/getting-started-config/apple.ios.mdx
+++ b/src/platform-includes/getting-started-config/apple.ios.mdx
@@ -1,0 +1,68 @@
+Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
+
+Here you can also set context data - data about the <PlatformLink to="/enriching-events/identify-user/">user</PlatformLink>, for example, or <PlatformLink to="/enriching-events/tags/">tags</PlatformLink>, or even <PlatformLink to="/enriching-events/context/">arbitrary data</PlatformLink> - which will be added to every event sent to Sentry.
+
+## Experimental features
+
+> Want to play with some new features? Try out our experimental features for [View Hierarchy](/platforms/apple/guides/ios/enriching-events/viewhierarchy/), [Time to Full Display (TTFD)](/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display), [MetricKit](/platforms/apple/guides/watchos/configuration/metric-kit/), [Prewarmed App Start Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing), and [Swift Async Stack Traces](/platforms/apple/guides/ios/#stitch-together-swift-concurrency-stack-traces). Experimental features are still a work-in-progress and may have bugs. We recognize the irony.
+>
+> Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-cocoa/issues).
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    // ...
+
+    // Enable all experimental features
+    options.attachViewHierarchy = true
+    options.enablePreWarmedAppStartTracing = true
+    options.enableMetricKit = true
+    options.enableTimeToFullDisplayTracing = true
+    options.swiftAsyncStacktraces = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    // ...
+
+    // Enable all experimental features
+    options.attachViewHierarchy = YES;
+    options.enablePreWarmedAppStartTracing = YES;
+    options.enableMetricKit = YES;
+    options.enableTimeToFullDisplayTracing = YES;
+}];
+```
+
+## Stitch Together Swift Concurrency Stack Traces
+
+<Note>This feature is experimental and may have bugs.</Note>
+
+If you use Swift concurrency, this feature will stitch your stack traces together. That means you will be able to see the full stack trace of your async code.
+For this to happen you need to enable the `swiftAsyncStacktraces` option.
+You can also enable this in your Objective-C project, however, only async code written in Swift will be stitched together.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    // ...
+    options.swiftAsyncStacktraces = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    // ...
+    options.swiftAsyncStacktraces = YES;
+}];
+```
+
+## Use Sentry with SwiftUI
+
+If you want to find out the performance of your Views in a SwiftUI project, [try the SentrySwiftUI library](/platforms/apple/performance/instrumentation/swiftui-instrumentation).

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -1,29 +1,21 @@
-The easiest way to get started is to install the Sentry Android Gradle plugin to your app module's `build.gradle` file.
+We recommend installing the SDK through our installation wizard. Just run the following command inside your project directory:
 
-```groovy {filename:app/build.gradle}
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-}
-
-plugins {
-  id "com.android.application"
-  id "io.sentry.android.gradle" version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
-}
+```bash
+brew install getsentry/tools/sentry-wizard && sentry-wizard -i android
 ```
 
-```kotlin {filename:app/build.gradle.kts}
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-}
+The wizard will prompt you to log in to Sentry. It will then automatically do the following steps for you:
 
-plugins {
-  id("com.android.application")
-  id("io.sentry.android.gradle") version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
-}
-```
+- update your app's `build.gradle` file with the Sentry Gradle plugin and configure it
+- update your `AndroidManifest.xml` with the default Sentry configuration
+- create `sentry.properties` with an auth token to upload proguard mappings (this file is automatically added to `.gitignore`)
+- add an example error to your app's Main Activity to verify your Sentry setup
 
-The plugin version `{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` will automatically add the Sentry Android SDK (version `{{@inject packages.version('sentry.java.android', '4.2.0') }}`) to your app.
+After the wizard setup is completed, the SDK will automatically capture unhandled exceptions, and monitor performance.
+You can also <PlatformLink to="/usage/">manually capture errors</PlatformLink>.
+
+<Note>
+
+If the setup through the wizard doesn't work for you, you can also <PlatformLink to="/manual-setup/">set up the SDK manually</PlatformLink>.
+
+</Note>

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -4,7 +4,7 @@ We recommend installing the SDK through our installation wizard by running the f
 brew install getsentry/tools/sentry-wizard && sentry-wizard -i android
 ```
 
-The wizard will prompt you to log in to Sentry. It will then automatically do the following steps for you:
+The wizard will prompt you to log in to Sentry. It'll then automatically do the following steps for you:
 
 - update your app's `build.gradle` file with the Sentry Gradle plugin and configure it
 - update your `AndroidManifest.xml` with the default Sentry configuration

--- a/src/platform-includes/getting-started-install/android.mdx
+++ b/src/platform-includes/getting-started-install/android.mdx
@@ -1,4 +1,4 @@
-We recommend installing the SDK through our installation wizard. Just run the following command inside your project directory:
+We recommend installing the SDK through our installation wizard by running the following command inside your project directory:
 
 ```bash
 brew install getsentry/tools/sentry-wizard && sentry-wizard -i android

--- a/src/platform-includes/getting-started-install/apple.ios.mdx
+++ b/src/platform-includes/getting-started-install/apple.ios.mdx
@@ -4,7 +4,7 @@ We recommend installing the SDK through our installation wizard by running the f
 brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios
 ```
 
-The wizard will prompt you to log in to Sentry. It will then automatically do the following steps for you:
+The wizard will prompt you to log in to Sentry. It'll then automatically do the following steps for you:
 
 - install the Sentry SDK via Swift Package Manager or Cocoapods
 - update your `AppDelegate` or SwiftUI App Initializer with the default Sentry configuration and an example error

--- a/src/platform-includes/getting-started-install/apple.ios.mdx
+++ b/src/platform-includes/getting-started-install/apple.ios.mdx
@@ -1,14 +1,22 @@
-The minimum version for iOS is 9.0.
+We recommend installing the SDK through our installation wizard. Just run the following command inside your project directory:
 
-We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
-
-```ruby {filename:Podfile}
-platform :ios, '11.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
+```bash
+brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios
 ```
 
-Then run `pod install`.
+The wizard will prompt you to log in to Sentry. It will then automatically do the following steps for you:
+
+- install the Sentry SDK via Swift Package Manager or Cocoapods
+- update your `AppDelegate` or SwiftUI App Initializer with the default Sentry configuration and an example error
+- add a new `Upload Debug Symbols` phase to your `xcodebuild` build script
+- create `.sentryclirc` with an auth token to upload debug symbols (this file is automatically added to `.gitignore`)
+- when you're using Fastlane, it will add a Sentry lane for uploading debug symbols
+
+After the wizard setup is completed, the SDK will automatically capture unhandled exceptions, and monitor performance.
+You can also <PlatformLink to="/usage/">manually capture errors</PlatformLink>.
+
+<Note>
+
+If the setup through the wizard doesn't work for you, you can also <PlatformLink to="/manual-setup/">set up the SDK manually</PlatformLink>.
+
+</Note>

--- a/src/platform-includes/getting-started-install/apple.ios.mdx
+++ b/src/platform-includes/getting-started-install/apple.ios.mdx
@@ -1,4 +1,4 @@
-We recommend installing the SDK through our installation wizard. Just run the following command inside your project directory:
+We recommend installing the SDK through our installation wizard by running the following command inside your project directory:
 
 ```bash
 brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios

--- a/src/platform-includes/getting-started-verify/android.mdx
+++ b/src/platform-includes/getting-started-verify/android.mdx
@@ -1,6 +1,6 @@
 <Note>
 
-If you're using [automatic insallation via the wizard](/platforms/android/#install), this step is not necessary.
+If you're using [automatic installation via the wizard](/platforms/android/#install), this step isn't necessary.
 
 </Note>
 

--- a/src/platform-includes/getting-started-verify/android.mdx
+++ b/src/platform-includes/getting-started-verify/android.mdx
@@ -1,3 +1,9 @@
+<Note>
+
+If you're using [automatic insallation via the wizard](/platforms/android/#install), this step is not necessary.
+
+</Note>
+
 ```java
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;

--- a/src/platforms/android/manual-setup.mdx
+++ b/src/platforms/android/manual-setup.mdx
@@ -36,7 +36,7 @@ plugins {
 }
 ```
 
-The plugin version `{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` will automatically add the Sentry Android SDK (version `{{@inject packages.version('sentry.java.android', '4.2.0') }}`) to your app.
+Version `{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` of the plugin will automatically add the Sentry Android SDK (version `{{@inject packages.version('sentry.java.android', '4.2.0') }}`) to your app.
 
 ## Configuration
 

--- a/src/platforms/android/manual-setup.mdx
+++ b/src/platforms/android/manual-setup.mdx
@@ -63,7 +63,7 @@ Configuration is done via the application `AndroidManifest.xml`. Here's an examp
 </application>
 ```
 
-Under the hood Sentry uses a `ContentProvider` to initialize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
+Under the hood, Sentry uses a `ContentProvider` to initialize the SDK based on the values provided above. This way, the SDK can capture important crashes and metrics right from the app start.
 
 Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
 

--- a/src/platforms/android/manual-setup.mdx
+++ b/src/platforms/android/manual-setup.mdx
@@ -4,7 +4,7 @@ sidebar_order: 1
 description: "Learn how to set up the SDK manually."
 ---
 
-If you can't (or prefer not to) run the [automatic setup](/platforms/android/#install), you can follow the instructions below to configure your application.
+If you can't (or prefer not to) run the [automatic setup](/platforms/android/#install), you can follow the instructions below to configure your application manually.
 
 ## Installation
 

--- a/src/platforms/android/manual-setup.mdx
+++ b/src/platforms/android/manual-setup.mdx
@@ -1,0 +1,70 @@
+---
+title: Manual Setup
+sidebar_order: 1
+description: "Learn how to set up the SDK manually."
+---
+
+If you can't (or prefer not to) run the [automatic setup](/platforms/android/#install), you can follow the instructions below to configure your application.
+
+## Installation
+
+The easiest way to get started is to install the Sentry Android Gradle plugin to your app module's `build.gradle` file.
+
+```groovy {filename:app/build.gradle}
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id "com.android.application"
+  id "io.sentry.android.gradle" version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
+}
+```
+
+```kotlin {filename:app/build.gradle.kts}
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("com.android.application")
+  id("io.sentry.android.gradle") version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}"
+}
+```
+
+The plugin version `{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0') }}` will automatically add the Sentry Android SDK (version `{{@inject packages.version('sentry.java.android', '4.2.0') }}`) to your app.
+
+## Configuration
+
+Configuration is done via the application `AndroidManifest.xml` Here's an example config which should get you started:
+
+<SignInNote />
+
+```xml {filename:AndroidManifest.xml}
+<application>
+  <!-- Required: set your sentry.io project identifier (DSN) -->
+  <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
+
+  <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+  <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+  <!-- enable screenshot for crashes -->
+  <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
+  <!-- enable view hierarchy for crashes -->
+  <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
+
+  <!-- enable the performance API by setting a sample-rate, adjust in production env -->
+  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+  <!-- enable profiling when starting transactions, adjust in production env -->
+  <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
+</application>
+```
+
+Under the hood Sentry uses a `ContentProvider` to initialize the SDK based on the values provided above. This way the SDK can capture important crashes and metrics right from the app start.
+
+Additional options can be found <PlatformLink to="/configuration/options/">on our dedicated options page</PlatformLink>.
+
+If you want to customize the SDK init behaviour, you can still use the <PlatformLink to="/configuration/manual-init/">Manual Initialization method</PlatformLink>.

--- a/src/platforms/android/manual-setup.mdx
+++ b/src/platforms/android/manual-setup.mdx
@@ -40,7 +40,7 @@ Version `{{@inject packages.version('sentry.java.android.gradle-plugin', '3.0.0'
 
 ## Configuration
 
-Configuration is done via the application `AndroidManifest.xml` Here's an example config which should get you started:
+Configuration is done via the application `AndroidManifest.xml`. Here's an example config which should get you started:
 
 <SignInNote />
 

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -65,7 +65,7 @@ func application(_ application: UIApplication,
 }
 ```
 
-When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
+If you're using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
 
 <SignInNote />
 

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -25,7 +25,7 @@ Then run `pod install`.
 
 ## Configuration
 
-We recommend initializing the SDK on the main thread as soon as possible, such as in your AppDelegate `application:didFinishLaunchingWithOptions` method:
+We recommend initializing the SDK on the main thread as soon as possible – in your AppDelegate `application:didFinishLaunchingWithOptions` method, for example:
 
 <SignInNote />
 

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -8,7 +8,7 @@ If you can't (or prefer not to) run the [automatic setup](/platforms/apple/guide
 
 ## Installation
 
-The minimum version for iOS is 11.0.
+The minimum required version for iOS is 11.0.
 
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/guides/ios/install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -1,0 +1,89 @@
+---
+title: Manual Setup
+sidebar_order: 1
+description: "Learn how to set up the SDK manually."
+---
+
+If you can't (or prefer not to) run the [automatic setup](/platforms/apple/guides/ios/#install), you can follow the instructions below to configure your application.
+
+## Installation
+
+The minimum version for iOS is 9.0.
+
+We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/guides/ios/install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+
+```ruby {filename:Podfile}
+platform :ios, '11.0'
+use_frameworks! # This is important
+
+target 'YourApp' do
+  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
+end
+```
+
+Then run `pod install`.
+
+## Configuration
+
+We recommend initializing the SDK on the main thread as soon as possible, such as in your AppDelegate `application:didFinishLaunchingWithOptions` method:
+
+<SignInNote />
+
+```swift {tabTitle:Swift}
+import Sentry // Make sure you import Sentry
+
+// ....
+
+func application(_ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    SentrySDK.start { options in
+        options.dsn = "___PUBLIC_DSN___"
+        options.debug = true // Enabled debug when first installing is always helpful
+    }
+
+    return true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+
+    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+        options.dsn = @"___PUBLIC_DSN___";
+        options.debug = YES; // Enabled debug when first installing is always helpful
+
+        // Enable tracing to capture 100% of transactions for performance monitoring.
+        // Use 'options.tracesSampleRate' to set the sampling rate.
+        // We recommend setting a sample rate in production.
+        options.enableTracing = YES;
+    }];
+
+    return YES;
+}
+```
+
+When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [App conformer's initializer](<https://developer.apple.com/documentation/swiftui/app/main()>):
+
+<SignInNote />
+
+```swift
+import Sentry
+
+@main
+struct SwiftUIApp: App {
+    init() {
+        SentrySDK.start { options in
+            options.dsn = "___PUBLIC_DSN___"
+            options.debug = true // Enabled debug when first installing is always helpful
+
+            // Enable tracing to capture 100% of transactions for performance monitoring.
+            // Use 'options.tracesSampleRate' to set the sampling rate.
+            // We recommend setting a sample rate in production.
+            options.enableTracing = true
+        }
+    }
+}
+```

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -4,7 +4,7 @@ sidebar_order: 1
 description: "Learn how to set up the SDK manually."
 ---
 
-If you can't (or prefer not to) run the [automatic setup](/platforms/apple/guides/ios/#install), you can follow the instructions below to configure your application.
+If you can't (or prefer not to) run the [automatic setup](/platforms/apple/guides/ios/#install), you can follow the instructions below to configure your application manually.
 
 ## Installation
 

--- a/src/platforms/apple/guides/ios/manual-setup.mdx
+++ b/src/platforms/apple/guides/ios/manual-setup.mdx
@@ -8,7 +8,7 @@ If you can't (or prefer not to) run the [automatic setup](/platforms/apple/guide
 
 ## Installation
 
-The minimum version for iOS is 9.0.
+The minimum version for iOS is 11.0.
 
 We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](/platforms/apple/guides/ios/install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
 

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -22,7 +22,7 @@ Sentry captures data by using an SDK within your application’s runtime.
 
 ## Configure
 
-<PlatformSection notSupported={["android", "unity", "unreal", "javascript.nextjs"]}>
+<PlatformSection notSupported={["android", "unity", "unreal", "javascript.nextjs", "apple.ios"]}>
 
 Configuration should happen as early as possible in your application's lifecycle.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

* Switches from manual setup to sentry-wizard for Android and iOS in getting started
	* For apple I had to split this for ios and non-ios since the wizard supports only iOS I think? Let me know if I should  change it for all apple targets
* Introduces new "Manual Setup" top-level section to be redirected to the old getting started docs

Part of https://github.com/getsentry/sentry-java/issues/2877 and https://github.com/getsentry/sentry-cocoa/issues/3198