### PR TITLE
feat: Update JavaScript & Node docs to avoid `configureScope()`

### DIFF
--- a/src/platform-includes/enriching-events/add-attachment/javascript.mdx
+++ b/src/platform-includes/enriching-events/add-attachment/javascript.mdx
@@ -2,14 +2,13 @@ Attachments live on the `Scope` and will be sent with all events.
 
 ```javascript
 // Add an attachment
-Sentry.configureScope((scope) => {
-  scope.addAttachment({ filename: "attachment.txt", data: "Some content" });
+Sentry.getCurrentScope().addAttachment({
+  filename: "attachment.txt",
+  data: "Some content",
 });
 
 // Clear attachments
-Sentry.configureScope((scope) => {
-  scope.clearAttachments();
-});
+Sentry.getCurrentScope().clearAttachments();
 ```
 
 An attachment has the following fields:

--- a/src/platform-includes/enriching-events/event-processors/javascript.mdx
+++ b/src/platform-includes/enriching-events/event-processors/javascript.mdx
@@ -1,16 +1,7 @@
-Event processors added to the global scope will run on every event sent after they are added.
+Event processors added to the current scope will run on every event sent after they are added.
 
 ```javascript
-Sentry.configureScope(function (scope) {
-  scope.addEventProcessor(function (event, hint) {
-    // Add anything to the event here
-    // returning `null` will drop the event
-    return event;
-  });
-});
-
-// You can do the same thing using `addGlobalEventProcessor`
-Sentry.addGlobalEventProcessor(function (event, hint) {
+Sentry.addEventProcessor(function (event, hint) {
   // Add anything to the event here
   // returning `null` will drop the event
   return event;

--- a/src/platform-includes/enriching-events/scopes/configure-scope/javascript.mdx
+++ b/src/platform-includes/enriching-events/scopes/configure-scope/javascript.mdx
@@ -1,9 +1,8 @@
 ```javascript
