### PR TITLE
Update dotnet.mdx to add stack trace linking as a feature

### DIFF
--- a/src/platform-includes/getting-started-primer/dotnet.mdx
+++ b/src/platform-includes/getting-started-primer/dotnet.mdx
@@ -21,4 +21,4 @@ This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with th
 - Offline caching of events when a device is unable to connect
 - Samples provided for [multiple C# app models](https://github.com/getsentry/sentry-dotnet/tree/main/samples),
   F# [Console](https://github.com/sentry-demos/fsharp), and [Giraffe](https://github.com/sentry-demos/giraffe)
-- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in  your source code provider
+- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in your source code provider

--- a/src/platform-includes/getting-started-primer/dotnet.mdx
+++ b/src/platform-includes/getting-started-primer/dotnet.mdx
@@ -19,6 +19,6 @@ This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with th
 - Automatically captures errors including: unhandled exceptions and unobserved task exceptions
 - Events <PlatformLink to="/enriching-events/context/">enriched</PlatformLink> with device data
 - Offline caching of events when a device is unable to connect
-- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in  your source code provider; supports [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink)
+- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in your source code provider; supports [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink)
 - Samples provided for [multiple C# app models](https://github.com/getsentry/sentry-dotnet/tree/main/samples),
   F# [Console](https://github.com/sentry-demos/fsharp), and [Giraffe](https://github.com/sentry-demos/giraffe)

--- a/src/platform-includes/getting-started-primer/dotnet.mdx
+++ b/src/platform-includes/getting-started-primer/dotnet.mdx
@@ -21,3 +21,4 @@ This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with th
 - Offline caching of events when a device is unable to connect
 - Samples provided for [multiple C# app models](https://github.com/getsentry/sentry-dotnet/tree/main/samples),
   F# [Console](https://github.com/sentry-demos/fsharp), and [Giraffe](https://github.com/sentry-demos/giraffe)
+- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in  your source code provider

--- a/src/platform-includes/getting-started-primer/dotnet.mdx
+++ b/src/platform-includes/getting-started-primer/dotnet.mdx
@@ -19,6 +19,6 @@ This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with th
 - Automatically captures errors including: unhandled exceptions and unobserved task exceptions
 - Events <PlatformLink to="/enriching-events/context/">enriched</PlatformLink> with device data
 - Offline caching of events when a device is unable to connect
+- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in  your source code provider; supports [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink)
 - Samples provided for [multiple C# app models](https://github.com/getsentry/sentry-dotnet/tree/main/samples),
   F# [Console](https://github.com/sentry-demos/fsharp), and [Giraffe](https://github.com/sentry-demos/giraffe)
-- [Stack Trace Linking](/product/integrations/integration-platform/ui-components/stacktrace-link/) to jump directly from a stack trace to the corresponding file in your source code provider


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds the stack trace linking feature to the .NET page, introduced in getsentry/sentry#57520

Closes getsentry/sentry#53249

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
