### PR TITLE
feat: Add docs about when to use the loader/npm

### DIFF
--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -21,21 +21,21 @@ notSupported:
 
 <PageGrid />
 
-## When to use which Installation Method
+## How To Decide Which Installation Method To Use
 
 Depending on the concrete needs of your application, you may wonder which installation method you should use.
 
 ### Why to use the Loader Script over NPM
 
-Using the Loader Script is the easiest way to start using Sentry. You only need to add a script tag to your application, and we'll take care of setting everything up correctly for you.
+Using the Loader Script is the easiest way to start using Sentry. Add a script tag to your application, and we'll take care of setting everything else up correctly for you.
 
-- **Easy to set up**: You only need to [add a script tag](./loader/#using-the-loader) to your application.
+- **Easy to set up**: Just [add a script tag](./loader/#using-the-loader) to your application.
 
-- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users - no action needed on your side.
+- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users. No action's needed from you.
 
-- **Easy to add additional configuration**: You can still [configure the SDK](./loader/#sdk-configuration) to your liking via `Sentry.onLoad()`.
+- **Easy to add additional configuration**: You can [configure the SDK](./loader/#sdk-configuration) to your liking via `Sentry.onLoad()`.
 
-- **Lazy-loading**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
+- **Lazy-loading**: If you just want to use Sentry for errors, we'll only load the SDK when an error occurs, reducing the amount of JavaScript loaded on your page until then.
 
   <Note>
     Note that when enabling Session Replay and/or Performance Monitoring, the
@@ -47,8 +47,8 @@ Using the Loader Script is the easiest way to start using Sentry. You only need 
 
 While using the Loader Script has definite advantages, it also comes with some drawbacks:
 
-- **No framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you'll not get any React, Vue, or similar framework-specific features for Sentry. If you want this, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
+- **No framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you won't get any React, Vue, or similar framework-specific features for Sentry. To get these features, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
 
-- **Reduced public API**: The Loader Script only exposes a subset of public APIs (e.g. `Sentry.captureException()`, ...). This means if you're planning to have a lot of custom functionality, you're likely better off with the npm package.
+- **Reduced public API**: The Loader Script only exposes a subset of public APIs (for example, `Sentry.captureException()`, ...). If you need a lot of custom functionality, you're likely better off with the npm package.
 
-- **No control over the SDK version**: If you happen to need exact control over the SDK version, you'll need to install the SDK via npm.
+- **No control over the SDK version**: If you need full control over the SDK version, you'll need to install the SDK via npm.

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -45,7 +45,7 @@ Using the Loader Script is the easiest way to start using Sentry. Add a script t
 
 ### Why Choose NPM Over the Loader Script
 
-While using the Loader Script has definite advantages, it also comes with some drawbacks. 
+While using the Loader Script has definite advantages, it also comes with some drawbacks.
 In these scenarios, using the npm package is the better choice:
 
 - **Framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you won't get any React, Vue, or similar framework-specific features for Sentry. To get these features, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -25,13 +25,13 @@ notSupported:
 
 Depending on the concrete needs of your application, you may wonder which installation method you should use.
 
-### Why to use the Loader Script over NPM
+### Why Choose the Loader Script Over NPM
 
 Using the Loader Script is the easiest way to start using Sentry. Add a script tag to your application, and we'll take care of setting everything else up correctly for you.
 
 - **Easy to set up**: Just [add a script tag](./loader/#using-the-loader) to your application.
 
-- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users. No action's needed from you.
+- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users. No action's needed from you. This ensures you'll always get the latest features and bug fixes of the Sentry SDK.
 
 - **Easy to add additional configuration**: You can [configure the SDK](./loader/#sdk-configuration) to your liking via `Sentry.onLoad()`.
 
@@ -43,12 +43,13 @@ Using the Loader Script is the easiest way to start using Sentry. Add a script t
     on the page as early as possible.
   </Note>
 
-### Why to use NPM over the Loader Script
+### Why Choose NPM Over the Loader Script
 
-While using the Loader Script has definite advantages, it also comes with some drawbacks:
+While using the Loader Script has definite advantages, it also comes with some drawbacks. 
+In these scenarios, using the npm package is the better choice:
 
-- **No framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you won't get any React, Vue, or similar framework-specific features for Sentry. To get these features, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
+- **Framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you won't get any React, Vue, or similar framework-specific features for Sentry. To get these features, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
 
-- **Reduced public API**: The Loader Script only exposes a subset of public APIs (for example, `Sentry.captureException()`, ...). If you need a lot of custom functionality, you're likely better off with the npm package.
+- **Full public API**: The Loader Script only exposes a subset of public APIs (for example, `Sentry.captureException()`, ...). If you need a lot of custom functionality, you're likely better off with the npm package.
 
-- **No control over the SDK version**: If you need full control over the SDK version, you'll need to install the SDK via npm.
+- **Full control over the SDK version**: If you need full control over the SDK version, you'll need to install the SDK via npm.

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -29,11 +29,11 @@ Depending on the concrete needs of your application, you may wonder which instal
 
 Using the Loader Script is the easiest way to start using Sentry. You only need to add a script tag to your application, and we'll take care of setting everything up correctly for you.
 
-- **Easy to set up**: You only need to add a script tag to your application.
+- **Easy to set up**: You only need to [add a script tag](./loader/#using-the-loader) to your application.
 
 - **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users - no action needed on your side.
 
-- **Easy to add additional configuration**: You can still configure Sentry to your liking via `Sentry.onLoad()`.
+- **Easy to add additional configuration**: You can still [configure the SDK](./loader/#sdk-configuration) to your liking via `Sentry.onLoad()`.
 
 - **Lazy-loading**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
 

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -38,9 +38,9 @@ Using the Loader Script is the easiest way to start using Sentry. You only need 
 - **Lazy-loading**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
 
   <Note>
-    Note that when enabling Session Replay and/or Performance Monitoring, the SDK will be loaded
-    immediately because we need to capture what's happening on the page as early
-    as possible.
+    Note that when enabling Session Replay and/or Performance Monitoring, the
+    SDK will be loaded immediately because we need to capture what's happening
+    on the page as early as possible.
   </Note>
 
 ### Why to use NPM over the Loader Script

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -20,3 +20,35 @@ notSupported:
 ---
 
 <PageGrid />
+
+## When to use which Installation Method
+
+Depending on the concrete needs of your application, you may wonder which installation method you should use.
+
+### Why to use the Loader Script over NPM
+
+Using the Loader Script is the easiest way to start using Sentry. You only need to add a script tag to your application, and we'll take care of setting everything up correctly for you.
+
+- **Easy to set up**: You only need to add a script tag to your application.
+
+- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to you - no action needed on your side.
+
+- **Easy to add additional configuration**: You can still configure Sentry to your liking via `Sentry.onLoad()`.
+
+- **Lazy-loading for errors-only mode**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
+
+  <Note>
+    Note that when enabling Replay and/or Performance, the SDK will be loaded
+    immediately because we need to capture what's happening on the page as early
+    as possible.
+  </Note>
+
+### Why to use NPM over the Loader Script
+
+While using the Loader Script has definite advantages, it also comes with some drawbacks:
+
+- **No framework-specific initialization**: As of now, the Loader Script only serves the generic JavaScript Browser SDK. This means that you'll not get any React, Vue, or similar framework-specific initialization. If you need this, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
+
+- **Reduced public API**: The Loader Script only exposes a subset of public APIs (e.g. `Sentry.captureException()`, ...).
+
+- **No control over the SDK version**: If you happen to need exact control over the SDK version, you'll need to install the SDK via npm.

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -31,14 +31,14 @@ Using the Loader Script is the easiest way to start using Sentry. You only need 
 
 - **Easy to set up**: You only need to add a script tag to your application.
 
-- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to you - no action needed on your side.
+- **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users - no action needed on your side.
 
 - **Easy to add additional configuration**: You can still configure Sentry to your liking via `Sentry.onLoad()`.
 
-- **Lazy-loading for errors-only mode**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
+- **Lazy-loading**: If you only want to use Sentry for errors, we'll only load the SDK when an error occurs. This means that we can reduce the amount of JavaScript loaded on your page until an error occurs.
 
   <Note>
-    Note that when enabling Replay and/or Performance, the SDK will be loaded
+    Note that when enabling Session Replay and/or Performance Monitoring, the SDK will be loaded
     immediately because we need to capture what's happening on the page as early
     as possible.
   </Note>
@@ -47,8 +47,8 @@ Using the Loader Script is the easiest way to start using Sentry. You only need 
 
 While using the Loader Script has definite advantages, it also comes with some drawbacks:
 
-- **No framework-specific initialization**: As of now, the Loader Script only serves the generic JavaScript Browser SDK. This means that you'll not get any React, Vue, or similar framework-specific initialization. If you need this, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
+- **No framework-specific initialization**: As of now, the Loader Script only provides generic Browser JavaScript instrumentation. This means that you'll not get any React, Vue, or similar framework-specific features for Sentry. If you want this, you'll need to install the framework SDK (e.g. `@sentry/react` or `@sentry/vue`) via npm.
 
-- **Reduced public API**: The Loader Script only exposes a subset of public APIs (e.g. `Sentry.captureException()`, ...).
+- **Reduced public API**: The Loader Script only exposes a subset of public APIs (e.g. `Sentry.captureException()`, ...). This means if you're planning to have a lot of custom functionality, you're likely better off with the npm package.
 
 - **No control over the SDK version**: If you happen to need exact control over the SDK version, you'll need to install the SDK via npm.


### PR DESCRIPTION
This was requested every now and then, so I added a section to the browser SDK installation methods overview to explain when to use which installation method.