### PR TITLE
feat(python): Prepare for Django 5.0 support

### DIFF
--- a/src/platforms/python/integrations/django/index.mdx
+++ b/src/platforms/python/integrations/django/index.mdx
@@ -9,11 +9,11 @@ redirect_from:
 description: "Learn about using Sentry with Django."
 ---
 
-Sentry's [Django](https://www.djangoproject.com/) integration adds support for the Django Framework. It enables automatic reporting of errors and exceptions as well as performance monitoring. In order to get started using the integration, you should have a [Sentry account](https://sentry.io) and a project set up.
+Sentry's [Django](https://www.djangoproject.com/) integration adds support for the Django framework. It enables automatic reporting of errors and exceptions as well as performance monitoring. In order to get started using the integration, you should have a [Sentry account](https://sentry.io) and a project set up.
 
 <Note>
 
-If you're using Python 3.7., Django applications with Channels 2.0 will be correctly instrumented. Older versions of Python will require the installation of [aiocontextvars](https://pypi.org/project/aiocontextvars/).
+If you're using Python 3.7, Django applications with `channels` 2.0 will be correctly instrumented. Older versions of Python will require the installation of [aiocontextvars](https://pypi.org/project/aiocontextvars/).
 
 </Note>
 
@@ -123,7 +123,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 - `signals_spans`:
 
-  Create spans and track performance of all [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/) receiver functions in your Django project. Set to `False` to disable.
+  Create spans and track performance of all synchronous [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/) receiver functions in your Django project. Set to `False` to disable.
 
   The default is `True`.
 
@@ -139,3 +139,4 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 - Django 2.x (Python: 3.5+)
 - Django 3.x (Python: 3.6+)
 - Django 4.x (Python: 3.8+)
+- Django 5.x (Python: 3.10+)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

With the next release of the Python SDK [we'll support Django 5.0](https://github.com/getsentry/sentry-python/issues/2489). Updating the integration docs to reflect this.

Direct link to the affected page: https://sentry-docs-git-ivana-django-50.sentry.dev/platforms/python/integrations/django

(Will only merge this once we've released the SDK, so in a couple of weeks.)


## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
