### PR TITLE
Get rid of "our" in tutorial

### DIFF
--- a/src/api/guides/teams-tutorial.mdx
+++ b/src/api/guides/teams-tutorial.mdx
@@ -23,7 +23,7 @@ We recommend using a free [Sentry developer account](https://sentry.io/pricing/)
 
 ## List an Organization's Teams
 
-First, you will use the [List an Organization's Teams](/api/teams/list-an-organizations-teams/) API to list all the teams in our organization.
+First, you will use the [List an Organization's Teams](/api/teams/list-an-organizations-teams/) API to list all the teams in your organization.
 
 ### Find your organization ID
 
@@ -87,7 +87,7 @@ You can find your organization ID in the browser URL of your Sentry instance. Fo
 
    The output gives you details about the teams within the specified organization.
 
-   If your organization has enough teams, the API will return paginated results. See our docs on [Pagination](/api/pagination/) to learn how to handle paginated results.
+   If your organization has enough teams, the API will return paginated results. See Sentry's docs on [Pagination](/api/pagination/) to learn how to handle paginated results.
 
 1. [Optional] To list information about the projects associated with each team you can set the `detailed` query parameter to `1`:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
