### PR TITLE
feat(stats-detectors): List transaction ops for endpoint regression

### DIFF
--- a/src/docs/product/issues/issue-details/performance-issues/endpoint-regressions/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/endpoint-regressions/index.mdx
@@ -12,6 +12,15 @@ Endpoint Regression issues are a generic class of problems where the duration of
 
 The detector for performance issues periodically checks the 95th percentile transaction duration of the most common endpoints in your project. When a significant increase in the p95 value is detected and has been sustained for some time, a regression issue is created.
 
+To be categorized as an endpoint, the transaction operation must be one of the following
+
+- `function.aws`
+- `function.aws.lambda`
+- `http.server`
+- `serverless.function`
+- `asgi.server`
+- `rails.request`
+
 ## Regression Evidence
 
 To find additional info, go to the Issues page and click on the Endpoint Regression issue you're interested in. In the top section of the "Details" tab, you'll find the following:

--- a/src/docs/product/issues/issue-details/performance-issues/endpoint-regressions/index.mdx
+++ b/src/docs/product/issues/issue-details/performance-issues/endpoint-regressions/index.mdx
@@ -12,7 +12,7 @@ Endpoint Regression issues are a generic class of problems where the duration of
 
 The detector for performance issues periodically checks the 95th percentile transaction duration of the most common endpoints in your project. When a significant increase in the p95 value is detected and has been sustained for some time, a regression issue is created.
 
-To be categorized as an endpoint, the transaction operation must be one of the following
+To be categorized as an endpoint, the transaction operation must be one of the following:
 
 - `function.aws`
 - `function.aws.lambda`


### PR DESCRIPTION
Since not all transactions qualify for the endpoint regression feature, explicitly list all the transaction ops that qualify.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
