### PR TITLE
Clarify window.SENTRY_RELEASE

### DIFF
--- a/src/platforms/android/configuration/options.mdx
+++ b/src/platforms/android/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/apple/common/configuration/options.mdx
+++ b/src/platforms/apple/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/dart/configuration/options.mdx
+++ b/src/platforms/dart/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/dotnet/common/configuration/options.mdx
+++ b/src/platforms/dotnet/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/elixir/configuration/options.mdx
+++ b/src/platforms/elixir/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/flutter/configuration/options.mdx
+++ b/src/platforms/flutter/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/java/common/configuration/options.mdx
+++ b/src/platforms/java/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/javascript/common/configuration/options.mdx
+++ b/src/platforms/javascript/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/kotlin-multiplatform/configuration/options.mdx
+++ b/src/platforms/kotlin-multiplatform/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/native/common/configuration/options.mdx
+++ b/src/platforms/native/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/node/common/configuration/options.mdx
+++ b/src/platforms/node/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/php/common/configuration/options.mdx
+++ b/src/platforms/php/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/python/configuration/options.mdx
+++ b/src/platforms/python/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/react-native/configuration/options.mdx
+++ b/src/platforms/react-native/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/rust/common/configuration/options.mdx
+++ b/src/platforms/rust/common/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/unity/configuration/options.mdx
+++ b/src/platforms/unity/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 

--- a/src/platforms/unreal/configuration/options.mdx
+++ b/src/platforms/unreal/configuration/options.mdx
@@ -111,7 +111,7 @@ Sets the release. Some SDKs will try to automatically configure a release out of
 
 <PlatformSection notSupported={["unity", "javascript.electron"]}>
 
-By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE` if available).
+By default the SDK will try to read this value from the `SENTRY_RELEASE` environment variable (in the browser SDK, this will be read off of the `window.SENTRY_RELEASE.id` if available).
 
 </PlatformSection>
 


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-docs/pull/8679

the SDK does not read the value of window.SENTRY_RELEASE it releases the value of window.SENTRY_RELEASE.id

[getsentry/sentry-javascript@b3f8d9b/packages/browser/src/sdk.ts#L111](https://github.com/getsentry/sentry-javascript/blob/b3f8d9bcb067b391c1d0eba4f537ff09be56c1e9/packages/browser/src/sdk.ts#L111)