### PR TITLE
Added mention of requests

### DIFF
--- a/src/platforms/python/common/integrations/index.mdx
+++ b/src/platforms/python/common/integrations/index.mdx
@@ -60,7 +60,8 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 | ------------------------------------------------------------------------------------------------------------------------------ | :--------------: |
 | <linkWithPlatformIcon platform="python.aiohttp" label="AIOHTTP" url="/platforms/python/integrations/aiohttp/aiohttp-client" /> |        ✓         |
 | <linkWithPlatformIcon platform="python.httpx"   label="HTTPX"   url="/platforms/python/integrations/httpx" />                  |        ✓         |
-| Python standard HTTP client (in the [Default Integrations](default-integrations/))                                             |        ✓         |
+| Python standard HTTP client (in the [Default Integrations](default-integrations/#stdlib))                                      |        ✓         |
+| `Requests` HTTP instrumentation is done via the [Default Integrations](/default-integrations/#stdlib).                         |        ✓         |
 
 ## GraphQL
 


### PR DESCRIPTION
Small fix to mention that `Requests` instrumentation is done with the default integrations.