### PR TITLE
9.0.0 broke a public API for configuration that was "soft deprecated"

### DIFF
--- a/src/platforms/elixir/index.mdx
+++ b/src/platforms/elixir/index.mdx
@@ -42,7 +42,7 @@ config :sentry,
   dsn: "___PUBLIC_DSN___",
   environment_name: :prod,
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!(),
+  root_source_code_paths: [File.cwd!()],
   tags: %{
     env: "production"
   },
@@ -197,12 +197,12 @@ defp aliases do
 end
 ```
 
-To enable, set `:enable_source_code_context` and `root_source_code_path`:
+To enable, set `:enable_source_code_context` and `root_source_code_paths`:
 
 ```elixir
 config :sentry,
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!()
+  root_source_code_paths: [File.cwd!()]
 ```
 
 For more documentation, see [Sentry.Sources](https://hexdocs.pm/sentry/Sentry.Sources.html).


### PR DESCRIPTION
The documentation was never updated with the new configuration property and also I don't know if it was ever truly soft deprecated in the code. Easy to miss and I'm glad it's finally been hard deprecated.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
