### PR TITLE
feat(feedback): Change "Report a problem" link to open feedback modal

### DIFF
--- a/src/components/feedback/feedbackWidgetLoader.tsx
+++ b/src/components/feedback/feedbackWidgetLoader.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, Suspense, lazy} from 'react';
+import React, {Fragment, lazy, Suspense} from 'react';
 
 const FeedbackWidget = lazy(() => import('./feedbackWidget'));
 

--- a/src/components/feedback/feedbackWidgetLoader.tsx
+++ b/src/components/feedback/feedbackWidgetLoader.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, lazy, Suspense} from 'react';
+import React, {Fragment, Suspense, lazy} from 'react';
 
 const FeedbackWidget = lazy(() => import('./feedbackWidget'));
 

--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -34,13 +34,16 @@ export function GitHubCTA({sourceInstanceName, relativePath}: GitHubCTAProps) {
                 <SmartLink
                   to="https://github.com/getsentry/sentry-docs/issues/new/choose"
                   onClick={e => {
-                    if (window.Sentry?.getCurrentHub?.()) {
-                      // Only Stop event propagation if Sentry SDK is loaded
-                      // (i.e. feedback is supported), otherwise will send you to github
-                      e.preventDefault();
-                      showModal();
-                      return false;
+                    return true;
+                    if (!window.Sentry?.getCurrentHub?.()) {
+                      return true;
                     }
+
+                    // Only Stop event propagation if Sentry SDK is loaded
+                    // (i.e. feedback is supported), otherwise will send you to github
+                    e.preventDefault();
+                    showModal();
+                    return false;
                   }}
                 >
                   Report a problem

--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -34,7 +34,6 @@ export function GitHubCTA({sourceInstanceName, relativePath}: GitHubCTAProps) {
                 <SmartLink
                   to="https://github.com/getsentry/sentry-docs/issues/new/choose"
                   onClick={e => {
-                    return true;
                     if (!window.Sentry?.getCurrentHub?.()) {
                       return true;
                     }

--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 
+import {FeedbackModal} from './feedback/feedbackModal';
 import {SmartLink} from './smartLink';
 
 type GitHubCTAProps = {
@@ -27,9 +28,26 @@ export function GitHubCTA({sourceInstanceName, relativePath}: GitHubCTAProps) {
             Contribute to Docs
           </SmartLink>{' '}
           &nbsp;&nbsp;|&nbsp;&nbsp;
-          <SmartLink to="https://github.com/getsentry/sentry-docs/issues/new/choose">
-            Report a problem
-          </SmartLink>{' '}
+          <FeedbackModal title="Report a Problem">
+            {({showModal}) => (
+              <Fragment>
+                <SmartLink
+                  to="https://github.com/getsentry/sentry-docs/issues/new/choose"
+                  onClick={e => {
+                    if (window.Sentry?.getCurrentHub?.()) {
+                      // Only Stop event propagation if Sentry SDK is loaded
+                      // (i.e. feedback is supported), otherwise will send you to github
+                      e.preventDefault();
+                      showModal();
+                      return false;
+                    }
+                  }}
+                >
+                  Report a problem
+                </SmartLink>{' '}
+              </Fragment>
+            )}
+          </FeedbackModal>
         </div>
       </small>
     </div>

--- a/src/components/smartLink.tsx
+++ b/src/components/smartLink.tsx
@@ -5,7 +5,7 @@ import {marketingUrlParams} from 'sentry-docs/utils';
 
 import {ExternalLink} from './externalLink';
 
-type Props = {
+interface Props extends Omit<React.ComponentProps<typeof Link>, 'to'> {
   activeClassName?: string;
   children?: React.ReactNode;
   className?: string;
@@ -15,7 +15,7 @@ type Props = {
   target?: string;
   title?: string;
   to?: string;
-};
+}
 
 export function SmartLink({
   to,

--- a/src/components/smartLink.tsx
+++ b/src/components/smartLink.tsx
@@ -5,12 +5,13 @@ import {marketingUrlParams} from 'sentry-docs/utils';
 
 import {ExternalLink} from './externalLink';
 
-interface Props extends Omit<React.ComponentProps<typeof Link>, 'to'> {
+interface Props {
   activeClassName?: string;
   children?: React.ReactNode;
   className?: string;
   href?: string;
   isActive?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
   remote?: boolean;
   target?: string;
   title?: string;


### PR DESCRIPTION
Changes the "Report a problem" link to open feedback modal (when Sentry SDK is loaded). Otherwise will preserve previous behavior of opening link to GH issue.

Depends on https://github.com/getsentry/sentry-docs/pull/7876