### PR TITLE
Add Python integration docs for Strawberry

### DIFF
--- a/src/platforms/python/common/integrations/index.mdx
+++ b/src/platforms/python/common/integrations/index.mdx
@@ -62,6 +62,13 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 | <linkWithPlatformIcon platform="python.httpx"   label="HTTPX"   url="/platforms/python/integrations/httpx" />                  |        ✓         |
 | Python standard HTTP client (in the [Default Integrations](default-integrations/))                                             |        ✓         |
 
+## GraphQL
+
+|                                                                                                                       | **Auto enabled** |
+| --------------------------------------------------------------------------------------------------------------------- | :--------------: |
+| <linkWithPlatformIcon platform="python.graphql" label="GQL" url="/platforms/python/integrations/gql" />               |                  |
+| <linkWithPlatformIcon platform="python.graphql" label="Strawberry" url="/platforms/python/integrations/strawberry" /> |                  |
+
 ## RPC
 
 |                                                                                                        | **Auto enabled** |

--- a/src/platforms/python/common/integrations/index.mdx
+++ b/src/platforms/python/common/integrations/index.mdx
@@ -66,8 +66,8 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 
 |                                                                                                                       | **Auto enabled** |
 | --------------------------------------------------------------------------------------------------------------------- | :--------------: |
-| <linkWithPlatformIcon platform="python.graphql" label="GQL" url="/platforms/python/integrations/gql" />               |                  |
-| <linkWithPlatformIcon platform="python.graphql" label="Strawberry" url="/platforms/python/integrations/strawberry" /> |                  |
+| <linkWithPlatformIcon platform="python.graphql" label="GQL" url="/platforms/python/integrations/gql/" />               |                  |
+| <linkWithPlatformIcon platform="python.graphql" label="Strawberry" url="/platforms/python/integrations/strawberry/" /> |                  |
 
 ## RPC
 

--- a/src/platforms/python/common/integrations/index.mdx
+++ b/src/platforms/python/common/integrations/index.mdx
@@ -60,12 +60,19 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 | ------------------------------------------------------------------------------------------------------------------------------ | :--------------: |
 | <linkWithPlatformIcon platform="python.aiohttp" label="AIOHTTP" url="/platforms/python/integrations/aiohttp/aiohttp-client" /> |        ✓         |
 | <linkWithPlatformIcon platform="python.httpx"   label="HTTPX"   url="/platforms/python/integrations/httpx" />                  |        ✓         |
