### PR TITLE
feat(feedback): Add onClose description to user-feedback

### DIFF
--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/_default.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/_default.mdx
@@ -1,0 +1,13 @@
+_Requires JS SDK version v7.82.0 or higher._
+
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onClose() {
+      // Refresh the page after the user closes the report dialog
+      location.reload();
+    },
+  });
+</script>
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/javascript.electron.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/javascript.electron.mdx
@@ -1,0 +1,11 @@
+_Requires JS SDK version v7.82.0 or higher._
+
+```javascript
+Sentry.showReportDialog({
+  // ...
+  onClose() {
+    // Refresh the window after the user closes the report dialog
+    win.reload();
+  },
+});
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/javascript.mdx
@@ -1,0 +1,11 @@
+_Requires JS SDK version v7.82.0 or higher._
+
+```javascript
+Sentry.showReportDialog({
+  // ...
+  onClose() {
+    // Refresh the page after the user closes the report dialog
+    location.reload();
+  },
+});
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/python.django.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/python.django.mdx
@@ -1,0 +1,13 @@
+_Requires JS SDK version v7.82.0 or higher._
+
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onClose() {
+      // Refresh the page after the user closes the report dialog
+      location.reload();
+    },
+  });
+</script>
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/python.flask.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onclose/python.flask.mdx
@@ -1,0 +1,13 @@
+_Requires JS SDK version v7.82.0 or higher._
+
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onClose() {
+      // Refresh the page after the user closes the report dialog
+      location.reload();
+    },
+  });
+</script>
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onload/_default.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onload/_default.mdx
@@ -1,0 +1,11 @@
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onLoad() {
+      // Log an event to amplitude when the report dialog opens
+      amplitude.logEvent("report_dialog_seen");
+    },
+  });
+</script>
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onload/javascript.electron.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onload/javascript.electron.mdx
@@ -1,0 +1,9 @@
+```javascript
+Sentry.showReportDialog({
+  // ...
+  onLoad() {
+    // Log an event to amplitude when the report dialog opens
+    amplitude.logEvent("report_dialog_seen");
+  },
+});
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onload/javascript.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onload/javascript.mdx
@@ -1,0 +1,9 @@
+```javascript
+Sentry.showReportDialog({
+  // ...
+  onLoad() {
+    // Log an event to amplitude when the report dialog opens
+    amplitude.logEvent("report_dialog_seen");
+  },
+});
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onload/python.django.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onload/python.django.mdx
@@ -1,0 +1,11 @@
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onLoad() {
+      // Log an event to amplitude when the report dialog opens
+      amplitude.logEvent("report_dialog_seen");
+    },
+  });
+</script>
+```

--- a/src/platform-includes/enriching-events/user-feedback/example-widget-onload/python.flask.mdx
+++ b/src/platform-includes/enriching-events/user-feedback/example-widget-onload/python.flask.mdx
@@ -1,0 +1,11 @@
+```html
+<script>
+  Sentry.showReportDialog({
+    // ...
+    onLoad() {
+      // Log an event to amplitude when the report dialog opens
+      amplitude.logEvent("report_dialog_seen");
+    },
+  });
+</script>
+```

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -20,7 +20,7 @@ While this feature isn't currently supported for Ruby or most of its frameworks,
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript", "java", "apple", "android", "dart", "flutter", "unreal", "react-native", "kotlin-multiplatform"]} >
+<PlatformSection supported={["javascript", "java", "apple", "android", "dart", "flutter", "unreal", "react-native", "kotlin-multiplatform"]}>
 
 ## User Feedback API
 
@@ -109,8 +109,20 @@ An override for Sentry’s automatic language detection (e.g. `lang=de`)
 | `errorGeneric`   | An unknown error occurred while submitting your report. Please try again.                         |
 | `errorFormEntry` | Some fields were invalid. Please correct the errors and try again.                                |
 | `successMessage` | Your feedback has been sent. Thank you!                                                           |
-| `onLoad`         | n/a - **an optional callback that will be invoked when the widget opens**                         |
-| `onClose`        | n/a - **an optional callback that will be invoked when the widget closes**                        |
+| `onLoad`         | n/a                                                                                               |
+| `onClose`        | n/a                                                                                               |
+
+<PlatformSection supported={["javascript", "python"]}>
+
+The optional callback `onLoad` will be called when users see the widget. You can use this to run custom logic, for example to log an analytics event:
+
+<PlatformContent includePath="enriching-events/user-feedback/example-widget-onload" />
+
+The optional callback `onClose` will be called when users close the widget. You can use this to run custom logic, for example to reload the page:
+
+<PlatformContent includePath="enriching-events/user-feedback/example-widget-onclose" />
+
+</PlatformSection>
 
 ## User Feedback API
 

--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -109,7 +109,8 @@ An override for Sentry’s automatic language detection (e.g. `lang=de`)
 | `errorGeneric`   | An unknown error occurred while submitting your report. Please try again.                         |
 | `errorFormEntry` | Some fields were invalid. Please correct the errors and try again.                                |
 | `successMessage` | Your feedback has been sent. Thank you!                                                           |
-| `onLoad`         | n/a                                                                                               |
+| `onLoad`         | n/a - **an optional callback that will be invoked when the widget opens**                         |
+| `onClose`        | n/a - **an optional callback that will be invoked when the widget closes**                        |
 
 ## User Feedback API
 
@@ -160,7 +161,8 @@ An override for Sentry’s automatic language detection (e.g. `lang=de`)
 | `errorGeneric`   | An unknown error occurred while submitting your report. Please try again.                         |
 | `errorFormEntry` | Some fields were invalid. Please correct the errors and try again.                                |
 | `successMessage` | Your feedback has been sent. Thank you!                                                           |
-| `onLoad`         | n/a                                                                                               |
+| `onLoad`         | n/a - **an optional callback that will be invoked when the widget opens**                         |
+| `onClose`        | n/a - **an optional callback that will be invoked when the widget closes**                        |
 
 ## User Feedback API
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9433

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adds `onClose` to the user-feedback section and a short description for both `onClose` and `onLoad`.

Please see the accompanying PRs:
* for the sdk: https://github.com/getsentry/sentry-javascript/pull/9550
* for the backend: https://github.com/getsentry/sentry/pull/59885

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
