### PR TITLE
Remove requirement for "Business Plan" 

### DIFF
--- a/src/docs/product/performance/retention-priorities/index.mdx
+++ b/src/docs/product/performance/retention-priorities/index.mdx
@@ -29,7 +29,6 @@ It's important to note that even when we begin to only store the most valuable d
 
 ## Prerequisites
 
-- Latest version of [Sentry Business plan](https://sentry.io/pricing/).
 - Admin-level permissions.
 - Latest version of one of the below SDKs:
   - Python: 1.7.2 or later


### PR DESCRIPTION
Retention priorities are available on all AM2 plans with more than 1M tx/month, so this line is misleading. We explain the availability on latest plans in the callout on the top of the page, so I would remove it completely.

<img width="768" alt="Screenshot 2023-09-25 at 11 36 58" src="https://github.com/getsentry/sentry-docs/assets/26696515/274ec388-86c0-4493-b9a8-7d8794765f08">

