### PR TITLE
feat(apple): Prewarmed app start tracing is stable

### DIFF
--- a/src/platform-includes/getting-started-config/basic-config/apple.mdx
+++ b/src/platform-includes/getting-started-config/basic-config/apple.mdx
@@ -12,7 +12,6 @@ SentrySDK.start { options in
 
     // Enable all experimental features
     options.attachViewHierarchy = true
-    options.enablePreWarmedAppStartTracing = true
     options.enableMetricKit = true
     options.enableTimeToFullDisplayTracing = true
     options.swiftAsyncStacktraces = true
@@ -27,7 +26,6 @@ SentrySDK.start { options in
 
     // Enable all experimental features
     options.attachViewHierarchy = YES;
-    options.enablePreWarmedAppStartTracing = YES;
     options.enableMetricKit = YES;
     options.enableTimeToFullDisplayTracing = YES;
     options.swiftAsyncStacktraces = YES;

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -86,7 +86,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracing
 
-Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. However, with [sentry-cocoa 7.31.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0), we’ve introduced an `enablePreWarmedAppStartTracing` feature (still in its experimental phase), which allows us to collect prewarmed app starts.
+Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. Enabling the `enablePreWarmedAppStartTracing` feature allows you to collect prewarmed app starts.
 
 Once enabled, the SDK drops the first app start span if prewarming pauses. This approach shortens the app start duration, but it accurately represents the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:
@@ -108,9 +108,6 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.enablePreWarmedAppStartTracing = true
-
-    // Before 8.0.0
-    options.enablePreWarmedAppStartTracking = true
 }
 ```
 
@@ -120,9 +117,6 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.enablePreWarmedAppStartTracing = YES;
-
-    // Before 8.0.0
-    options.enablePreWarmedAppStartTracking = YES;
 }];
 ```
 

--- a/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/src/platforms/apple/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -86,7 +86,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracing
 
-Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. Enabling the `enablePreWarmedAppStartTracing` feature allows you to collect prewarmed app starts.
+Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. Enable the `enablePreWarmedAppStartTracing` feature to collect prewarmed app starts.
 
 Once enabled, the SDK drops the first app start span if prewarming pauses. This approach shortens the app start duration, but it accurately represents the span of time from when a user clicks the app icon to when the app is responsive.
 With this feature, the SDK differentiates between four different app start types:


### PR DESCRIPTION

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Since Cocoa 8.18.0 enablePreWarmedAppStartTracking is stable. This PR also removes code samples on enabling the feature before 8.0.0, which we released over a year ago. As we only removed the experimental note in the code docs of the SDK and didn't make any other changes, we don't need to specify a minimum SDK version.

We need to wait until we release Cocoa 8.18.0 to merge this.

