### PR TITLE
Link to vite plugin options v0.6.1

### DIFF
--- a/src/platform-includes/sourcemaps/primer/javascript.sveltekit.mdx
+++ b/src/platform-includes/sourcemaps/primer/javascript.sveltekit.mdx
@@ -1,3 +1,3 @@
 `@sentry/sveltekit` will generate and upload source maps automatically, so that errors in Sentry will contain readable stack traces.
 
-The SvelteKit SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin) to upload source maps. See the [Manual Configuration](../manual-setup/#configure-source-maps-upload) page and the Sentry [Vite documentation](https://www.npmjs.com/package/@sentry/vite-plugin) for more details.
+The SvelteKit SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1) to upload source maps. See the [Manual Configuration](../manual-setup/#configure-source-maps-upload) page and the Sentry [Vite documentation](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1#configuration) for more details.

--- a/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/src/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -200,7 +200,7 @@ You can set them as environment variables, for example in a `.env` file:
 - `SENTRY_AUTH_TOKEN` your Sentry auth token (can be obtained from the [Organization Token Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/))
 - `SENTRY_URL` your Sentry instance URL. This is only required if you use your own Sentry instance (as opposed to `https://sentry.io`).
 
-Or, you can set them by passing a `sourceMapsUploadOptions` object to `sentrySvelteKit`, as seen in the example below. All available options are documented at [the Sentry Vite plugin repo](https://www.npmjs.com/package/@sentry/vite-plugin#options).
+Or, you can set them by passing a `sourceMapsUploadOptions` object to `sentrySvelteKit`, as seen in the example below. All available options are documented at [the Sentry Vite plugin repo](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1#configuration).
 
 <OrgAuthTokenNote />
 


### PR DESCRIPTION
We linked to the `latest` version which is incorrect in the context of sveltekit.