### PR TITLE
docs(release-automation): make the upload-sourcemaps command clearer

### DIFF
--- a/src/docs/product/releases/setup/release-automation/jenkins/index.mdx
+++ b/src/docs/product/releases/setup/release-automation/jenkins/index.mdx
@@ -69,7 +69,7 @@ pipeline {
                     export SENTRY_RELEASE=$(sentry-cli releases propose-version)
                     sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
                     sentry-cli releases set-commits $SENTRY_RELEASE --auto
-                    sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
+                    sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps /path/to/sourcemaps
                     sentry-cli releases finalize $SENTRY_RELEASE
                     sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
                 '''


### PR DESCRIPTION
The previous command was ambiguous and inconsistent with the other commands in other places. The new command specifies the path to the sourcemaps as /path/to/sourcemaps, which is easier to understand and modify.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

changed the path

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
