### PR TITLE
fix(js): Remove span status enum usage in js docs

### DIFF
--- a/src/platform-includes/performance/add-spans-example/javascript.mdx
+++ b/src/platform-includes/performance/add-spans-example/javascript.mdx
@@ -21,9 +21,9 @@ function shopCheckout() {
   });
   try {
     processAndValidateShoppingCart(result);
-    span.setStatus(SpanStatus.Ok);
+    span.setStatus("ok");
   } catch (err) {
-    span.setStatus(SpanStatus.UnknownError);
+    span.setStatus("unknown_error");
     throw err;
   } finally {
     span.finish();

--- a/src/platform-includes/performance/retrieve-transaction/javascript.mdx
+++ b/src/platform-includes/performance/retrieve-transaction/javascript.mdx
@@ -13,9 +13,9 @@ function myJsFunction() {
 
     try {
       // Do something
-      span.setStatus(SpanStatus.Ok);
+      span.setStatus("ok");
     } catch (err) {
-      span.setStatus(SpanStatus.UnknownError);
+      span.setStatus("unknown_error");
       throw err;
     } finally {
       span.finish();

--- a/src/wizard/react-native/index.md
+++ b/src/wizard/react-native/index.md
@@ -111,9 +111,9 @@ shopCheckout() {
   });
   try {
     processAndValidateShoppingCart(result);
-    span.setStatus(SpanStatus.Ok);
+    span.setStatus('ok');
   } catch (err) {
-    span.setStatus(SpanStatus.UnknownError);
+    span.setStatus('unknown_error');
     throw err;
   } finally {
     span.finish();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/7789

`SpanStatus` enum is deprecated, so let's replace with normal strings.