### PR TITLE
fix(electron): The `EventToMain` integration is no longer used

### DIFF
--- a/src/platforms/javascript/guides/electron/configuration/integrations/eventtomain.mdx
+++ b/src/platforms/javascript/guides/electron/configuration/integrations/eventtomain.mdx
@@ -1,8 +1,0 @@
----
-title: EventToMain
-excerpt: ""
-description: "Captures events in the renderer processes and forwards them to the Electron main process. (default)"
-sidebar_order: 10
----
-
-Captures events in the renderer processes and forwards them to the Electron main process. This integration prevents events from being sent by the underlying `@sentry/browser` SDK.


### PR DESCRIPTION
This integration is no longer used and there is no reason customers should be using it. 

https://github.com/getsentry/sentry-electron/pull/759