### PR TITLE
Don't make it seem like `off` and `on` are keywords

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -211,12 +211,12 @@ When enabled, stack traces are automatically attached to all messages logged. St
 
 <PlatformSection supported={["android", "apple", "java"]}>
 
-This option is `on` by default.
+This option is turned on by default.
 
 </PlatformSection>
 <PlatformSection notSupported={["android", "apple", "java", "dotnet"]}>
 
-This option is `off` by default.
+This option is turned off by default.
 
 </PlatformSection>
 
@@ -234,7 +234,7 @@ If you are using Sentry in your mobile app, read our [frequently asked questions
 
 </Note>
 
-This option is `off` by default.
+This option is turned off by default.
 
 If you enable this option, be sure to manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
 
@@ -242,7 +242,7 @@ If you enable this option, be sure to manually remove what you don't want to sen
 
 <ConfigKey name="event-scrubber" supported={["python"]}>
 
-If <PlatformIdentifier name="send-default-pii" /> is `off`, scrubs the event payload for sensitive information from a `denylist`. See how to [configure the scrubber here](../../data-management/sensitive-data/#event-scrubber).
+If <PlatformIdentifier name="send-default-pii" /> is turned off, scrubs the event payload for sensitive information from a `denylist`. See how to [configure the scrubber here](../../data-management/sensitive-data/#event-scrubber).
 
 </ConfigKey>
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/7815

We can't make it true or false because that might be wrong for some languages but we can at least not make it seem like on and off are keywords.