### PR TITLE
chore(android): Add note on min. required Kotlin version

### DIFF
--- a/src/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
+++ b/src/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
@@ -17,7 +17,7 @@ The [Sentry Kotlin Compiler Plugin](https://github.com/getsentry/sentry-android-
 
 <Note>
 
-The Sentry Kotlin Compiler plugin is considered _experimental_. Give it a try and provide early feedback [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin).
+Because the Sentry Compiler plugin uses newer Kotlin Compiler features, the minimum supported Kotlin version is `1.8.20`.
 
 </Note>
 

--- a/src/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
+++ b/src/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
@@ -17,7 +17,7 @@ The [Sentry Kotlin Compiler Plugin](https://github.com/getsentry/sentry-android-
 
 <Note>
 
-Because the Sentry Compiler plugin uses newer Kotlin Compiler features, the minimum supported Kotlin version is `1.8.20`.
+The minimum supported Kotlin version is `1.8.20`.
 
 </Note>
 


### PR DESCRIPTION
Since the compiler plugin has been out for more than half-a-year, I think it's fine to replace the experimental note altogether.

Came up in https://github.com/getsentry/sentry-android-gradle-plugin/issues/591