### PR TITLE
Crash free user/session clarification

### DIFF
--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -109,7 +109,7 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 
 <Alert level="info">
 
-The number of crashes unhandled events is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/product/data-management-settings/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
+Please note that the number of crashes is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/product/data-management-settings/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
 
 </Alert>
 

--- a/src/docs/product/releases/health/index.mdx
+++ b/src/docs/product/releases/health/index.mdx
@@ -85,7 +85,7 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 
 ## Crashes {#crash}
 
-A _crash_ is when the application had an explicit unhandled error or hard crash. You'll typically be able to view the corresponding issue that captures this event in [sentry.io](https://sentry.io), and errors that did not cause the end of the application should not be included. To search for crash events in **Discover** or on the **Issues** page, filter by `error.unhandled:true`. The number of unhandled events is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/product/data-management-settings/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
+A _crash_ is when the application had an explicit unhandled error or hard crash. You'll typically be able to view the corresponding issue that captures this event in [sentry.io](https://sentry.io), and errors that did not cause the end of the application should not be included. To search for crash events in **Discover** or on the **Issues** page, filter by `error.unhandled:true`.
 
 <Note>
 
@@ -106,6 +106,12 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 ![Sort By: Crash Free Sessions dropdown](release_crash_free_sessions.png)
 
 ![Sort By: Crash Free Users dropdown](release_crash_free_users.png)
+
+<Alert level="info">
+
+The number of crashes unhandled events is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/product/data-management-settings/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
+
+</Alert>
 
 ### Crashed Users
 


### PR DESCRIPTION
Turned note about crash events not matching crash rates into an alert for more visibility.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)