### PR TITLE
docs(browser-starfish): add note on resource parameterization 

### DIFF
--- a/src/docs/product/performance/resources.md
+++ b/src/docs/product/performance/resources.md
@@ -97,8 +97,9 @@ To enable Sentry to group similar resources together, Sentry parameterizes resou
 
 <Note>
 
-We are actively working on improving our parametrization strategies. When grouping improvements are released, you will temporarily see instances of new and old span groups.
+Resource parametrization is still a work-in-progress. As these improvements are made, you will will temporarily see instances of the new and old groupings in your Resource Module.
 
+Let us know of any feedback through Github Issues.
 </Note>
 
 To see an example of resource URL from a group, hover over a URL in the resource table.

--- a/src/docs/product/performance/resources.md
+++ b/src/docs/product/performance/resources.md
@@ -100,6 +100,7 @@ To enable Sentry to group similar resources together, Sentry parameterizes resou
 Resource parametrization is still a work-in-progress. As these improvements are made, you will will temporarily see instances of the new and old groupings in your Resource Module.
 
 Let us know of any feedback through Github Issues.
+
 </Note>
 
 To see an example of resource URL from a group, hover over a URL in the resource table.


### PR DESCRIPTION
Add a note that any changes in parameterization might result in both old and new groups being present.

Update to this #8594, Didn't realize it would auto merge without approval.