### PR TITLE
fix(sentry-ruby): A note on Rack apps without Rackup

### DIFF
--- a/src/platform-includes/getting-started-config/ruby.rack.mdx
+++ b/src/platform-includes/getting-started-config/ruby.rack.mdx
@@ -40,7 +40,7 @@ Sentry.init do |config|
   config.breadcrumbs_logger = [:sentry_logger, :http_logger]
 end
 
-# Notice: requiring sinatra must go after Sentry SDK is initialized in a non-rackup environment
+# in a non-rackup environment you must initialize the Sentry SDK before requiring sinatra
 require 'sinatra'
 use Sentry::Rack::CaptureExceptions
 

--- a/src/platform-includes/getting-started-config/ruby.rack.mdx
+++ b/src/platform-includes/getting-started-config/ruby.rack.mdx
@@ -1,8 +1,10 @@
+### With Rackup
+
 Add `use Sentry::Rack::CaptureExceptions` to your `config.ru` or other rackup file:
 
 <SignInNote />
 
-```ruby {filename:config.ru}
+```Ruby {filename:config.ru}
 require 'sentry-ruby'
 
 Sentry.init do |config|
@@ -19,4 +21,30 @@ Sentry.init do |config|
 end
 
 use Sentry::Rack::CaptureExceptions
+```
+
+### Without Rackup
+
+<Alert level="warning">
+
+If you're not using Rackup to run your app, then Sentry initialization code **must**
+be placed before your code requires Sinatra:
+
+</Alert>
+
+```Ruby {filename:app.rb}
+require 'sentry-ruby'
+
+Sentry.init do |config|
+  config.dsn = '___PUBLIC_DSN___'
+  config.breadcrumbs_logger = [:sentry_logger, :http_logger]
+end
+
+# Notice: requiring sinatra must go after Sentry SDK is initialized in a non-rackup environment
+require 'sinatra'
+use Sentry::Rack::CaptureExceptions
+
+get "/" do
+  raise "foo"
+end
 ```


### PR DESCRIPTION
## Summary

This pull request adds a note on using Sentry in Rack apps that are run directly with Ruby, without Rackup. Closes #8519. Related to [this Sentry-Ruby issue](https://github.com/getsentry/sentry-ruby/issues/2167).

/cc @sl0thentr0py

<img width="1612" alt="Screenshot 2023-11-22 at 11 38 00 AM" src="https://github.com/getsentry/sentry-docs/assets/43633/d3fc38fd-6a1c-4a08-b52d-86850f351746">


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
