### PR TITLE
ref(sdks): Add sample rate defaults to Sampling page

### DIFF
--- a/src/platforms/common/configuration/sampling.mdx
+++ b/src/platforms/common/configuration/sampling.mdx
@@ -33,6 +33,8 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 <PlatformContent includePath="configuration/sample-rate" />
 
+The error sample rate defaults to `1`, meaning all errors are sent to Sentry.
+
 <Note>
 
 Changing the error sample rate requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
@@ -64,6 +66,8 @@ The Sentry SDKs have two configuration options to control the volume of transact
    - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out some
      transactions entirely
    - Modifies default [precedence](#precedence) and [inheritance](#inheritance) behavior
+
+By default, none of these options are set, meaning no transactions will be sent to Sentry. You must set either one of the options to start sending transactions.
 
 <PlatformSection supported={["rust", "native"]}>
 


### PR DESCRIPTION
Adds default behaviour for `sampleRate` and `tracesSampleRate`

closes #7764 