### PR TITLE
feat(docs): add feedback searchable properties

### DIFF
--- a/src/docs/product/cli/releases.mdx
+++ b/src/docs/product/cli/releases.mdx
@@ -163,7 +163,7 @@ The following options exist to change the behavior of the upload command:
 
 `--dist`
 
-: Sets the distribution identifier for uploaded files. This identifier is used to make a distinction between multiple files of the same name within a single release. `dist` can be used to disambiguate build or deployment variants. For example, `dist` can be the build number of an XCode build or the version code of an Android build.
+: Sets the distribution identifier for uploaded files. This identifier is used to make a distinction between multiple files of the same name within a single release. `dist` can be used to disambiguate build or deployment variants. For example, `dist` can be the build number of an Xcode build or the version code of an Android build.
 
 `--no-sourcemap-reference`
 

--- a/src/docs/product/reference/search/searchable-properties/events.mdx
+++ b/src/docs/product/reference/search/searchable-properties/events.mdx
@@ -166,7 +166,7 @@ Deprecated
 
 ### `dist`
 
-Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.
+Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an Xcode build or the version code of an Android build.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/index.mdx
+++ b/src/docs/product/reference/search/searchable-properties/index.mdx
@@ -15,6 +15,7 @@ Sentry's searchable properties fall into one of four categories:
 - [Issue properties](/product/sentry-basics/search/searchable-properties/issues/)
 - [Event properties](/product/sentry-basics/search/searchable-properties/events/)
 - [Session Replay properties](/product/sentry-basics/search/searchable-properties/session-replay/)
+- [User Feedback properties](/product/sentry-basics/search/searchable-properties/user-feedback/)
 - [Release properties](/product/sentry-basics/search/searchable-properties/releases/)
 
 ## Search Tips

--- a/src/docs/product/reference/search/searchable-properties/index.mdx
+++ b/src/docs/product/reference/search/searchable-properties/index.mdx
@@ -14,7 +14,7 @@ Sentry's searchable properties fall into one of four categories:
 
 - [Issue properties](/product/sentry-basics/search/searchable-properties/issues/)
 - [Event properties](/product/sentry-basics/search/searchable-properties/events/)
-- [Session replay properties](/product/sentry-basics/search/searchable-properties/session-replay/)
+- [Session Replay properties](/product/sentry-basics/search/searchable-properties/session-replay/)
 - [Release properties](/product/sentry-basics/search/searchable-properties/releases/)
 
 ## Search Tips

--- a/src/docs/product/reference/search/searchable-properties/index.mdx
+++ b/src/docs/product/reference/search/searchable-properties/index.mdx
@@ -10,7 +10,7 @@ Sentry's search provides you with reserved keywords, like `is`, `user`, `server`
 
 ## Search Properties
 
-Sentry's searchable properties fall into one of four categories:
+Sentry's searchable properties fall into one of five categories:
 
 - [Issue properties](/product/sentry-basics/search/searchable-properties/issues/)
 - [Event properties](/product/sentry-basics/search/searchable-properties/events/)

--- a/src/docs/product/reference/search/searchable-properties/issues.mdx
+++ b/src/docs/product/reference/search/searchable-properties/issues.mdx
@@ -112,7 +112,7 @@ Deprecated
 
 ### `dist`
 
-Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.
+Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an Xcode build or the version code of an Android build.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/releases.mdx
+++ b/src/docs/product/reference/search/searchable-properties/releases.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release Properties
-sidebar_order: 40
+sidebar_order: 50
 description: "Learn more about searchable release properties."
 redirect_from:
   - /product/sentry-basics/search/searchable-properties/releases/

--- a/src/docs/product/reference/search/searchable-properties/session-replay.mdx
+++ b/src/docs/product/reference/search/searchable-properties/session-replay.mdx
@@ -154,7 +154,7 @@ Details of the device
 
 ### `dist`
 
-Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.
+Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an Xcode build or the version code of an Android build.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -118,7 +118,7 @@ The URL of the page that the feedback is triggered on.
 
 ### `user.email`
 
