### PR TITLE
fix(perf): Relax `http.server` requirement for database view

### DIFF
--- a/src/docs/product/performance/queries.md
+++ b/src/docs/product/performance/queries.md
@@ -38,8 +38,6 @@ Query monitoring works best with up-to-date SDK versions. The following minimum 
 
 ### Span Eligibility
 
-The data shown is pulled from `db` and `db.sql` spans.
-
 Sentry tries to extract metrics for all SQL-like dialects. NoSQL databases like MongoDB, graph databases like Neo4j, and other non-SQL database systems are not currently eligible for this feature.
 
 If you are using <PlatformLink to="/performance/instrumentation/automatic-instrumentation">automatic instrumentation</PlatformLink>, query monitoring should work without any configuration. If you've manually instrumented Sentry, you'll need to make sure that your spans conform to our standards for the best experience:

--- a/src/docs/product/performance/queries.md
+++ b/src/docs/product/performance/queries.md
@@ -23,12 +23,6 @@ The gif below demonstrates how to use performance monitoring for queries.
 
 The queries widget and pages are only available for backend projects with performance monitoring enabled.
 
-<Note>
-
-The **Queries** page collects queries from your application's endpoints. Queries that run in async tasks are not shown. If a query runs in an endpoint _and_ a task, the metrics will reflect its performance within endpoints only.
-
-</Note>
-
 ### Recommended SDK Versions
 
 Query monitoring works best with up-to-date SDK versions. The following minimum versions are recommended:


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/57501 we show queries from all transactions, not just endpoints! Also, removes a note about database ops. That's covered in more details in the `op` requirements listed below, and isn't very correct anyway.
