### PR TITLE
chore(jira): Remove jira server blurb about not having alert rule action

### DIFF
--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -165,12 +165,6 @@ Issue management can be configured in two ways - automatically or manually.
 
 #### Automatically
 
-<Note>
-
-This configuration method does not apply to Jira Server. Jira Server [requires manual configuration](#manually).
-
-</Note>
-
 To configure issue management automatically, create an [**Issue Alert**](/product/alerts-notifications/issue-alerts/). When selecting the [**action**](/product/alerts/create-alerts/issue-alert-config/#then-conditions-actions), choose **Create a new Jira issue**.
 
 ![Create Jira ticket alert rule action](jira-ticket-rule.png)


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/58019

Should be merged after Jira Server alert rule action has been entirely merged