### PR TITLE
tunnel example, mention built in

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -106,7 +106,12 @@ Sentry.init({
 Once configured, all events will be sent to the `/tunnel` endpoint. This solution, however, requires an additional configuration on the server, as the events now need to be parsed and redirected to Sentry. Here's an example for your server component:
 
 ```csharp
-// Requires .NET Core 3.1 and C# 9 or higher
+
+// This functionality is built-in to the Sentry.AspNetCore package.
+// https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#tunnel
+
+// It basically works similar to this example:
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -107,10 +107,11 @@ Once configured, all events will be sent to the `/tunnel` endpoint. This solutio
 
 ```csharp
 
-// This functionality is built-in to the Sentry.AspNetCore package.
-// https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#tunnel
+// This functionality is now built-in to the Sentry.AspNetCore package.
+// See https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#tunnel
+// docs for more information.
 
-// It basically works similar to this example:
+// This example shows how you could implement it yourself:
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Since this is just example, its' fine to keep but lets call out this is built int