### PR TITLE
Replace traces_sample_rate with enable_tracing

### DIFF
--- a/src/includes/opentelemetry-available.mdx
+++ b/src/includes/opentelemetry-available.mdx
@@ -1,3 +1,8 @@
 <Alert level="note">
-  Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more information about it <PlatformLink to="/performance/instrumentation/opentelemetry/">here</PlatformLink>.
+  Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more
+  information about it{" "}
+  <PlatformLink to="/performance/instrumentation/opentelemetry/">
+    here
+  </PlatformLink>
+  .
 </Alert>

--- a/src/includes/opentelemetry-available.mdx
+++ b/src/includes/opentelemetry-available.mdx
@@ -1,8 +1,3 @@
 <Alert level="note">
-  Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more
-  information about it{" "}
-  <PlatformLink to="/performance/instrumentation/opentelemetry/">
-    <strong>here</strong>
-  </PlatformLink>
-  .
+  Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more information about it <PlatformLink to="/performance/instrumentation/opentelemetry/">here</PlatformLink>.
 </Alert>

--- a/src/platform-includes/configuration/config-intro/python.mdx
+++ b/src/platform-includes/configuration/config-intro/python.mdx
@@ -9,11 +9,7 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     max_breadcrumbs=50,
     debug=True,
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 
     # By default the SDK will try to use the SENTRY_RELEASE
     # environment variable, or infer a git commit

--- a/src/platform-includes/getting-started-config/python.mdx
+++ b/src/platform-includes/getting-started-config/python.mdx
@@ -8,9 +8,7 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
-    traces_sample_rate=1.0,
+    # Enable performance monitoring
+    enable_tracing=True,
 )
 ```

--- a/src/platform-includes/performance/configure-sample-rate/python.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/python.mdx
@@ -1,24 +1,12 @@
-Performance Monitoring is available for the Sentry Python SDK version ≥ 0.11.2.
+Activate performance monitoring by setting `enable_tracing` to `True`. Performance Monitoring is available for the Sentry Python SDK version ≥ 0.11.2.
 
 <SignInNote />
 
 ```python
 import sentry_sdk
 
