### PR TITLE
feat(reactnative): Add source maps upload guide with Debug IDs

### DIFF
--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -6,6 +6,45 @@ redirect_from:
   - /platforms/react-native/hermes/
 ---
 
+Sentry React Native SDK supports `Hermes` engine out of the box.
+
+## Source maps
+
+Read our [React Native source maps documentation](/platforms/react-native/sourcemaps/) to learn how to upload source maps for your app.
+
+## Throubleshooting
+
+This section describes common issues when using Hermes and how to resolve them.
+
+### Multiple ways of enabling source maps in Xcode
+
+If you use `EXTRA_PACKAGER_ARGS`, only the packager source map is needed. This is the default behavior if you used [`@sentry/wizard`](/platforms/react-native/#install). If you use [`SOURCEMAP_FILE`](https://reactnative.dev/docs/sourcemaps#enable-source-maps-on-ios), the combined Hermes soruc map is necessary.
+
+### Check steps of RN tooling
+
+Our [React Native source maps documentation](/platforms/react-native/sourcemaps/) is based on [`react-native-xcode.sh`](https://github.com/facebook/react-native/blob/0.71-stable/scripts/react-native-xcode.sh) for iOS and on [`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) for Android. If you are having issues with the manually generated artifacts check the steps of your React Native tooling using the meantioned links.
+
+<Note>
+
+React Native [`0.70`](https://github.com/facebook/react-native/blob/e3a5fbe72f966b27b967192317d7072db52d1c8c/scripts/react-native-xcode.sh#L141) and CodePush Update minifies the packager bundle by default.
+
+</Note>
+
+<Note>
+
+[`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) is only available from version `0.71` on. For previous versions, use [`react.gradle`](https://github.com/facebook/react-native/blob/0.70-stable/react.gradle).
+
+</Note>
+
+For more details see [this issue](https://github.com/facebook/react-native/issues/34043) in the React Native repository.
+
+
+### Don't combine Hermes and RAM bundles
+
+If you are using Hermes, you should not have the [RAM bundles](/platforms/react-native/manual-setup/ram-bundles/) feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.
+
+### Minimum Required Versions
+
 Sentry added support for `react-native` builds that use the `hermes` engine, which required changes to the Sentry SDK, `sentry-cli` as well as Sentry itself.
 
 Sentry customers using the SaaS product (sentry.io) will need to update the SDK, and `sentry-cli`.
@@ -15,120 +54,6 @@ and `@sentry/cli` [version `1.51.1`](https://github.com/getsentry/sentry-cli/rel
 For self-hosted Sentry users, the minimum version required is [f07352b](https://hub.docker.com/r/getsentry/sentry/tags?page=1&name=f07352b).
 
 Once you have the minimum version of the SDK, Sentry provides the standard integration as described in the [React Native Sentry documentation](/platforms/react-native/).
-
-<Note>
-
-If you are using Hermes, you should not have the [RAM bundles](/platforms/react-native/manual-setup/ram-bundles/) feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.
-
-</Note>
-
-## Source Maps
-
-If you do not need custom source maps, the `sentry.gradle` build step fully supports Hermes source maps.
-
-## Custom Source Maps
-
-This document walks through the steps to manually generate and upload custom source maps. When generating your source maps, it's important to match the steps of your React Native tooling exactly, otherwise the generated bundle won't work correctly, and your errors may point to unrelated lines.
-
-The React Native tooling steps are extracted from [`react-native-xcode.sh`](https://github.com/facebook/react-native/blob/0.71-stable/scripts/react-native-xcode.sh) for iOS and from [`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) for Android.
-
-<Note>
-
-[`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) is only available from version `0.71` on. For previous versions, use [`react.gradle`](https://github.com/facebook/react-native/blob/0.70-stable/react.gradle).
-
-</Note>
-
-### Compile Source maps
-
-Depending on how your app bundle was generated not all these compilation steps are required:
-
-- If you use `EXTRA_PACKAGER_ARGS` on `iOS`, only the first step applies. This is the default behavior if you used [`@sentry/wizard`](/platforms/react-native/#install).
-- If you use [`SOURCEMAP_FILE`](https://reactnative.dev/docs/sourcemaps#enable-source-maps-on-ios), all steps are necessary.
-
-<Note>
-
-We recommend using the bundle and source maps generated by React Native tooling. If you are having issues with the manually generated artifacts see [this issue](https://github.com/facebook/react-native/issues/34043) for more information.
-
-</Note>
-
-1. Bundle/minify with `metro` (`react-native`) to get the bundle (`.bundle` or `.jsbundle`) and packager source map (`.map`):
-
-<Note>
-
-React Native [`0.70`](https://github.com/facebook/react-native/blob/e3a5fbe72f966b27b967192317d7072db52d1c8c/scripts/react-native-xcode.sh#L141) and CodePush Update minifies the packager bundle by default.
-
-</Note>
-
-```bash {tabTitle:Android}
-npx react-native bundle --platform android --dev false --entry-file index.js --reset-cache --bundle-output index.android.bundle --sourcemap-output index.android.bundle.packager.map --minify false
-```
-
-```bash {tabTitle:iOS}
-npx react-native bundle --platform ios --dev false --entry-file index.js --reset-cache --bundle-output main.jsbundle --sourcemap-output main.jsbundle.map --minify false
-```
-
-2. Compile to bytecode using `hermes` to get the compiler source map (`.hbc.map`):
-
-<Note>
-
-`OS-BIN` is `osx-bin`, `win64-bin`, or `linux64-bin`, depending on which operating system you are using.
-
-</Note>
-
-If you're using Hermes with **React Native 0.68 or below**:
-
-```bash {tabTitle:Android}
-node_modules/hermes-engine/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.hbc index.android.bundle
-rm -f index.android.bundle
-mv index.android.bundle.hbc index.android.bundle
-```
-
-```bash {tabTitle:iOS}
-ios/Pods/hermes-engine/destroot/bin/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.hbc main.jsbundle
-rm -f main.jsbundle
-mv main.jsbundle.hbc main.jsbundle
-```
-
-Starting with **React Native 0.69**, `hermes` has been [shipped with React Native](https://reactnative.dev/blog/2022/06/21/version-069#bundled-hermes), so you should use `hermesc` from `react-native`:
-
-```bash {tabTitle:Android}
-node_modules/react-native/sdks/hermesc/{OS-BIN}/hermesc -O -emit-binary -output-source-map -out=index.android.bundle.hbc index.android.bundle
-rm -f index.android.bundle
-mv index.android.bundle.hbc index.android.bundle
-```
-
-```bash {tabTitle:iOS}
-ios/Pods/hermes-engine/destroot/bin/hermesc -O -emit-binary -output-source-map -out=main.jsbundle.hbc main.jsbundle
-rm -f main.jsbundle
-mv main.jsbundle.hbc main.jsbundle
-```
-
-3. Merge the two source maps using `compose-source-maps` to get the final source map (`.map`):
-
-```bash {tabTitle:Android}
-node node_modules/react-native/scripts/compose-source-maps.js index.android.bundle.packager.map index.android.bundle.hbc.map -o index.android.bundle.map
-```
-
-```bash {tabTitle:iOS}
-mv main.jsbundle.map main.jsbundle.packager.map
-node node_modules/react-native/scripts/compose-source-maps.js main.jsbundle.packager.map main.jsbundle.hbc.map -o main.jsbundle.map
-```
-
-### Upload the Bundle and Source Maps
-
-Upload your source maps following [Step 3 on the normal source maps guide](/platforms/react-native/sourcemaps/#3-upload-the-bundle-and-source-maps).
-
-<Note>
-
-You will upload the `index.android.bundle` and `index.android.bundle.map` for Android, `main.jsbundle` and `main.jsbundle.map` for iOS.
-
-</Note>
-
-<Note>
-
-When uploaded, the `index.android.bundle` file will be sized at 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
-
-</Note>
 
 ### Upload Using Sentry Fastlane Plugin
 

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -8,21 +8,21 @@ redirect_from:
 
 Sentry React Native SDK supports `Hermes` engine out of the box.
 
-## Source maps
+## Source Maps
 
-Read our [React Native source maps documentation](/platforms/react-native/sourcemaps/) to learn how to upload source maps for your app.
+Read our React Native [Source Maps](/platforms/react-native/sourcemaps/) documentation to learn how to upload source maps for your app.
 
 ## Throubleshooting
 
 This section describes common issues when using Hermes and how to resolve them.
 
-### Multiple ways of enabling source maps in Xcode
+### Multiple ways of Enabling Source Maps in Xcode
 
-If you use `EXTRA_PACKAGER_ARGS`, only the packager source map is needed. This is the default behavior if you used [`@sentry/wizard`](/platforms/react-native/#install). If you use [`SOURCEMAP_FILE`](https://reactnative.dev/docs/sourcemaps#enable-source-maps-on-ios), the combined Hermes soruc map is necessary.
+If you use `EXTRA_PACKAGER_ARGS`, you only need the packager source map. This is the default behavior if you used [`@sentry/wizard`](/platforms/react-native/#install). If you use [`SOURCEMAP_FILE`](https://reactnative.dev/docs/sourcemaps#enable-source-maps-on-ios), the combined Hermes source map is necessary.
 
-### Check steps of RN tooling
+### Check RN Tooling Steps
 
-Our [React Native source maps documentation](/platforms/react-native/sourcemaps/) is based on [`react-native-xcode.sh`](https://github.com/facebook/react-native/blob/0.71-stable/scripts/react-native-xcode.sh) for iOS and on [`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) for Android. If you are having issues with the manually generated artifacts check the steps of your React Native tooling using the meantioned links.
+Our React Native [Source Maps](/platforms/react-native/sourcemaps/) documentation is based on [`react-native-xcode.sh`](https://github.com/facebook/react-native/blob/0.71-stable/scripts/react-native-xcode.sh) for iOS and on [`BundleHermesCTask.kt`](https://github.com/facebook/react-native/blob/0.71-stable/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt) for Android. If you are having issues with the manually generated artifacts check the steps of your React Native tooling using the previous links.
 
 <Note>
 
@@ -38,7 +38,7 @@ React Native [`0.70`](https://github.com/facebook/react-native/blob/e3a5fbe72f96
 
 For more details see [this issue](https://github.com/facebook/react-native/issues/34043) in the React Native repository.
 
-### Don't combine Hermes and RAM bundles
+### Don't Combine Hermes and RAM Bundles
 
 If you are using Hermes, you should not have the [RAM bundles](/platforms/react-native/manual-setup/ram-bundles/) feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.
 
@@ -46,7 +46,7 @@ If you are using Hermes, you should not have the [RAM bundles](/platforms/react-
 
 Sentry added support for `react-native` builds that use the `hermes` engine, which required changes to the Sentry SDK, `sentry-cli` as well as Sentry itself.
 
-Sentry customers using the SaaS product (sentry.io) will need to update the SDK, and `sentry-cli`.
+Sentry customers using the SaaS product ([sentry.io](https://sentry.io/)) will need to update the SDK and `sentry-cli`.
 The minimum required version for the SDK is `@sentry/react-native` [SDK version `1.3.3`](https://github.com/getsentry/sentry-react-native/releases/tag/1.3.3),
 and `@sentry/cli` [version `1.51.1`](https://github.com/getsentry/sentry-cli/releases/tag/1.51.1).
 

--- a/src/platforms/react-native/manual-setup/hermes.mdx
+++ b/src/platforms/react-native/manual-setup/hermes.mdx
@@ -38,7 +38,6 @@ React Native [`0.70`](https://github.com/facebook/react-native/blob/e3a5fbe72f96
 
 For more details see [this issue](https://github.com/facebook/react-native/issues/34043) in the React Native repository.
 
-
 ### Don't combine Hermes and RAM bundles
 
 If you are using Hermes, you should not have the [RAM bundles](/platforms/react-native/manual-setup/ram-bundles/) feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.

--- a/src/platforms/react-native/sourcemaps/index.mdx
+++ b/src/platforms/react-native/sourcemaps/index.mdx
@@ -30,11 +30,30 @@ The wizard will guide you through the following steps:
 - Installing the necessary Sentry packages
 - Configuring RN build tools to generate and upload source maps
 
-Supports JavaScript Core (including RAM Bundle) and Hermes. If you want to configure automatic source maps upload manually, follow the steps on [Manual Configuration](/platforms/react-native/manual-setup/manual-setup) page.
+It supports JavaScript Core (including RAM Bundle) and Hermes. If you want to configure automatic source maps upload manually, follow the steps on [Manual Configuration](/platforms/react-native/manual-setup/manual-setup) page.
+
+### Disable the Automatic Upload
+
+If you want to disable the automatic upload of source maps, you can set the `SENTRY_DISABLE_AUTO_UPLOAD` environment variable:
+
+```bash
+export SENTRY_DISABLE_AUTO_UPLOAD=true
+```
+
+Add use `shouldSentryAutoUpload` function in `android/app/build.gradle`.
+
+```gradle
+apply from: "../../../sentry.gradle"
+
+sentry {
+    autoUploadProguardMapping = shouldSentryAutoUpload()
+    uploadNativeSymbols = shouldSentryAutoUpload()
+}
+```
 
 ## Manual Upload Hermes
 
-The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then, you need to upload them to Sentry.
+The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then combile the Hermes bytecode bundle. And finaly upload the source map to Sentry.
 
 Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
 
@@ -81,7 +100,7 @@ npx react-native bundle \
 Compile Hermes bytecode bundle and source map:
 
 ```bash {tabTitle:Android}
-node_modules/hermes-engine/{OS-BIN}/hermesc \
+node_modules/react-native/sdks/hermesc/osx-bin/hermesc \
   -O -emit-binary \
   -output-source-map \
   -out=index.android.bundle.hbc \
@@ -101,12 +120,35 @@ mv main.jsbundle.hbc main.jsbundle
 ```
 
 ```bash {tabTitle:Android on Linux}
+node_modules/react-native/sdks/hermesc/linux64-bin/hermesc \
+  -O -emit-binary \
+  -output-source-map \
+  -out=index.android.bundle.hbc \
+  index.android.bundle
+rm -f index.android.bundle
+mv index.android.bundle.hbc index.android.bundle
 ```
 
 ```bash {tabTitle:Android on Windows}
+node_modules/react-native/sdks/hermesc/win64-bin/hermesc \
+  -O -emit-binary \
+  -output-source-map \
+  -out=index.android.bundle.hbc \
+  index.android.bundle
+rm -f index.android.bundle
+mv index.android.bundle.hbc index.android.bundle
 ```
 
 ```bash {tabTitle:RN 0.68 and older}
+# node_modules/hermes-engine/win64-bin/hermesc \
+# node_modules/hermes-engine/linux64-bin/hermesc \
+node_modules/hermes-engine/osx-bin/hermesc \
+  -O -emit-binary \
+  -output-source-map \
+  -out=index.android.bundle.hbc \
+  index.android.bundle
+rm -f index.android.bundle
+mv index.android.bundle.hbc index.android.bundle
 ```
 
 Compose Hermes bytecode and (React Native Packager) Metro source maps:
@@ -118,6 +160,9 @@ node \
   index.android.bundle.packager.map \
   index.android.bundle.hbc.map \
   -o index.android.bundle.map
+node \
+  node_modules/@sentry/react-native/scripts/copy-debugid.js \
+  index.android.bundle.packager.map index.android.bundle.map
 ```
 
 ```bash {tabTitle:iOS}
@@ -127,42 +172,133 @@ node \
   main.jsbundle.packager.map \
   main.jsbundle.hbc.map \
   -o main.jsbundle.map
+node \
+  node_modules/@sentry/react-native/scripts/copy-debugid.js \
+  main.jsbundle.packager.map main.jsbundle.map
 ```
 
-## Manual Upload JavaScript Core
+Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
 
+<OrgAuthTokenNote />
 
+```bash {filename:.env}
+SENTRY_ORG=___ORG_SLUG___
+SENTRY_PROJECT=___PROJECT_SLUG___
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
 
-## Using custom Release and Distribution
+Upload the bundle and source map to Sentry:
 
-However, if you use custom values for your release other than the version included with the build in Xcode or Android Studio, the automatic source maps upload script will no longer work because it does not detect custom values. As a result, you'll need to manually upload source maps using these steps:
+```bash {tabTitle:Android}
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+  --strip-prefix /path/to/project/root \
+  index.android.bundle index.android.bundle.map
+```
 
-### 1. Set the Release and Distribution
-
-For events sent from Sentry to correctly be attributed to a release and subsequently its source maps, **both the `release` and `dist` values will need to be set.** You can set these values in the call to `init`, as discussed in our [Releases & Health content](/platforms/react-native/configuration/releases/).
+```bash {tabTitle:iOS}
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+  --strip-prefix /path/to/project/root \
+  main.jsbundle main.jsbundle.map
+```
 
 <Note>
 
-Before disabling the automatic source maps upload, you can set the `release` and `dist` as environment variables, `SENTRY_RELEASE` and `SENTRY_DIST` respectively. The script that performs the automatic source maps upload will use those values instead the default ones, and they will match the given `release` and `dist`. This ensures that the given custom `release` and `dist` values are used.
+When uploaded, the `bundle` file will be sized at 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
 
 </Note>
+
+For more Hermes guides, see [Hermes Throubleshooting section](/platforms/react-native/manual-setup/hermes/#throubleshooting).
+
+## Manual Upload JavaScript Core
+
+The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then, you need to upload them to Sentry.
+
+Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
+
+```js {filename="metro.config.js"}
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const {
+  createSentryMetroSerializer,
+} = require('@sentry/react-native/dist/js/tools/sentryMetroSerializer');
+
+const config = {
+  serializer: {
+    customSerializer: createSentryMetroSerializer(),
+  },
+};
+
+const m = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = m;
+```
+
+Generate the React Native Packager (Metro) bundle and source maps:
+
+```bash {tabTitle:Android}
+npx react-native bundle \
+  --dev false \
+  --minify true \
+  --platform android \
+  --entry-file index.js \
+  --reset-cache \
+  --bundle-output index.android.bundle \
+  --sourcemap-output index.android.bundle.map
+```
+
+```bash {tabTitle:iOS}
+npx react-native bundle \
+  --dev false \
+  --minify true \
+  --platform ios \
+  --entry-file index.js \
+  --reset-cache \
+  --bundle-output main.jsbundle \
+  --sourcemap-output main.jsbundle.map
+```
+
+Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
+
+<OrgAuthTokenNote />
+
+```bash {filename:.env}
+SENTRY_ORG=___ORG_SLUG___
+SENTRY_PROJECT=___PROJECT_SLUG___
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+Upload the bundle and source map to Sentry:
+
+```bash {tabTitle:Android}
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+  --strip-prefix /path/to/project/root \
+  index.android.bundle index.android.bundle.map
+```
+
+```bash {tabTitle:iOS}
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+  --strip-prefix /path/to/project/root \
+  main.jsbundle main.jsbundle.map
+```
+
+## Optional Release and Distribution
+
+For events sent from Sentry to correctly be attributed to a release **both the `release` and `dist` values will need to be set.** You can set these values in the call to `init`, as discussed in our [Releases & Health content](/platforms/react-native/configuration/releases/).
+
+```js
+Sentry.init({
+  dsn: '___DSN___',
+  release: 'my-project-name@2.3.12',
+  dist: '52',
+});
+```
+
+If you use custom values for your release other than the version included with the build in Xcode or Android Studio, the automatic source maps upload script will no longer work because it does not detect custom values. Use environment variables `SENTRY_RELEASE` and `SENTRY_DIST`. The script that performs the automatic source maps upload will use those values instead the default ones, and they will match the given `release` and `dist`. This ensures that the given custom `release` and `dist` values are used.
 
 ```bash
 export SENTRY_RELEASE="my-project-name@2.3.12"
 export SENTRY_DIST="52"
 ```
 
-If you've exported the environment variables and they match the given `release` and `dist` during the `Sentry.init` call, you can skip the next steps.
-
-### 2. Disable the automatic source maps upload script
-
-When you set a custom release or manually upload source maps, you will need to disable the automatic source map upload script:
-
-- In iOS, [revert the build script "Bundle React Native code and images"](/platforms/react-native/manual-setup/manual-setup/#bundle-react-native-code-and-images).
-
-- In Android, [remove the gradle integration](/platforms/react-native/manual-setup/manual-setup/#enable-gradle-integration).
-
-## Preparing Source Maps for a Release
+## Legacy Source Maps for Release Upload
 
 You need to generate and upload the source maps at build time for **every release** of your app for the events sent to be correctly unminified. To do so, follow these steps:
 

--- a/src/platforms/react-native/sourcemaps/index.mdx
+++ b/src/platforms/react-native/sourcemaps/index.mdx
@@ -58,10 +58,10 @@ The manual upload of source maps consists of a few simple steps. First, you need
 Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
 
 ```js {filename="metro.config.js"}
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 const {
   createSentryMetroSerializer,
-} = require('@sentry/react-native/dist/js/tools/sentryMetroSerializer');
+} = require("@sentry/react-native/dist/js/tools/sentryMetroSerializer");
 
 const config = {
   serializer: {
@@ -216,10 +216,10 @@ The manual upload of source maps consists of a few simple steps. First, you need
 Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
 
 ```js {filename="metro.config.js"}
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 const {
   createSentryMetroSerializer,
-} = require('@sentry/react-native/dist/js/tools/sentryMetroSerializer');
+} = require("@sentry/react-native/dist/js/tools/sentryMetroSerializer");
 
 const config = {
   serializer: {
@@ -285,9 +285,9 @@ For events sent from Sentry to correctly be attributed to a release **both the `
 
 ```js
 Sentry.init({
-  dsn: '___DSN___',
-  release: 'my-project-name@2.3.12',
-  dist: '52',
+  dsn: "___DSN___",
+  release: "my-project-name@2.3.12",
+  dist: "52",
 });
 ```
 

--- a/src/platforms/react-native/sourcemaps/index.mdx
+++ b/src/platforms/react-native/sourcemaps/index.mdx
@@ -16,9 +16,9 @@ If you are on an older version and you want to upload source maps we recommend u
 
 To get unminified stack traces for JavaScript code, source maps must be generated and uploaded. The React Native SDK handles source maps _automatically_ for iOS with Xcode and Android with Gradle, if you do not use custom values.
 
-## Setup Automatic Upload
+## Set Up Automatic Upload
 
-The easiest way to configure automatic uploading source maps is by using the Sentry Wizard:
+The easiest way to configure automatic source maps upload is to use the Sentry Wizard:
 
 ```bash
 npx @sentry/wizard@latest -i reactNative
@@ -30,9 +30,9 @@ The wizard will guide you through the following steps:
 - Installing the necessary Sentry packages
 - Configuring RN build tools to generate and upload source maps
 
-It supports JavaScript Core (including RAM Bundle) and Hermes. If you want to configure automatic source maps upload manually, follow the steps on [Manual Configuration](/platforms/react-native/manual-setup/manual-setup) page.
+It supports JavaScript Core (including RAM Bundle) and Hermes. If you want to configure automatic source maps upload manually, follow the steps on the [Manual Configuration](/platforms/react-native/manual-setup/manual-setup) page.
 
-### Disable the Automatic Upload
+### Disable Automatic Upload
 
 If you want to disable the automatic upload of source maps, you can set the `SENTRY_DISABLE_AUTO_UPLOAD` environment variable:
 
@@ -40,7 +40,7 @@ If you want to disable the automatic upload of source maps, you can set the `SEN
 export SENTRY_DISABLE_AUTO_UPLOAD=true
 ```
 
-Add use `shouldSentryAutoUpload` function in `android/app/build.gradle`.
+Add the `shouldSentryAutoUpload` function in `android/app/build.gradle`:
 
 ```gradle
 apply from: "../../../sentry.gradle"
@@ -51,13 +51,13 @@ sentry {
 }
 ```
 
-## Manual Upload Hermes
+## Manual Upload With Hermes
 
-The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then combile the Hermes bytecode bundle. And finaly upload the source map to Sentry.
+To manually upload source maps, first, you need to generate the source maps and bundle. Then compile the Hermes bytecode bundle, and finally upload the source map to Sentry.
 
 Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
 
-```js {filename="metro.config.js"}
+```javascript {filename="metro.config.js"}
 const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 const {
   createSentryMetroSerializer,
@@ -177,7 +177,7 @@ node \
   main.jsbundle.packager.map main.jsbundle.map
 ```
 
-Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
+Make sure `sentry-cli` is configured for your project and set up your environment variables:
 
 <OrgAuthTokenNote />
 
@@ -203,19 +203,19 @@ node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
 
 <Note>
 
-When uploaded, the `bundle` file will be sized at 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
+When uploaded, the `bundle` file will have a size of 0 bytes. This is expected with Hermes bytecode and won't affect the source maps resolution.
 
 </Note>
 
-For more Hermes guides, see [Hermes Throubleshooting section](/platforms/react-native/manual-setup/hermes/#throubleshooting).
+For more Hermes guides, see the [Hermes Throubleshooting](/platforms/react-native/manual-setup/hermes/#throubleshooting) docs section.
 
-## Manual Upload JavaScript Core
+## Manual Upload With JavaScript Core
 
-The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then, you need to upload them to Sentry.
+To manually upload source maps, first, you need to generate the source maps and bundle. Then compile the Hermes bytecode bundle, and finally upload the source map to Sentry.
 
-Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
+Start by adding Sentry React Native Metro Plugin to your `metro.config.js`:
 
-```js {filename="metro.config.js"}
+```javascript {filename="metro.config.js"}
 const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 const {
   createSentryMetroSerializer,
@@ -255,7 +255,7 @@ npx react-native bundle \
   --sourcemap-output main.jsbundle.map
 ```
 
-Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
+Make sure `sentry-cli` is configured for your project and set up your environment variables:
 
 <OrgAuthTokenNote />
 
@@ -281,9 +281,9 @@ node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
 
 ## Optional Release and Distribution
 
-For events sent from Sentry to correctly be attributed to a release **both the `release` and `dist` values will need to be set.** You can set these values in the call to `init`, as discussed in our [Releases & Health content](/platforms/react-native/configuration/releases/).
+To correctly attribute events sent to Sentry to a release, **both the `release` and `dist` values will need to be set.** You can set these values in the call to `init`, as discussed in our [Releases & Health](/platforms/react-native/configuration/releases/) documentation.
 
-```js
+```javascript
 Sentry.init({
   dsn: "___DSN___",
   release: "my-project-name@2.3.12",
@@ -291,14 +291,14 @@ Sentry.init({
 });
 ```
 
-If you use custom values for your release other than the version included with the build in Xcode or Android Studio, the automatic source maps upload script will no longer work because it does not detect custom values. Use environment variables `SENTRY_RELEASE` and `SENTRY_DIST`. The script that performs the automatic source maps upload will use those values instead the default ones, and they will match the given `release` and `dist`. This ensures that the given custom `release` and `dist` values are used.
+The automatic source maps upload script doesn't detect custom values for releases. This means that if you use a custom value for your release, other than the version included with the built-in Xcode or Android Studio, the automatic source maps upload script won't work. Instead, you can set the `SENTRY_RELEASE` and `SENTRY_DIST` environment variables, which the automatic source maps upload script will use. This will ensure that the given custom `release` and `dist` values are used.
 
 ```bash
 export SENTRY_RELEASE="my-project-name@2.3.12"
 export SENTRY_DIST="52"
 ```
 
-## Legacy Source Maps for Release Upload
+## Legacy Instructions for Preparing Source Maps for a Release
 
 You need to generate and upload the source maps at build time for **every release** of your app for the events sent to be correctly unminified. To do so, follow these steps:
 

--- a/src/platforms/react-native/sourcemaps/index.mdx
+++ b/src/platforms/react-native/sourcemaps/index.mdx
@@ -6,7 +6,132 @@ redirect_from:
 description: "Learn more about how to upload your source maps to Sentry."
 ---
 
+<Note>
+
+This guide assumes you are using a Sentry React Native SDK on version `5.11.0` or higher.
+
+If you are on an older version and you want to upload source maps we recommend upgrading your SDK to the newest version.
+
+</Note>
+
 To get unminified stack traces for JavaScript code, source maps must be generated and uploaded. The React Native SDK handles source maps _automatically_ for iOS with Xcode and Android with Gradle, if you do not use custom values.
+
+## Setup Automatic Upload
+
+The easiest way to configure automatic uploading source maps is by using the Sentry Wizard:
+
+```bash
+npx @sentry/wizard@latest -i reactNative
+```
+
+The wizard will guide you through the following steps:
+
+- Logging into Sentry and selecting a project
+- Installing the necessary Sentry packages
+- Configuring RN build tools to generate and upload source maps
+
+Supports JavaScript Core (including RAM Bundle) and Hermes. If you want to configure automatic source maps upload manually, follow the steps on [Manual Configuration](/platforms/react-native/manual-setup/manual-setup) page.
+
+## Manual Upload Hermes
+
+The manual upload of source maps consists of a few simple steps. First, you need to generate the source maps and bundle. Then, you need to upload them to Sentry.
+
+Start with adding Sentry React Native Metro Plugin to your `metro.config.js`:
+
+```js {filename="metro.config.js"}
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const {
+  createSentryMetroSerializer,
+} = require('@sentry/react-native/dist/js/tools/sentryMetroSerializer');
+
+const config = {
+  serializer: {
+    customSerializer: createSentryMetroSerializer(),
+  },
+};
+
+const m = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = m;
+```
+
+Generate the React Native Packager (Metro) bundle and source maps:
+
+```bash {tabTitle:Android}
+npx react-native bundle \
+  --dev false \
+  --minify false \
+  --platform android \
+  --entry-file index.js \
+  --reset-cache \
+  --bundle-output index.android.bundle \
+  --sourcemap-output index.android.bundle.map
+```
+
+```bash {tabTitle:iOS}
+npx react-native bundle \
+  --dev false \
+  --minify false \
+  --platform ios \
+  --entry-file index.js \
+  --reset-cache \
+  --bundle-output main.jsbundle \
+  --sourcemap-output main.jsbundle.map
+```
+
+Compile Hermes bytecode bundle and source map:
+
+```bash {tabTitle:Android}
+node_modules/hermes-engine/{OS-BIN}/hermesc \
+  -O -emit-binary \
+  -output-source-map \
+  -out=index.android.bundle.hbc \
+  index.android.bundle
+rm -f index.android.bundle
+mv index.android.bundle.hbc index.android.bundle
+```
+
+```bash {tabTitle:iOS}
+ios/Pods/hermes-engine/destroot/bin/hermesc
+  -O -emit-binary \
+  -output-source-map \
+  -out=main.jsbundle.hbc \
+  main.jsbundle
+rm -f main.jsbundle
+mv main.jsbundle.hbc main.jsbundle
+```
+
+```bash {tabTitle:Android on Linux}
+```
+
+```bash {tabTitle:Android on Windows}
+```
+
+```bash {tabTitle:RN 0.68 and older}
+```
+
+Compose Hermes bytecode and (React Native Packager) Metro source maps:
+
+```bash {tabTitle:Android}
+mv index.android.bundle.map index.android.bundle.packager.map
+node \
+  node_modules/react-native/scripts/compose-source-maps.js \
+  index.android.bundle.packager.map \
+  index.android.bundle.hbc.map \
+  -o index.android.bundle.map
+```
+
+```bash {tabTitle:iOS}
+mv main.jsbundle.map main.jsbundle.packager.map
+node \
+  node_modules/react-native/scripts/compose-source-maps.js \
+  main.jsbundle.packager.map \
+  main.jsbundle.hbc.map \
+  -o main.jsbundle.map
+```
+
+## Manual Upload JavaScript Core
+
+
 
 ## Using custom Release and Distribution
 


### PR DESCRIPTION
Update Source Maps upload guides to reflect changes released in https://github.com/getsentry/sentry-react-native/releases/tag/5.11.0