### PR TITLE
Removed superfluous dot from upstream URL.

### DIFF
--- a/src/docs/product/relay/getting-started.mdx
+++ b/src/docs/product/relay/getting-started.mdx
@@ -77,7 +77,7 @@ relay:
   mode: managed
   # The upstream hostname is taken from any of your DSNs.
   # Go to your Project Settings, and then to "Client Keys (DSN)" to see them.
-  upstream: https://___ORG_INGEST_DOMAIN___.
+  upstream: https://___ORG_INGEST_DOMAIN___
   host: 0.0.0.0
   port: 3000
 ```
@@ -87,7 +87,7 @@ relay:
   mode: managed
   # The upstream hostname is taken from any of your DSNs.
   # Go to your Project Settings, and then to "Client Keys (DSN)" to see them.
-  upstream: https://___ORG_INGEST_DOMAIN___.
+  upstream: https://___ORG_INGEST_DOMAIN___
   host: 127.0.0.1
   port: 3000
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

I assume that this additional `.` is wrong, at least I get a `Hostname mismatch` error when starting Relay with default configuration.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
