### PR TITLE
Python: Added new options for query source

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -986,7 +986,7 @@ This option is disabled by default.
 
 </ConfigKey>
 
-<ConfigKey name="db_query_source_threshold_ms" supported={["python"]}>
+<ConfigKey name="db-query-source-threshold-ms" supported={["python"]}>
 
 The threshold in milliseconds for adding the source location to database queries. The query location will be added to the query for queries slower than the specified threshold.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -988,7 +988,7 @@ This option is disabled by default.
 
 <ConfigKey name="db_query_source_threshold_ms" supported={["python"]}>
 
-The threshold in milliseconds for adding the source location to database queries. Only for queries slower than the threshold the query location will be added to the query.
+The threshold in milliseconds for adding the source location to database queries. The query location will be added to the query for queries slower than the specified threshold.
 
 You need to set `enable_db_query_source` to `True` for this to work.
 

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -978,6 +978,24 @@ This option is enabled by default.
 
 </ConfigKey>
 
+<ConfigKey name="enable-db-query-source" supported={["python"]}>
+
+When enabled, the source location will be added to database queries.
+
+This option is disabled by default.
+
+</ConfigKey>
+
+<ConfigKey name="db_query_source_threshold_ms" supported={["python"]}>
+
+The threshold in milliseconds for adding the source location to database queries. Only for queries slower than the threshold the query location will be added to the query.
+
+You need to set `enable_db_query_source` to `True` for this to work.
+
+Default is `100` ms.
+
+</ConfigKey>
+
 <ConfigKey name="trace-options-requests" supported={["java"]}>
 
 <PlatformSection supported={["java"]}>


### PR DESCRIPTION
We have a new feature in Python to add the source location of database queries. See [this PR](https://github.com/getsentry/sentry-python/pull/2521).

This documents the two new options we introduced for this feature.