### PR TITLE
feat(python): Add a workaround to GCP docs

### DIFF
--- a/src/platforms/python/integrations/gcp-functions/index.mdx
+++ b/src/platforms/python/integrations/gcp-functions/index.mdx
@@ -17,7 +17,7 @@ Add the Sentry SDK to your `requirements.txt`:
 
 The GCP integration currently supports only the Python `3.7` runtime environment. If you try to run it with a newer version (such as `3.9`), an error message will be displayed (with debug mode on).
 
-Even though not they're not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
+Even though they're not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
 
 </Note>
 

--- a/src/platforms/python/integrations/gcp-functions/index.mdx
+++ b/src/platforms/python/integrations/gcp-functions/index.mdx
@@ -17,6 +17,8 @@ Add the Sentry SDK to your `requirements.txt`:
 
 The GCP integration currently supports only the Python `3.7` runtime environment. If you try to run it with a newer version (such as `3.9`), an error message will be displayed (with debug mode on).
 
+Even though not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
+
 </Note>
 
 ## Configure

--- a/src/platforms/python/integrations/gcp-functions/index.mdx
+++ b/src/platforms/python/integrations/gcp-functions/index.mdx
@@ -17,7 +17,7 @@ Add the Sentry SDK to your `requirements.txt`:
 
 The GCP integration currently supports only the Python `3.7` runtime environment. If you try to run it with a newer version (such as `3.9`), an error message will be displayed (with debug mode on).
 
-Even though they're not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
+Limited Sentry support is available on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
 
 </Note>
 

--- a/src/platforms/python/integrations/gcp-functions/index.mdx
+++ b/src/platforms/python/integrations/gcp-functions/index.mdx
@@ -17,7 +17,7 @@ Add the Sentry SDK to your `requirements.txt`:
 
 The GCP integration currently supports only the Python `3.7` runtime environment. If you try to run it with a newer version (such as `3.9`), an error message will be displayed (with debug mode on).
 
-Even though not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
+Even though not they're not directly supported, you can still get some Sentry support on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
 
 </Note>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Add a possible workaround for using the GCP integration on newer Python runtimes that are currently not supported directly.

Direct link to page: https://sentry-docs-git-ivana-gcf-with-newer-runtimes.sentry.dev/platforms/python/integrations/gcp-functions

Related: https://github.com/getsentry/sentry-python/issues/1666

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
