### PR TITLE
fix(mobile-vitals): Add TTID/TTFD links to Apple

### DIFF
--- a/src/docs/product/performance/mobile-vitals.mdx
+++ b/src/docs/product/performance/mobile-vitals.mdx
@@ -61,7 +61,9 @@ In the example below, the detail view of the transaction displays the time-to-in
 You can track time to initial display for:
 
 - [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/#time-to-initial-display)
+- [Apple](/platforms/apple/performance/instrumentation/automatic-instrumentation/#time-to-initial-display)
 
 You can track time to full display for:
 
 - [Android](/platforms/android/performance/instrumentation/automatic-instrumentation/#time-to-full-display)
+- [Apple](/platforms/apple/performance/instrumentation/automatic-instrumentation/#time-to-full-display)


### PR DESCRIPTION


## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Add missing links for TTID/TTFD at the bottom of the section in mobile vitals.
