### PR TITLE
feat(replay): Update performance overhead

### DIFF
--- a/src/docs/product/session-replay/performance-overhead.mdx
+++ b/src/docs/product/session-replay/performance-overhead.mdx
@@ -51,9 +51,7 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
 </p>
 
 <p>
-  <sub>
-  Benchmarks last updated on Sept 25, 2023
-  </sub>
+  <sub>Benchmarks last updated on Sept 25, 2023</sub>
 </p>
 
 The benchmarks were run on an Apple M1 MacBook Pro against a remote preview server and a remote API backend with 50 iterations. The scenario can be summarized as loading Sentry, navigating to Discover, adding 4 columns, waiting for results, adding another column, and finally waiting for results a second time.

--- a/src/docs/product/session-replay/performance-overhead.mdx
+++ b/src/docs/product/session-replay/performance-overhead.mdx
@@ -33,16 +33,20 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
 
 | Metric                           | Without Sentry | Sentry SDK only | Sentry + Replay SDK |
 | -------------------------------- | -------------- | --------------- | ------------------- |
-| Largest Contentful Paint (LCP)\* | 1336.05 ms     | 1896.80 ms      | 1643.00 ms          |
-| Cumulative Layout Shift (CLS)    | 0.39 ms        | 0.39 ms         | 0.39 ms             |
-| First Input Delay (FID)          | 1.30 ms        | 1.30 ms         | 1.60 ms             |
-| Total Blocking Time (TBT)        | 2629.00 ms     | 2742.00 ms      | 3267.50 ms          |
-| Average Memory                   | 118.79 MB      | 113.79 MB       | 132.05 MB           |
-| Max Memory                       | 311.4 MB       | 316.57 MB       | 334.82 MB           |
-| Network Upload                   | 21 B           | 3.79 KB         | 392.98 KB           |
-| Network Download                 | 7.11 MB        | 6.93 MB         | 6.87 MB             |
+| Largest Contentful Paint (LCP)\* | 1599.19 ms     | 1546.07 ms      | 1643.00 ms          |
+| Cumulative Layout Shift (CLS)    | 0.40 ms        | 0.40 ms         | 0.39 ms             |
+| First Input Delay (FID)          | 1.26 ms        | 1.30 ms         | 1.60 ms             |
+| Total Blocking Time (TBT)        | 2621.67 ms     | 2663.35 ms      | 3267.50 ms          |
+| Average Memory                   | 119.26 MB      | 125.12 MB       | 132.05 MB           |
+| Max Memory                       | 320.66 MB      | 359.21 MB       | 334.82 MB           |
+| Network Upload                   | 21 B           | 3.84 KB         | 392.98 KB           |
+| Network Download                 | 8.06 MB        | 8.09 MB         | 6.87 MB             |
 
 <p>
+  <sub>
+  Benchmarks last updated on Sept 25, 2023
+  </sub>
+
   <sub>
     * The standard deviation for LCP was 386, 511, and 354 ms, respectively.
     This means that the LCP values are quite spread out and explains why the
@@ -50,7 +54,7 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
   </sub>
 </p>
 
-The benchmarks were run on an Apple M1 MacBook Pro against a remote preview server and a remote API backend with 100 iterations. The scenario can be summarized as loading Sentry, navigating to Discover, adding 4 columns, waiting for results, adding another column, and finally waiting for results a second time.
+The benchmarks were run on an Apple M1 MacBook Pro against a remote preview server and a remote API backend with 50 iterations. The scenario can be summarized as loading Sentry, navigating to Discover, adding 4 columns, waiting for results, adding another column, and finally waiting for results a second time.
 
 The benchmark test was a strenuous recording scenario (the Discover data table is one of our most complex, in regards to DOM nodes and mutations). A simpler scenario consisting of navigation to four different "Settings" pages was also ran and produced an increase of ~100 ms of total JS blocking time.
 

--- a/src/docs/product/session-replay/performance-overhead.mdx
+++ b/src/docs/product/session-replay/performance-overhead.mdx
@@ -33,14 +33,14 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
 
 | Metric                           | Without Sentry | Sentry SDK only | Sentry + Replay SDK |
 | -------------------------------- | -------------- | --------------- | ------------------- |
-| Largest Contentful Paint (LCP)\* | 1599.19 ms     | 1546.07 ms      | 1643.00 ms          |
-| Cumulative Layout Shift (CLS)    | 0.40 ms        | 0.40 ms         | 0.39 ms             |
-| First Input Delay (FID)          | 1.26 ms        | 1.30 ms         | 1.60 ms             |
-| Total Blocking Time (TBT)        | 2621.67 ms     | 2663.35 ms      | 3267.50 ms          |
-| Average Memory                   | 119.26 MB      | 125.12 MB       | 132.05 MB           |
-| Max Memory                       | 320.66 MB      | 359.21 MB       | 334.82 MB           |
-| Network Upload                   | 21 B           | 3.84 KB         | 392.98 KB           |
-| Network Download                 | 8.06 MB        | 8.09 MB         | 6.87 MB             |
+| Largest Contentful Paint (LCP)\* | 1599.19 ms     | 1546.07 ms      | 1529.11 ms          |
+| Cumulative Layout Shift (CLS)    | 0.40 ms        | 0.40 ms         | 0.40 ms             |
+| First Input Delay (FID)          | 1.26 ms        | 1.30 ms         | 1.50 ms             |
+| Total Blocking Time (TBT)        | 2621.67 ms     | 2663.35 ms      | 3036.80 ms          |
+| Average Memory                   | 119.26 MB      | 125.12 MB       | 124.84 MB           |
+| Max Memory                       | 320.66 MB      | 359.21 MB       | 339.03 MB           |
+| Network Upload                   | 21 B           | 3.84 KB         | 272.51 KB           |
+| Network Download                 | 8.06 MB        | 8.09 MB         | 8.07 MB             |
 
 <p>
   <sub>

--- a/src/docs/product/session-replay/performance-overhead.mdx
+++ b/src/docs/product/session-replay/performance-overhead.mdx
@@ -44,13 +44,15 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
 
 <p>
   <sub>
-  Benchmarks last updated on Sept 25, 2023
-  </sub>
-
-  <sub>
     * The standard deviation for LCP was 386, 511, and 354 ms, respectively.
     This means that the LCP values are quite spread out and explains why the
     Sentry standalone LCP value is higher than the Sentry with Replay value.
+  </sub>
+</p>
+
+<p>
+  <sub>
+  Benchmarks last updated on Sept 25, 2023
   </sub>
 </p>
 


### PR DESCRIPTION
Updates performance overhead benchmarks + benchmark against rrweb2.

I didn't include rrweb1 benchmarks but here they are for reference:

<img width="235" alt="Pasted Graphic 1" src="https://github.com/getsentry/sentry-docs/assets/79684/306a0b3d-125b-4346-98e7-a6e781fd35e8">

LCP is not very reliable, but here we can see total blocking time (tbt) has improved with rrweb2.