### PR TITLE
fix: micro-frontend Add a beforeSend callback that sets an extra prop…

### DIFF
--- a/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
+++ b/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
@@ -219,9 +219,9 @@ init({
       const frames = event.exception.values[0].stacktrace.frames;
       // Find the last frame with module metadata containing a DSN
       const routeTo =
-        frames.findLast(
-          (frame) => frame.module_metadata && frame.module_metadata.dsn
-        ) || [];
+        frames
+          .filter(frame => frame.module_metadata && frame.module_metadata.dsn)
+          .map(v => v.module_metadata);
 
       if (routeTo.length) {
         event.extra = {

--- a/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
+++ b/src/platforms/javascript/common/configuration/micro-frontend-support.mdx
@@ -218,10 +218,9 @@ init({
     if (event?.exception?.values?.[0].stacktrace.frames) {
       const frames = event.exception.values[0].stacktrace.frames;
       // Find the last frame with module metadata containing a DSN
-      const routeTo =
-        frames
-          .filter(frame => frame.module_metadata && frame.module_metadata.dsn)
-          .map(v => v.module_metadata);
+      const routeTo = frames
+        .filter((frame) => frame.module_metadata && frame.module_metadata.dsn)
+        .map((v) => v.module_metadata);
 
       if (routeTo.length) {
         event.extra = {


### PR DESCRIPTION
…erty with the target DSN/release

FindLast cannot be used here because it does not return an array, and the current writing method cannot obtain dsn and release. Only by using the modified writing method, can the correct event. xtra be uploaded to the sub application's Sentry through Transport

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