-def traces_sampler(sampling_context):
-    # ...
-    # return a number between 0 and 1 or a boolean
-
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-
-    # To set a uniform sample rate
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
-
-    # Alternatively, to control sampling dynamically
-    traces_sampler=traces_sampler
+    enable_tracing=True
 )
 ```

--- a/src/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -7,7 +7,8 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    traces_sample_rate=1.0,
+    enable_tracing=True,
+
     # set the instrumenter to use OpenTelemetry instead of Sentry
     instrumenter="otel",
 )

--- a/src/platform-includes/profiling/index/preface/go.mdx
+++ b/src/platform-includes/profiling/index/preface/go.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+Go Profiling is currently in alpha. Alpha features are still in progress and may have bugs. We recognize the irony.
+
+</Note>

--- a/src/platform-includes/profiling/index/preface/react-native.mdx
+++ b/src/platform-includes/profiling/index/preface/react-native.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+React Native Profiling is currently in beta. Beta features are still in progress and may have bugs. We recognize the irony.
+
+</Note>

--- a/src/platform-includes/profiling/index/preface/ruby.mdx
+++ b/src/platform-includes/profiling/index/preface/ruby.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+Ruby Profiling is currently in beta. Beta features are still in progress and may have bugs. We recognize the irony.
+
+</Note>

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -65,14 +65,16 @@ Automatic instrumentation for monitoring the performance of your application is 
 
 </PlatformSection>
 
-## Configure the Sample Rate
+## Configure
 
+<PlatformSection notSupported={["python"]}>
 First, enable tracing and configure the sampling rate for transactions. Set the sample rate for your transactions by either:
 
 - Setting a uniform sample rate for all transactions using the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 - Controlling the sample rate based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
 
 The two options are meant to be mutually exclusive. If you set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.
+</PlatformSection>
 
 <PlatformSection supported={["native"]}>
 
@@ -86,8 +88,9 @@ The Native SDK doesn't currently support sampling functions (<PlatformIdentifier
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about how the options work in <PlatformLink to="/configuration/sampling/">Sampling Transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/">sample transactions</PlatformLink>.
 
+<PlatformSection notSupported={["python"]}>
 ## Verify
 
 <PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript", "apple", "dart", "rust"]}>
@@ -178,6 +181,8 @@ After you set up Relay, you should see a dramatic improvement to the impact on y
 
 </PlatformSection>
 
-**Next Steps:**
+</PlatformSection>
+
+## Next Steps
 
 <PageGrid />

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -89,7 +89,7 @@ The Native SDK doesn't currently support sampling functions (<PlatformIdentifier
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 <PlatformSection notSupported={["python"]}>
 ## Verify

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -74,6 +74,7 @@ First, enable tracing and configure the sampling rate for transactions. Set the 
 - Controlling the sample rate based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.
 
 The two options are meant to be mutually exclusive. If you set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.
+
 </PlatformSection>
 
 <PlatformSection supported={["native"]}>

--- a/src/platforms/common/profiling/index.mdx
+++ b/src/platforms/common/profiling/index.mdx
@@ -29,35 +29,7 @@ notSupported:
 description: "Learn how to enable profiling in your app if it is not already set up."
 ---
 
-<PlatformSection supported={["react-native"]}>
-
-<Note>
-
-React Native Profiling is currently in beta. Beta features are still in progress and may have bugs. We recognize the irony.
-
-</Note>
-
-</PlatformSection>
-
-<PlatformSection supported={["go"]}>
-
-<Note>
-
-Go Profiling is currently in alpha. Alpha features are still in progress and may have bugs. We recognize the irony.
-
-</Note>
-
-</PlatformSection>
-
-<PlatformSection supported={["ruby"]}>
-
-<Note>
-
-Ruby Profiling is currently in beta. Beta features are still in progress and may have bugs. We recognize the irony.
-
-</Note>
-
-</PlatformSection>
+<PlatformContent includePath="profiling/index/preface" />
 
 With [profiling](/product/profiling/), Sentry allows you to collect and analyze performance profiles from real user devices in production to give you a complete picture of how your application performs in a variety of environments.
 

--- a/src/platforms/python/integrations/aiohttp/aiohttp-client.mdx
+++ b/src/platforms/python/integrations/aiohttp/aiohttp-client.mdx
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    # Enable performance monitoring
     enable_tracing=True,
     integrations=[
         AioHttpIntegration(),

--- a/src/platforms/python/integrations/aiohttp/aiohttp-client.mdx
+++ b/src/platforms/python/integrations/aiohttp/aiohttp-client.mdx
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         AioHttpIntegration(),
     ],

--- a/src/platforms/python/integrations/aiohttp/index.mdx
+++ b/src/platforms/python/integrations/aiohttp/index.mdx
@@ -34,9 +34,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True
 )
 ```
 
