### PR TITLE
fix(replay): Clarify streaming video capture

### DIFF
--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -29,6 +29,8 @@ There's currently no support for `canvas`. It's being tracked in this [GitHub is
 
 The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site. Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources.
 
+Please note that only static videos can be captured by Replay, e.g. `src="./my-video.mp4"`. Streamed videos and similar are not supported.
+
 <Alert>
 
 Due to [browser limitations](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use), SVGs containing `<use>` tags with links to your domain cannot be accessed from other origins, even if you add `sentry.io` to your CORS policy. This is a known issue and we are working on a solution.

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -29,7 +29,7 @@ There's currently no support for `canvas`. It's being tracked in this [GitHub is
 
 The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site. Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources.
 
-Please note that only static, publicly hosted videos can be captured by Replay, e.g. `src="./my-video.mp4"`. Streamed videos and similar are not supported.
+Note that only static, publicly hosted videos (for example, `src="./my-video.mp4"`) can be captured by Replay. Streamed videos and similar are not supported.
 
 <Alert>
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -29,7 +29,7 @@ There's currently no support for `canvas`. It's being tracked in this [GitHub is
 
 The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site. Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources.
 
-Please note that only static videos can be captured by Replay, e.g. `src="./my-video.mp4"`. Streamed videos and similar are not supported.
+Please note that only static, publicly hosted videos can be captured by Replay, e.g. `src="./my-video.mp4"`. Streamed videos and similar are not supported.
 
 <Alert>
 


### PR DESCRIPTION
This clarifies in replay troubleshooting docs that only static videos can be captured.

Closes https://github.com/getsentry/sentry-javascript/issues/9447#issuecomment-1801639171