### PR TITLE
fetch API docs URL and display in package details box

### DIFF
--- a/src/components/platformSdkDetail.tsx
+++ b/src/components/platformSdkDetail.tsx
@@ -14,6 +14,7 @@ const query = graphql`
         url
         repoUrl
         version
+        apiDocsUrl
       }
     }
   }
@@ -79,7 +80,15 @@ export function PlatformSdkDetail() {
         <dd>{packageData.version}</dd>
         <dt>Repository:</dt>
         <dd>
-          <SmartLink to={packageData.repoUrl} />
+          <SmartLink to={packageData.repoUrl} target="_blank" />
+        </dd>
+        <dt>API Documentation:</dt>
+        <dd>
+          {packageData.apiDocsUrl ? (
+            <SmartLink to={packageData.apiDocsUrl} target="_blank" />
+          ) : (
+            '-'
+          )}
         </dd>
       </dl>
     </PackageDetail>

--- a/src/components/platformSdkDetail.tsx
+++ b/src/components/platformSdkDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {graphql, useStaticQuery} from 'gatsby';
 
@@ -82,14 +82,14 @@ export function PlatformSdkDetail() {
         <dd>
           <SmartLink to={packageData.repoUrl} target="_blank" />
         </dd>
-        <dt>API Documentation:</dt>
-        <dd>
-          {packageData.apiDocsUrl ? (
-            <SmartLink to={packageData.apiDocsUrl} target="_blank" />
-          ) : (
-            '-'
-          )}
-        </dd>
+        {packageData.apiDocsUrl && (
+          <Fragment>
+            <dt>API Documentation:</dt>
+            <dd>
+              <SmartLink to={packageData.apiDocsUrl} target="_blank" />
+            </dd>
+          </Fragment>
+        )}
       </dl>
     </PackageDetail>
   );

--- a/src/gatsby/createSchemaCustomization/packageSchema.ts
+++ b/src/gatsby/createSchemaCustomization/packageSchema.ts
@@ -18,6 +18,7 @@ export const getPackageTypeDefs = () => {
         url: String
         repoUrl: String!
         version: String!
+        apiDocsUrl: String
         files: [PackageFile!]
       }
       `,

--- a/src/gatsby/sourceNodes/appRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/appRegistryNodes.ts
@@ -18,6 +18,7 @@ export const sourceAppRegistryNodes = async ({
       version: appData.version,
       url: appData.package_url,
       repoUrl: appData.repo_url,
+      apiDocsUrl: appData.api_docs_url,
       files: appData.files
         ? Object.entries(appData.files).map(([fileName, fileData]: [string, any]) =>
             fileData.checksums

--- a/src/gatsby/sourceNodes/packageRegistryNodes.ts
+++ b/src/gatsby/sourceNodes/packageRegistryNodes.ts
@@ -18,6 +18,7 @@ export const sourcePackageRegistryNodes = async ({
       version: sdkData.version,
       url: sdkData.package_url,
       repoUrl: sdkData.repo_url,
+      apiDocsUrl: sdkData.api_docs_url,
       files: sdkData.files
         ? Object.entries(sdkData.files).map(([fileName, fileData]: [string, any]) =>
             fileData.checksums
@@ -34,6 +35,7 @@ export const sourcePackageRegistryNodes = async ({
     };
 
     const content = JSON.stringify(data);
+
     const nodeMeta = {
       id: sdkName,
       parent: null,

--- a/src/gatsby/utils/genericRegistry.ts
+++ b/src/gatsby/utils/genericRegistry.ts
@@ -13,6 +13,7 @@ type VersionData = {
   name: string;
   repo_url: string;
   version: string;
+  api_docs_url?: string;
   files?: {
     [name: string]: FileData;
   };

--- a/src/types/platform.tsx
+++ b/src/types/platform.tsx
@@ -14,7 +14,7 @@ export interface Platform extends PlatformConfig {
    */
   key: string;
   /**
-   * Same as key. Use `title` for a human readable platform name.
+   * Same as key. Use `title` for a human-readable platform name.
    *
    * @see Platform.key
    */


### PR DESCRIPTION
Please have a look at the package details box in the right sidebar

<img width="1173" alt="Screenshot 2023-10-25 at 21 26 08" src="https://github.com/getsentry/sentry-docs/assets/7096858/5bdb4eeb-460d-4023-838a-a2fb42e0e535">

<img width="1113" alt="Screenshot 2023-10-25 at 21 52 47" src="https://github.com/getsentry/sentry-docs/assets/7096858/d387d8f4-0516-47b7-84e1-3da0a9ec1f9d">

