### PR TITLE
fix: Fix order of npm vs yarn

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -35,18 +35,18 @@ export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 
 Next, run the upload script with the following command:
 
-```bash {tabTitle:Yarn}
-yarn sentry-upload-sourcemaps
-
-# For usage details run
-yarn sentry-upload-sourcemaps --help
-```
-
 ```bash {tabTitle:npm}
 node ./node_modules/@sentry/remix/scripts/sentry-upload-sourcemaps.js
 
 # For usage details run
 node ./node_modules/@sentry/remix/scripts/sentry-upload-sourcemaps.js --help
+```
+
+```bash {tabTitle:Yarn}
+yarn sentry-upload-sourcemaps
+
+# For usage details run
+yarn sentry-upload-sourcemaps --help
 ```
 
 <Note>


### PR DESCRIPTION
We streamlined this some while ago, but forgot a place, where we still had `yarn` before `npm`.