### PR TITLE
Remove deprecated Elixir option

### DIFF
--- a/src/platform-includes/getting-started-config/elixir.mdx
+++ b/src/platform-includes/getting-started-config/elixir.mdx
@@ -1,6 +1,6 @@
 Sentry has a range of configuration options, but most applications will have a configuration that looks like the following:
 
-    <SignInNote />
+<SignInNote />
 
 ```elixir {filename:config/config.exs}
 config :sentry,

--- a/src/platform-includes/getting-started-config/elixir.mdx
+++ b/src/platform-includes/getting-started-config/elixir.mdx
@@ -1,12 +1,11 @@
 Sentry has a range of configuration options, but most applications will have a configuration that looks like the following:
 
-<SignInNote />
+    <SignInNote />
 
 ```elixir {filename:config/config.exs}
 config :sentry,
   dsn: "___PUBLIC_DSN___",
   environment_name: Mix.env(),
-  included_environments: [:prod],
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()]
 ```


### PR DESCRIPTION
## Description of changes

As per the title 🙃 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
