### PR TITLE
Spring Boot Quartz `SchedulerFactoryBeanCustomizer` add note

### DIFF
--- a/src/platforms/java/common/integrations/quartz.mdx
+++ b/src/platforms/java/common/integrations/quartz.mdx
@@ -66,6 +66,6 @@ Setting the monitor slug on the `Trigger` will override what is set on the `JobD
 
 <Note>
 
-In case you are using Spring Boot, have defined a `SchedulerFactoryBeanCustomizer` and are setting a global job listener you have to manually add a new `SentryJobListener` instance to the global job listeners as well.
+Setting a global job listener using a `SchedulerFactoryBeanCustomizer` in Spring Boot, will override the listener set by Sentry. For Sentry to work properly, you need to add a new `SentryJobListener` instance to the global job listeners.
 
 </Note>

--- a/src/platforms/java/common/integrations/quartz.mdx
+++ b/src/platforms/java/common/integrations/quartz.mdx
@@ -63,3 +63,9 @@ trigger.setJobDataAsMap(Collections.singletonMap(SENTRY_SLUG_KEY, "monitor_slug_
 Setting the monitor slug on the `Trigger` will override what is set on the `JobDetail`. This also means you can set up a separate monitor per `Trigger`.
 
 </Note>
+
+<Note>
+
+In case you are using Spring Boot, have defined a `SchedulerFactoryBeanCustomizer` and are setting a global job listener you have to manually add a new `SentryJobListener` instance to the global job listeners as well.
+
+</Note>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We've just changed the order of `SentrySchedulerFactoryBeanCustomizer` so users own `SchedulerFactoryBeanCustomizer` will run after it and override whatever the Sentry customizer does. While this means we no longer break the users config, it also means our Quartz integration breaks if they set a global job listener. Unless `SentryJobListener` is manually added by the user in their own `SchedulerFactoryBeanCustomizer`.

[Java PR](https://github.com/getsentry/sentry-java/pull/3095)


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
