### PR TITLE
fix(ruby): Add clarification for setting logger levels

### DIFF
--- a/src/platforms/ruby/common/configuration/options.mdx
+++ b/src/platforms/ruby/common/configuration/options.mdx
@@ -90,7 +90,7 @@ config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
 `debug`
 
-: Activation of debugging mode. When enabled, SDK errors will be logged with backtrace. Default is `false`.
+: Activation of debugging mode. When enabled, SDK errors will be logged with backtrace. Default is `false`. Please use `config.logger.level` for more output; this is merely for attaching backtraces to the messages.
 
 `enabled_environments`
 
@@ -130,13 +130,12 @@ config.inspect_exception_causes_for_exclusion = true
 
 `logger`
 
-: The logger used by Sentry. Default is `Rails.logger` in Rails, otherwise an instance of `Sentry::Logger`.
+: The logger used by Sentry. Default is `Rails.logger` in Rails, otherwise an instance of `Sentry::Logger`. Make sure to change the logger level if you need debug output.
 
 ```ruby
 config.logger = Sentry::Logger.new(STDOUT)
+config.logger.level = ::Logger::DEBUG # defaults to INFO
 ```
-
-Sentry respects logger levels.
 
 `max_breadcrumbs`
 


### PR DESCRIPTION
closes #8508