### PR TITLE
fix(python): Add missing `auto_enabling_integrations` config option

### DIFF
--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -695,6 +695,10 @@ In some SDKs, the integrations are configured through this parameter on library 
 
 This can be used to disable integrations that are added by default. When set to `false`, no default integrations are added.
 
+<ConfigKey name="auto-enabling-integrations" supported={["python"]} />
+
+This can be used to disable integrations that are enabled by default if the SDK detects that the corresponding framework or library is installed. When set to `false`, no auto enabling integrations are added.
+
 </PlatformSection>
 
 ## Hooks

--- a/src/platforms/common/configuration/options.mdx
+++ b/src/platforms/common/configuration/options.mdx
@@ -697,7 +697,7 @@ This can be used to disable integrations that are added by default. When set to 
 
 <ConfigKey name="auto-enabling-integrations" supported={["python"]} />
 
-This can be used to disable integrations that are enabled by default if the SDK detects that the corresponding framework or library is installed. When set to `false`, no auto enabling integrations are added.
+This can be used to disable integrations that are enabled by default if the SDK detects that the corresponding framework or library is installed. When set to `false`, none of these integrations will be enabled by default, even if the corresponding framework/library is detected.
 
 </PlatformSection>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adding a missing config option.

Direct link: https://sentry-docs-git-ivana-add-auto-enabling-integrations.sentry.dev/platforms/python/configuration/options/

