### PR TITLE
Disable sourceContext option to make build work.

### DIFF
--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -223,13 +223,13 @@ sentry {
 
 ### Source Context for Generated Code
 
-In case you have a code generation step in your build (e.g. Quarkus) you will face an error similiar to this:
+If you have a code generation step in your build (e.g. Quarkus) you will see an error similar to this:
 
 ```
 Task ':xxx:sentryCollectSourcesJava' uses this output of task ':xxx:quarkusGenerateCode' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
 ```
 
-To resolve this you need to declare a task dependency for `sentryCollectSourcesJava` on code generation tasks that exist in your build:
+To resolve this, declare a task dependency for `sentryCollectSourcesJava` on code generation tasks that exist in your build:
 
 ```groovy
 tasks.named("sentryCollectSourcesJava") {

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -221,26 +221,26 @@ sentry {
 
 </PlatformSection>
 
-### Include Generated Code in Source Context
+### Source Context for Generated Code
 
-In case you have a code generation step in your build(e.g. Quarkus) you will face an error similiar to this:
+In case you have a code generation step in your build (e.g. Quarkus) you will face an error similiar to this:
+
 ```
 Task ':xxx:sentryCollectSourcesJava' uses this output of task ':xxx:quarkusGenerateCode' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
 ```
 
-To resolve this you need to declare a dependency for `sentryCollectSourcesJava` on code generation tasks that exist in your build. This can be done by defining the depdency in your build file:
+To resolve this you need to declare a task dependency for `sentryCollectSourcesJava` on code generation tasks that exist in your build:
 
 ```groovy
 tasks.named("sentryCollectSourcesJava") {
-    // Replace CodeGenTask with name of the task that generates code during build
-    mustRunAfter("CodeGenTask")
+    // Make the task run after the tasks that generate code during build
+    mustRunAfter("CodeGenTask1", "CodeGenTask2")
 }
 ```
-
 ```kotlin
 tasks.named("sentryCollectSourcesJava") {
-    // Replace CodeGenTask with name of the task that generates code during build
-    mustRunAfter("CodeGenTask")
+    // Make the task run after the tasks that generate code during build
+    mustRunAfter("CodeGenTask1", "CodeGenTask2")
 }
 ```
 

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -237,6 +237,7 @@ tasks.named("sentryCollectSourcesJava") {
     mustRunAfter("CodeGenTask1", "CodeGenTask2")
 }
 ```
+
 ```kotlin
 tasks.named("sentryCollectSourcesJava") {
     // Make the task run after the tasks that generate code during build

--- a/src/platform-includes/source-context/java.mdx
+++ b/src/platform-includes/source-context/java.mdx
@@ -221,6 +221,29 @@ sentry {
 
 </PlatformSection>
 
+### Include Generated Code in Source Context
+
+In case you have a code generation step in your build(e.g. Quarkus) you will face an error similiar to this:
+```
+Task ':xxx:sentryCollectSourcesJava' uses this output of task ':xxx:quarkusGenerateCode' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
+```
+
+To resolve this you need to declare a dependency for `sentryCollectSourcesJava` on code generation tasks that exist in your build. This can be done by defining the depdency in your build file:
+
+```groovy
+tasks.named("sentryCollectSourcesJava") {
+    // Replace CodeGenTask with name of the task that generates code during build
+    mustRunAfter("CodeGenTask")
+}
+```
+
+```kotlin
+tasks.named("sentryCollectSourcesJava") {
+    // Replace CodeGenTask with name of the task that generates code during build
+    mustRunAfter("CodeGenTask")
+}
+```
+
 <PlatformSection notSupported={["android"]}>
 
 ## Using the Maven Build Tool Plugin

--- a/src/platforms/java/common/gradle/index.mdx
+++ b/src/platforms/java/common/gradle/index.mdx
@@ -50,7 +50,7 @@ sentry {
     // This enables source context, allowing you to see your source
     // code as part of your stack traces in Sentry.
     //
-    // Default is disabled. To enable view the source context guide.
+    // Default is disabled. To enable, see the source context guide.
     includeSourceContext = true
 
     // Includes additional source directories into the source bundle.
@@ -83,7 +83,7 @@ sentry {
     // This enables source context, allowing you to see your source
     // code as part of your stack traces in Sentry.
     //
-    // Default is disabled. To enable view the source context guide.
+    // Default is disabled. To enable, see the source context guide.
     includeSourceContext.set(true)
 
     // Includes additional source directories into the source bundle.

--- a/src/platforms/java/common/gradle/index.mdx
+++ b/src/platforms/java/common/gradle/index.mdx
@@ -51,7 +51,7 @@ sentry {
     // code as part of your stack traces in Sentry.
     //
     // Default is disabled. To enable view the source context guide.
-    includeSourceContext = false
+    includeSourceContext = true
 
     // Includes additional source directories into the source bundle.
     // These directories are resolved relative to the project directory.
@@ -84,7 +84,7 @@ sentry {
     // code as part of your stack traces in Sentry.
     //
     // Default is disabled. To enable view the source context guide.
-    includeSourceContext.set(false)
+    includeSourceContext.set(true)
 
     // Includes additional source directories into the source bundle.
     // These directories are resolved relative to the project directory.

--- a/src/platforms/java/common/gradle/index.mdx
+++ b/src/platforms/java/common/gradle/index.mdx
@@ -50,8 +50,8 @@ sentry {
     // This enables source context, allowing you to see your source
     // code as part of your stack traces in Sentry.
     //
-    // Default is disabled.
-    includeSourceContext = true
+    // Default is disabled. To enable view the source context guide.
+    includeSourceContext = false
 
     // Includes additional source directories into the source bundle.
     // These directories are resolved relative to the project directory.
@@ -83,8 +83,8 @@ sentry {
     // This enables source context, allowing you to see your source
     // code as part of your stack traces in Sentry.
     //
-    // Default is disabled.
-    includeSourceContext.set(true)
+    // Default is disabled. To enable view the source context guide.
+    includeSourceContext.set(false)
 
     // Includes additional source directories into the source bundle.
     // These directories are resolved relative to the project directory.


### PR DESCRIPTION
## Changes

- Disable sourceContext option to make build work: This option was set to true in example config but this option cannot be enabled without setting `org`, `project`, and `authToken` so in result the config you copy from the docs fail. I think adding the comment to enable it after reading the docs would communicate that some additional steps are needed for this feature.
- Add section for specifying dependencies of sentry task: When running the plugin in a build where there is a code generation task, the plugin fails. This section provides guidance for running sentry plugin step after the code generation tasks.

Fix: https://github.com/getsentry/sentry-android-gradle-plugin/issues/546



<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
