### PR TITLE
feat(rn): Add new Xcode scripts to RN Manual Setup

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -12,12 +12,12 @@ If you can’t (or prefer not to) run the [automatic setup](/platforms/react-nat
 
 Install the `@sentry/react-native` package:
 
-```bash {tabTitle:Yarn}
-yarn add @sentry/react-native
-```
-
 ```bash {tabTitle:npm}
 npm install --save @sentry/react-native
+```
+
+```bash {tabTitle:Yarn}
+yarn add @sentry/react-native
 ```
 
 ## iOS

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -22,9 +22,9 @@ yarn add @sentry/react-native
 
 ## iOS
 
-For iOS, we wrap the React Native bundle process to automatically upload source maps to Sentry. We also add new Xcode Build Phase to upload debug symbols to make sure that you get readable stack traces for your native crashes.
+For iOS, the Sentry SDK wraps the React Native bundle process to upload source maps automatically. The SDK also adds a new Xcode Build Phase to upload debug symbols to ensure you get readable stack traces for your native crashes.
 
-### Add sentry.properties
+### Add `sentry.properties`
 
 Add a `sentry.properties` file to your `ios` directory.
 
@@ -35,7 +35,7 @@ defaults.project=___PROJECT_SLUG___
 auth.token=___ORG_AUTH_TOKEN___
 ```
 
-### Add auto source maps upload
+### Configure Automatic Source Maps Upload
 
 We modify the React Native build phase (“Bundle React Native code and images”) slightly from this:
 
@@ -65,7 +65,7 @@ BUNDLE_REACT_NATIVE="/bin/sh $SENTRY_XCODE $REACT_NATIVE_XCODE"
 # /bin/sh -c "$BUNDLE_REACT_NATIVE"
 ```
 
-To cahnge the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:
+To change the default behavior, pass the following environment variables in `.xcode.env` or in the Build Phase script:
 
 ```bash {filename:.xcode.env}
 export SENTRY_PROPERTIES=path/to/sentry.properties
@@ -83,7 +83,7 @@ export MODULES_PATHS="../node_modules,../my-custom-module"
 
 By default, uploading of source maps for debug simulator builds is disabled for speed reasons. If you want to generate source maps for debug builds, you can pass `--allow-fetch` as a parameter to `SENTRY_CLI_RN_XCODE_EXTRA_ARGS` in the above mentioned script.
 
-### Add auto debug symbols upload
+### Configure Automatic Debug Symbols Upload
 
 To upload debug symbols to Sentry, create a new Run Script build phase using the following script:
 
@@ -95,7 +95,7 @@ SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
 $SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 ```
 
-To cahnge the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:
+To change the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:
 
 ```bash {filename:.xcode.env}
 export SENTRY_PROPERTIES=path/to/sentry.properties
@@ -107,13 +107,13 @@ export SENTRY_CLI_EXTRA_ARGS="--extra --flags" # Extra arguments for sentry-cli 
 export SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS="--extra --flags"
 ```
 
-For more information about what options to use in `SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS` visit [Sentry CLI Apple Debug Symbols](/platforms/apple/dsym/#sentry-cli) documentation.
+For more information about what options to use in `SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS` visit the [Sentry CLI Apple Debug Symbols](/platforms/apple/dsym/#sentry-cli) documentation.
 
 ### Linking the Native Library via CocoaPods
 
-To link the Native library via CocoaPods, link to the Native module in your Podfile. In React Native versions 0.60 and above, the podspec should be automatically linked, if that's not the case, you can link to the native module manually by adding the `RNSentry.podspec` to your Podfile. See below:
+To link the native library via CocoaPods, link to the native module in your Podfile. In React Native versions 0.60 and above, the podspec should be automatically linked. If isn't, you can link to the native module manually by adding the `RNSentry.podspec` to your Podfile as follows:
 
-```rb
+```ruby
 pod 'RNSentry', :path => '../node_modules/@sentry/react-native/RNSentry.podspec'
 ```
 
@@ -125,7 +125,7 @@ If you are using nvm or Volta, Xcode has trouble locating the default node binar
 
 For Android, we hook into Gradle for the source map build process. When you run `npx @sentry/wizard@latest -i reactNative`, the Gradle files are automatically updated. If you can't or don't want to do that, you can follow the steps below to update the files.
 
-### Add sentry.properties
+### Add `sentry.properties`
 
 Add a `sentry.properties` file to your `android` directory.
 

--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -8,31 +8,38 @@ description: "Learn about manual configuration for iOS and Android."
 
 If you can’t (or prefer not to) run the [automatic setup](/platforms/react-native), use the instructions below to configure your application.
 
-<Alert level="info" title="Prerequisite">
+## Install SDK Package
 
-Before you can begin, you need to create a `sentry.properties` file at the root of your React Native _android_ and _ios_ project directories. Check out these examples of property files for [iOS](https://github.com/getsentry/examples/blob/master/react-native/AwesomeProject/ios/sentry.properties) and [Android](https://github.com/getsentry/examples/blob/master/react-native/AwesomeProject/android/sentry.properties).
+Install the `@sentry/react-native` package:
 
-</Alert>
+```bash {tabTitle:Yarn}
+yarn add @sentry/react-native
+```
+
+```bash {tabTitle:npm}
+npm install --save @sentry/react-native
+```
 
 ## iOS
 
-### Linking the Native Library via CocoaPods
+For iOS, we wrap the React Native bundle process to automatically upload source maps to Sentry. We also add new Xcode Build Phase to upload debug symbols to make sure that you get readable stack traces for your native crashes.
 
-To link the Native library via CocoaPods, link to the Native module in your Podfile. In React Native versions 0.60 and above, the podspec should be automatically linked, if that's not the case, you can link to the native module manually by adding the `RNSentry.podspec` to your Podfile. See below:
+### Add sentry.properties
 
-```rb
-pod 'RNSentry', :path => '../node_modules/@sentry/react-native/RNSentry.podspec'
+Add a `sentry.properties` file to your `ios` directory.
+
+```properties {filename: ios/sentry.properties}
+defaults.url=https://sentry.io/
+defaults.org=___ORG_SLUG___
+defaults.project=___PROJECT_SLUG___
+auth.token=___ORG_AUTH_TOKEN___
 ```
 
-### Upload Debug Symbols
-
-[Debug symbols](/platforms/native/data-management/debug-files/) help provide you with readable stack traces, which Sentry displays on the **Issue Details** page, to help you triage an issue. With our React Native SDK, debug symbols are used to symbolicate Native layer (iOS/Android) events. When you use Xcode, you can hook directly into the build process to upload debug symbols. When linking, one build phase script is changed and two more are added.
-
-#### Bundle React Native Code and Images
+### Add auto source maps upload
 
 We modify the React Native build phase (“Bundle React Native code and images”) slightly from this:
 
-```bash
+```bash {filename:Bundle React Native code and images}
 set -e
 
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
@@ -43,33 +50,44 @@ REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
 
 To this:
 
-```bash
-export SENTRY_PROPERTIES=sentry.properties
-export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"
+```bash {filename:Bundle React Native code and images}
 set -e
 
-# RN 0.69+
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
-SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
+SENTRY_XCODE="../node_modules/@sentry/react-native/scripts/sentry-xcode.sh"
+BUNDLE_REACT_NATIVE="/bin/sh $SENTRY_XCODE $REACT_NATIVE_XCODE"
 
-/bin/sh -c "$WITH_ENVIRONMENT \"$SENTRY_CLI react-native xcode $REACT_NATIVE_XCODE\""
+# RN 0.69+
+/bin/sh -c "$WITH_ENVIRONMENT \"$BUNDLE_REACT_NATIVE\""
 
 # RN 0.46 – 0.68
-# ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \
-#  ../node_modules/react-native/scripts/react-native-xcode.sh
-
-# All versions
-/bin/sh ../node_modules/@sentry/react-native/scripts/collect-modules.sh
+# /bin/sh -c "$BUNDLE_REACT_NATIVE"
 ```
 
-Additionally, we add a build script named “Upload Debug Symbols to Sentry” to upload debug symbols to Sentry.
+To cahnge the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:
 
-#### Upload Debug Symbols to Sentry
+```bash {filename:.xcode.env}
+export SENTRY_PROPERTIES=path/to/sentry.properties
+export SENTRY_DISABLE_AUTO_UPLOAD=true # Temporarily disable source map upload
 
-To upload source maps and symbols to Sentry, create a new Run Script build phase using the following script:
+export AUTO_RELEASE=true # Automatically detect release from Xcode project
+export SENTRY_CLI_EXECUTABLE="paht/to/@sentry/cli/bin/sentry-cli"
+export SENTRY_CLI_EXTRA_ARGS="--extra --flags" # Extra arguments for sentry-cli in all build phases
+export SENTRY_CLI_RN_XCODE_EXTRA_ARGS="--extra --flags"
 
-```bash
+export SOURCE_MAP_PATH="path/to/source-maps" # From where collect-modules should read modules
+export SENTRY_COLLECT_MODULES="path/to/collect-modules.sh"
+export MODULES_PATHS="../node_modules,../my-custom-module"
+```
+
+By default, uploading of source maps for debug simulator builds is disabled for speed reasons. If you want to generate source maps for debug builds, you can pass `--allow-fetch` as a parameter to `SENTRY_CLI_RN_XCODE_EXTRA_ARGS` in the above mentioned script.
+
+### Add auto debug symbols upload
+
+To upload debug symbols to Sentry, create a new Run Script build phase using the following script:
+
+```bash {filename:Upload Debug Symbols to Sentry}
 export SENTRY_PROPERTIES=sentry.properties
 
 [[ $SENTRY_INCLUDE_NATIVE_SOURCES == "true" ]] && INCLUDE_SOURCES_FLAG="--include-sources" || INCLUDE_SOURCES_FLAG=""
@@ -77,9 +95,27 @@ SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
 $SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 ```
 
-By default, uploading of debug simulator builds is disabled for speed reasons. If you want to generate debug symbols for debug builds, you can pass `--allow-fetch` as a parameter to `react-native-xcode` in the above mentioned build phase.
+To cahnge the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:
 
-For more information visit [Sentry CLI Apple Debug Symbols](/platforms/apple/dsym/#sentry-cli) documentation.
+```bash {filename:.xcode.env}
+export SENTRY_PROPERTIES=path/to/sentry.properties
+export SENTRY_DISABLE_AUTO_UPLOAD=true # Temporarily disable debug symbols upload
+
+export SENTRY_INCLUDE_NATIVE_SOURCES=true # Upload native iOS sources
+export SENTRY_CLI_EXECUTABLE="paht/to/@sentry/cli/bin/sentry-cli"
+export SENTRY_CLI_EXTRA_ARGS="--extra --flags" # Extra arguments for sentry-cli in all build phases
+export SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS="--extra --flags"
+```
+
+For more information about what options to use in `SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS` visit [Sentry CLI Apple Debug Symbols](/platforms/apple/dsym/#sentry-cli) documentation.
+
+### Linking the Native Library via CocoaPods
+
+To link the Native library via CocoaPods, link to the Native module in your Podfile. In React Native versions 0.60 and above, the podspec should be automatically linked, if that's not the case, you can link to the native module manually by adding the `RNSentry.podspec` to your Podfile. See below:
+
+```rb
+pod 'RNSentry', :path => '../node_modules/@sentry/react-native/RNSentry.podspec'
+```
 
 ### Using node with nvm or Volta
 
@@ -87,7 +123,18 @@ If you are using nvm or Volta, Xcode has trouble locating the default node binar
 
 ## Android
 
-For Android, we hook into Gradle for the source map build process. When you run `npx @sentry/wizard -i reactNative -p ios android`, the Gradle files are automatically updated. If you can't or don't want to do that, you can follow the steps below to update the files.
+For Android, we hook into Gradle for the source map build process. When you run `npx @sentry/wizard@latest -i reactNative`, the Gradle files are automatically updated. If you can't or don't want to do that, you can follow the steps below to update the files.
+
+### Add sentry.properties
+
+Add a `sentry.properties` file to your `android` directory.
+
+```properties {filename: android/sentry.properties}
+defaults.url=https://sentry.io/
+defaults.org=___ORG_SLUG___
+defaults.project=___PROJECT_SLUG___
+auth.token=___ORG_AUTH_TOKEN___
+```
 
 ### Enable Gradle Integration
 

--- a/src/platforms/react-native/troubleshooting/index.mdx
+++ b/src/platforms/react-native/troubleshooting/index.mdx
@@ -256,6 +256,40 @@ module.exports = {
 
 React Native 0.60.3 tooling was unexpectedly moving source maps files, which caused the Sentry Gradle plugin to fail. This was fixed in version 0.60.4. For more detailed information, follow the [issue](https://github.com/getsentry/sentry-react-native/issues/2442).
 
+## SDK v5.10.0 and older Xcode Build phases
+
+If you're using SDK v5.10.0 or older, use the following build phases in Xcode. If you are using SDK v5.11.0 or newer, read the current [Manual Setup](/platforms/react-native/manual-setup/manual-setup/).
+
+```bash {filename:Bundle React Native code and images}
+export SENTRY_PROPERTIES=sentry.properties
+export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"
+set -e
+
+# RN 0.69+
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
+SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
+
+/bin/sh -c "$WITH_ENVIRONMENT \"$SENTRY_CLI react-native xcode $REACT_NATIVE_XCODE\""
+
+# RN 0.46 – 0.68
+# ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \
+#  ../node_modules/react-native/scripts/react-native-xcode.sh
+
+# All versions
+/bin/sh ../node_modules/@sentry/react-native/scripts/collect-modules.sh
+```
+
+And Build Phase for native debug symbols upload.
+
+```bash {filename:Upload Debug Symbols to Sentry}
+export SENTRY_PROPERTIES=sentry.properties
+
+[[ $SENTRY_INCLUDE_NATIVE_SOURCES == "true" ]] && INCLUDE_SOURCES_FLAG="--include-sources" || INCLUDE_SOURCES_FLAG=""
+SENTRY_CLI="../node_modules/@sentry/cli/bin/sentry-cli"
+$SENTRY_CLI debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
+```
+
 ## Missing Java stack trace on the New Architecture
 
 If you're using the new architecture on React Native, you might be missing the Java stack trace. Follow the [issue](https://github.com/facebook/react-native/issues/34923) for more information.

--- a/src/platforms/react-native/troubleshooting/index.mdx
+++ b/src/platforms/react-native/troubleshooting/index.mdx
@@ -256,7 +256,7 @@ module.exports = {
 
 React Native 0.60.3 tooling was unexpectedly moving source maps files, which caused the Sentry Gradle plugin to fail. This was fixed in version 0.60.4. For more detailed information, follow the [issue](https://github.com/getsentry/sentry-react-native/issues/2442).
 
-## SDK v5.10.0 and older Xcode Build phases
+## SDK v5.10.0 and Older Xcode Build Phases
 
 If you're using SDK v5.10.0 or older, use the following build phases in Xcode. If you are using SDK v5.11.0 or newer, read the current [Manual Setup](/platforms/react-native/manual-setup/manual-setup/).
 


### PR DESCRIPTION
Adds docs for new Xcode Build Phase scripts shipped in https://github.com/getsentry/sentry-react-native/releases/tag/5.11.0
