### PR TITLE
ref(feedback): De-couple button from modal

### DIFF
--- a/src/components/feedback/feedbackForm.tsx
+++ b/src/components/feedback/feedbackForm.tsx
@@ -1,0 +1,166 @@
+import React, {FormEvent, useRef} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface FeedbackFormProps {
+  onClose: () => void;
+  onSubmit: (data: {comment: string; email: string; name: string}) => void;
+}
+
+const retrieveStringValue = (formData: FormData, key: string) => {
+  const value = formData.get(key);
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return '';
+};
+
+export function FeedbackForm({onClose, onSubmit}: FeedbackFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    onSubmit({
+      name: retrieveStringValue(formData, 'name'),
+      email: retrieveStringValue(formData, 'email'),
+      comment: retrieveStringValue(formData, 'comment'),
+    });
+  };
+
+  const user = window.Sentry?.getCurrentHub().getScope()?.getUser();
+
+  return (
+    <Form ref={formRef} onSubmit={handleSubmit}>
+      <FlexColumns>
+        <Label htmlFor="sentry-feedback-name">
+          Your Name
+          <Input
+            type="text"
+            id="sentry-feedback-name"
+            name="name"
+            placeholder="Anonymous"
+            defaultValue={user?.username}
+          />
+        </Label>
+        <Label htmlFor="sentry-feedback-email">
+          Your Email
+          <Input
+            type="text"
+            id="sentry-feedback-email"
+            name="email"
+            placeholder="you@test.com"
+            defaultValue={user?.email}
+          />
+        </Label>
+      </FlexColumns>
+      <Label htmlFor="sentry-feedback-comment">
+        Comment
+        <TextArea
+          onKeyDown={event => {
+            if (event.key === 'Enter' && event.ctrlKey) {
+              formRef.current.requestSubmit();
+            }
+          }}
+          id="sentry-feedback-comment"
+          name="comment"
+          placeholder="Explain what bothers you"
+        />
+      </Label>
+      <ModalFooter>
+        <CancelButton type="button" onClick={onClose}>
+          Cancel
+        </CancelButton>
+        <SubmitButton type="submit">Submit</SubmitButton>
+      </ModalFooter>
+    </Form>
+  );
+}
+
+const Form = styled.form`
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+`;
+
+const Label = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0px;
+`;
+
+const inputStyles = css`
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  padding: 6px 8px;
+  &:focus {
+    outline: 1px solid rgba(108, 95, 199, 1);
+    border-color: rgba(108, 95, 199, 1);
+  }
+`;
+
+const Input = styled.input`
+  ${inputStyles}
+`;
+
+const TextArea = styled.textarea`
+  ${inputStyles}
+  min-height: 64px;
+  resize: vertical;
+`;
+
+const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+const buttonStyles = css`
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 6px 16px;
+`;
+
+const SubmitButton = styled.button`
+  ${buttonStyles}
+  background-color: rgba(108, 95, 199, 1);
+  color: #fff;
+  &:hover {
+    background-color: rgba(88, 74, 192, 1);
+  }
+  &:focus-visible {
+    outline: 1px solid rgba(108, 95, 199, 1);
+    background-color: rgba(88, 74, 192, 1);
+  }
+`;
+
+const CancelButton = styled.button`
+  ${buttonStyles}
+  background-color: #fff;
+  color: #231c3d;
+  font-weight: 500;
+  &:hover {
+    background-color: #eee;
+  }
+  &:focus-visible {
+    outline: 1px solid rgba(108, 95, 199, 1);
+    background-color: #eee;
+  }
+`;
+
+const FlexColumns = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  & > * {
+    flex: 1;
+  }
+`;

