### PR TITLE
Correct default value for `transaction_style` for `DjangoIntegration`

### DIFF
--- a/src/platforms/python/common/integrations/django/index.mdx
+++ b/src/platforms/python/common/integrations/django/index.mdx
@@ -117,7 +117,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
   - `"/myproject/myview/<foo>"` if you set `transaction_style="url"`.
   - `"myproject.myview"` if you set `transaction_style="endpoint"`.
 
-  The default is `"endpoint"`.
+  The default is `"url"`.
 
 - `middleware_spans`:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The [documentation for the options of `DjangoIntegration`](https://docs.sentry.io/platforms/python/integrations/django/#options) show that the default value for `transaction_style` is `endpoint` while it is `url`. See [here](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/django/__init__.py#L112) for the code.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