-| Python standard HTTP client (in the [Default Integrations](default-integrations/))                                             |        ✓         |
+| Python standard HTTP client (in the [Default Integrations](default-integrations/#stdlib))                                      |        ✓         |
+| `Requests` HTTP instrumentation is done via the [Default Integrations](default-integrations/#stdlib).                          |        ✓         |
 
 ## GraphQL
 
-|                                                                                                                       | **Auto enabled** |
-| --------------------------------------------------------------------------------------------------------------------- | :--------------: |
+|                                                                                                         | **Auto enabled** |
+| ------------------------------------------------------------------------------------------------------- | :--------------: |
+| <linkWithPlatformIcon platform="python.graphql" label="GQL" url="/platforms/python/integrations/gql" /> |                  |
+
+## GraphQL
+
+|                                                                                                                        | **Auto enabled** |
+| ---------------------------------------------------------------------------------------------------------------------- | :--------------: |
 | <linkWithPlatformIcon platform="python.graphql" label="GQL" url="/platforms/python/integrations/gql/" />               |                  |
 | <linkWithPlatformIcon platform="python.graphql" label="Strawberry" url="/platforms/python/integrations/strawberry/" /> |                  |
 

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -120,9 +120,9 @@ sentry_sdk.init(
 
 <Alert level="warning" title="Note">
 
-Since `send_default_pii` is a global SDK option, setting it to `True` affects all
-integrations, not just Strawberry. Please make sure to take care of
-[removing sensitive data](/platforms/python/data-management/sensitive-data/)
+Since `send_default_pii` is a global SDK option, setting it to `True` will affect all
+integrations, not just Strawberry. Please make sure to
+[remove sensitive data](/platforms/python/data-management/sensitive-data/)
 from events before enabling this option.
 
 </Alert>

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -131,9 +131,7 @@ from events before enabling this option.
 
 Strawberry comes with a (now deprecated) built-in
 [Sentry tracing extension](https://strawberry.rocks/docs/extensions/sentry-tracing)
-that this integration is built on. If you're using both, the Sentry SDK
-integration will deactivate the built-in Strawberry extension to prevent
-duplicate traces.
+that this integration is built on. To prevent duplicate traces, the Sentry SDK integration will deactivate the built-in Strawberry extension if you happen to be using both.
 
 ## Supported Versions
 

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -91,7 +91,7 @@ Strawberry supports both synchronous and asynchronous execution of GraphQL
 queries. If you have at least one async resolver, you should initialize
 `StrawberryIntegration` with `async_execution=True`, otherwise set it to `False`.
 
-The SDK will make a best-effort guess if `async_execution` is not provided
+The SDK will make a best-effort guess if `async_execution` is not provided,
 based on installed web frameworks.
 
 ```python

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -73,15 +73,13 @@ strawberry server schema
 Navigate to [http://127.0.0.1:8000/graphql](http://127.0.0.1:8000/graphql) in your
 browser. You should see the GraphiQL graphical interface.
 
-Type `query HelloQuery { hello }` into the query input field and press the
-"Execute query" button. Your web server will be queried, which will result in an
-exception thanks to the `ZeroDivisionError` we've snuck into the `resolve_hello`
+Type `query HelloQuery { hello }` into the query input field then press the
+"Execute query" button. Your web server will be queried, which should result in an
+exception due to the `ZeroDivisionError` we've snuck into the `resolve_hello`
 resolver.
 
 This will create a `GraphQLError` in the Issues section as well as a transaction
-in the Performance section of [sentry.io](https://sentry.io).
-
-It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+in the Performance section of [sentry.io](https://sentry.io). It will take a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 
 ## Options
 

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -78,7 +78,7 @@ Type `query HelloQuery { hello }` into the query input field and press the
 exception thanks to the `ZeroDivisionError` we've snuck into the `resolve_hello`
 resolver.
 
-This will create a `GraphQLError` in the Issues section  as well as a transaction
+This will create a `GraphQLError` in the Issues section as well as a transaction
 in the Performance section of [sentry.io](https://sentry.io).
 
 It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
@@ -106,7 +106,7 @@ sentry_sdk.init(
 ### Capturing request and response bodies
 
 The Strawberry integration can capture request and response bodies
-for each GraphQL error that happens. Since these may contain sensitive data, 
+for each GraphQL error that happens. Since these may contain sensitive data,
 this is the default behavior. To enable capturing request and response bodies, the
 SDK needs to be initialized with the
 [send_default_pii](https://docs.sentry.io/platforms/python/configuration/options/#send-default-pii) option set to `True`.

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -135,7 +135,6 @@ that this integration is build on. If you're using both, the Sentry SDK
 integration will deactivate the built-in Strawberry extension to prevent
 duplicate traces.
 
-
 ## Supported Versions
 
 - strawberry-graphql: 0.209.5+

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Strawberry
-description: "Learn about importing the Strawberry GraphQL integration and how it captures GraphQL errors and spans."
+description: "Learn how to import the Strawberry GraphQL integration and how it captures GraphQL errors and spans."
 ---
 
 The Strawberry integration captures errors and operations from the

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -4,7 +4,7 @@ description: "Learn how to import the Strawberry GraphQL integration and how it 
 ---
 
 The Strawberry integration captures errors and operations from the
-[Strawberry GraphQL library](https://strawberry.rocks/). These can then be viewed
+[Strawberry GraphQL library](https://strawberry.rocks/), which can then be viewed
 in [Sentry](https://sentry.io).
 
 ## Install

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -87,7 +87,7 @@ in the Performance section of [sentry.io](https://sentry.io). It will take a cou
 
 Strawberry supports both synchronous and asynchronous execution of GraphQL
 queries. If you have at least one async resolver, you should initialize
-`StrawberryIntegration` with `async_execution=True`, otherwise `False`.
+`StrawberryIntegration` with `async_execution=True`, otherwise set it to `False`.
 
 The SDK will make a best-effort guess if `async_execution` is not provided
 based on installed web frameworks.

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -83,7 +83,7 @@ in the Performance section of [sentry.io](https://sentry.io). It will take a cou
 
 ## Options
 
-### Synchronous vs. asynchronous execution
+### Synchronous vs. Asynchronous Execution
 
 Strawberry supports both synchronous and asynchronous execution of GraphQL
 queries. If you have at least one async resolver, you should initialize

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -46,7 +46,7 @@ pip install 'strawberry-graphql[debug-server]'
 pip install fastapi
 ```
 
-Create a `schema.py` file with the following contents:
+Create a `schema.py` file with the below content:
 
 ```python
 import strawberry

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -83,6 +83,8 @@ in the Performance section of [sentry.io](https://sentry.io). It will take a cou
 
 ## Options
 
+There are several options you will get to choose from:
+
 ### Synchronous vs. Asynchronous Execution
 
 Strawberry supports both synchronous and asynchronous execution of GraphQL

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -131,7 +131,7 @@ from events before enabling this option.
 
 Strawberry comes with a (now deprecated) built-in
 [Sentry tracing extension](https://strawberry.rocks/docs/extensions/sentry-tracing)
-that this integration is build on. If you're using both, the Sentry SDK
+that this integration is built on. If you're using both, the Sentry SDK
 integration will deactivate the built-in Strawberry extension to prevent
 duplicate traces.
 

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -103,7 +103,7 @@ sentry_sdk.init(
 )
 ```
 
-### Capturing request and response bodies
+### Capturing Request and Response Bodies
 
 The Strawberry integration can capture request and response bodies
 for each GraphQL error that happens. Since these may contain sensitive data,

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -1,0 +1,134 @@
+---
+title: Strawberry
+description: "Learn about importing the Strawberry GraphQL integration and how it captures GraphQL errors and spans."
+---
+
+The Strawberry integration captures errors and operations from the
+[Strawberry GraphQL library](https://strawberry.rocks/). These can then be viewed
+in [Sentry](https://sentry.io).
+
+## Install
+
+To get started, install `sentry-sdk` from PyPI.
+
+```bash
+pip install --upgrade sentry-sdk
+```
+
+## Configure
+
+Add `StrawberryIntegration()` to your `integrations` list:
+
+<SignInNote />
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.strawberry import StrawberryIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
+    integrations=[
+        # Set async_execution to True if you have at least one async resolver
+        StrawberryIntegration(async_execution=True),
+    ],
+)
+```
+
+## Verify
+
+Make sure you have all the prerequisites installed:
+
+```bash
+pip install 'strawberry-graphql[debug-server]'
+pip install fastapi
+```
+
+Create a `schema.py` file with the following contents:
+
+```python
+import strawberry
+
+sentry_sdk.init(...)  # as above
+
+async def resolve_hello(root) -> str:
+    1 / 0
+    return "Hello world!"
+
+@strawberry.type
+class Query:
+    hello: str = strawberry.field(resolver=resolve_hello)
+
+schema = strawberry.Schema(Query)
+```
+
+To start the web server, run:
+
+```bash
+strawberry server schema
+```
+
+Navigate to [http://127.0.0.1:8000/graphql](http://127.0.0.1:8000/graphql) in your
+browser. You should see the GraphiQL graphical interface.
+
+Type `query HelloQuery { hello }` into the query input field and press the
+"Execute query" button. Your web server will be queried, which will result in an
+exception thanks to the `ZeroDivisionError` we've snuck into the `resolve_hello`
+resolver.
+
+This will create a `GraphQLError` in the Issues section  as well as a transaction
+in the Performance section of [sentry.io](https://sentry.io).
+
+It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+
+## Options
+
+### Synchronous vs. asynchronous execution
+
+Strawberry supports both synchronous and asynchronous execution of GraphQL
+queries. If you have at least one async resolver, you should initialize
+`StrawberryIntegration` with `async_execution=True`, otherwise `False`.
+
+The SDK will make a best-effort guess if `async_execution` is not provided
+based on installed web frameworks.
+
+```python
+sentry_sdk.init(
+    # (...) more options
+    integrations=[
+        StrawberryIntegration(async_execution=True),  # or False
+    ],
+)
+```
+
+### Capturing request and response bodies
+
+The Strawberry integration can capture request and response bodies
+for each GraphQL error that happens. Since these may contain sensitive data, 
+this is the default behavior. To enable capturing request and response bodies, the
+SDK needs to be initialized with the
+[send_default_pii](https://docs.sentry.io/platforms/python/configuration/options/#send-default-pii) option set to `True`.
+
+```python
+sentry_sdk.init(
+    # same options as above
+    send_default_pii=True,
+)
+```
+
+<Alert level="warning" title="Note">
+
+Since `send_default_pii` is a global SDK option, setting it to `True` affects all
+integrations, not just Strawberry. Please make sure to take care of
+[removing sensitive data](/platforms/python/data-management/sensitive-data/)
+from events before enabling this option.
+
+</Alert>
+
+## Supported Versions
+
+- strawberry-graphql: 0.208+
+- Python: 3.8+
+- sentry_sdk: 1.32.0+

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -51,7 +51,7 @@ Create a `schema.py` file with the following contents:
 ```python
 import strawberry
 
-sentry_sdk.init(...)  # as above
+sentry_sdk.init(...)  # same as above
 
 async def resolve_hello(root) -> str:
     1 / 0
@@ -127,8 +127,16 @@ from events before enabling this option.
 
 </Alert>
 
+## Notes
+
+Strawberry comes with a (now deprecated) built-in
+[Sentry tracing extension](https://strawberry.rocks/docs/extensions/sentry-tracing)
+that this integration is build on. If you're using both, the Sentry SDK
+integration will deactivate the built-in Strawberry extension to prevent
+duplicate traces.
+
+
 ## Supported Versions
 
-- strawberry-graphql: 0.208+
+- strawberry-graphql: 0.209.5+
 - Python: 3.8+
-- sentry_sdk: 1.32.0+

--- a/src/platforms/python/common/integrations/strawberry/index.mdx
+++ b/src/platforms/python/common/integrations/strawberry/index.mdx
@@ -96,7 +96,7 @@ based on installed web frameworks.
 
 ```python
 sentry_sdk.init(
-    # (...) more options
+    # (...) other options
     integrations=[
         StrawberryIntegration(async_execution=True),  # or False
     ],


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We're adding a Strawberry integration to the SDK in https://github.com/getsentry/sentry-python/pull/2393, this adds the docs for it.

Direct link to the added page: https://sentry-docs-git-ivana-python-strawberry-integration.sentry.dev/platforms/python/integrations/strawberry/

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
