### PR TITLE
fix(releases-flutter): Replace reference to Rust SDK with correct Flutter version

### DIFF
--- a/src/platform-includes/configuration/auto-session-tracking/flutter.mdx
+++ b/src/platform-includes/configuration/auto-session-tracking/flutter.mdx
@@ -1,4 +1,4 @@
-To benefit from the health data, you must use at least version 0.4.0 of the Rust SDK.
+To benefit from the health data, you must use at least version 4.0.0 of the Flutter SDK.
 
 By default, the session is terminated once the application is in the background for more than 30 seconds. You can change the time out with the option named `sessionTrackingIntervalMillis`. It takes the amount in milliseconds. For example, to configure it to be 60 seconds:
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/7877

## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Removed mention of Rusk SDK and replaced with Flutter. v4.0.0 should be correct according to this page: https://pub.dev/packages/sentry_flutter/changelog#400