### PR TITLE
ref(apple): attachments intro and note about crash attachments

### DIFF
--- a/src/platforms/apple/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/apple/common/enriching-events/attachments/index.mdx
@@ -3,7 +3,7 @@ title: Attachments
 description: "Learn more about how Sentry can store additional files in the same request as event attachments."
 ---
 
-On this page you will learn how you to enrich your events for further investigation by attaching additional files, such as config or log files.
+On this page, you will learn how to attach files, such as logs or config files, to your events. You'll be able to see these attachments in [sentry.io](https://sentry.io/) alongside other event details.
 
 ## Creating Attachments
 

--- a/src/platforms/apple/common/enriching-events/attachments/index.mdx
+++ b/src/platforms/apple/common/enriching-events/attachments/index.mdx
@@ -3,9 +3,7 @@ title: Attachments
 description: "Learn more about how Sentry can store additional files in the same request as event attachments."
 ---
 
-Please note that attachments don't work yet with crashes.
-
-Sentry can enrich your events for further investigation by storing additional files, such as config or log files, as attachments.
+On this page you will learn how you to enrich your events for further investigation by attaching additional files, such as config or log files.
 
 ## Creating Attachments
 
@@ -32,6 +30,12 @@ In addition, you can set these parameters:
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.
+
+<Note>
+
+Adding attachments to crashes is currently not supported.
+
+</Note>
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 


### PR DESCRIPTION
Small updates to wording of intro and placement/wording of note about crash attachments

related: https://github.com/getsentry/sentry-cocoa/issues/1247