### PR TITLE
ruby on rails: user feedback modal

### DIFF
--- a/src/platforms/common/enriching-events/user-feedback.mdx
+++ b/src/platforms/common/enriching-events/user-feedback.mdx
@@ -8,7 +8,7 @@ description: "Learn more about collecting user feedback when an event occurs. Se
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. You can collect feedback according to the method supported by the SDK.
 
-<PlatformSection supported={["ruby"]} notSupported={["ruby.rails"]}>
+<PlatformSection supported={["ruby.rails"]} notSupported={["ruby"]}>
 
 While this feature isn't currently supported for Ruby or most of its frameworks, it is supported for [Rails](/platforms/ruby/guides/rails/enriching-events/user-feedback/).
 


### PR DESCRIPTION
We support the modal on RoR but not on Ruby, correct?
Do we have the logic inverted?

Please note we're moving docs around: https://github.com/getsentry/sentry-docs/pull/8528/files