### PR TITLE
feat(astro): Document `assets` sourcemaps upload option

### DIFF
--- a/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -28,6 +28,42 @@ export default defineConfig({
 });
 ```
 
+### Disable Source Maps Upload
+
+You can disable automatic source maps upload in your Astro config:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentry({
+      // Other Sentry options
+      sourceMapsUploadOptions: {
+        enabled: false,
+      },
+    }),
+  ],
+});
+```
+
+### Setting Source Maps Assets directory
+
+By default, the Sentry Astro integration will look for source maps in sensible default directories, depending on your `outDir`, `rootDir` and `adapter` configuration.
+If these defaults don't work for you (e.g. due to an advanced customized build setup or an unsupported adapter), you can specify the `assets` option to point to the folder(s) where your source maps are located:
+
+```javascript {filename:astro.config.mjs}
+export default defineConfig({
+  integrations: [
+    sentry({
+      sourceMapsUploadOptions: {
+        assets: [".clientOut/**/*", ".serverOut/**/*"],
+      },
+    }),
+  ],
+});
+```
+
+The specified patterns must follow the [glob syntax](https://www.npmjs.com/package/glob#glob-primer).
+
 ### Working With Old Authentication Tokens
 
 Source maps work best with [organization-scoped auth tokens](/product/accounts/auth-tokens/#organization-auth-tokens). If you are using an old self-hosted Sentry version that doesn't yet support org-based tokens or you're using a different type of Sentry auth token, you'll need to additionally specify your `org` slug in your `sourceMapsUploadOptions`:
@@ -41,23 +77,6 @@ export default defineConfig({
         project: "___PROJECT_SLUG___",
         org: "___ORG_SLUG___",
         authToken: process.env.SENTRY_AUTH_TOKEN,
-      },
-    }),
-  ],
-});
-```
-
-### Disable Source Maps Upload
-
-You can disable automatic source maps upload in your Astro config:
-
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentry({
-      // Other Sentry options
-      sourceMapsUploadOptions: {
-        enabled: false,
       },
     }),
   ],

--- a/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/src/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -45,10 +45,10 @@ export default defineConfig({
 });
 ```
 
-### Setting Source Maps Assets directory
+### Setting the Source Maps Assets Directory
 
 By default, the Sentry Astro integration will look for source maps in sensible default directories, depending on your `outDir`, `rootDir` and `adapter` configuration.
-If these defaults don't work for you (e.g. due to an advanced customized build setup or an unsupported adapter), you can specify the `assets` option to point to the folder(s) where your source maps are located:
+If these defaults don't work for you (for example, due to an advanced customized build setup or an unsupported adapter), you can specify the `assets` option to point to the folder(s) where your source maps are located:
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({


### PR DESCRIPTION
This small PR adds documentation for the new `assets` option soon to be released in the Astro 
SDK. Functionality it's 1:1 on par with the Vite plugin assets option but we don't expose the 
full Vite Plugin API in the Astro SDK; hence the dedicated documentation.

Only merge after https://github.com/getsentry/sentry-javascript/pull/9668 is relased but otherwise ready to review
