### PR TITLE
Add Expo manual setup steps

### DIFF
--- a/src/platforms/flutter/troubleshooting.mdx
+++ b/src/platforms/flutter/troubleshooting.mdx
@@ -13,6 +13,7 @@ If you need help solving issues with Sentry's Flutter SDK, you can read the edge
 - If you enable the `split-debug-info` and `obfuscate` features, you must upload [debug symbols](/platforms/flutter/upload-debug/).
 - Issue titles might be obfuscated as we rely on the `runtimeType`, but they may not be human-readable. See the [Obfuscate Caveat](https://flutter.dev/docs/deployment/obfuscate#caveat).
 - Layout related errors are only caught by [FlutterError.onError](https://api.flutter.dev/flutter/foundation/FlutterError/onError.html) in debug mode. In release mode, they are removed by the Flutter framework. See [Flutter build modes](https://flutter.dev/docs/testing/build-modes).
+- Use [inbound filters](/product/data-management-settings/filtering/) to exclude unhandled errors that are caught outside of your application in release builds. The SDK cannot filter these directly due to obfuscated stack traces.
 - If your app runs on Windows and uses a Flutter version below `3.3.0`, you need to set the version and build number manually, see [this issue on GitHub](https://github.com/flutter/flutter/issues/73652). To do so:
   - Use Dart defines to build the app: `flutter build windows --dart-define=SENTRY_RELEASE=my_app@1.0.0+1`
   - Or, set the release on SentryOptions `options.release = 'my_app@1.0.0+1'` during SDK initialization.

--- a/src/platforms/react-native/manual-setup/expo.mdx
+++ b/src/platforms/react-native/manual-setup/expo.mdx
@@ -13,7 +13,7 @@ Experimental support means it may have bugs. We recognize the irony.
 
 To set up the Sentry React Native SDK in your Expo-managed project, follow the steps on this page.
 
-### Install SDK Package
+### Install the Sentry SDK
 
 Install the `@sentry/react-native` package:
 
@@ -57,7 +57,7 @@ function App() {
 export default Sentry.wrap(App);
 ```
 
-### Add Sentry Expo plugin
+### Add the Sentry Expo Plugin
 
 To ensure the bundles and source maps are automatically uploaded during the native applications builds, add `withSentry` to the Expo application configuration:
 

--- a/src/platforms/react-native/manual-setup/expo.mdx
+++ b/src/platforms/react-native/manual-setup/expo.mdx
@@ -1,0 +1,158 @@
+---
+title: Expo
+description: "Learn how to set up Expo managed project with Sentry React Native SDK."
+---
+
+<Alert level="info" title="Experimental Support">
+
+The Expo support is currently experimental and available since version `5.16.0-alpha.1`.
+
+Experimental support means it may have bugs. We recognize the irony.
+
+</Alert>
+
+Sentry React Native SDK can be setup in Expo managed project using just one command of `@sentry-wizard`. If you prefer or can't the Wizard you can follow the manual steps on this page.
+
+## Automatic Setup
+
+Run `@sentry/wizard`:
+
+```bash {tabTitle:npm}
+npx @sentry/wizard@latest -s -i reactNative
+```
+
+## Manual Setup
+
+If you can’t (or prefer not to) run the [automatic setup](/platforms/react-native), use the instructions below to configure your application.
+
+### Install SDK Package
+
+Install the `@sentry/react-native` package:
+
+```bash {tabTitle:npm}
+npm install --save @sentry/react-native
+```
+
+```bash {tabTitle:Yarn}
+yarn add @sentry/react-native
+```
+
+### Intialize the SDK
+
+Import the `@sentry/react-native` package and call `init` with your DSN:
+
+```javascript {tabTitle:App.js/App.tsx}
+import { Text, View } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+
+Sentry.init({
+  dsn: '___DSN___',
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+});
+
+function App() {
+  return (
+    <View>
+      <Text>Expo Example!</Text>
+    </View>
+  );
+}
+
+export default Sentry.wrap(App);
+```
+
+### Add Sentry Expo plugin
+
+To ensure bundle and source map are automatically uploaded during the native application build, add `withSentry` to the Expo application configuration:
+
+```javascript {tabTitle:app.json/app.config.json}
+{
+  "expo": {
+    "plugins": [
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "warning": "DO NOT COMMIT YOUR AUTH TOKEN",
+          "authToken": "___ORG_AUTH_TOKEN___",
+          "project": "___PROJECT_SLUG___",
+          "organization": "___ORG_SLUG___"
+        }
+      ]
+    ]
+  }
+}
+```
+
+```javascript {tabTitle:app.config.js}
+const {
+  withSentry
+} = require("@sentry/react-native/expo");
+
+const config = {
+  name: 'Expo Example',
+  slug: 'expo-example',
+};
+
+module.exports = withSentry(config, {
+  url: "https://sentry.io/",
+  // DO NOT COMMIT YOUR AUTH TOKEN
+  authToken: "___ORG_AUTH_TOKEN___",
+  project: "___PROJECT_SLUG___s",
+  organization: "___ORG_SLUG___",
+});
+```
+
+```typescript {tabTitle:app.config.ts}
+import { ExpoConfig } from 'expo/config';
+import { withSentry } from "@sentry/react-native/expo";
+
+const config: ExpoConfig = {
+  name: 'Expo Example',
+  slug: 'expo-example',
+};
+
+export default withSentry(config, {
+  url: "https://sentry.io/",
+  // DO NOT COMMIT YOUR AUTH TOKEN
+  authToken: "___ORG_AUTH_TOKEN___",
+  project: "___PROJECT_SLUG___s",
+  organization: "___ORG_SLUG___",
+});
+```
+
+### Add Sentry Metro Plugin
+
+To ensure unique Debug ID gets assigned to the generated bundle and source maps, add Sentry Serializer to the Metro configuration:
+
+```javascript {tabTitle:metro.config.js}
+const { getDefaultConfig } = require()'expo/metro-config');
+const { mergeConfig } = require("metro");
+const { createSentryMetroSerializer } = require("@sentry/react-native/metro");
+
+const sentryConfig = {
+  serializer: {
+    customSerializer: createSentryMetroSerializer(),
+  },
+};
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = mergeConfig(config, sentryConfig);
+```
+
+## Verify Setup
+
+To verify that everything is working as expected, build `Release` version of your application and send a test event to Sentry by adding:
+
+```javascript
+<Button
+  title='Try!'
+  onPress={() => {
+    Sentry.captureException(new Error('First error'));
+  }}/>
+```

--- a/src/platforms/react-native/manual-setup/expo.mdx
+++ b/src/platforms/react-native/manual-setup/expo.mdx
@@ -5,7 +5,7 @@ description: "Learn how to set up Expo managed project with Sentry React Native 
 
 <Alert level="info" title="Experimental Support">
 
-The Expo support is currently experimental and available since version `5.16.0-alpha.1`.
+The Expo support is currently experimental and available since version `5.16.0-alpha.1` and Expo SDK 50.
 
 Experimental support means it may have bugs. We recognize the irony.
 
@@ -18,7 +18,7 @@ Sentry React Native SDK can be setup in Expo managed project using just one comm
 Run `@sentry/wizard`:
 
 ```bash {tabTitle:npm}
-npx @sentry/wizard@latest -s -i reactNative
+npx @sentry/wizard@latest -i reactNative
 ```
 
 ## Manual Setup
@@ -28,6 +28,10 @@ If you can’t (or prefer not to) run the [automatic setup](/platforms/react-nat
 ### Install SDK Package
 
 Install the `@sentry/react-native` package:
+
+```bash {tabTitle:Expo}
+npx expo install @sentry/react-native
+```
 
 ```bash {tabTitle:npm}
 npm install --save @sentry/react-native

--- a/src/platforms/react-native/manual-setup/expo.mdx
+++ b/src/platforms/react-native/manual-setup/expo.mdx
@@ -1,29 +1,17 @@
 ---
 title: Expo
-description: "Learn how to set up Expo managed project with Sentry React Native SDK."
+description: "Learn how to set up an Expo-managed project with the Sentry React Native SDK."
 ---
 
 <Alert level="info" title="Experimental Support">
 
-The Expo support is currently experimental and available since version `5.16.0-alpha.1` and Expo SDK 50.
+Expo support is currently experimental and available since Sentry React Native SDK version `5.16.0-alpha.1` and Expo SDK version 50.
 
 Experimental support means it may have bugs. We recognize the irony.
 
 </Alert>
 
-Sentry React Native SDK can be setup in Expo managed project using just one command of `@sentry-wizard`. If you prefer or can't the Wizard you can follow the manual steps on this page.
-
-## Automatic Setup
-
-Run `@sentry/wizard`:
-
-```bash {tabTitle:npm}
-npx @sentry/wizard@latest -i reactNative
-```
-
-## Manual Setup
-
-If you can’t (or prefer not to) run the [automatic setup](/platforms/react-native), use the instructions below to configure your application.
+To set up the Sentry React Native SDK in your Expo-managed project, follow the steps on this page.
 
 ### Install SDK Package
 
@@ -71,7 +59,7 @@ export default Sentry.wrap(App);
 
 ### Add Sentry Expo plugin
 
-To ensure bundle and source map are automatically uploaded during the native application build, add `withSentry` to the Expo application configuration:
+To ensure the bundles and source maps are automatically uploaded during the native applications builds, add `withSentry` to the Expo application configuration:
 
 ```javascript {tabTitle:app.json/app.config.json}
 {
@@ -129,12 +117,15 @@ export default withSentry(config, {
 
 ### Add Sentry Metro Plugin
 
-To ensure unique Debug ID gets assigned to the generated bundle and source maps, add Sentry Serializer to the Metro configuration:
+To ensure unique Debug IDs get assigned to the generated bundles and source maps, add Sentry Serializer to the Metro configuration:
 
 ```javascript {tabTitle:metro.config.js}
-const { getDefaultConfig } = require()'expo/metro-config');
-const { mergeConfig } = require("metro");
+const { mergeConfig } = require('metro');
+const { getDefaultConfig } = require('expo/metro-config');
 const { createSentryMetroSerializer } = require("@sentry/react-native/metro");
