### PR TITLE
fix(replay): Fix quoted replay on-demand price

### DIFF
--- a/src/docs/product/accounts/pricing.mdx
+++ b/src/docs/product/accounts/pricing.mdx
@@ -80,7 +80,7 @@ Performance Units can be used towards multiple Performance event types, dependin
 |---|---|---|---|
 | >10k-25k | 15k | $0.002850 | $0.003705 |
 | >25k-100k | 25k | $0.002850 | $0.003705 |
-| >100k-1M | 100k | $0.002565 | $0.000195 | $0.003335 |
+| >100k-1M | 100k | $0.002565 | $0.003335 |
 
 #### Attachments Pricing
 


### PR DESCRIPTION
On [Replays Pricing](https://docs.sentry.io/product/accounts/pricing/#replays-pricing) we were showing the incorrect price for on-demand replays.

The price of `$0.000195` is for errors
Replays are at `$0.003335`

**Incorrect Price**
![SentryPricingReplays (view-only conflicts 2023-09-07)](https://github.com/getsentry/sentry-docs/assets/187460/a9ffe18c-c7e9-4f4b-a0b0-61d09518015c)
