### PR TITLE
feat(discord): Update docs for issue alerts to allow for url

### DIFF
--- a/src/docs/product/integrations/notification-incidents/discord/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/discord/index.mdx
@@ -59,13 +59,9 @@ To create an issue alert that sends notifications to Discord, follow the steps b
 
 5. Choose the Discord server and channel you'd like to send the alert to. You'll also have the option to specify any tags you'd like to include in the notification.
 
-Note that the channel field must be filled in with a Discord channel ID, **_not_** a channel name. To get it, right click on your channel, select "Copy Link", then highlight the string of numbers at the end.
+Note that the channel field must be filled in with a Discord channel ID or channel URL, **_not_** a channel name. To get the URL, right click on your channel, select "Copy Link".
 
 ![Discord Channel Link](discord-copy-channel-link.png)
-
-For example, if the URL is `https://discord.com/channels/server-id/channel-id`, the ID is `channel-id`.
-
-![Channel ID in Link](discord-link-channel-id.png)
 
 6. Test your configuration by clicking "Send Test Notification". If the bot has access to the given channel, you should see an example notification there.
 

--- a/src/docs/product/integrations/notification-incidents/discord/index.mdx
+++ b/src/docs/product/integrations/notification-incidents/discord/index.mdx
@@ -115,10 +115,11 @@ To unlink your accounts, use the `/unlink` command. Follow the link and click "U
 
 Here are some ideas to help with troubleshooting.
 
-#### Your channel ID isn't working in the alert creation wizard
+#### Your channel ID or URL isn't working in the alert creation wizard
 
 If you're trying to create an alert with a Discord action and Sentry can't access the channel you've provided, please double-check the following:
 
 - You're giving us a channel ID and not a channel name or something else. See [Configure](#configure) for more details.
+- Your channel URL has no extra slashes.
 - The channel you're trying to add is in the same server as the one selected in the alert action.
 - The bot has access to the channel you're trying to use. A quick way to verify this is to check whether you can find the bot in the desired channel's member list. If you don't see the bot in the list of users, you may need to update your Discord role and/or channel permissions to allow the bot access. See [Install](#install) for more details.


### PR DESCRIPTION
Users can create an issue alert with a Discord notification with the channel URL or channel id, instead of just the id.