### PR TITLE
dependabot: initial configuration for npm and gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    open-pull-requests-limit: 0 # security updates only
+    directory: '/'
+    schedule:
+      # Going to start with a high interval, and then tone it back
+      interval: daily
+    reviewers:
+      - '@getsentry/owners-docs'
+    labels: []
+    # Group dependency updates together in one PR
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+    groups:
+      # The name of the group, it will be used in PR titles and branch
+      babel-dependencies:
+        patterns:
+          - '@babel/*'
+      emotion-dependencies:
+        patterns:
+          - '@emotion/*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'
+      day: 'sunday'


### PR DESCRIPTION
Custom configuration for Dependabot. This uses the new "groups" feature to hopefully reduce the number of PRs and to keep versions matching. 🙂 

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups