### PR TITLE
Add docs for Java Maven plugin

### DIFF
--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -246,6 +246,8 @@ Add the Sentry Maven Plugin to your project by adding the following lines to you
             <groupId>io.sentry</groupId>
             <artifactId>sentry-maven-plugin</artifactId>
             <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+            <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+            <extensions>true</extensions>
             <configuration>
                 <!-- for showing output of sentry-cli -->
                 <debugSentryCli>true</debugSentryCli>
@@ -267,8 +269,10 @@ Add the Sentry Maven Plugin to your project by adding the following lines to you
             </configuration>
             <executions>
                 <execution>
-                    <phase>generate-resources</phase>
                     <goals>
+                        <!--  Generates a source bundle and uploads it to Sentry. -->
+                        <!--  This enables source context, allowing you to see your source -->
+                        <!--  code as part of your stack traces in Sentry. -->
                         <goal>uploadSourceBundle</goal>
                     </goals>
                 </execution>

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -245,7 +245,7 @@ Add the Sentry Maven Plugin to your project by adding the following lines to you
         <plugin>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-maven-plugin</artifactId>
-            <version>{{@inject packages.version('sentry.java.mavenplugin', '0.0.2') }}</version>
+            <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
             <configuration>
                 <!-- for showing output of sentry-cli -->
                 <debugSentryCli>true</debugSentryCli>

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -254,7 +254,7 @@ Add the Sentry Maven Plugin to your project by adding the following lines to you
 
                 <!-- optionally specify the path to sentry-cli -->
                 <!-- download it here: https://github.com/getsentry/sentry-cli/releases -->
-                <!-- minimum required version is 2.17.3 -->
+                <!-- minimum required version is 2.21.2 -->
                 <!-- by default the sentry-cli bundled with the plugin will be used -->
                 <!-- <sentryCliExecutablePath>/path/to/sentry-cli</sentryCliExecutablePath> -->
 

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -252,10 +252,11 @@ Add the Sentry Maven Plugin to your project by adding the following lines to you
                 <!-- for showing output of sentry-cli -->
                 <debugSentryCli>true</debugSentryCli>
 
-                <!-- download the latest sentry-cli and provide path to it here -->
+                <!-- optionally specify the path to sentry-cli -->
                 <!-- download it here: https://github.com/getsentry/sentry-cli/releases -->
                 <!-- minimum required version is 2.17.3 -->
-                <sentryCliExecutablePath>/path/to/sentry-cli</sentryCliExecutablePath>
+                <!-- by default the sentry-cli bundled with the plugin will be used -->
+                <!-- <sentryCliExecutablePath>/path/to/sentry-cli</sentryCliExecutablePath> -->
 
                 <org>___ORG_SLUG___</org>
 

--- a/src/platforms/java/common/maven/index.mdx
+++ b/src/platforms/java/common/maven/index.mdx
@@ -38,7 +38,7 @@ Using Maven in your application module's `pom.xml` add:
 
 ### Configure
 
-We expose the following configuration values for the plugin in `pom.xml`:
+We expose the following configuration values, by adding a `<configuration>` section to the the plugin in `pom.xml`:
 
 ```xml
 <project>

--- a/src/platforms/java/common/maven/index.mdx
+++ b/src/platforms/java/common/maven/index.mdx
@@ -1,0 +1,92 @@
+---
+title: Maven
+description: "Learn about using the Sentry Maven Plugin."
+sidebar_order: 105
+---
+
+The [Sentry Maven Plugin](https://github.com/getsentry/sentry-maven-plugin) is an addition to the main Java SDK and offers
+seamless integration with the Maven build system. It supports the following features:
+
+- Auto-installation of Sentry Java SDK and relevant integrations
+- Uploading Source Context
+
+## Setup
+
+### Install
+
+Using Maven in your application module's `pom.xml` add:
+
+```xml
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-maven-plugin</artifactId>
+        <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+        <extensions>true</extensions>
+      </plugin>
+      ...
+    </plugins>
+    ...
+  </build>
+...
+</project>
+```
+
+### Configure
+
+We expose the following configuration values for the plugin in `pom.xml`:
+
+```xml
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-maven-plugin</artifactId>
+        <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <!-- for showing output of sentry-cli -->
+          <debugSentryCli>true</debugSentryCli>
+
+          <!--  Generates a source bundle and uploads it to Sentry. -->
+          <!--  This enables source context, allowing you to see your source -->
+          <!--  code as part of your stack traces in Sentry. -->
+
+          <!--  Disable the plugin -->
+          <skip>false</skip>
+
+          <!--  Disable source-context -->
+          <skipSourceBundle>false</skipSourceBundle>
+
+          <!--  Disable auto-install of SDK and integrations -->
+          <skipAutoInstall>false</skipAutoInstall>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>uploadSourceBundle</goal>
+              <goal>collectDependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      ...
+    </plugins>
+    ...
+  </build>
+  ...
+</project>
+```
+
+## Auto Installation
+
+The plugin automatically adds the Sentry Java SDK as well as available Sentry integrations as dependencies if it detects a library dependency we support. For example, if your project has a dependency on `graphql-java` the plugin will automatically add `sentry-graphql` as an additional dependency.
+
+## Source Context
+
+See our documentation on <PlatformLink to="/source-context/">Source Context</PlatformLink>.

--- a/src/platforms/java/common/maven/index.mdx
+++ b/src/platforms/java/common/maven/index.mdx
@@ -48,14 +48,11 @@ We expose the following configuration values for the plugin in `pom.xml`:
         <groupId>io.sentry</groupId>
         <artifactId>sentry-maven-plugin</artifactId>
         <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+        <!-- Required to allow auto-install of Sentry SDK and Integrations -->
         <extensions>true</extensions>
         <configuration>
           <!-- for showing output of sentry-cli -->
           <debugSentryCli>true</debugSentryCli>
-
-          <!--  Generates a source bundle and uploads it to Sentry. -->
-          <!--  This enables source context, allowing you to see your source -->
-          <!--  code as part of your stack traces in Sentry. -->
 
           <!--  Disable the plugin -->
           <skip>false</skip>
@@ -63,14 +60,16 @@ We expose the following configuration values for the plugin in `pom.xml`:
           <!--  Disable source-context -->
           <skipSourceBundle>false</skipSourceBundle>
 
-          <!--  Disable auto-install of SDK and integrations -->
+          <!--  Disable auto-install of SDK and Integrations -->
           <skipAutoInstall>false</skipAutoInstall>
         </configuration>
         <executions>
           <execution>
             <goals>
+              <!--  Generates a source bundle and uploads it to Sentry. -->
+              <!--  This enables source context, allowing you to see your source -->
+              <!--  code as part of your stack traces in Sentry. -->
               <goal>uploadSourceBundle</goal>
-              <goal>collectDependencies</goal>
             </goals>
           </execution>
         </executions>

--- a/src/platforms/java/common/maven/index.mdx
+++ b/src/platforms/java/common/maven/index.mdx
@@ -25,6 +25,7 @@ Using Maven in your application module's `pom.xml` add:
         <groupId>io.sentry</groupId>
         <artifactId>sentry-maven-plugin</artifactId>
         <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+        <!-- Required to allow auto-install of Sentry SDK and Integrations -->
         <extensions>true</extensions>
       </plugin>
       ...


### PR DESCRIPTION
Adds documentation for the Java Maven Plugin that allow auto-install of Sentry Dependencies and Source-Bundle upload.

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
