### PR TITLE
replay(options): point out how to opt-in for text if safe

### DIFF
--- a/src/platform-includes/replay/privacy-configuration/javascript.mdx
+++ b/src/platform-includes/replay/privacy-configuration/javascript.mdx
@@ -1,4 +1,16 @@
-The following options can be configured as options to the integration, in `new Replay({})`:
+For a static website, free of personal identifiable or other type of private data.
+You can easily opt-in to text and media with:
+
+```javascript
+new Sentry.Replay({
+      maskAllText: false,
+      blockAllMedia: false,
+    }),
+  },
+});
+```
+
+The following is the complete list of options that can be used in `new Replay({})`:
 
 | key           | type                     | default                                  | description                                                                                                                                                                                       |
 | ------------- | ------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/platform-includes/replay/privacy-configuration/javascript.mdx
+++ b/src/platform-includes/replay/privacy-configuration/javascript.mdx
@@ -1,12 +1,10 @@
 For a static website, free of personal identifiable or other type of private data.
-You can easily opt-in to text and media with:
+You can easily opt-out out of the default text masking and image blocking by configuring the `maskAllText` and `blockAllMedia` configuration options respectively:
 
 ```javascript
 new Sentry.Replay({
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
-  },
+  maskAllText: false,
+  blockAllMedia: false,
 });
 ```
 

--- a/src/platform-includes/replay/privacy-configuration/javascript.mdx
+++ b/src/platform-includes/replay/privacy-configuration/javascript.mdx
@@ -1,5 +1,5 @@
-For a static website, free of personal identifiable or other type of private data.
-You can easily opt-out out of the default text masking and image blocking by configuring the `maskAllText` and `blockAllMedia` configuration options respectively:
+If you're working on a static website that's free of personal identifiable or other type of private data,
+you can opt out of the default text masking and image blocking by configuring the `maskAllText` and `blockAllMedia` configuration options respectively:
 
 ```javascript
 new Sentry.Replay({
@@ -8,7 +8,7 @@ new Sentry.Replay({
 });
 ```
 
-The following is the complete list of options that can be used in `new Replay({})`:
+The following is a complete list of options that can be used in `new Replay({})`:
 
 | key           | type                     | default                                  | description                                                                                                                                                                                       |
 | ------------- | ------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Before giving a huge table for the user to parse, lets cover a common use case with a code snippet.
The snippet also benefits in a way to show how the user can place the options listed in the table below in code. (they go under `Replay({ ... })`

This include is used in the following pages:
 * https://docs.sentry.io/platforms/javascript/session-replay/configuration
 * https://docs.sentry.io/platforms/javascript/session-replay/privacy/
