### PR TITLE
Link to fingerprinting grammar

### DIFF
--- a/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
@@ -15,7 +15,7 @@ These rules can be configured on a per-project basis in **[Project] > Settings >
 1. Identify the match logic for grouping issues together.
 1. Set the match logic and the fingerprint for it.
 
-The syntax for fingerprint rules is similar to that of [**Discover** queries](/product/sentry-basics/search/#syntax). If you want to negate the match, prefix the expression with an exclamation mark (`!`). The full grammar is defined [here](https://github.com/getsentry/sentry/blob/c5b84a393365a833348dd7fd9378d34c353ca6ca/src/sentry/grouping/fingerprinting.py#L17-L55).
+The syntax for fingerprint rules is similar to syntax in [**Discover** queries](/product/sentry-basics/search/#syntax). To negate a match, add an exclamation mark (`!`) at the beginning of the expression. See the full grammar [here](https://github.com/getsentry/sentry/blob/c5b84a393365a833348dd7fd9378d34c353ca6ca/src/sentry/grouping/fingerprinting.py#L17-L55).
 
 Sentry attempts to match against all values that are configured in the fingerprint. In the case of stack traces, all frames are considered. If the event data matches all the values in a line for a matcher and expression, then the fingerprint is applied. When there are multiple rules that match the event, the first matching rule in the list is applied.
 

--- a/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
+++ b/src/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
@@ -15,7 +15,7 @@ These rules can be configured on a per-project basis in **[Project] > Settings >
 1. Identify the match logic for grouping issues together.
 1. Set the match logic and the fingerprint for it.
 
-The syntax follows the [syntax](/product/sentry-basics/search/#syntax) from **Discover** queries. If you want to negate the match, prefix the expression with an exclamation mark (`!`).
+The syntax for fingerprint rules is similar to that of [**Discover** queries](/product/sentry-basics/search/#syntax). If you want to negate the match, prefix the expression with an exclamation mark (`!`). The full grammar is defined [here](https://github.com/getsentry/sentry/blob/c5b84a393365a833348dd7fd9378d34c353ca6ca/src/sentry/grouping/fingerprinting.py#L17-L55).
 
 Sentry attempts to match against all values that are configured in the fingerprint. In the case of stack traces, all frames are considered. If the event data matches all the values in a line for a matcher and expression, then the fingerprint is applied. When there are multiple rules that match the event, the first matching rule in the list is applied.
 


### PR DESCRIPTION
Fingerprint rules do not support the full scope of Discover queries. Update docs to make this more clear.
