### PR TITLE
split up get started with sentry page

### DIFF
--- a/src/docs/product/index.mdx
+++ b/src/docs/product/index.mdx
@@ -4,4 +4,63 @@ sidebar_order: 1
 description: "Learn more about Sentry's features with our Product Guides. Guides include Sentry Basics, Error Monitoring, Performance Monitoring, Alerts & Notifications, and more."
 ---
 
+## What is Sentry?
+
+Sentry is a software monitoring tool that helps developers identify and fix code-related issues. From error tracking to performance monitoring, Sentry provides code-level observability that makes it easy to diagnose issues and learn continuously about your application code health.
+
+## What Can Sentry Help With?
+
+As a full-stack application monitoring solution, Sentry provides the following features to help you keep your app running smoothly.
+
+### Error Monitoring
+
+Sentry's error monitoring capabilities make it possible to quickly get to the root of a problem so you can understand and fix what's broken.
+
+Sentry automatically captures unhandled exceptions (errors). It then groups similar errors into [issues](/product/issues/), making it possible to triage and manage them more efficiently.
+
+- If you're monitoring a web project, you can [**replay**](/product/session-replay/) what the user experienced on your app and connect that error to the problematic line of code with [**source maps**](/product/sentry-basics/integrate-frontend/upload-source-maps/).
+- If you set up Sentry for both your frontend and backend, you'll be able to use [**distributed tracing**](/product/sentry-basics/concepts/tracing/distributed-tracing/) to see the sequence of events (both frontend and backend) that led up to the event of interest.
+- Additionally, you can set up [**integrations**](/product/integrations/source-code-mgmt/) to link your source code so that Sentry can surface [**suspect commits**](/product/issues/suspect-commits/) and [**stack traces**](/product/integrations/source-code-mgmt/github/#stack-trace-linking) to show the problematic line of code, as well as [**suggest assignees**](/product/integrations/source-code-mgmt/github/#suspect-commits-and-suggested-assignees) for issues based on commit authors.
+
+### Performance Monitoring
+
+Our performance monitoring feature helps you track application performance, measure metrics like throughput and latency, and see the impact of errors across multiple services.
+
+- You can drill down into any slowdowns and optimize the performance of your code with [**distributed traces**](/product/sentry-basics/concepts/tracing/distributed-tracing/), which consist of transactions and spans and measure the performance of individual services and operations. This means you can easily [trace](/product/sentry-basics/concepts/tracing/trace-view/) slow-loading pages all the way back to poor-performing API calls.
+- Sentry [**Profiling**](/product/profiling/) provides code-level insights into your application performance in production so you can find and fix the problematic line of code faster. It profiles code in every environment your application is running on so you can quickly see which functions are contributing to a slow span.
+- Sentry helps you discover and act on [**trends**](/product/performance/trends/) before they become a bigger problem by surfacing transactions whose performance has changed significantly over time.
+- Sentry's [**query monitoring**](/product/performance/queries/) can help you investigate the performance of your queries and get more information to improve them.
+
+### Release Health Monitoring
+
+Giving Sentry visibility into your [**releases**](/product/releases/) makes it possible to see the moment a release starts to degrade and quickly take action. You get real-time visibility across your releases, allowing you to see core metrics like crash-free sessions, version adoption, and failure rate.
+
+Releases are integrated with the rest of Sentry so you can directly see how an error or performance issue was affected by a release, in addition to being able to resolve release-specific issues.
+
+### Recurring Job Monitoring
+
+[**Cron Monitors**](/product/crons/) allows you to monitor the uptime and performance of any scheduled, recurring job in Sentry. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.
+
+### Visibility Into Your Data Across Environmentss
+
+[**Discover**](/product/discover-queries/) provides visibility into your data across environments by building upon and enriching your error data. You can [**query**](/product/discover-queries/query-builder/) and unlock insights into the health of your entire system and get answers to critical business questions — all in one place. You can also build your own [**dashboards**](/product/dashboards/) to help you monitor what's most important for your app.
+
+### Code Coverage
+
+[Codecov](/product/codecov/) provides **test code coverage** for developers. It helps improve testing, coverage, and code reliability, allowing you to get test coverage insights directly in Sentry while monitoring your errors.
+
+### Seamless Developer Workflow
+
+Sentry provides many [**integrations**](/product/integrations/) to support a seamless developer workflow, including:
+
+- [Source code management](/product/integrations/source-code-mgmt/), code mapping, code owners, and suspect commits with GitHub, GitLab, Azure DevOps, and Bitbucket.
+- [Issue tracking](/product/integrations/issue-tracking/) with Jira, Github, and many other tools.
+- [Alerts and notifications](/product/integrations/notification-incidents/) with Slack, Discord, PagerDuty, and more.
+
+### SDK Support for Over 100 Platforms
+
+Sentry supports over [100 platforms and frameworks](/platforms/), including 30+ coding languages, so you can track errors and performance issues no matter what your application is built on. Our SDKs have you covered so you can get started with Sentry in just a few lines of code.
+
+## Explore the Docs
+
 <PageGrid />

--- a/src/docs/product/sentry-basics/index.mdx
+++ b/src/docs/product/sentry-basics/index.mdx
@@ -7,72 +7,15 @@ redirect_from:
   - /product/sentry-basics/guides/
 ---
 
-## What is Sentry?
-
-Sentry is a software monitoring tool that helps developers identify and fix code-related issues. From error tracking to performance monitoring, Sentry provides code-level observability that makes it easy to diagnose issues and learn continuously about your application code health.
-
 ## How to Get the Most Out of Sentry
 
 There are three things we recommend you do to get the most out of Sentry:
 
 - **Connect your codebase**, making sure you've also set up [source code management integrations](/product/integrations/source-code-mgmt/) and [source maps](/product/sentry-basics/integrate-frontend/upload-source-maps/) (if applicable). This will allow Sentry to link errors and performance issues directly to the problematic line of code via readable stack traces and suspect commits.
-- **Set up [alerts](/product/alerts/)** to make sure you know when things you care about are going wrong. Be sure to follow [alert best practices](/product/alerts/best-practices/), so that you only get relevant notifications.
-- **Customize [Discover](/product/discover-queries/), [Dashboards](/product/dashboards/), and [queries](/product/discover-queries/query-builder/)** to unlock custom insights about the things that are going wrong in your app.
+- **Set up [alerts](/product/alerts/)** to make sure you know when things you care about are going wrong. For convenience, set up chat integrations such as [Slack](/product/integrations/notification-incidents/slack/) or [Discord](/product/integrations/notification-incidents/discord/), to deliver notifications to where your team collaborates. Be sure to follow [alert best practices](/product/alerts/best-practices/), so that you only get relevant notifications.
+- **Customize [Discover](/product/discover-queries/), [Dashboards](/product/dashboards/), and [queries](/product/discover-queries/query-builder/)** to unlock custom insights about the things that are going wrong in your app. Use [custom tags](/product/reference/search/searchable-properties/#custom-tags) tailored to your use case for more granular searching and querying.
 
 **Want a TL;DR for getting started? Download our ["Developer Quick Reference Guide"](/developer-quick-reference-guide.pdf)**
-
-## What Can Sentry Help With?
-
-As a full-stack application monitoring solution, Sentry provides the following features to help you keep your app running smoothly.
-
-### Error Monitoring
-
-Sentry's error monitoring capabilities make it possible to quickly get to the root of a problem so you can understand and fix what's broken.
-
-Sentry automatically captures unhandled exceptions (errors). It then groups similar errors into [issues](/product/issues/), making it possible to triage and manage them more efficiently.
-
-- If you're monitoring a web project, you can [**replay**](/product/session-replay/) what the user experienced on your app and connect that error to the problematic line of code with [**source maps**](/product/sentry-basics/integrate-frontend/upload-source-maps/).
-- If you set up Sentry for both your frontend and backend, you'll be able to use [**distributed tracing**](/product/sentry-basics/concepts/tracing/distributed-tracing/) to see the sequence of events (both frontend and backend) that led up to the event of interest.
-- Additionally, you can set up [**integrations**](/product/integrations/source-code-mgmt/) to link your source code so that Sentry can surface [**suspect commits**](/product/issues/suspect-commits/) and [**stack traces**](/product/integrations/source-code-mgmt/github/#stack-trace-linking) to show the problematic line of code, as well as [**suggest assignees**](/product/integrations/source-code-mgmt/github/#suspect-commits-and-suggested-assignees) for issues based on commit authors.
-
-### Performance Monitoring
-
-Our performance monitoring feature helps you track application performance, measure metrics like throughput and latency, and see the impact of errors across multiple services.
-
-- You can drill down into any slowdowns and optimize the performance of your code with [**distributed traces**](/product/sentry-basics/concepts/tracing/distributed-tracing/), which consist of transactions and spans and measure the performance of individual services and operations. This means you can easily [trace](/product/sentry-basics/concepts/tracing/trace-view/) slow-loading pages all the way back to poor-performing API calls.
-- Sentry [**Profiling**](/product/profiling/) provides code-level insights into your application performance in production so you can find and fix the problematic line of code faster. It profiles code in every environment your application is running on so you can quickly see which functions are contributing to a slow span.
-- Sentry helps you discover and act on [**trends**](/product/performance/trends/) before they become a bigger problem by surfacing transactions whose performance has changed significantly over time.
-- Sentry's [**query monitoring**](/product/performance/queries/) can help you investigate the performance of your queries and get more information to improve them.
-
-### Release Health Monitoring
-
-Giving Sentry visibility into your [**releases**](/product/releases/) makes it possible to see the moment a release starts to degrade and quickly take action. You get real-time visibility across your releases, allowing you to see core metrics like crash-free sessions, version adoption, and failure rate.
-
-Releases are integrated with the rest of Sentry so you can directly see how an error or performance issue was affected by a release, in addition to being able to resolve release-specific issues.
-
-### Recurring Job Monitoring
-
-[**Cron Monitors**](/product/crons/) allows you to monitor the uptime and performance of any scheduled, recurring job in Sentry. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.
-
-### Visibility Into Your Data Across Environmentss
-
-[**Discover**](/product/discover-queries/) provides visibility into your data across environments by building upon and enriching your error data. You can [**query**](/product/discover-queries/query-builder/) and unlock insights into the health of your entire system and get answers to critical business questions — all in one place. You can also build your own [**dashboards**](/product/dashboards/) to help you monitor what's most important for your app.
-
-### Code Coverage
-
-[Codecov](/product/codecov/) provides **test code coverage** for developers. It helps improve testing, coverage, and code reliability, allowing you to get test coverage insights directly in Sentry while monitoring your errors.
-
-### Seamless Developer Workflow
-
-Sentry provides many [**integrations**](/product/integrations/) to support a seamless developer workflow, including:
-
-- [Source code management](/product/integrations/source-code-mgmt/), code mapping, code owners, and suspect commits with GitHub, GitLab, Azure DevOps, and Bitbucket.
-- [Issue tracking](/product/integrations/issue-tracking/) with Jira, Github, and many other tools.
-- [Alerts and notifications](/product/integrations/notification-incidents/) with Slack, Discord, PagerDuty, and more.
-
-### SDK Support for Over 100 Platforms
-
-Sentry supports over [100 platforms and frameworks](/platforms/), including 30+ coding languages, so you can track errors and performance issues no matter what your application is built on. Our SDKs have you covered so you can get started with Sentry in just a few lines of code.
 
 ## Get Started Now
 

--- a/src/docs/product/sentry-basics/index.mdx
+++ b/src/docs/product/sentry-basics/index.mdx
@@ -1,11 +1,15 @@
 ---
-title: Get Started with Sentry
+title: Get Started
 sidebar_order: 10
 description: "These tutorials will get you started with using Sentry."
 redirect_from:
   - /basics/
   - /product/sentry-basics/guides/
 ---
+
+Sentry is a developer-first error tracking and performance monitoring platform. If you haven't already:
+
+**→ [Sign up for Sentry here](https://sentry.io/signup/)**
 
 ## How to Get the Most Out of Sentry
 
@@ -17,15 +21,7 @@ There are three things we recommend you do to get the most out of Sentry:
 
 **Want a TL;DR for getting started? Download our ["Developer Quick Reference Guide"](/developer-quick-reference-guide.pdf)**
 
-## Get Started Now
-
-If you haven't already:
-
-**→ [Sign up for Sentry here](https://sentry.io/signup/)**
-
-**→ [Set up error monitoring for a frontend project](/product/sentry-basics/integrate-frontend/)**
-
-### Tutorials and Concepts
+## Tutorials and Concepts
 
 Get insights and fix what's broken with help from the following tutorials and concepts.
 


### PR DESCRIPTION
- move "what is sentry" and "what can sentry help with" sections up to the product index page
- add more details to how to get the most value out of sentry based on feedback from PMs