### PR TITLE
fix: Env file name for Astro source map uploads

### DIFF
--- a/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
@@ -1,10 +1,10 @@
 ## Add Readable Stack Traces to Errors
 
-To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, like in a `.env` file or in your CI setup.
+To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, like in a `.env.sentry-build-plugin` file or in your CI setup.
 
 <OrgAuthTokenNote />
 
-```bash {filename:.env}
+```bash {filename:.env.sentry-build-plugin}
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 

--- a/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-sourcemaps/javascript.astro.mdx
@@ -1,6 +1,6 @@
 ## Add Readable Stack Traces to Errors
 
-To get readable stack traces in your production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, like in a `.env.sentry-build-plugin` file or in your CI setup.
+To get readable stack traces in your production builds, set the `SENTRY_AUTH_TOKEN` environment variable in your build environment. You can also add the environment variable to a `.env.sentry-build-plugin` file in the root of your project.
 
 <OrgAuthTokenNote />
 

--- a/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -4,11 +4,11 @@ Source maps upload should work if you followed the [Astro CLI installation guide
 
 ### Enable Source Maps Upload
 
-To automatically upload source maps during production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, for example in a `.env` file or in your CI setup.
+To automatically upload source maps during production builds, add the `SENTRY_AUTH_TOKEN` environment variable to your environment, for example in a `.env.sentry-build-plugin` file or in your CI setup.
 
 <OrgAuthTokenNote />
 
-```bash {filename:.env}
+```bash {filename:.env.sentry-build-plugin}
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
@@ -17,7 +17,7 @@ Next, add your project slug to the `sourceMapsUploadOptions` in your Astro confi
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
   integrations: [
-    sentryAstro({
+    sentry({
       // Other Sentry options
       sourceMapsUploadOptions: {
         project: "___PROJECT_SLUG___",
@@ -35,7 +35,7 @@ Source maps work best with [organization-scoped auth tokens](/product/accounts/a
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
   integrations: [
-    sentryAstro({
+    sentry({
       // Other Sentry options
       sourceMapsUploadOptions: {
         project: "___PROJECT_SLUG___",
@@ -54,7 +54,7 @@ You can disable automatic source maps upload in your Astro config:
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
   integrations: [
-    sentryAstro({
+    sentry({
       // Other Sentry options
       sourceMapsUploadOptions: {
         enabled: false,
@@ -74,7 +74,7 @@ You can disable telemetry collection by setting `telemetry` to `false`:
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
   integrations: [
-    sentryAstro({
+    sentry({
       // Other Sentry options
       sourceMapsUploadOptions: {
         telemetry: false,


### PR DESCRIPTION
Also fixed remaining wrong imports

If the file is just `.env` and not `.env.sentry-build-plugin` the Vite Plugin doesn't pick it up correctly