### PR TITLE
fix: Exclude wizard pages from VScode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "search.exclude": {
+    "**/src/wizard/**": true,
+  }
 }


### PR DESCRIPTION
We should no longer show the wizard content in the search - so people stop editing these pages