### PR TITLE
ref(js): Add note that Sentry Testkit is community-maintained

### DIFF
--- a/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
+++ b/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
@@ -8,6 +8,13 @@ When building tests for your application, you want to assert that the right flow
 
 [Sentry Testkit](https://zivl.github.io/sentry-testkit/) is a Sentry plugin that allows Sentry's reports to be intercepted for further data inspection. It enables Sentry to work natively in your application, by overriding Sentry's default transport mechanism, which makes it so that the report isn't really sent, but rather logged locally into memory. This way, logged reports can be fetched later for your own usage, verification, or any other purpose you may have in your local developing or testing environment.
 
+<Alert level="warning">
+
+Sentry Testkit is a community-maintained 3rd party library, and is **not officially supported by Sentry**.
+If you have any questions or issues with Sentry Testkit, please open an issue in the [Sentry Testkit repository](https://zivl.github.io/sentry-testkit/)
+
+</Alert>
+
 ## Installation
 
 ```bash {tabTitle:npm}

--- a/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
+++ b/src/platforms/javascript/common/configuration/sentry-testkit/index.mdx
@@ -6,12 +6,12 @@ description: "Learn how to assert that the right flow-tracking or error is being
 
 When building tests for your application, you want to assert that the right flow-tracking or error is being sent to Sentry, but without really sending it to the Sentry servers. This way you won't swamp Sentry with false reports during test runs or other CI operations.
 
-[Sentry Testkit](https://zivl.github.io/sentry-testkit/) is a Sentry plugin that allows Sentry's reports to be intercepted for further data inspection. It enables Sentry to work natively in your application, by overriding Sentry's default transport mechanism, which makes it so that the report isn't really sent, but rather logged locally into memory. This way, logged reports can be fetched later for your own usage, verification, or any other purpose you may have in your local developing or testing environment.
+[Sentry Testkit](https://zivl.github.io/sentry-testkit/) is a community-maintained Sentry plugin that allows Sentry's reports to be intercepted for further data inspection. It enables Sentry to work natively in your application, by overriding Sentry's default transport mechanism, which makes it so that the report isn't really sent, but rather logged locally into memory. This way, logged reports can be fetched later for your own usage, verification, or any other purpose you may have in your local developing or testing environment.
 
-<Alert level="warning">
+<Alert>
 
-Sentry Testkit is a community-maintained 3rd party library, and is **not officially supported by Sentry**.
-If you have any questions or issues with Sentry Testkit, please open an issue in the [Sentry Testkit repository](https://zivl.github.io/sentry-testkit/)
+Sentry Testkit is community-maintained and not officially supported by Sentry.
+Please open an issue in the [Sentry Testkit repository](https://zivl.github.io/sentry-testkit/) if you have any questions or feedback.
 
 </Alert>
 


### PR DESCRIPTION
Sentry Testkit is a [community-maintained library](https://github.com/zivl/sentry-testkit), meaning we don't offer official support for it. However, we quite prominently feature them in our docs. This PR adds a note that this library is not maintained by us and that support requests should be made in the maintainer's repository. 