### PR TITLE
fix(spike protection): add note about SP during trials

### DIFF
--- a/src/docs/product/accounts/quotas/spike-protection.mdx
+++ b/src/docs/product/accounts/quotas/spike-protection.mdx
@@ -11,6 +11,12 @@ Spike Protection currently applies to errors, transactions, and attachments.
 
 <Note>
 
+Spike Protection does not apply during trials as category quotas are unlimited for the duration of the trial. For example, new organizations on a trial will not be spike-protected until the trial is over even if projects have Spike Protection enabled.
+
+</Note>
+
+<Note>
+
 Notifications for Spike Protection are turned off by default to avoid excessive noise for users. Read the [notification](/product/accounts/quotas/spike-protection/#notifications) section below to learn how to turn them on for key projects.
 
 </Note>

--- a/src/docs/product/accounts/quotas/spike-protection.mdx
+++ b/src/docs/product/accounts/quotas/spike-protection.mdx
@@ -7,6 +7,8 @@ description: "Learn how to manage your quota and make sure that your volume isn'
 
 A spike is a significant, temporary increase in your event volume. Because Sentry bills based on the number of events sent monthly, spikes can quickly consume your quota for an entire month. Spike Protection guards against this by establishing a spike threshold for the average number of events each of your projects sends and then dropping them after that threshold is reached.
 
+Spike Protection does not apply during trials as category quotas are unlimited for the duration of the trial. For example, new organizations on a trial will not be spike-protected until the trial is over even if projects have Spike Protection enabled, since trials include unlimited quota.
+
 Spike Protection currently applies to errors, transactions, and attachments.
 
 <Note>

--- a/src/docs/product/accounts/quotas/spike-protection.mdx
+++ b/src/docs/product/accounts/quotas/spike-protection.mdx
@@ -7,8 +7,6 @@ description: "Learn how to manage your quota and make sure that your volume isn'
 
 A spike is a significant, temporary increase in your event volume. Because Sentry bills based on the number of events sent monthly, spikes can quickly consume your quota for an entire month. Spike Protection guards against this by establishing a spike threshold for the average number of events each of your projects sends and then dropping them after that threshold is reached.
 
-Spike Protection does not apply during trials as category quotas are unlimited for the duration of the trial. For example, new organizations on a trial will not be spike-protected until the trial is over even if projects have Spike Protection enabled.
-
 Spike Protection currently applies to errors, transactions, and attachments.
 
 <Note>

--- a/src/docs/product/accounts/quotas/spike-protection.mdx
+++ b/src/docs/product/accounts/quotas/spike-protection.mdx
@@ -7,7 +7,7 @@ description: "Learn how to manage your quota and make sure that your volume isn'
 
 A spike is a significant, temporary increase in your event volume. Because Sentry bills based on the number of events sent monthly, spikes can quickly consume your quota for an entire month. Spike Protection guards against this by establishing a spike threshold for the average number of events each of your projects sends and then dropping them after that threshold is reached.
 
-Spike Protection does not apply during trials as category quotas are unlimited for the duration of the trial. For example, new organizations on a trial will not be spike-protected until the trial is over even if projects have Spike Protection enabled, since trials include unlimited quota.
+Spike Protection does not apply during trials as category quotas are unlimited for the duration of the trial. For example, new organizations on a trial will not be spike-protected until the trial is over even if projects have Spike Protection enabled.
 
 Spike Protection currently applies to errors, transactions, and attachments.
 


### PR DESCRIPTION
New orgs on a trial will not be spike protected because they have unlimited quotas for the duration of the trial.