### PR TITLE
feat: Use `getClient()` instead of `getCurrentHub().getClient()`

### DIFF
--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -6,7 +6,7 @@ There are a few steps necessary in order to ensure that your OpenTelemetry setup
 // Sentry dependencies
 const Sentry = require("@sentry/node");
 const {
-  getCurrentHub,
+  getClient,
   setupGlobalHub,
   SentryPropagator,
   SentrySampler,
@@ -41,7 +41,7 @@ function setupSentry() {
     // ...
   });
 
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   setupEventContextTrace(client);
 
   // You can wrap whatever local storage context manager you want to use

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -150,7 +150,7 @@ window.Sentry &&
   Sentry.onLoad(function () {
     // Inside of this callback,
     // we guarantee that `Sentry` is fully loaded and all APIs are available
-    const client = Sentry.getCurrentHub().getClient();
+    const client = Sentry.getClient();
     // do something custom here
   });
 ```

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -34,7 +34,7 @@ It is also possible to defer the initialization and loading of the Replay integr
 
 ```javascript
 async function init(sessionSampleRate, errorSampleRate) {
-  const client = Sentry.getCurrentHub().getClient();
+  const client = Sentry.getClient();
   const options = client.getOptions();
   options.replaysSessionSampleRate = sessionSampleRate;
   options.replaysOnErrorSampleRate = errorSampleRate;
@@ -62,7 +62,7 @@ Sentry.init({
 });
 
 // You can access the active replay instance from anywhere in your code like this:
-const replay = Sentry.getCurrentHub().getIntegration(Sentry.Replay);
+const replay = Sentry.getClient().getIntegrationById('Replay');
 
 // This starts in `session` mode, regardless of sample rates
 replay.start();
@@ -132,9 +132,7 @@ Sentry.init({
 // Check if user is an employee, if so, always record a replay
 if (loggedInUser.isEmployee) {
   // You can get a reference to the Sentry Replay integration like so:
-  const replay = Sentry.getCurrentHub().getIntegration(Sentry.Replay);
-  // or alternatively
-  // const replay = Sentry.getCurrentHub().getClient().getIntegrationById('Replay');
+  const replay = Sentry.getClient().getIntegrationByid('Replay');
 
   replay.flush();
 }

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -62,7 +62,7 @@ Sentry.init({
 });
 
 // You can access the active replay instance from anywhere in your code like this:
-const replay = Sentry.getClient().getIntegrationById('Replay');
+const replay = Sentry.getClient().getIntegrationById("Replay");
 
 // This starts in `session` mode, regardless of sample rates
 replay.start();
@@ -132,7 +132,7 @@ Sentry.init({
 // Check if user is an employee, if so, always record a replay
 if (loggedInUser.isEmployee) {
   // You can get a reference to the Sentry Replay integration like so:
-  const replay = Sentry.getClient().getIntegrationByid('Replay');
+  const replay = Sentry.getClient().getIntegrationByid("Replay");
 
   replay.flush();
 }

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -314,7 +314,7 @@ class HappyIntegration {
 
   setupOnce() {
     Sentry.addGlobalEventProcessor((event) => {
-      const self = Sentry.getCurrentHub().getIntegration(HappyIntegration);
+      const self = Sentry.getClient().getIntegration(HappyIntegration);
       // Run the integration ONLY when it was installed on the current Hub
       if (self) {
         event.message = `\\o/ ${event.message} \\o/`;


### PR DESCRIPTION
One step towards removing `getCurrentHub()` from the docs!