### PR TITLE
Reference tunnelRoute in Next.js tunnel docs

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -86,6 +86,19 @@ You can work around our CDN bundles being blocked by [using our NPM packages](#u
 
 ### Using the `tunnel` Option
 
+<PlatformSection supported={["javascript.nextjs"]}>
+
+<Note>
+  The Sentry Next.js SDK has a separate option to make setting up tunnels very
+  straight-forward, allowing you to skip the setup below. See{" "}
+  <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers">
+    Configure Tunneling to avoid Ad-Blockers
+  </PlatformLink>{" "}
+  to learn how to set up tunneling on Next.js.
+</Note>
+
+</PlatformSection>
+
 A tunnel is an HTTP endpoint that acts as a proxy between Sentry and your application. Because you control this server, there is no risk of any requests sent to it being blocked. When the endpoint lives under the same origin (although it does not have to in order for the tunnel to work), the browser will not treat any requests to the endpoint as a third-party request. As a result, these requests will have different security measures applied which, by default, don't trigger ad-blockers. A quick summary of the flow can be found below.
 
 ![Tunnel Flow](./tunnel.png)

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -335,6 +335,8 @@ const nextConfig = {
 };
 ```
 
+Setting this option will add an API endpoint to your application that is used to forward Sentry events to the Sentry servers.
+
 Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.
 
 The `tunnelRoute` option does currently not work with self-hosted Sentry instances.


### PR DESCRIPTION
Adds a quick note to the tunnel option docs to say that there is a quicker setup route in Next.js.

