### PR TITLE
Monitor upsert support docs

### DIFF
--- a/src/docs/product/crons/getting-started/cli.mdx
+++ b/src/docs/product/crons/getting-started/cli.mdx
@@ -3,13 +3,13 @@ title: CLI
 sidebar_order: 200
 ---
 
-<Include name="feature-stage-beta-crons.mdx" />
+        <Include name="feature-stage-beta-crons.mdx" />
 
-<Alert level="note" title="Deprecation Notice">
+        <Alert level="note" title="Deprecation Notice">
 
-Starting with v2.16.1 of the Sentry CLI, the ability to monitor check-ins using an auth token for authorization has been deprecated. Read on to learn how to update your CLI and use your project's DSN instead.
 
-</Alert>
+
+                </Alert>
 
 Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.
 
@@ -24,7 +24,7 @@ To begin monitoring your recurring, scheduled job:
 
 The Sentry CLI uses your Monitor's project DSN to authorize check-ins. To set it up, export the `SENTRY_DSN` environment variable:
 
-<SignInNote />
+        <SignInNote />
 
 ```bash
 export SENTRY_DSN=___PUBLIC_DSN___
@@ -32,7 +32,7 @@ export SENTRY_DSN=___PUBLIC_DSN___
 
 Alternatively, you can add it to your `~/.sentryclirc` config:
 
-<SignInNote />
+        <SignInNote />
 
 ```ini {filename:~/.sentryclirc}
 [auth]
@@ -57,6 +57,29 @@ sentry-cli monitors run my-monitor-slug -- python path/to/file.py
 
 ```bash {tabTitle: Node.JS}
 sentry-cli monitors run my-monitor-slug -- node path/to/file.js
+```
+
+### Configuring Your Monitor via the CLI
+
+You can also use the Sentry CLI to configure your cron monitor when you run your job. This way, you can avoid having to first set up the monitor through the Sentry web interface.
+
+Configure the cron monitor by providing the cron schdule in crontab format using the `--schedule` or the equivalent `-s` argument when executing the `sentry cli monitors run` command. Please make sure to enclose the schedule in quotes, so that your shell parses the argument correctly, like so:
+```bash
+sentry-cli monitors run --schedule "<expected schedule>" <monitor-slug> -- <command> <args>
+```
+
+When providing the `--schedule` argument, we also support the following optional arguments to provide additional configuration:
+  - `--check-in-margin`: The allowed margin of minutes after the expected check-in time that the monitor will not be considered missed for.
+  - `--max-runtime`: The allowed duration in minutes that the monitor may be in progress for before being considered failed due to timeout.
+  - `--timezone` *(beta, use cautiously!)*: A tz database string (e.g. "Europe/Vienna") representing the monitor's execution schedule's timezone. Please be **absolutely sure that you provide a valid tz database string** when using this argument; as of writing, the CLI lacks the capability to validate this string, and so **the monitor creation will silently fail when the string is invalid!** For now, we recommend verifying that the cron monitor was created successfully in Sentry when using this argument.
+
+Below are some usage examples:
+```bash {tabTitle: Every Minute}
+sentry-cli monitors run -s "* * * * *" -- my-command
+```
+
+```bash {tabTitle: Every Hour (+ Optional Arguments)}
+sentry-cli monitors run -s "0 * * * *" --check-in-margin 10 --max-runtime 5 --timezone "Europe/Vienna" -- my-command
 ```
 
 ### Specifying Monitor Environments (Optional)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds documentation for the new monitor upserts feature in the Sentry CLI, which allows users to create a cron monitor directly from the command line, without having to set it up in the Sentry web UI first.

Closes #8482 
