### PR TITLE
fix(rn): Update CodePush commands to generate and upload source maps

### DIFF
--- a/src/platforms/react-native/manual-setup/codepush.mdx
+++ b/src/platforms/react-native/manual-setup/codepush.mdx
@@ -56,10 +56,10 @@ export default codePush(Sentry.wrap(App));
 
 After updating your CodePush release, you have to upload the new assets to Sentry:
 
-When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap-output` and `--output-dir ./build`. This will output to the `./build/CodePush` folder.
+When making the release with CodePush, make sure to output the bundle and source maps by specifying `--sourcemap-output-dir ./build` and `--output-dir ./build`.
 
 ```bash
-appcenter codepush release-react -a {APP} -d {DEPLOYMENT} --sourcemap-output --output-dir ./build
+appcenter codepush release-react -a {APP} -d {DEPLOYMENT} --sourcemap-output-dir ./build --output-dir ./build
 ```
 
 Exporting the `SENTRY_PROPERTIES` will tell sentry-cli to use the properties in your project. The sentry-wizard install step should have generated this file for you. Alternatively, you can either pass it via parameters or a global settings file. To find more about this refer to [Working with Projects](/product/cli/configuration/#sentry-cli-working-with-projects).
@@ -72,7 +72,7 @@ Upload the outputted bundle and source maps to Sentry.
 If you use custom deployment names in CodePush, you will need to use `--deployment` to specify the deployment.
 
 ```bash
-sentry-cli react-native appcenter {APP} ios ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST}
+sentry-cli react-native appcenter {APP} ios ./build ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST}
 ```
 
 For non-macOS devices building for iOS, you will need to pass extra parameters that can't be computed automatically (`--bundle-id` and `--version-name`).
@@ -81,13 +81,13 @@ Within your `Info.plist`, `--version-name` corresponds to `CFBundleShortVersionS
 On iOS:
 
 ```bash
-sentry-cli react-native appcenter {APP} ios ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST} --bundle-id {BUNDLE_ID} --version-name {VERSION_NAME}
+sentry-cli react-native appcenter {APP} ios ./build ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST} --bundle-id {BUNDLE_ID} --version-name {VERSION_NAME}
 ```
 
 If you don't want to use the automatically computed release format, instead of passing `--bundle-id` and `--version-name`, you'll need to pass the `--release-name` parameter.
 
 ```bash
-sentry-cli react-native appcenter {APP} ios ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST} --release-name {RELEASE_NAME}
+sentry-cli react-native appcenter {APP} ios ./build ./build/CodePush --deployment {DEPLOYMENT} --dist {DIST} --release-name {RELEASE_NAME}
 ```
 
 <Alert level="info">


### PR DESCRIPTION
- relates to https://github.com/getsentry/sentry-react-native/issues/3279
- related appcenter cli pr https://github.com/microsoft/appcenter-cli/pull/2452

- reflects the current behavior of the appcenter cli https://github.com/microsoft/appcenter-cli/blob/7b637743eec2fd4e960823bfa76fe568c4f5e4ff/src/commands/codepush/release-react.ts#L89-L100

combination of `--sourcemap-output` and `--output-dir` no longer works.

source map path must be explicitly set

Bundle will be generated in ./path/CodePush -> source maps should not be in the same directory. So sentry-cli commands have to include paths to source map dir and bundle dir.
