### PR TITLE
docs(deno): Fix DenoCron reference in docs for Deno.cron

### DIFF
--- a/src/platform-includes/crons/setup/javascript.deno.mdx
+++ b/src/platform-includes/crons/setup/javascript.deno.mdx
@@ -9,7 +9,7 @@ import * as Sentry from "https://deno.land/x/sentry/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.DenoCron()],
+  integrations: [new Sentry.Integrations.DenoCron()],
 });
 ```
 


### PR DESCRIPTION
## Description of changes

[`DenoCron`](https://github.com/getsentry/sentry-deno/blob/2bd56ebf652a3f6131cf9ec853cbbd87ca2b12cf/index.mjs#L9895) is exported as part of the [`INTEGRATIONS`](https://github.com/getsentry/sentry-deno/blob/2bd56ebf652a3f6131cf9ec853cbbd87ca2b12cf/index.mjs#L10087) object (not a top-level class). This PR updates the docs to reflect this :)

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
