### PR TITLE
ref(workflow): Update participants docs

### DIFF
--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -41,7 +41,7 @@ You receive workflow notifications when you’re subscribed to an issue, and you
 - Resolving, unresolving, or archiving an issue
 - Resolving an unassigned issue and having the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option on
 
-If you are subscribed to an issue, you or your team will become a participant of the issue. These notifications may have some overlap with alerts that are configured for a project. You will become unsubscribed from an issue by:
+If you are subscribed to an issue, you or your team will become a participant of the issue. Participants are shown on the right hand sidebar at the bottom of the issue details page. These notifications may have some overlap with alerts that are configured for a project. You will become unsubscribed from an issue by:
 
 - No longer being assigned to the issue
 - Deleting the only comment you left on an issue

--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -41,7 +41,7 @@ You receive workflow notifications when you subscribe to an issue in one of the 
 - Resolving, unresolving, or archiving an issue
 - Resolving an unassigned issue with the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option turned on
 
-You or your team will become participants once you're subscribed to an issue. Participants can be viewed from the right hand sidebar at the bottom of the issue details page. Note that participant notifications may have some overlap with alerts that are configured on a per-project basis. 
+You or your team will become participants once you're subscribed to an issue. Participants can be viewed from the right hand sidebar at the bottom of the issue details page. Note that participant notifications may have some overlap with alerts that are configured on a per-project basis.
 
 You'll be unsubscribed from an issue if you:
 

--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -34,12 +34,12 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 
 You receive workflow notifications when you’re subscribed to an issue, and you subscribe to issues by:
 
-- You or your team are assigned to the issue
+- You or your team being assigned to the issue
 - Clicking the subscribe bell icon on an issue
 - Commenting on an issue
 - Bookmarking an issue
 - Resolving, unresolving, or archiving an issue
-- Resolving an unassigned issue and having the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option on
+- Resolving an unassigned issue with the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option turned on
 
 If you are subscribed to an issue, you or your team will become a participant of the issue. Participants are shown on the right hand sidebar at the bottom of the issue details page. These notifications may have some overlap with alerts that are configured for a project. You will become unsubscribed from an issue by:
 

--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -32,20 +32,22 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 - **User Feedback**: When an issue has new <PlatformLink to="/enriching-events/user-feedback/">user feedback</PlatformLink>.
 - **Event Processing Problems**: When there's a problem with processing error events you've sent to Sentry.
 
-You receive workflow notifications when you’re subscribed to an issue, and you subscribe to issues by:
+You receive workflow notifications when you subscribe to an issue in one of the following ways by:
 
 - You or your team being assigned to the issue
-- Clicking the subscribe bell icon on an issue
+- Clicking the bell icon to subscribe to an issue
 - Commenting on an issue
 - Bookmarking an issue
 - Resolving, unresolving, or archiving an issue
 - Resolving an unassigned issue with the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option turned on
 
-If you are subscribed to an issue, you or your team will become a participant of the issue. Participants are shown on the right hand sidebar at the bottom of the issue details page. These notifications may have some overlap with alerts that are configured for a project. You will become unsubscribed from an issue by:
+You or your team will become participants once you're subscribed to an issue. Participants can be viewed from the right hand sidebar at the bottom of the issue details page. Note that participant notifications may have some overlap with alerts that are configured on a per-project basis. 
 
-- No longer being assigned to the issue
-- Deleting the only comment you left on an issue
-- Removing a bookmark on an issue
+You'll be unsubscribed from an issue if you:
+
+- Are unassigned from the issue
+- Delete the only comment you left on an issue
+- Remove a bookmark from an issue
 
 ## Deploy Notifications
 

--- a/src/docs/product/alerts/notifications/index.mdx
+++ b/src/docs/product/alerts/notifications/index.mdx
@@ -26,7 +26,6 @@ You can manage these notifications in **User Settings > Notifications**.
 Sentry sends workflow notifications to let you know about [issue state](/product/issues/states-triage/) changes. Workflow relates to actions that help you manage your issues, such as changing an issue’s state or commenting on it. By default, Sentry sends these notifications by email to members who are subscribed to the issue (see below for how subscription is determined). Workflow notifications are sent for:
 
 - **Issue Resolved**: When a new issue is spotted in your code, it's in the Unresolved state. The issue state changes to Resolved when a project team member resolves it, either by manually changing its state in [sentry.io](https://sentry.io)) or by submitting a fix, or because of the project’s auto-resolve feature (if configured).
-- **Issue Escalating**: When the number of events an issue has is significantly higher than the previous week, based on the [escalating limit calculation](/product/issues/states-triage/escalating-issues/#escalating-limit-calculation).
 - **Regressions**: A regression happens when the state of an issue changes from Resolved back to Unresolved. An email is sent to all project team members.
 - **Comments**: When a team member adds a new comment in the “Activity” tab of the detail page for the issue.
 - **Assignment**: When an issue is assigned or unassigned.
@@ -35,14 +34,18 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 
 You receive workflow notifications when you’re subscribed to an issue, and you subscribe to issues by:
 
+- You or your team are assigned to the issue
 - Clicking the subscribe bell icon on an issue
-- Involvement in a commit related to the issue
-- Commenting on or bookmarking the issue
-- Mention of you or your team in the issue
-- You or your team being assigned to the issue
-- Archiving an issue until it escalates
+- Commenting on an issue
+- Bookmarking an issue
+- Resolving, unresolving, or archiving an issue
+- Resolving an unassigned issue and having the ["Claim Unassigned Issues I've Resolved"](/product/alerts/notifications/notification-settings/#my-activity) option on
 
-These notifications may have some overlap with alerts that are configured for a project.
+If you are subscribed to an issue, you or your team will become a participant of the issue. These notifications may have some overlap with alerts that are configured for a project. You will become unsubscribed from an issue by:
+
+- No longer being assigned to the issue
+- Deleting the only comment you left on an issue
+- Removing a bookmark on an issue
 
 ## Deploy Notifications
 


### PR DESCRIPTION
Update the participant docs (and say the word "participants" in them) to reflect the new ways you can subscribe and unsubscribe from an issue. 

Don't merge until these changes are GA'd.

Closes https://github.com/getsentry/sentry/issues/57722