### PR TITLE
fix(docs): Fix root_source_code_paths option

### DIFF
--- a/src/platforms/elixir/configuration/options.mdx
+++ b/src/platforms/elixir/configuration/options.mdx
@@ -51,9 +51,9 @@ The backend can also be configured to capture Logger metadata, which is detailed
 
 : The DSN provided by Sentry.
 
-`root_source_code_path`
+`root_source_code_paths`
 
-: This is only required if `enable_source_code_context` is enabled. Should generally be set to `File.cwd!`.
+: This is only required if `enable_source_code_context` is enabled. Should generally be set to `[File.cwd!]`.
 
 ## Optional settings
 
@@ -127,7 +127,7 @@ The backend can also be configured to capture Logger metadata, which is detailed
 
 `source_code_path_pattern`
 
-: A glob that is expanded to select files from the `:root_source_code_path`. Defaults to `"**/*.ex"`.
+: A glob that is expanded to select files from the `:root_source_code_paths`. Defaults to `"**/*.ex"`.
 
 `json_library`
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

I was doing the Sentry onboarding today and it didn't work. I noticed the instructions were wrong because the configuration expects `root_source_code_paths` (plural) and not `root_source_code_path`. Plus, it expects a list instead of a string.

This PR updates the docs to cover that.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
