### PR TITLE
ref(docs): add example for comparison operator searches

### DIFF
--- a/src/docs/product/sentry-basics/search/index.mdx
+++ b/src/docs/product/sentry-basics/search/index.mdx
@@ -44,6 +44,12 @@ Sentry search supports the use of comparison operators:
 
 Typically, when you search using properties that are numbers or durations, you should use comparison operators rather than just a colon (`:`) to find exact matches, since an exact match isn't likely to exist.
 
+Here are some examples of valid comparison operator searches:
+
+- `event.timestamp:>2023-09-28T00:00:00-07:00`
+- `count_dead_clicks:<=10`
+- `transaction.duration:>5s`
+
 ### Using `OR` and `AND`
 
 <Note>


### PR DESCRIPTION
Helps address this feedback we received:

<img width="762" alt="271721703-3f78a727-a732-481e-a0ca-7c3264ae1f6c" src="https://github.com/getsentry/sentry-docs/assets/187460/8abec34d-d719-4ddf-a6b5-56311fd3d19c">


