### PR TITLE
Add docs for `huey` integration

### DIFF
--- a/src/platforms/python/common/integrations/huey/index.mdx
+++ b/src/platforms/python/common/integrations/huey/index.mdx
@@ -52,9 +52,9 @@ with sentry_sdk.start_transaction(name="testing_huey"):
     result = add(1, 2)
 ```
 
-Running this will make a new transaction called `testing_huey` appear in the
-Performance section of [sentry.io](https://sentry.io). Note that it might
-take a couple moments for it to show up.
+Running this will create a new transaction called `testing_huey` in the
+Performance section of [sentry.io](https://sentry.io). It may
+take a couple of moments for the transaction to show up.
 
 ## Supported Versions
 

--- a/src/platforms/python/common/integrations/huey/index.mdx
+++ b/src/platforms/python/common/integrations/huey/index.mdx
@@ -1,0 +1,62 @@
+---
+title: huey
+description: "Learn how to import and use the huey integration."
+---
+
+The huey integration adds support for the
+[huey task queue library](https://huey.readthedocs.io/en/latest/).
+
+## Install
+
+To get started, install `sentry-sdk` from PyPI.
+
+```bash
+pip install --upgrade sentry-sdk
+```
+
+## Configure
+
+Add `HueyIntegration()` to your `integrations` list:
+
+<SignInNote />
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.huey import HueyIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        HueyIntegration(),
+    ],
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
+)
+```
+
+## Verify
+
+```python
+from huey import SqliteHuey
+
+sentry_sdk.init(...)  # same as above
+
+huey = SqliteHuey(filename='demo.db')
+
+@huey.task()
+def add(a, b):
+    return a + b
+
+with sentry_sdk.start_transaction(name="testing_huey"):
+    result = add(1, 2)
+```
+
+Running this will make a new transaction called `testing_huey` appear in the
+Performance section of [sentry.io](https://sentry.io). Note that it might
+take a couple moments for it to show up.
+
+## Supported Versions
+
+- huey: 2.0.0+
+- Python: 2.7, 3.5+

--- a/src/platforms/python/common/integrations/index.mdx
+++ b/src/platforms/python/common/integrations/index.mdx
@@ -41,6 +41,7 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 | <linkWithPlatformIcon platform="python.spark"   label="Apache Spark"   url="/platforms/python/integrations/spark" />   |                  |
 | <linkWithPlatformIcon platform="python.arq"     label="ARQ"            url="/platforms/python/integrations/arq" />     |                  |
 | <linkWithPlatformIcon platform="python.celery"  label="Celery"         url="/platforms/python/integrations/celery" />  |        ✓         |
+| <linkWithPlatformIcon platform="python.huey"    label="huey"           url="/platforms/python/integrations/huey" />    |                  |
 | <linkWithPlatformIcon platform="python.rq"      label="RQ"             url="/platforms/python/integrations/rq" />      |        ✓         |
 
 ## Cloud Computing


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The `huey` integration was added to the Python SDK [quite some time ago](https://github.com/getsentry/sentry-python/releases/tag/1.15.0) and we don't have any docs for it.

Integration table preview: https://sentry-docs-git-ivana-add-huey.sentry.dev/platforms/python/integrations/
Integration page preview: https://sentry-docs-git-ivana-add-huey.sentry.dev/platforms/python/integrations/huey/

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
