### PR TITLE
feedback: Remove extra escape chars and misplaced sentence

### DIFF
--- a/src/platforms/common/user-feedback/configuration.mdx
+++ b/src/platforms/common/user-feedback/configuration.mdx
@@ -20,7 +20,7 @@ The following options can be configured as options for the integration in `new F
 | -------------- | ------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `autoInject`   | `boolean`                       | `true`     | Injects the Feedback widget into the application when the integration is added. Set `autoInject: false` if you want to call `feedback.attachTo()` or `feedback.openDialog()` directly, or only want to show the widget on certain views. |
 | `showBranding` | `boolean`                       | `true`     | Displays the Sentry logo inside of the form                                                                                                                                                                                              |
-| `colorScheme`  | `"system" \| "light" \| "dark"` | `"system"` | The color theme to use. `"system"` will follow your OS colorscheme.                                                                                                                                                                      |
+| `colorScheme`  | `"system" | "light" | "dark"` | `"system"` | The color theme to use. `"system"` will follow your OS colorscheme.                                                                                                                                                                      |
 
 ### User and Form
 
@@ -236,8 +236,6 @@ document.getElementById('my-feedback-form').addEventListener('submit', (event) =
 ## Crash-Report Modal
 
 You can customize the Crash-Report modal to your organization's needs, for example, for localization purposes. All options can be passed through the `Sentry.showReportDialog` call.
-
-An override for Sentry’s automatic language detection (e.g. `lang=de`)
 
 | Param            | Default                                                                                           |
 | ---------------- | ------------------------------------------------------------------------------------------------- |

--- a/src/platforms/common/user-feedback/configuration.mdx
+++ b/src/platforms/common/user-feedback/configuration.mdx
@@ -16,11 +16,11 @@ The User Feedback Widget offers many customization options, and if the available
 
 The following options can be configured as options for the integration in `new Feedback({})`:
 
-| key            | type                            | default    | description                                                                                                                                                                                                                              |
-| -------------- | ------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autoInject`   | `boolean`                       | `true`     | Injects the Feedback widget into the application when the integration is added. Set `autoInject: false` if you want to call `feedback.attachTo()` or `feedback.openDialog()` directly, or only want to show the widget on certain views. |
-| `showBranding` | `boolean`                       | `true`     | Displays the Sentry logo inside of the form                                                                                                                                                                                              |
-| `colorScheme`  | `"system" | "light" | "dark"` | `"system"` | The color theme to use. `"system"` will follow your OS colorscheme.                                                                                                                                                                      |
+| key            | type      | default | description                                                                                                                                                                                                                              |
+| -------------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------- |
+| `autoInject`   | `boolean` | `true`  | Injects the Feedback widget into the application when the integration is added. Set `autoInject: false` if you want to call `feedback.attachTo()` or `feedback.openDialog()` directly, or only want to show the widget on certain views. |
+| `showBranding` | `boolean` | `true`  | Displays the Sentry logo inside of the form                                                                                                                                                                                              |
+| `colorScheme`  | `"system" | "light" | "dark"`                                                                                                                                                                                                                                  | `"system"` | The color theme to use. `"system"` will follow your OS colorscheme. |
 
 ### User and Form
 


### PR DESCRIPTION
Fixes extra escaping here:

<img width="753" alt="SCR-20231205-joaj" src="https://github.com/getsentry/sentry-docs/assets/187460/a9ea713e-7df3-4f5c-83fd-bf6949f376ff">

Also removes a misplaced sentence, this was the context:
<img width="791" alt="SCR-20231205-jkjc" src="https://github.com/getsentry/sentry-docs/assets/187460/44423fe8-1c61-492d-b9d6-8b05e1c35b3d">
