### PR TITLE
Update RN Kotlin example for MainApplication.kt in manual-setup.mdx 

### DIFF
--- a/src/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/src/platforms/react-native/manual-setup/manual-setup.mdx
@@ -245,11 +245,10 @@ public class MainApplication extends Application implements ReactApplication {
 import io.sentry.react.RNSentryPackage
 
 class MainApplication() : Application(), ReactApplication {
-  override fun getPackages():List<ReactPackage> {
-    val packages = new PackageList(this).getPackages();
-    packages.add(new RNSentryPackage());
-    return packages;
-  }
+  override fun getPackages():List<ReactPackage> =
+    PackageList(this).packages.apply {
+      add(RNSentryPackage())
+    }
 }
 ```
 


### PR DESCRIPTION
I believe the getPackages Kotlin example is not valid Kotlin (it may have been ported from the react-native example comment - which now has a ticket to update the application of adding packages https://github.com/facebook/react-native/pull/41856)

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Update Kotlin example to valid Kotlin for MainApplication.kt

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
