### PR TITLE
Document no data scrubbing in filenames

### DIFF
--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -201,3 +201,5 @@ The following limitations generally apply to all server-side data scrubbing, be 
 - Hashing, masking or replacing a JSON object, array or number (anything that is not a string) cannot be done in all circumstances as it would change the JSON type of the value and violate assumptions Sentry's internals make about the data schema. Data scrubbing will ignore the _Method_ in those cases and always remove/replace with `null` as that is always safe.
 
 - Sentry's internals require that the event user's IP address must either be `null` or a valid IPv4/IPv6 address. If you're trying to hash, mask or replace IP addresses, data scrubbing will move the replacement value into the user ID (if one is not already set) in order to avoid breaking this requirement while still providing useful data for the Users count on an issue.
+
+- Scrubbing cannot be done in file names as it would violate assumptions in the processing pipeline resulting in a poor usage experience. You can scrub filenames in the SDK itself.

--- a/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/src/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -202,4 +202,4 @@ The following limitations generally apply to all server-side data scrubbing, be 
 
 - Sentry's internals require that the event user's IP address must either be `null` or a valid IPv4/IPv6 address. If you're trying to hash, mask or replace IP addresses, data scrubbing will move the replacement value into the user ID (if one is not already set) in order to avoid breaking this requirement while still providing useful data for the Users count on an issue.
 
-- Scrubbing cannot be done in file names as it would violate assumptions in the processing pipeline resulting in a poor usage experience. You can scrub filenames in the SDK itself.
+- In stack traces, scrubbing works on file paths but not on a file's base name. This would violate assumptions in the processing pipeline resulting in a poor user experience. Instead, you can scrub a file's base name in the SDK itself, using the [`RewriteFrames` integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/rewriteframes/) or [`beforeSend`](https://docs.sentry.io/platforms/javascript/configuration/filtering/).


### PR DESCRIPTION
[Advanced data scrubbing](https://docs.sentry.io/product/data-management-settings/scrubbing/advanced-datascrubbing/) does [not scrub file names](https://github.com/getsentry/relay/blob/d17608ca5d0cb9b897d7c96e99b5a7cddb09ae82/relay-pii/src/processor.rs#L125-L126):

> In NativeImagePath we must not strip the file's basename because that would break processing.

Not sure if it's exactly the same, but minidumps also follow the [same approach](https://docs.sentry.io/product/data-management-settings/scrubbing/attachment-scrubbing/#minidump-selectors:~:text=Any%20modification%20will%20exclude%20the%20basename%20of%20the%20pathnames%20to%20ensure%20the%20event%20processing%20pipeline%20can%20still%20operate%20correctly%20on%20the%20minidump.):

> Any modification will exclude the basename of the pathnames to ensure the event processing pipeline can still operate correctly on the minidump.

One can scrub filenames in the SDKs. For JavaScript SDKs, there's a [`RewriteFrames` integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/rewriteframes/) for it.