### PR TITLE
Clarify sentry pagerduty alert config

### DIFF
--- a/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
@@ -57,7 +57,7 @@ In [metric alerts](/product/alerts/alert-types/#metric-alerts), select the Pager
 
 ![PagerDuty metric alert rule action](pd_metric_alert_rule.png)
 
-If a PagerDuty incident is created from the critical trigger of a metric alert with no warning threshold set, it will resolve itself when the Sentry metric alert is resolved. If the metric alert has a warning threshold set, you may need to manually resolve the PagerDuty incident.
+If a PagerDuty incident is created from the critical trigger of a metric alert and no warning threshold has been set, it will resolve itself when the Sentry metric alert is resolved. Metric alerts that have set warning thresholds may need to be manually resolved as PagerDuty incidents.
 
 ## Deleting the Legacy PagerDuty Integration
 

--- a/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/pagerduty/index.mdx
@@ -57,7 +57,7 @@ In [metric alerts](/product/alerts/alert-types/#metric-alerts), select the Pager
 
 ![PagerDuty metric alert rule action](pd_metric_alert_rule.png)
 
-If a PagerDuty incident is created from the critical trigger of a metric alert, it will resolve itself when the Sentry metric alert is resolved.
+If a PagerDuty incident is created from the critical trigger of a metric alert with no warning threshold set, it will resolve itself when the Sentry metric alert is resolved. If the metric alert has a warning threshold set, you may need to manually resolve the PagerDuty incident.
 
 ## Deleting the Legacy PagerDuty Integration
 


### PR DESCRIPTION
call out edge case for warning thresholds 