### PR TITLE
feat: Add docs for replay tree shaking flags

### DIFF
--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -36,6 +36,8 @@ To make optional code eligible for tree shaking, you can replace various flags i
 : Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
 **Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`). This flag is intended to be used in combination with packages like `@sentry/next` or `@sentry/sveltekit`, which automatically include performance monitoring functionality.
 
+<PlatformSection notSupported={["javascript.wasm", "javascript.cordova"]}>
+
 `__RRWEB_EXCLUDE_CANVAS__`
 
 : Replacing this flag with `true` will tree shake all code in the SDK that is related capturing canvas elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any canvas elements on your page you care to record.
@@ -47,6 +49,8 @@ To make optional code eligible for tree shaking, you can replace various flags i
 `__RRWEB_EXCLUDE_SHADOW_DOM__`
 
 : Replacing this flag with `true` will tree shake all code in the SDK that is related capturing shadow dom elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any shadow dom elements on your page you care to record.
+
+</PlatformSection>
 
 <PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -65,7 +65,7 @@ sentryPlugin({
     excludeReplayCanvas: true,
     excludeReplayIframe: true,
     excludeReplayShadowDom: true,
-  }
+  },
 });
 ```
 

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -25,7 +25,7 @@ The Sentry SDK ships with code that is not strictly required for it to collect y
 
 ### List Of Flags
 
-To make optional code eligible for tree shaking, you can replace various flags in the Sentry SDK with `false`.
+To make optional code eligible for tree shaking, you can replace various flags in the Sentry SDK in order to remove the code from your build output. The following flags are available:
 
 `__SENTRY_DEBUG__`
 