@@ -85,6 +83,7 @@ from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         AioHttpIntegration(
             transaction_style="method_and_path_pattern",

--- a/src/platforms/python/integrations/ariadne/index.mdx
+++ b/src/platforms/python/integrations/ariadne/index.mdx
@@ -27,9 +27,6 @@ from sentry_sdk.integrations.ariadne import AriadneIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
     integrations=[
         AriadneIntegration(),
     ],

--- a/src/platforms/python/integrations/arq/index.mdx
+++ b/src/platforms/python/integrations/arq/index.mdx
@@ -17,7 +17,7 @@ pip install --upgrade "sentry-sdk[arq]"
 
 <SignInNote />
 
-Add `ArqIntegration()` to your `integrations` list:
+Add `ArqIntegration()` to your `integrations` list and make sure that tracing is enabled:
 
 ```python
 import sentry_sdk
@@ -25,9 +25,7 @@ from sentry_sdk.integrations.arq import ArqIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         ArqIntegration(),
     ],

--- a/src/platforms/python/integrations/asgi/index.mdx
+++ b/src/platforms/python/integrations/asgi/index.mdx
@@ -29,10 +29,7 @@ from my_asgi_app import app
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True
 )
 
 app = SentryAsgiMiddleware(app)

--- a/src/platforms/python/integrations/asyncio/index.mdx
+++ b/src/platforms/python/integrations/asyncio/index.mdx
@@ -3,7 +3,7 @@ title: asyncio
 description: "Learn about the asyncio integration and how it adds support for applications the asyncio module."
 ---
 
-The `AsyncioIntegration` integrates with applications doing concurrent code execution using Pythons [asyncio](https://docs.python.org/3/library/asyncio.html) module.
+The `AsyncioIntegration` integrates with applications doing concurrent code execution using Python's [asyncio](https://docs.python.org/3/library/asyncio.html) module.
 
 ## Install
 
@@ -13,7 +13,7 @@ pip install --upgrade 'sentry-sdk'
 
 ## Configure
 
-Add `AsyncioIntegration()` to your list of `integrations` and be sure to call `sentry_sdk.init()` at the beginning of your async loop:
+Add `AsyncioIntegration()` to your list of `integrations`, enable tracing and be sure to call `sentry_sdk.init()` at the beginning of your async loop:
 
 <SignInNote />
 
@@ -24,9 +24,7 @@ from sentry_sdk.integrations.asyncio import AsyncioIntegration
 async def main():
     sentry_sdk.init(
         dsn="___PUBLIC_DSN___",
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        traces_sample_rate=1.0,
+        enable_tracing=True,
         integrations=[
             AsyncioIntegration(),
         ],

--- a/src/platforms/python/integrations/asyncpg/index.mdx
+++ b/src/platforms/python/integrations/asyncpg/index.mdx
@@ -3,7 +3,7 @@ title: asyncpg
 description: "Learn about importing the asyncpg integration and how it captures queries from asyncpg."
 ---
 
-The asyncpg integration captures queries from
+The `AsyncPGIntegration` captures queries from
 [asyncpg](https://github.com/MagicStack/asyncpg), which can be viewed in Sentry's **Performance** page.
 
 ## Install
@@ -16,7 +16,7 @@ pip install --upgrade sentry-sdk[asyncpg]
 
 ## Configure
 
-Add `AsyncPGIntegration()` to your `integrations` list:
+Add `AsyncPGIntegration()` to your `integrations` list, and enable tracing:
 
 <SignInNote />
 
@@ -26,9 +26,7 @@ from sentry_sdk.integrations.asyncpg import AsyncPGIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         AsyncPGIntegration(),
     ],

--- a/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -25,7 +25,7 @@ Next, set the following environment variables in AWS:
 - Set `SENTRY_DSN` to your Sentry DSN
 - Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
 
-Alternatively to AWS, you can also set the environment variables in your Dockerfile. Please note, that values in AWS override the values in a Dockerfile if both are provided.
+Alternatively, you can also set the environment variables in your Dockerfile. Values set in AWS override the values in a Dockerfile if both are provided.
 
 <SignInNote />
 

--- a/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -19,13 +19,13 @@ Set your image’s CMD value to the Sentry Handler:
 CMD ["sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"]
 ```
 
-Also, set the following environment variables in AWS:
+Next, set the following environment variables in AWS:
 
 - Set `SENTRY_INITIAL_HANDLER` to the path of your function handler
 - Set `SENTRY_DSN` to your Sentry DSN
 - Set `SENTRY_TRACES_SAMPLE_RATE` to your preferred [sampling rate](/platforms/python/configuration/sampling/#sampling-transaction-events) for transactions
 
-Alternatively, you can also set the environment variables in the Dockerfile:
+Alternatively to AWS, you can also set the environment variables in your Dockerfile. Please note, that values in AWS override the values in a Dockerfile if both are provided.
 
 <SignInNote />
 
@@ -34,9 +34,3 @@ ENV SENTRY_INITIAL_HANDLER="<PATH_TO_FUNCTION_HANDLER>"
 ENV SENTRY_DSN="___PUBLIC_DSN___"
 ENV SENTRY_TRACES_SAMPLE_RATE="1.0"
 ```
-
-<Note>
-
-The values you set in AWS override the value in the Dockerfile if both are set.
-
-</Note>

--- a/src/platforms/python/integrations/aws-lambda/index.mdx
+++ b/src/platforms/python/integrations/aws-lambda/index.mdx
@@ -33,14 +33,10 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         AwsLambdaIntegration(),
-    ],
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
+    ]
 )
 
 def my_function(event, context):
@@ -57,8 +53,7 @@ If you are using another web framework inside of AWS Lambda, the framework might
 
 ## Timeout Warning
 
-The timeout warning reports an issue when the function execution time is near
-the [configured timeout](https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html).
+The timeout warning reports an issue when the function execution time is near the [configured timeout](https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html).
 
 To enable the warning, update the SDK initialization to set `timeout_warning` to
 `true`:
@@ -68,14 +63,12 @@ To enable the warning, update the SDK initialization to set `timeout_warning` to
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
-        AwsLambdaIntegration(timeout_warning=True),
+        AwsLambdaIntegration(
+            timeout_warning=True
+        ),
     ],
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
 )
 ```
 

--- a/src/platforms/python/integrations/beam/index.mdx
+++ b/src/platforms/python/integrations/beam/index.mdx
@@ -5,9 +5,9 @@ redirect_from:
 description: "Learn about using Sentry with Beam."
 ---
 
-The Beam integration currently parses the functions in [ParDo](https://github.com/apache/beam/blob/release-2.13.0/sdks/python/apache_beam/transforms/core.py#L991) to return exceptions in their respective setup, start_bundle, process, and finish_bundle functions.
+The Beam integration currently parses the functions in [ParDo](https://github.com/apache/beam/blob/release-2.13.0/sdks/python/apache_beam/transforms/core.py#L991) to return exceptions in their respective `setup`, `start_bundle`, `process`, and `finish_bundle` functions.
 
-**This integration is experimental.** It may be removed in minor versions. When enabling this integration, expect to see incorrect server_name and ip due to some distributed properties within Beam.
+**This integration is experimental.** It may be removed in minor versions. When enabling this integration, expect to see incorrect `server_name` and `ip` due to some distributed properties within Beam.
 
 A Beam version of 2.12 or later is required.
 
@@ -21,14 +21,10 @@ from sentry_sdk.integrations.beam import BeamIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         BeamIntegration(),
     ],
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
 )
 ```
 

--- a/src/platforms/python/integrations/boto3/index.mdx
+++ b/src/platforms/python/integrations/boto3/index.mdx
@@ -24,9 +24,7 @@ Initialization should happen as early as possible in your application's lifecycl
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True
 )
 ```
 

--- a/src/platforms/python/integrations/bottle/index.mdx
+++ b/src/platforms/python/integrations/bottle/index.mdx
@@ -30,9 +30,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True
 )
 
 app = Bottle()
@@ -79,12 +77,10 @@ from sentry_sdk.integrations.bottle import BottleIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-    integrations = [
+    enable_tracing=True,
+    integrations=[
         BottleIntegration(
-          transaction_style="endpoint",
+            transaction_style="endpoint",
         ),
     ],
 )

--- a/src/platforms/python/integrations/celery/crons.mdx
+++ b/src/platforms/python/integrations/celery/crons.mdx
@@ -38,13 +38,17 @@ from celery import signals
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 
-
 #@signals.beat_init.connect
 @signals.celeryd_init.connect
 def init_sentry(**kwargs):
     sentry_sdk.init(
         dsn='___PUBLIC_DSN___',
-        integrations=[CeleryIntegration(monitor_beat_tasks=True)],  # 👈
+        enable_tracing=True,
+        integrations=[
+            CeleryIntegration(
+                monitor_beat_tasks=True
+            )
+        ],
         environment="local.dev.grace",
         release="v1.0",
     )
@@ -67,18 +71,18 @@ You can exclude Celery Beat tasks from being auto-instrumented. To do this, add 
 <SignInNote />
 
 ```python
-    exclude_beat_tasks = [
-        "some-task-a",
-        "payment-check-.*",
-    ]
-
     sentry_sdk.init(
         dsn='___PUBLIC_DSN___',
+        enable_tracing=True,
         integrations=[
             CeleryIntegration(
                 monitor_beat_tasks=True,
-                exclude_beat_tasks=exclude_beat_tasks),
-            ],
+                exclude_beat_tasks=[
+                    "some-task-a",
+                    "payment-check-.*",
+                ]
+            ),
+        ],
         environment="local.dev.grace",
         release="v1.0",
     )
@@ -107,15 +111,16 @@ from celery import Celery, signals
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 
-
 app = Celery('tasks', broker='...')
-
 
 @signals.celeryd_init.connect
 def init_sentry(**kwargs):
     sentry_sdk.init(
         dsn='___PUBLIC_DSN___',
-        integrations=[CeleryIntegration()],
+        enable_tracing=True,
+        integrations=[
+            CeleryIntegration()
+        ],
         environment="local.dev.grace",
         release="v1.0",
     )

--- a/src/platforms/python/integrations/celery/index.mdx
+++ b/src/platforms/python/integrations/celery/index.mdx
@@ -30,9 +30,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn='___PUBLIC_DSN___',
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True
 )
 ```
 
@@ -81,11 +79,15 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     # ...
     integrations=[
         CeleryIntegration(
             monitor_beat_tasks=True,
-            exclude_beat_tasks=["unimportant-task", "payment-check-.*"],
+            exclude_beat_tasks=[
+                "unimportant-task",
+                "payment-check-.*"
+            ],
         ),
     ],
 )
