### PR TITLE
fix: azure functions name

### DIFF
--- a/src/platforms/dotnet/guides/azure-functions-worker/index.mdx
+++ b/src/platforms/dotnet/guides/azure-functions-worker/index.mdx
@@ -3,7 +3,7 @@ title: Azure Functions (Isolated Worker)
 description: "Learn about Sentry's .NET integration with Azure Functions."
 ---
 
-Sentry provides an integration with Azure Functions through the [Sentry.AzureFunctions.Worker NuGet package](https://www.nuget.org/packages/Sentry.AzureFunctions.Worker).
+Sentry provides an integration with Azure Functions through the [Sentry.Azure.Functions.Worker NuGet package](https://www.nuget.org/packages/Sentry.Azure.Functions.Worker).
 All triggers are supported.
 
 ## Install
@@ -11,11 +11,11 @@ All triggers are supported.
 Add the Sentry dependency to your Azure Functions application:
 
 ```shell {tabTitle:.NET Core CLI}
-dotnet add package Sentry.AzureFunctions.Worker -v {{@inject packages.version('sentry.dotnet.azurefunctions.worker') }}
+dotnet add package Sentry.Azure.Functions.Worker -v {{@inject packages.version('sentry.dotnet.azure.functions.worker') }}
 ```
 
 ```powershell {tabTitle:Package Manager}
-Install-Package Sentry.AzureFunctions.Worker -Version {{@inject packages.version('sentry.dotnet.azurefunctions.worker') }}
+Install-Package Sentry.Azure.Functions.Worker -Version {{@inject packages.version('sentry.dotnet.azure.functions.worker') }}
 ```
 
 This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extensions-logging/). This means that besides the Azure Functions related features, through this package you'll also get access to the `ILogger<T>` integration and also the features available in the main [Sentry](/platforms/dotnet/) SDK.
@@ -44,4 +44,4 @@ await host.RunAsync();
 
 ## Samples
 
-- [Integration with Azure Functions](https://github.com/getsentry/sentry-dotnet/tree/main/src/Sentry.AzureFunctions.Worker) sample demonstrates Sentry with Azure Functions Isolated Worker SDK. (**C#**)
+- [Integration with Azure Functions](https://github.com/getsentry/sentry-dotnet/tree/main/src/Sentry.Azure.Functions.Worker) sample demonstrates Sentry with Azure Functions Isolated Worker SDK. (**C#**)


### PR DESCRIPTION
See: https://github.com/getsentry/sentry-dotnet/pull/2637

Blocked on:
* A non-beta new version of the .NET SDK has to be published first. cc @bitsandfoxes 
* Redoing this with the right name: https://github.com/getsentry/sentry-release-registry/pull/112

Craft is already configured to publish this package to release registry: https://github.com/getsentry/sentry-dotnet/blob/56797bd7951e72f452d636f0f6f34c1fb672ff04/.craft.yml#L20 cc @jamescrosswell 