### PR TITLE
fix(python): Add docs for Starlite

### DIFF
--- a/src/platforms/python/integrations/index.mdx
+++ b/src/platforms/python/integrations/index.mdx
@@ -4,7 +4,7 @@ description: "Sentry provides additional integrations designed to change configu
 sidebar_order: 40
 ---
 
-The Sentry SDK uses Integrations to hook into the functionality of popular libraries to automatically instrument your application and give you the best data out of the box.
+The Sentry SDK uses integrations to hook into the functionality of popular libraries to automatically instrument your application and give you the best data out of the box.
 
 ## Web Frameworks
 
@@ -20,6 +20,7 @@ The Sentry SDK uses Integrations to hook into the functionality of popular libra
 | <linkWithPlatformIcon platform="python.quart"     label="Quart"     url="/platforms/python/integrations/quart" />     |                  |
 | <linkWithPlatformIcon platform="python.sanic"     label="Sanic"     url="/platforms/python/integrations/sanic" />     |        ✓         |
 | <linkWithPlatformIcon platform="python.starlette" label="Starlette" url="/platforms/python/integrations/starlette" /> |        ✓         |
+| <linkWithPlatformIcon platform="python.starlite"  label="Starlite"  url="/platforms/python/integrations/starlite" />  |                  |
 | <linkWithPlatformIcon platform="python.tornado"   label="Tornado"   url="/platforms/python/integrations/tornado" />   |        ✓         |
 
 ## Databases

--- a/src/platforms/python/integrations/starlite/index.mdx
+++ b/src/platforms/python/integrations/starlite/index.mdx
@@ -59,7 +59,6 @@ When you point your browser to [http://localhost:8000/hello](http://localhost:80
 
 It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 
-
 ## Supported Versions
 
 <Alert level="warning" title="Note">

--- a/src/platforms/python/integrations/starlite/index.mdx
+++ b/src/platforms/python/integrations/starlite/index.mdx
@@ -1,0 +1,74 @@
+---
+title: Starlite
+redirect_from:
+  - /clients/python/integrations/starlite/
+  - /platforms/python/starlite/
+description: "Learn about using Sentry with Starlite."
+---
+
+The Starlite integration adds support for the [Starlite framework](https://docs.litestar.dev/1/).
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `starlite` extra:
+
+```bash
+pip install --upgrade 'sentry-sdk[starlite]' uvicorn
+```
+
+## Configure
+
+<SignInNote />
+
+```python
+from starlite import Starlite, get
+import sentry_sdk
+from sentry_sdk.integrations.starlite import StarliteIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    enable_tracing=True,
+    integrations=[StarliteIntegration()],
+)
+
+app = Starlite(route_handlers=[])
+```
+
+## Verify
+
+```python
+from starlite import Starlite, get
+
+sentry_sdk.init(...)  # same as above
+
+@get("/hello")
+async def hello_world() -> str:
+    1 / 0
+    return "Hello!"
+
+app = Starlite(route_handlers=[hello_world])
+```
+
+Save the file above as `app.py` and start the development server with:
+
+```bash
+uvicorn app:app
+```
+
+When you point your browser to [http://localhost:8000/hello](http://localhost:8000/hello) a transaction will be created in the Performance section of [sentry.io](https://sentry.io). Additionally, the `ZeroDivisionError` we've snuck into our `hello_world` handler will be sent to [sentry.io](https://sentry.io) and will be connected to the transaction.
+
+It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+
+
+## Supported Versions
+
+<Alert level="warning" title="Note">
+
+Starlite was [renamed to Litestar](https://litestar.dev/about/organization.html#litestar-and-starlite)
+with the release of version 2.0. We don't support Litestar yet, so this guide only applies to Starlite 1.51.14
+and below.
+
+</Alert>
+
+- Starlite: 1.48.0 - 1.51.14
+- Python: 3.8+


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

I've noticed we're missing integration docs for Starlite. The actual integration was added to the Python SDK in January of this year.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
