### PR TITLE
feat(replay): Add docs for `beforeErrorSampling()`

### DIFF
--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -20,17 +20,18 @@ The following options can be configured on the root level of your browser-based 
 
 The following can be configured as integration options in `new Replay({})`:
 
-| Key                     | Type                     | Default  | Description                                                                                                                                                   |
-| ----------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| stickySession           | boolean                  | `true`   | Keep track of users across page loads. Note, because closing a tab ends the session, a single user using multiple tabs will be recorded as multiple sessions. |
-| mutationLimit           | number                   | 10000    | The upper bound of mutations to process before Session Replay stops recording due to performance impacts. See [Mutation Limits](#mutation-limits)             |
-| mutationBreadcrumbLimit | number                   | 750      | The upper bound of mutations to process before Session Replay sends a breadcrumb to warn of large mutations. See [Mutation Limits](#mutation-limits)          |
-| minReplayDuration       | number                   | 5000     | The length of the replay, **in milliseconds**, before the SDK should start sending to Sentry. Max value is 15000.                                             |
-| networkDetailAllowUrls  | (string \| RegExp)[]     | `[]`     | Capture request and response details for XHR and fetch requests that match the given URLs.                                                                    |
-| networkCaptureBodies    | boolean                  | `true`   | Decide whether to capture request and response bodies for URLs defined in `networkDetailAllowUrls`.                                                           |
-| networkRequestHeaders   | string[]                 | `[]`     | Additional request headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                    |
-| networkResponseHeaders  | string[]                 | `[]`     | Additional response headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                   |
-| beforeAddRecordingEvent | (event) => event \| null | `i => i` | Filter additional recording events that include console logs and network requests/responses.                                                                  |
+| Key                     | Type                     | Default     | Description                                                                                                                                                   |
+| ----------------------- | ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stickySession           | boolean                  | `true`      | Keep track of users across page loads. Note, because closing a tab ends the session, a single user using multiple tabs will be recorded as multiple sessions. |
+| mutationLimit           | number                   | 10000       | The upper bound of mutations to process before Session Replay stops recording due to performance impacts. See [Mutation Limits](#mutation-limits)             |
+| mutationBreadcrumbLimit | number                   | 750         | The upper bound of mutations to process before Session Replay sends a breadcrumb to warn of large mutations. See [Mutation Limits](#mutation-limits)          |
+| minReplayDuration       | number                   | 5000        | The length of the replay, **in milliseconds**, before the SDK should start sending to Sentry. Max value is 15000.                                             |
+| networkDetailAllowUrls  | (string \| RegExp)[]     | `[]`        | Capture request and response details for XHR and fetch requests that match the given URLs.                                                                    |
+| networkCaptureBodies    | boolean                  | `true`      | Decide whether to capture request and response bodies for URLs defined in `networkDetailAllowUrls`.                                                           |
+| networkRequestHeaders   | string[]                 | `[]`        | Additional request headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                    |
+| networkResponseHeaders  | string[]                 | `[]`        | Additional response headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                   |
+| beforeAddRecordingEvent | (event) => event \| null | `i => i`    | Filter additional recording events that include console logs and network requests/responses.                                                                  |
+| beforeErrorSampling     | (event) => boolean       | `i => true` | Filter error events which should be skipped for error sampling. Return `false` if error sampling should be skipped for this error event, or `true` to sample for this error. |
 
 ## Privacy Configuration
 

--- a/src/platforms/javascript/common/session-replay/configuration.mdx
+++ b/src/platforms/javascript/common/session-replay/configuration.mdx
@@ -20,17 +20,17 @@ The following options can be configured on the root level of your browser-based 
 
 The following can be configured as integration options in `new Replay({})`:
 
-| Key                     | Type                     | Default     | Description                                                                                                                                                   |
-| ----------------------- | ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| stickySession           | boolean                  | `true`      | Keep track of users across page loads. Note, because closing a tab ends the session, a single user using multiple tabs will be recorded as multiple sessions. |
-| mutationLimit           | number                   | 10000       | The upper bound of mutations to process before Session Replay stops recording due to performance impacts. See [Mutation Limits](#mutation-limits)             |
-| mutationBreadcrumbLimit | number                   | 750         | The upper bound of mutations to process before Session Replay sends a breadcrumb to warn of large mutations. See [Mutation Limits](#mutation-limits)          |
-| minReplayDuration       | number                   | 5000        | The length of the replay, **in milliseconds**, before the SDK should start sending to Sentry. Max value is 15000.                                             |
-| networkDetailAllowUrls  | (string \| RegExp)[]     | `[]`        | Capture request and response details for XHR and fetch requests that match the given URLs.                                                                    |
-| networkCaptureBodies    | boolean                  | `true`      | Decide whether to capture request and response bodies for URLs defined in `networkDetailAllowUrls`.                                                           |
-| networkRequestHeaders   | string[]                 | `[]`        | Additional request headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                    |
-| networkResponseHeaders  | string[]                 | `[]`        | Additional response headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                   |
-| beforeAddRecordingEvent | (event) => event \| null | `i => i`    | Filter additional recording events that include console logs and network requests/responses.                                                                  |
+| Key                     | Type                     | Default     | Description                                                                                                                                                                  |
+| ----------------------- | ------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stickySession           | boolean                  | `true`      | Keep track of users across page loads. Note, because closing a tab ends the session, a single user using multiple tabs will be recorded as multiple sessions.                |
+| mutationLimit           | number                   | 10000       | The upper bound of mutations to process before Session Replay stops recording due to performance impacts. See [Mutation Limits](#mutation-limits)                            |
+| mutationBreadcrumbLimit | number                   | 750         | The upper bound of mutations to process before Session Replay sends a breadcrumb to warn of large mutations. See [Mutation Limits](#mutation-limits)                         |
+| minReplayDuration       | number                   | 5000        | The length of the replay, **in milliseconds**, before the SDK should start sending to Sentry. Max value is 15000.                                                            |
+| networkDetailAllowUrls  | (string \| RegExp)[]     | `[]`        | Capture request and response details for XHR and fetch requests that match the given URLs.                                                                                   |
+| networkCaptureBodies    | boolean                  | `true`      | Decide whether to capture request and response bodies for URLs defined in `networkDetailAllowUrls`.                                                                          |
+| networkRequestHeaders   | string[]                 | `[]`        | Additional request headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                                   |
+| networkResponseHeaders  | string[]                 | `[]`        | Additional response headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                                  |
+| beforeAddRecordingEvent | (event) => event \| null | `i => i`    | Filter additional recording events that include console logs and network requests/responses.                                                                                 |
 | beforeErrorSampling     | (event) => boolean       | `i => true` | Filter error events which should be skipped for error sampling. Return `false` if error sampling should be skipped for this error event, or `true` to sample for this error. |
 
 ## Privacy Configuration

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -180,10 +180,10 @@ If you want to skip capturing a Replay for certain errors, you can use the `befo
 ```js
 new Replay({
   beforeErrorSampling: (error) => {
-    return error.message?.includes('drop me'); 
-  }
+    return error.message?.includes("drop me");
+  },
 });
 ```
 
-If you return `false` from this method for a given error, we will not check the error sample rate for this error. 
+If you return `false` from this method for a given error, we will not check the error sample rate for this error.
 If you return `true`, we will continue to check the error sample rate as normal.

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -171,3 +171,19 @@ navigation.addEventListener("navigate", (event) => {
   }
 });
 ```
+
+### Ignore certain Errors for Error Sampling
+
+When using `replaysOnErrorSampleRate`, we "roll the dice" on any Error that is captured & sent to Sentry.
+If you want to skip capturing a Replay for certain errors, you can use the `beforeErrorSampling` callback:
+
+```js
+new Replay({
+  beforeErrorSampling: (error) => {
+    return error.message?.includes('drop me'); 
+  }
+});
+```
+
+If you return `false` from this method for a given error, we will not check the error sample rate for this error. 
+If you return `true`, we will continue to check the error sample rate as normal.


### PR DESCRIPTION
This adds docs for the new replay config method.