### PR TITLE
Add Disabled Alerts section

### DIFF
--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -66,7 +66,7 @@ Metric alerts work in the same way as Issue alerts and can be muted on the **Ale
 
 Sentry has disabled duplicate alerts and alerts with no actions. If a noisy alert is sent to a communication channel and receives no engagement for an extended time, Sentry will proactively disable it to reduce unnecessary noise.
 
-Anyone with [alert edit access](product/accounts/membership/) can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](product/alerts/best-practices/) for guidance on writing useful alerts.
+Anyone with [alert edit access](/product/accounts/membership/) can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
 
 ## Notifications
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -70,7 +70,7 @@ To ensure that your alerts are working properly, Sentry will proactively disable
 - Is missing actions.
 - Has been sent over 500 times to a communication channel in the last month with no engagement.
 
-Alert owners can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
+Anyone in the organization can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
 
 ## Notifications
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -66,11 +66,9 @@ Metric alerts work in the same way as Issue alerts and can be muted on the **Ale
 
 To ensure that your alerts are working properly, Sentry will proactively disable an alert from sending if we detect that the alert:
 
-- is a duplicate of an existing alert rule.
-- is missing actions.
-- has been sent over 500 times to a communication channel in the last month with no engagement.
-
-Disabled alerts are indicated with a "Disabled" status on the **Alerts** page.
+- Is a duplicate of an existing alert rule.
+- Is missing actions.
+- Has been sent over 500 times to a communication channel in the last month with no engagement.
 
 Alert owners can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -64,13 +64,9 @@ Metric alerts work in the same way as Issue alerts and can be muted on the **Ale
 
 ## Disabled Alerts
 
-To ensure that your alerts are working properly without causing unnecessary noise, Sentry will proactively disable an alert from sending if we detect that the alert:
+Sentry has disabled duplicate alerts and alerts with no actions. If a noisy alert is sent to a communication channel and receives no engagement for an extended time, Sentry will proactively disable it to reduce unnecessary noise.
 
-- Is a duplicate of an existing alert rule.
-- Is missing actions.
-- Has been sent over 500 times to a communication channel in the last month with no engagement.
-
-Anyone in the organization can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
+Anyone with [alert edit access](product/accounts/membership/) can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](product/alerts/best-practices/) for guidance on writing useful alerts.
 
 ## Notifications
 

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -62,6 +62,18 @@ Issue alerts can be muted on the **Alerts** details page by clicking the "Mute" 
 
 Metric alerts work in the same way as Issue alerts and can be muted on the **Alerts** details page by clicking the "Mute" button.
 
+## Disabled Alerts
+
+To ensure that your alerts are working properly, Sentry will proactively disable an alert from sending if we detect that the alert:
+
+- is a duplicate of an existing alert rule.
+- is missing actions.
+- has been sent over 500 times to a communication channel in the last month with no engagement.
+
+Disabled alerts are indicated with a "Disabled" status on the **Alerts** page.
+
+Alert owners can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
+
 ## Notifications
 
 Besides alerts, Sentry sends you notifications about various things like [issue state changes](/product/issues/states-triage/), [release deploys](/product/releases/), and [quota usage](/product/accounts/quotas/). You can fine tune these notifications, as well as your personal alert settings, in **User Settings > Notifications**. Learn more about notifications and adjusting their associated settings in [the full documentation](/product/alerts/notifications/).

--- a/src/docs/product/alerts/index.mdx
+++ b/src/docs/product/alerts/index.mdx
@@ -64,7 +64,7 @@ Metric alerts work in the same way as Issue alerts and can be muted on the **Ale
 
 ## Disabled Alerts
 
-To ensure that your alerts are working properly, Sentry will proactively disable an alert from sending if we detect that the alert:
+To ensure that your alerts are working properly without causing unnecessary noise, Sentry will proactively disable an alert from sending if we detect that the alert:
 
 - Is a duplicate of an existing alert rule.
 - Is missing actions.


### PR DESCRIPTION

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

- Add section on disabled alerts

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
