### PR TITLE
ref(sveltekit): Update SvelteKit version compatibility

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.sveltekit.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.sveltekit.mdx
@@ -2,8 +2,8 @@ Sentry's SvelteKit SDK enables automatic reporting of errors and performance dat
 
 ## Compatibility
 
-The minimum supported **SvelteKit version is `1.0.0`**. This SDK works best with **Vite 4.2** and newer.
-Older Vite versions might not generate source maps correctly.
+The minimum supported SvelteKit version is `1.0.0` but we recommend using **SvelteKit version `1.24.0` or newer** for best performance.
+This SDK works best with **Vite 4.2** and newer. Older Vite versions might not generate source maps correctly.
 
 <Note>
 


### PR DESCRIPTION
This PR adds a recommendation to use our SDK with SvelteKit 1.24.0 or newer. The reason is that 1.24.0 contains an important [fix](https://github.com/sveltejs/kit/pull/10576) that lets us [avoid invalidating route data ](https://github.com/getsentry/sentry-javascript/pull/9071 )that previously caused an additional round of data loading. 

To be clear, we're not breaking compatibility with our minimum supported version (1.0.0) but for everything before 1.24.0 the SDK causes a slight performance hit, hence the recommendation.

ref https://github.com/getsentry/sentry-javascript/issues/8818