### PR TITLE
Add CSP compatibility note for report-uri and report-to usage

### DIFF
--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -21,15 +21,25 @@ To configure CSP reports in Sentry, you’ll need to send a header from your ser
 <SignInNote />
 
 ```
-Content-Security-Policy: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
+Content-Security-Policy: ...; 
+    report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
+    report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
+
+<Alert level="note" title="Compatibility Recommendation">
+
+Though the `report-to` directive is intended to replace the deprecated `report-uri` directive, `report-to` isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get `report-to` support, you can specify both `report-uri` and `report-to` in your Content-Security-Policy (CSP).
+
+</Alert>
 
 Alternatively you can setup CSP reports to simply send reports rather than actually enforcing the policy:
 
 <SignInNote />
 
 ```
-Content-Security-Policy-Report-Only: ...; report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___
+Content-Security-Policy-Report-Only: ...; 
+    report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___; 
+    report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 
 When defining your policy it is important to ensure that `sentry.io` or your self-hosted Sentry domain is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.

--- a/src/docs/product/security-policy-reporting.mdx
+++ b/src/docs/product/security-policy-reporting.mdx
@@ -21,7 +21,7 @@ To configure CSP reports in Sentry, you’ll need to send a header from your ser
 <SignInNote />
 
 ```
-Content-Security-Policy: ...; 
+Content-Security-Policy: ...;
     report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
     report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
@@ -37,8 +37,8 @@ Alternatively you can setup CSP reports to simply send reports rather than actua
 <SignInNote />
 
 ```
-Content-Security-Policy-Report-Only: ...; 
-    report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___; 
+Content-Security-Policy-Report-Only: ...;
+    report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
     report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Updated the documentation to include a note about the deprecation of report-uri and the recommendation to use both report-uri and report-to in the Content-Security-Policy for broader browser compatibility. This change reflects the current state of browser support for CSP directives as noted by Mozilla.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
