### PR TITLE
fix(spend-viz): remove replay checks from spike protection and spend allocation

### DIFF
--- a/src/docs/product/accounts/quotas/index.mdx
+++ b/src/docs/product/accounts/quotas/index.mdx
@@ -37,8 +37,8 @@ The first 6 actions in the list can all be done in [sentry.io](https://sentry.io
 
 | Action | Errors | Performance Units | Replays |Attachments |
 | ------ | ------ | ------------ | ----------- |----------- |
-| [Ensure spike protection is enabled](#spike-protection) | &check; | &check; | &check; | &check; |
-| [Set a spend allocation budget](#spend-allocation) | &check; | &check; | &check; | &check; |
+| [Ensure spike protection is enabled](#spike-protection) | &check; | &check; |  | &check; |
+| [Set a spend allocation budget](#spend-allocation) | &check; | &check; |  | &check; |
 | [Adjust your quota](#increasing-quotas) | &check; | &check; | &check; | &check; |
 | [Rate limit your events or attachments](#limiting-events) | &check; |  |  | &check; |
 | [Review repeated events](#4-event-repetition) | &check; |  |  |  |


### PR DESCRIPTION
Spike protection and spend allocation currently do not support replays.