### PR TITLE
ref(js): Add Source Maps wizard snippet to Vue Source Maps page

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -1,4 +1,4 @@
-## Uploading Source Maps using Vite
+## Uploading Source Maps in a Vue Project
 
 <Note>
 
@@ -8,10 +8,20 @@ If you are on an older version and you want to upload source maps we recommend u
 
 </Note>
 
+### Using the Sentry Wizard
+
+The easiest and recommended way to configure uploading source maps is by using the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx" />
+
+If you want to configure source maps upload manually, follow the guide for your bundler or build tool below.
+
+### Manual Setup with Vite
+
 If you are using Vue, chances are good you are using Vite to bundle your project.
 You can use the Sentry Vite plugin to automatically create [releases](/product/releases/) and upload source maps to Sentry when bundling your app.
 
-### Installation
+#### Installation
 
 ```bash {tabTitle:npm}
 npm install @sentry/vite-plugin --save-dev
@@ -21,7 +31,7 @@ npm install @sentry/vite-plugin --save-dev
 yarn add @sentry/vite-plugin --dev
 ```
 
-### Configuration
+#### Configuration
 
 Learn more about configuring the plugin in our [Sentry Vite Plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
 
@@ -69,11 +79,11 @@ We recommend running a production build to test your implementation.
 
 </Note>
 
-## Other Bundlers
+### Other Bundlers
 
 In case you are using a bundler other than Vite to build your Vue project, we've compiled a list of guides on how to upload source maps to Sentry for the most popular JavaScript bundlers:
 
-- <PlatformLink to="/sourcemaps/uploading/webpack/">webpack</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/webpack/">Webpack</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/typescript/">
     TypeScript (tsc)
   </PlatformLink>


### PR DESCRIPTION
As part of completing https://github.com/getsentry/team-sdks/issues/2, this PR adds an improvement to the Vue source maps page. Seems like we forgot to add the source maps wizard snippet to the Vue-specific version of this page. This PR adds the snippet and aligns the structure with the Angular and Svelte-specific pages (i.e. automatic and manual setup sections). 

ref: https://github.com/getsentry/team-sdks/issues/2