### PR TITLE
Update nextjs guide `global-error.tsx` example types

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -115,7 +115,11 @@ import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
-export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -135,7 +139,7 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import Error from "next/error";
+import NextError from "next/error";
 import { useEffect } from "react";
 
 export default function GlobalError({ error }) {
@@ -147,7 +151,7 @@ export default function GlobalError({ error }) {
     <html>
       <body>
         {/* This is the default Next.js error component. */}
-        <Error />
+        <NextError />
       </body>
     </html>
   );
@@ -163,7 +167,7 @@ This means, that if you want to report errors that are caught by `error.js` file
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 
-export default function Error({
+export default function ErrorPage({
   error,
 }: {
   error: Error & { digest?: string };
@@ -187,7 +191,7 @@ export default function Error({
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 
-export default function Error({ error }) {
+export default function ErrorPage({ error }) {
   useEffect(() => {
     // Log the error to Sentry
     Sentry.captureException(error);

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -112,7 +112,7 @@ Create a [Custom Next.js Global Error component](https://nextjs.org/docs/app/bui
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import Error from "next/error";
+import NextError from "next/error";
 import { useEffect } from "react";
 
 export default function GlobalError({ error }: { error: Error }) {
@@ -124,7 +124,7 @@ export default function GlobalError({ error }: { error: Error }) {
     <html>
       <body>
         {/* This is the default Next.js error component but it doesn't allow omitting the statusCode property yet. */}
-        <Error statusCode={undefined as any} />
+        <NextError statusCode={undefined as any} />
       </body>
     </html>
   );

--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -115,7 +115,7 @@ import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
-export default function GlobalError({ error }: { error: Error }) {
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

- Fix type error in Nextjs manual setup guide `global-error.tsx` example. Importing the Error component as `import Error from "next/error"`  interferes and overrides the global `Error ` type used in the props


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
