### PR TITLE
Document `sentry-cli sourcemaps upload`'s `--strict` argument

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -148,10 +148,10 @@ sentry-cli releases files "$VERSION" upload /path/to/file '~/file.js'
 For source map upload, a separate command is provided which assists you in uploading and verifying source maps:
 
 ```bash
-sentry-cli releases files "$VERSION" upload-sourcemaps /path/to/sourcemaps
+sentry-cli sourcemaps upload /path/to/sourcemaps
 ```
 
-This command provides a bunch of options and attempts as much auto detection as possible. By default, it will scan the provided path for files and upload them named by their path with a `~/` prefix. It will also attempt to figure out references between minified files and source maps based on the filename. So if you have a file named `foo.min.js` which is a minified JavaScript file and a source map named `foo.min.map` for example, it will send a long a `Sourcemap` header to associate them. This works for files the system can detect a relationship of.
+This command provides several options and attempts as much auto detection as possible. By default, it will scan the provided path for files and upload them named by their path with a `~/` prefix. It will also attempt to figure out references between minified files and source maps based on the filename. So if you have a file named `foo.min.js` which is a minified JavaScript file and a source map named `foo.min.map` for example, it will send a long a `Sourcemap` header to associate them. This works for files the system can detect a relationship of.
 
 By default, `sentry-cli` rewrites source maps before upload:
 
@@ -176,7 +176,7 @@ The following options exist to change the behavior of the upload command:
 `--strip-prefix` / `--strip-common-prefix`
 
 : Unless `--no-rewrite` is specified, this will chop-off a prefix from all sources references inside uploaded source maps. For instance, you can use this to remove a path that is build machine specific. The common prefix version will attempt to automatically guess what the common prefix is and chop that one off automatically.
-This will not modify the uploaded sources paths. To do that, point the `upload` or `upload-sourcemaps` command to a more precise directory instead.
+This will not modify the uploaded sources paths. To do that, point the `sourcemaps upload` command to a more precise directory instead.
 
 `--validate`
 
@@ -202,19 +202,16 @@ Some example usages:
 
 ```bash
 # Rewrite and upload all sourcemaps in /path/to/sourcemaps
-sentry-cli releases files "$VERSION" upload-sourcemaps /path/to/sourcemaps
+sentry-cli sourcemaps upload /path/to/sourcemaps
 
 # Prefix all paths with ~/static/js to match where the sources are hosted online
-sentry-cli releases files "$VERSION" upload-sourcemaps /path/to/sourcemaps \
-    --url-prefix '~/static/js'
+sentry-cli sourcemaps upload /path/to/sourcemaps --url-prefix '~/static/js'
 
 # Remove a common prefix if all source maps are located in a subdirectory
-sentry-cli releases files "$VERSION" upload-sourcemaps /path/to/sourcemaps \
-    --url-prefix '~/static/js' --strip-common-prefix
+sentry-cli sourcemaps upload /path/to/sourcemaps --url-prefix '~/static/js' --strip-common-prefix
 
 # Omit all files specified in .sentryignore
-sentry-cli releases files "$VERSION" upload-sourcemaps /path/to/sourcemaps \
-    --ignore-file .sentryignore
+sentry-cli sourcemaps upload /path/to/sourcemaps --ignore-file .sentryignore
 ```
 
 ### List Files

--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -198,6 +198,10 @@ This will not modify the uploaded sources paths. To do that, point the `sourcema
 
 : Specifies a file containing patterns of files and folders to ignore during the scan. Ignore patterns follow the [gitignore](https://git-scm.com/docs/gitignore#_pattern_format) rules and are evaluated relative to the location of the ignore file. The file is assumed in the current working directory or any of its parent directories.
 
+`--strict`
+
+: Fail with a non-zero exit code if there are no sourcemaps to upload in the provided directory. Without this argument, the command succeeds if there are no sourcemaps to upload.
+
 Some example usages:
 
 ```bash

--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -212,7 +212,8 @@ sentry-cli sourcemaps upload /path/to/sourcemaps
 sentry-cli sourcemaps upload /path/to/sourcemaps --url-prefix '~/static/js'
 
 # Remove a common prefix if all source maps are located in a subdirectory
-sentry-cli sourcemaps upload /path/to/sourcemaps --url-prefix '~/static/js' --strip-common-prefix
+sentry-cli sourcemaps upload /path/to/sourcemaps --url-prefix '~/static/js' \
+  --strip-common-prefix
 
 # Omit all files specified in .sentryignore
 sentry-cli sourcemaps upload /path/to/sourcemaps --ignore-file .sentryignore


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Document `--strict` argument of the `sentry-cli sourcemaps upload` command, which we added in https://github.com/getsentry/sentry-cli/pull/1829. This PR also updates references to the old `sentry-cli releases files "$VERSION" upload-sourcemaps` command to refer to `sentry-cli sourcemaps upload` instead because `sentry-cli releases files "$VERSION" upload-sourcemaps` only exists for backwards-compatibility with Sentry CLI versions below 2.0.0.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
