### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,53 +1,53 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-/src/platforms/android/ @getsentry/team-mobile-core
-/src/wizard/android/ @getsentry/team-mobile-core
-/src/platforms/apple/ @getsentry/team-mobile-core
-/src/wizard/apple/ @getsentry/team-mobile-core
-/src/platforms/flutter/ @getsentry/team-mobile-cross-platform
-/src/wizard/flutter/ @getsentry/team-mobile-cross-platform
-/src/platforms/dart/ @getsentry/team-mobile-cross-platform
-/src/wizard/dart/ @getsentry/team-mobile-cross-platform
-/src/platforms/react-native/ @getsentry/team-mobile-cross-platform
-/src/wizard/react-native/ @getsentry/team-mobile-cross-platform
-/src/platforms/unity/ @getsentry/team-mobile-cross-platform
-/src/wizard/unity/ @getsentry/team-mobile-cross-platform
-/src/wizard/cordova/ @getsentry/team-mobile-cross-platform
-
-/src/platforms/dotnet/ @getsentry/team-mobile-cross-platform
-/src/wizard/dotnet/ @getsentry/team-mobile-cross-platform
-/src/platforms/java/ @getsentry/team-mobile-core
-/src/wizard/java/ @getsentry/team-mobile-core
-
-/src/platforms/native/ @getsentry/owners-native
-/src/wizard/native/ @getsentry/owners-native
-/src/wizard/minidump/ @getsentry/owners-native
-/src/platforms/rust/ @getsentry/owners-native
-/src/wizard/rust/ @getsentry/owners-native
-
-/src/docs/product/discover-queries/ @getsentry/visibility
-/src/docs/product/performance/ @getsentry/visibility
-
-/src/docs/product/cli/dif/ @getsentry/owners-native
-
-/.github/labels.yml @getsentry/open-source
-/.github/workflows/react-to-product-owners-yml-changes.yml @getsentry/open-source
-/bin/react-to-product-owners-yml-changes.py @getsentry/open-source
-/bin/react-to-product-owners-yml-changes.sh @getsentry/open-source
-
-###### Replays #######
-
-/src/docs/product/session-replay/                       @getsentry/replay
-/src/includes/feature-stage-beta-session-replay.mdx     @getsentry/replay
-/src/platform-includes/session-replay/                  @getsentry/replay @getsentry/replay-sdk
-/src/platforms/javascript/common/session-replay/        @getsentry/replay @getsentry/replay-sdk
-/src/wizard/javascript/replay-onboarding/               @getsentry/replay @getsentry/replay-sdk
-
-###### End Replays #######
-
-###### Security ########
-
 # Requiring review from security team for Content-Security-Policy changes
 /vercel.json @getsentry/security
 
-###### End Security ####
+
+# Codeowners listed below are used as a reference for the Sentry team to know who to contact for a given area of the codebase.
+
+# /src/platforms/android/ @getsentry/team-mobile-core
+# /src/wizard/android/ @getsentry/team-mobile-core
+# /src/platforms/apple/ @getsentry/team-mobile-core
+# /src/wizard/apple/ @getsentry/team-mobile-core
+# /src/platforms/flutter/ @getsentry/team-mobile-cross-platform
+# /src/wizard/flutter/ @getsentry/team-mobile-cross-platform
+# /src/platforms/dart/ @getsentry/team-mobile-cross-platform
+# /src/wizard/dart/ @getsentry/team-mobile-cross-platform
+# /src/platforms/react-native/ @getsentry/team-mobile-cross-platform
+# /src/wizard/react-native/ @getsentry/team-mobile-cross-platform
+# /src/platforms/unity/ @getsentry/team-mobile-cross-platform
+# /src/wizard/unity/ @getsentry/team-mobile-cross-platform
+# /src/wizard/cordova/ @getsentry/team-mobile-cross-platform
+
+# /src/platforms/dotnet/ @getsentry/team-mobile-cross-platform
+# /src/wizard/dotnet/ @getsentry/team-mobile-cross-platform
+# /src/platforms/java/ @getsentry/team-mobile-core
+# /src/wizard/java/ @getsentry/team-mobile-core
+
+# /src/platforms/native/ @getsentry/owners-native
+# /src/wizard/native/ @getsentry/owners-native
+# /src/wizard/minidump/ @getsentry/owners-native
+# /src/platforms/rust/ @getsentry/owners-native
+# /src/wizard/rust/ @getsentry/owners-native
+
+# /src/docs/product/discover-queries/ @getsentry/visibility
+# /src/docs/product/performance/ @getsentry/visibility
+
+# /src/docs/product/cli/dif/ @getsentry/owners-native
+
+# /.github/labels.yml @getsentry/open-source
+# /.github/workflows/react-to-product-owners-yml-changes.yml @getsentry/open-source
+# /bin/react-to-product-owners-yml-changes.py @getsentry/open-source
+# /bin/react-to-product-owners-yml-changes.sh @getsentry/open-source
+
+# ###### Replays #######
+
+# /src/docs/product/session-replay/                       @getsentry/replay
+# /src/includes/feature-stage-beta-session-replay.mdx     @getsentry/replay
+# /src/platform-includes/session-replay/                  @getsentry/replay @getsentry/replay-sdk
+# /src/platforms/javascript/common/session-replay/        @getsentry/replay @getsentry/replay-sdk
+# /src/wizard/javascript/replay-onboarding/               @getsentry/replay @getsentry/replay-sdk
+
+# ###### End Replays #######
+


### PR DESCRIPTION
Discussed with @lizokm on how CODEOWNERS were used in the repo, most items are not in use for codeowners review/approve in PRs, but as a reference for who is responsible for certain parts in the repo.
Keeping them in the file but comment them out so that it does not create blockers for the team on development