### PR TITLE
ref(apple): Move opt out to bottom

### DIFF
--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -324,39 +324,6 @@ func loadUserDataOnClick() {
 
 When the user interaction transaction is not finished yet, but the user makes a new interaction, or the SDK starts a new UIViewController transaction, the SDK automatically finishes the previous user interaction transaction. This is because only one transaction can be bound to the scope at a time. However, if the same view has been interacted with (for example, a `UIButton` was clicked again within the `idleTimeout` window), the idle timer will be reset and the transaction duration will be extended with the `idleTimeout` value.
 
-## Opt Out
-
-You can opt out of all automatic instrumentations using the options:
-
-<SignInNote />
-
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.enableAutoPerformanceTracing = false
-
-    // Before 8.0.0
-    options.enableAutoPerformanceTracking = false
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-    options.enableAutoPerformanceTracing = NO;
-
-    // Before 8.0.0
-    options.enableAutoPerformanceTracking = NO;
-}];
-```
-
-[UIWindow]: https://developer.apple.com/documentation/uikit/uiwindowdidbecomevisiblenotification
-[didFinishLaunching]: https://developer.apple.com/documentation/uikit/uiapplication/1622971-didfinishlaunchingnotification
-
 ### Time to Initial Display
 
 _(New in version 8.4.0)_
@@ -414,3 +381,36 @@ SentrySDK.reportFullyDisplayed()
 
 If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it will be finished by the SDK automatically, and its `status` will be set to `SpanStatus.DEADLINE_EXCEEDED`, also its duration will match the same of the `Time to initial display` span and the description will contain `Deadline Exceeded` suffix.
 If a call to `reportFullyDisplayed()` happens before the view controller appears, the reported time will be shifted to `Time to initial display` measured time.
+
+## Opt Out
+
+You can opt out of all automatic instrumentations using the options:
+
+<SignInNote />
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enableAutoPerformanceTracing = false
+
+    // Before 8.0.0
+    options.enableAutoPerformanceTracking = false
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enableAutoPerformanceTracing = NO;
+
+    // Before 8.0.0
+    options.enableAutoPerformanceTracking = NO;
+}];
+```
+
+[UIWindow]: https://developer.apple.com/documentation/uikit/uiwindowdidbecomevisiblenotification
+[didFinishLaunching]: https://developer.apple.com/documentation/uikit/uiapplication/1622971-didfinishlaunchingnotification


### PR DESCRIPTION


## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Move the opt-out section of APM to the bottom of the page.

| Before | After |
|--------|--------|
| ![CleanShot 2023-11-07 at 11 40 46@2x](https://github.com/getsentry/sentry-docs/assets/2443292/f83670be-cbb3-4f07-83ad-c66b7e9d9df0)| ![CleanShot 2023-11-07 at 11 41 21@2x](https://github.com/getsentry/sentry-docs/assets/2443292/7483ae7e-d769-4317-be76-03ec787806cd) | 


