### PR TITLE
`enable_db_query_source` is now on by default

### DIFF
--- a/src/docs/product/performance/queries.mdx
+++ b/src/docs/product/performance/queries.mdx
@@ -129,7 +129,7 @@ The gif below provides a detailed walkthrough of the **Query Summary** page.
 
 <Note>
 
-Query Sources are currently supported in Sentry's [Laravel](/platforms/php/guides/laravel/configuration/laravel-options/) (enabled with the `SENTRY_TRACE_SQL_ORIGIN_ENABLED` option) and [Python](/platforms/python/configuration/options/#enable-db-query-source) (enabled with the `enable-db-query-source` option) SDKs. For Python, Sentry only attaches query sources to queries that are slower than a [configurable threshold](/platforms/python/configuration/options/#db-query-source-threshold-ms) to reduce the performance impact.
+Query Sources are currently supported in Sentry's [Laravel](/platforms/php/guides/laravel/configuration/laravel-options/) (enabled with the `SENTRY_TRACE_SQL_ORIGIN_ENABLED` option) and [Python](/platforms/python/configuration/options/#enable-db-query-source) (enabled by default) SDKs. For Python, Sentry only attaches query sources to queries that are slower than a [configurable threshold](/platforms/python/configuration/options/#db-query-source-threshold-ms) to reduce the performance impact.
 
 </Note>
 

--- a/src/platforms/python/configuration/options.mdx
+++ b/src/platforms/python/configuration/options.mdx
@@ -321,15 +321,13 @@ This option is enabled by default.
 
 When enabled, the source location will be added to database queries.
 
-This option is disabled by default.
+This option is enabled by default.
 
 </ConfigKey>
 
 <ConfigKey name="db-query-source-threshold-ms">
 
 The threshold in milliseconds for adding the source location to database queries. The query location will be added to the query for queries slower than the specified threshold.
-
-You need to set `enable_db_query_source` to `True` for this to work.
 
 Default is `100` ms.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We'll be changing the default for the `enable_db_query_source` Python SDK option from `False` to `True` in https://github.com/getsentry/sentry-python/pull/2629 -- updating the docs.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
