### PR TITLE
Add link to Sentry

### DIFF
--- a/src/docs/product/accounts/getting-started/index.mdx
+++ b/src/docs/product/accounts/getting-started/index.mdx
@@ -7,7 +7,7 @@ redirect_from:
 description: "Learn how to set up a Sentry organization account so you can start fixing errors right away."
 ---
 
-In this guide, we'll provide the recommended checklist for setting up your Sentry organization account so you can get started with Sentry error monitoring.
+In this guide, we'll provide the recommended checklist for setting up your [Sentry organization account](https://sentry.io) so you can get started with Sentry error monitoring.
 
 We understand that some of you are running enterprise organizations, while others of you are hobbyists just coding for fun. Below, we've linked where you should get started, depending on your situation.
 


### PR DESCRIPTION
Make it possible for users to create Sentry account by adding link in docs.

