### PR TITLE
Add canonical tags for SEO

### DIFF
--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -21,6 +21,7 @@ export type PageContext = {
 };
 
 type Props = {
+  slug: string;
   children?: React.ReactNode;
   data?: {
     file?: {
@@ -46,6 +47,7 @@ export function BasePage({
   sidebar,
   children,
   prependToc,
+  slug,
 }: Props) {
   const tx = getCurrentTransaction();
   if (tx) {
@@ -59,6 +61,10 @@ export function BasePage({
 
   const pageDescription = description || (excerpt ? excerpt.slice(0, 160) : '');
 
+  // if (slug.startsWith('platforms/')) {
+  //   console.log('SHANA LOOK AGAIN:' + slug);
+  // }
+
   return (
     // @ts-expect-error TODO(epurkhiser): Understand why these types are
     // totally different
@@ -67,7 +73,7 @@ export function BasePage({
         title={seoTitle ?? title ?? 'Sentry Docs'}
         description={pageDescription}
         noindex={pageContext.noindex}
-        slug={file.relativePath ?? ''}
+        slug={slug}
       />
 
       <div className="row">

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -61,10 +61,6 @@ export function BasePage({
 
   const pageDescription = description || (excerpt ? excerpt.slice(0, 160) : '');
 
-  // if (slug.startsWith('platforms/')) {
-  //   console.log('SHANA LOOK AGAIN:' + slug);
-  // }
-
   return (
     // @ts-expect-error TODO(epurkhiser): Understand why these types are
     // totally different

--- a/src/components/basePage.tsx
+++ b/src/components/basePage.tsx
@@ -67,6 +67,7 @@ export function BasePage({
         title={seoTitle ?? title ?? 'Sentry Docs'}
         description={pageDescription}
         noindex={pageContext.noindex}
+        slug={file.relativePath ?? ''}
       />
 
       <div className="row">

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -50,8 +50,6 @@ export function BaseSEO({
 }: ChildProps) {
   const metaDescription = description || data.site.siteMetadata.description;
 
-  const canonicalSlug = slug ?? '';
-
   return (
     <Helmet
       htmlAttributes={{
@@ -128,10 +126,12 @@ export function BaseSEO({
         )
         .concat(meta)}
     >
-      <link
-        rel="canonical"
-        href={`https://${data.site.siteMetadata.sitePath}/${canonicalSlug}`}
-      />
+      {slug && (
+        <link
+          rel="canonical"
+          href={`https://${data.site.siteMetadata.sitePath}/${slug}`}
+        />
+      )}
     </Helmet>
   );
 }

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -126,12 +126,7 @@ export function BaseSEO({
         )
         .concat(meta)}
     >
-      {slug && (
-        <link
-          rel="canonical"
-          href={`https://${data.site.siteMetadata.sitePath}/${slug}`}
-        />
-      )}
+      <link rel="canonical" href={`https://${data.site.siteMetadata.sitePath}/${slug}`} />
     </Helmet>
   );
 }

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -52,10 +52,6 @@ export function BaseSEO({
 
   const canonicalSlug = slug ?? '';
 
-  if (canonicalSlug.startsWith('platforms/')) {
-    console.log('SHANA LOOK A THIRD TIME:' + canonicalSlug);
-  }
-
   return (
     <Helmet
       htmlAttributes={{

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -16,6 +16,7 @@ const detailsQuery = graphql`
 `;
 
 type Props = {
+  slug: string;
   title: string;
   description?: string;
   keywords?: string[];
@@ -45,8 +46,11 @@ export function BaseSEO({
   keywords = [],
   title,
   noindex,
+  slug,
 }: ChildProps) {
   const metaDescription = description || data.site.siteMetadata.description;
+
+  console.log('SLUG: ' + slug);
 
   return (
     <Helmet
@@ -71,6 +75,10 @@ export function BaseSEO({
         {
           property: 'og:type',
           content: 'website',
+        },
+        {
+          property: `og:url`,
+          content: `https://${data.site.siteMetadata.sitePath}/${slug}`,
         },
         {
           property: 'og:image',

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -50,7 +50,11 @@ export function BaseSEO({
 }: ChildProps) {
   const metaDescription = description || data.site.siteMetadata.description;
 
-  console.log('SLUG: ' + slug);
+  const canonicalSlug = slug ?? '';
+
+  if (canonicalSlug.startsWith('platforms/')) {
+    console.log('SHANA LOOK A THIRD TIME:' + canonicalSlug);
+  }
 
   return (
     <Helmet
@@ -75,10 +79,6 @@ export function BaseSEO({
         {
           property: 'og:type',
           content: 'website',
-        },
-        {
-          property: `og:url`,
-          content: `https://${data.site.siteMetadata.sitePath}/${slug}`,
         },
         {
           property: 'og:image',
@@ -131,7 +131,12 @@ export function BaseSEO({
             : []
         )
         .concat(meta)}
-    />
+    >
+      <link
+        rel="canonical"
+        href={`https://${data.site.siteMetadata.sitePath}/${canonicalSlug}`}
+      />
+    </Helmet>
   );
 }
 

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -50,6 +50,12 @@ export function BaseSEO({
 }: ChildProps) {
   const metaDescription = description || data.site.siteMetadata.description;
 
+  // slug === '' is the homepage and a valid value
+  const canonical =
+    data.site.siteMetadata.sitePath && (slug || slug === '')
+      ? `https://${data.site.siteMetadata.sitePath}/${slug}`
+      : false;
+
   return (
     <Helmet
       htmlAttributes={{
@@ -126,7 +132,7 @@ export function BaseSEO({
         )
         .concat(meta)}
     >
-      <link rel="canonical" href={`https://${data.site.siteMetadata.sitePath}/${slug}`} />
+      {canonical && <link rel="canonical" href={canonical} />}
     </Helmet>
   );
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -16,6 +16,7 @@ function NotFoundPage() {
       <SEO
         title="Page Not Found"
         description="We couldn’t find the page you were looking for."
+        slug="404/"
       />
       <h1>Page Not Found</h1>
       <p>We couldn&apos;t find the page you were looking for.</p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ function IndexPage() {
 
   return (
     <div className="index-wrapper">
-      <SEO title="Sentry Documentation" />
+      <SEO title="Sentry Documentation" slug="" />
       <div className="hero-section">
         <div className="index-container">
           <div className="index-navbar">

--- a/src/templates/apiDoc.tsx
+++ b/src/templates/apiDoc.tsx
@@ -11,9 +11,12 @@ export default function ApiDoc(props) {
     data: {allOpenApi, apiDescription},
   } = props;
 
+  // remove leading '/'
+  const slug = props.location.pathname.replace(/^\//, '');
+
   // todo shana fix leading slash
   return (
-    <BasePage sidebar={<ApiSidebar />} slug={props['*']} {...props}>
+    <BasePage sidebar={<ApiSidebar />} slug={slug} {...props}>
       {apiDescription && <Content file={apiDescription} />}
       <ul data-noindex>
         {allOpenApi.edges.map(({node: {path}}) => (

--- a/src/templates/apiDoc.tsx
+++ b/src/templates/apiDoc.tsx
@@ -10,8 +10,10 @@ export default function ApiDoc(props) {
   const {
     data: {allOpenApi, apiDescription},
   } = props;
+
+  // todo shana fix leading slash
   return (
-    <BasePage sidebar={<ApiSidebar />} {...props}>
+    <BasePage sidebar={<ApiSidebar />} slug={props['*']} {...props}>
       {apiDescription && <Content file={apiDescription} />}
       <ul data-noindex>
         {allOpenApi.edges.map(({node: {path}}) => (

--- a/src/templates/apiDoc.tsx
+++ b/src/templates/apiDoc.tsx
@@ -14,7 +14,6 @@ export default function ApiDoc(props) {
   // remove leading '/'
   const slug = props.location.pathname.replace(/^\//, '');
 
-  // todo shana fix leading slash
   return (
     <BasePage sidebar={<ApiSidebar />} slug={slug} {...props}>
       {apiDescription && <Content file={apiDescription} />}

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -172,11 +172,14 @@ export default function ApiPage(props) {
     ? ['RESPONSE', 'SCHEMA']
     : ['RESPONSE'];
 
+  // remove leading '/'
+  const slug = props.location.pathname.replace(/^\//, '');
+
   useEffect(() => {
     Prism.highlightAll();
   }, []);
   return (
-    <BasePage sidebar={<ApiSidebar />} slug={props['*']} {...props}>
+    <BasePage sidebar={<ApiSidebar />} slug={slug} {...props}>
       <div className="row">
         <div className="col-12">
           <div className="api-block">

--- a/src/templates/apiPage.tsx
+++ b/src/templates/apiPage.tsx
@@ -176,7 +176,7 @@ export default function ApiPage(props) {
     Prism.highlightAll();
   }, []);
   return (
-    <BasePage sidebar={<ApiSidebar />} {...props}>
+    <BasePage sidebar={<ApiSidebar />} slug={props['*']} {...props}>
       <div className="row">
         <div className="col-12">
           <div className="api-block">

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -13,8 +13,10 @@ export default function Doc(props: any) {
   } else if (props.path.startsWith('/contributing/')) {
     sidebar = <InternalDocsSidebar />;
   }
+
+  // todo shana fix leading slash
   return (
-    <BasePage sidebar={sidebar} {...props}>
+    <BasePage sidebar={sidebar} slug={props['*']} {...props}>
       <Content file={props.data.file} />
     </BasePage>
   );

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -14,9 +14,12 @@ export default function Doc(props: any) {
     sidebar = <InternalDocsSidebar />;
   }
 
+  // remove leading '/'
+  const slug = props.location.pathname.replace(/^\//, '');
+
   // todo shana fix leading slash
   return (
-    <BasePage sidebar={sidebar} slug={props['*']} {...props}>
+    <BasePage sidebar={sidebar} slug={slug} {...props}>
       <Content file={props.data.file} />
     </BasePage>
   );

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -17,7 +17,6 @@ export default function Doc(props: any) {
   // remove leading '/'
   const slug = props.location.pathname.replace(/^\//, '');
 
-  // todo shana fix leading slash
   return (
     <BasePage sidebar={sidebar} slug={slug} {...props}>
       <Content file={props.data.file} />

--- a/src/templates/platform.tsx
+++ b/src/templates/platform.tsx
@@ -36,9 +36,13 @@ export default function Platform(props: Props) {
       : `${props.pageContext.title} for ${
           (props.pageContext.guide || props.pageContext.platform).title
         }`;
+
+  const slug = props['*'];
+
   return (
     <BasePage
       {...props}
+      slug={slug}
       seoTitle={seoTitle}
       prependToc={<PlatformSdkDetail />}
       sidebar={

--- a/src/templates/platform.tsx
+++ b/src/templates/platform.tsx
@@ -10,6 +10,9 @@ type Props = {
   data: {
     file: any;
   };
+  location: {
+    pathname: string;
+  };
   pageContext: {
     platform: {
       name: string;
@@ -37,7 +40,8 @@ export default function Platform(props: Props) {
           (props.pageContext.guide || props.pageContext.platform).title
         }`;
 
-  const slug = props['*'];
+  // remove leading '/'
+  const slug = props.location.pathname.replace(/^\//, '');
 
   return (
     <BasePage

--- a/src/templates/wizardDebugIndex.tsx
+++ b/src/templates/wizardDebugIndex.tsx
@@ -10,7 +10,7 @@ export default function WizardDebug({
   },
 }) {
   return (
-    <BasePage pageContext={{title: 'Wizard Previews'}}>
+    <BasePage pageContext={{title: 'Wizard Previews'}} slug="wizard-debug/">
       <ul>
         {nodes
           .sort((a, b) =>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Add canonical tag (`<link rel="canonical" href="https://docs.sentry.io/<slug>" data-react-helmet="true">`) to each page of docs to help with SEO. This prevents Google from indexing the same page twice when there are URL params, so these 2 URLs aren't indexed twice:
- https://docs.sentry.io/platforms/javascript/
- https://docs.sentry.io/platforms/javascript/?original_referrer=https%3A%2F%2Fwww.google.com%2F
