### PR TITLE
Update PHP docs regarding changes to the `ErrorHandler`

### DIFF
--- a/src/platforms/php/common/integrations/index.mdx
+++ b/src/platforms/php/common/integrations/index.mdx
@@ -25,7 +25,7 @@ This integration hooks into the global PHP `error_handler` and emits events when
 
 To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a callback to it as an error listener. By default, the `ErrorHandler` reserves 16 KiB of memory to handle fatal errors. When handling out of memory errors, the `ErrorHandler` additionally increases the [`memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) by an additional 5 MiB to have enough room to send the out of memory event to Sentry. This change is only done once and only affects the handling of the out of memory error.
 
-If you want to change the amount of reserved memory for fatal error handling or the amount the `memory_limit` is increased with when handling an out of memory error you can register the fatal error handler yourself before calling `\Sentry\init(...)`:
+To change the amount of memory reserved for fatal error handling or the amount the `memory_limit` is increased when handling an out of memory error, you can register the fatal error handler yourself before calling `\Sentry\init(...)`:
 
 ```php
 // The amount of reserved memory every request (in bytes), this has to be a positive integer amount of bytes. Defaults to 16 KiB

--- a/src/platforms/php/common/integrations/index.mdx
+++ b/src/platforms/php/common/integrations/index.mdx
@@ -23,7 +23,7 @@ To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a call
 
 This integration hooks into the global PHP `error_handler` and emits events when an error occurs.
 
-To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a callback to it as an error listener. By default, the `ErrorHandler` reserves 16 KiB of memory to handle fatal errors. When handling out of memory errors the `ErrorHandler` additionally increases the [`memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) by an additional 5 MiB to have enough room to send the out of memory event to Sentry, this change is only done once and only has effect for the handling of the out of memory error.
+To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a callback to it as an error listener. By default, the `ErrorHandler` reserves 16 KiB of memory to handle fatal errors. When handling out of memory errors, the `ErrorHandler` additionally increases the [`memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) by an additional 5 MiB to have enough room to send the out of memory event to Sentry. This change is only done once and only affects the handling of the out of memory error.
 
 If you want to change the amount of reserved memory for fatal error handling or the amount the `memory_limit` is increased with when handling an out of memory error you can register the fatal error handler yourself before calling `\Sentry\init(...)`:
 

--- a/src/platforms/php/common/integrations/index.mdx
+++ b/src/platforms/php/common/integrations/index.mdx
@@ -23,7 +23,16 @@ To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a call
 
 This integration hooks into the global PHP `error_handler` and emits events when an error occurs.
 
-To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a callback to it as an error listener. By default, the `ErrorHandler` reserves 10 kilobytes of memory to handle fatal errors.
+To do so, it ensures that Sentry's `ErrorHandler` is registered, and adds a callback to it as an error listener. By default, the `ErrorHandler` reserves 16 KiB of memory to handle fatal errors. When handling out of memory errors the `ErrorHandler` additionally increases the [`memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) by an additional 5 MiB to have enough room to send the out of memory event to Sentry, this change is only done once and only has effect for the handling of the out of memory error.
+
+If you want to change the amount of reserved memory for fatal error handling or the amount the `memory_limit` is increased with when handling an out of memory error you can register the fatal error handler yourself before calling `\Sentry\init(...)`:
+
+```php
+// The amount of reserved memory every request (in bytes), this has to be a positive integer amount of bytes. Defaults to 16 KiB
+$errorHandler = \Sentry\ErrorHandler::registerOnceFatalErrorHandler(16 * 1024);
+// The amount of memory in bytes to increase the `memory_limit` to when handling a out of memory error, can also be set to `null` to disable increasing the `memory_limit`. Defaults to 5 MiB
+$errorHandler->setMemoryLimitIncreaseOnOutOfMemoryErrorInBytes(5 * 1024 * 1024);
+```
 
 For some frameworks or projects, specific integrations are provided both officially and by third-party users that automatically register the error handlers. Please refer to their documentation.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

In https://github.com/getsentry/sentry-php/pull/1633 we are changing how the PHP `ErrorHandler` works to correctly handle out of memory errors. These docs changes reflect those changes.

/cc @cleptric 