### PR TITLE
chore(android): Mention sdk 7.0.0 will capture failed GraphQL requests by default

### DIFF
--- a/src/platforms/android/integrations/apollo3/index.mdx
+++ b/src/platforms/android/integrations/apollo3/index.mdx
@@ -126,11 +126,11 @@ val apollo = ApolloClient.builder()
 
 ## GraphQL Client Errors
 
-Once enabled, this feature will automatically capture GraphQL client errors such as bad operations and response codes, and report them to Sentry as error events. Each error event will contain the `request` and `response` data, including the `url`, `status_code`, and `data` (stringified `query`).
+This feature automatically captures GraphQL client errors (like bad operations and response codes) as error events and reports them to Sentry. The error event will contain the `request` and `response` data, including the `url`, `status_code`, and `data` (stringified `query`).
 
 Sentry will group GraphQL client errors by the `operationName`, `operationType`, and `statusCode`, so that you can easily see the number of errors that happened for each.
 
-This is an opt-in feature and can be enabled by setting the `captureFailedRequests` option to `true`:
+Starting with SDK version `7.0.0`, GraphQL client error capturing is enabled by default. For prior versions of the SDK, this feature is opt-in and can be enabled by setting the `captureFailedRequests` option to `true`:
 
 ```kotlin
 import com.apollographql.apollo3.ApolloClient


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

To be merged once sentry-java 7.0.0 is released.

Relevant PR: https://github.com/getsentry/sentry-java/pull/2958
