### PR TITLE
Show guide list also when no ToC is present; add ToC/headlines for Gatsby's "Getting Started" page

### DIFF
--- a/src/components/guideGrid.tsx
+++ b/src/components/guideGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import {PlatformIcon} from 'platformicons';
 
 import {usePlatform} from './hooks/usePlatform';
@@ -20,20 +20,29 @@ export function GuideGrid({platform, className}: Props) {
     return null;
   }
 
+  if (currentPlatform.guides.length === 0) {
+    return null;
+  }
+
   return (
-    <ul className={className}>
-      {currentPlatform.guides.map(guide => (
-        <li key={guide.key}>
-          <SmartLink to={guide.url}>
-            <PlatformIcon
-              platform={guide.icon ?? guide.key}
-              style={{marginRight: '0.5rem', border: 0, boxShadow: 'none'}}
-              format="sm"
-            />
-            <h4 style={{display: 'inline-block'}}>{guide.title}</h4>
-          </SmartLink>
-        </li>
-      ))}
-    </ul>
+    <Fragment>
+      <div className="doc-toc-title">
+        <h6>Related Guides</h6>
+      </div>
+      <ul className={className}>
+        {currentPlatform.guides.map(guide => (
+          <li key={guide.key}>
+            <SmartLink to={guide.url}>
+              <PlatformIcon
+                platform={guide.icon ?? guide.key}
+                style={{marginRight: '0.5rem', border: 0, boxShadow: 'none'}}
+                format="sm"
+              />
+              <h4 style={{display: 'inline-block'}}>{guide.title}</h4>
+            </SmartLink>
+          </li>
+        ))}
+      </ul>
+    </Fragment>
   );
 }

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo} from 'react';
+import React, {useMemo} from 'react';
 
 import {PageContext} from './basePage';
 import {GuideGrid} from './guideGrid';
@@ -113,7 +113,11 @@ export function TableOfContents({content, pageContext}: Props) {
   const items = useMemo(() => buildTocTree(getAnchorHeadings({content})), [content]);
 
   if (items.length === 0) {
-    return null;
+    return (
+      <div className="doc-toc">
+        {platform && <GuideGrid platform={platform.name} className="section-nav" />}
+      </div>
+    );
   }
 
   return (
@@ -122,14 +126,7 @@ export function TableOfContents({content, pageContext}: Props) {
         <h6>On this page</h6>
       </div>
       <ul className="section-nav">{recursiveRender(items)}</ul>
-      {platform && platform.name !== 'python' && (
-        <Fragment>
-          <div className="doc-toc-title">
-            <h6>Related Guides</h6>
-          </div>
-          <GuideGrid platform={platform.name} className="section-nav" />
-        </Fragment>
-      )}
+      {platform && <GuideGrid platform={platform.name} className="section-nav" />}
     </div>
   );
 }

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -7,6 +7,8 @@ redirect_from:
 description: "Learn how to use Sentry with Gatsby."
 ---
 
+## Install
+
 To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK):
 
 ```bash {tabTitle:npm}
@@ -34,6 +36,9 @@ module.exports = {
   ],
 };
 ```
+
+
+## Configure
 
 Then, configure your `Sentry.init`:
 

--- a/src/platforms/javascript/guides/gatsby/index.mdx
+++ b/src/platforms/javascript/guides/gatsby/index.mdx
@@ -37,7 +37,6 @@ module.exports = {
 };
 ```
 
-
 ## Configure
 
 Then, configure your `Sentry.init`:


### PR DESCRIPTION
Currently, the list of guides is only rendered, if the getting started page will render a table of contents. If that is not the case (the page has no further headlines other than the h1), the list of guides will also not render. 

## Fixed in this PR:
- Render the list of guides when no headlines are present
- Add headlines to the Gatsby site
- Move the headline "Related Guides" into the component, and don't render it when there are no guides listed

## Before (site without headlines):
<img width="1501" alt="Screenshot 2023-10-03 at 15 38 41" src="https://github.com/getsentry/sentry-docs/assets/7096858/8dd3cd1a-0f6a-473d-b1c7-f761f3fe6567">

## Before (site without guides):
<img width="1468" alt="Screenshot 2023-10-03 at 15 39 56" src="https://github.com/getsentry/sentry-docs/assets/7096858/b3ab6ee4-962d-4f43-b825-f710e221f27a">

## After (site without headlines):
<img width="1119" alt="Screenshot 2023-10-03 at 15 29 26" src="https://github.com/getsentry/sentry-docs/assets/7096858/54180fc0-18f8-4f11-a54f-159b044ccda7">

## After (final version):
<img width="1473" alt="Screenshot 2023-10-03 at 15 39 25" src="https://github.com/getsentry/sentry-docs/assets/7096858/f6d13734-d569-4926-b4d2-3e3c80d0e197">
