### PR TITLE
feat(replay): Include `project_id` in the list of searchable Session Replay fields

### DIFF
--- a/src/docs/product/sentry-basics/search/searchable-properties/session-replay.mdx
+++ b/src/docs/product/sentry-basics/search/searchable-properties/session-replay.mdx
@@ -192,6 +192,12 @@ Name of the platform. This is only a metrics property for [valid platforms](http
 
 - **Type:** string
 
+### `project_id`
+
+The id of the project.
+
+- **Type:** string
+
 ### `release`
 
 A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.


### PR DESCRIPTION
![SCR-20230912-mlap](https://github.com/getsentry/sentry-docs/assets/187460/34cf6920-ebeb-4a1d-9324-b4ae912a0069)
