### PR TITLE
docs: remove release property

### DIFF
--- a/src/docs/product/sentry-basics/integrate-frontend/configure-scms.mdx
+++ b/src/docs/product/sentry-basics/integrate-frontend/configure-scms.mdx
@@ -74,12 +74,9 @@ You'll need to pass your auth token to your build command later on. We recommend
          project: "___PROJECT_SLUG___",
          authToken: process.env.SENTRY_AUTH_TOKEN,
 
-         // Enable automatically creating releases and associating commits
-         release: {
-         create: true,
+         // Enable automatically associating commits
          setCommits: {
             auto: true,
-         },
          },
       }),
    ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes
`@sentry/webpack-plugin` option problem

2.0 has `release.setCommits` option ([Link](https://www.npmjs.com/package/@sentry/webpack-plugin#releasesetcommits))
but, 1.0 has only `setCommits` option  ([Link](https://www.npmjs.com/package/@sentry/webpack-plugin/v/1.20.0))

Sentry SDKs use 1.0 ([Link](https://github.com/search?q=repo%3Agetsentry%2Fsentry-javascript+%22%40sentry%2Fwebpack-plugin%22%3A&type=code))
This example code should be based on 1.0




## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
