### PR TITLE
docs: specify supported nuxt version

### DIFF
--- a/src/platforms/index.mdx
+++ b/src/platforms/index.mdx
@@ -45,7 +45,7 @@ These SDKs are maintained and supported by [the Sentry community](https://open.s
 - [_Kubernetes_](https://github.com/alekitto/sentry-kubernetes)
 - [_Lua_](https://github.com/cloudflare/raven-lua)
 - [_NestJS_](https://github.com/ntegral/nestjs-sentry) or [_NestJS_](https://github.com/mentos1386/nest-raven)
-- [_Nuxt_](https://github.com/nuxt-community/sentry-module)
+- [_Nuxt 2_](https://github.com/nuxt-community/sentry-module)
 - [_OCaml_](https://github.com/brendanlong/sentry-ocaml)
 - [_Perl_](https://github.com/getsentry/perl-raven)
 - [_Scrapy_](https://github.com/llonchj/scrapy-sentry)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

While looking for a Sentry SDK for Nuxt 3, I found the link to the `sentry-module` from the `nuxt-community`.
Unfortunately, at first glance, there is no disclaimer there explaining that the module is only for Nuxt 2.
So with these changes I am trying to help others save some* time.

*: by _some_ I really mean a lot.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this PR here. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
