### PR TITLE
chore(open-source): Fix product owner script

### DIFF
--- a/bin/react-to-product-owners-yml-changes.py
+++ b/bin/react-to-product-owners-yml-changes.py
@@ -39,11 +39,14 @@ for line in labels:
     current.append(line)
 
 for area in product_owners['by_area']:
-    if "'" in area:
-        product_areas.append(f'- name: "Product Area: {area}"\n')
-    else:
-        product_areas.append(f"- name: 'Product Area: {area}'\n")
-    product_areas.append("  color: '8D5494'\n")
+    # These are specifically placed at the front and end of the list of product areas.
+    # They will always exist, so ignore what is coming in from security-as-code as a workaround.
+    if area != 'Other' and area != 'Unknown':
+        if "'" in area:
+            product_areas.append(f'- name: "Product Area: {area}"\n')
+        else:
+            product_areas.append(f"- name: 'Product Area: {area}'\n")
+        product_areas.append("  color: '8D5494'\n")
 
 product_areas += ["- name: 'Product Area: Other'\n", "  color: '8D5494'\n"]
 


### PR DESCRIPTION
Product Areas Unknown and Other need to be at the front and bottom of the product areas list respectively. They are now mapped to team-ospo in security-as-code, so let's not repeat those values here and preserve the order with this workaround