### PR TITLE
fix(webvitals): Updates text about charts

### DIFF
--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -91,7 +91,7 @@ You can click through any of your application's pages from the **Web Vitals** pa
 
 From the table in **Web Vitals** or a Web Vital Summary panel, click on a page to open its **Page Overview**. Here, you can see summary of that single page's Web Vitals. In **Page Overview**, you can further drill down to a specific page load sample [Event](/product/sentry-basics/concepts/tracing/event-detail/), [Replay](/product/session-replay/), or [Profile](/product/profiling/).
 
-The **Page Overview** page displays a series of "Throughput", "P75 Duration", "5XX Responses" charts in the right sidebar of the page. A mini **Aggregate Span Waterfall** is also displayed in the right sidebar, which shows you common span paths that your application's page may take. Click the "View Full Waterfall" button or the "Aggregate Spans" tab at the top of the page to see the full **Aggregate Span Waterfall**.
+The **Page Overview** page displays a "Page Loads" chart in the right sidebar of the page. A mini **Aggregate Span Waterfall** is also displayed in the right sidebar, which shows you common span paths that your application's page may take. Click the "View Full Waterfall" button or the "Aggregate Spans" tab at the top of the page to see the full **Aggregate Span Waterfall**.
 
 ### Samples List
 

--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -81,7 +81,7 @@ Open the **Web Vitals** page by clicking "Web Vitals" in the sidebar, under "Per
 
 In the top left, the [Performance Score](#performance-score) ring shows the overall performance rating of your application. Each component of the ring represents a single Web Vital and its relative weight and impact on the Performance Score. The area chart on the right shows you a breakdown - by Web Vitals - of your performance score over time. You can find out more about how Performance Score is calculated [here](#performance-score).
 
-Below this, you can see your application's raw vital values and the individual scores for each Web Vital. These metrics can help you prioritize which Web Vitals need attention most. Click on a Web Vital to open a more detailed summary of that metric and see which pages have the most [Opportunity](#opportunity) for improvement.
+Below this, you can see your application's P75 vital values and the individual scores for each Web Vital. These metrics can help you prioritize which Web Vitals need attention most. Click on a Web Vital to open a more detailed summary of that metric and see which pages have the most [Opportunity](#opportunity) for improvement.
 
 At the bottom of the **Web Vitals** page, a sortable table shows a list of your application's pages, along with their associated P75 values for each Web Vital. Each page also has its own individual Performance Score. The [Opportunity](#opportunity) column displays a page score's potential improvement to your application's overall Performance Score if maximized to 100. The search bar above this table allows you to filter for specific pages by route name.
 
@@ -95,7 +95,7 @@ The **Page Overview** page displays a "Page Loads" chart in the right sidebar of
 
 ### Samples List
 
-At the center of the **Page Overview**, Web Vital scores and suspect tags are displayed. Clicking a Web Vital score will open a slideout panel containing a variety of **Page Load** samples with good to poor scores. Each sample contains an **Event ID** that can be clicked to open the [Event Detail](/product/sentry-basics/concepts/tracing/event-detail/) page for further investigation. If there is a [Replay](/product/session-replay/) or [Profile](/product/profiling/) associated with the sample page load, links will be included in the associated table columns.
+At the center of the **Page Overview**, Web Vital P75 values and scores are displayed. Clicking a Web Vital score will open a slideout panel containing a variety of **Page Load** samples with good to poor scores. Each sample contains an **Event ID** that can be clicked to open the [Event Detail](/product/sentry-basics/concepts/tracing/event-detail/) page for further investigation. If there is a [Replay](/product/session-replay/) or [Profile](/product/profiling/) associated with the sample page load, links will be included in the associated table columns.
 
 ## Performance Score
 


### PR DESCRIPTION
"Throughput", "P75 Duration", "5XX Responses" charts were replaced with a "Page Loads" chart