### PR TITLE
ref(flutter): Add inbound filter hint

### DIFF
--- a/src/platforms/flutter/troubleshooting.mdx
+++ b/src/platforms/flutter/troubleshooting.mdx
@@ -13,7 +13,7 @@ If you need help solving issues with Sentry's Flutter SDK, you can read the edge
 - If you enable the `split-debug-info` and `obfuscate` features, you must upload [debug symbols](/platforms/flutter/upload-debug/).
 - Issue titles might be obfuscated as we rely on the `runtimeType`, but they may not be human-readable. See the [Obfuscate Caveat](https://flutter.dev/docs/deployment/obfuscate#caveat).
 - Layout related errors are only caught by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode, they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
-- Use [inbound filters](https://docs.sentry.io/product/data-management-settings/filtering/) to exclude unhandled errors that are caught outside of your application in release builds. The SDK cannot filter these directly due to obfuscated stack traces.
+- Use [inbound filters](/product/data-management-settings/filtering/) to exclude unhandled errors that are caught outside of your application in release builds. The SDK cannot filter these directly due to obfuscated stack traces.
 - If your app runs on Windows and uses a Flutter version below `3.3.0`, you need to set the version and build number manually, see [this issue on GitHub](https://github.com/flutter/flutter/issues/73652). To do so:
   - Use Dart defines to build the app: `flutter build windows --dart-define=SENTRY_RELEASE=my_app@1.0.0+1`
   - Or, set the release on SentryOptions `options.release = 'my_app@1.0.0+1'` during SDK initialization.


### PR DESCRIPTION
Adds a troublesooting line for uncaught errors outside of the target application on Flutter

Ref: https://github.com/getsentry/sentry-dart/issues/1751