### PR TITLE
ref(crons): Remove documentation on Attachments

### DIFF
--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -200,46 +200,6 @@ It's important to provide a timezone for non-repeating crontab schedules, such a
 
 </Alert>
 
-### Check-in Attachment (Optional)
-
-Sentry Crons can help you better understand your job check-ins by storing a file, such as a log output. You'll be able to use this to debug check-in failures or track job statuses. To upload your attachment, execute the following `HTTP POST (multipart/form-data)` request:
-
-<SignInNote />
-
-```bash {tabTitle: curl}
-# Perform a POST request to attach a file to a check-in
-curl -X POST \
-  'https://sentry.io/api/0/organizations/___ORG_SLUG___/monitors/<monitor_slug>/checkins/latest/attachment/' \
-  --header 'Authorization: DSN ___PUBLIC_DSN___' \
-  --form 'file=<file_path>'
-```
-
-```http {tabTitle: HTTP}
-POST /api/0/organizations/___ORG_SLUG___/monitors/<monitor_slug>/checkins/latest/attachment/ HTTP/1.1
-Host: sentry.io
-Authorization: DSN ___PUBLIC_DSN___
-Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
-
-------WebKitFormBoundary7MA4YWxkTrZu0gW
-Content-Disposition: form-data; name="file"
-
-<file_path>
-------WebKitFormBoundary7MA4YWxkTrZu0gW--
-```
-
-<Note>
-  We recommend uploading your attachment before you complete your second
-  check-in.
-</Note>
-
-Attachments can be downloaded in each corresponding check-in on your “Monitor Details” page.
-
-Current attachment limitations:
-
-1. Each job is limited to one attachment.
-2. The maximum file size is 100kb.
-3. Attachments aren't currently supported by our CLI or SDKs.
-
 ### Overlapping Jobs (Optional)
 
 A job execution that begins before the previous job execution has been completed is called an overlapping job. This happens if you have a job with a runtime duration longer than your job's interval schedule.


### PR DESCRIPTION
Attachments are currently underutilized in the Crons product. As it
stands, the new endpoints (using relay) do not support attachments
easily, so we should avoid documenting this for now.