### PR TITLE
feat(data-scrubbing): Add sction about advanced safe field usage

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
@@ -68,6 +68,36 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 - While you cannot delete a single event, you can delete the issue the event is in by clicking the trash icon on the **Issue Details** page.
 - If a large number of unique events - representing multiple issues - contain the data, you may need to delete and re-create the project to effectively cleanse the system.
 
+## Safe Fields
+
+Safe Fields are used to exclude fields and data from scrubbing. For example this event payload:
+
+```json
+{
+  "user": {
+    "id": "4111111111111111"
+  },
+  "extra": {
+    "id": "sensitive",
+    "sys.argv": ["script.py", "password"],
+    "credentials": { "username": "jane", "password": "p4ssw0rd!" }
+  }
+}
+```
+
+With scrubbing enabled and `id` added as a sensitive field, the `user.id` field will be scrubbed
+(it matches a credit card), the `password` string in `extra.'sys.argv'` as well as the entire `credentials` object.
+
+To accomodate more fine grained filtering the Safe Fields support the same syntax as the
+[Advanced Datascrubbing Sources](/product/data-management-settings/scrubbing/advanced-datascrubbing/#sources).
+
+To leave the the `user.id` field intact one could configure simply `id` as a Safe Field, but this also
+marks `extra.id` as a Safe Field. In order to only select the user id the full path can be used instead: `user.id`.
+
+Marking elements of an array as safe requires a wildcard selector, for example `'sys.argv'.*`. A deep wildcard
+can be used to mark all elements contained within an object as safe. The two selectors `extra.credentials`,
+`extra.credentials.**` mark the `credentials` object and all of its members as safe.
+
 ## Known Limitations
 
 It's not currently possible to avoid scrubbing data in [breadcrumbs](/product/issues/issue-details/breadcrumbs/) by adding the category name in "Safe Fields". Only the message and data in breadcrumbs are used for data scrubbing. Also, if custom JSON data is provided, the fields will be scrubbed according to the configured rules and the entries in "Safe Fields".

--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
@@ -70,7 +70,7 @@ If you’ve accidentally sent sensitive data to the server, you likely don't to 
 
 ## Safe Fields
 
-Safe Fields are used to exclude fields and data from scrubbing. For example this event payload:
+Safe Fields are used to exclude fields and data from scrubbing. For example, take the following event payload:
 
 ```json
 {
@@ -85,18 +85,17 @@ Safe Fields are used to exclude fields and data from scrubbing. For example this
 }
 ```
 
-With scrubbing enabled and `id` added as a sensitive field, the `user.id` field will be scrubbed
-(it matches a credit card), the `password` string in `extra.'sys.argv'` as well as the entire `credentials` object.
+When scrubbing is enabled and `id` added as a sensitive field, the `password` string in `extra.'sys.argv'`, the `user.id` field (because it matches a credit card), as well as the entire `credentials` object will be scrubbed.
 
-To accomodate more fine grained filtering the Safe Fields support the same syntax as the
+To accomodate more fine-grained filtering, the Safe Fields support the same syntax as the
 [Advanced Datascrubbing Sources](/product/data-management-settings/scrubbing/advanced-datascrubbing/#sources).
 
-To leave the the `user.id` field intact one could configure simply `id` as a Safe Field, but this also
-marks `extra.id` as a Safe Field. In order to only select the user id the full path can be used instead: `user.id`.
+If you want to leave the `user.id` field intact, you can configure the `id` as a Safe Field, but this will also
+mark `extra.id` as a Safe Field. To specifically select the user id, use the full path instead of `user.id`.
 
 Marking elements of an array as safe requires a wildcard selector, for example `'sys.argv'.*`. A deep wildcard
-can be used to mark all elements contained within an object as safe. The two selectors `extra.credentials`,
-`extra.credentials.**` mark the `credentials` object and all of its members as safe.
+can be used to mark all elements contained within an object. The two selectors: `extra.credentials` and
+`extra.credentials**` will mark the `credentials` object and all of its members as safe.
 
 ## Known Limitations
 

--- a/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/server-side-scrubbing/index.mdx
@@ -85,7 +85,8 @@ Safe Fields are used to exclude fields and data from scrubbing. For example, tak
 }
 ```
 
-When scrubbing is enabled and `id` added as a sensitive field, the `password` string in `extra.'sys.argv'`, the `user.id` field (because it matches a credit card), as well as the entire `credentials` object will be scrubbed.
+When scrubbing is enabled and `id` added as a sensitive field, the `password` string in `extra.'sys.argv'`,
+both `id` fields (`user.id` and `extra.id`), as well as the entire `credentials` object will be scrubbed.
 
 To accomodate more fine-grained filtering, the Safe Fields support the same syntax as the
 [Advanced Datascrubbing Sources](/product/data-management-settings/scrubbing/advanced-datascrubbing/#sources).
@@ -95,7 +96,7 @@ mark `extra.id` as a Safe Field. To specifically select the user id, use the ful
 
 Marking elements of an array as safe requires a wildcard selector, for example `'sys.argv'.*`. A deep wildcard
 can be used to mark all elements contained within an object. The two selectors: `extra.credentials` and
-`extra.credentials**` will mark the `credentials` object and all of its members as safe.
+`extra.credentials.**` will mark the `credentials` object and all of its members as safe.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Relay recently added additional functionality for the `Safe Fields` option in Sentry Data Scrubbing. This adds an example with some documentation as well as a link to the full syntax description.

