### PR TITLE
chore(jira): Document issue with fetching priorities

### DIFF
--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -230,9 +230,9 @@ This issue typically occurs if you have an ad blocker blocking the conversation 
 
 We don’t support custom required fields for the Jira integration. The only required fields we support are the ones that are pre-populated by us. If possible, you can edit your required fields in Jira, or as a workaround, you can create a ticket in Jira first and then link it in Sentry.
 
-### Can't Create Issues Automatically or Manually
+### Issue Alert not Creating Jira Issues
 
-If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your selected priority is available on your chosen project.
+If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your alert's saved priority is available on your chosen project.
 
 ### Receiving a 4xx/5xx Error for the Jira Server Integration
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -230,6 +230,9 @@ This issue typically occurs if you have an ad blocker blocking the conversation 
 
 We don’t support custom required fields for the Jira integration. The only required fields we support are the ones that are pre-populated by us. If possible, you can edit your required fields in Jira, or as a workaround, you can create a ticket in Jira first and then link it in Sentry.
 
+### Can't Create Issues Automatically or Manually
+If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your selected priority is available on your chosen project.
+
 ### Receiving a 4xx/5xx Error for the Jira Server Integration
 
 A `400` error is often generated because the Jira instance is not publicly accessible. Make sure your instance is routable (that is, our server can reach it!). If not, you’ll need to put your Jira instance on the internet so that we can reach it.

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -230,8 +230,9 @@ This issue typically occurs if you have an ad blocker blocking the conversation 
 
 We don’t support custom required fields for the Jira integration. The only required fields we support are the ones that are pre-populated by us. If possible, you can edit your required fields in Jira, or as a workaround, you can create a ticket in Jira first and then link it in Sentry.
 
-### Issue Alert not Creating Jira Issues
-If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your alert's saved priority is available on your chosen project.
+### Can't Create Issues Automatically or Manually
+
+If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your selected priority is available on your chosen project.
 
 ### Receiving a 4xx/5xx Error for the Jira Server Integration
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -230,8 +230,8 @@ This issue typically occurs if you have an ad blocker blocking the conversation 
 
 We don’t support custom required fields for the Jira integration. The only required fields we support are the ones that are pre-populated by us. If possible, you can edit your required fields in Jira, or as a workaround, you can create a ticket in Jira first and then link it in Sentry.
 
-### Can't Create Issues Automatically or Manually
-If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your selected priority is available on your chosen project.
+### Issue Alert not Creating Jira Issues
+If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your alert's saved priority is available on your chosen project.
 
 ### Receiving a 4xx/5xx Error for the Jira Server Integration
 

--- a/src/docs/product/integrations/issue-tracking/jira/index.mdx
+++ b/src/docs/product/integrations/issue-tracking/jira/index.mdx
@@ -232,7 +232,7 @@ We don’t support custom required fields for the Jira integration. The only req
 
 ### Issue Alert not Creating Jira Issues
 
-If your project configuration contains the "Priority" field, the dropdown will show every priority from all projects. Please ensure your alert's saved priority is available on your chosen project.
+This problem occurs when you've selected a priority option for the alert that doesn't exist for the given project. If your project configuration contains the "Priority" field, the dropdown will show every priority from **all** projects. Ensure your alert's saved priority is available on your chosen project.
 
 ### Receiving a 4xx/5xx Error for the Jira Server Integration
 


### PR DESCRIPTION
There's been an existing bug for a long time when you try to manually or automatically create a Jira/Jira Server issue. The priority dropdown will show all priorities from all projects, not the one you've currently selected.

The alert rule action can be created, but will fail silently when triggered and fail to create Jira issues. Creating it manually is fine b/c it shows the error, but we don't validate for alert rule actions b/c we're not sending the webhook to actually create the issue (b/c there is no issue obv)

### Creating Manually
![Screenshot 2023-11-02 at 2 29 11 PM](https://github.com/getsentry/sentry-docs/assets/67301797/aa02b9f9-4bcd-46ab-b882-3417fbb130c3)

We're limited by Jira/Jira server APIs to fetch priorities per project, b/c this requires elevated global/project admin permissions that our integration does not have.
See https://github.com/getsentry/sentry/pull/58749 and https://github.com/getsentry/sentry/pull/59197 for failed attempts

### Updated Docs
![Screenshot 2023-11-02 at 2 35 05 PM](https://github.com/getsentry/sentry-docs/assets/67301797/704dfc8d-d0db-43c2-aab0-f11a9ffc8ac0)