### PR TITLE
fix(replay): Fix links to replay start/stop

### DIFF
--- a/src/docs/product/session-replay/index.mdx
+++ b/src/docs/product/session-replay/index.mdx
@@ -22,13 +22,13 @@ The start of a replay recording can be triggered by:
 
 - A user session being part of a sampling rate, as controlled by [replaysSessionSampleRate](/platforms/javascript/session-replay/#sampling). When a user loads a page, a decision is made whether to sample it or not.
 - An error occurring during a session that’s not being recorded. The session is then recorded based on [replaysOnErrorSampleRate](/platforms/javascript/session-replay/#sampling)
-- Manually calling the [replay.start()](/platforms/javascript/session-replay/configuration/#start-and-stop-recording) method
+- Manually calling the [replay.start()](/platforms/javascript/session-replay/understanding-sessions/#manually-starting-replay) method
 
 The end of a replay recording can be triggered by:
 
 - User inactivity within the tab/page that’s being recorded. (If a user doesn’t click or navigate around the site for more than 15 minutes. Mouse scrolls, mouse movements, and keyboard events don’t currently qualify as activity.)
 - A recording reaching the maximum replay duration limit (currently 60 minutes)
-- Manually calling the [replay.stop()](/platforms/javascript/session-replay/configuration/#start-and-stop-recording) method
+- Manually calling the [replay.stop()](/platforms/javascript/session-replay/understanding-sessions/#manually-stopping-replay) method
 
 <Note>
 


### PR DESCRIPTION
Fixing links as mentioned here: https://github.com/getsentry/sentry-javascript/issues/9871