@@ -136,8 +138,11 @@ import sentry_sdk
 # Enable global distributed traces (this is the default, just to be explicit.)
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
-        CeleryIntegration(propagate_traces=True),
+        CeleryIntegration(
+            propagate_traces=True
+        ),
     ],
 )
 

--- a/src/platforms/python/integrations/chalice/index.mdx
+++ b/src/platforms/python/integrations/chalice/index.mdx
@@ -25,9 +25,7 @@ from sentry_sdk.integrations.chalice import ChaliceIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         ChaliceIntegration(),
     ],

--- a/src/platforms/python/integrations/clickhouse-driver/index.mdx
+++ b/src/platforms/python/integrations/clickhouse-driver/index.mdx
@@ -27,9 +27,7 @@ from sentry_sdk.integrations.clickhouse_driver import ClickhouseDriverIntegratio
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         ClickhouseDriverIntegration(),
     ],

--- a/src/platforms/python/integrations/cloudresourcecontext/index.mdx
+++ b/src/platforms/python/integrations/cloudresourcecontext/index.mdx
@@ -25,9 +25,7 @@ from sentry_sdk.integrations.cloud_resource_context import CloudResourceContextI
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         CloudResourceContextIntegration(),
     ],

--- a/src/platforms/python/integrations/django/index.mdx
+++ b/src/platforms/python/integrations/django/index.mdx
@@ -36,11 +36,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 
@@ -80,7 +76,7 @@ The following parts of your Django project are monitored:
 
 <Note>
 
