### PR TITLE
feat(js): Add Documentation for Sentry Astro SDK

### DIFF
--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -38,7 +38,7 @@ export function OrgAuthTokenNote() {
           <ExternalLink href={`https://sentry.io/auth/login/?next=${url}`}>
             sign in
           </ExternalLink>{' '}
-          to create a token directly from the docs.
+          to create a token directly from this page.
         </Note>
       </SignedInCheck>
 
@@ -48,7 +48,7 @@ export function OrgAuthTokenNote() {
           <ExternalLink href={orgAuthTokenUrl} target="_blank">
             manually create an Auth Token
           </ExternalLink>{' '}
-          or create a token directly from the docs. A created token will only be visible
+          or create a token directly from this page. A created token will only be visible
           once right after creation - make sure to copy it!
         </Alert>
       </SignedInCheck>

--- a/src/platform-includes/capture-error/javascript.astro.mdx
+++ b/src/platform-includes/capture-error/javascript.astro.mdx
@@ -1,0 +1,11 @@
+You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stack trace.
+
+```javascript
+import * as Sentry from "@sentry/astro";
+
+try {
+  aFunctionThatMightFail();
+} catch (err) {
+  Sentry.captureException(err);
+}
+```

--- a/src/platform-includes/capture-error/javascript.astro.mdx
+++ b/src/platform-includes/capture-error/javascript.astro.mdx
@@ -1,4 +1,4 @@
-You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stack trace.
+You can pass an `Error` object to `captureException()` to have it captured as an event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stack trace.
 
 ```javascript
 import * as Sentry from "@sentry/astro";

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -6,9 +6,6 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -1,0 +1,14 @@
+If you're using our Astro SDK, distributed tracing will work out of the box for the client and server runtimes.
+To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` on the client-side.
+
+```js
+// sentry.client.config.js
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new BrowserTracing()],
+  tracePropagationTargets: [
+    "https://myproject.org",
+    "https://.*.otherservice.org/.*",
+  ],
+});
+```

--- a/src/platform-includes/enriching-events/import/javascript.astro.mdx
+++ b/src/platform-includes/enriching-events/import/javascript.astro.mdx
@@ -1,0 +1,3 @@
+```javascript
+import * as Sentry from "@sentry/astro";
+```

--- a/src/platform-includes/getting-started-config/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-config/javascript.astro.mdx
@@ -19,4 +19,4 @@ export default defineConfig({
 });
 ```
 
-Once you added your `dsn`, the SDK will automatically capture and send errors and performance events to Sentry.
+Once you've added your `dsn`, the SDK will automatically capture and send errors and performance events to Sentry.

--- a/src/platform-includes/getting-started-config/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-config/javascript.astro.mdx
@@ -1,0 +1,22 @@
+Get started by adding your DSN to your Astro config file:
+
+<SignInNote />
+
+```javascript {filename:astro.config.mjs}
+import { defineConfig } from "astro/config";
+import sentry from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentry({
+      dsn: "___PUBLIC_DSN___",
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+Once you added your `dsn`, the SDK will automatically capture and send errors and performance events to Sentry.

--- a/src/platform-includes/getting-started-install/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-install/javascript.astro.mdx
@@ -4,6 +4,6 @@ We recommend installing the SDK by using the `astro` CLI:
 npx astro add @sentry/astro
 ```
 
-The `astro` CLI takes care of installing the SDK package and adding the Sentry integration to your `astro.config.mjs` file.
+The `astro` CLI installs the SDK package and adds the Sentry integration to your `astro.config.mjs` file.
 
-To finish the Setup, you still need to configure the sentry integration.
+To finish the setup, configure the Sentry integration.

--- a/src/platform-includes/getting-started-install/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-install/javascript.astro.mdx
@@ -1,0 +1,9 @@
+We recommend installing the SDK by using the `astro` CLI:
+
+```bash
+npx astro add @sentry/astro
+```
+
+The `astro` CLI takes care of installing the SDK package and adding the Sentry integration to your `astro.config.mjs` file.
+
+To finish the Setup, you still need to configure the sentry integration.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,0 +1,14 @@
+Sentry's SvelteKit SDK enables automatic reporting of errors and performance data.
+
+<Alert level="warning">
+
+The SDK for Astro is currently in **Alpha state** and it might still experience **breaking changes**.
+Please report any issues you encounter in our [Github Repository](https://github.com/getsentry/sentry-javascript/issues/new/choose).
+
+</Alert>
+
+## Compatibility
+
+The minimum supported Astro version is `3.0.0`.
+Furthermore, this SDK currently only works on Node runtimes.
+None-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,8 +1,8 @@
-Sentry's SvelteKit SDK enables automatic reporting of errors and performance data.
+Sentry's Astro SDK enables automatic reporting of errors and performance data.
 
 <Alert level="warning">
 
-The SDK for Astro is currently in **Alpha state** and it might still experience **breaking changes**.
+The Astro SDK is in **Alpha** and may undergo **breaking changes**.
 Please report any issues you encounter in our [Github Repository](https://github.com/getsentry/sentry-javascript/issues/new/choose).
 
 </Alert>
@@ -10,5 +10,5 @@ Please report any issues you encounter in our [Github Repository](https://github
 ## Compatibility
 
 The minimum supported Astro version is `3.0.0`.
-Furthermore, this SDK currently only works on Node runtimes.
-None-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+This SDK currently only works on Node runtimes.
+Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
@@ -1,0 +1,11 @@
+## Add Readable Stack Traces to Errors
+
+To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment (e.g. via a `.env` file or in your CI setup).
+
+<OrgAuthTokenNote />
+
+```bash {filename:.env}
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+This, in combination with your `sourceMapsUploadOptions` configuration, will upload source maps to Sentry every time you make a production build.

--- a/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
@@ -8,4 +8,4 @@ To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOK
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-This, in combination with your `sourceMapsUploadOptions` configuration, will upload source maps to Sentry every time you make a production build.
+This, in combination with your `sourceMapsUploadOptions` configuration, will <PlatformLink to="/sourcemaps">upload source maps</PlatformLink> to Sentry every time you make a production build.

--- a/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
@@ -1,6 +1,6 @@
 ## Add Readable Stack Traces to Errors
 
-To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment (e.g. via a `.env` file or in your CI setup).
+To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, like in a `.env` file or in your CI setup.
 
 <OrgAuthTokenNote />
 

--- a/src/platform-includes/getting-started-verify/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-verify/javascript.astro.mdx
@@ -1,0 +1,13 @@
+Trigger a test error somewhere in your Astro app, for example in one of your pages:
+
+```html {filename: home.astro}
+<button onclick="throw new Error('This is a test error')">
+  Throw test error
+</button>
+```
+
+<Note>
+
+Errors triggered from within Browser DevTools are sandboxed and won't trigger an error handler. Place the snippet directly in your code instead.
+
+</Note>

--- a/src/platform-includes/performance/automatic-instrumentation-intro/javascript.astro.mdx
+++ b/src/platform-includes/performance/automatic-instrumentation-intro/javascript.astro.mdx
@@ -1,0 +1,2 @@
+The Sentry SvelteKit SDK provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications, which is enabled by default.
+The SDK also automatically enables performance monitoring in your server-side code.

--- a/src/platform-includes/performance/automatic-instrumentation-intro/javascript.astro.mdx
+++ b/src/platform-includes/performance/automatic-instrumentation-intro/javascript.astro.mdx
@@ -1,2 +1,2 @@
-The Sentry SvelteKit SDK provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications, which is enabled by default.
+The Sentry Astro SDK provides a `BrowserTracing` integration to add automatic instrumentation for monitoring the performance of browser applications, which is enabled by default.
 The SDK also automatically enables performance monitoring in your server-side code.

--- a/src/platform-includes/performance/configure-sample-rate/javascript.astro.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.astro.mdx
@@ -1,0 +1,42 @@
+Either set `tracesSampleRate` in your `astro.config.mjs` file or in `sentry.(client|server).init.js`:
+
+<SignInNote />
+
+```javascript {tabTitle:Integration Config}{filename:astro.config.mjs}
+import { defineConfig } from "astro/config";
+import sentryAstro from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      dsn: "___PUBLIC_DSN___",
+      tracesSampleRate: 1.0,
+    }),
+  ],
+});
+```
+
+```javascript {tabTitle:Custom Config (client)} {filename:sentry.client.config.js}
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
+```
+
+```javascript {tabTitle:Custom Config (server)} {filename:sentry.server.config.js}
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
+```
+
+<Alert level="warning">
+
+The `tracesSampler` callback can only be specified in <PlatformLink to="/manual-setup/#manual-sdk-initialization">custom SDK init files</PlatformLink>.
+It is **not supported** in the `astro.config.mjs` file.
+
+</Alert>

--- a/src/platform-includes/performance/enable-automatic-instrumentation/javascript.astro.mdx
+++ b/src/platform-includes/performance/enable-automatic-instrumentation/javascript.astro.mdx
@@ -1,0 +1,1 @@
+To enable tracing, set either a `tracesSampleRate` or a `tracesSampler` in your SDK configuration options, as described in <PlatformLink to="/performance/">Set Up Performance</PlatformLink>.

--- a/src/platform-includes/performance/enable-tracing/javascript.astro.mdx
+++ b/src/platform-includes/performance/enable-tracing/javascript.astro.mdx
@@ -1,0 +1,1 @@
+The Sentry Astro SDK comes with performance monitoring included. To enable it, configure the sample rate as described below.

--- a/src/platform-includes/session-replay/install/javascript.astro.mdx
+++ b/src/platform-includes/session-replay/install/javascript.astro.mdx
@@ -1,11 +1,11 @@
-The Replay integration is **already included** with the Astro SDK package.
+The Replay integration is already included with the Sentry Astro SDK.
 
-```bash {tabTitle:Npx}
+```bash {tabTitle:npx}
 npx astro add @sentry/astro
 ```
 
 <Note>
 
-If the setup through the Astro CLI doesn't work for you, you can also <PlatformLink to="/manual-setup/">set up the SDK manually</PlatformLink>.
+If the Astro CLI setup doesn't work for you, you can also <PlatformLink to="/manual-setup/">set up the SDK manually</PlatformLink>.
 
 </Note>

--- a/src/platform-includes/session-replay/install/javascript.astro.mdx
+++ b/src/platform-includes/session-replay/install/javascript.astro.mdx
@@ -1,0 +1,11 @@
+The Replay integration is **already included** with the Astro SDK package.
+
+```bash {tabTitle:Npx}
+npx astro add @sentry/astro
+```
+
+<Note>
+
+If the setup through the Astro CLI doesn't work for you, you can also <PlatformLink to="/manual-setup/">set up the SDK manually</PlatformLink>.
+
+</Note>

--- a/src/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -1,4 +1,4 @@
-Session replay is **enabled by default** if you use the SDK configuration in your `astro.config.mjs` file.
+Session replay is enabled by default if you use the SDK configuration in your `astro.config.mjs` file.
 
 You can customize Replay sample rates like so:
 
@@ -41,7 +41,7 @@ Session Replay can only be included on the client side.
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -1,0 +1,53 @@
+Session replay is **enabled by default** if you use the SDK configuration in your `astro.config.mjs` file.
+
+You can customize Replay sample rates like so:
+
+```javascript {filename:astro.config.mjs}
+import { defineConfig } from "astro/config";
+import sentry from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentry({
+      dsn: "___PUBLIC_DSN___",
+      replaysSessionSampleRate: 0.2, // defaults to 0.1
+      replaysOnErrorSampleRate: 1.0, // defaults to 1.0
+    }),
+  ],
+});
+```
+
+If you have a <PlatformLink to="/manual-setup/#manual-sdk-initialization">custom SDK configuration file</PlatformLink> for the client side (`sentry.client.config.js`), add the Sentry `Replay` integration:
+
+```javascript {filename:sentry.client.config.js}
+import * as sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  integrations: [new Sentry.Replay()],
+});
+```
+
+<Alert level="warning">
+
+Do not add the `Replay` integration to your server-side Sentry config file (`sentry.server.config.js`).
+Session Replay can only be included on the client side.
+
+</Alert>
+
+### Lazy-loading Replay
+
+Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
+
+```js
+Sentry.init({
+  // Note, Replay is NOT instantiated below:
+  integrations: [],
+});
+
+// Sometime later
+const { Replay } = await import("@sentry/astro");
+Sentry.addIntegration(new Replay());
+```

--- a/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -1,0 +1,85 @@
+## Configure Source Maps Upload
+
+Source maps upload should work if you followed the [Astro CLI installation guide](/platforms/javascript/guides/astro/#add-readable-stack-traces-to-errors). However, there are some options to configure source maps upload for your production builds for other configurations.
+
+### Enable Source Maps Upload
+
+To automatically upload source maps during production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, for example in a `.env` file or in your CI setup.
+
+<OrgAuthTokenNote />
+
+```bash {filename:.env}
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+Next, add your project slug to the `sourceMapsUploadOptions` in your Astro config:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // Other Sentry options
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+### Working With Old Authentication Tokens
+
+Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // Other Sentry options
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        org: "___ORG_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+### Disable Source Maps Upload
+
+You can disable automatic source maps upload in your Astro config:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // Other Sentry options
+      sourceMapsUploadOptions: {
+        enabled: false,
+      },
+    }),
+  ],
+});
+```
+
+### Disabeling Telemetry Data Collection
+
+The Astro SDK uses the Sentry Vite plugin to upload source maps.
+This plugin collects telemetry data to help us improve the source map uploading experience.
+Read more about this in our [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin#telemetry).
+You can disable telemetry collection by setting `telemetry` to `false`:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // Other Sentry options
+      sourceMapsUploadOptions: {
+        telemetry: false,
+      },
+    }),
+  ],
+});
+```

