### PR TITLE
fix(browser-profiling): Remove `BrowserTracing` from Nextjs and Sveltekit snippets

### DIFF
--- a/src/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
+++ b/src/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
@@ -5,7 +5,6 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    new Sentry.BrowserTracing(),
     new Sentry.BrowserProfilingIntegration(),
   ],
 

--- a/src/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
+++ b/src/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
@@ -5,7 +5,6 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    new Sentry.BrowserTracing(),
     new Sentry.BrowserProfilingIntegration(),
   ],
 


### PR DESCRIPTION
Both, the NextJS and SvelteKit SDKs, already add `BrowserTracing` by default. There's no harm in adding them as a user but on the other hand, it's not necessary either. So this PR removes the intgration from the respective snippets.

The same thing applies to Astro but I don't think we have Astro specific Browser profiling docs yet. @JonasBa are you currently adding more platforms or should I quickly add a snippet for Astro?

ref: https://github.com/syntaxfm/website/pull/1346#discussion_r1381817262