### PR TITLE
feat(loader): update loader docs for new config

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -47,7 +47,7 @@ function SentryLoaderConfig() {
       key="sentry-loader-config"
       dangerouslySetInnerHTML={{
         __html: `
-  window.Sentry && Sentry.onLoad(function() {
+window.sentryOnLoad = function() {
   Sentry.init({
     integrations: [
       new Sentry.Replay({
@@ -66,7 +66,7 @@ function SentryLoaderConfig() {
       'X-Sentry-Rate-Limit-Reset',
     ],
   });
-});`,
+};`,
       }}
     />
   );
@@ -75,7 +75,7 @@ function SentryLoaderConfig() {
 export const onRenderBody: GatsbySSR['onRenderBody'] = ({setHeadComponents}) => {
   // Sentry SDK setup
   if (sentryLoaderUrl) {
-    setHeadComponents([SentryLoaderScript(), SentryLoaderConfig()]);
+    setHeadComponents([SentryLoaderConfig(), SentryLoaderScript()]);
   }
 
   setHeadComponents([

--- a/src/platform-includes/configuration/capture-console/javascript.mdx
+++ b/src/platform-includes/configuration/capture-console/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.CaptureConsole()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'captureconsole.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.CaptureConsole()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.ContextLines()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'contextlines.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.ContextLines()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/debug/javascript.mdx
+++ b/src/platform-includes/configuration/debug/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.Debug()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'debug.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.Debug()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/dedupe/javascript.mdx
+++ b/src/platform-includes/configuration/dedupe/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.Dedupe()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'dedupe.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.Dedupe()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -33,7 +33,7 @@ Sentry.addIntegration(new ReportingObserver());
 
 <script>
   // Later in your application
-   // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
+  // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
   window.Sentry &&
     Sentry.onLoad(function () {
       Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -12,6 +12,15 @@ Sentry.addIntegration(new ReportingObserver());
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -23,21 +32,12 @@ Sentry.addIntegration(new ReportingObserver());
 ></script>
 
 <script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
+  // Later in your application
+   // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
   window.Sentry &&
     Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [],
-      });
-
-      const client = Sentry.getCurrentHub().getClient();
-      if (client) {
-        client.addIntegration(new Sentry.Integrations.ReportingObserver());
-      }
+      Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());
     });
-
-    Sentry.addIntegration(new Sentry.Integrations.ReportingObserver());
-  });
 </script>
 ```
 

--- a/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.ReportingObserver()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.ReportingObserver()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/src/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.ExtraErrorData()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'extraerrordata.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.ExtraErrorData()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/http-client/javascript.mdx
+++ b/src/platform-includes/configuration/http-client/javascript.mdx
@@ -14,6 +14,18 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.HttpClient()],
+
+      // This option is required for capturing headers and cookies.
+      sendDefaultPii: true,
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -23,19 +35,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'httpclient.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.HttpClient()],
-
-        // This option is required for capturing headers and cookies.
-        sendDefaultPii: true,
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/module-metadata/javascript.mdx
+++ b/src/platform-includes/configuration/module-metadata/javascript.mdx
@@ -10,20 +10,19 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.ModuleMetadata()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.ModuleMetadata()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/src/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.ReportingObserver()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.ReportingObserver()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -11,6 +11,15 @@ Sentry.init({
 ```
 
 ```html {tabTitle: Loader}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [new Sentry.Integrations.RewriteFrames()],
+    });
+  };
+</script>
+
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
@@ -20,16 +29,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'rewriteframes.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        integrations: [new Sentry.Integrations.RewriteFrames()],
-      });
-    });
-</script>
 ```
 
 ```html {tabTitle: CDN}

--- a/src/platform-includes/session-replay/install/javascript.mdx
+++ b/src/platform-includes/session-replay/install/javascript.mdx
@@ -20,18 +20,17 @@ This will initialize Replay with the default config:
 You can change it with:
 -->
 <script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry &&
-    Sentry.onLoad(function () {
-      Sentry.init({
-        replaysSessionSampleRate: 0.5,
-        integrations: [
-          new Sentry.Replay({
-            maskAllText: true,
-          }),
-        ],
-      });
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      replaysSessionSampleRate: 0.5,
+      integrations: [
+        new Sentry.Replay({
+          maskAllText: true,
+        }),
+      ],
     });