--- a/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -30,7 +30,7 @@ export default defineConfig({
 
 ### Working With Old Authentication Tokens
 
-Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
+Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using an old self-hosted Sentry version that doesn't yet support org-based tokens or you're using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({

--- a/src/platform-includes/sourcemaps/primer/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/primer/javascript.astro.mdx
@@ -1,0 +1,3 @@
+`@sentry/astro` will generate and upload source maps automatically, so that errors in Sentry will contain readable stack traces.
+
+The Astro SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin/) to upload source maps. See the <PlatformLink to="/manual-setup/#configure-source-maps-upload">Manual Configuration</PlatformLink> page and the Sentry [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin/#configuration) for more details.

--- a/src/platform-includes/sourcemaps/primer/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/primer/javascript.astro.mdx
@@ -1,3 +1,5 @@
-`@sentry/astro` will generate and upload source maps automatically, so that errors in Sentry will contain readable stack traces.
+The Sentry Astro SDK will generate and upload source maps automatically during a production build, so that errors in Sentry contain readable stack traces.
+
+![Readable Stack Traces](/readable-stacktraces.png)
 
 The Astro SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin/) to upload source maps. See the <PlatformLink to="/manual-setup/#configure-source-maps-upload">Manual Configuration</PlatformLink> page and the Sentry [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin/#configuration) for more details.

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -22,7 +22,7 @@ Sentry captures data by using an SDK within your application’s runtime.
 
 ## Configure
 
-<PlatformSection notSupported={["android", "unity", "unreal", "javascript.nextjs", "apple.ios"]}>
+<PlatformSection notSupported={["android", "unity", "unreal", "javascript.nextjs", "javascript.astro", "apple.ios"]}>
 
 Configuration should happen as early as possible in your application's lifecycle.
 

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -4,6 +4,7 @@ sidebar_order: 1
 description: "Review our alternate installation methods."
 notSupported:
   - javascript.angular
+  - javascript.astro
   - javascript.bun
   - javascript.capacitor
   - javascript.cordova

--- a/src/platforms/javascript/common/sourcemaps/uploading/index.mdx
+++ b/src/platforms/javascript/common/sourcemaps/uploading/index.mdx
@@ -6,6 +6,7 @@ notSupported:
   - javascript.nextjs
   - javascript.remix
   - javascript.sveltekit
+  - javascript.astro
 ---
 
 <PlatformContent includePath="sourcemaps/upload/primer" />

--- a/src/platforms/javascript/guides/astro/config.yml
+++ b/src/platforms/javascript/guides/astro/config.yml
@@ -1,0 +1,8 @@
+title: Astro
+sdk: sentry.javascript.astro
+fallbackPlatform: javascript
+caseStyle: camelCase
+supportLevel: production
+categories:
+  - browser
+  - server

--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -58,7 +58,7 @@ This integration enables the following features by default:
 
 ### Astro Integration Options
 
-Besides the required `dsn` option, you can specify the following options in the integration directly. These are a subset of the full PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>.
+Besides the required `dsn` option, you can specify the following options in the integration directly. These are a subset of the full <PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>.
 
 - <PlatformLink to="/configuration/options/#release">release</PlatformLink>
 - <PlatformLink to="/configuration/options/#environment">
@@ -180,7 +180,7 @@ To change the location of your `sentry.(client|server).config.js` files, specify
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
-  // Rest of your Astro project config
+  // Other Astro project options
   integrations: [
     sentryAstro({
       clientInitPath: ".config/sentryClientInit.js",
@@ -192,61 +192,4 @@ export default defineConfig({
 
 ## Configure Source Maps Upload
 
-Source maps upload should work if you followed the [Astro CLI installation guide](/platforms/javascript/guides/astro/#add-readable-stack-traces-to-errors). However, there are some options to configure source maps upload for your production builds for other configurations.
-
-Note that source maps upload only works if an auth token is specified.
-
-### Working With Old Authentication Tokens
-
-Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
-
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentryAstro({
-      // rest of your sentry options
-      sourceMapsUploadOptions: {
-        project: "___PROJECT_SLUG___",
-        org: "___ORG_SLUG___",
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-      },
-    }),
-  ],
-});
-```
-
-### Disable Source Maps Upload
-
-You can disable automatic source maps upload in your Astro config:
-
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentryAstro({
-      // Other Sentry options
-      sourceMapsUploadOptions: {
-        enabled: false,
-      },
-    }),
-  ],
-});
-```
-
-### Disabeling Telemetry Data Collection
-
-By default, our Vite plugin collects telemetry data to help us improve the source map uploading experience.
-Read more about this in our [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin#telemetry).
-You can disable telemetry collection by setting `telemetry` to `false`:
-
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentryAstro({
-      // rest of your sentry options
-      sourceMapsUploadOptions: {
-        telemetry: false,
-      },
-    }),
-  ],
-});
-```
+To enable readable stack traces, <PlatformLink to="/sourcemaps">set up source maps upload</PlatformLink> for your production builds.

--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -4,7 +4,7 @@ sidebar_order: 1
 description: "Learn how to manually customize the SDK setup."
 ---
 
-If you can't (or prefer not to) use the <PlatformLink to="/#install">Astro CLI</PlatformLink> to install the Astro SDK, follow the instructions below to configure the Sentry SvelteKit SDK in your application.
+If you can't (or prefer not to) use the <PlatformLink to="/#install">Astro CLI</PlatformLink> to install the Sentry Astro SDK, follow the instructions below to configure the SDK in your application manually.
 
 This guide also explains how to further customize your SDK setup.
 
@@ -47,18 +47,18 @@ export default defineConfig({
 });
 ```
 
-This integration is designed to get you started quickly and it enables the following features by default:
+This integration enables the following features by default:
 
 - Error Monitoring with 100% sample rate
 - Performance Monitoring with 100% sample rate
 - Session Replay with
-  - 10% sample rate for regular replaysSessions
+  - 10% sample rate for regular replay sessions
   - 100% sample rate for sessions where an error occurred
-- Automatic source maps upload for production builds, if you [set up a Sentry auth token and specified your project slug](../#add-readable-stack-traces-to-errors).
+- Automatic source maps upload for production builds to [Add Readable Stack Traces to Errors](/platforms/javascript/guides/astro/#add-readable-stack-traces-to-errors). This requires providing an auth token and project slug.
 
 ### Astro Integration Options
 
-Besides the required `dsn` option, you can specify a subset of Sentry SDK options in the integration directly.
+Besides the required `dsn` option, you can specify the following options in the integration directly. These are a subset of the full PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>. 
 
 - <PlatformLink to="/configuration/options/#release">release</PlatformLink>
 - <PlatformLink to="/configuration/options/#environment">
@@ -104,17 +104,16 @@ export default defineConfig({
 });
 ```
 
-If you want to fully customize the browser and client SDKs, e.g. (add a `beforeSend` callback) you can also [manually initialize the SDK](#manual-initialization).
 
 ## Manual SDK Initialization
 
-To fully customize the SDK initialization, you can manually initialize the SDK for the client or server side or both.
+To fully customize the SDK initialization, you can manually initialize the SDK for the client, server, or both.
 At build time, the integration looks for the following two files in the root directory of your config:
 
 - `sentry.client.config.js` containing a `Sentry.init` call for the client side
 - `sentry.server.config.js` containing a `Sentry.init` call for the sever side
 
-These file can also be a `.ts`, `.mjs`, `.mts`, etc. file.
+This file can also be a `.ts`, `.mjs`, `.mts`, etc. file.
 
 In these files, you can specify the full range of <PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>.
 
@@ -178,7 +177,7 @@ Sentry.init({
 
 ### Changing config files location
 
-If you want to change the location of your `sentry.(client|server).config.js` files, specify the path to the files in the Sentry Astro integration options in your `astro.config.mjs`:
+To change the location of your `sentry.(client|server).config.js` files, specify the path to the files in the Sentry Astro integration options in your `astro.config.mjs`:
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
@@ -194,13 +193,13 @@ export default defineConfig({
 
 ## Configure Source Maps Upload
 
-You can specify a few options to configure source maps upload for your production builds. Generally, this should work if you followed the [Astro CLI installation guide](../#add-readable-stack-traces-to-errors).
+Source maps upload should work if you followed the [Astro CLI installation guide](/platforms/javascript/guides/astro/#add-readable-stack-traces-to-errors). However, there are some options to configure source maps upload for your production builds for other configurations.
 
 Note that source maps upload only works if an auth token is specified.
 
-### Working with old authentication tokens
+### Working With Old Authentication Tokens
 
-If you're not using our new [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens) yet, you need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
+Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
@@ -219,13 +218,13 @@ export default defineConfig({
 
 ### Disable Source Maps Upload
 
-You can disable automatic source maps upload in your Vite config:
+You can disable automatic source maps upload in your Astro config:
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
   integrations: [
     sentryAstro({
-      // rest of your sentry options
+      // Other Sentry options
       sourceMapsUploadOptions: {
         enabled: false,
       },

--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -1,0 +1,254 @@
+---
+title: Manual Setup
+sidebar_order: 1
+description: "Learn how to manually customize the SDK setup."
+---
+
+If you can't (or prefer not to) use the <PlatformLink to="/#install">Astro CLI</PlatformLink> to install the Astro SDK, follow the instructions below to configure the Sentry SvelteKit SDK in your application.
+
+This guide also explains how to further customize your SDK setup.
+
+## Manual Installation
+
+```bash {tabTitle:npm}
+npm install --save @sentry/astro
+```
+
+```bash {tabTitle:Yarn}
+yarn add @sentry/astro
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/astro
+```
+
+If you're updating your Sentry SDK to the latest version, check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md) to learn more about breaking changes.
+
+## Configure the Astro Integration
+
+Import and install the Sentry Astro integration:
+
+<SignInNote />
+
+```javascript {filename:astro.config.mjs}
+import { defineConfig } from "astro/config";
+import sentryAstro from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      dsn: "___PUBLIC_DSN___",
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+This integration is designed to get you started quickly and it enables the following features by default:
+
+- Error Monitoring with 100% sample rate
+- Performance Monitoring with 100% sample rate
+- Session Replay with
+  - 10% sample rate for regular replaysSessions
+  - 100% sample rate for sessions where an error occurred
+- Automatic source maps upload for production builds, if you [set up a Sentry auth token and specified your project slug](../#add-readable-stack-traces-to-errors).
+
+### Astro Integration Options
+
+Besides the required `dsn` option, you can specify a subset of Sentry SDK options in the integration directly.
+
+- <PlatformLink to="/configuration/options/#release">release</PlatformLink>
+- <PlatformLink to="/configuration/options/#environment">
+    environment
+  </PlatformLink>
+- <PlatformLink to="/configuration/options/#sample-rate">
+    sampleRate
+  </PlatformLink>
+- <PlatformLink to="/configuration/options/#traces-sample-rate">
+    tracesSampleRate
+  </PlatformLink>
+- <PlatformLink to="/session-replay/configuration/#general-integration-configuration">
+    replaysSessionSampleRate
+  </PlatformLink>
+- <PlatformLink to="/session-replay/configuration/#general-integration-configuration">
+    replaysOnErrorSampleRate
+  </PlatformLink>
+- <PlatformLink to="/configuration/options/#debug">debug</PlatformLink>
+
+Here's an example with all available integration options:
+
+```javascript {filename:astro.config.mjs}
+import { defineConfig } from "astro/config";
+import sentryAstro from "@sentry/astro";
+
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      dsn: "___PUBLIC_DSN___",
+      release: "1.0.0",
+      environment: "production",
+      sampleRate: 0.5,
+      tracesSampleRate: 1.0,
+      replaysSessionSampleRate: 0.2,
+      replaysOnErrorSampleRate: 0.8,
+      debug: false,
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+If you want to fully customize the browser and client SDKs, e.g. (add a `beforeSend` callback) you can also [manually initialize the SDK](#manual-initialization).
+
+## Manual SDK Initialization
+
+To fully customize the SDK initialization, you can manually initialize the SDK for the client or server side or both.
+At build time, the integration looks for the following two files in the root directory of your config:
+
+- `sentry.client.config.js` containing a `Sentry.init` call for the client side
+- `sentry.server.config.js` containing a `Sentry.init` call for the sever side
+
+These file can also be a `.ts`, `.mjs`, `.mts`, etc. file.
+
+In these files, you can specify the full range of <PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>.
+
+<Alert level="warning">
+
+If you add a `sentry.client.config.js` or `sentry.server.config.js` file, the options specified in the [Sentry Astro integration](#astro-integration-options) are ignored for the respective runtime.
+The only exception is `sourceMapsUploadOptions` which **always** needs to be set in the integration options.
+
+</Alert>
+
+### Client Side
+
+Here's an example of a custom client-side SDK setup:
+
+```javascript {filename:sentry.client.config.js}
+import * as sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  integrations: [
+    new Sentry.Replay({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+    new BrowserTracing({
+      tracePropagationTargets: [/\//, "my-api-domain.com"],
+    }),
+  ],
+  tracesSampler: (samplingContext) => {
+    if (samplingContext.transactionContext.name === "/home") {
+      return 0.5;
+    }
+    return 0.1;
+  },
+});
+```
+
+### Server Side
+
+Here's an example of a custom server-side SDK setup:
+
+```javascript {filename:sentry.server.config.js}
+import * as sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampler: (samplingContext) => {
+    if (samplingContext.transactionContext.name === "/home") {
+      return 0.5;
+    }
+    return 0.1;
+  },
+  beforeSend: (event) => {
+    console.log("before send", event);
+    return event;
+  },
+});
+```
+
+### Changing config files location
+
+If you want to change the location of your `sentry.(client|server).config.js` files, specify the path to the files in the Sentry Astro integration options in your `astro.config.mjs`:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  // Rest of your Astro project config
+  integrations: [
+    sentryAstro({
+      clientInitPath: ".config/sentryClientInit.js",
+      serverInitPath: ".config/sentryServerInit.js",
+    }),
+  ],
+});
+```
+
+## Configure Source Maps Upload
+
+You can specify a few options to configure source maps upload for your production builds. Generally, this should work if you followed the [Astro CLI installation guide](../#add-readable-stack-traces-to-errors).
+
+Note that source maps upload only works if an auth token is specified.
+
+### Working with old authentication tokens
+
+If you're not using our new [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens) yet, you need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // rest of your sentry options
+      sourceMapsUploadOptions: {
+        project: "___PROJECT_SLUG___",
+        org: "___ORG_SLUG___",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      },
+    }),
+  ],
+});
+```
+
+### Disable Source Maps Upload
+
+You can disable automatic source maps upload in your Vite config:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // rest of your sentry options
+      sourceMapsUploadOptions: {
+        enabled: false,
+      },
+    }),
+  ],
+});
+```
+
+### Disabeling Telemetry Data Collection
+
+By default, our Vite plugin collects telemetry data to help us improve the source map uploading experience.
+Read more about this in our [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin#telemetry).
+You can disable telemetry collection by setting `telemetry` to `false`:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentryAstro({
+      // rest of your sentry options
+      sourceMapsUploadOptions: {
+        telemetry: false,
+      },
+    }),
+  ],
+});
+```

--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -58,7 +58,7 @@ This integration enables the following features by default:
 
 ### Astro Integration Options
 
-Besides the required `dsn` option, you can specify the following options in the integration directly. These are a subset of the full PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>. 
+Besides the required `dsn` option, you can specify the following options in the integration directly. These are a subset of the full PlatformLink to="/configuration/options">Sentry SDK options</PlatformLink>.
 
 - <PlatformLink to="/configuration/options/#release">release</PlatformLink>
 - <PlatformLink to="/configuration/options/#environment">
@@ -103,7 +103,6 @@ export default defineConfig({
   ],
 });
 ```
-
 
 ## Manual SDK Initialization
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds SDK docs for the new Sentry Astro SDK. It's still in Alpha which we clearly point out in the new docs.

This PR includes adjustments for Astro in the following pages:
* Getting Started shows the semi-automatic setup via the `astro` CLI
* Added "Manual Setup" page similarly, to SvelteKit, Remix and NextJS with all possible configuration options
* Adjusted source map docs to not display the full range of source maps upload material. The Astro SDK ships with the Vite plugin, so there shouldn't be too much need for other resources than troubleshooting. 
* Added Astro specific setup for Replay (This is the first SDK that actually enables Replay by default. However, there are two ways how users can manually customize or add Replay).
* Added various platform includes for performance monitoring snippets

ref: https://github.com/getsentry/sentry-javascript/issues/9182