### PR TITLE
docs: `@sentry_sdk.trace` and static/class method decorator ordering

### DIFF
--- a/src/platforms/python/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/python/performance/instrumentation/custom-instrumentation.mdx
@@ -71,6 +71,12 @@ def eat_pizza(pizza):
 
 ```
 
+<Alert title="Static & Class Methods" level="warning">
+
+When tracing a static or class method, you **must** add the `@sentry_sdk.trace` decorator **after** the `@staticmethod` or `@classmethod` decorator (i.e., **closer** to the function definition). Otherwise, your function will break!
+
+</Alert>
+
 ## Nested Spans
 
 Spans can be nested to form a span tree. If you'd like to learn more, read our [distributed tracing](/product/sentry-basics/tracing/distributed-tracing/) documentation.


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR updates the Sentry Python SDK tracing docs to inform users that when tracing a static or class method using the `@sentry_sdk.trace` decorator, the decorator must be placed **after** the `@staticmethod` or `@classmethod` decorator. 

Failing to adhere to this ordering will break the function (specifically when it is called on an instance rather than on the class), due to how static and class methods work in the Python language (see https://github.com/getsentry/sentry-python/issues/2525). Unfortunately, because of how static and class methods work in Python it is probably impossible to change the `@sentry_sdk.trace` decorator to allow a flipped ordering, so alerting users in the documentation is likely the best solution.