### PR TITLE
fix(feedback): Fix `getCurrentHub` undefined

### DIFF
--- a/src/components/feedback/feedbackModal.tsx
+++ b/src/components/feedback/feedbackModal.tsx
@@ -188,7 +188,10 @@ export function FeedbackModal({open, onClose, onSubmit}: FeedbackModalProps) {
     });
   };
 
-  const user = window.Sentry?.getCurrentHub().getScope()?.getUser();
+  const user =
+    typeof window.Sentry?.getCurrentHub === 'function'
+      ? window.Sentry?.getCurrentHub().getScope()?.getUser()
+      : null;
 
   return (
     <Dialog id="feedbackModal" open={open} ref={dialogRef} onClick={onClose}>


### PR DESCRIPTION
Possible that the loader SDK has not loaded before rendering the widget modal (seems unlikely though)

Fixes DOCS-6A1
