### PR TITLE
replay: mask only user data

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -57,7 +57,8 @@ Sentry.onLoad(function() {
   Sentry.init({
     integrations: [
       new Sentry.Replay({
-        unmask: ['.hover-card-link'],
+        maskAllText: false,
+        blockAllMedia: false,
       }),
     ],
     tracesSampleRate: ${sentryEnvironment === 'development' ? 0 : 1},

--- a/src/components/codeKeywords.tsx
+++ b/src/components/codeKeywords.tsx
@@ -220,6 +220,7 @@ function OrgAuthTokenCreator() {
             {orgSlugs.map(org => {
               return (
                 <ItemButton
+                  data-sentry-mask
                   key={org}
                   isActive={false}
                   onClick={() => {
@@ -332,6 +333,7 @@ function KeywordSelector({keyword, group, index}: KeywordSelectorProps) {
               const isActive = idx === currentSelectionIdx;
               return (
                 <ItemButton
+                  data-sentry-mask
                   key={idx}
                   isActive={isActive}
                   onClick={() => {

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -126,7 +126,7 @@ export function CodeTabs({children}: CodeTabProps) {
   return (
     <Container ref={containerRef}>
       <TabBar>{buttons}</TabBar>
-      <div className="tab-content">{code}</div>
+      <div className="tab-content" data-sentry-mask>{code}</div>
     </Container>
   );
 }

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -126,7 +126,9 @@ export function CodeTabs({children}: CodeTabProps) {
   return (
     <Container ref={containerRef}>
       <TabBar>{buttons}</TabBar>
-      <div className="tab-content" data-sentry-mask>{code}</div>
+      <div className="tab-content" data-sentry-mask>
+        {code}
+      </div>
     </Container>
   );
 }


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-docs/issues/7951

Seems to work locally, lets check vercel:

![image](https://github.com/getsentry/sentry-docs/assets/1633368/b947cb33-65d7-49a1-8144-de8d0b704279)

![image](https://github.com/getsentry/sentry-docs/assets/1633368/bbe4c120-3423-42e4-acd5-ad7bdd699ef4)

Masking all code snippets which is more than we wants, but a step forward.

Thanks @billyvg for helping chase down the places to mask