+  };
 </script>
 ```
 

--- a/src/platforms/javascript/common/install/index.mdx
+++ b/src/platforms/javascript/common/install/index.mdx
@@ -34,7 +34,7 @@ Using the Loader Script is the easiest way to start using Sentry. Add a script t
 
 - **Easy to upgrade**: We'll take care of always shipping the latest version of the SDK to your users. No action's needed from you. This ensures you'll always get the latest features and bug fixes of the Sentry SDK.
 
-- **Easy to add additional configuration**: You can [configure the SDK](./loader/#sdk-configuration) to your liking via `Sentry.onLoad()`.
+- **Easy to add additional configuration**: You can [configure the SDK](./loader/#sdk-configuration) to your liking via `window.sentryOnLoad`.
 
 - **Lazy-loading**: If you just want to use Sentry for errors, we'll only load the SDK when an error occurs, reducing the amount of JavaScript loaded on your page until then.
 

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -74,6 +74,16 @@ If Performance Monitoring and/or Session Replay is enabled, the SDK will immedia
 
 ## SDK Configuration
 
+While the Loader Script will work out of the box without any configuration in your application, you can still configure the SDK according to your needs.
+
+### Default Configuration
+
+For Performance Monitoring, the SDK will be initialized with `tracesSampleRate: 1` by default. This means that the SDK will capture all traces.
+
+For Session Replay, the defaults are `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1`. This means Replays will be captured for 10% of all normal sessions and for all sessions with an error.
+
+### Release Configuration
+
 You can configure the release by adding the following to your page:
 
 ```html
@@ -83,12 +93,6 @@ You can configure the release by adding the following to your page:
   };
 </script>
 ```
-
-### Default Configuration
-
-For Performance Monitoring the SDK will be initialized with `tracesSampleRate: 1` by default. This means that the SDK will capture all traces.
-
-For Session Replay, the defaults are `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1`. This means Replays will be captured for 10% of all normal sessions and for all sessions with an error.
 
 ### Custom Configuration
 
@@ -115,18 +119,20 @@ Inside of the `window.sentryOnLoad` function, you can configure a custom `Sentry
 ```html
 <script>
   // Configure sentryOnLoad before adding the Loader Script
-    window.sentryOnLoad = function () {
-      Sentry.init({
-        release: " ... ",
-        environment: " ... "
-      });
-      Sentry.setTag(...);
-      // etc.
-    };
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      release: " ... ",
+      environment: " ... "
+    });
+    Sentry.setTag(...);
+    // etc.
+  };
 </script>
 ```
 
-In addition to `window.sentryOnLoad`, you can also use `Sentry.onLoad()` to make sure the SDK is loaded before you call any other SDK methods. The loader will by default make sure that these functions can be called directly on `Sentry` at all times:
+### Guarding SDK Function Calls
+
+The loader will by default make sure that these functions can be called directly on `Sentry` at all times, even if the SDK is not yet loaded:
 
 - `Sentry.captureException()`
 - `Sentry.captureMessage()`
@@ -136,13 +142,14 @@ In addition to `window.sentryOnLoad`, you can also use `Sentry.onLoad()` to make
 - `Sentry.withScope()`
 - `Sentry.showReportDialog()`
 
-If you want to call any other method when using the Loader, you have to guard it with `Sentry.onLoad()`:
+If you want to call any other method when using the Loader, you have to guard it with `Sentry.onLoad()`. Any callback given to `onLoad()` will be called either immediately (if the SDK is already loaded), or later once the SDK has been loaded:
 
 ```javascript
 // Guard against window.Sentry not being available, e.g. due to Ad-blockers
 window.Sentry &&
   Sentry.onLoad(function () {
-    // Inside of this callback, we guarantee that `Sentry` is fully loaded and all APIs are available
+    // Inside of this callback,
+    // we guarantee that `Sentry` is fully loaded and all APIs are available
     const client = Sentry.getCurrentHub().getClient();
     // do something custom here
   });

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -132,7 +132,7 @@ Inside of the `window.sentryOnLoad` function, you can configure a custom `Sentry
 
 ### Guarding SDK Function Calls
 
-The loader will by default make sure that these functions can be called directly on `Sentry` at all times, even if the SDK is not yet loaded:
+By default, the loader will make sure you can call these functions directly on `Sentry` at any time, even if the SDK is not yet loaded:
 
 - `Sentry.captureException()`
 - `Sentry.captureMessage()`

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -84,42 +84,71 @@ You can configure the release by adding the following to your page:
 </script>
 ```
 
-The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to [configure your SDK](../../configuration/options/) beyond that, you'll need a second script tag, in which you'll call `Sentry.onLoad`. This script must come _after_ the main loader script.
-
-```html
-<script
-  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry && Sentry.onLoad(function() { ... });
-</script>
-```
-
-`Sentry.onLoad` is a function that only the loader provides, and - as the name suggests - it sets a function to be run once the full SDK has been loaded. In that function, you can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init` call doesn't need to include your DSN, since it's already been set. We recommend checking if `Sentry` exists before calling `Sentry.onLoad` in case the loader script failed to load.
-
-```html
-<script>
-  // Check for existence of Sentry in case Ad-blockers block the Sentry Loader Script
-  window.Sentry && Sentry.onLoad(function() {
-    Sentry.init({
-      release: " ... ",
-      environment: " ... "
-    });
-    Sentry.configureScope(scope => {
-      scope.setTag( ... );
-    });
-    // etc.
-  });
-</script>
-```
+### Default Configuration
 
 For Performance Monitoring, by default, the SDK will be initialized with `tracesSampleRate: 1`. This means that the SDK will capture all traces.
 
 For Session Replay, the defaults are set to `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1`. This means Replays will be captured for 10% of all normal sessions and for all sessions with an error.
 
