### PR TITLE
docs(redux): add attachReduxState option documentation

### DIFF
--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -110,6 +110,8 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
 
 `attachReduxState` (Boolean)
 
+_(Available in version 7.68.0 and above)_
+
 This is `true` by default. It attaches a file `redux_state.json` with Redux state to all error events sent to Sentry. It is beneficial where Redux states are too big. Note if the stateTransformer function is provided, it will attach the transformed state. If you don't want to attach the state to error events, set this to `false`.
 
 ```javascript

--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -112,7 +112,7 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
 
 _(Available in version 7.68.0 and above)_
 
-This is `true` by default. It attaches a file `redux_state.json` with Redux state to all error events sent to Sentry. It is beneficial where Redux states are too big. Note if the stateTransformer function is provided, it will attach the transformed state. If you don't want to attach the state to error events, set this to `false`.
+This is `true` by default. It attaches a file `redux_state.json` with Redux state to all error events sent to Sentry. It is beneficial where Redux states are too big. If the `stateTransformer` function is provided, it will attach the transformed state. If you don't want to attach the state to error events, set this to `false`.
 
 ```javascript
 const sentryReduxEnhancer = Sentry.createReduxEnhancer({

--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -107,3 +107,13 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
   },
 });
 ```
+
+`attachReduxState` (Boolean)
+
+This is `true` by default. It attaches a file `redux_state.json` with Redux state to all error events sent to Sentry. It is beneficial where Redux states are too big. Note if the stateTransformer function is provided, it will attach the transformed state. If you don't want to attach the state to error events, set this to `false`.
+
+```javascript
+const sentryReduxEnhancer = Sentry.createReduxEnhancer({
+  attachReduxState: false,
+});
+```

--- a/src/includes/platforms/configuration/integrations/redux.mdx
+++ b/src/includes/platforms/configuration/integrations/redux.mdx
@@ -110,7 +110,7 @@ const sentryReduxEnhancer = Sentry.createReduxEnhancer({
 
 `attachReduxState` (Boolean)
 
-_(Available in version 7.68.0 and above)_
+_(Available in version 7.69.0 and above)_
 
 This is `true` by default. It attaches a file `redux_state.json` with Redux state to all error events sent to Sentry. It is beneficial where Redux states are too big. If the `stateTransformer` function is provided, it will attach the transformed state. If you don't want to attach the state to error events, set this to `false`.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [X] Checked Vercel preview for correctness, including links 
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Added documentation for an option added in `createReduxEnhancer` which helps to attach redux state to error events sent to sentry. 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
