### PR TITLE
feat: Add note to tree shaking docs

### DIFF
--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -14,9 +14,11 @@ If you want to minimize the bundle size of the Sentry SDK, we recommend reading 
 The Sentry SDK ships with code that is not strictly required for it to collect your errors. This includes, for example, code to debug your Sentry configuration or code to enable performance monitoring. While debug code can be very useful in development environments, it's not typically necessary to include it in your production bundles where it takes up valuable space. The JavaScript SDK includes a special flags in its CommonJS and ESM distributions, which can be used to facilitate tree shaking (removal) of such code during the build process.
 
 <Note>
-  Anything that you do not import & use will <i>automatically</i> be tree shaken away. 
-  This means that optional integrations like Replay, BrowserTracing, BrowserProfiling or any unusued utility methods will not be included in your bundle unless you import & use them yourself. 
-  The rest of this page relates to ways to tree shake things that Sentry uses internally.
+  Anything that you do not import & use will <i>automatically</i> be tree shaken
+  away. This means that optional integrations like Replay, BrowserTracing,
+  BrowserProfiling or any unusued utility methods will not be included in your
+  bundle unless you import & use them yourself. The rest of this page relates to
+  ways to tree shake things that Sentry uses internally.
 </Note>
 
 ### List Of Flags

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -17,8 +17,9 @@ The Sentry SDK ships with code that is not strictly required for it to collect y
   Anything that you do not import & use will <i>automatically</i> be tree shaken
   away. This means that optional integrations like Replay, BrowserTracing,
   BrowserProfiling or any unusued utility methods will not be included in your
-  bundle unless you import and use them yourself. The rest of this page relates to
-  ways to tree shake internal SDK code, which is not strictly required in case you do not use certain features.
+  bundle unless you import and use them yourself. The rest of this page relates
+  to ways to tree shake internal SDK code, which is not strictly required in
+  case you do not use certain features.
 </Note>
 
 ### List Of Flags

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -17,8 +17,8 @@ The Sentry SDK ships with code that is not strictly required for it to collect y
   Anything that you do not import & use will <i>automatically</i> be tree shaken
   away. This means that optional integrations like Replay, BrowserTracing,
   BrowserProfiling or any unusued utility methods will not be included in your
-  bundle unless you import & use them yourself. The rest of this page relates to
-  ways to tree shake things that Sentry uses internally.
+  bundle unless you import and use them yourself. The rest of this page relates to
+  ways to tree shake internal SDK code, which is not strictly required in case you do not use certain features.
 </Note>
 
 ### List Of Flags

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -13,6 +13,12 @@ If you want to minimize the bundle size of the Sentry SDK, we recommend reading 
 
 The Sentry SDK ships with code that is not strictly required for it to collect your errors. This includes, for example, code to debug your Sentry configuration or code to enable performance monitoring. While debug code can be very useful in development environments, it's not typically necessary to include it in your production bundles where it takes up valuable space. The JavaScript SDK includes a special flags in its CommonJS and ESM distributions, which can be used to facilitate tree shaking (removal) of such code during the build process.
 
+<Note>
+  Anything that you do not import & use will <i>automatically</i> be tree shaken away. 
+  This means that optional integrations like Replay, BrowserTracing, BrowserProfiling or any unusued utility methods will not be included in your bundle unless you import & use them yourself. 
+  The rest of this page relates to ways to tree shake things that Sentry uses internally.
+</Note>
+
 ### List Of Flags
 
 To make optional code eligible for tree shaking, you can replace various flags in the Sentry SDK with `false`.

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -11,15 +11,15 @@ If you want to minimize the bundle size of the Sentry SDK, we recommend reading 
 
 ## Tree Shaking Optional Code
 
-The Sentry SDK ships with code that is not strictly required for it to collect your errors. This includes, for example, code to debug your Sentry configuration or code to enable performance monitoring. While debug code can be very useful in development environments, it's not typically necessary to include it in your production bundles where it takes up valuable space. The JavaScript SDK includes a special flags in its CommonJS and ESM distributions, which can be used to facilitate tree shaking (removal) of such code during the build process.
+The Sentry SDK ships with code that is not strictly required for it to collect your errors. This includes code to debug your Sentry configuration or code to enable performance monitoring, for example. While debug code can be very useful in development environments, it's not typically necessary to include it in your production bundles where it takes up valuable space. The JavaScript SDK includes special flags in its CommonJS and ESM distributions, which can be used to facilitate tree shaking (removal) of this kind of code during the build process.
 
 <Note>
-  Anything that you do not import & use will <i>automatically</i> be tree shaken
-  away. This means that optional integrations like Replay, BrowserTracing,
-  BrowserProfiling or any unusued utility methods will not be included in your
+  Anything that you don't import and use will <i>automatically</i> be tree shaken
+  away when using any modern bundler like Webpack, Rollup, Vite, or similar. This means that optional integrations like Replay, BrowserTracing,
+  BrowserProfiling, and any unused utility methods won't be included in your
   bundle unless you import and use them yourself. The rest of this page relates
-  to ways to tree shake internal SDK code, which is not strictly required in
-  case you do not use certain features.
+  to ways to tree shake internal SDK code, which isn't strictly required unless
+  you use certain features.
 </Note>
 
 ### List Of Flags

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -14,8 +14,9 @@ If you want to minimize the bundle size of the Sentry SDK, we recommend reading 
 The Sentry SDK ships with code that is not strictly required for it to collect your errors. This includes code to debug your Sentry configuration or code to enable performance monitoring, for example. While debug code can be very useful in development environments, it's not typically necessary to include it in your production bundles where it takes up valuable space. The JavaScript SDK includes special flags in its CommonJS and ESM distributions, which can be used to facilitate tree shaking (removal) of this kind of code during the build process.
 
 <Note>
-  Anything that you don't import and use will <i>automatically</i> be tree shaken
-  away when using any modern bundler like Webpack, Rollup, Vite, or similar. This means that optional integrations like Replay, BrowserTracing,
+  Anything that you don't import and use will <i>automatically</i> be tree
+  shaken away when using any modern bundler like Webpack, Rollup, Vite, or
+  similar. This means that optional integrations like Replay, BrowserTracing,
   BrowserProfiling, and any unused utility methods won't be included in your
   bundle unless you import and use them yourself. The rest of this page relates
   to ways to tree shake internal SDK code, which isn't strictly required unless


### PR DESCRIPTION
This adds a note to the tree shaking docs, clarifying that optional integrations/utils like replay are _automatically_ tree shaken if not used.