### PR TITLE
feat(java): Migration from 6.x.x to 7.0.0

### DIFF
--- a/src/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/src/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -176,3 +176,72 @@ val apollo = ApolloClient.builder()
     }
     .build()
 ```
+
+## GraphQL Client Errors
+
+This feature automatically captures GraphQL client errors (like bad operations and response codes) as error events and reports them to Sentry. The error event will contain the `request` and `response` data, including the `url`, `status_code`, and `data` (stringified `query`).
+
+Sentry will group GraphQL client errors by the `operationName`, `operationType`, and `statusCode`, so that you can easily see the number of errors that happened for each.
+
+This feature is enabled by default and can be disabled by setting the `captureFailedRequests` option to `false`:
+
+```kotlin
+import com.apollographql.apollo3.ApolloClient
+import io.sentry.apollo3.sentryTracing
+
+val apollo = ApolloClient.builder()
+    .serverUrl("https://your-api-host/")
+    .sentryTracing(captureFailedRequests = false)
+    .build()
+```
+
+By default, only GraphQL client errors with a response that includes the [errors](https://spec.graphql.org/October2021/#sec-Errors) array will be captured as error events.
+
+GraphQL client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+
+```kotlin
+import com.apollographql.apollo3.ApolloClient
+import io.sentry.apollo3.sentryTracing
+
+val apollo = ApolloClient.builder()
+    .serverUrl("https://your-api-host/")
+    .sentryTracing(captureFailedRequests = true, failedRequestTargets = listOf("myapi.com"))
+    .build()
+```
+
+By default, error events won't contain `Headers` or `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`:
+
+```kotlin
+Sentry.init { options ->
+  options.isSendDefaultPii = true
+}
+```
+
+Error events will contain the raw bodies of GraphQL requests and responses, which may include sensitive data. To avoid this, parameterize your queries using the [variables](https://spec.graphql.org/October2021/#sec-Language.Variables) field. [Relay](/product/relay) will then run [PII Data Scrubbing](/product/relay/#pii-data-scrubbing), automatically transforming values into `[Filtered]`.
+
+Alternatively, you can customize the event and scrub the data yourself.
+
+### Customize or Drop the Error Event
+
+The captured error event can be customized or dropped with a `BeforeSendCallback`:
+
+```kotlin
+import io.sentry.Sentry
+import io.sentry.SentryOptions.BeforeSendCallback
+import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.api.http.HttpResponse
+import io.sentry.TypeCheckHint.APOLLO_REQUEST
+import io.sentry.TypeCheckHint.APOLLO_RESPONSE
+
+Sentry.init { options ->
+  // Add a callback that will be used before the event is sent to Sentry.
+  // With this callback, you can modify the event or, when returning null, also discard the event.
+  options.beforeSend = BeforeSendCallback { event, hint ->
+    val request = hint.getAs(APOLLO_REQUEST, HttpRequest::class.java)
+    val response = hint.getAs(APOLLO_RESPONSE, HttpResponse::class.java)
+
+    // customize or drop the event
+    event
+  }
+}
+```

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -14,7 +14,7 @@ To be able to capture transactions, you'll need to first <PlatformLink to="/perf
 
 </Note>
 
-Sentry's OkHttp integration provides both the `SentryOkHttpInterceptor` and the `SentryOkHttpEventListener`, which create a span for each outgoing HTTP request executed with an [OkHttp](https://github.com/square/okhttp) client.
+The `sentry-okhttp` library provides [OkHttp](https://github.com/square/okhttp) support for Sentry via the `SentryOkHttpInterceptor` and the `SentryOkHttpEventListener`, which create a span for each outgoing HTTP request executed with an OkHttp client. The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/main/sentry-okhttp).
 
 ## Install
 

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -1,0 +1,294 @@
+---
+title: OkHttp Integration
+sidebar_order: 35
+description: "Learn how to capture the performance of OkHttp client."
+notSupported:
+  - java.logback
+  - java.log4j2
+  - java.jul
+---
+
+<Note>
+
+To be able to capture transactions, you'll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>.
+
+</Note>
+
+Sentry's OkHttp integration provides both the `SentryOkHttpInterceptor` and the `SentryOkHttpEventListener`, which create a span for each outgoing HTTP request executed with an [OkHttp](https://github.com/square/okhttp) client.
+
+## Install
+
+To install the integration:
+
+```xml {tabTitle:Maven}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-okhttp</artifactId>
+    <version>{{@inject packages.version('sentry.java.okhttp', '7.0.0') }}</version>
+</dependency>
+```
+
+```groovy {tabTitle:Gradle}
+implementation 'io.sentry:sentry-okhttp:{{@inject packages.version('sentry.java.okhttp', '7.0.0') }}'
+```
+
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-okhttp" % "{{@inject packages.version('sentry.java.okhttp', '7.0.0') }}"
+```
+
+For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-okhttp).
+
+## Configure
+
+Configuration should happen once you create your `OkHttpClient` instance.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+
+private val client = OkHttpClient.Builder()
+  .addInterceptor(SentryOkHttpInterceptor())
+  .eventListener(SentryOkHttpEventListener())
+  .build()
+```
+
+```java
+import okhttp3.OkHttpClient;
+import io.sentry.okhttp.SentryOkHttpEventListener;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
+
+private final OkHttpClient client = new OkHttpClient.Builder()
+  .addInterceptor(new SentryOkHttpInterceptor())
+  .eventListener(new SentryOkHttpEventListener())
+  .build();
+```
+
+The SDK uses the `SentryOkHttpInterceptor` to support [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) and creates a span for any http call.
+The SDK can give more in-depth information through the `SentryOkHttpEventListener` by creating a span for each operation reported by OkHttp, including: dns setup, proxy selection, http connect, ssl setup, send request headers, send request body, receive response headers, and receive response body.
+
+## Verify
+
+This snippet includes a HTTP Request and captures an intentional message, so you can test that everything is working as soon as you set it up:
+
+```kotlin
+import io.sentry.Sentry
+import java.io.IOException
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Throws(IOException::class)
+fun run(url: String): String? {
+  val request = Request.Builder()
+    .url(url)
+    .build()
+
+  val bodyStr = client
+    .newCall(request)
+    .execute()
+    .body?.toString()
+
+  Sentry.captureMessage("The Message $bodyStr")
+
+  return bodyStr
+}
+```
+
+```java
+import io.sentry.Sentry;
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+
+String run(String url) throws IOException {
+  Request request = new Request.Builder()
+    .url(url)
+    .build();
+
+  ResponseBody body = client
+    .newCall(request)
+    .execute()
+    .body();
+
+  String bodyStr = body != null ? body.toString() : null;
+
+  Sentry.captureMessage("The Message " + bodyStr);
+
+  return bodyStr;
+}
+```
+
+To view and resolve the recorded message, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+
+## Customize the Recorded Span
+
+The captured span can be customized or dropped with a `BeforeSpanCallback`:
+
+```kotlin
+import io.sentry.ISpan
+import io.sentry.okhttp.SentryOkHttpInterceptor
+import okhttp3.Request
+import okhttp3.Response
+
+class CustomBeforeSpanCallback : SentryOkHttpInterceptor.BeforeSpanCallback {
+  override fun execute(span: ISpan, request: Request, response: Response?): ISpan? {
+    return if (request.url.toUri().toString().contains("/admin")) {
+      null
+    } else {
+      span
+    }
+  }
+}
+```
+
+```java
+import io.sentry.ISpan;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+class CustomBeforeSpanCallback implements SentryOkHttpInterceptor.BeforeSpanCallback {
+  public ISpan execute(ISpan span, Request request, Response response) {
+    if (request.getUrl().toUri().toString().contains("/admin")) {
+      return null;
+    } else {
+      return span;
+    }
+  }
+}
+```
+
+The callback instance must be set on the `SentryOkHttpInterceptor` once you create your `OkHttpClient` instance.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+
+private val client = OkHttpClient.Builder()
+  .eventListener(SentryOkHttpEventListener())
+  .addInterceptor(SentryOkHttpInterceptor(CustomBeforeSpanCallback()))
+  .build()
+```
+
+```java
+import okhttp3.OkHttpClient;
+import io.sentry.okhttp.SentryOkHttpEventListener;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
+
+private final OkHttpClient client = new OkHttpClient.Builder()
+  .eventListener(new SentryOkHttpEventListener())
+  .addInterceptor(new SentryOkHttpInterceptor(new CustomBeforeSpanCallback()))
+  .build();
+```
+
+## Using Multiple Event Listeners
+
+The event listener can propagate calls to another `EventListener` or `EventListener.Factory` that's set on the `SentryOkHttpEventListener` once you create your `OkHttpClient` instance.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+
+private val client = OkHttpClient.Builder()
+  .eventListener(SentryOkHttpEventListener(MyEventListener()))
+  .addInterceptor(SentryOkHttpInterceptor(CustomBeforeSpanCallback()))
+  .build()
+```
+
+```java
+import okhttp3.OkHttpClient;
+import io.sentry.okhttp.SentryOkHttpEventListener;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
+
+private final OkHttpClient client = new OkHttpClient.Builder()
+  .eventListener(new SentryOkHttpEventListener(new MyEventListener()))
+  .addInterceptor(new SentryOkHttpInterceptor(new CustomBeforeSpanCallback()))
+  .build();
+```
+
+## HTTP Client Errors
+
+This feature automatically captures HTTP client errors (like bad response codes) as error events and reports them to Sentry. The error event will contain the `request` and `response` data, including the `url`, `status_code`, and so on.
+
+This feature is enabled by default and can be disabled by setting the `captureFailedRequests` option to `false`:
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+
+private val client = OkHttpClient.Builder()
+  .eventListener(SentryOkHttpEventListener())
+  .addInterceptor(SentryOkHttpInterceptor(captureFailedRequests = false))
+  .build()
+```
+
+By default, only HTTP client errors with a response code between `500` and `599` are captured as error events, but you can change this behavior by setting the `failedRequestStatusCodes` option:
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+import io.sentry.HttpStatusCodeRange
+
+private val client = OkHttpClient.Builder()
+  .eventListener(SentryOkHttpEventListener())
+  .addInterceptor(SentryOkHttpInterceptor(
+    captureFailedRequests = true,
+    failedRequestStatusCodes = listOf(HttpStatusCodeRange(400, 599))))
+  .build()
+```
+
+HTTP client errors from every target (`.*` regular expression) are automatically captured, but you can change this behavior by setting the `failedRequestTargets` option with either a regular expression or a plain `String`. A plain string must contain at least one of the items from the list. Plain strings don't have to be full matches, meaning the URL of a request is matched when it contains a string provided through the option.
+
+```kotlin
+import okhttp3.OkHttpClient
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
+import io.sentry.HttpStatusCodeRange
+
+private val client = OkHttpClient.Builder()
+  .eventListener(SentryOkHttpEventListener())
+  .addInterceptor(SentryOkHttpInterceptor(
+    captureFailedRequests = true,
+    failedRequestTargets = listOf("myapi.com")))
+  .build()
+```
+
+By default, error events won't contain any PII data, such as `Headers` and `Cookies`, but you can change this behavior by setting the `sendDefaultPii` option to `true`:
+
+```kotlin
+Sentry.init { options ->
+  options.isSendDefaultPii = true
+}
+```
+
+Those events are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
+
+### Customize or Drop the Error Event
+
+The captured error event can be customized or dropped with a `BeforeSendCallback`:
+
+```kotlin
+import io.sentry.Sentry
+import io.sentry.SentryOptions.BeforeSendCallback
+import okhttp3.Request
+import okhttp3.Response
+import io.sentry.TypeCheckHint.OKHTTP_REQUEST
+import io.sentry.TypeCheckHint.OKHTTP_RESPONSE
+
+Sentry.init { options ->
+  // Add a callback that will be used before the event is sent to Sentry.
+  // With this callback, you can modify the event or, when returning null, also discard the event.
+  options.beforeSend = BeforeSendCallback { event, hint ->
+    val request = hint.getAs(OKHTTP_REQUEST, Request::class.java)
+    val response = hint.getAs(OKHTTP_RESPONSE, Response::class.java)
+
+    // customize or drop the event
+    event
+  }
+}
+```

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -185,7 +185,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
 
 ## Using Multiple Event Listeners
 
-The event listener can propagate calls to another `EventListener` or `EventListener.Factory` that's set on the `SentryOkHttpEventListener` once you create your `OkHttpClient` instance.
+The integration's event listener can propagate calls to another `EventListener` or `EventListener.Factory` that's set on the `SentryOkHttpEventListener` once you create your `OkHttpClient` instance.
 
 ```kotlin
 import okhttp3.OkHttpClient

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -64,7 +64,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
   .build();
 ```
 
-The SDK uses the `SentryOkHttpInterceptor` to support [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) and creates a span for any http call.
+The SDK uses the `SentryOkHttpInterceptor` to support [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) and creates a span for any HTTP call.
 The SDK can give more in-depth information through the `SentryOkHttpEventListener` by creating a span for each operation reported by OkHttp, including DNS setup, proxy selection, HTTP connect, SSL setup, send request headers, send request body, receive response headers, and receive response body.
 
 ## Verify

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -65,7 +65,7 @@ private final OkHttpClient client = new OkHttpClient.Builder()
 ```
 
 The SDK uses the `SentryOkHttpInterceptor` to support [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/) and creates a span for any http call.
