### PR TITLE
Update Apple breadcrumbs docs because swift/obj-c don't have a `null` keyword.

### DIFF
--- a/src/platforms/apple/common/enriching-events/breadcrumbs/index.mdx
+++ b/src/platforms/apple/common/enriching-events/breadcrumbs/index.mdx
@@ -29,6 +29,6 @@ Manually record a breadcrumb:
 
 SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook.
 
-This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
+This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `nil`:
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Updated the docs because `null` isn't a thing in Swift or Objective-c. `nil` is a thing and `NULL` is a thing, but `null` is not.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
