### PR TITLE
feat(go): add temp file leak section to troubleshooting

### DIFF
--- a/src/platforms/go/common/troubleshooting.mdx
+++ b/src/platforms/go/common/troubleshooting.mdx
@@ -21,3 +21,9 @@ Since the Go SDK tries to read the source files from your local disk, it's possi
 This is common in Go because you can compile the binary, and then have no more need for the source code. Without access to the source code, however, we can’t map anything back, and we don’t support uploading Go source code with a release to stitch this data on.
 
 You can see [in the Serverless section](/platforms/go/serverless/#source-context) how to bundle the source code with the binary, which applies to other forms of deployment as well.
+
+## Avoiding Temporary File Leaks In File Upload Handlers
+
+Go SDK middleware has to modify the request context in order to function correctly. This results in a shallow copy of the request being passed to upstream handlers. Temporary files created from calling `ParseMultipartForm` on this request will not automatically be cleaned up. It's important ensure these files are cleaned up by calling `request.Multipart.RemoveAll()` after.
+
+See the [multipart documentation](https://pkg.go.dev/mime/multipart#Form.RemoveAll) for more information.

--- a/src/platforms/go/common/troubleshooting.mdx
+++ b/src/platforms/go/common/troubleshooting.mdx
@@ -24,6 +24,6 @@ You can see [in the Serverless section](/platforms/go/serverless/#source-context
 
 ## Avoiding Temporary File Leaks In File Upload Handlers
 
-Go SDK middleware has to modify the request context in order to function correctly. This results in a shallow copy of the request being passed to upstream handlers. Temporary files created from calling `ParseMultipartForm` on this request will not automatically be cleaned up. It's important ensure these files are cleaned up by calling `request.Multipart.RemoveAll()` after.
+Sentry's Go SDK middleware has to modify the request context in order to function correctly. This results in a shallow copy of the request being passed to upstream handlers. This means that temporary files created from calling `ParseMultipartForm` on this request won't automatically be cleaned up. It's important to clean these files up by calling `request.Multipart.RemoveAll()` after.
 
 See the [multipart documentation](https://pkg.go.dev/mime/multipart#Form.RemoveAll) for more information.


### PR DESCRIPTION
Add a section on avoiding temporary file leaks when using Go SDK middleware with file upload handlers.

See this issue: https://github.com/getsentry/sentry-go/issues/673