### PR TITLE
ref(js): Clarify release creation in Sentry CLI source maps upload guide

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -28,6 +28,11 @@ The value can be arbitrary, but for certain platforms, recommendations exist:
 - if you use a DVCS we recommend using the identifying hash (eg: the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let sentry-cli automatically determine this hash for supported version control systems with `sentry-cli releases propose-version`.
 - if you tag releases we recommend using the release tag prefixed with a product or package name (for example, `my-project-name@2.3.12`).
 
+```bash
+#!/bin/sh
+sentry-cli releases new "$VERSION"
+```
+
 Releases can also be auto created by different systems. For instance upon uploading a source map a release is automatically created. Likewise releases are created by some clients when an event for a release comes in.
 
 ## Finalizing Releases

--- a/src/includes/sentry-cli-sourcemaps.mdx
+++ b/src/includes/sentry-cli-sourcemaps.mdx
@@ -82,7 +82,8 @@ sentry-cli sourcemaps upload --release=<release_name> /path/to/directory
 
 <Note>
 
-Running `upload` with `--release` **doesn't automatically create a release in Sentry**. For that, you should create a release with the same name as a separate step in your pipeline or send the first event to Sentry with that release.
+Running `upload` with `--release` **doesn't automatically create a release in Sentry**.
+Either wait until the first event with the new release set in `Sentry.init` is sent to Sentry, or create a release with the same name in a separate step [with the CLI](/product/cli/releases).
 
 </Note>
 


### PR DESCRIPTION
As part of completing https://github.com/getsentry/team-sdks/issues/2, this PR slightly improves wording around how to deal with releases in the new artifact bundle upload procedure. This is the result of a customer call where the customer explained how they were confused if they had to create a release with the CLI or not. It's just a slight improvement though, nothing too fancy.

ref: https://github.com/getsentry/team-sdks/issues/2