### PR TITLE
Remove crons error context for SDKs supporting TwP

### DIFF
--- a/src/platform-includes/crons/connect-errors/javascript.mdx
+++ b/src/platform-includes/crons/connect-errors/javascript.mdx
@@ -1,7 +1,0 @@
-```javascript
-Sentry.configureScope(function (scope) {
-  scope.setContext("monitor", {
-    slug: "<monitor-slug>",
-  });
-});
-```

--- a/src/platform-includes/crons/connect-errors/node.mdx
+++ b/src/platform-includes/crons/connect-errors/node.mdx
@@ -1,7 +1,0 @@
-```javascript
-Sentry.configureScope(function (scope) {
-  scope.setContext("monitor", {
-    slug: "<monitor-slug>",
-  });
-});
-```

--- a/src/platform-includes/crons/connect-errors/php.mdx
+++ b/src/platform-includes/crons/connect-errors/php.mdx
@@ -1,7 +1,0 @@
-```php
-\Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
-    $scope->setContext('monitor', [
-        'slug' => '<monitor-slug>',
-    ]);
-});
-```

--- a/src/platform-includes/crons/connect-errors/python.mdx
+++ b/src/platform-includes/crons/connect-errors/python.mdx
@@ -1,5 +1,0 @@
-```python
-sentry_sdk.set_context("monitor", {
-    "slug": "<monitor_slug>",
-})
-```

--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -24,11 +24,15 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 <PlatformContent includePath="crons/setup" />
 
+<PlatformSection supported={["go"]}>
+
 ## Connecting Errors to Cron Monitors
 
 To link any exceptions captured during your job's lifecycle, use <PlatformLink to="/enriching-events/context/">Sentry's context</PlatformLink> with your monitor slug.
 
 <PlatformContent includePath="crons/connect-errors" />
+
+</PlatformSection>
 
 </PlatformSection>
 


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs

## Description of changes

Most SDKs added support for Tracing without Performance, hence we do not need to tell users to set the slug manually.