### PR TITLE
Performance: fixed Verify heading markup

### DIFF
--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -92,6 +92,7 @@ The Native SDK doesn't currently support sampling functions (<PlatformIdentifier
 Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 <PlatformSection notSupported={["python"]}>
+
 ## Verify
 
 <PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript", "apple", "dart", "rust"]}>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Verified the change and ran linters locally.
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs) /cc @getsentry/docs

## Description of changes

I've been diving into Sentry and reading the docs on performance monitoring, and noticed a malformed heading, so I fixed it. It's a one character change 🙃. 

It makes it so `Verify` renders as a second level heading instead of `## Verify`, and hopefully restores whatever heading links were out there in the wild. 

<img width="1612" alt="Screenshot 2023-10-28 at 7 35 09 PM" src="https://github.com/getsentry/sentry-docs/assets/43633/9662c8c8-67fa-4066-bafa-2de7950a7a98">


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

