### PR TITLE
kmp: add version compatibility table

### DIFF
--- a/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
@@ -34,8 +34,8 @@ kotlin {
     homepage = "Link to the Shared Module homepage"
     ios.deploymentTarget = "14.1"
     podfile = project.file("../iosApp/Podfile")
-    pod("Sentry", "~> 8.4.0")
-
+    // Use the proper version according to the Cocoa compatibility version.
+    pod("Sentry", "~> 8.17.2")
     framework {
       baseName = "shared"
     }

--- a/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
@@ -34,7 +34,7 @@ kotlin {
     homepage = "Link to the Shared Module homepage"
     ios.deploymentTarget = "14.1"
     podfile = project.file("../iosApp/Podfile")
-    // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
+    // Make sure you use the proper version according to our Cocoa SDK Version Compatibility Table.
     pod("Sentry", "~> 8.17.2")
     framework {
       baseName = "shared"

--- a/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-install/kotlin-multiplatform.mdx
@@ -34,7 +34,7 @@ kotlin {
     homepage = "Link to the Shared Module homepage"
     ios.deploymentTarget = "14.1"
     podfile = project.file("../iosApp/Podfile")
-    // Use the proper version according to the Cocoa compatibility version.
+    // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
     pod("Sentry", "~> 8.17.2")
     framework {
       baseName = "shared"

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,10 +1,5 @@
 Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications. Installing this SDK will enable native crash reporting and automatic breadcrumbs for app lifecycle and UI events.
 
-<Note>
-  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
-  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
-  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
-    Cocoa SDK Version Compatibility Table
-  </Link>
-  .
-</Note>
+## Prerequisites
+
+Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our [Cocoa SDK Version Compatibility Table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility)

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,4 +1,4 @@
-Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications.
+Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications. Installing this SDK will enable native crash reporting and automatic breadcrumbs for app lifecycle and UI events.
 
 <Note>
   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,12 +1,5 @@
 Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications.
 
-## Overview of Features
-
-- Native crash reporting for Android and JVM, leveraging our [Android SDK](/platforms/android) and [Java SDK](/platforms/java)
-- Native crash reporting for iOS, macOS, tvOS, and watchOS, leveraging our [Cocoa SDK](/platforms/apple)
-- Automatic breadcrumbs for app lifecycle and UI events
-
 <Note>
-Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
-Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
 </Note>

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,9 +1,8 @@
 Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications. Installing this SDK will enable native crash reporting and automatic breadcrumbs for app lifecycle and UI events.
 
 <Note>
- ## Prerequisites
-   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
-  the version of the Cocoa SDK specified in our{" "}
+  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
+  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
     Cocoa SDK Version Compatibility Table
   </Link>

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -7,7 +7,6 @@ Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowin
 - Automatic breadcrumbs for app lifecycle and UI events
 
 <Note>
-
-Kotlin Multiplatform requires using version **8.4.0** of the Sentry Cocoa SDK, specifically. Other versions, including newer ones, aren't guaranteed to work.
-
+Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
+Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
 </Note>

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,5 +1,10 @@
 Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications.
 
 <Note>
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
+  the version of the Cocoa SDK specified in our{" "}
+  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
+    Cocoa SDK Version Compatibility Table
+  </Link>
+  .
 </Note>

--- a/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-primer/kotlin-multiplatform.mdx
@@ -1,7 +1,8 @@
 Sentry's Kotlin Multiplatform SDK builds on top of multiple Sentry SDKs, allowing developers to use the same codebase and share code between platforms while being able to integrate Sentry's features into their applications. Installing this SDK will enable native crash reporting and automatic breadcrumbs for app lifecycle and UI events.
 
 <Note>
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
+ ## Prerequisites
+   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
   the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
     Cocoa SDK Version Compatibility Table

--- a/src/platform-includes/getting-started-verify/kotlin-multiplatform.mdx
+++ b/src/platform-includes/getting-started-verify/kotlin-multiplatform.mdx
@@ -2,10 +2,10 @@
 import io.sentry.kotlin.multiplatform.Sentry
 
 fun captureError() {
-    try {
-      throw Exception("This is a test.")
-    } catch (e: Exception) {
-      Sentry.captureException(e)
-    }
+  try {
+    throw Exception("This is a test.")
+  } catch (e: Exception) {
+    Sentry.captureException(e)
+  }
 }
 ```

--- a/src/platforms/kotlin-multiplatform/debug-symbols.mdx
+++ b/src/platforms/kotlin-multiplatform/debug-symbols.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upload Debug Symbols
 description: "Learn more about how to upload debug symbols in Sentry Kotlin Multiplatform."
-sidebar_order: 1
+sidebar_order: 4
 ---
 
 To symbolicate your stack traces, you need to provide debug information to Sentry.

--- a/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
+++ b/src/platforms/kotlin-multiplatform/initialization-strategies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Initialization Strategies
 description: "Strategies for initializing the Kotlin Multiplatform SDK."
-sidebar_order: 2
+sidebar_order: 3
 ---
 
 When it comes to initializing a Kotlin Multiplatform SDK, there are three strategies to consider:

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -6,8 +6,7 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Co
 To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 <Note>
-  Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
-  Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
 </Note>
 
 ```kotlin {filename:shared/build.gradle.kts}
@@ -39,7 +38,7 @@ kotlin {
       homepage = "Link to the Shared Module homepage"
       ios.deploymentTarget = "14.1"
       podfile = project.file("../iosApp/Podfile")
-      // Use the proper version according to the Cocoa compatibility version.
+      // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
       pod("Sentry", "~> 8.17.2")
       framework {
         baseName = "shared"

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -6,6 +6,7 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Co
 To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 <Note>
+  ## Prerequisites
   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
   the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -6,9 +6,8 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Co
 To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 <Note>
-  ## Prerequisites
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
-  the version of the Cocoa SDK specified in our{" "}
+  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
+  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
     Cocoa SDK Version Compatibility Table
   </Link>

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -6,7 +6,12 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Co
 To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 <Note>
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
+  the version of the Cocoa SDK specified in our{" "}
+  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
+    Cocoa SDK Version Compatibility Table
+  </Link>
+  .
 </Note>
 
 ```kotlin {filename:shared/build.gradle.kts}

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -6,8 +6,8 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Co
 To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 <Note>
-  Kotlin Multiplatform requires using version **8.4.0** of the Sentry Cocoa SDK,
-  specifically. Other versions, including newer ones, aren't guaranteed to work.
+  Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
+  Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
 </Note>
 
 ```kotlin {filename:shared/build.gradle.kts}
@@ -39,8 +39,8 @@ kotlin {
       homepage = "Link to the Shared Module homepage"
       ios.deploymentTarget = "14.1"
       podfile = project.file("../iosApp/Podfile")
-      pod("Sentry", "~> 8.4.0")
-
+      // Use the proper version according to the Cocoa compatibility version.
+      pod("Sentry", "~> 8.17.2")
       framework {
         baseName = "shared"
       }

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -38,7 +38,7 @@ kotlin {
       homepage = "Link to the Shared Module homepage"
       ios.deploymentTarget = "14.1"
       podfile = project.file("../iosApp/Podfile")
-      // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
+      // Make sure you use the proper version according to our Cocoa SDK Version Compatibility Table.
       pod("Sentry", "~> 8.17.2")
       framework {
         baseName = "shared"

--- a/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
+++ b/src/platforms/kotlin-multiplatform/install/cocoapods.mdx
@@ -3,16 +3,13 @@ title: Cocoapods
 description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Cocoapods."
 ---
 
-To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
+## Prerequisites
 
-<Note>
-  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
-  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
-  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
-    Cocoa SDK Version Compatibility Table
-  </Link>
-  .
-</Note>
+Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our [Cocoa SDK Version Compatibility Table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility)
+
+## Install
+
+To install the Kotlin Multiplatform SDK and setup your Apple targets with Cocoapods, you need to add the following to your `build.gradle.kts` file in your shared module:
 
 ```kotlin {filename:shared/build.gradle.kts}
 repositories {

--- a/src/platforms/kotlin-multiplatform/install/index.mdx
+++ b/src/platforms/kotlin-multiplatform/install/index.mdx
@@ -9,7 +9,7 @@ sidebar_order: 3
 ## Cocoa SDK Version Compatibility
 
 Every version of our Kotlin Multiplatform SDK is compiled with a specific version of the [Sentry Cocoa SDK](/platforms/apple/).
-The table below shows the recommended Sentry Cocoa SDK versions for corresponding versions of the Kotlin Multiplatform SDK.
+Use the table below to find the recommended Sentry Cocoa SDK versions for specific versions of the Kotlin Multiplatform SDK.
 Using these specific combinations ensures the best compatibility and stability.
 
 | Kotlin Multiplatform SDK Version | Cocoa SDK Version |

--- a/src/platforms/kotlin-multiplatform/install/index.mdx
+++ b/src/platforms/kotlin-multiplatform/install/index.mdx
@@ -1,7 +1,19 @@
 ---
 title: Apple Installation Methods
 description: "All the installation methods for the Apple platform."
-sidebar_order: 1
+sidebar_order: 3
 ---
 
 <PageGrid />
+
+## Cocoa SDK Version Compatibility
+
+Every version of our Kotlin Multiplatform SDK is compiled with a specific version of the [Sentry Cocoa SDK](/platforms/apple/).
+The table below shows the recommended Sentry Cocoa SDK versions for corresponding versions of the Kotlin Multiplatform SDK.
+Using these specific combinations ensures the best compatibility and stability.
+
+| Kotlin Multiplatform SDK Version | Cocoa SDK Version |
+|----------------------------------|-------------------|
+| Up to 0.3.0                      | 8.4.0             |
+| 0.4.0                            | 8.17.2            |
+

--- a/src/platforms/kotlin-multiplatform/install/index.mdx
+++ b/src/platforms/kotlin-multiplatform/install/index.mdx
@@ -13,7 +13,6 @@ The table below shows the recommended Sentry Cocoa SDK versions for correspondin
 Using these specific combinations ensures the best compatibility and stability.
 
 | Kotlin Multiplatform SDK Version | Cocoa SDK Version |
-|----------------------------------|-------------------|
+| -------------------------------- | ----------------- |
 | Up to 0.3.0                      | 8.4.0             |
 | 0.4.0                            | 8.17.2            |
-

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -4,7 +4,12 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Sw
 ---
 
 <Note>
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
+  the version of the Cocoa SDK specified in our{" "}
+  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
+    Cocoa SDK Version Compatibility Table
+  </Link>
+  .
 </Note>
 
 Add the Sentry Cocoa SDK as a package in Xcode in your iOS app via **File > Add Packages**.

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -4,8 +4,7 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Sw
 ---
 
 <Note>
-  Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
-  Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
+  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">Cocoa SDK Version Compatibility Table</Link>.
 </Note>
 
 Add the Sentry Cocoa SDK as a package in Xcode in your iOS app via **File > Add Packages**.

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -4,8 +4,8 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Sw
 ---
 
 <Note>
-  Kotlin Multiplatform requires using version **8.4.0** of the Sentry Cocoa SDK,
-  specifically. Other versions, including newer ones, aren't guaranteed to work.
+  Kotlin Multiplatform targeting Cocoa requires using a specific Cocoa SDK version.
+  Use the proper version according to the [Cocoa compatibility table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility).
 </Note>
 
 Add the Sentry Cocoa SDK as a package in Xcode in your iOS app via **File > Add Packages**.
@@ -15,12 +15,12 @@ Enter the Git repo URL in the search field:
 https://github.com/getsentry/sentry-cocoa.git
 ```
 
-Define your dependency rule to have the exact version `8.4.0` and then click the "Add Package" button.
+Define your dependency rule to have the exact version `8.17.2` and then click the "Add Package" button.
 
 Alternatively, if your project uses a `Package.swift` file to manage dependencies, you can specify the target with:
 
 ```swift {tabTitle:Swift}
-.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.4.0"),
+.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.17.2"),
 ```
 
 Next, install the Kotlin Multiplatform SDK and setup your Apple targets by adding the following to your `build.gradle.kts` file in your shared module:

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -4,10 +4,8 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Sw
 ---
 
 <Note>
- ## Prerequisites
- 
-   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
-  the version of the Cocoa SDK specified in our{" "}
+  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
+  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
     Cocoa SDK Version Compatibility Table
   </Link>

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -4,7 +4,9 @@ description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Sw
 ---
 
 <Note>
-  Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
+ ## Prerequisites
+ 
+   Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using
   the version of the Cocoa SDK specified in our{" "}
   <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
     Cocoa SDK Version Compatibility Table

--- a/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
+++ b/src/platforms/kotlin-multiplatform/install/swift-package-manager.mdx
@@ -3,14 +3,11 @@ title: Swift Package Manager (SPM)
 description: "Learn about installing the Sentry Kotlin Multiplatform SDK with Swift Package Manager."
 ---
 
-<Note>
-  ## Prerequisites Ensure compatibility in Kotlin Multiplatform projects
-  targeting Cocoa by using the version of the Cocoa SDK specified in our{" "}
-  <Link to="/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility">
-    Cocoa SDK Version Compatibility Table
-  </Link>
-  .
-</Note>
+## Prerequisites
+
+Ensure compatibility in Kotlin Multiplatform projects targeting Cocoa by using the version of the Cocoa SDK specified in our [Cocoa SDK Version Compatibility Table](/platforms/kotlin-multiplatform/install/#cocoa-sdk-version-compatibility)
+
+## Install
 
 Add the Sentry Cocoa SDK as a package in Xcode in your iOS app via **File > Add Packages**.
 Enter the Git repo URL in the search field:

--- a/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
+++ b/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
@@ -26,7 +26,7 @@ cocoapods {
   homepage = "Link to the Shared Module homepage"
   ios.deploymentTarget = "14.1"
   podfile = project.file("../iosApp/Podfile")
-  // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
+  // Make sure you use the proper version according to our Cocoa SDK Version Compatibility Table.
   pod("Sentry", "~> 8.17.2")
   framework {
     baseName = "shared"

--- a/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
+++ b/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
@@ -26,7 +26,7 @@ cocoapods {
   homepage = "Link to the Shared Module homepage"
   ios.deploymentTarget = "14.1"
   podfile = project.file("../iosApp/Podfile")
-  // Use the proper version according to the Cocoa compatibility version.
+  // Use the recommended version according to our Cocoa SDK Version Compatibility Table.
   pod("Sentry", "~> 8.17.2")
   framework {
     baseName = "shared"

--- a/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
+++ b/src/platforms/kotlin-multiplatform/native-access-sdk.mdx
@@ -26,7 +26,8 @@ cocoapods {
   homepage = "Link to the Shared Module homepage"
   ios.deploymentTarget = "14.1"
   podfile = project.file("../iosApp/Podfile")
-  pod("Sentry", "~> 8.4.0")
+  // Use the proper version according to the Cocoa compatibility version.
+  pod("Sentry", "~> 8.17.2")
   framework {
     baseName = "shared"
     export("io.sentry:sentry-kotlin-multiplatform:{{@inject packages.version('sentry.kotlin.kmp', '0.0.1-alpha.2') }}")


### PR DESCRIPTION
With more and more KMP SDK releases coming, we need to be able to track which KMP SDK version is compatible with which Cocoa SDK version. 

Ideally we can automate this in the future but now it's the best alternative we can do.

Closes https://github.com/getsentry/sentry-kotlin-multiplatform/issues/159