### PR TITLE
fix(replay): update treeshaking docs to remove canvas flag

### DIFF
--- a/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/src/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -40,10 +40,6 @@ The following flags are available:
 
 <PlatformSection notSupported={["javascript.wasm", "javascript.cordova"]}>
 
-`__RRWEB_EXCLUDE_CANVAS__`
-
-: Replacing this flag with `true` will tree shake all code in the SDK that's related to capturing canvas elements with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). Enable this flag if you don't have any canvas elements on your page you want to record.
-
 `__RRWEB_EXCLUDE_IFRAME__`
 
 : Replacing this flag with `true` will tree shake all code in the SDK that is related capturing iframe content with Session Replay. This is only relevant when using [Session Replay](../../session-replay/). You can enable this flag if you don't have any iframes on your page you care to record.
@@ -68,7 +64,6 @@ sentryPlugin({
   bundleSizeOptimizations: {
     excludeDebugStatements: true,
     excludePerformanceMonitoring: true,
-    excludeReplayCanvas: true,
     excludeReplayIframe: true,
     excludeReplayShadowDom: true,
   },
@@ -99,7 +94,6 @@ module.exports = {
     new webpack.DefinePlugin({
       __SENTRY_DEBUG__: false,
       __SENTRY_TRACING__: false,
-      __RRWEB_EXCLUDE_CANVAS__: true,
       __RRWEB_EXCLUDE_IFRAME__: true,
       __RRWEB_EXCLUDE_SHADOW_DOM__: true,
     }),
@@ -127,7 +121,6 @@ export default {
     replace({
       __SENTRY_DEBUG__: false,
       __SENTRY_TRACING__: false,
-      __RRWEB_EXCLUDE_CANVAS__: true,
       __RRWEB_EXCLUDE_IFRAME__: true,
       __RRWEB_EXCLUDE_SHADOW_DOM__: true,
     }),
@@ -151,7 +144,6 @@ const nextConfig = {
       new webpack.DefinePlugin({
         __SENTRY_DEBUG__: false,
         __SENTRY_TRACING__: false,
-        __RRWEB_EXCLUDE_CANVAS__: true,
         __RRWEB_EXCLUDE_IFRAME__: true,
         __RRWEB_EXCLUDE_SHADOW_DOM__: true,
       })


### PR DESCRIPTION
This is now excluded by default, no need to manually configure anything.