### PR TITLE
Fix on premise config for debug-symbols-apple

### DIFF
--- a/src/platform-includes/debug-symbols-apple/_default.mdx
+++ b/src/platform-includes/debug-symbols-apple/_default.mdx
@@ -55,10 +55,10 @@ sentry_upload_dif(
 
 <Alert level="" title="On Prem">
 
-By default fastlane will connect to sentry.io. For on-prem you need to provide the _api_host_ parameter to instruct the tool to connect to your server:
+By default fastlane will connect to sentry.io. For on-prem you need to provide the _url_ parameter to instruct the tool to connect to your server:
 
 ```
-api_host: 'https://mysentry.invalid/'
+url: 'https://mysentry.invalid/'
 ```
 
 </Alert>


### PR DESCRIPTION
## Pre-merge checklist

_If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason._

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Using `api_host`` will output the following error:

```
Could not find option 'api_host' in the list...
```

For the anecdote, I wrote pretty much [the same pull request](https://github.com/getsentry/sentry-docs/pull/2704) about 3 years ago. 😉

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
