### PR TITLE
docs(sourcemaps): Update sourcemaps index.mdx to highlight the React Native documentation regarding Source Map generation

### DIFF
--- a/src/platforms/react-native/sourcemaps/index.mdx
+++ b/src/platforms/react-native/sourcemaps/index.mdx
@@ -16,6 +16,8 @@ If you are on an older version and you want to upload source maps we recommend u
 
 To get unminified stack traces for JavaScript code, source maps must be generated and uploaded. The React Native SDK handles source maps _automatically_ for iOS with Xcode and Android with Gradle, if you do not use custom values.
 
+Ensure that you have followed the relevant React Native documentation to enable Source Maps since their generation may be disabled by default depending on the platform you are building for and whether you are using Hermes or not.
+
 ## Set Up Automatic Upload
 
 The easiest way to configure automatic source maps upload is to use the Sentry Wizard:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

- Include a note to ensure readers check the React Native documentation to confirm how to enable Source Maps for their platform and App build configuration

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
