### PR TITLE
Inline related guides for frameworks

### DIFF
--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -2,17 +2,19 @@
 
 On this page, we get you up and running with Sentry's SDK.
 
+<Note>
+
+If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+
+</Note>
+
 <PlatformSection noGuides notSupported={["android", "dart", "elixir", "flutter", "perl", "react-native", "unity", "unreal", "kotlin-multiplatform", "python"]}>
 
-<Alert level="info" title="Using a framework?">
+Using a framework? Take a look at our specific guides to get started.
 
-Get started using a guide listed in the right sidebar.
-
-</Alert>
+<GuideGrid />
 
 </PlatformSection>
-
-Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
 ## Install
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Summary

This PR fixes #6977 by always displaying the list of related guides. Here's the video of how that looks: 

<div>
    <a href="https://www.loom.com/share/beeb90904d674b77823f4204cecdac2d">
      <p>Code Base Issue with Sentry Docs - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/beeb90904d674b77823f4204cecdac2d">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/beeb90904d674b77823f4204cecdac2d-with-play.gif">
    </a>
  </div>

/cc @shanamatthews. I am not absolutely sure if this is the right approach — this does duplicate the list of guides in the main and right column, and does take a bit of space from the main column. So no hard feelings if we decide not to go in this direction. 

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*
- [x] Local linters are happy
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR changes `common/index.mdx` file, which makes it so that most platform pages that don't have their own `index.mdx`, would default to that. 

The actual change replaces the alert to see the list of framework-related guides in the right sidebar with the actual list of framework-related guides, inline. 


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
