### PR TITLE
ref(astro): Improve Getting Started introduction

### DIFF
--- a/src/platform-includes/getting-started-install/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-install/javascript.astro.mdx
@@ -1,14 +1,14 @@
 Install the SDK by using the `astro` CLI:
 
-```bash {tabTitle:Npm}
+```bash {tabTitle:npm}
 npx astro add @sentry/astro
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn astro add @sentry/astro
 ```
 
-```bash {tabTitle:Pnpm}
+```bash {tabTitle:pnpm}
 pnpm astro add @sentry/astro
 ```
 

--- a/src/platform-includes/getting-started-install/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-install/javascript.astro.mdx
@@ -1,7 +1,15 @@
-We recommend installing the SDK by using the `astro` CLI:
+Install the SDK by using the `astro` CLI:
 
-```bash
+```bash {tabTitle:Npm}
 npx astro add @sentry/astro
+```
+
+```bash {tabTitle:Yarn}
+yarn astro add @sentry/astro
+```
+
+```bash {tabTitle:Pnpm}
+pnpm astro add @sentry/astro
 ```
 
 The `astro` CLI installs the SDK package and adds the Sentry integration to your `astro.config.mjs` file.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,6 +1,7 @@
 Sentry's Astro SDK enables automatic reporting of errors and performance data in your Astro application.
 Our Astro integration instruments both the client as well as the server side of your Astro application.
 This page walks you through adding Sentry to your Astro project, configuring it, adding readable stack traces, and verifying your setup.
+
 <Alert>
 
 The Astro SDK is in **Beta** and might still contain bugs. We recognize the irony.
@@ -17,4 +18,4 @@ Before we get started, make sure you have the following:
 - An Astro project that uses Astro `3.0.0` or newer.
 - A Node runtime:
   - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions).
-  Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+    Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -16,4 +16,5 @@ Before we get started, make sure you have the following:
   - Don't have an account yet? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 - An Astro project that uses Astro `3.0.0` or newer.
 - A Node runtime:
-  - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions) Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+  - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions).
+  Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,7 +1,6 @@
 Sentry's Astro SDK enables automatic reporting of errors and performance data in your Astro application.
-Our Astro integration instruments both, the client as well as the server side of your Astro application.
+Our Astro integration instruments both the client as well as the server side of your Astro application.
 This page walks you through adding Sentry to your Astro project, configuring it, adding readable stack traces, and verifying your setup.
-
 <Alert>
 
 The Astro SDK is in **Beta** and might still contain bugs. We recognize the irony.
@@ -13,8 +12,8 @@ Please report any issues you encounter in our [Github Repository](https://github
 
 Before we get started, make sure you have the following:
 
-- A Sentry account and a project.
+- A Sentry account.
   - Don't have an account yet? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
-- An Astro project using Astro `3.0.0` or newer.
-- This SDK currently only works on Node runtimes.
-  - Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+- An Astro project that uses Astro `3.0.0` or newer.
+- A Node runtime:
+  - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions) Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,4 +1,6 @@
-Sentry's Astro SDK enables automatic reporting of errors and performance data.
+Sentry's Astro SDK enables automatic reporting of errors and performance data in your Astro application.
+Our Astro integration instruments both, the client as well as the server side of your Astro application.
+This page walks you through adding Sentry to your Astro project, configuring it, adding readable stack traces and verifying your setup.
 
 <Alert>
 
@@ -7,8 +9,12 @@ Please report any issues you encounter in our [Github Repository](https://github
 
 </Alert>
 
-## Compatibility
+## Prerequisites
 
-The minimum supported Astro version is `3.0.0`.
-This SDK currently only works on Node runtimes.
-Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+Before we get started, make sure you have the following:
+
+- A Sentry account and a project.
+  - Don't have an account yet? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+- An Astro project using Astro `3.0.0` or newer.
+- This SDK currently only works on Node runtimes.
+  - Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.

--- a/src/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/src/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -1,6 +1,6 @@
 Sentry's Astro SDK enables automatic reporting of errors and performance data in your Astro application.
 Our Astro integration instruments both, the client as well as the server side of your Astro application.
-This page walks you through adding Sentry to your Astro project, configuring it, adding readable stack traces and verifying your setup.
+This page walks you through adding Sentry to your Astro project, configuring it, adding readable stack traces, and verifying your setup.
 
 <Alert>
 

--- a/src/platforms/javascript/common/index.mdx
+++ b/src/platforms/javascript/common/index.mdx
@@ -4,6 +4,8 @@
 
 On this page, we get you up and running with Sentry's SDK.
 
+</PlatformSection>
+
 <PlatformSection noGuides>
 
 <Alert level="info" title="Using a framework?">

--- a/src/platforms/javascript/common/index.mdx
+++ b/src/platforms/javascript/common/index.mdx
@@ -1,5 +1,7 @@
 <PlatformContent includePath="getting-started-primer" />
 
+<PlatformSection notSupported={["javascript.astro"]}>
+
 On this page, we get you up and running with Sentry's SDK.
 
 <PlatformSection noGuides>


### PR DESCRIPTION
This PR refactors the  Astro "Getting Started" intro section. I tried the suggested "ramp" approach for docs. Figured as Astro is new and relatively small it's ideal to experiment with. Feel free to close this PR if you wanna tackle this more generally. Appreciate feedback either way. 

<img width="772" alt="image" src="https://github.com/getsentry/sentry-docs/assets/8420481/e8a1e144-78d1-4b4f-8bfd-7ffde2ece18b">

Motivation for this change: Other than the meeting last week, we had users writing in ([example](https://github.com/getsentry/sentry-javascript/issues/9777)) about Cloudflare and Edge support and it seemed like our previous compatibility note didn't state clearly enough that these runtimes are currently not supported. 

Note: I also wanted to add numbering to the steps but this requires more fundamental changes to the common "getting started" template and I want to avoid this for now. IMO we should get rid of this common template. It's full of special cases already and I don't think we benefit much from it anymore. Probably collides with the rewrite anyway... 
