### PR TITLE
Add SSL/TLS support as a benefit of a proxy in front of Relay

### DIFF
--- a/src/docs/product/relay/operating-guidelines.mdx
+++ b/src/docs/product/relay/operating-guidelines.mdx
@@ -13,7 +13,7 @@ This page reviews our guidelines for operation when self-hosting external Relays
 
 - We recommend [running Relay](/product/relay/getting-started/) using the officially provided Docker image (`getsentry/relay`) found on [DockerHub](https://hub.docker.com/r/getsentry/relay/) and tagged with its Git revision identifier, rather than building from source.
 
-- We recommend running at least two Relay instances (containers) with a reverse proxy (such as [HAProxy](https://www.haproxy.org/) or [Nginx](https://nginx.org)) in front of them for both improved availability and simplified Relay updates.
+- We recommend running at least two Relay instances (containers) with a reverse proxy (such as [HAProxy](https://www.haproxy.org/) or [Nginx](https://nginx.org)) in front of them for improved availability, simplified Relay updates, and SSL/TLS support.
 
 - To monitor your Relay setup, configure [Logging](/product/relay/monitoring/#logging), [Metrics](/product/relay/monitoring/#metrics), and [Health Checks](/product/relay/monitoring/#health-checks).
 


### PR DESCRIPTION
Relay [no longer supports SSL/TLS](https://github.com/getsentry/relay/blob/d17608ca5d0cb9b897d7c96e99b5a7cddb09ae82/relay-server/src/actors/server.rs#L25-L27) and the recommendation is to offload this responsibility to a proxy. The [Getting Started page no longer references TLS options](https://github.com/getsentry/sentry-docs/pull/7621), but there are currently no docs on setting it up. This PR adds such docs.