### PR TITLE
feat: Update loader docs to guard against unexisting `Sentry.onLoad()`

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -53,7 +53,7 @@ function SentryLoaderConfig() {
       key="sentry-loader-config"
       dangerouslySetInnerHTML={{
         __html: `
-Sentry.onLoad(function() {
+  window.Sentry && Sentry.onLoad(function() {
   Sentry.init({
     integrations: [
       new Sentry.Replay({

--- a/src/platform-includes/configuration/capture-console/javascript.mdx
+++ b/src/platform-includes/configuration/capture-console/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.CaptureConsole()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.CaptureConsole()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.ContextLines()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.ContextLines()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/debug/javascript.mdx
+++ b/src/platform-includes/configuration/debug/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.Debug()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.Debug()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/dedupe/javascript.mdx
+++ b/src/platform-includes/configuration/dedupe/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.Dedupe()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.Dedupe()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -23,9 +23,17 @@ Sentry.addIntegration(new ReportingObserver());
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [],
+      });
+
+      const client = Sentry.getCurrentHub().getClient();
+      if (client) {
+        client.addIntegration(new Sentry.Integrations.ReportingObserver());
+      }
     });
 
     Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());

--- a/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.ReportingObserver()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.ReportingObserver()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/src/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.ExtraErrorData()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.ExtraErrorData()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/http-client/javascript.mdx
+++ b/src/platform-includes/configuration/http-client/javascript.mdx
@@ -25,14 +25,16 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.HttpClient()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.HttpClient()],
 
-      // This option is required for capturing headers and cookies.
-      sendDefaultPii: true,
+        // This option is required for capturing headers and cookies.
+        sendDefaultPii: true,
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/module-metadata/javascript.mdx
+++ b/src/platform-includes/configuration/module-metadata/javascript.mdx
@@ -16,11 +16,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.ModuleMetadata()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.ModuleMetadata()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/src/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.ReportingObserver()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.ReportingObserver()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -22,11 +22,13 @@ Sentry.init({
 ></script>
 
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      integrations: [new Sentry.Integrations.RewriteFrames()],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        integrations: [new Sentry.Integrations.RewriteFrames()],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -20,16 +20,18 @@ This will initialize Replay with the default config:
 You can change it with:
 -->
 <script>
-  Sentry.onLoad(function () {
-    Sentry.init({
-      replaysSessionSampleRate: 0.5,
-      integrations: [
-        new Sentry.Replay({
-          maskAllText: true,
-        }),
-      ],
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      Sentry.init({
+        replaysSessionSampleRate: 0.5,
+        integrations: [
+          new Sentry.Replay({
+            maskAllText: true,
+          }),
+        ],
+      });
     });
-  });
 </script>
 ```
 

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -92,15 +92,17 @@ The loader script always includes a call to `Sentry.init` with a default configu
   crossorigin="anonymous"
 ></script>
 <script>
-  Sentry.onLoad(function() { ... });
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry && Sentry.onLoad(function() { ... });
 </script>
 ```
 
-`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set.
+`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set. Note that we check if `Sentry` exists before we call `Sentry.onLoad` to guard against the case that the loader script failed to load.
 
 ```html
 <script>
-  Sentry.onLoad(function() {
+  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  window.Sentry && Sentry.onLoad(function() {
     Sentry.init({
       release: " ... ",
       environment: " ... "

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -97,7 +97,7 @@ The loader script always includes a call to `Sentry.init` with a default configu
 </script>
 ```
 
-`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set. Note that we check if `Sentry` exists before we call `Sentry.onLoad` to guard against the case that the loader script failed to load.
+`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set. We recommend checking if `Sentry` exists before calling `Sentry.onLoad` in case the loader script failed to load.
 
 ```html
 <script>


### PR DESCRIPTION
It is possible that the loader script fails to load (e.g. if it is adblocked or something like this), so to be safe we should recommend to guard against `Sentry` not existing before calling `Sentry.onLoad()`.