-Sentry.configureScope(function (scope) {
-  scope.setTag("my-tag", "my value");
-  scope.setUser({
-    id: 42,
-    email: "john.doe@example.com",
-  });
+const scope = Sentry.getCurrentScope();
+scope.setTag("my-tag", "my value");
+scope.setUser({
+  id: 42,
+  email: "john.doe@example.com",
 });
 ```

--- a/src/platform-includes/enriching-events/set-transaction-name/javascript.mdx
+++ b/src/platform-includes/enriching-events/set-transaction-name/javascript.mdx
@@ -1,3 +1,3 @@
 ```javascript
-Sentry.configureScope((scope) => scope.setTransactionName("UserListView"));
+Sentry.getCurrentScope().setTransactionName("UserListView");
 ```

--- a/src/platform-includes/set-extra/javascript.mdx
+++ b/src/platform-includes/set-extra/javascript.mdx
@@ -1,5 +1,0 @@
-```javascript
-Sentry.configureScope(function (scope) {
-  scope.setExtra("character.name", "Mighty Fighter");
-});
-```

--- a/src/platform-includes/set-fingerprint/static/javascript.mdx
+++ b/src/platform-includes/set-fingerprint/static/javascript.mdx
@@ -1,5 +1,0 @@
-```javascript
-Sentry.configureScope(function (scope) {
-  scope.setFingerprint(["my-view-function"]);
-});
-```

--- a/src/platform-includes/set-fingerprint/static/node.mdx
+++ b/src/platform-includes/set-fingerprint/static/node.mdx
@@ -1,5 +1,0 @@
-```javascript
-Sentry.configureScope(function (scope) {
-  scope.setFingerprint(["my-view-function"]);
-});
-```

--- a/src/platform-includes/set-level/javascript.mdx
+++ b/src/platform-includes/set-level/javascript.mdx
@@ -9,9 +9,7 @@ Available levels are `"fatal"`, `"error"`, `"warning"`, `"log"`, `"info"`, and `
 To set the level within scope, you can call `setLevel()`:
 
 ```javascript
-Sentry.configureScope(function (scope) {
-  scope.setLevel("warning");
-});
+Sentry.getCurrentScope().setLevel("warning");
 ```
 
 or per event:

--- a/src/platforms/javascript/common/enriching-events/context/index.mdx
+++ b/src/platforms/javascript/common/enriching-events/context/index.mdx
@@ -100,10 +100,10 @@ With the following snippet, the `user` context will be updated for all future ev
 Sentry.setUser(someUser);
 ```
 
-If you want to remove data from the current scope, you can call:
+If you want to remove all data from the current scope, you can call:
 
 ```javascript
-Sentry.configureScope((scope) => scope.clear());
+Sentry.getCurrentScope().clear();
 ```
 
 The following will only configure the `user` context for the error captured inside the `withScope` callback. The context will be automatically restored to the previous state afterwards:

--- a/src/platforms/javascript/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/javascript/common/enriching-events/scopes/index.mdx
@@ -40,7 +40,7 @@ then merge the event with the topmost scope's data.
 
 ## Configuring the Scope
 
-The most useful operation when working with scopes is the <PlatformIdentifier name="configure-scope" /> function. It can be used to reconfigure the current scope.
+There are two main ways to interact with the scope. You can access the current scope via `Sentry.getCurrentScope()`, and use setters on the resulting scope, or you can use the global methods like `Sentry.setTag()` directly, which will under the hood set on the respective scope.
 
 You'll first need to import the SDK, as usual:
 
@@ -48,14 +48,24 @@ You'll first need to import the SDK, as usual:
 
 You can, for instance, add custom tags or inform Sentry about the currently authenticated user.
 
-<PlatformContent includePath="enriching-events/scopes/configure-scope" />
+```javascript
+const scope = Sentry.getCurrentScope();
+scope.setTag("my-tag", "my value");
+scope.setUser({
+  id: 42,
+  email: "john.doe@example.com",
+});
 
-You can also apply this configuration when unsetting a user at logout:
-
-<PlatformContent includePath="enriching-events/unset-user" />
+// Or use the global methods
+Sentry.setTag("my-tag", "my value");
+Sentry.setUser({
+  id: 42,
+  email: "john.doe@example.com",
+});
+```
 
 To learn what useful information can be associated with scopes see
-[the context documentation](../context/).
+[context](../context/), [tags](../tags), [users](../identify-user) and [breadcrumbs](../breadcrumbs/).
 
 ## Local Scopes
 
@@ -69,11 +79,7 @@ In the following example we use <PlatformIdentifier name="with-scope" /> to atta
 
 <PlatformContent includePath="enriching-events/scopes/with-scope" />
 
-While this example looks similar to <PlatformIdentifier name="configure-scope" />, it is actually very different.
-Calls to <PlatformIdentifier name="configure-scope" /> change the current active scope; all successive calls to <PlatformIdentifier name="configure-scope" /> will maintain previously set changes unless they are explicitly unset.
-
-On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of the current scope, and the changes
-made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
+The scope inside of the `withScope()` callback is only valid inside of the callback - once the callback ended, the scope will be removed and no longer applied. The inner scope is only applied to events that are captured inside of the callback. `withScope()` will clone (or fork) the current scope, so that the current scope is not modified. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
 

--- a/src/platforms/javascript/common/install/loader.mdx
+++ b/src/platforms/javascript/common/install/loader.mdx
@@ -138,7 +138,6 @@ By default, the loader will make sure you can call these functions directly on `
 - `Sentry.captureMessage()`
 - `Sentry.captureEvent()`
 - `Sentry.addBreadcrumb()`
-- `Sentry.configureScope()`
 - `Sentry.withScope()`
 - `Sentry.showReportDialog()`
 

--- a/src/platforms/javascript/common/troubleshooting/index.mdx
+++ b/src/platforms/javascript/common/troubleshooting/index.mdx
@@ -353,17 +353,13 @@ const hub2 = new Sentry.Hub(client2);
 hub1.run((currentHub) => {
   // The `hub.run` method makes sure that `Sentry.getCurrentHub()` returns this hub during the callback
   currentHub.captureMessage("a");
-  currentHub.configureScope(function (scope) {
-    scope.setTag("a", "b");
-  });
+  Sentry.getCurrentScope().setTag("a", "b");
 });
 
 hub2.run((currentHub) => {
   // The `hub.run` method makes sure that `Sentry.getCurrentHub()` returns this hub during the callback
   currentHub.captureMessage("x");
-  currentHub.configureScope(function (scope) {
-    scope.setTag("c", "d");
-  });
+  Sentry.getCurrentScope().setTag("c", "d");
 });
 ```
 

--- a/src/platforms/node/common/enriching-events/context/index.mdx
+++ b/src/platforms/node/common/enriching-events/context/index.mdx
@@ -106,10 +106,10 @@ With the following snippet, the `user` context will be updated for all future ev
 Sentry.setUser(someUser);
 ```
 
-If you want to remove data from the current scope, you can call:
+If you want to remove all data from the current scope, you can call:
 
 ```javascript
-Sentry.configureScope((scope) => scope.clear());
+Sentry.getCurrentScope().clear();
 ```
 
 The following will only configure the `user` context for the error captured inside the `withScope` callback. The context will be automatically restored to the previous state afterwards:

--- a/src/platforms/node/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/node/common/enriching-events/scopes/index.mdx
@@ -40,7 +40,7 @@ then merge the event with the topmost scope's data.
 
 ## Configuring the Scope
 
-The most useful operation when working with scopes is the <PlatformIdentifier name="configure-scope" /> function. It can be used to reconfigure the current scope.
+There are two main ways to interact with the scope. You can access the current scope via `Sentry.getCurrentScope()`, and use setters on the resulting scope, or you can use the global methods like `Sentry.setTag()` directly, which will under the hood set on the respective scope.
 
 You'll first need to import the SDK, as usual:
 
@@ -48,14 +48,24 @@ You'll first need to import the SDK, as usual:
 
 You can, for instance, add custom tags or inform Sentry about the currently authenticated user.
 
-<PlatformContent includePath="enriching-events/scopes/configure-scope" />
+```javascript
+const scope = Sentry.getCurrentScope();
+scope.setTag("my-tag", "my value");
+scope.setUser({
+  id: 42,
+  email: "john.doe@example.com",
+});
 
-You can also apply this configuration when unsetting a user at logout:
-
-<PlatformContent includePath="enriching-events/unset-user" />
+// Or use the global methods
+Sentry.setTag("my-tag", "my value");
+Sentry.setUser({
+  id: 42,
+  email: "john.doe@example.com",
+});
+```
 
 To learn what useful information can be associated with scopes see
-[the context documentation](../context/).
+[context](../context/), [tags](../tags), [users](../identify-user) and [breadcrumbs](../breadcrumbs/).
 
 ## Local Scopes
 
@@ -69,11 +79,7 @@ In the following example we use <PlatformIdentifier name="with-scope" /> to atta
 
 <PlatformContent includePath="enriching-events/scopes/with-scope" />
 
-While this example looks similar to <PlatformIdentifier name="configure-scope" />, it is actually very different.
-Calls to <PlatformIdentifier name="configure-scope" /> change the current active scope; all successive calls to <PlatformIdentifier name="configure-scope" /> will maintain previously set changes unless they are explicitly unset.
-
-On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of the current scope, and the changes
-made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
+The scope inside of the `withScope()` callback is only valid inside of the callback - once the callback ended, the scope will be removed and no longer applied. The inner scope is only applied to events that are captured inside of the callback. `withScope()` will clone (or fork) the current scope, so that the current scope is not modified. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
 

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -65,9 +65,7 @@ const transaction = Sentry.startTransaction({
 // Note that we set the transaction as the span on the scope.
 // This step makes sure that if an error happens during the lifetime of the transaction
 // the transaction context will be attached to the error event
-Sentry.configureScope((scope) => {
-  scope.setSpan(transaction);
-});
+Sentry.getCurrentScope().setSpan(transaction);
 
 let request;
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/8778

Updates the docs around scopes in JS/Node. There is some further room for improvement there (e.g. explaining isolation/global scopes etc.) but keeping this minimal for now!