### PR TITLE
environment: default and env var

### DIFF
--- a/src/platforms/common/configuration/environments.mdx
+++ b/src/platforms/common/configuration/environments.mdx
@@ -6,6 +6,12 @@ description: "Learn how to configure your SDK to tell Sentry about your environm
 
 Environments tell you where an error occurred, whether that's in your production system, your staging server, or elsewhere.
 
+<Note>
+
+The default value is `production`.
+
+</Note>
+
 Sentry automatically creates an environment when it receives an event with the `environment` parameter set.
 
 Environments are case sensitive. The environment name can't contain newlines, spaces or forward slashes, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](/product/sentry-basics/environments/#hidden-environments) them.
@@ -13,3 +19,5 @@ Environments are case sensitive. The environment name can't contain newlines, sp
 <PlatformContent includePath="set-environment" />
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).
+
+When applicable, you can control the value via the environment variable `SENTRY_ENVIRONMENT`.


### PR DESCRIPTION
Ideally we mention the env var only where its applicable. Most SDKs, when running via the command line, for example. But not really mobile apps.