### PR TITLE
build: Remove `format` command and add `lint:fix` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "lint:eslint:fix": "eslint --fix \"src/**/*.{ts,tsx,js,jsx}\"",
     "lint:prettier": "prettier --check \"./src/**/*.{md,mdx,ts,tsx,js,jsx}\"",
     "lint:prettier:fix": "prettier --write \"./src/**/*.{md,mdx,ts,tsx,js,jsx}\"",
+    "lint:fix": "yarn run lint:prettier:fix && yarn run lint:eslint:fix",
     "start": "yarn run develop",
-    "format": "prettier --write \"src/**/*.js\"",
     "remove-preview-deployments": "ts-node scripts/remove-preview-deployments.ts",
     "test": "jest"
   },


### PR DESCRIPTION
Noticed that the `yarn format` command doesn't really work properly, so I removed it and instead added a new `yarn lint:fix` command that will run all autofixing locally.