### PR TITLE
feat(ruby): Add community fork link to migration guide

### DIFF
--- a/src/platforms/ruby/common/migration.mdx
+++ b/src/platforms/ruby/common/migration.mdx
@@ -11,6 +11,7 @@ description: "Learn about how to migrate from the deprecated sentry-raven SDK."
 - [Configuration Changes](#configuration-changes)
 - [API Changes](#api-changes)
 - [Example Apps](#example-apps)
+- [Community Fork](#community-fork)
 
 ## Benefits
 
@@ -297,3 +298,8 @@ end
 - Sidekiq examples:
   - [with Rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)
   - [without Rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-sidekiq/example)
+
+## Community Fork
+
+A community maintained fork of `sentry-ruby` that works with older Ruby versions (2.1, 2.2 and 2.3) is [available here](https://github.com/ifad/sentry-legacy-ruby).
+You can use this in cases where it is impossible for you to upgrade but please note that we don't officially support it.


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-ruby/issues/2152