### PR TITLE
Python Crons - Note on supported schedulers.

### DIFF
--- a/src/platforms/python/integrations/celery/crons.mdx
+++ b/src/platforms/python/integrations/celery/crons.mdx
@@ -58,7 +58,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-Currently only the default scheduler of Celery Beat is officially supported. Other schedulers (like `RedBeat`) are not supported.
+Currently, only the default scheduler of Celery Beat is officially supported. Other schedulers (like `RedBeat`) are not supported.
 
 <Note>
 

--- a/src/platforms/python/integrations/celery/crons.mdx
+++ b/src/platforms/python/integrations/celery/crons.mdx
@@ -58,6 +58,8 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
+Currently only the default scheduler of Celery Beat is officially supported. Other schedulers (like `RedBeat`) are not supported.
+
 <Note>
 
 You don't need to create Cron Monitors for your tasks on Sentry.io, we'll do it for you.


### PR DESCRIPTION
Tell people that non standard Celery beat schedulers are not supported yet
