### PR TITLE
Remove known CLI monitor limitation

### DIFF
--- a/src/docs/product/crons/getting-started/cli.mdx
+++ b/src/docs/product/crons/getting-started/cli.mdx
@@ -75,15 +75,6 @@ When providing the `--schedule` argument, we also support the following optional
 - `--max-runtime`: The allowed duration in minutes that the monitor may be in progress for before being considered failed due to timeout.
 - `--timezone`: A valid [tz database identifier string](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) (e.g. "Europe/Vienna") representing the monitor's execution schedule's timezone.
 
-<Alert>
-
-**Known limitation**: When an invalid `--timezone` argument is provided, the command will silently fail to create/update the cron monitor. Therefore, when using this argument, please:
-
-- Ensure you are using a valid tz database identifier string when using this argument, and
-- Verify that the cron monitor was created successfully in Sentry after running the command.
-
-</Alert>
-
 Below are some usage examples:
 
 ```bash {tabTitle: Every Minute}


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

https://github.com/getsentry/sentry-cli/pull/1847 added validation for the `sentry-cli monitors run` command's `--timezone` argument. We should therefore delete the "Known Limitation" notice, which informs users that the `--timezone` argument is not validated, from the docs. 