### PR TITLE
Ruby: add proxy config docs

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -251,6 +251,30 @@ config.trusted_proxies = ["2.2.2.2"]
 config.transport.transport_class = MyTransportClass
 ```
 
+`proxy`
+
+: Setup a proxy to use to connect to Sentry. This option is respected by the default `Sentry::HTTPTransport` class. You can set `config.transport.proxy` with as a `String` containing a proxy URI, or a `URI` object, or a `Hash` containing `uri`, `user` and `password` keys.
+
+```ruby
+Sentry.init do |config|
+  # ...
+
+  # Provide proxy config as a String
+  config.transport.proxy = "http://user:password@proxyhost.net:8080"
+
+  # Or a URI
+  config.transport.proxy = URI("http://user:password@proxyhost.net:8080")
+
+  # Or a Hash
+  config.transport.proxy = {
+    uri: "http://proxyhost.net:8080",
+    user: "user",
+    password: "password"
+  }
+end
+
+```
+
 ## Environment Variables
 
 `SENTRY_DSN`


### PR DESCRIPTION
## Summary

This PR adds a little blob on configuring proxy in `sentry-ruby`. 

I worked on https://github.com/getsentry/sentry-ruby/pull/2161 and realized that proxy configuration is not documented yet — so here we go. 

@shanamatthews, in `sentry-ruby` 5.1.2, we don't yet support reading proxy from env variables, but we just pushed up a PR with it. Is it a good idea to document the env var behavior in this PR, or wait until it's merged and released?

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
