### PR TITLE
Added available levels to set-level.mdx

### DIFF
--- a/src/platforms/common/usage/set-level.mdx
+++ b/src/platforms/common/usage/set-level.mdx
@@ -9,3 +9,5 @@ notSupported:
 The level - similar to logging levels - is generally added by default based on the integration. You can also override it within an event.
 
 <PlatformContent includePath="set-level" />
+
+Available levels are "fatal", "error", "warning", "log", "info", and "debug".


### PR DESCRIPTION

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Show the user the range of levels that they can use.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