-The parameter `traces_sample_rate` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
+The parameter `enable_tracing` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
 
 </Note>
 

--- a/src/platforms/python/integrations/falcon/index.mdx
+++ b/src/platforms/python/integrations/falcon/index.mdx
@@ -29,9 +29,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 api = falcon.API()
@@ -80,12 +78,10 @@ from sentry_sdk.integrations.falcon import FalconIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations = [
         FalconIntegration(
-          transaction_style="path",
+            transaction_style="path",
         ),
     ],
 )

--- a/src/platforms/python/integrations/fastapi/index.mdx
+++ b/src/platforms/python/integrations/fastapi/index.mdx
@@ -28,9 +28,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 app = FastAPI()
@@ -80,7 +78,7 @@ The following parts of your FastAPI project are monitored:
 
 <Note>
 
-The parameter `traces_sample_rate` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
+The parameter `enable_tracing` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
 
 </Note>
 
@@ -95,12 +93,14 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
-        StarletteIntegration(transaction_style="endpoint",),
-        FastApiIntegration(transaction_style="endpoint",),
+        StarletteIntegration(
+            transaction_style="endpoint"
+        ),
+        FastApiIntegration(
+            transaction_style="endpoint"
+        ),
     ]
 )
 ```
@@ -119,8 +119,12 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
   sentry_sdk.init(
       # ...
       integrations=[
-          StarletteIntegration(transaction_style="endpoint"),
-          FastApiIntegration(transaction_style="endpoint"),
+          StarletteIntegration(
+              transaction_style="endpoint"
+          ),
+          FastApiIntegration(
+              transaction_style="endpoint"
+          ),
       ],
   )
 

--- a/src/platforms/python/integrations/flask/index.mdx
+++ b/src/platforms/python/integrations/flask/index.mdx
@@ -27,9 +27,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 app = Flask(__name__)
@@ -78,12 +76,10 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations = [
         FlaskIntegration(
-          transaction_style="url",
+            transaction_style="url",
         ),
     ],
 )

--- a/src/platforms/python/integrations/gcp-functions/index.mdx
+++ b/src/platforms/python/integrations/gcp-functions/index.mdx
@@ -31,14 +31,10 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         GcpIntegration(),
     ],
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
 )
 
 def http_function_entrypoint(request):
@@ -66,14 +62,12 @@ To enable the warning, update the SDK initialization to set `timeout_warning` to
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
-        GcpIntegration(timeout_warning=True),
+        GcpIntegration(
+            timeout_warning=True
+        ),
     ],
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
 )
 ```
 

