### PR TITLE
fix(site): Fix typo in "edit this page" footer

### DIFF
--- a/src/components/githubCta.tsx
+++ b/src/components/githubCta.tsx
@@ -14,7 +14,7 @@ export function GitHubCTA({sourceInstanceName, relativePath}: GitHubCTAProps) {
       <br />
       <small>
         Our documentation is open source and available on GitHub. Your contributions are
-        welcome, whether fixing a typo (drat!) to suggesting an update ("yeah, this would
+        welcome, whether fixing a typo (drat!) or suggesting an update ("yeah, this would
         be better").
         <div className="muted">
           <SmartLink


### PR DESCRIPTION
We're currently mixing "from x to y" and "whether x or y" in our "edit this page" footer. I went with the latter option, because I think it makes more sense in context.
