### PR TITLE
feat: Use new `Sentry.addIntegration()`

### DIFF
--- a/src/includes/platforms/configuration/integrations/plugin.mdx
+++ b/src/includes/platforms/configuration/integrations/plugin.mdx
@@ -8,7 +8,7 @@ For example:
 
 <PlatformContent includePath="configuration/enable-pluggable-integrations" />
 
-Alternatively, you can add integrations lazily via `client.addIntegration()`.
+Alternatively, you can add integrations lazily via `Sentry.addIntegration()`.
 This is useful if you only want to enable an integration in a specific environment or if you want to lazy-load an integration.
 For all other cases, we recommend you use the `integrations` option.
 

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -8,10 +8,7 @@ Sentry.init({
   integrations: [],
 });
 
-const client = Sentry.getCurrentHub().getClient();
-if (client) {
-  client.addIntegration(new ReportingObserver());
-}
+Sentry.addIntegration(new ReportingObserver());
 ```
 
 ```html {tabTitle: Loader}
@@ -31,10 +28,7 @@ if (client) {
       integrations: [],
     });
 
-    const client = Sentry.getCurrentHub().getClient();
-    if (client) {
-      client.addIntegration(new Sentry.Integrations.ReportingObserver());
-    }
+    Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());
   });
 </script>
 ```
@@ -57,9 +51,6 @@ if (client) {
     integrations: [],
   });
 
-  const client = Sentry.getCurrentHub().getClient();
-  if (client) {
-    client.addIntegration(new Sentry.Integrations.ReportingObserver());
-  }
+  Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());
 </script>
 ```

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/react-native.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/react-native.mdx
@@ -6,8 +6,5 @@ Sentry.init({
   integrations: [],
 });
 
-const client = Sentry.getCurrentHub().getClient();
-if (client) {
-  client.addIntegration(new DedupeIntegration());
-}
+Sentry.addIntegration(new DedupeIntegration());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/angular-ivy");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/angular-ivy");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -41,5 +41,5 @@ Sentry.init({
 
 // Sometime later
 const { Replay } = await import("@sentry/electron/renderer");
-getCurrentHub().getClient().addIntegration(new Replay());
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/ember");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/ember");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/gatsby");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/gatsby");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -41,6 +41,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/browser");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/browser");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -42,6 +42,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/nextjs");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/nextjs");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.react.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/react");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/react");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -42,6 +42,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/remix");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/remix");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/svelte");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/svelte");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -42,6 +42,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/sveltekit");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/sveltekit");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -40,6 +40,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { getCurrentHub, Replay } = await import("@sentry/vue");
-getCurrentHub().getClient().addIntegration(new Replay());
+const { Replay } = await import("@sentry/vue");
+Sentry.addIntegration(new Replay());
 ```

--- a/src/platforms/javascript/common/configuration/integrations/index.mdx
+++ b/src/platforms/javascript/common/configuration/integrations/index.mdx
@@ -50,7 +50,7 @@ You can add additional integrations in your `init` call:
 
 <PlatformContent includePath="configuration/enable-pluggable-integrations" />
 
-Alternatively, you can add integrations lazily via `client.addIntegration()`.
+Alternatively, you can add integrations lazily via `Sentry.addIntegration()`.
 This is useful if you only want to enable an integration in a specific environment or if you want to lazy-load an integration.
 For all other cases, we recommend you use the `integrations` option.
 

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -62,8 +62,7 @@ Sentry.init({
 });
 
 // You can access the active replay instance from anywhere in your code like this:
-const client = Sentry.getCurrentHub().getClient();
-const replay = client?.getIntegration(Sentry.Replay);
+const replay = Sentry.getCurrentHub().getIntegration(Sentry.Replay);
 
 // This starts in `session` mode, regardless of sample rates
 replay.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2558,10 +2558,10 @@
   dependencies:
     dequal "^2.0.2"
 
-"@sentry-internal/global-search@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/global-search/-/global-search-0.5.7.tgz#2749d24b01123b5d92f6326a33c5d4c81ec8c239"
-  integrity sha512-+fN8bsdXqo0nqppNR2JvZ5acEDKhVA/uCsE0jvLNcGqQgbr6JREbTje/nCCZNgoDwJ+BoTROALKIx/YBlhdp7g==
+"@sentry-internal/global-search@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/global-search/-/global-search-0.5.8.tgz#440f830be09f6bd7ca626422b1e49aae29822234"
+  integrity sha512-wG/w1N6qNEzg8Vj310+H7hL8bpSyB2C6DVMTtI4sxK69Jdk+KdAY07mqkYEP2BLgMdA2zO/3VpZs4qZqMz9a/A==
   dependencies:
     "@types/react" ">=16"
     "@types/react-dom" ">=16"


### PR DESCRIPTION
This updates the docs to use the new `Sentry.addIntegration()` method vs. requiring to pick the current hub & client etc.