### PR TITLE
[Python] On main page link to integrations list

### DIFF
--- a/src/platform-includes/getting-started-primer/python.mdx
+++ b/src/platform-includes/getting-started-primer/python.mdx
@@ -1,7 +1,1 @@
-<Note>
-
-If you are still using our legacy "Raven" SDK, you can access the <Link rel={`nofollow`} to={`/platforms/python/legacy-sdk/`}>legacy SDK documentation</Link>, until further notice. Migrating from older versions is documented [here](./migration/).
-
-</Note>
-
 Sentry's Python SDK enables automatic reporting of errors and performance data in your application.

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -16,7 +16,7 @@ Get started using a guide listed in the right sidebar.
 
 <Alert level="info" title="Using a framework?">
 
-See our <PlatformLink to="/integrations/">Integrations</PlatformLink> to get started.
+See our <PlatformLink to="/integrations/">Integrations</PlatformLink> page to get started.
 
 </Alert>
 

--- a/src/platforms/common/index.mdx
+++ b/src/platforms/common/index.mdx
@@ -12,6 +12,16 @@ Get started using a guide listed in the right sidebar.
 
 </PlatformSection>
 
+<PlatformSection supported={["python"]}>
+
+<Alert level="info" title="Using a framework?">
+
+See our <PlatformLink to="/integrations/">Integrations</PlatformLink> to get started.
+
+</Alert>
+
+</PlatformSection>
+
 Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
 ## Install


### PR DESCRIPTION
Bring back the note about frameworks in Python. Because Python has no guides anymore, we link to the integrations list instead.
