### PR TITLE
fix: Authtoken is not read from env by default

### DIFF
--- a/src/platform-includes/getting-started-config/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-config/javascript.astro.mdx
@@ -12,7 +12,7 @@ export default defineConfig({
       dsn: "___PUBLIC_DSN___",
       sourceMapsUploadOptions: {
         project: "___PROJECT_SLUG___",
-        authToken: process.env.SENTRY_AUTH_TOKEN,
+        authToken: ___ORG_AUTH_TOKEN___,
       },
     }),
   ],


### PR DESCRIPTION
process.env is not read by default, let's add directly the auto token