### PR TITLE
chore(astro): Promote Astro SDK to Beta

### DIFF
--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,6 +1,6 @@
 Sentry's Astro SDK enables automatic reporting of errors and performance data.
 
-<Alert level="warning">
+<Alert>
 
 The Astro SDK is in **Beta** and might still contain bugs. We recognize the irony.
 Please report any issues you encounter in our [Github Repository](https://github.com/getsentry/sentry-javascript/issues/new/choose).

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -2,7 +2,7 @@ Sentry's Astro SDK enables automatic reporting of errors and performance data.
 
 <Alert level="warning">
 
-The Astro SDK is in **Alpha** and may undergo **breaking changes**.
+The Astro SDK is in **Beta** and might still contain bugs. We recognize the irony.
 Please report any issues you encounter in our [Github Repository](https://github.com/getsentry/sentry-javascript/issues/new/choose).
 
 </Alert>


### PR DESCRIPTION
Replaces the Alpha warning with a Beta Note.