### PR TITLE
fix(python): Fix OpenTelemetry example

### DIFF
--- a/src/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -16,7 +16,7 @@ sentry_sdk.init(
 
 This disables all Sentry instrumentation and relies on the chosen OpenTelemetry tracers for creating spans.
 
-Next, configure OpenTelemetry as you need and hook in the Sentry span processor and propagator:
+Next, configure OpenTelemetry as you need and hook in the Sentry span processor and propagator. Here's a minimal example that doesn't require any additional OpenTelemetry setup:
 
 ```python
 from opentelemetry import trace

--- a/src/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -21,9 +21,24 @@ Next, configure OpenTelemetry as you need and hook in the Sentry span processor 
 ```python
 from opentelemetry import trace
 from opentelemetry.propagate import set_global_textmap
+from opentelemetry.sdk.trace import TracerProvider
 from sentry_sdk.integrations.opentelemetry import SentrySpanProcessor, SentryPropagator
 
-provider = trace.get_tracer_provider()
+provider = TracerProvider()
 provider.add_span_processor(SentrySpanProcessor())
+trace.set_tracer_provider(provider)
 set_global_textmap(SentryPropagator())
+```
+
+Finally, try it out with:
+
+```python
+import time
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span("test_otel_span"):
+    print("Processing some data...")
+    # Simulate some processing
+    time.sleep(3)
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The Python OpenTelemetry example doesn't work out of the box. Additional OpenTelemetry setup is needed to make it work, which we don't describe in the docs, [leaving folks confused](https://github.com/getsentry/sentry-python/issues/1976). This PR:
* changes the OpenTelemetry setup example so that it works without requiring any background OTel setup
* adds an example to verify that the setup is working

Preview: https://sentry-docs-git-ivana-fix-opentelemetry-python-setup.sentry.dev/platforms/python/performance/instrumentation/opentelemetry/

Fixes https://github.com/getsentry/sentry-python/issues/1976

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