-The SDK can give more in-depth information through the `SentryOkHttpEventListener` by creating a span for each operation reported by OkHttp, including: dns setup, proxy selection, http connect, ssl setup, send request headers, send request body, receive response headers, and receive response body.
+The SDK can give more in-depth information through the `SentryOkHttpEventListener` by creating a span for each operation reported by OkHttp, including DNS setup, proxy selection, HTTP connect, SSL setup, send request headers, send request body, receive response headers, and receive response body.
 
 ## Verify
 

--- a/src/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/src/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -266,7 +266,7 @@ Sentry.init { options ->
 }
 ```
 
-Those events are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
+HTTP client errors sent to Sentry are searchable and you can set alerts on them if you use the `http.url` and `http.status_code` properties. Learn more in our full [Searchable Properties](/product/sentry-basics/search/searchable-properties/) documentation.
 
 ### Customize or Drop the Error Event
 

--- a/src/platforms/java/migration/6.x-to-7.0.mdx
+++ b/src/platforms/java/migration/6.x-to-7.0.mdx
@@ -13,6 +13,16 @@ description: "Learn about migrating from version 6.x to 7.0.0"
 - If you're using `sentry-kotlin-extensions`, it now requires `kotlinx-coroutines-core` version `1.6.1` or higher.
 - Changed the return type of `SentryApolloInterceptor.BeforeSpanCallback` from `ISpan` to `ISpan?`.
 - `Scope` now implements the `IScope` interface, therefore some methods like `ScopeCallback.run` accept `IScope` now.
+- Some `Sentry.startTransaction` overloads do not exist anymore, and instead, you can set old options by passing a `TransactionOptions` object in.
+
+For example:
+
+```kotlin
+// old
+val transaction = Sentry.startTransaction("name", "op", bindToScope = true)
+// new
+val transaction = Sentry.startTransaction("name", "op", TransactionOptions().apply { isBindToScope = true })
+```
 
 ### Behavioral Changes
 

--- a/src/platforms/java/migration/6.x-to-7.0.mdx
+++ b/src/platforms/java/migration/6.x-to-7.0.mdx
@@ -27,7 +27,7 @@ val transaction = Sentry.startTransaction("name", "op", TransactionOptions().app
 ### Behavioral Changes
 
 - The SDK now captures failed HTTP and GraphQL (Apollo) requests by default.
-  - This can increase your event consumption and may affect your quota, because we will report failed network requests as Sentry events if you're using the `sentry-okhttp` or `sentry-apollo-3` integrations by default. You can customize what errors you want/don't want to have reported for [OkHttp](/platforms/java/performance/instrumentation/okhttp/#http-client-errors) and [Apollo3](/platforms/java/performance/instrumentation/apollo3/#graphql-client-errors) respectively.
+  - This can increase your event consumption and may affect your quota, because the SDK will report failed network requests as Sentry events if you're using the `sentry-okhttp` or `sentry-apollo-3` integrations by default. You can customize what errors you want/don't want to have reported for [OkHttp](/platforms/java/performance/instrumentation/okhttp/#http-client-errors) and [Apollo3](/platforms/java/performance/instrumentation/apollo3/#graphql-client-errors) respectively.
 - The SDK now sets `ip_address` to {{auto}} by default, even if sendDefaultPII is disabled.
   - We recommend you instead use the "Prevent Storing of IP Addresses" option in the "Security & Privacy" project settings on [sentry.io](https://sentry.io/).
 - The `maxSpans` setting (defaults to 1000) is now enforced for nested child spans. This means a single transaction can have `maxSpans` number of children (nested or not) at most.

--- a/src/platforms/java/migration/6.x-to-7.0.mdx
+++ b/src/platforms/java/migration/6.x-to-7.0.mdx
@@ -1,0 +1,45 @@
+---
+title: Migrating Version 6.x to 7.0
+sidebar_order: 996
+description: "Learn about migrating from version 6.x to 7.0.0"
+---
+
+## Migrating from `io.sentry:sentry` `6.x` to `io.sentry:sentry` `7.0.0`
+
+### Breaking Changes
+
+- The `sentry-android-okhttp` classes were deprecated in favor of `sentry-okhttp`, which is a pure Java module and can be used in non-Android projects. Check the [OkHttp Integration](/platforms/java/performance/instrumentation/okhttp) documentation to see how to use it.
+  - The `SentryOkHttpUtils` class was removed from the public API. If you were using it, consider filing a [feature request](https://github.com/getsentry/sentry-java/issues).
+- If you're using `sentry-kotlin-extensions`, it now requires `kotlinx-coroutines-core` version `1.6.1` or higher.
+- Changed the return type of `SentryApolloInterceptor.BeforeSpanCallback` from `ISpan` to `ISpan?`.
+- `Scope` now implements the `IScope` interface, therefore some methods like `ScopeCallback.run` accept `IScope` now.
+
+### Behavioral Changes
+
+- The SDK now captures failed HTTP and GraphQL (Apollo) requests by default.
+  - This can increase your event consumption and may affect your quota, because we will report failed network requests as Sentry events if you're using the `sentry-okhttp` or `sentry-apollo-3` integrations by default. You can customize what errors you want/don't want to have reported for [OkHttp](/platforms/java/performance/instrumentation/okhttp/#http-client-errors) and [Apollo3](/platforms/java/performance/instrumentation/apollo3/#graphql-client-errors) respectively.
+- Added a deadline timeout for automatic transactions.
+  - This affects all automatically generated transactions on Android (UI, clicks). The default timeout is 30s, meaning the automatic transaction will be force-finished with the status `deadline_exceeded` when it reaches the deadline.
+- The SDK now sets `ip_address` to {{auto}} by default, even if sendDefaultPII is disabled.
+  - We recommend you instead use the "Prevent Storing of IP Addresses" option in the "Security & Privacy" project settings on [sentry.io](https://sentry.io/).
+- The `maxSpans` setting (defaults to 1000) is now enforced for nested child spans. This means a single transaction can have `maxSpans` number of children (nested or not) at most.
+
+### Sentry Integrations Version Compatibility
+
+Make sure to align _all_ Sentry dependencies (like `-timber`, `-okhttp` or other packages) to the same version when bumping the SDK to 7.+, otherwise, it will crash at runtime due to binary incompatibility.
+
+For example, if you're using the [Sentry Android Gradle plugin](https://github.com/getsentry/sentry-android-gradle-plugin) with the `autoInstallation` [feature](/platforms/android/configuration/gradle/#auto-installation) (enabled by default), make sure to use version 4.+ of the Gradle plugin together with version 7.+ of the SDK. If you can't do that for some reason, you can specify the Sentry version via the plugin config block:
+
+```kotlin
+sentry {
+  autoInstallation {
+    sentryVersion.set("7.0.0")
+  }
+}
+```
+
+Similarly, if you have a Sentry SDK (e.g. `sentry-android-core`) dependency on one of your Gradle modules and you're updating it to 7.+, make sure the Gradle plugin is at 4.+ or specify the SDK version as shown in the snippet above.
+
+### Sentry Self-hosted Compatibility
+
+- Starting with version `7.0.0` of the SDK, [Sentry's version >= v22.12.0](https://github.com/getsentry/self-hosted/releases) is required to properly ingest transactions with unfinished spans. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.

--- a/src/platforms/java/migration/6.x-to-7.0.mdx
+++ b/src/platforms/java/migration/6.x-to-7.0.mdx
@@ -18,27 +18,9 @@ description: "Learn about migrating from version 6.x to 7.0.0"
 
 - The SDK now captures failed HTTP and GraphQL (Apollo) requests by default.
   - This can increase your event consumption and may affect your quota, because we will report failed network requests as Sentry events if you're using the `sentry-okhttp` or `sentry-apollo-3` integrations by default. You can customize what errors you want/don't want to have reported for [OkHttp](/platforms/java/performance/instrumentation/okhttp/#http-client-errors) and [Apollo3](/platforms/java/performance/instrumentation/apollo3/#graphql-client-errors) respectively.
-- Added a deadline timeout for automatic transactions.
-  - This affects all automatically generated transactions on Android (UI, clicks). The default timeout is 30s, meaning the automatic transaction will be force-finished with the status `deadline_exceeded` when it reaches the deadline.
 - The SDK now sets `ip_address` to {{auto}} by default, even if sendDefaultPII is disabled.
   - We recommend you instead use the "Prevent Storing of IP Addresses" option in the "Security & Privacy" project settings on [sentry.io](https://sentry.io/).
 - The `maxSpans` setting (defaults to 1000) is now enforced for nested child spans. This means a single transaction can have `maxSpans` number of children (nested or not) at most.
-
-### Sentry Integrations Version Compatibility
-
-Make sure to align _all_ Sentry dependencies (like `-timber`, `-okhttp` or other packages) to the same version when bumping the SDK to 7.+, otherwise, it will crash at runtime due to binary incompatibility.
-
-For example, if you're using the [Sentry Android Gradle plugin](https://github.com/getsentry/sentry-android-gradle-plugin) with the `autoInstallation` [feature](/platforms/android/configuration/gradle/#auto-installation) (enabled by default), make sure to use version 4.+ of the Gradle plugin together with version 7.+ of the SDK. If you can't do that for some reason, you can specify the Sentry version via the plugin config block:
-
-```kotlin
-sentry {
-  autoInstallation {
-    sentryVersion.set("7.0.0")
-  }
-}
-```
-
-Similarly, if you have a Sentry SDK (e.g. `sentry-android-core`) dependency on one of your Gradle modules and you're updating it to 7.+, make sure the Gradle plugin is at 4.+ or specify the SDK version as shown in the snippet above.
 
 ### Sentry Self-hosted Compatibility
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

* Migration doc from 6.x.x to 7.0.0
* Added new okhttp integration doc as we can use it in non-android modules now
* Added graphql client errors section to apollo3 as it was missing
