### PR TITLE
Update elixir documentation to reflect library behavior

### DIFF
--- a/src/platforms/elixir/usage/index.mdx
+++ b/src/platforms/elixir/usage/index.mdx
@@ -82,8 +82,8 @@ user: %{
 
 ## Breadcrumbs
 
-Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context.
+Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context. Note that the breadcrumbs must be in the format in https://docs.sentry.io/product/issues/issue-details/breadcrumbs/#breadcrumbs-display, or else the library will fail to submit correct breadcrumbs.
 
 ```elixir
-Sentry.Context.add_breadcrumb(%{my: "crumb"})
+Sentry.Context.add_breadcrumb(%{type: "default", message: "breadcrumb", level: info})
 ```

--- a/src/platforms/elixir/usage/index.mdx
+++ b/src/platforms/elixir/usage/index.mdx
@@ -82,7 +82,7 @@ user: %{
 
 ## Breadcrumbs
 
-Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context. Note that the breadcrumbs must be in the format in https://docs.sentry.io/product/issues/issue-details/breadcrumbs/#breadcrumbs-display, or else the library will fail to submit correct breadcrumbs.
+Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context. Breadcrumbs must be in the format described in the [Breadcrumbs](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/#breadcrumbs-display) docs, or else the library will fail to submit correct breadcrumbs.
 
 ```elixir
 Sentry.Context.add_breadcrumb(%{type: "default", message: "breadcrumb", level: info})

--- a/src/platforms/elixir/usage/index.mdx
+++ b/src/platforms/elixir/usage/index.mdx
@@ -82,7 +82,7 @@ user: %{
 
 ## Breadcrumbs
 
-Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context. Breadcrumbs must be in the format described in the [Breadcrumbs](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/#breadcrumbs-display) docs, or else the library will fail to submit correct breadcrumbs.
+Sentry supports capturing breadcrumbs – events that happened prior to an issue. We need to be careful because breadcrumbs are per-process. If a process dies it might lose its context. Breadcrumbs must be in the format described in the [Breadcrumbs](/product/issues/issue-details/breadcrumbs/#breadcrumbs-display) docs, or else the library will fail to submit correct breadcrumbs.
 
 ```elixir
 Sentry.Context.add_breadcrumb(%{type: "default", message: "breadcrumb", level: info})


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The current Elixir library doesn't have functionality for submitting arbitrary breadcrumbs without the user coercing the format. If the format is a random dictionary, the library silently fails. This updates the documentation to reflect the behavior.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
