### PR TITLE
remove examples repo in tunneling docs.

### DIFF
--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -194,8 +194,6 @@ class HomeController < ApplicationController
 end
 ```
 
-Check out our [examples repository](https://github.com/getsentry/examples/tree/master/tunneling) to learn more about it.
-
 If your use-case is related to the SDK package itself being blocked, any of the following solutions will help you resolve this issue.
 
 ### Using the NPM Package


### PR DESCRIPTION
examples repo has been archived.