### PR TITLE
fix: code formatting Objective-C

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/frame-drop/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/frame-drop/index.mdx
@@ -48,7 +48,7 @@ The “Stack Trace” section shows a full stack trace view, highlighting the lo
 
 The following code executes a long-running `while` loop on the main thread:
 
-```objective-c
+```objc
 // given an array of number strings...
 
 NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSString *> orderedSet];
@@ -61,7 +61,7 @@ NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSStri
 
 Performance could be improved by moving the long computation off of the main thread. The simplest approach is dispatching it to a lower Quality of Service (QoS) queue (or `NSOperationQueue`):
 
-```objective-c {tabTitle:Dispatch to Background Queue}
+```objc {tabTitle:Dispatch to Background Queue}
 // given an array of number strings...
 
 NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSString *> orderedSet];
@@ -80,7 +80,7 @@ Another avenue to consider for loops is to parallelize iterations. There are sev
 
 1. Use `dispatch_apply` to perform iterations of a general loop on a concurrent queue.
 
-```objective-c {tabTitle:Foundation Collection Concurrent Enumeration}
+```objc {tabTitle:Foundation Collection Concurrent Enumeration}
 // given an array of number strings...
 
 NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSString *> orderedSet];
@@ -91,7 +91,7 @@ NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSStri
 }];
 ```
 
-```objective-c {tabTitle:dispatch_apply}
+```objc {tabTitle:dispatch_apply}
 // given an array of number strings...
 
 NSMutableOrderedSet<NSString *> *sortedEvenNumbers = [NSMutableOrderedSet<NSString *> orderedSet];


### PR DESCRIPTION
Local build warned me:

> warn unable to find prism language 'objective-c' for highlighting. applying generic code block

No styling before https://docs.sentry.io/product/issues/issue-details/performance-issues/frame-drop/:

![image](https://github.com/getsentry/sentry-docs/assets/1633368/7162bbac-b603-4a45-af59-149e41fc405f)


After:

![image](https://github.com/getsentry/sentry-docs/assets/1633368/a0e330ad-1041-4fce-a433-c520a0287afd)
