### PR TITLE
Remove duplicate login note on unity getting started page

### DIFF
--- a/src/platform-includes/getting-started-config/unity.mdx
+++ b/src/platform-includes/getting-started-config/unity.mdx
@@ -6,12 +6,6 @@ The minimum configuration required is the [DSN](/product/sentry-basics/dsn-expla
 ___PUBLIC_DSN___
 ```
 
-<Note>
-
-If you are logged in you can also select your project and copy its DSN directly from here.
-
-</Note>
-
 Sentry can be configured via the Sentry configuration window or [programatically](/platforms/unity/configuration/options/).
 The window can be accessed by going to Unity's top menu: `Tools` > `Sentry`.
 


### PR DESCRIPTION
<img width="751" alt="Screenshot 2023-09-28 at 17 32 37" src="https://github.com/getsentry/sentry-docs/assets/7096858/f469d4e6-4ac5-4516-ac4e-322fc49e79b4">
