### PR TITLE
feat(remix): Add note about Vite project sourcemap uploads.

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -7,6 +7,12 @@ If you installed the SDK manually or the wizard failed, follow the steps below t
 
 ### Configure Source Maps Upload
 
+<Alert level="info" title="Uploading sourcemaps on Vite projects">
+
+Starting from version 2.2.0, Remix supports [Vite](https://vitejs.dev/) as a build tool. If you use Vite to build your project, you can use the [Vite plugin](/platforms/javascript/sourcemaps/uploading/vite/) to upload source maps to Sentry. You do not need to follow the steps below.
+
+</Alert>
+
 The Sentry Remix SDK provides a script to automatically create a release and upload source maps after you've built your project.
 Under the hood, it uses the [Sentry CLI](/product/cli/).
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/9421
Ref: https://github.com/getsentry/sentry-wizard/issues/487

Adds a note and redirects users to Vite soucemaps upload instruction page in Remix sourcemaps page.