--- a/src/components/feedback/feedbackModal.tsx
+++ b/src/components/feedback/feedbackModal.tsx
@@ -1,9 +1,120 @@
-import React, {FormEvent, useEffect, useRef} from 'react';
-import {css} from '@emotion/react';
+import React, {Fragment, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {useFocusTrap} from '../hooks/useFocusTrap';
 import {useShortcut} from '../hooks/useShortcut';
+
+import {FeedbackForm} from './feedbackForm';
+import {FeedbackSuccessMessage} from './feedbackSuccessMessage';
+import {sendFeedbackRequest} from './sendFeedbackRequest';
+
+interface RenderFunctionProps {
+  /**
+   * Is the modal open/visible
+   */
+  open: boolean;
+
+  /**
+   * Shows the feedback modal
+   */
+  showModal: () => void;
+}
+type FeedbackRenderFunction = (
+  renderFunctionProps: RenderFunctionProps
+) => React.ReactNode;
+
+interface FeedbackModalProps {
+  children: FeedbackRenderFunction;
+  title: string;
+}
+
+interface FeedbackFormData {
+  comment: string;
+  email: string;
+  name: string;
+}
+
+async function sendFeedback(
+  data: FeedbackFormData,
+  replayId: string,
+  pageUrl: string
+): Promise<Response | null> {
+  const feedback = {
+    message: data.comment,
+    email: data.email,
+    replay_id: replayId,
+    url: pageUrl,
+  };
+  return await sendFeedbackRequest(feedback);
+}
+
+function stopPropagation(e: React.MouseEvent) {
+  e.stopPropagation();
+}
+
+export function FeedbackModal({title, children}: FeedbackModalProps) {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSubmit = (data: FeedbackFormData) => {
+    const replay = window.Sentry?.getCurrentHub?.()
+      ?.getClient()
+      ?.getIntegration(window.Sentry?.Replay);
+
+    // Prepare session replay
+    replay?.flush();
+    const replayId = replay?.getReplayId();
+
+    const pageUrl = document.location.href;
+
+    sendFeedback(data, replayId, pageUrl).then(response => {
+      if (response) {
+        setOpen(false);
+        setShowSuccessMessage(true);
+      } else {
+        // eslint-disable-next-line no-alert
+        alert('Error submitting your feedback. Please try again');
+      }
+    });
+  };
+
+  const showModal = () => {
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!showSuccessMessage) {
+      return () => {};
+    }
+    const timeout = setTimeout(() => {
+      setShowSuccessMessage(false);
+    }, 6000);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [showSuccessMessage]);
+
+  useFocusTrap(dialogRef, open);
+  useShortcut('Escape', handleClose);
+
+  return (
+    <Fragment>
+      <Dialog id="feedbackModal" open={open} ref={dialogRef} onClick={handleClose}>
+        <Content onClick={stopPropagation}>
+          <Header>{title}</Header>
+          {open && <FeedbackForm onSubmit={handleSubmit} onClose={handleClose} />}
+        </Content>
+      </Dialog>
+      <FeedbackSuccessMessage show={showSuccessMessage} />
+      {children({open, showModal})}
+    </Fragment>
+  );
+}
 
 const Dialog = styled.dialog`
   background-color: rgba(0, 0, 0, 0.05);
@@ -48,196 +159,3 @@ const Header = styled.h2`
   padding: 20px 24px;
   margin: 0px;
 `;
-
-const Form = styled.form`
-  display: flex;
-  overflow: auto;
-  flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-`;
-
-const Label = styled.label`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 0px;
-`;
-
-const inputStyles = css`
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
-  padding: 6px 8px;
-  &:focus {
-    outline: 1px solid rgba(108, 95, 199, 1);
-    border-color: rgba(108, 95, 199, 1);
-  }
-`;
-
-const Input = styled.input`
-  ${inputStyles}
-`;
-
-const TextArea = styled.textarea`
-  ${inputStyles}
-  min-height: 64px;
-  resize: vertical;
-`;
-
-const ModalFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
-`;
-
-const buttonStyles = css`
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 600;
-  padding: 6px 16px;
-`;
-
-const SubmitButton = styled.button`
-  ${buttonStyles}
-  background-color: rgba(108, 95, 199, 1);
-  color: #fff;
-  &:hover {
-    background-color: rgba(88, 74, 192, 1);
-  }
-  &:focus-visible {
-    outline: 1px solid rgba(108, 95, 199, 1);
-    background-color: rgba(88, 74, 192, 1);
-  }
-`;
-
-const CancelButton = styled.button`
-  ${buttonStyles}
-  background-color: #fff;
-  color: #231c3d;
-  font-weight: 500;
-  &:hover {
-    background-color: #eee;
-  }
-  &:focus-visible {
-    outline: 1px solid rgba(108, 95, 199, 1);
-    background-color: #eee;
-  }
-`;
-
-const FlexColumns = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 16px;
-  & > * {
-    flex: 1;
-  }
-`;
-
-interface FeedbackModalProps {
-  onClose: () => void;
-  onSubmit: (data: {comment: string; email: string; name: string}) => void;
-  open: boolean;
-}
-
-function stopPropagation(e: React.MouseEvent) {
-  e.stopPropagation();
-}
-
-const retrieveStringValue = (formData: FormData, key: string) => {
-  const value = formData.get(key);
-  if (typeof value === 'string') {
-    return value.trim();
-  }
-  return '';
-};
-
-export function FeedbackModal({open, onClose, onSubmit}: FeedbackModalProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
-
-  useFocusTrap(dialogRef, open);
-  useShortcut('Escape', onClose);
-
-  // Reset on close
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-    if (!open) {
-      timeoutId = setTimeout(() => {
-        formRef.current.reset();
-      }, 200);
-    }
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [open]);
-
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.target as HTMLFormElement);
-    onSubmit({
-      name: retrieveStringValue(formData, 'name'),
-      email: retrieveStringValue(formData, 'email'),
-      comment: retrieveStringValue(formData, 'comment'),
-    });
-  };
-
-  const user = window.Sentry?.getCurrentHub?.()?.getScope()?.getUser();
-
-  return (
-    <Dialog id="feedbackModal" open={open} ref={dialogRef} onClick={onClose}>
-      <Content onClick={stopPropagation}>
-        <Header>Got any Feedback?</Header>
-        <Form ref={formRef} onSubmit={handleSubmit}>
-          <FlexColumns>
-            <Label htmlFor="sentry-feedback-name">
-              Your Name
-              <Input
-                type="text"
-                id="sentry-feedback-name"
-                name="name"
-                placeholder="Anonymous"
-                defaultValue={user?.username}
-              />
-            </Label>
-            <Label htmlFor="sentry-feedback-email">
-              Your Email
-              <Input
-                type="text"
-                id="sentry-feedback-email"
-                name="email"
-                placeholder="you@test.com"
-                defaultValue={user?.email}
-              />
-            </Label>
-          </FlexColumns>
-          <Label htmlFor="sentry-feedback-comment">
-            Comment
-            <TextArea
-              onKeyDown={event => {
-                if (event.key === 'Enter' && event.ctrlKey) {
-                  formRef.current.requestSubmit();
-                }
-              }}
-              id="sentry-feedback-comment"
-              name="comment"
-              placeholder="Explain what bothers you"
-            />
-          </Label>
-          <ModalFooter>
-            <CancelButton type="button" onClick={onClose}>
-              Cancel
-            </CancelButton>
-            <SubmitButton type="submit">Submit</SubmitButton>
-          </ModalFooter>
-        </Form>
-      </Content>
-    </Dialog>
-  );
-}

--- a/src/components/feedback/feedbackWidget.tsx
+++ b/src/components/feedback/feedbackWidget.tsx
@@ -1,74 +1,24 @@
-import React, {Fragment, useEffect, useState} from 'react';
+import React from 'react';
 
 import {FeedbackButton} from './feedbackButton';
 import {FeedbackModal} from './feedbackModal';
-import {FeedbackSuccessMessage} from './feedbackSuccessMessage';
-import {sendFeedbackRequest} from './sendFeedbackRequest';
 
-interface FeedbackForm {
-  comment: string;
-  email: string;
-  name: string;
+interface FeedbackWidgetProps {
+  title?: string;
 }
 
-async function sendFeedback(
-  data: FeedbackForm,
-  replayId: string,
-  pageUrl: string
-): Promise<Response | null> {
-  const feedback = {
-    message: data.comment,
-    email: data.email,
-    replay_id: replayId,
-    url: pageUrl,
-  };
-  const response = await sendFeedbackRequest(feedback);
-  return response;
-}
-
-export default function FeedbackWidget() {
-  const [open, setOpen] = useState(false);
-  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-
-  useEffect(() => {
-    if (!showSuccessMessage) {
-      return () => {};
-    }
-    const timeout = setTimeout(() => {
-      setShowSuccessMessage(false);
-    }, 6000);
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [showSuccessMessage]);
-
-  const handleSubmit = (data: FeedbackForm) => {
-    const replay = window.Sentry?.getCurrentHub()
-      ?.getClient()
-      ?.getIntegration(window.Sentry?.Replay);
-
-    // Prepare session replay
-    replay?.flush();
-    const replayId = replay?.getReplayId();
-
-    const pageUrl = document.location.href;
-
-    sendFeedback(data, replayId, pageUrl).then(response => {
-      if (response) {
-        setOpen(false);
-        setShowSuccessMessage(true);
-      } else {
-        // eslint-disable-next-line no-alert
-        alert('Error submitting your feedback. Please try again');
-      }
-    });
-  };
+/**
+ * The "Widget" connects the default Feedback button with the Feedback Modal
+ */
+export default function FeedbackWidget({title = 'Got Feedback?'}: FeedbackWidgetProps) {
+  // Don't render anything if Sentry is not already loaded
+  if (!window.Sentry?.getCurrentHub?.()) {
+    return null;
+  }
 
   return (
-    <Fragment>
-      {!open && <FeedbackButton onClick={() => setOpen(true)} />}
-      <FeedbackModal open={open} onSubmit={handleSubmit} onClose={() => setOpen(false)} />
-      <FeedbackSuccessMessage show={showSuccessMessage} />
-    </Fragment>
+    <FeedbackModal title={title}>
+      {({open, showModal}) => (open ? null : <FeedbackButton onClick={showModal} />)}
+    </FeedbackModal>
   );
 }

--- a/src/components/feedback/feedbackWidgetLoader.tsx
+++ b/src/components/feedback/feedbackWidgetLoader.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, Suspense, lazy} from 'react';
+import React, {Fragment, lazy, Suspense} from 'react';
 
 const FeedbackWidget = lazy(() => import('./feedbackWidget'));
 

--- a/src/components/feedback/feedbackWidgetLoader.tsx
+++ b/src/components/feedback/feedbackWidgetLoader.tsx
@@ -1,4 +1,4 @@
-import React, {lazy} from 'react';
+import React, {Fragment, Suspense, lazy} from 'react';
 
 const FeedbackWidget = lazy(() => import('./feedbackWidget'));
 
@@ -9,12 +9,12 @@ export function FeedbackWidgetLoader() {
   const isSSR = typeof window === 'undefined';
 
   return (
-    <React.Fragment>
+    <Fragment>
       {!isSSR && (
-        <React.Suspense fallback={<div />}>
+        <Suspense fallback={<div />}>
           <FeedbackWidget />
-        </React.Suspense>
+        </Suspense>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/src/components/feedback/sendFeedbackRequest.ts
+++ b/src/components/feedback/sendFeedbackRequest.ts
@@ -22,7 +22,12 @@ export async function sendFeedbackRequest({
   replay_id,
   url,
 }): Promise<Response | null> {
-  const hub = window.Sentry.getCurrentHub();
+  const hub = window.Sentry?.getCurrentHub();
+
+  if (!hub) {
+    return null;
+  }
+
   const client = hub.getClient();
   const scope = hub.getScope();
   const transport = client && client.getTransport();


### PR DESCRIPTION
De-couple the feedback button from the modal so that we can show the modal using other components as the actor.

This change does the following:

* Move the form in `<FeedbackModal>` to `<FeedbackForm>`
* Move business logic of the modal/form into `<FeedbackModal>` (from `<FeedbackWidget>`)
* `<FeedbackModal>` requires `children` as a render function
* `<FeedbackWidget>` is refactored to use new `<FeedbackModal>` and remains the same (shows our `<FeedbackButton>` which controls the modal)
