### PR TITLE
update docs for vue 3 component tracking update

### DIFF
--- a/src/platforms/javascript/guides/vue/features/component-tracking.mdx
+++ b/src/platforms/javascript/guides/vue/features/component-tracking.mdx
@@ -47,19 +47,25 @@ The default is `false`.
 
 #### `hooks`
 
-Control which lifecycle hooks should be tracked. This is helpful if, for example, you want to know if some components are removed during the initial page load, in which case you can add a `destroy` hook to the default:
+Control which lifecycle hooks should be tracked. This is helpful if, for example, you want to know if some components are removed during the initial page load, in which case you can add a `unmount` hook to the default:
 
 ```javascript
 Sentry.init({
   // ...
   trackComponents: true
-  hooks: ["mount", "update", "destroy"],
+  hooks: ["mount", "update", "unmount"],
 });
 ```
 
-The following hooks are available to track: `['activate', 'create', 'destroy', 'mount', 'update']`
+The following hooks are available to track in Vue 3: `['activate', 'create', 'unmount', 'mount', 'update']`
 
-Note that when specifying `hooks`, we use the simple verb rather than `before` and `-ed` pairs. For example, `destroy` is correct, while `beforeDestroy` and `destroyed` are incorrect.
+Note that when specifying `hooks`, we use the simple verb rather than `before` and `-ed` pairs. For example, `unmount` is correct, while `beforeUnmount` and `unmounted` are incorrect.
+
+<Alert>
+
+In Vue 2, use `destroy` instead of `unmount`. `destroy` does not work in Vue 3, as the names of the lifecycle hooks themselves [have changed](https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes) in Vue 3.
+
+</Alert>
 
 The default set of hooks is `['activate', 'mount', 'update']`.
 

--- a/src/platforms/javascript/guides/vue/features/component-tracking.mdx
+++ b/src/platforms/javascript/guides/vue/features/component-tracking.mdx
@@ -63,7 +63,7 @@ Note that when specifying `hooks`, we use the simple verb rather than `before` a
 
 <Alert>
 
-In Vue 2, use `destroy` instead of `unmount`. `destroy` does not work in Vue 3, as the names of the lifecycle hooks themselves [have changed](https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes) in Vue 3.
+In Vue 2, use `destroy` instead of `unmount`. `destroy` does not work in Vue 3, as the names of the lifecycle hooks themselves [changed](https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes) in Vue 3.
 
 </Alert>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adds documentation for Vue 3 compatible performance tracing hooks added in https://github.com/getsentry/sentry-javascript/pull/9578. Screenshot of changed section:

<img width="777" alt="image" src="https://github.com/getsentry/sentry-docs/assets/5778364/6e94c3e9-826f-4777-b57c-f979111696fd">

I chose to update the examples to be vue 3 first because vue 2 is [reaching EOL](https://v2.vuejs.org/lts/) at the end of the year - so it made sense to update the docs here to be Vue 3 first as that is already the default for most people right now (or at least, I would expect so).

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
