### PR TITLE
Fix rust automatic-instrumentation.mdx

### DIFF
--- a/src/platforms/rust/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/rust/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -50,13 +50,13 @@ fn main_span2() {
 
 The Sentry SDK offers an integration for the `tower` ecosystem which can automatically continue a trace from an incoming HTTP request.
 
+When combining both layers, take care of the ordering of both. For example with tower::ServiceBuilder, always define the Hub layer before the Http one, like so:
+
 ```rust
 use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use tower::ServiceBuilder;
 
 let layer = ServiceBuilder::new()
-    // continue trace from incoming request
-    .layer(SentryHttpLayer::with_transaction())
-    // bind a new hub for each request
-    .layer(NewSentryLayer::new_from_top());
+    .layer(NewSentryLayer::new_from_top())
+    .layer(SentryHttpLayer::with_transaction());
 ```

--- a/src/platforms/rust/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/rust/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -50,7 +50,7 @@ fn main_span2() {
 
 The Sentry SDK offers an integration for the `tower` ecosystem which can automatically continue a trace from an incoming HTTP request.
 
-When combining both layers, take care of the ordering of both. For example with tower::ServiceBuilder, always define the Hub layer before the Http one, like so:
+When combining both layers, order matters. For example, with tower::ServiceBuilder, you must define the Hub layer before the Http one, like so:
 
 ```rust
 use sentry_tower::{NewSentryLayer, SentryHttpLayer};


### PR DESCRIPTION
## Description of changes

Update the instrumentation docs to be inline with the sentry-tower crate.

The Hub layer should always be before the Http layer as seen here:

https://docs.rs/sentry-tower/latest/sentry_tower/#usage-with-tower-http

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
