### PR TITLE
feat(browser-starfish): add parameterization docs

### DIFF
--- a/src/docs/product/performance/resources.md
+++ b/src/docs/product/performance/resources.md
@@ -97,7 +97,8 @@ To enable Sentry to group similar resources together, Sentry parameterizes resou
 
 If you would like to further improve your groupings, consider the following rules we use when parameterizing urls. These rules can help you understand how you can name urls to improve grouping.
 
-The following tokens will be replaced with * within a resource url
+The following tokens will be replaced with \* within a resource url
+
 1. A version string (`myfile.v3.0.js` is replace with `myfile.*.js`)
 2. Hexadecimal strings with more than 5 digits (`myfile.7A9B3E.js` is replaced with `myfile.*.js`)
 3. UUID's

--- a/src/docs/product/performance/resources.md
+++ b/src/docs/product/performance/resources.md
@@ -93,7 +93,17 @@ To view more details, click on a resource from the table to open its **Resource 
 
 ### Resource Parameterization
 
-To enable Sentry to group similar resources together, Sentry parameterizes resource URLs, removing potenially dynamic elements. This helps track the performance of a particular resource across different releases, even when they have dynamic segments (used for busting caches or CDNS).
+To enable Sentry to group similar resources together, Sentry parameterizes resource URLs, removing potentially dynamic elements. This helps track the performance of a particular resource across different releases, even when they have dynamic segments (used for busting caches or CDNS).
+
+If you would like to further improve your groupings, consider the following rules we use when parameterizing urls. These rules can help you understand how you can name urls to improve grouping.
+
+The following tokens will be replaced with * within a resource url
+1. A version string (`myfile.v3.0.js` is replace with `myfile.*.js`)
+2. Hexadecimal strings with more than 5 digits (`myfile.7A9B3E.js` is replaced with `myfile.*.js`)
+3. UUID's
+4. Integer IDs with more than one digit (`1234.7A9B3E.js` is replace with `*.*.js`)
+5. Strings longer then 25 characters
+6. The entire path except for common path segments such as static, chunks, media, etc
 
 <Note>
 


### PR DESCRIPTION
Work towards https://github.com/getsentry/sentry/issues/60482

This adds docs to explain how we parameterize resource urls. If users are experiencing poor parameterization, or they are just curious why things are grouped in a certain way, they can use this to understand why.

@phacops @jjbayer If there is anything critical here that i've missed please lmk!