### PR TITLE
Remove mention of Falcon from ASGI docs

### DIFF
--- a/src/platforms/python/common/integrations/asgi/index.mdx
+++ b/src/platforms/python/common/integrations/asgi/index.mdx
@@ -7,7 +7,7 @@ The ASGI middleware can be used to instrument any [ASGI](https://asgi.readthedoc
 
 <Note>
 
-If you use an ASGI framework, please use our specific integrations for [FastAPI](/platforms/python/integrations/fastapi/), [Starlette](/platforms/python/integrations/starlette/), [Falcon](/platforms/python/integrations/falcon/), [Quart](/platforms/python/integrations/quart/), and [Sanic](/platforms/python/integrations/sanic/) instead of this ASGI middleware as those are easier to use and capture more useful information.
+If you use an ASGI framework, please use our specific integrations for [FastAPI](/platforms/python/integrations/fastapi/), [Starlette](/platforms/python/integrations/starlette/), [Quart](/platforms/python/integrations/quart/), and [Sanic](/platforms/python/integrations/sanic/) instead of this ASGI middleware as those are easier to use and capture more useful information.
 
 </Note>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

[We do not support ASGI Falcon apps](https://github.com/getsentry/sentry-python/blob/b31d498861fbcf33d96808170120ed6ea6935bc8/sentry_sdk/integrations/falcon.py#L213) in our integration, so we should not be mentioning it in our ASGI docs, since the Falcon integration does nothing when it detects it is being used with an ASGI app

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
