### PR TITLE
fix(remix): Add Remix-specific Performance monitoring setup code snippets

### DIFF
--- a/src/platform-includes/performance/configure-sample-rate/javascript.remix.mdx
+++ b/src/platform-includes/performance/configure-sample-rate/javascript.remix.mdx
@@ -1,0 +1,41 @@
+<SignInNote />
+
+```typescript {tabTitle:Client} {filename: entry.client.tsx}
+import { useLocation, useMatches } from "@remix-run/react";
+import * as Sentry from "@sentry/remix";
+import { useEffect } from "react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    new Sentry.BrowserTracing({
+      routingInstrumentation: Sentry.remixRouterInstrumentation(
+        useEffect,
+        useLocation,
+        useMatches
+      ),
+    }),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+  tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+});
+```
+
+```typescript {tabTitle:Server} {filename: entry.server.tsx}
+import * as Sentry from "@sentry/remix";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+```

--- a/src/platform-includes/performance/enable-tracing/javascript.remix.mdx
+++ b/src/platform-includes/performance/enable-tracing/javascript.remix.mdx
@@ -1,0 +1,1 @@
+Tracing is available by default in the Sentry Remix SDK package.

--- a/src/platforms/common/performance/index.mdx
+++ b/src/platforms/common/performance/index.mdx
@@ -92,6 +92,7 @@ The Native SDK doesn't currently support sampling functions (<PlatformIdentifier
 Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 <PlatformSection notSupported={["python"]}>
+
 ## Verify
 
 <PlatformSection supported={["react-native", "java.spring", "java.spring-boot", "android", "javascript", "apple", "dart", "rust"]}>


### PR DESCRIPTION
Currently, we only showed the generic `@sentry/browser` code snippet to set up performance monitoring for the Remix SDK. This PR adds Remix-specific code snippets that show both, client and server code for Remix projects.  

Side note: I think we can probably go the same route with Remix as with Next/Sveltekit/Astro and always add BrowserTracing under the hood. This however is a larger task for which I currently don't have time. So let's go with correct docs for now and adjust later when/if we get to simplify things in the Remix SDK. 