### PR TITLE
chore(android): Clarify draining behavior for Android SDK

### DIFF
--- a/src/platform-includes/configuration/drain-example/android.mdx
+++ b/src/platform-includes/configuration/drain-example/android.mdx
@@ -1,1 +1,3 @@
-The Android SDK automatically stores the Sentry events on the device's disk before shutdown.
+The Android SDK automatically stores the Sentry events on the device's disk before trying to send them. This way any unsent events due to app shutdown will be sent on the next app start.
+
+You can use `Sentry.flush(timeoutMillis: Long)` to block execution and wait for any unsent events to be sent.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes
The draining behaviour of our SDK wasn't documented very well, so I added a paragraph to hopefully make it more clear.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
