### PR TITLE
fix(apple): VisionOS Install Methods

### DIFF
--- a/src/platforms/apple/common/install/carthage.mdx
+++ b/src/platforms/apple/common/install/carthage.mdx
@@ -1,6 +1,8 @@
 ---
 title: Carthage
 description: "Learn about integrating Sentry into your Xcode project using Carthage."
+notSupported:
+  - apple.visionos
 ---
 
 To integrate Sentry into your Xcode project using Carthage, specify it in your _Cartfile_:

--- a/src/platforms/apple/common/install/swift-package-manager.mdx
+++ b/src/platforms/apple/common/install/swift-package-manager.mdx
@@ -1,6 +1,8 @@
 ---
 title: Swift Package Manager (SPM)
 description: "Integrate Sentry into your Xcode project using Swift Package Manager (SPM)."
+notSupported:
+  - apple.visionos
 ---
 
 To integrate Sentry into your Xcode project using Swift Package Manager (SPM), open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:

--- a/src/platforms/apple/common/install/swift-package-manager.mdx
+++ b/src/platforms/apple/common/install/swift-package-manager.mdx
@@ -1,8 +1,6 @@
 ---
 title: Swift Package Manager (SPM)
 description: "Integrate Sentry into your Xcode project using Swift Package Manager (SPM)."
-notSupported:
-  - apple.visionos
 ---
 
 To integrate Sentry into your Xcode project using Swift Package Manager (SPM), open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Clarify that visionOS is not supported for installation via Carthage and Swift package manager.

