### PR TITLE
fix: implicit using typo

### DIFF
--- a/src/platform-includes/troubleshooting/dotnet.mdx
+++ b/src/platform-includes/troubleshooting/dotnet.mdx
@@ -50,4 +50,4 @@ In some scenarios Implicit Usings can result in type name conflicts. For example
 using SentrySession = Sentry.Session;
 ```
 
-Then `SentrySession` can be used instead of `SentrySession`.
+Then `SentrySession` can be used instead of `Sentry.Session`.


### PR DESCRIPTION
Fixes:

![image](https://github.com/getsentry/sentry-docs/assets/1633368/ed903c42-e20f-4df6-9d21-f7b4d6254336)
