### PR TITLE
fix(issues): remove note about DB on main thread for Android

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/db-main-thread-io.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/db-main-thread-io.mdx
@@ -4,12 +4,6 @@ sidebar_order: 20
 description: "Learn more about Database on Main Thread and how to diagnose and fix these issues."
 ---
 
-<Note>
-
-This feature is available **only for iOS devices** using `sentry-cocoa` >= v8.5.0. We are working on adding support for Android devices and will update this page with the latest changes.
-
-</Note>
-
 The main UI thread in a mobile application handles user interface events such as button presses and page scrolls. To prevent App Hangs and Application Not Responding errors, the main UI thread shouldn't be used for performing long-running operations like database queries. These kinds of operations block the whole UI until they finish running and get in the way of the user interacting with the app.
 
 ## Detection Criteria


### PR DESCRIPTION
Remove note that DB on main thread perf issues is not available on Android - it's generally available now, see e.g. https://demo.sentry.io/issues/4327317740/?project=1801383

Note: This PR aligns the DB on main thread page with the other pages. We generally do not document compatibility of Mobile perf issues on the docs, but availability is intuitively subject to SDK version, frameworks, and configuration used (i.e. the File/DB APIs/frameworks used need to be instrumented by the SDK for the backend detector to be able to detect perf issues).