### PR TITLE
chore(github): Mention github action restricted to business plan

### DIFF
--- a/src/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/src/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -199,7 +199,21 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 
 ### Issue Management
 
-Issue tracking allows you to create GitHub issues from within Sentry, and link Sentry issues to existing GitHub Issues.
+Issue tracking allows you to create GitHub issues from within Sentry, and link
+Sentry issues to existing GitHub Issues.
+
+<Alert title="Note" level="info">
+  <p>
+    Manual issue management is available to organizations on Team, Business, and
+    Enterprise plans.
+  </p>
+  <p>
+    Automatic issue management is available to organizations that include
+    transactions in their Business and Enterprise plans.
+  </p>
+</Alert>
+
+Issue management can be configured in two ways - automatically or manually.
 
 #### Automatically
 


### PR DESCRIPTION
Copied from Jira/Azure, will look like below (except github instead of jira)
<img width="782" alt="Screenshot 2023-11-03 at 2 30 03 PM" src="https://github.com/getsentry/sentry-docs/assets/67301797/2e871120-d582-427c-b794-304cb2329c9b">
