### PR TITLE
fix(replay): Set explicit size for feedback svg

### DIFF
--- a/src/components/feedback/feedbackButton.tsx
+++ b/src/components/feedback/feedbackButton.tsx
@@ -24,6 +24,11 @@ const Button = styled.button`
   &:hover {
     background-color: #eee;
   }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
 `;
 
 const ButtonText = styled.span`


### PR DESCRIPTION
Looks like rrweb does not record height/width attrs on svgs, so if you have images disabled, the replay can look inaccurate due the svg size.
