### PR TITLE
Deprecate AWS Lambda Images

### DIFF
--- a/src/platforms/node/guides/aws-lambda/container-image/index.mdx
+++ b/src/platforms/node/guides/aws-lambda/container-image/index.mdx
@@ -3,7 +3,14 @@ title: AWS Lambda Container Image (Node)
 description: "Learn how to set up Sentry with a Container Image."
 ---
 
-You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
+<Alert level="warning" title="Deprecation Notice">
+
+The Node.js AWS Lambda Container Image is deprecated.
+Instead, please either use the <PlatformLink to="/layer/">Sentry AWS Lambda Layer</PlatformLink> or use the <PlatformLink to="/">Sentry AWS Lambda SDK</PlatformLink> directly.
+
+</Alert>
+
+As an alternative setup method, you can add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
 
 ```{tabTitle: Dockerfile}
 COPY --from=public.ecr.aws/sentry/sentry-node-serverless-sdk:<VERSION> /opt/ /opt

--- a/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 3000
 <Alert level="warning" title="Deprecation Notice">
 
 The Python AWS Lambda Container Image is deprecated.
-Instead, please either use the <PlatformLink to="/integrations/aws-lambda/manual-layer/">Sentry AWS Lambda Layer</PlatformLink> or use set up <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">Manual AWS Lambda Instrumentation</PlatformLink>.
+Instead, please either use the <PlatformLink to="/integrations/aws-lambda/manual-layer/">Sentry AWS Lambda Layer</PlatformLink> or set up <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">Manual AWS Lambda Instrumentation</PlatformLink>.
 
 </Alert>
 

--- a/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/src/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -4,7 +4,14 @@ description: "Learn how to set up Sentry with a Container Image."
 sidebar_order: 3000
 ---
 
-You can also add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
+<Alert level="warning" title="Deprecation Notice">
+
+The Python AWS Lambda Container Image is deprecated.
+Instead, please either use the <PlatformLink to="/integrations/aws-lambda/manual-layer/">Sentry AWS Lambda Layer</PlatformLink> or use set up <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">Manual AWS Lambda Instrumentation</PlatformLink>.
+
+</Alert>
+
+As an alternative setup method, you can add Sentry to your [Container Image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html). To import Sentry's Layer Image, add the following to your Dockerfile:
 
 ```{tabTitle: Dockerfile}
 COPY --from=public.ecr.aws/sentry/sentry-python-serverless-sdk:<VERSION> /opt/ /opt


### PR DESCRIPTION
These images are unmaintained (last updated 2y ago) and seem to cause confusion. Let's deprecate them and remove when we do new majors.

Ref: https://github.com/getsentry/sentry-javascript/issues/9762