### PR TITLE
ref(android-perf): Remove redundant Android prefix

### DIFF
--- a/src/platforms/android/integrations/jetpack-compose/index.mdx
+++ b/src/platforms/android/integrations/jetpack-compose/index.mdx
@@ -31,7 +31,7 @@ With Jetpack Compose performance metrics the Sentry Android SDK can automaticall
 This feature requires an underlying transaction to attach it's spans to. Transactions can be created manually or automatically by configuring
 
 - <PlatformLink to="/performance/instrumentation/automatic-instrumentation/">
-    Android's Activity instrumentation
+    Activity instrumentation
   </PlatformLink>
 - [Navigation Instrumentation](#jetpack-compose-navigation)
 - [User Interactions](#user-interactions)

--- a/src/platforms/android/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/android/performance/instrumentation/automatic-instrumentation.mdx
@@ -14,7 +14,7 @@ Supported in Sentry's Android SDK version `4.3.0` and above.
 
 </Note>
 
-### Android's Activity Instrumentation
+### Activity Instrumentation
 
 The Activity's instrumentation, once enabled, captures transactions for each launch of an Activity. The SDK sets the Transaction name to the name of the Activity, for example, `MainActivity`, and Transaction operation to `ui.load`.
 
@@ -110,15 +110,15 @@ fun displayUserData() {
 
 When you didn't finish the transaction yet, but you start a new Activity, the SDK always automatically finishes the previous Activity transaction. This is due to the fact that only one transaction at a time can be bound to the Scope. To work around that, you may create transactions manually using the custom instrumentation and its instance to start spans instead of the Static API.
 
-### Android's Fragment Instrumentation
+### Fragment Instrumentation
 
-Once enabled, Android's Fragment Instrumentation starts a span for each launch of a fragment. The SDK sets the span operation to `ui.load` and the span description to the fragment's name, for example, `LoginFragment`.
+Once enabled, Fragment Instrumentation starts a span for each launch of a fragment. The SDK sets the span operation to `ui.load` and the span description to the fragment's name, for example, `LoginFragment`.
 
 The span starts after each fragment's `onCreate` method is called and before its `onCreateView` method is called.
 
 The span finishes after each fragment's `onResume` method is executed.
 
-Android's Fragment Instrumentation depends on having an active transaction bound to the scope, and ideally it'd be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
+Fragment Instrumentation depends on having an active transaction bound to the scope, and ideally it'd be used along with [Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
 Learn more in our [Fragment documentation](/platforms/android/integrations/fragment/).
 
@@ -141,7 +141,7 @@ The app start is only measured if the process is of the importance [RunningAppPr
 
 </Note>
 
-You can opt out of Android's Activity Instrumentation and App Start Instrumentation using options:
+You can opt out of Activity Instrumentation and App Start Instrumentation using options:
 
 ```xml {filename:AndroidManifest.xml}
 <application>
@@ -159,7 +159,7 @@ Supported on Android OS version `7.0` and above.
 
 </Note>
 
-Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are _slow frames_ and _frozen frames_. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the [Android's Activity](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation) transactions.
+Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are _slow frames_ and _frozen frames_. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the [Activity](/platforms/android/performance/instrumentation/automatic-instrumentation/#activity-instrumentation) transactions.
 
 Slow and frozen frames are Mobile Vitals, which you can learn about in the [full documentation](/product/performance/mobile-vitals).
 
@@ -403,7 +403,7 @@ The span starts when each Activity is launched, which is defined as an applicati
 
 The span finishes after the Activity draws its first frame.
 
-Time to initial display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
+Time to initial display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
 ### Time to Full Display
 
@@ -435,7 +435,7 @@ import io.sentry.Sentry
 Sentry.reportFullyDisplayed()
 ```
 
-Time to full display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Android's Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#androids-activity-instrumentation), which starts a transaction and binds it to the scope automatically.
+Time to full display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Activity Instrumentation](/platforms/android/performance/instrumentation/automatic-instrumentation/#activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
 If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
 If the span finishes before the Activity is first drawn and displayed as measured by the `Time to initial display`, the reported time will be shifted to `Time to initial display` measured time.


### PR DESCRIPTION


## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

On the automatic performance page for Android, we don't need to prefix Activity and Fragment Instrumentation with Android; for Android users, it's clear what the docs refer to.