-## **Limitations of error-only capturing**
+### Custom Configuration
+
+The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to [configure your SDK](../../configuration/options/) beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:
+
+```html
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      // add custom config here
+    });
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+```
+
+Inside of the `window.sentryOnLoad` function, you can configure a custom `Sentry.init()` call. You can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init()` call doesn't need to include your DSN, since it's already been set. Inside of this function, the full Sentry SDK is guaranteed to be loaded & available.
+
+```html
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+    window.sentryOnLoad = function () {
+      Sentry.init({
+        release: " ... ",
+        environment: " ... "
+      });
+      Sentry.setTag(...);
+      // etc.
+    };
+</script>
+```
+
+In addition to `window.sentryOnLoad`, you can also use `Sentry.onLoad()` to make sure the SDK is loaded before you call any other SDK methods. The loader will by default make sure that these functions can be called directly on `Sentry` at all times:
+
+- `Sentry.captureException()`
+- `Sentry.captureMessage()`
+- `Sentry.captureEvent()`
+- `Sentry.addBreadcrumb()`
+- `Sentry.configureScope()`
+- `Sentry.withScope()`
+- `Sentry.showReportDialog()`
+
+If you want to call any other method when using the Loader, you have to guard it with `Sentry.onLoad()`:
+
+```javascript
+// Guard against window.Sentry not being available, e.g. due to Ad-blockers
+window.Sentry &&
+  Sentry.onLoad(function () {
+    // Inside of this callback, we guarantee that `Sentry` is fully loaded and all APIs are available
+    const client = Sentry.getCurrentHub().getClient();
+    // do something custom here
+  });
+```
+
+## Limitations of error-only capturing
 
 When using the Loader Script with just errors, the script injects the SDK asynchronously. This means that only _unhandled errors_ and _unhandled promise rejections_ will be caught and buffered before the SDK is fully loaded. Specifically, capturing [breadcrumb data](../../enriching-events/breadcrumbs/) will not be available until the SDK is fully loaded and initialized. To reduce the amount of time these features are unavailable, set `data-lazy="no"` or call `forceLoad()` as described above.
 

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -86,13 +86,13 @@ You can configure the release by adding the following to your page:
 
 ### Default Configuration
 
-For Performance Monitoring, by default, the SDK will be initialized with `tracesSampleRate: 1`. This means that the SDK will capture all traces.
+For Performance Monitoring the SDK will be initialized with `tracesSampleRate: 1` by default. This means that the SDK will capture all traces.
 
-For Session Replay, the defaults are set to `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1`. This means Replays will be captured for 10% of all normal sessions and for all sessions with an error.
+For Session Replay, the defaults are `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1`. This means Replays will be captured for 10% of all normal sessions and for all sessions with an error.
 
 ### Custom Configuration
 
-The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to [configure your SDK](../../configuration/options/) beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:
+The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to <PlatformLink to="/configuration/options/">configure your SDK</PlatformLink> beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:
 
 ```html
 <script>
@@ -110,7 +110,7 @@ The loader script always includes a call to `Sentry.init` with a default configu
 ></script>
 ```
 
-Inside of the `window.sentryOnLoad` function, you can configure a custom `Sentry.init()` call. You can configure your SDK exactly the way you would were you using the CDN, with one difference: your `Sentry.init()` call doesn't need to include your DSN, since it's already been set. Inside of this function, the full Sentry SDK is guaranteed to be loaded & available.
+Inside of the `window.sentryOnLoad` function, you can configure a custom `Sentry.init()` call. You can configure your SDK exactly the way you would if you were using the CDN, with one difference: your `Sentry.init()` call doesn't need to include your DSN, since it's already been set. Inside of this function, the full Sentry SDK is guaranteed to be loaded & available.
 
 ```html
 <script>


### PR DESCRIPTION
Updates the docs for the loader to use the newly added `window.sentryOnLoad` config, which is better than `onLoad()` as it has better timing guarantees and also we do not need to check for existence of `Sentry`.