### PR TITLE
feat(webvtials): Adds links to performance score distributions for each webvital

### DIFF
--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -147,11 +147,11 @@ The **Performance Score** is comprised of 5 individual **Web Vital** components.
 
 | Web Vital                                                       | P90    | P50    | Weight |
 | --------------------------------------------------------------- | ------ | ------ | ------ |
-| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP) | 1200ms | 2400ms | 30%    |
-| [First Input Delay](#first-input-delay-fid) (FID)               | 100ms  | 300ms  | 30%    |
-| [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)   | 0.1    | 0.25   | 15%    |
-| [First Contentful Paint](#first-contentful-paint-fcp) (FCP)     | 900ms  | 1600ms | 15%    |
-| [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)           | 200ms  | 400ms  | 10%    |
+| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP) | [1200ms](https://www.desmos.com/calculator/ejhjazajbd) | [2400ms](https://www.desmos.com/calculator/ejhjazajbd) | 30%    |
+| [First Input Delay](#first-input-delay-fid) (FID)               | [100ms](https://www.desmos.com/calculator/vy5qiu1idj)  | [300ms](https://www.desmos.com/calculator/vy5qiu1idj)  | 30%    |
+| [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)   | [0.1](https://www.desmos.com/calculator/irdoqfftdf)    | [0.25](https://www.desmos.com/calculator/irdoqfftdf)   | 15%    |
+| [First Contentful Paint](#first-contentful-paint-fcp) (FCP)     | [900ms](https://www.desmos.com/calculator/gcxbiypuuh)  | [1600ms](https://www.desmos.com/calculator/gcxbiypuuh) | 15%    |
+| [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)           | [200ms](https://www.desmos.com/calculator/ykzahw9goi)  | [400ms](https://www.desmos.com/calculator/ykzahw9goi)  | 10%    |
 
 ## Opportunity
 

--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -145,8 +145,8 @@ At the center of the **Page Overview**, Web Vital average values and scores are 
 
 The **Performance Score** is comprised of 5 individual **Web Vital** components. Each **Web Vital** is given a rating between 0 to 100 through a [Log-Normal Distribution](https://www.desmos.com/calculator/o98tbeyt1t). Each **Web Vital** rating is given a weight, which is summed up to create the overall **Performance Score** with a maximum value of 100. Some browsers may not support all the **Web Vitals** used in Sentry's **Performance Score** calculation, so weights are dynamically adjusted depending on which **Web Vitals** are available on a page load. The default weights, p90, and p50 distribution values of each **Web Vital** can be found in the table below:
 
-| Web Vital                                                       | P90    | P50    | Weight |
-| --------------------------------------------------------------- | ------ | ------ | ------ |
+| Web Vital                                                       | P90                                                    | P50                                                    | Weight |
+| --------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ | ------ |
 | [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP) | [1200ms](https://www.desmos.com/calculator/ejhjazajbd) | [2400ms](https://www.desmos.com/calculator/ejhjazajbd) | 30%    |
 | [First Input Delay](#first-input-delay-fid) (FID)               | [100ms](https://www.desmos.com/calculator/vy5qiu1idj)  | [300ms](https://www.desmos.com/calculator/vy5qiu1idj)  | 30%    |
 | [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)   | [0.1](https://www.desmos.com/calculator/irdoqfftdf)    | [0.25](https://www.desmos.com/calculator/irdoqfftdf)   | 15%    |


### PR DESCRIPTION
Updates the P90 and P50 values in the web vitals score table to link out to distribution charts for more context.

![image](https://github.com/getsentry/sentry-docs/assets/83961295/62a50f94-cf74-4a2b-90de-cfb9c0a90637)