### PR TITLE
Fix paht typo in manual-setup.mdx

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -72,7 +72,7 @@ export SENTRY_PROPERTIES=path/to/sentry.properties
 export SENTRY_DISABLE_AUTO_UPLOAD=true # Temporarily disable source map upload
 
 export AUTO_RELEASE=true # Automatically detect release from Xcode project
-export SENTRY_CLI_EXECUTABLE="paht/to/@sentry/cli/bin/sentry-cli"
+export SENTRY_CLI_EXECUTABLE="path/to/@sentry/cli/bin/sentry-cli"
 export SENTRY_CLI_EXTRA_ARGS="--extra --flags" # Extra arguments for sentry-cli in all build phases
 export SENTRY_CLI_RN_XCODE_EXTRA_ARGS="--extra --flags"
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

paht paht paht

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
