### PR TITLE
feedback: product docs mention search

### DIFF
--- a/src/docs/product/user-feedback/index.mdx
+++ b/src/docs/product/user-feedback/index.mdx
@@ -54,6 +54,14 @@ You can either manually resolve user feedback submissions on the **User Feedback
 
 You can also assign a team member to a specific user feedback submission on the **User Feedback Details** view.
 
+## Searching for User Feedback
+
+You can search by feedbacks using the search box. It can, for example, allow you to search by feedback sent on a specific page.
+
+Example sarch: `url:*/payments/*`
+
+For a list of search fields, refer to the [search documentation](https://docs.sentry.io/product/reference/search/searchable-properties/user-feedback/).
+
 ## Getting User Feedback Alerts
 
 If you have Sentry's default issue alert ("Alert me on every new issue") turned on for the project(s) with user feedback set up, then you should automatically get alerted every time new user feedback comes in via the User Feedback Widget.


### PR DESCRIPTION
Add reference to https://docs.sentry.io/product/reference/search/searchable-properties/user-feedback/