@@ -36,7 +36,49 @@ To make optional code eligible for tree shaking, you can replace various flags i
 : Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
 **Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`). This flag is intended to be used in combination with packages like `@sentry/next` or `@sentry/sveltekit`, which automatically include performance monitoring functionality.
 
-<PlatformSection notSupported={["javascript.nextjs"]}>
+`__RRWEB_EXCLUDE_CANVAS__`
+
+: Replacing this flag with `true` will tree shake all code in the SDK that is related capturing canvas elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any canvas elements on your page you care to record.
+
+`__RRWEB_EXCLUDE_IFRAME__`
+
+: Replacing this flag with `true` will tree shake all code in the SDK that is related capturing iframe content with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any iframes on your page you care to record.
+
+`__RRWEB_EXCLUDE_SHADOW_DOM__`
+
+: Replacing this flag with `true` will tree shake all code in the SDK that is related capturing shadow dom elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any shadow dom elements on your page you care to record.
+
+<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
+
+### Tree Shaking Optional Code With Sentry Bundler Plugins
+
+If you are using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
+
+```javascript
+sentryPlugin({
+  // other config
+  excludeDebugStatements: true,
+  excludePerformanceMonitoring: true,
+  excludeReplayCanvas: true,
+  excludeReplayIframe: true,
+  excludeReplayShadowDom: true,
+})
+```
+
+For more details, see the documentation for the specific bundler plugin you're using:
+
+* [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin)
+* [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin)
+* [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
+* [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
+
+<Note>
+  This configuration is available since v2.9.0 of the bundler plugins.
+</Note>
+
+</PlatformSection>
+
+<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
 
 ### Tree Shaking Optional Code With Webpack
 
@@ -51,6 +93,9 @@ module.exports = {
     new webpack.DefinePlugin({
       __SENTRY_DEBUG__: false,
       __SENTRY_TRACING__: false,
+      __RRWEB_EXCLUDE_CANVAS__: true,
+      __RRWEB_EXCLUDE_IFRAME__: true,
+      __RRWEB_EXCLUDE_SHADOW_DOM__: true,
     }),
     // ... other plugins
   ],
@@ -59,7 +104,7 @@ module.exports = {
 
 </PlatformSection>
 
-<PlatformSection notSupported={["javascript.nextjs"]}>
+<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
 
 ### Tree Shaking Optional Code With Rollup
 
@@ -76,6 +121,9 @@ export default {
     replace({
       __SENTRY_DEBUG__: false,
       __SENTRY_TRACING__: false,
+      __RRWEB_EXCLUDE_CANVAS__: true,
+      __RRWEB_EXCLUDE_IFRAME__: true,
+      __RRWEB_EXCLUDE_SHADOW_DOM__: true,
     }),
     // ... other plugins (best placed after)
   ],
@@ -97,6 +145,9 @@ const nextConfig = {
       new webpack.DefinePlugin({
         __SENTRY_DEBUG__: false,
         __SENTRY_TRACING__: false,
+        __RRWEB_EXCLUDE_CANVAS__: true,
+        __RRWEB_EXCLUDE_IFRAME__: true,
+        __RRWEB_EXCLUDE_SHADOW_DOM__: true,
       })
     );
 

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -48,20 +48,24 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 : Replacing this flag with `true` will tree shake all code in the SDK that is related capturing shadow dom elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any shadow dom elements on your page you care to record.
 
-<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
+<PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 
 ### Tree Shaking Optional Code With Sentry Bundler Plugins
+
+_This configuration is available since v2.9.0 of the bundler plugins._
 
 If you are using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
 
 ```javascript
 sentryPlugin({
   // other config
-  excludeDebugStatements: true,
-  excludePerformanceMonitoring: true,
-  excludeReplayCanvas: true,
-  excludeReplayIframe: true,
-  excludeReplayShadowDom: true,
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
+    excludePerformanceMonitoring: true,
+    excludeReplayCanvas: true,
+    excludeReplayIframe: true,
+    excludeReplayShadowDom: true,
+  }
 });
 ```
 
@@ -72,13 +76,9 @@ For more details, see the documentation for the specific bundler plugin you're u
 - [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
 - [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
 
-<Note>
-  This configuration is available since v2.9.0 of the bundler plugins.
-</Note>
-
 </PlatformSection>
 
-<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
+<PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 
 ### Tree Shaking Optional Code With Webpack
 
@@ -104,7 +104,7 @@ module.exports = {
 
 </PlatformSection>
 
-<PlatformSection notSupported={["javascript.nextjs", 'javascript.sveltekit', 'javascript.remix']}>
+<PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 
 ### Tree Shaking Optional Code With Rollup
 

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -25,7 +25,9 @@ The Sentry SDK ships with code that is not strictly required for it to collect y
 
 ### List Of Flags
 
-To make optional code eligible for tree shaking, you can replace various flags in the Sentry SDK in order to remove the code from your build output. The following flags are available:
+To make optional code eligible for tree shaking, you can remove the code from your build output by replacing various flags in the Sentry SDK.
+
+The following flags are available:
 
 `__SENTRY_DEBUG__`
 
@@ -40,7 +42,7 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 `__RRWEB_EXCLUDE_CANVAS__`
 
-: Replacing this flag with `true` will tree shake all code in the SDK that is related capturing canvas elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any canvas elements on your page you care to record.
+: Replacing this flag with `true` will tree shake all code in the SDK that's related to capturing canvas elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). Enable this flag if you don't have any canvas elements on your page you want to record.
 
 `__RRWEB_EXCLUDE_IFRAME__`
 
@@ -48,7 +50,7 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 `__RRWEB_EXCLUDE_SHADOW_DOM__`
 
-: Replacing this flag with `true` will tree shake all code in the SDK that is related capturing shadow dom elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any shadow dom elements on your page you care to record.
+: Replacing this flag with `true` will tree shake all code in the SDK that's related to capturing shadow dom elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). Enable this flag if you don't have any shadow dom elements on your page you want to record.
 
 </PlatformSection>
 
@@ -56,9 +58,9 @@ To make optional code eligible for tree shaking, you can replace various flags i
 
 ### Tree Shaking Optional Code With Sentry Bundler Plugins
 
-_This configuration is available since v2.9.0 of the bundler plugins._
+_This configuration is available starting with v2.9.0 of the bundler plugins._
 
-If you are using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
+If you're using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
 
 ```javascript
 sentryPlugin({

--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -62,15 +62,15 @@ sentryPlugin({
   excludeReplayCanvas: true,
   excludeReplayIframe: true,
   excludeReplayShadowDom: true,
-})
+});
 ```
 
 For more details, see the documentation for the specific bundler plugin you're using:
 
-* [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin)
-* [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin)
-* [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
-* [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
+- [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin)
+- [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin)
+- [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
+- [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
 
 <Note>
   This configuration is available since v2.9.0 of the bundler plugins.

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -54,16 +54,13 @@ To mitigate these problems, SDK version 7.54.0 will [truncate console messages](
 
 If you're having any problems with the latest SDK version, we want to hear about it. Please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=bug.yml) and describe your situation.
 
-## Using Session Replay increases the bundle size of my application.
+## Using Session Replay Increases the Bundle Size of My Application.
 
-Enabling Session Replay will add about 50 kb (gzipped) to your application bundle.
-While this is a significant increase, we believe the benefits of Session Replay outweigh the cost.
-Due to the inherent complexity of the browser enviornment, there is a considerable amount of code necessary in order for Session Replay to work.
+Because of the complexity of the browser environment, there's a significant amount of code necessary in order for Session Replay to work. And while enabling Session Replay will add about 50 kb (gzipped) to your application bundle, we believe the benefits will outweigh the cost.
 
-While we are generally working on ways to reduce the bundle size, there are a few steps you can take right now in order to reduce the size of Session Replay,
-based on your specific use case. See [Tree Shaking](../../configuration/tree-shaking/) for more information.
+We're always working on ways to reduce the bundle size. Additionally, there are steps you can take in order to reduce the size of Session Replay based on your specific use case. See [Tree Shaking](../../configuration/tree-shaking/) for more information.
 
-## I see the message: "A large number of mutations was detected (N). This can slow down the Replay SDK and impact your customers."
+## I See the Message: "A large number of mutations was detected (N). This can slow down the Replay SDK and impact your customers."
 
 The Sentry SDK attempts to minimize potential [performance overhead](/product/session-replay/performance-overhead/#how-is-session-replay-optimized) in a few different ways. For example, by keeping track of the number of DOM mutations that are happening then disabling recording when a large number of changes are detected. Many simultaneous mutations can slow down a web page whether Session Replay is installed or not, but when a large number of mutations happen, the Replay client can incur an additional slowdown because it records each change.
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -57,7 +57,7 @@ If you're having any problems with the latest SDK version, we want to hear about
 ## Using Session Replay increases the bundle size of my application.
 
 Enabling Session Replay will add about 50 kb (gzipped) to your application bundle.
-While this is a significant increase, we believe the benefits of Session Replay outweigh the cost. 
+While this is a significant increase, we believe the benefits of Session Replay outweigh the cost.
 Due to the inherent complexity of the browser enviornment, there is a considerable amount of code necessary in order for Session Replay to work.
 
 While we are generally working on ways to reduce the bundle size, there are a few steps you can take right now in order to reduce the size of Session Replay,

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -54,6 +54,15 @@ To mitigate these problems, SDK version 7.54.0 will [truncate console messages](
 
 If you're having any problems with the latest SDK version, we want to hear about it. Please open a [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/new?assignees=&labels=Type%3A+Bug&projects=&template=bug.yml) and describe your situation.
 
+## Using Session Replay increases the bundle size of my application.
+
+Enabling Session Replay will add about 50 kb (gzipped) to your application bundle.
+While this is a significant increase, we believe the benefits of Session Replay outweigh the cost. 
+Due to the inherent complexity of the browser enviornment, there is a considerable amount of code necessary in order for Session Replay to work.
+
+While we are generally working on ways to reduce the bundle size, there are a few steps you can take right now in order to reduce the size of Session Replay,
+based on your specific use case. See [Tree Shaking](../../configuration/tree-shaking/) for more information.
+
 ## I see the message: "A large number of mutations was detected (N). This can slow down the Replay SDK and impact your customers."
 
 The Sentry SDK attempts to minimize potential [performance overhead](/product/session-replay/performance-overhead/#how-is-session-replay-optimized) in a few different ways. For example, by keeping track of the number of DOM mutations that are happening then disabling recording when a large number of changes are detected. Many simultaneous mutations can slow down a web page whether Session Replay is installed or not, but when a large number of mutations happen, the Replay client can incur an additional slowdown because it records each change.


### PR DESCRIPTION
This adds the new tree shaking flags for Replay, as well as the new bundler plugin configs for bundle size optimizations.

I also excluded the webpack/rollup examples for sveltekit and remix as well (??) - not sure if we should show something (?) else for these platforms?