+const { withExpoSerializers } = require('@expo/metro-config/build/serializer/withExpoSerializers');
+
+const config = getDefaultConfig(__dirname);
 
 const sentryConfig = {
   serializer: {
@@ -142,14 +133,13 @@ const sentryConfig = {
   },
 };
 
-const config = getDefaultConfig(__dirname);
-
-module.exports = mergeConfig(config, sentryConfig);
+const finalConfig = mergeConfig(config, sentryConfig);
+module.exports = withExpoSerializers(finalConfig);
 ```
 
 ## Verify Setup
 
-To verify that everything is working as expected, build `Release` version of your application and send a test event to Sentry by adding:
+To verify that everything is working as expected, build the `Release` version of your application and send a test event to Sentry by adding:
 
 ```javascript
 <Button

--- a/src/platforms/react-native/manual-setup/expo.mdx
+++ b/src/platforms/react-native/manual-setup/expo.mdx
@@ -120,10 +120,12 @@ export default withSentry(config, {
 To ensure unique Debug IDs get assigned to the generated bundles and source maps, add Sentry Serializer to the Metro configuration:
 
 ```javascript {tabTitle:metro.config.js}
-const { mergeConfig } = require('metro');
-const { getDefaultConfig } = require('expo/metro-config');
+const { mergeConfig } = require("metro");
+const { getDefaultConfig } = require("expo/metro-config");
 const { createSentryMetroSerializer } = require("@sentry/react-native/metro");
-const { withExpoSerializers } = require('@expo/metro-config/build/serializer/withExpoSerializers');
+const {
+  withExpoSerializers,
+} = require("@expo/metro-config/build/serializer/withExpoSerializers");
 
 const config = getDefaultConfig(__dirname);
 


### PR DESCRIPTION
- related to https://github.com/getsentry/sentry-react-native/issues/3262

Sentry RN SDK will support Expo projects out of the box.