### PR TITLE
fix(native): remove obsolete warning note...

### DIFF
--- a/src/platforms/native/configuration/transports.mdx
+++ b/src/platforms/native/configuration/transports.mdx
@@ -59,10 +59,3 @@ sentry_init(options);
 
 /* ... */
 ```
-
-<Alert level="warning" title="Note">
-  While both transport implementations (`Curl` and `WinHTTP`) honor the
-  configuration on all supported platforms, the `crashpad-handler` doesn't
-  provide a proxy configuration and will be unable to send crash reports from
-  behind a proxy.
-</Alert>


### PR DESCRIPTION
... for the missing proxy support in the crashpad handler.

We've added proxy support to the crashpad fork here:

https://github.com/getsentry/sentry-native/pull/847

This was released as part of https://github.com/getsentry/sentry-native/releases/tag/0.6.3