--- a/src/platforms/python/integrations/graphene/index.mdx
+++ b/src/platforms/python/integrations/graphene/index.mdx
@@ -27,9 +27,7 @@ from sentry_sdk.integrations.graphene import GrapheneIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         GrapheneIntegration(),
     ],

--- a/src/platforms/python/integrations/grpc/index.mdx
+++ b/src/platforms/python/integrations/grpc/index.mdx
@@ -33,9 +33,7 @@ from sentry_sdk.integrations.grpc.server import ServerInterceptor
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 ...
@@ -56,9 +54,7 @@ from sentry_sdk.integrations.grpc.client import ClientInterceptor
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 ...

--- a/src/platforms/python/integrations/httpx/index.mdx
+++ b/src/platforms/python/integrations/httpx/index.mdx
@@ -24,9 +24,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 

--- a/src/platforms/python/integrations/huey/index.mdx
+++ b/src/platforms/python/integrations/huey/index.mdx
@@ -26,12 +26,10 @@ from sentry_sdk.integrations.huey import HueyIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
     integrations=[
         HueyIntegration(),
     ],
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
 )
 ```
 

--- a/src/platforms/python/integrations/index.mdx
+++ b/src/platforms/python/integrations/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 description: "Sentry provides additional integrations designed to change configuration or add instrumentation to your application."
-sidebar_order: 4
+sidebar_order: 40
 ---
 
 The Sentry SDK uses Integrations to hook into the functionality of popular libraries to automatically instrument your application and give you the best data out of the box.

--- a/src/platforms/python/integrations/logging/index.mdx
+++ b/src/platforms/python/integrations/logging/index.mdx
@@ -26,10 +26,7 @@ The logging integrations is a default integration so it will be enabled automati
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    dsn="___PUBLIC_DSN___"
 )
 ```
 
