### PR TITLE
fix: Remove glob syntax from `tracePropagationTargets` example

### DIFF
--- a/src/platform-includes/distributed-tracing/how-to-use/apple.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/apple.mdx
@@ -7,7 +7,7 @@ SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.tracePropagationTargets = [
         "https://myproject.org",
-        "https://.*.otherservice.org/.*",
+        "https://api.otherservice.org/",
     ]
 }
 ```
@@ -19,7 +19,7 @@ SentrySDK.start { options in
     options.dsn = @"___PUBLIC_DSN___";
     options.tracePropagationTargets = @[
         @"https://myproject.org",
-        @"https://.*.otherservice.org/.*"
+        @"https://api.otherservice.org/"
     ];
 }];
 ```

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -4,10 +4,7 @@ If you're using the current version of our JavaScript SDK and have enabled the `
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
 

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -7,10 +7,7 @@ For client-side you might have to define `tracePropagationTargets` to get around
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
 

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -5,10 +5,7 @@ If you're using the current version of our Remix SDK, distributed tracing will w
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
 

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -5,10 +5,7 @@ If you're using the current version of our SvelteKit SDK, distributed tracing wi
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
 

--- a/src/platform-includes/distributed-tracing/how-to-use/react-native.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/react-native.mdx
@@ -3,10 +3,7 @@ If you're using the current version of our React Native SDK distributed tracing 
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
 

--- a/src/platform-includes/distributed-tracing/limiting-traces/javascript.mdx
+++ b/src/platform-includes/distributed-tracing/limiting-traces/javascript.mdx
@@ -4,9 +4,6 @@
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```

--- a/src/platform-includes/distributed-tracing/limiting-traces/node.mdx
+++ b/src/platform-includes/distributed-tracing/limiting-traces/node.mdx
@@ -3,9 +3,6 @@
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  tracePropagationTargets: [
-    "https://myproject.org",
-    "https://.*.otherservice.org/.*",
-  ],
+  tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```


### PR DESCRIPTION
As discovered by @lforst in https://github.com/getsentry/sentry-docs/pull/8267#discussion_r1368295746, we showed an incorrect example for `tracePropagationTargets` values in the "Usage->Distributed Tracing" page ([example](https://docs.sentry.io/platforms/javascript/guides/sveltekit/usage/distributed-tracing/#how-to-use-distributed-tracing)). TPT values can only be String.contains matches or regex matches but glob patterns in strings like `"https://.*.otherservice.org/.*"` are not supported. 

This PR removes the glob pattern and adds a regex example to show both types of TPT values. 
(Adjusted the one for Astro in #8267)

Note: The same value is used in Flutter and iOS docs but I'm not yet sure if these SDKs support globs or not. Asked in Slack for clarification. 