### PR TITLE
Docs for Java SDK Check-ins

### DIFF
--- a/src/docs/product/crons/getting-started/index.mdx
+++ b/src/docs/product/crons/getting-started/index.mdx
@@ -19,6 +19,8 @@ To set up Sentry Crons, use the links below for supported SDKs or the Sentry CLI
   - [SvelteKit](/platforms/javascript/guides/sveltekit/crons/)
   - [Remix](/platforms/javascript/guides/remix/crons/)
 - [Go](/platforms/go/crons/)
+- [Java](/platforms/java/crons/)
+  - [Spring Boot](/platforms/java/guides/spring-boot/crons/)
 
 <Alert level="note" title="Don't see your platform?">
 

--- a/src/platform-includes/crons/requirements/java.mdx
+++ b/src/platform-includes/crons/requirements/java.mdx
@@ -1,0 +1,2 @@
+- Use our <PlatformLink to="/">getting started</PlatformLink> guide to install and configure the Sentry Java SDK (min 6.30.0) for your recurring job.
+- [Create and configure](https://sentry.io/crons/create/) your first Monitor.

--- a/src/platform-includes/crons/setup/java.mdx
+++ b/src/platform-includes/crons/setup/java.mdx
@@ -1,0 +1,136 @@
+If you are using [Quartz](http://www.quartz-scheduler.org/), please see <PlatformLink to="/configuration/integrations/quartz/">our Quartz integration</PlatformLink>. If you are using Spring Boot with `@Scheduled` tasks, see [our Spring Boot integration](/platforms/java/guides/spring-boot/crons/).
+
+## Check-Ins (Recommended)
+
+Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+```java
+import io.sentry.CheckIn;
+import io.sentry.CheckInStatus;
+import io.sentry.Sentry;
+import io.sentry.protocol.SentryId;
+
+// 🟡 Notify Sentry your job is running:
+SentryId checkInId = Sentry.captureCheckIn(
+    new CheckIn(
+        "<monitor-slug>",
+        CheckInStatus.IN_PROGRESS
+    )
+);
+
+// Execute your scheduled task here...
+
+// 🟢 Notify Sentry your job has completed successfully:
+Sentry.captureCheckIn(
+    new CheckIn(
+        checkInId,
+        "<monitor-slug>",
+        CheckInStatus.OK
+    )
+);
+```
+
+If your job execution fails, you can notify Sentry about the failure:
+
+```java
+// 🔴 Notify Sentry your job has failed:
+Sentry.captureCheckIn(
+    new CheckIn(
+        checkInId,
+        "<monitor-slug>",
+        CheckInStatus.ERROR
+    )
+);
+```
+
+## Heartbeat
+
+Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
+
+```java
+import io.sentry.CheckIn;
+import io.sentry.CheckInStatus;
+import io.sentry.Sentry;
+import io.sentry.protocol.SentryId;
+
+// Execute your scheduled task...
+
+// 🟢 Notify Sentry your job completed successfully:
+CheckIn checkIn = new CheckIn(
+    "<monitor-slug>",
+    CheckInStatus.OK
+);
+checkIn.setDuration(10.0);
+Sentry.captureCheckIn(checkIn);
+```
+
+If your job execution fails, you can:
+
+```java
+import io.sentry.CheckIn;
+import io.sentry.CheckInStatus;
+import io.sentry.Sentry;
+import io.sentry.protocol.SentryId;
+
+// 🔴 Notify Sentry your job has failed:
+CheckIn checkIn = new CheckIn(
+    "<monitor-slug>",
+    CheckInStatus.ERROR
+);
+checkIn.setDuration(10.0);
+Sentry.captureCheckIn(checkIn);
+```
+
+## Upserting Cron Monitors
+
+You can create and update your Monitors programmatically with code
+rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/).
+
+```java
+import io.sentry.MonitorSchedule;
+import io.sentry.MonitorScheduleUnit;
+
+// Create a crontab schedule object (every 10 minutes)
+MonitorSchedule monitorSchedule = MonitorSchedule.crontab("*/10 * * * *");
+
+// Or create an interval schedule object (every 10 minutes)
+MonitorSchedule monitorSchedule = MonitorSchedule.interval(10, MonitorScheduleUnit.MINUTE);
+```
+
+Supported units are:
+
+- `MonitorScheduleUnit.MINUTE`
+- `MonitorScheduleUnit.HOUR`
+- `MonitorScheduleUnit.DAY`
+- `MonitorScheduleUnit.WEEK`
+- `MonitorScheduleUnit.MONTH`
+- `MonitorScheduleUnit.YEAR`
+
+```java
+import io.sentry.MonitorConfig;
+
+// Create a config object
+MonitorConfig monitorConfig = new MonitorConfig(monitorSchedule);
+monitorConfig.setTimezone("Europe/Vienna"); // Optional timezone
+monitorConfig.setCheckinMargin(5L); // Optional check-in margin in minutes
+monitorConfig.setMaxRuntime(15L); // Optional max runtime in minutes
+
+// 🟡 Notify Sentry your job is running:
+CheckIn checkIn = new CheckIn(
+    "<monitor-slug>",
+    CheckInStatus.IN_PROGRESS
+);
+checkIn.setMonitorConfig(monitorConfig);
+SentryId checkInId = Sentry.captureCheckIn(checkIn);
+
+// Execute your scheduled task here...
+
+// 🟢 Notify Sentry your job has completed successfully:
+Sentry.captureCheckIn(
+    new CheckIn(
+        checkInId,
+        "<monitor-slug>",
+        CheckInStatus.OK
+    )
+);
+```

--- a/src/platform-includes/crons/setup/java.spring-boot.mdx
+++ b/src/platform-includes/crons/setup/java.spring-boot.mdx
@@ -1,0 +1,65 @@
+If you are using [Quartz](http://www.quartz-scheduler.org/), please see <PlatformLink to="/configuration/integrations/quartz/">our Quartz integration</PlatformLink>. You may also [send check-ins manually](/platforms/java/crons/).
+
+## Check-Ins (Recommended)
+
+Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+```java {tabTitle:Java (Spring Boot 3)}
+import io.sentry.spring.jakarta.checkin.SentryCheckIn;
+
+@Component
+public class CustomJob {
+
+  @Scheduled(fixedRate = 3 * 60 * 1000L)
+  @SentryCheckIn("<monitor-slug>") // 👈
+  void execute() throws InterruptedException {
+    // your task code
+  }
+}
+```
+
+```java {tabTitle:Java (Spring Boot 2)}
+import io.sentry.spring.checkin.SentryCheckIn;
+
+@Component
+public class CustomJob {
+
+  @Scheduled(fixedRate = 3 * 60 * 1000L)
+  @SentryCheckIn("<monitor-slug>") // 👈
+  void execute() throws InterruptedException {
+    // your task code
+  }
+}
+```
+
+## Heartbeat
+
+Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
+
+```java {tabTitle:Java (Spring Boot 3)}
+import io.sentry.spring.jakarta.checkin.SentryCheckIn;
+
+@Component
+public class CustomJob {
+
+  @Scheduled(fixedRate = 3 * 60 * 1000L)
+  @SentryCheckIn(monitorSlug = "<monitor-slug>", heartbeat = true) // 👈
+  void execute() throws InterruptedException {
+    // your task code
+  }
+}
+```
+
+```java {tabTitle:Java (Spring Boot 2)}
+import io.sentry.spring.checkin.SentryCheckIn;
+
+@Component
+public class CustomJob {
+
+  @Scheduled(fixedRate = 3 * 60 * 1000L)
+  @SentryCheckIn(monitorSlug = "<monitor-slug>", heartbeat = true) // 👈
+  void execute() throws InterruptedException {
+    // your task code
+  }
+}
+```

--- a/src/platform-includes/crons/setup/java.spring-boot.mdx
+++ b/src/platform-includes/crons/setup/java.spring-boot.mdx
@@ -2,7 +2,7 @@ If you are using [Quartz](http://www.quartz-scheduler.org/), please see <Platfor
 
 ## Check-Ins (Recommended)
 
-Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+Check-in monitoring allows you to track a job's progress by completing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed). To start sending check-ins simply add the `@SentryCheckIn("<monitor-slug>")` annotation to the method you want to send check-ins for.
 
 ```java {tabTitle:Java (Spring Boot 3)}
 import io.sentry.spring.jakarta.checkin.SentryCheckIn;
@@ -34,7 +34,7 @@ public class CustomJob {
 
 ## Heartbeat
 
-Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead.
+Heartbeat monitoring notifies Sentry of a job's status through one check-in. This setup will only notify you if your job didn't start when expected (missed). If you need to track a job to see if it exceeded its maximum runtime (failed), use check-ins instead. To start sending heartbeats simply add the `@SentryCheckIn(monitorSlug = "<monitor-slug>", heartbeat = true)` annotation to the method you want to send heartbeats for.
 
 ```java {tabTitle:Java (Spring Boot 3)}
 import io.sentry.spring.jakarta.checkin.SentryCheckIn;

--- a/src/platform-includes/crons/troubleshooting/java.mdx
+++ b/src/platform-includes/crons/troubleshooting/java.mdx
@@ -1,0 +1,3 @@
+### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
+
+Attachments aren't supported by our Java SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/src/platforms/common/crons/index.mdx
+++ b/src/platforms/common/crons/index.mdx
@@ -5,6 +5,7 @@ supported:
   - python
   - php
   - node
+  - java
   - javascript.nextjs
   - javascript.sveltekit
   - javascript.remix
@@ -16,7 +17,7 @@ description: "Learn how to enable Cron Monitoring in your app"
 
 Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.
 
-<PlatformSection supported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go"]}>
+<PlatformSection supported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go", "java"]}>
 
 ## Requirements
 
@@ -36,7 +37,7 @@ To link any exceptions captured during your job's lifecycle, use <PlatformLink t
 
 </PlatformSection>
 
-<PlatformSection notSupported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go"]}>
+<PlatformSection notSupported={["python", "php", "node", "javascript.nextjs", "javascript.sveltekit", "javascript.remix", "go", "java"]}>
 
 ## Requirements
 

--- a/src/platforms/common/crons/troubleshooting.mdx
+++ b/src/platforms/common/crons/troubleshooting.mdx
@@ -5,6 +5,7 @@ supported:
   - python
   - php
   - node
+  - java
   - javascript.nextjs
   - javascript.sveltekit
   - javascript.remix

--- a/src/platforms/common/crons/troubleshooting.mdx
+++ b/src/platforms/common/crons/troubleshooting.mdx
@@ -17,6 +17,7 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
     "python",
     "php",
     "node",
+    "java",
     "javascript.nextjs",
     "javascript.sveltekit",
     "javascript.remix"

--- a/src/platforms/java/common/configuration/integrations/index.mdx
+++ b/src/platforms/java/common/configuration/integrations/index.mdx
@@ -2,10 +2,6 @@
 title: Integrations
 sidebar_order: 200
 description: "Learn more about how integrations extend the functionality of our SDK to cover common libraries and environments automatically."
-notSupported:
-  - java.logback
-  - java.log4j2
-  - java.jul
 ---
 
 <PageGrid />

--- a/src/platforms/java/common/configuration/integrations/quartz.mdx
+++ b/src/platforms/java/common/configuration/integrations/quartz.mdx
@@ -1,0 +1,69 @@
+---
+title: Quartz Integration
+sidebar_order: 7
+description: "Learn how to send check-ins for your Quartz jobs."
+notSupported:
+  - java.logback
+  - java.log4j2
+  - java.jul
+---
+
+Sentry's [Quartz](http://www.quartz-scheduler.org/) integration is provided through `SenryJobListener` which you have to add to your scheduler instance.
+
+Our Quartz integration can be configured automatically if you're using `spring-boot-starter-quartz` with either the `sentry-spring-boot-starter` or the `sentry-spring-boot-jakarta-starter` integration. However you still have to specify the monitor slug as shown below.
+
+Check-ins may also be [sent manually](/platforms/java/crons/) or by using our [`@SentryCheckIn` annotation](/platforms/java/guides/spring-boot/crons/), in case you are using our Spring Boot integration and would like to send check-ins for your `@Scheduled` tasks.
+
+## Install
+
+To install use:
+
+```groovy {tabTitle:Gradle Plugin}
+plugins {
+  id "io.sentry.jvm.gradle" version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.13.0') }}"
+}
+```
+
+```groovy {tabTitle:Gradle}
+implementation 'io.sentry:sentry-quartz:{{@inject packages.version('sentry.java.quartz', '6.30.0') }}'
+```
+
+```xml {tabTitle:Maven}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-quartz</artifactId>
+    <version>{{@inject packages.version('sentry.java.quartz', '6.30.0') }}</version>
+</dependency>
+```
+
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-quartz" % "{{@inject packages.version('sentry.java.quartz', '6.30.0') }}"
+```
+
+For other dependency managers, check out the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-quartz).
+
+## Set Up
+
+You have to provide the monitor slug either
+- when building a Quartz `JobDetail` instance
+- or when building a Quartz `Trigger` instance
+
+To do so, you have to add an entry to the jobs data map:
+
+```java
+import io.sentry.quartz.SentryJobListener;
+
+// you can set the monitor slug on the job detail
+JobDetailFactoryBean jobDetailFactory = new JobDetailFactoryBean();
+jobDetailFactory.setJobDataAsMap(Collections.singletonMap(SentryJobListener.SENTRY_SLUG_KEY, "<monitor-slug>"));
+
+// you can also set the monitor slug on the trigger
+SimpleTriggerFactoryBean trigger = new SimpleTriggerFactoryBean();
+trigger.setJobDataAsMap(Collections.singletonMap(SENTRY_SLUG_KEY, "monitor_slug_simple_trigger"));
+```
+
+<Note>
+
+Setting the monitor slug on the `Trigger` will override what is set on the `JobDetail`. This also means you can set up a separate monitor per `Trigger`.
+
+</Note>

--- a/src/platforms/java/common/configuration/integrations/quartz.mdx
+++ b/src/platforms/java/common/configuration/integrations/quartz.mdx
@@ -1,14 +1,14 @@
 ---
 title: Quartz Integration
-sidebar_order: 7
+sidebar_order: 10
 description: "Learn how to send check-ins for your Quartz jobs."
 ---
 
 Sentry's [Quartz](http://www.quartz-scheduler.org/) integration is provided through `SenryJobListener` which you have to add to your scheduler instance.
 
-Our Quartz integration can be configured automatically if you're using `spring-boot-starter-quartz` with either the `sentry-spring-boot-starter` or the `sentry-spring-boot-jakarta-starter` integration. However you still have to specify the monitor slug as shown below.
+The Quartz integration will be configured automatically if you're using `spring-boot-starter-quartz` with either the `sentry-spring-boot-starter` or the `sentry-spring-boot-jakarta-starter` integration. However, you still have to specify the monitor slug as shown below.
 
-Check-ins may also be [sent manually](/platforms/java/crons/) or by using our [`@SentryCheckIn` annotation](/platforms/java/guides/spring-boot/crons/), in case you are using our Spring Boot integration and would like to send check-ins for your `@Scheduled` tasks.
+Check-ins may also be [sent manually](/platforms/java/crons/) or if you're using Sentry's Spring Boot integration you can send send check-ins for your `@Scheduled` tasks by using our [`@SentryCheckIn` annotation](/platforms/java/guides/spring-boot/crons/).
 
 ## Install
 

--- a/src/platforms/java/common/configuration/integrations/quartz.mdx
+++ b/src/platforms/java/common/configuration/integrations/quartz.mdx
@@ -45,6 +45,7 @@ For other dependency managers, check out the [central Maven repository](https://
 ## Set Up
 
 You have to provide the monitor slug either
+
 - when building a Quartz `JobDetail` instance
 - or when building a Quartz `Trigger` instance
 

--- a/src/platforms/java/common/configuration/integrations/quartz.mdx
+++ b/src/platforms/java/common/configuration/integrations/quartz.mdx
@@ -2,10 +2,6 @@
 title: Quartz Integration
 sidebar_order: 7
 description: "Learn how to send check-ins for your Quartz jobs."
-notSupported:
-  - java.logback
-  - java.log4j2
-  - java.jul
 ---
 
 Sentry's [Quartz](http://www.quartz-scheduler.org/) integration is provided through `SenryJobListener` which you have to add to your scheduler instance.


### PR DESCRIPTION
Docs for https://github.com/getsentry/sentry-java/issues/2875

We support
- manual check-ins through `Sentry.captureCheckIn`
- Quartz by registering a `SentryJobListener` (happens automatically for Spring Boot) and having users provide a monitor slug trough the job data map
- Spring `@Scheduled` by having advice config for a new `@SentryCheckIn` annotation which allows users to specify methods to send check-ins for and what monitor slug to use.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