-User's email addrss. This email search applies only if Sentry receives the user email from the `Sentry.setUser` SDK option as a tag.
+The user's email address exists only if Sentry received it from the `Sentry.setUser` SDK option as a tag. This property does not apply to emails entered inside the user feedback widget, which are not searchable.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -52,7 +52,7 @@ Name of the device.
 
 ### `dist`
 
-Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.
+Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an Xcode build or the version code of an Android build.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -1,0 +1,441 @@
+---
+title: Issue Properties
+sidebar_order: 40
+description: "Learn more about searchable user feedback properties."
+---
+
+<Include name="searchable-properties/intro-for-user-feedback.mdx" />
+
+## Searchable Properties
+
+Below is a list of keys and tokens that can be used in the user feedback search.
+
+<DefinitionList>
+
+### `age`
+
+Returns issues created since the time defined by the value. The syntax is similar to the Unix find command. Supported suffixes: `m - minutes`, `h - hours`, `d - days`, `w - weeks`. For example, `age:-24h` returns isssues that are new in the last 24 hours, while `age:+12h` returns ones that are older than 12 hours. Entering `age:+12h age:-24h` would return issues created between 12 and 24 hours ago.
+
+- **Type:** relative time
+
+### `app.in_foreground`
+
+Indicates if the app is in the foreground or background. Values are `1/0` or `true/false`
+
+- **Type:** boolean
+
+### `assigned`
+
+Returns issues assigned to the defined user(s) or team(s). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee, `my_teams` or `#team-name` for teams you belong to.
+
+- **Type:** team or org user
+
+### `assigned_or_suggested`
+
+Returns issues that are assigned to or suggested to be assigned to the defined user(s) or team(s). Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.
+
+- **Type:** team or org user
+
+### `bookmarks`
+
+Returns issues bookmarked by the defined user. Values can be your user ID (your email address) or `me` for yourself.
+
+- **Type:** team or org user
+
+### `device.arch`
+
+CPU architecture
+
+- **Type:** string
+
+### `device.brand`
+
+Brand of the device
+
+- **Type:** string
+
+### `device.family`
+
+Family of the device. Typically, the common part of a model name across generations. For example, iPhone, Samsung Galaxy.
+
+- **Type:** string
+
+### `device.locale`
+
+Deprecated
+
+- **Type:** string
+
+### `device.model_id`
+
+Internal hardware revision to identify the device exactly.
+
+- **Type:** n/a
+
+### `device.orientation`
+
+Describes the orientation of the device and can be either `portrait` or `landscape`.
+
+- **Type:** string
+
+### `device.screen_density`
+
+Device screen density in pixels.
+
+- **Type:** string
+
+### `device.screen_dpi`
+
+Number of dots per inch of the device screen.
+
+- **Type:** string
+
+### `device.screen_height_pixels`
+
+Device screen height in pixels.
+
+- **Type:** string
+
+### `device.screen_width_pixels`
+
+Device screen width in pixels.
+
+- **Type:** string
+
+### `device.uuid`
+
+Deprecated
+
+- **Type:** UUID
+
+### `dist`
+
+Distinguishes build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.
+
+- **Type:** string
+
+### `error.handled`
+
+Indicates whether the user has handled the exception — for example, using try...catch. An error is considered handled if all stack traces handle the error. Values are `1/0` or `true/false`
+
+- **Type:** boolean
+
+### `error.main_thread`
+
+Indicates if the error occurred on the main thread. Values are `1/0` or `true/false`
+
+- **Type:** boolean
+
+### `error.mechanism`
+
+An object describing the mechanism that created this exception.
+
+- **Type:** array
+
+### `error.type`
+
+The type of exception. For example, `ValueError`.
+
+- **Type:** array
+
+### `error.unhandled`
+
+The inversion of `error.handled`.
+
+- **Type:** boolean
+
+### `error.value`
+
+Original value of a field that causes or exhibits the error.
+
+- **Type:** array
+
+### `event.timestamp`
+
+Returns issues with matching datetime.
+
+- **Type:** datetime
+
+### `event.type`
+
+Type of the event (transaction, error, default, csp, and so on). The transaction type is unavailable in **Issues**.
+
+- **Type:** string
+
+### `firstRelease`
+
+Returns issues first seen within the given release. Can be an exact match on the version of a release, or `first-release:latest` to pick the most recent release.
+
+- **Type:** datetime
+
+### `firstSeen`
+
+Returns issues with a matching first time seen. Syntax is the same as `age`.
+
+- **Type:** datetime
+
+### `geo.city`
+
+Full name of the city
+
+- **Type:** string
+
+### `geo.country_code`
+
+ISO 3166-1 country code
+
+- **Type:** string
+
+### `geo.region`
+
+Full name of the country
+
+- **Type:** string
+
+### `has`
+
+Returns results with the defined tag or field, but not the value of that tag or field. For example, entering `has:user` would find events with the `user` tag.
+
+- **Type:** error
+
+### `http.method`
+
+HTTP method of the [request](https://develop.sentry.dev/sdk/event-payloads/request/) that created the event.
+
+- **Type:** string
+
+### `http.referer`
+
+Identifies the web page from which the resource was requested.
+
+- **Type:** string
+
+### `http.status_code`
+
+HTTP status code, which indicates whether a response was successful. For example, `200` or `404`.
+
+- **Type:** string
+
+### `http.url`
+
+Full URL of the request that caused the error, but without any parameters
+
+- **Type:** string
+
+### `id`
+
+The event or replay id. In **Issues**, use only the ID value without the `id` key.
+
+- **Type:** UUID
+
+### `is`
+
+The properties of an issue. Values can be: `unresolved`, `resolved`, `archived`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not.
+
+- **Type:** status
+
+### `issue`
+
+The short issue code, for example `SENTRY-ABC`.
+
+- **Type:** string
+
+### `issue.category`
+
+The category of the issue (either `error` or `performance`).
+
+- **Type:** string
+
+### `issue.type`
+
+The specific type of issue. For example `issue.type:performance_n_plus_one_db_queries ` returns the n plus one db query performance issues.
+
+- **Type:** string
+
+### `lastSeen`
+
+Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`.
+
+- **Type:** datetime
+
+### `level`
+
+Severity of the event (such as: fatal, error, warning). Always set to info for transactions.
+
+- **Type:** string
+
+### `location`
+
+Location where the error happened.
+
+- **Type:** string
+
+### `message`
+
+Returns errors with the matching message or transactions with matching transaction name. Also matches on any message containing the supplied value.Searching `message:undefined` will match an event with a message of `undefined is not an object`.Raw text searches (searches without the `message` key) are also checked against this field. For errors, the message can be a concatenatenation of elements, so searches might include unexpected results.
+
+- **Type:** string
+
+### `os.build`
+
+The internal build revision of the operating system.
+
+- **Type:** string
+
+### `os.kernel_version`
+
+The independent kernel version string. This is typically the entire output of the `uname` syscall.
+
+- **Type:** string
+
+### `platform.name`
+
+Name of the platform
+
+- **Type:** string
+
+### `project`
+
+The name of the project. In some pages of [sentry.io](https://sentry.io), you can also filter on project using a dropdown.
+
+- **Type:** string
+
+### `project.id`
+
+The id of the project.
+
+- **Type:** number
+
+### `release`
+
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+
+- **Type:** string
+
+### `release.build`
+
+The number that identifies an iteration of your app. For example, `CFBundleVersion` on iOS or `versionCode` on Android. [Learn more](/product/releases/usage/sorting-filtering/).
+
+- **Type:** number
+
+### `release.package`
+
+The unique identifier of the project/app. For example, `CFBundleIdentifier` on iOS or `packageName` on Android. [Learn more](/product/releases/usage/sorting-filtering/).
+
+- **Type:** string
+
+### `release.stage`
+
+The usage your release is seeing relative to other releases. Values can be `adopted`, `low`, or `replaced`. [Learn more](/product/releases/health/#adoption-stages).
+
+- **Type:** string
+
+### `release.version`
+
+A shorter version of the name; name without the package or short version of the hash. [Learn more](/product/releases/usage/sorting-filtering/).
+
+- **Type:** string
+
+### `sdk.name`
+
+Name of the Sentry SDK that sent the event.
+
+- **Type:** string
+
+### `sdk.version`
+
+Version of the Sentry SDK that sent the event.
+
+- **Type:** string
+
+### `stack.abs_path`
+
+The absolute path to the source file. In events, this is an array; in issues, this is a single value.
+
+- **Type:** array, single value
+
+### `stack.filename`
+
+The path to the source file relative to the project root directory. In events, this is an array. In issues, this is a single value.
+
+- **Type:** array, single value
+
+### `stack.function`
+
+Name of the function being called. In events, this is an array. In issues, this is a single value.
+
+- **Type:** array, single value
+
+### `stack.module`
+
+Platform-specific module path. For example, `sentry.interfaces.Stacktrace`. In events, this is an array. In issues, this is a single value.
+
+- **Type:** array, single value
+
+### `stack.package`
+
+The "package" the frame was contained in. Depending on the platform, this can be different things. For C#, it can be the name of the assembly. For native code, it can be the path of the dynamic library or something else. In events, this is an array. In issues, this is a single value.
+
+- **Type:** array, single value
+
+### `timesSeen`
+
+Returns results with a matching count. (Same as `count()` in events.)
+
+- **Type:** number
+
+### `timestamp`
+
+The finish timestamp of the transaction. Returns events with matching datetime.
+
+- **Type:** datetime
+
+### `title`
+
+Title of the error or the transaction name.
+
+- **Type:** string
+
+### `trace`
+
+A trace represents the record of the entire operation you want to measure or track — like page load, searched using the UUID generated by Sentry’s SDK.
+
+- **Type:** UUID
+
+### `transaction`
+
+For [transactions](/product/performance/transaction-summary/#what-is-a-transaction), the name of the transaction. For errors, the name of the associated transaction.
+
+- **Type:** string
+
+### `unreal.crash_type`
+
+The [Unreal Crash Context Type](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/GenericPlatform/ECrashContextType/)
+
+- **Type:** string
+
+### `user.email`
+
+An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.
+
+- **Type:** string
+
+### `user.id`
+
+Application-specific internal identifier for the user.
+
+- **Type:** string
+
+### `user.ip`
+
+User's IP address. Sentry uses the IP address as a unique identifier for unauthenticated users.
+
+- **Type:** string
+
+### `user.username`
+
+Username, which is typically a better label than the `user.id`.
+
+- **Type:** string
+
+</DefinitionList>

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -76,7 +76,7 @@ The properties of a user feedback submission. Values can be: `unresolved`, `reso
 
 ### `level`
 
-The severity of the user feedback for submissions that came in through the crash-report modal and have an error attached. For all reports that came in through the user feedback widget, the level will be `info`.
+The severity of the user feedback submissions. If the feedback came in through the crash-report modal then the level is tied to the error experienced by the end-user. For feedback from the user feedback widget, the level is `info`.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -14,7 +14,7 @@ Below is a list of keys and tokens that can be used in the user feedback search.
 
 ### `assigned`
 
-Returns issues assigned to the defined user(s) or team(s). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee, `my_teams` or `#team-name` for teams you belong to.
+Returns user feedback submissions assigned to the defined user(s) or team(s). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee, `my_teams` or `#team-name` for teams you belong to.
 
 - **Type:** team or org user
 
@@ -68,13 +68,13 @@ The feedback ID.
 
 ### `is`
 
-The properties of an issue. Values can be: `unresolved`, `resolved`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not.
+The properties of a user feedback submission. Values can be: `unresolved`, `resolved`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return user feedback submissions based on whether they are linked to an external issue tracker or not.
 
 - **Type:** status
 
 ### `level`
 
-The severity of the user feedback. If the feedback came in through the crash-report modal, then the level would be `error`; otherwise, the level is `info`.
+The severity of the user feedback for submissions that came in through the crash-report modal and have an error attached. For all reports that came in through the user feedback widget, the level will be `info`.
 
 - **Type:** string
 
@@ -116,7 +116,7 @@ The URL of the page that the feedback is triggered on.
 
 ### `user.email`
 
-An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.
+User's email addrss. This email search applies only if Sentry receives the user email from the `Sentry.setUser` SDK option as a tag.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -2,6 +2,8 @@
 title: User Feedback Properties
 sidebar_order: 40
 description: "Learn more about searchable user feedback properties."
+redirect_from:
+  - /product/sentry-basics/search/searchable-properties/user-feedback/
 ---
 
 <Include name="searchable-properties/intro-for-user-feedback.mdx" />

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -1,5 +1,5 @@
 ---
-title: Issue Properties
+title: User Feedback Properties
 sidebar_order: 40
 description: "Learn more about searchable user feedback properties."
 ---
@@ -12,45 +12,21 @@ Below is a list of keys and tokens that can be used in the user feedback search.
 
 <DefinitionList>
 
-### `age`
-
-Returns issues created since the time defined by the value. The syntax is similar to the Unix find command. Supported suffixes: `m - minutes`, `h - hours`, `d - days`, `w - weeks`. For example, `age:-24h` returns isssues that are new in the last 24 hours, while `age:+12h` returns ones that are older than 12 hours. Entering `age:+12h age:-24h` would return issues created between 12 and 24 hours ago.
-
-- **Type:** relative time
-
-### `app.in_foreground`
-
-Indicates if the app is in the foreground or background. Values are `1/0` or `true/false`
-
-- **Type:** boolean
-
 ### `assigned`
 
 Returns issues assigned to the defined user(s) or team(s). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee, `my_teams` or `#team-name` for teams you belong to.
 
 - **Type:** team or org user
 
-### `assigned_or_suggested`
+### `browser.name`
 
-Returns issues that are assigned to or suggested to be assigned to the defined user(s) or team(s). Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.
-
-- **Type:** team or org user
-
-### `bookmarks`
-
-Returns issues bookmarked by the defined user. Values can be your user ID (your email address) or `me` for yourself.
-
-- **Type:** team or org user
-
-### `device.arch`
-
-CPU architecture
+Name of the browser.
 
 - **Type:** string
 
 ### `device.brand`
 
-Brand of the device
+Brand of the device.
 
 - **Type:** string
 
@@ -60,53 +36,17 @@ Family of the device. Typically, the common part of a model name across generati
 
 - **Type:** string
 
-### `device.locale`
-
-Deprecated
-
-- **Type:** string
-
 ### `device.model_id`
 
 Internal hardware revision to identify the device exactly.
 
 - **Type:** n/a
 
-### `device.orientation`
+### `device.name`
 
-Describes the orientation of the device and can be either `portrait` or `landscape`.
-
-- **Type:** string
-
-### `device.screen_density`
-
-Device screen density in pixels.
+Name of the device.
 
 - **Type:** string
-
-### `device.screen_dpi`
-
-Number of dots per inch of the device screen.
-
-- **Type:** string
-
-### `device.screen_height_pixels`
-
-Device screen height in pixels.
-
-- **Type:** string
-
-### `device.screen_width_pixels`
-
-Device screen width in pixels.
-
-- **Type:** string
-
-### `device.uuid`
-
-Deprecated
-
-- **Type:** UUID
 
 ### `dist`
 
@@ -114,225 +54,33 @@ Distinguishes build or deployment variants of the same release of an application
 
 - **Type:** string
 
-### `error.handled`
+### `environment`
 
-Indicates whether the user has handled the exception — for example, using try...catch. An error is considered handled if all stack traces handle the error. Values are `1/0` or `true/false`
-
-- **Type:** boolean
-
-### `error.main_thread`
-
-Indicates if the error occurred on the main thread. Values are `1/0` or `true/false`
-
-- **Type:** boolean
-
-### `error.mechanism`
-
-An object describing the mechanism that created this exception.
-
-- **Type:** array
-
-### `error.type`
-
-The type of exception. For example, `ValueError`.
-
-- **Type:** array
-
-### `error.unhandled`
-
-The inversion of `error.handled`.
-
-- **Type:** boolean
-
-### `error.value`
-
-Original value of a field that causes or exhibits the error.
-
-- **Type:** array
-
-### `event.timestamp`
-
-Returns issues with matching datetime.
-
-- **Type:** datetime
-
-### `event.type`
-
-Type of the event (transaction, error, default, csp, and so on). The transaction type is unavailable in **Issues**.
-
-- **Type:** string
-
-### `firstRelease`
-
-Returns issues first seen within the given release. Can be an exact match on the version of a release, or `first-release:latest` to pick the most recent release.
-
-- **Type:** datetime
-
-### `firstSeen`
-
-Returns issues with a matching first time seen. Syntax is the same as `age`.
-
-- **Type:** datetime
-
-### `geo.city`
-
-Full name of the city
-
-- **Type:** string
-
-### `geo.country_code`
-
-ISO 3166-1 country code
-
-- **Type:** string
-
-### `geo.region`
-
-Full name of the country
-
-- **Type:** string
-
-### `has`
-
-Returns results with the defined tag or field, but not the value of that tag or field. For example, entering `has:user` would find events with the `user` tag.
-
-- **Type:** error
-
-### `http.method`
-
-HTTP method of the [request](https://develop.sentry.dev/sdk/event-payloads/request/) that created the event.
-
-- **Type:** string
-
-### `http.referer`
-
-Identifies the web page from which the resource was requested.
-
-- **Type:** string
-
-### `http.status_code`
-
-HTTP status code, which indicates whether a response was successful. For example, `200` or `404`.
-
-- **Type:** string
-
-### `http.url`
-
-Full URL of the request that caused the error, but without any parameters
+The environment that the event was first seen in.
 
 - **Type:** string
 
 ### `id`
 
-The event or replay id. In **Issues**, use only the ID value without the `id` key.
+The feedback ID.
 
 - **Type:** UUID
 
 ### `is`
 
-The properties of an issue. Values can be: `unresolved`, `resolved`, `archived`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not.
+The properties of an issue. Values can be: `unresolved`, `resolved`, `assigned`, `unassigned`, `linked`, or `unlinked`. The `linked` and `unlinked` values return issues based on whether they are linked to an external issue tracker or not.
 
 - **Type:** status
 
-### `issue`
-
-The short issue code, for example `SENTRY-ABC`.
-
-- **Type:** string
-
-### `issue.category`
-
-The category of the issue (either `error` or `performance`).
-
-- **Type:** string
-
-### `issue.type`
-
-The specific type of issue. For example `issue.type:performance_n_plus_one_db_queries ` returns the n plus one db query performance issues.
-
-- **Type:** string
-
-### `lastSeen`
-
-Datetime when the event was last seen. For example, `lastSeen:+30d` returns issues last seen 30 days ago or more; `lastSeen:-2d` returns issues last seen within the past two days. This is similar to `age`.
-
-- **Type:** datetime
-
 ### `level`
 
-Severity of the event (such as: fatal, error, warning). Always set to info for transactions.
+The severity of the user feedback. If the feedback came in through the crash-report modal, then the level would be `error`; otherwise, the level is `info`.
 
 - **Type:** string
 
-### `location`
+### `os.name`
 
-Location where the error happened.
-
-- **Type:** string
-
-### `message`
-
-Returns errors with the matching message or transactions with matching transaction name. Also matches on any message containing the supplied value.Searching `message:undefined` will match an event with a message of `undefined is not an object`.Raw text searches (searches without the `message` key) are also checked against this field. For errors, the message can be a concatenatenation of elements, so searches might include unexpected results.
-
-- **Type:** string
-
-### `os.build`
-
-The internal build revision of the operating system.
-
-- **Type:** string
-
-### `os.kernel_version`
-
-The independent kernel version string. This is typically the entire output of the `uname` syscall.
-
-- **Type:** string
-
-### `platform.name`
-
-Name of the platform
-
-- **Type:** string
-
-### `project`
-
-The name of the project. In some pages of [sentry.io](https://sentry.io), you can also filter on project using a dropdown.
-
-- **Type:** string
-
-### `project.id`
-
-The id of the project.
-
-- **Type:** number
-
-### `release`
-
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
-
-- **Type:** string
-
-### `release.build`
-
-The number that identifies an iteration of your app. For example, `CFBundleVersion` on iOS or `versionCode` on Android. [Learn more](/product/releases/usage/sorting-filtering/).
-
-- **Type:** number
-
-### `release.package`
-
-The unique identifier of the project/app. For example, `CFBundleIdentifier` on iOS or `packageName` on Android. [Learn more](/product/releases/usage/sorting-filtering/).
-
-- **Type:** string
-
-### `release.stage`
-
-The usage your release is seeing relative to other releases. Values can be `adopted`, `low`, or `replaced`. [Learn more](/product/releases/health/#adoption-stages).
-
-- **Type:** string
-
-### `release.version`
-
-A shorter version of the name; name without the package or short version of the hash. [Learn more](/product/releases/usage/sorting-filtering/).
+The name of the operating system.
 
 - **Type:** string
 
@@ -348,69 +96,15 @@ Version of the Sentry SDK that sent the event.
 
 - **Type:** string
 
-### `stack.abs_path`
-
-The absolute path to the source file. In events, this is an array; in issues, this is a single value.
-
-- **Type:** array, single value
-
-### `stack.filename`
-
-The path to the source file relative to the project root directory. In events, this is an array. In issues, this is a single value.
-
-- **Type:** array, single value
-
-### `stack.function`
-
-Name of the function being called. In events, this is an array. In issues, this is a single value.
-
-- **Type:** array, single value
-
-### `stack.module`
-
-Platform-specific module path. For example, `sentry.interfaces.Stacktrace`. In events, this is an array. In issues, this is a single value.
-
-- **Type:** array, single value
-
-### `stack.package`
-
-The "package" the frame was contained in. Depending on the platform, this can be different things. For C#, it can be the name of the assembly. For native code, it can be the path of the dynamic library or something else. In events, this is an array. In issues, this is a single value.
-
-- **Type:** array, single value
-
-### `timesSeen`
-
-Returns results with a matching count. (Same as `count()` in events.)
-
-- **Type:** number
-
 ### `timestamp`
 
 The finish timestamp of the transaction. Returns events with matching datetime.
 
 - **Type:** datetime
 
-### `title`
-
-Title of the error or the transaction name.
-
-- **Type:** string
-
-### `trace`
-
-A trace represents the record of the entire operation you want to measure or track — like page load, searched using the UUID generated by Sentry’s SDK.
-
-- **Type:** UUID
-
 ### `transaction`
 
-For [transactions](/product/performance/transaction-summary/#what-is-a-transaction), the name of the transaction. For errors, the name of the associated transaction.
-
-- **Type:** string
-
-### `unreal.crash_type`
-
-The [Unreal Crash Context Type](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/GenericPlatform/ECrashContextType/)
+The error or transaction name identifier.
 
 - **Type:** string
 

--- a/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
+++ b/src/docs/product/reference/search/searchable-properties/user-feedback.mdx
@@ -108,6 +108,12 @@ The error or transaction name identifier.
 
 - **Type:** string
 
+### `url`
+
+The URL of the page that the feedback is triggered on.
+
+- **Type:** string
+
 ### `user.email`
 
 An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.

--- a/src/includes/searchable-properties/intro-for-user-feedback.mdx
+++ b/src/includes/searchable-properties/intro-for-user-feedback.mdx
@@ -1,0 +1,3 @@
+[User Feedback](/product/user-feedback/) allows your users to create bug reports so they can let you know about sneaky issues right away. Every report will automatically include related replays, tags, and errors, making fixing the issue dead simple.
+
+You can search by user feedback properties on the **User Feedback** page.


### PR DESCRIPTION
Adds a section under `Searchable Properties` in the docs for User Feedback.

Closes https://github.com/getsentry/sentry-docs/issues/8585