### PR TITLE
feat: Remove context from Sentry.init in KMP

### DIFF
--- a/src/platform-includes/configuration/config-intro/kotlin-multiplatform.mdx
+++ b/src/platform-includes/configuration/config-intro/kotlin-multiplatform.mdx
@@ -3,8 +3,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.dsn = "___PUBLIC_DSN___"
   options.release = "io.sentry.samples@3.0.0+1"
 }

--- a/src/platform-includes/enriching-events/attach-screenshots/kotlin-multiplatform.mdx
+++ b/src/platform-includes/enriching-events/attach-screenshots/kotlin-multiplatform.mdx
@@ -1,8 +1,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.attachScreenshot = true
 }
 ```

--- a/src/platform-includes/enriching-events/attach-viewhierarchy/kotlin-multiplatform.mdx
+++ b/src/platform-includes/enriching-events/attach-viewhierarchy/kotlin-multiplatform.mdx
@@ -9,8 +9,7 @@ Currently only available on iOS and Android.
 ```kotlin
 import io.sentry.kotlin.multiplatform.sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.dsn = "___PUBLIC_DSN___"
   options.attachViewHierarchy = true
 }

--- a/src/platform-includes/enriching-events/attachment-max-size/kotlin-multiplatform.mdx
+++ b/src/platform-includes/enriching-events/attachment-max-size/kotlin-multiplatform.mdx
@@ -1,8 +1,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.maxAttachmentSize = 5 * 1024 * 1024 // 5 MiB
 }
 ```

--- a/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/kotlin-multiplatform.mdx
+++ b/src/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/kotlin-multiplatform.mdx
@@ -1,8 +1,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.beforeBreadcrumb = { breadcrumb ->
     if ("a.spammy.Logger" == breadcrumb.category) {
       null

--- a/src/platform-includes/getting-started-config/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-config/kotlin-multiplatform.mdx
@@ -3,8 +3,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { ->
+Sentry.init { ->
   options.dsn = "___PUBLIC_DSN___"
 }
 ```

--- a/src/platform-includes/set-environment/kotlin-multiplatform.mdx
+++ b/src/platform-includes/set-environment/kotlin-multiplatform.mdx
@@ -1,8 +1,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) {
+Sentry.init {
   it.environment = "production"
 }
 ```

--- a/src/platform-includes/set-release/kotlin-multiplatform.mdx
+++ b/src/platform-includes/set-release/kotlin-multiplatform.mdx
@@ -1,8 +1,7 @@
 ```kotlin
 import io.sentry.kotlin.multiplatform.Sentry
 
-// Application context is only needed for Android targets
-Sentry.init(context) { options ->
+Sentry.init { options ->
   options.release = "io.example@1.1.0"
 }
 ```

--- a/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
+++ b/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
@@ -21,20 +21,15 @@ To initialize the SDK, create a Kotlin file in your `commonMain` e.g. `AppSetup.
 <SignInNote />
 
 ```kotlin {filename:AppSetup.kt}
-import io.sentry.kotlin.multiplatform.Context
 import io.sentry.kotlin.multiplatform.Sentry
 
 // Application context is only needed for Android targets
-fun initializeSentry(context: Context?) {
+fun initializeSentry() {
   val configuration: (SentryOptions) -> Unit = {
     it.dsn = "___PUBLIC_DSN___"
     // Add common configuration here
   }
-  if (context != null) {
-      Sentry.init(context, configuration)
-  } else {
-      Sentry.init(configuration)
-  }
+  Sentry.init(configuration)
 }
 ```
 
@@ -48,8 +43,7 @@ import your.kmp.app.initializeSentry
 class YourApplication : Application() {
   override fun onCreate() {
     super.onCreate()
-      // Make sure to add the context!
-      initializeSentry(this)
+      initializeSentry()
    }
 }
 ```
@@ -63,7 +57,7 @@ func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
 ) -> Bool {
-    AppSetupKt.initializeSentry(context = nil)
+    AppSetupKt.initializeSentry()
     return true
 }
 ```
@@ -79,7 +73,7 @@ This approach gives you the flexibility to fine-tune the SDK's behavior to meet 
 ```kotlin {filename:commonMain/AppSetup.kt}
 import io.sentry.kotlin.multiplatform.Context
 
-expect fun initializeSentry(context: Context? = null)
+expect fun initializeSentry()
 ```
 
 ### androidMain
@@ -90,12 +84,10 @@ expect fun initializeSentry(context: Context? = null)
 import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.Context
 
-actual fun initializeSentry(context: Context?) {
-  if (context != null) {
-    Sentry.init(context) {
-      it.dsn = "___PUBLIC_DSN___"
-      // Add Android-specific configuration here
-    }
+actual fun initializeSentry() {
+  Sentry.init {
+    it.dsn = "___PUBLIC_DSN___"
+    // Add Android-specific configuration here
   }
 }
 ```
@@ -108,7 +100,7 @@ actual fun initializeSentry(context: Context?) {
 import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.Context
 
-actual fun initializeSentry(context: Context?) {
+actual fun initializeSentry() {
   Sentry.init {
     it.dsn = "___PUBLIC_DSN___"
     // Add iOS-specific configuration here
@@ -126,8 +118,7 @@ import your.kmp.app.initializeSentry
 class YourApplication : Application() {
   override fun onCreate() {
     super.onCreate()
-      // Make sure to add the context!
-      initializeSentry(this)
+      initializeSentry()
    }
 }
 ```
@@ -141,7 +132,7 @@ func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
 ) -> Bool {
-    AppSetupKt.initializeSentry(context = nil)
+    AppSetupKt.initializeSentry()
     return true
 }
 ```


### PR DESCRIPTION
Android `context` is not needed anymore since KMP `0.3.0`. 

Related PR: https://github.com/getsentry/sentry-kotlin-multiplatform/pull/117