### PR TITLE
feat(crons): Ruby docs for auto-instrumentation

### DIFF
--- a/src/platform-includes/crons/setup/ruby.mdx
+++ b/src/platform-includes/crons/setup/ruby.mdx
@@ -1,6 +1,20 @@
 ## Job Monitoring
 
-Standard job frameworks such as `ActiveJob` and `Sidekiq` with a `perform` method can use the `Sentry::Cron::MonitorCheckIns` mixin module to automatically capture check-ins.
+If you're using `sidekiq-cron` or `sidekiq-scheduler`, Sentry can automatically
+capture check-ins for all jobs that are scheduled to run periodically. To
+achieve this, you need to enable the corresponding Sentry plugin:
+
+```rb
+Sentry.init do |config|
+  config.enabled_plugins += [:sidekiq_cron]
+  # or, for sidekiq-scheduler:
+  config.enabled_plugins += [:sidekiq_scheduler]
+end
+```
+
+More generally, popular job frameworks such as `ActiveJob` and `Sidekiq` with
+a `perform` method can use the `Sentry::Cron::MonitorCheckIns` mixin module
+to automatically capture check-ins.
 
 ```rb {tabTitle: ActiveJob}
 class ExampleJob < ApplicationJob
@@ -34,6 +48,7 @@ You can pass in optional attributes to `sentry_monitor_check_ins` as follows.
 sentry_monitor_check_ins slug: 'custom_slug'
 
 # define the monitor config with an interval
+# the units supported are :year, :month, :week, :day, :hour, :minute
 sentry_monitor_check_ins monitor_config: Sentry::Cron::MonitorConfig.from_interval(1, :minute)
 
 # define the monitor config with a crontab
@@ -41,6 +56,9 @@ sentry_monitor_check_ins monitor_config: Sentry::Cron::MonitorConfig.from_cronta
 ```
 
 ## Manual Setup
+
+If you're using `Clockwork` or `Whenever`, you'll need to instrument your jobs
+manually.
 
 ### Check-Ins (Recommended)
 


### PR DESCRIPTION
## Summary

This is a satellite PR to Sentry-Ruby's Crons auto-instrumentation support. We should only merge this when the three PRs below are merged and shipped:
- [x] `sentry-cron`: https://github.com/getsentry/sentry-ruby/pull/2170
- [ ] `sentry-scheduler`: https://github.com/getsentry/sentry-ruby/pull/2172
- [ ] `sentry-cron` cleanup: https://github.com/getsentry/sentry-ruby/pull/2173

/cc @sl0thentr0py 

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
