### PR TITLE
feat: Add express & fastify tunnel examples

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -103,11 +103,11 @@ Sentry.init({
 });
 ```
 
-Once configured, all events will be sent to the `/tunnel` endpoint. This solution, however, requires an additional configuration on the server, as the events now need to be parsed and redirected to Sentry.
+Once configured, all events will be sent to the `/tunnel` endpoint. This will require an additional configuration on the server because the events will need to be parsed and redirected to Sentry.
 
 ### Using a Tunneling Server
 
-Here's an example of how to set up an endpoint on your server that tunnels events to Sentry:
+Here's an example of how to set up an endpoint on your server that will tunnel events to Sentry:
 
 ```js {tabTitle:Express}
 // Change this to suit your needs

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -103,7 +103,93 @@ Sentry.init({
 });
 ```
 
-Once configured, all events will be sent to the `/tunnel` endpoint. This solution, however, requires an additional configuration on the server, as the events now need to be parsed and redirected to Sentry. Here's an example for your server component:
+Once configured, all events will be sent to the `/tunnel` endpoint. This solution, however, requires an additional configuration on the server, as the events now need to be parsed and redirected to Sentry.
+
+### Using a Tunneling Server
+
+Here's an example for your server component:
+
+```js {tabTitle:Express}
+// Change this to suit your needs
+const SENTRY_HOST = "oXXXXXX.ingest.sentry.io";
+const SENTRY_KNOWN_PROJECTS = ["123456"];
+
+app.post("/bugs", async (req, res) => {
+  try {
+    const envelope = req.body;
+
+    const piece = envelope.toString().split("\n")[0];
+    const header = JSON.parse(piece);
+
+    const dsn = new URL(header.dsn);
+    if (dsn.hostname !== SENTRY_HOST) {
+      throw new Error(`Invalid Sentry host: ${dsn.hostname}`);
+    }
+
+    const projectId = dsn.pathname.substring(1);
+    if (!SENTRY_KNOWN_PROJECTS.includes(projectId)) {
+      throw new Error(`Invalid Project ID: ${projectId}`);
+    }
+
+    const url = `https://${SENTRY_HOST}/api/${projectId}/envelope/`;
+    await fetch(url, {
+      method: "POST",
+      body: envelope,
+      headers: {
+        "Content-Type": "application/x-sentry-envelope",
+      },
+    });
+  } catch (error) {
+    return res.sendStatus(400).send({ message: error.message });
+  }
+  return res.sendStatus(204);
+});
+```
+
+```js {tabTitle:Fastify}
+// Change this to suit your needs
+const SENTRY_HOST = "oXXXXXX.ingest.sentry.io";
+const SENTRY_KNOWN_PROJECTS = ["123456"];
+
+// Handle replay packets where no content-type header is available
+fastify.addContentTypeParser(
+  "*",
+  { parseAs: "buffer" },
+  function (req, body, done) {
+    done(null, body);
+  }
+);
+fastify.post("/bugs", async (request, reply) => {
+  try {
+    const envelope = request.body;
+
+    const piece = envelope.toString().split("\n")[0];
+    const header = JSON.parse(piece);
+
+    const dsn = new URL(header.dsn);
+    if (dsn.hostname !== SENTRY_HOST) {
+      throw new Error(`Invalid Sentry host: ${dsn.hostname}`);
+    }
+
+    const projectId = dsn.pathname.substring(1);
+    if (!SENTRY_KNOWN_PROJECTS.includes(projectId)) {
+      throw new Error(`Invalid Project ID: ${projectId}`);
+    }
+
+    const url = `https://${SENTRY_HOST}/api/${projectId}/envelope/`;
+    await fetch(url, {
+      method: "POST",
+      body: envelope,
+      headers: {
+        "Content-Type": "application/x-sentry-envelope",
+      },
+    });
+  } catch (error) {
+    return reply.code(400).send({ message: error.message });
+  }
+  return reply.code(204).send();
+});
+```
 
 ```csharp
 // Requires .NET Core 3.1 and C# 9 or higher

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -138,13 +138,16 @@ app.post("/bugs", (req, res) => {
       headers: {
         "Content-Type": "application/x-sentry-envelope",
       },
-    }).then(() => {
-      res.sendStatus(204);
-    }, (error) => {
-      res.sendStatus(400).send({ message: error.message });
-    });
+    }).then(
+      () => {
+        res.sendStatus(204);
+      },
+      (error) => {
+        res.sendStatus(400).send({ message: error.message });
+      }
+    );
   } catch (error) {
-   res.sendStatus(400).send({ message: error.message });
+    res.sendStatus(400).send({ message: error.message });
   }
 });
 ```

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -107,7 +107,7 @@ Once configured, all events will be sent to the `/tunnel` endpoint. This solutio
 
 ### Using a Tunneling Server
 
-Here's an example for your server component:
+Here's an example of how to set up an endpoint on your server that tunnels events to Sentry:
 
 ```js {tabTitle:Express}
 // Change this to suit your needs

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -114,7 +114,7 @@ Here's an example of how to set up an endpoint on your server that tunnels event
 const SENTRY_HOST = "oXXXXXX.ingest.sentry.io";
 const SENTRY_KNOWN_PROJECTS = ["123456"];
 
-app.post("/bugs", async (req, res) => {
+app.post("/bugs", (req, res) => {
   try {
     const envelope = req.body;
 
@@ -132,17 +132,20 @@ app.post("/bugs", async (req, res) => {
     }
 
     const url = `https://${SENTRY_HOST}/api/${projectId}/envelope/`;
-    await fetch(url, {
+    fetch(url, {
       method: "POST",
       body: envelope,
       headers: {
         "Content-Type": "application/x-sentry-envelope",
       },
+    }).then(() => {
+      res.sendStatus(204);
+    }, (error) => {
+      res.sendStatus(400).send({ message: error.message });
     });
   } catch (error) {
-    return res.sendStatus(400).send({ message: error.message });
+   res.sendStatus(400).send({ message: error.message });
   }
-  return res.sendStatus(204);
 });
 ```
 


### PR DESCRIPTION
This adds docs for setting up a tunnel with express or fastify, two main JS frameworks.

If we prefer to keep this "small", we could also only add the express example.

ref https://github.com/getsentry/sentry-docs/pull/8124