@@ -66,9 +63,6 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
     integrations=[
         LoggingIntegration(
             level=logging.INFO,        # Capture info and above as breadcrumbs

--- a/src/platforms/python/integrations/pure_eval/index.mdx
+++ b/src/platforms/python/integrations/pure_eval/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enhanced Locals
+title: pure_eval
 description: "Learn about `pure_eval` and how to add it to your integrations list."
 ---
 

--- a/src/platforms/python/integrations/pymongo/index.mdx
+++ b/src/platforms/python/integrations/pymongo/index.mdx
@@ -25,9 +25,7 @@ from sentry_sdk.integrations.pymongo import PyMongoIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         PyMongoIntegration(),
     ],

--- a/src/platforms/python/integrations/pyramid/index.mdx
+++ b/src/platforms/python/integrations/pyramid/index.mdx
@@ -27,9 +27,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 from pyramid.config import Configurator
@@ -90,9 +88,7 @@ from sentry_sdk.integrations.pyramid import PyramidIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         PyramidIntegration(
             transaction_style="route_pattern",

--- a/src/platforms/python/integrations/quart/index.mdx
+++ b/src/platforms/python/integrations/quart/index.mdx
@@ -27,9 +27,7 @@ from sentry_sdk.integrations.quart import QuartIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         QuartIntegration(),
     ],

--- a/src/platforms/python/integrations/redis/index.mdx
+++ b/src/platforms/python/integrations/redis/index.mdx
@@ -23,9 +23,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 sentry_sdk.init(
     dsn='___PUBLIC_DSN___',
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 
@@ -116,8 +114,11 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 sentry_sdk.init(
     dsn='___PUBLIC_DSN___',
+    enable_tracing=True,
     integrations=[
-        RedisIntegration(max_data_size=None),
+        RedisIntegration(
+            max_data_size=None
+        ),
     ]
 )
 ```
@@ -132,8 +133,11 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 sentry_sdk.init(
     dsn='___PUBLIC_DSN___',
+    enable_tracing=True,
     integrations=[
-        RedisIntegration(max_data_size=50),
+        RedisIntegration(
+            max_data_size=50
+        ),
     ]
 )
 ```

--- a/src/platforms/python/integrations/rq/index.mdx
+++ b/src/platforms/python/integrations/rq/index.mdx
@@ -29,10 +29,8 @@ Create a file called `mysettings.py` with the following content:
 import sentry_sdk
 
 sentry_sdk.init(
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
 )
 ```
 
@@ -58,9 +56,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn=___PUBLIC_DSN___,
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 
@@ -94,9 +90,7 @@ import sentry_sdk
 # Sentry configuration for RQ worker processes
 sentry_sdk.init(
     dsn=___PUBLIC_DSN___,
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 
@@ -114,9 +108,7 @@ import sentry_sdk
 # Sentry configuration for main.py process
 sentry_sdk.init(
     dsn=___PUBLIC_DSN___,
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 q = Queue(connection=Redis())

--- a/src/platforms/python/integrations/sanic/index.mdx
+++ b/src/platforms/python/integrations/sanic/index.mdx
@@ -33,9 +33,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 app = Sanic(__name__)
@@ -54,15 +52,15 @@ from sentry_sdk.integrations.sanic import SanicIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
 
-    # Configure the Sanic integration so that we
-    # generate transactions for all HTTP statuses,
-    # including 404
-    integrations=[SanicIntegration(unsampled_statuses=None)]
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    # Configure the Sanic integration so that we generate
+    # transactions for all HTTP status codes, including 404
+    integrations=[
+        SanicIntegration(
+            unsampled_statuses=None
+        )
+    ]
 )
 ```
 

--- a/src/platforms/python/integrations/serverless/index.mdx
+++ b/src/platforms/python/integrations/serverless/index.mdx
@@ -37,10 +37,8 @@ import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function
 
 sentry_sdk.init(
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
 )
 
 @serverless_function

--- a/src/platforms/python/integrations/socket/index.mdx
+++ b/src/platforms/python/integrations/socket/index.mdx
@@ -25,9 +25,7 @@ from sentry_sdk.integrations.socket import SocketIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         SocketIntegration(),
     ],

--- a/src/platforms/python/integrations/spark/index.mdx
+++ b/src/platforms/python/integrations/spark/index.mdx
@@ -25,14 +25,10 @@ from sentry_sdk.integrations.spark import SparkIntegration
 if __name__ == "__main__":
     sentry_sdk.init(
         dsn="___PUBLIC_DSN___",
+        enable_tracing=True,
         integrations=[
             SparkIntegration(),
         ],
-
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        # We recommend adjusting this value in production,
-        traces_sample_rate=1.0,
     )
 
     spark = SparkSession\
@@ -58,14 +54,10 @@ import pyspark.daemon as original_daemon
 if __name__ == '__main__':
     sentry_sdk.init(
         dsn="___PUBLIC_DSN___",
+        enable_tracing=True,
         integrations=[
             SparkWorkerIntegration(),
         ],
-
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        # We recommend adjusting this value in production,
-        traces_sample_rate=1.0,
     )
 
     original_daemon.manager()

--- a/src/platforms/python/integrations/sqlalchemy/index.mdx
+++ b/src/platforms/python/integrations/sqlalchemy/index.mdx
@@ -22,9 +22,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 ```
 

--- a/src/platforms/python/integrations/starlette/index.mdx
+++ b/src/platforms/python/integrations/starlette/index.mdx
@@ -27,10 +27,8 @@ from starlette.applications import Starlette
 import sentry_sdk
 
 sentry_sdk.init(
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
     dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
 )
 
 app = Starlette(routes=[...])
@@ -62,7 +60,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 - Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
-- If a `traces_sample_rate` is set, then performance information is also reported, which you can see on the **Performance** page of [sentry.io](https://sentry.io).
+- If `enable_tracing` or a `traces_sample_rate` is set, then performance information is also reported, which you can see on the **Performance** page of [sentry.io](https://sentry.io).
 
 ## Options
 
@@ -73,9 +71,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         StarletteIntegration(
             transaction_style="endpoint",
@@ -88,7 +84,7 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
 - `transaction_style`:
 
-  ```
+  ```python
   async def product_detail(request):
       return JSONResponse({...})
 

--- a/src/platforms/python/integrations/strawberry/index.mdx
+++ b/src/platforms/python/integrations/strawberry/index.mdx
@@ -27,12 +27,13 @@ from sentry_sdk.integrations.strawberry import StrawberryIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
-        # Set async_execution to True if you have at least one async resolver
-        StrawberryIntegration(async_execution=True),
+        StrawberryIntegration(
+            # Set async_execution to True if you have
+            # at least one async resolver
+            async_execution=True
+        ),
     ],
 )
 ```
@@ -98,7 +99,9 @@ based on installed web frameworks.
 sentry_sdk.init(
     # (...) other options
     integrations=[
-        StrawberryIntegration(async_execution=True),  # or False
+        StrawberryIntegration(
+            async_execution=True # or False
+        ),
     ],
 )
 ```

--- a/src/platforms/python/integrations/tornado/index.mdx
+++ b/src/platforms/python/integrations/tornado/index.mdx
@@ -33,9 +33,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 class MainHandler(tornado.web.RequestHandler):

--- a/src/platforms/python/integrations/tryton/index.mdx
+++ b/src/platforms/python/integrations/tryton/index.mdx
@@ -20,9 +20,7 @@ from sentry_sdk.integrations.trytond import TrytondWSGIIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
     integrations=[
         TrytondWSGIIntegration(),
     ],

--- a/src/platforms/python/integrations/wsgi/index.mdx
+++ b/src/platforms/python/integrations/wsgi/index.mdx
@@ -29,9 +29,7 @@ from my_wsgi_app import app
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    enable_tracing=True,
 )
 
 app = SentryWsgiMiddleware(app)


### PR DESCRIPTION
Now that we have efficient backpressure management in our Python SDK, we no longer need to instruct users on how to enable performance monitoring by configuring their `traces_sample_rate` or `traces_sampler`.

When we simply talk about activating performance monitoring, we should now use `enable_tracing` instead. Attached are some screenshots from the performance monitoring getting started page.

### Before
![before](https://github.com/getsentry/sentry-docs/assets/7096858/72d55281-95be-4d1d-8074-d1b38c31ad4a)

### After
![after](https://github.com/getsentry/sentry-docs/assets/7096858/61c6d88c-68a6-435d-8509-1c34bf3902ce)
