### PR TITLE
feat(replay): Add docs for canvas support in Replay

### DIFF
--- a/src/docs/product/accounts/early-adopter-features/index.mdx
+++ b/src/docs/product/accounts/early-adopter-features/index.mdx
@@ -24,3 +24,5 @@ Limitations:
 - [Issue Reprocessing](/product/issues/reprocessing/)
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
 - [Open PR Comments](/product/integrations/source-code-mgmt/github/#open-pull-request-comments)
+- [Investigation Mode](/product/performance/retention-priorities/#investigation-mode) for retention priorities in Performance Monitoring
+- <PlatformLink to="/session-replay/#canvas-recording">Replay Canvas Recording</PlatformLink>

--- a/src/docs/product/accounts/early-adopter-features/index.mdx
+++ b/src/docs/product/accounts/early-adopter-features/index.mdx
@@ -25,4 +25,6 @@ Limitations:
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
 - [Open PR Comments](/product/integrations/source-code-mgmt/github/#open-pull-request-comments)
 - [Investigation Mode](/product/performance/retention-priorities/#investigation-mode) for retention priorities in Performance Monitoring
-- <PlatformLink to="/session-replay/#canvas-recording">Replay Canvas Recording</PlatformLink>
+- <PlatformLink to="/session-replay/#canvas-recording">
+    Replay Canvas Recording
+  </PlatformLink>

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -65,9 +65,10 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
 
   integrations: [
+    // Keep the Replay integration as before
     new Sentry.Replay(),
 
-    // The following is all you need to enable canvas recording
+    // The following is all you need to enable canvas recording with Replay
     new Sentry.ReplayCanvas(),
   ],
 });

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -75,8 +75,21 @@ Sentry.init({
 
 #### Canvas Recording Performance
 
-The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop:
+The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
 
 ```js
-TODO;
+new Sentry.ReplayCanvas({
+  // Enabling the following will ensure your canvas elements are not forced
+  // into `preserveDrawingBuffer`.
+  enableManualSnapshot: true,
+});
+```
+
+Next, you need to call the the following `snapshot()` method inside of your application's paint loop. `snapshot()` needs to be called in the same execution loop as the canvas draw commands, otherwise you may be snapshotting empty canvas buffers. This is due to how WebGL works when `preserveDrawingBuffer` is `false`.
+
+```js
+function paint() {
+  const canvasRef = document.querySelector('#my-canvas');
+  Sentry.getClient().getIntegrationByName('ReplayCanvas').snapshot(canvasRef);
+}
 ```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -93,7 +93,6 @@ Sentry.init({
   integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'replay-canvas.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
-
 ```
 
 #### Canvas Recording Performance

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -89,7 +89,7 @@ Next, you need to call the the following `snapshot()` method inside of your appl
 
 ```js
 function paint() {
-  const canvasRef = document.querySelector('#my-canvas');
-  Sentry.getClient().getIntegrationByName('ReplayCanvas').snapshot(canvasRef);
+  const canvasRef = document.querySelector("#my-canvas");
+  Sentry.getClient().getIntegrationByName("ReplayCanvas").snapshot(canvasRef);
 }
 ```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -71,10 +71,10 @@ Sentry.init({
 
   integrations: [
     // Keep the Replay integration as before
-    new Sentry.Replay(),
+    Sentry.replayIntegration(),
 
     // The following is all you need to enable canvas recording with Replay
-    new Sentry.ReplayCanvas(),
+    Sentry.replayCanvasIntegration(),
   ],
 });
 ```
@@ -100,7 +100,7 @@ Sentry.init({
 The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
 
 ```javascript
-new Sentry.ReplayCanvas({
+Sentry.replayCanvasIntegration({
   // Enabling the following will ensure your canvas elements are not forced
   // into `preserveDrawingBuffer`.
   enableManualSnapshot: true,

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -46,3 +46,37 @@ Sentry.init({
 const { Replay } = await import("@sentry/browser");
 Sentry.addIntegration(replayIntegration());
 ```
+
+### Canvas Recording
+
+<Alert level="warning">
+There is currently no PII scrubbing in canvas recordings!
+</Alert>
+
+In order to record canvas, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required to be installed. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
+
+```js
+// import Sentry from your framework SDK (e.g. @sentry/react) instead of @sentry/browser
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [
+    new Sentry.Replay(),
+
+    // The following is all you need to enable canvas recording
+    new Sentry.ReplayCanvas(),
+  ],
+});
+```
+
+#### Canvas Recording Performance
+
+The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop:
+
+```js
+TODO
+```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -54,7 +54,8 @@ Sentry.addIntegration(replayIntegration());
 </Alert>
 
 <Alert level="">
-  Canvas recording is in beta and currently only available to <a href="/product/accounts/early-adopter-features/">early adopters</a>
+  Canvas recording is in beta and currently only available to{" "}
+  <a href="/product/accounts/early-adopter-features/">early adopters</a>
 </Alert>
 
 In order to record HTML canvas elements, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -53,7 +53,7 @@ Sentry.addIntegration(replayIntegration());
   There is currently no PII scrubbing in canvas recordings!
 </Alert>
 
-In order to record canvas, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required to be installed. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
+In order to record HTML canvas elements, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
 
 ```js
 // import Sentry from your framework SDK (e.g. @sentry/react) instead of @sentry/browser
@@ -75,7 +75,7 @@ Sentry.init({
 
 #### Canvas Recording Performance
 
-The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
+The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
 
 ```js
 new Sentry.ReplayCanvas({

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -97,9 +97,9 @@ Sentry.init({
 
 #### 3D and WebGL Canvases
 
-The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, you'll need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two steps to using manual snapshotting: 
+The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, you'll need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two steps to using manual snapshotting:
 
-**Step 1.** 
+**Step 1.**
 Enable manual snapshotting when initializing the `ReplayCanvas` integration.
 
 ```javascript

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -53,6 +53,10 @@ Sentry.addIntegration(replayIntegration());
   There is currently no PII scrubbing in canvas recordings!
 </Alert>
 
+<Alert level="">
+  Canvas recording is in beta and currently only available to <a href="/product/accounts/early-adopter-features/">early adopters</a>
+</Alert>
+
 In order to record HTML canvas elements, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
 
 ```js

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -60,7 +60,7 @@ Sentry.addIntegration(replayIntegration());
 
 In order to record HTML canvas elements, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
 
-```js
+```javascript
 // import Sentry from your framework SDK (e.g. @sentry/react) instead of @sentry/browser
 import * as Sentry from "@sentry/browser";
 
@@ -79,11 +79,28 @@ Sentry.init({
 });
 ```
 
+```html {tabTitle: CDN}
+<!-- Existing script tag for bundle with replay, error, and performance monitoring -->
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/bundle.tracing.replay.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'bundle.tracing.replay.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<!-- New script tag for the canvas replay integration -->
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/replay-canvas.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'replay-canvas.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+```
+
 #### Canvas Recording Performance
 
 The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
 
-```js
+```javascript
 new Sentry.ReplayCanvas({
   // Enabling the following will ensure your canvas elements are not forced
   // into `preserveDrawingBuffer`.
@@ -93,7 +110,7 @@ new Sentry.ReplayCanvas({
 
 Next, you need to call the the following `snapshot()` method inside of your application's paint loop. `snapshot()` needs to be called in the same execution loop as the canvas draw commands, otherwise you may be snapshotting empty canvas buffers. This is due to how WebGL works when `preserveDrawingBuffer` is `false`.
 
-```js
+```javascript
 function paint() {
   const canvasRef = document.querySelector("#my-canvas");
   Sentry.getClient().getIntegrationByName("ReplayCanvas").snapshot(canvasRef);

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -50,7 +50,7 @@ Sentry.addIntegration(replayIntegration());
 ### Canvas Recording
 
 <Alert level="warning">
-There is currently no PII scrubbing in canvas recordings!
+  There is currently no PII scrubbing in canvas recordings!
 </Alert>
 
 In order to record canvas, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required to be installed. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
@@ -78,5 +78,5 @@ Sentry.init({
 The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop:
 
 ```js
-TODO
+TODO;
 ```

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -58,7 +58,7 @@ Sentry.addIntegration(replayIntegration());
   <a href="/product/accounts/early-adopter-features/">early adopters</a>
 </Alert>
 
-In order to record HTML canvas elements, you will need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it is not used:
+If you want to record HTML canvas elements, you'll need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it's not being used:
 
 ```javascript
 // import Sentry from your framework SDK (e.g. @sentry/react) instead of @sentry/browser
@@ -95,9 +95,12 @@ Sentry.init({
 ></script>
 ```
 
-#### Canvas Recording Performance
+#### 3D and WebGL Canvases
 
-The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two things you must do in order to use manual snapshotting: first you must enable it when initializing the `ReplayCanvas` integration:
+The canvas recording integration works by exporting the canvas as an image (at a rate of 2 frames per second). However, in order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, you'll need to enable manual snapshotting and call a `snapshot()` method inside of your re-paint loop. There are two steps to using manual snapshotting: 
+
+**Step 1.** 
+Enable manual snapshotting when initializing the `ReplayCanvas` integration.
 
 ```javascript
 Sentry.replayCanvasIntegration({
@@ -107,7 +110,8 @@ Sentry.replayCanvasIntegration({
 });
 ```
 
-Next, you need to call the the following `snapshot()` method inside of your application's paint loop. `snapshot()` needs to be called in the same execution loop as the canvas draw commands, otherwise you may be snapshotting empty canvas buffers. This is due to how WebGL works when `preserveDrawingBuffer` is `false`.
+**Step 2**
+Call the the following `snapshot()` method inside your application's paint loop. `snapshot()` needs to be called in the same execution loop as the canvas draw commands, otherwise you may be snapshotting empty canvas buffers. This is due to how WebGL works when `preserveDrawingBuffer` is `false`.
 
 ```javascript
 function paint() {

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -32,7 +32,7 @@ Canvas is supported in SDK versions >= `7.94.0`. Please see the <PlatformLink to
 
 ## Replay is slowing down my `canvas`
 
-In order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.
+In order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.
 
 ## My Custom CSS/Images/Fonts/Media Aren't Appearing When I View the Replay
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -28,7 +28,11 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 ## My `canvas` Elements Aren't Getting Captured
 
-There's currently no support for `canvas`. It's being tracked in this [GitHub issue](https://github.com/getsentry/sentry-javascript/issues/6519). Feel free to 👍 and help us prioritize it.
+Canvas is supported in SDK versions >= `7.94.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
+
+## Replay is slowing down my `canvas`
+
+In order to export images from 3d and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.
 
 ## My Custom CSS/Images/Fonts/Media Aren't Appearing When I View the Replay
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -28,7 +28,7 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 ## My `canvas` Elements Aren't Getting Captured
 
-Canvas is supported in SDK versions >= `7.94.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
+Canvas is supported in SDK versions >= `7.94.1`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
 
 ## Replay is slowing down my `canvas`
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -28,7 +28,7 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 ## My `canvas` Elements Aren't Getting Captured
 
-Canvas is supported in SDK versions >= `7.94.1`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
+Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
 
 ## Replay is slowing down my `canvas`
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -26,15 +26,15 @@ redirect_from:
 
 This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubleshooting</PlatformLink> guide by covering Replay-specific scenarios.
 
-## My `canvas` Elements Aren't Getting Captured
+## My `canvas` elements aren't getting captured
 
 Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
 
 ## Replay is slowing down my `canvas`
 
-In order to export images from 3D and WebGL canvases, the integration needs to enable `preserveDrawingBuffer` which can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, then you will need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.
+The integration needs to enable `preserveDrawingBuffer` to export images from 3D and WebGL canvases. This can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, you'll need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.
 
-## My Custom CSS/Images/Fonts/Media Aren't Appearing When I View the Replay
+## My custom CSS/Images/Fonts/Media aren't appearing when I view the Replay
 
 The replay 'video' is actually a video-like reproduction of the HTML on your website. This means that all the external resources your site uses (CSS/Images/Fonts), will be rendered by the corresponding &lt;style&gt;, &lt;img&gt; and &lt;video&gt; tags on your site. Add `sentry.io` to your CORS policy so the iframe hosted on sentry.io can fetch and display these resources.
 

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -28,7 +28,7 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 ## My `canvas` elements aren't getting captured
 
-Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> for getting started with canvas recordings.
+Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> to get started with canvas recordings.
 
 ## Replay is slowing down my `canvas`
 


### PR DESCRIPTION
Adds documention on how to setup `<canvas>` recording support in Replay. Also updates the Troubleshooting section accordingly.

Closes https://github.com/getsentry/team-replay/issues/335
Closes https://github.com/getsentry/team-replay/issues/337
Related to https://github.com/getsentry/team-replay/issues/347