### PR TITLE
ref: Add link to explicit tag syntax from tag pages

### DIFF
--- a/src/platforms/android/enriching-events/tags/index.mdx
+++ b/src/platforms/android/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/android/enriching-events/tags/index.mdx
+++ b/src/platforms/android/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/apple/common/enriching-events/tags/index.mdx
+++ b/src/platforms/apple/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/apple/common/enriching-events/tags/index.mdx
+++ b/src/platforms/apple/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/dart/enriching-events/tags/index.mdx
+++ b/src/platforms/dart/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/dart/enriching-events/tags/index.mdx
+++ b/src/platforms/dart/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/dotnet/common/enriching-events/tags/index.mdx
+++ b/src/platforms/dotnet/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/dotnet/common/enriching-events/tags/index.mdx
+++ b/src/platforms/dotnet/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/elixir/enriching-events/tags/index.mdx
+++ b/src/platforms/elixir/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/elixir/enriching-events/tags/index.mdx
+++ b/src/platforms/elixir/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/flutter/enriching-events/tags/index.mdx
+++ b/src/platforms/flutter/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/flutter/enriching-events/tags/index.mdx
+++ b/src/platforms/flutter/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/go/common/enriching-events/tags/index.mdx
+++ b/src/platforms/go/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+ Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/go/common/enriching-events/tags/index.mdx
+++ b/src/platforms/go/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
- Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/go/common/enriching-events/tags/index.mdx
+++ b/src/platforms/go/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+ If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/go/common/enriching-events/tags/index.mdx
+++ b/src/platforms/go/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
- If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/java/common/enriching-events/tags/index.mdx
+++ b/src/platforms/java/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/java/common/enriching-events/tags/index.mdx
+++ b/src/platforms/java/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/javascript/common/enriching-events/tags/index.mdx
+++ b/src/platforms/javascript/common/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/javascript/common/enriching-events/tags/index.mdx
+++ b/src/platforms/javascript/common/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/kotlin-multiplatform/enriching-events/tags/index.mdx
+++ b/src/platforms/kotlin-multiplatform/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/kotlin-multiplatform/enriching-events/tags/index.mdx
+++ b/src/platforms/kotlin-multiplatform/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/native/common/enriching-events/tags/index.mdx
+++ b/src/platforms/native/common/enriching-events/tags/index.mdx
@@ -26,7 +26,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/native/common/enriching-events/tags/index.mdx
+++ b/src/platforms/native/common/enriching-events/tags/index.mdx
@@ -26,7 +26,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/node/common/enriching-events/tags/index.mdx
+++ b/src/platforms/node/common/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/node/common/enriching-events/tags/index.mdx
+++ b/src/platforms/node/common/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/php/common/enriching-events/tags/index.mdx
+++ b/src/platforms/php/common/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/php/common/enriching-events/tags/index.mdx
+++ b/src/platforms/php/common/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/python/enriching-events/tags/index.mdx
+++ b/src/platforms/python/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/python/enriching-events/tags/index.mdx
+++ b/src/platforms/python/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/react-native/enriching-events/tags/index.mdx
+++ b/src/platforms/react-native/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/react-native/enriching-events/tags/index.mdx
+++ b/src/platforms/react-native/enriching-events/tags/index.mdx
@@ -23,7 +23,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/ruby/common/enriching-events/tags/index.mdx
+++ b/src/platforms/ruby/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/ruby/common/enriching-events/tags/index.mdx
+++ b/src/platforms/ruby/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/rust/common/enriching-events/tags/index.mdx
+++ b/src/platforms/rust/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/rust/common/enriching-events/tags/index.mdx
+++ b/src/platforms/rust/common/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/unity/enriching-events/tags/index.mdx
+++ b/src/platforms/unity/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/unity/enriching-events/tags/index.mdx
+++ b/src/platforms/unity/enriching-events/tags/index.mdx
@@ -19,7 +19,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 

--- a/src/platforms/unreal/enriching-events/tags/index.mdx
+++ b/src/platforms/unreal/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/product/reference/search/#explicit-tag-syntax) to search for it.
 
 </Note>
 

--- a/src/platforms/unreal/enriching-events/tags/index.mdx
+++ b/src/platforms/unreal/enriching-events/tags/index.mdx
@@ -17,7 +17,7 @@ Define the tag:
 
 <Note>
 
-Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature.
+Some tags are automatically set by Sentry. We strongly recommend against overwriting those tags. Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](https://docs.sentry.io/product/reference/search/#explicit-tag-syntax/) to search for it.
 
 </Note>
 


### PR DESCRIPTION
Add link to explicit tag syntax from tag pages

related to https://github.com/getsentry/sentry/issues/61595