### PR TITLE
user-feedback: API for crash reports

### DIFF
--- a/src/docs/product/user-feedback/setup.mdx
+++ b/src/docs/product/user-feedback/setup.mdx
@@ -37,9 +37,10 @@ The Sentry SDK that injects the Feedback widget runs on the client's browser, an
 - [SvelteKit](/platforms/javascript/guides/sveltekit/user-feedback/)
 - [Vue](/platforms/javascript/guides/vue/user-feedback/)
 
-## Supported SDKs for Crash-Report Modal
+## Supported SDKs for Crash-Report API
 
-For non-browser-based applications, we provide an API to send Crash Reports. This allows you to connect your own user interface with Sentry's Crash-Reports. The following SDKs have support for the Crash-Report API:
+For non-browser-based applications, we provide an API to send user feedback attached to errors programatically.
+This allows you to connect your own user interface with Sentry's Crash-Reports. The following SDKs have support for the Crash-Report API:
 
 - [Android](/platforms/android/user-feedback/)
 - [Apple](/platforms/apple/user-feedback/)


### PR DESCRIPTION
Fix: not modal specific but SDK/API for 'crash report' as in, takes event_id