### PR TITLE
feat: Remove confusing note on `withScope` exception handling

### DIFF
--- a/src/platforms/go/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/go/common/enriching-events/scopes/index.mdx
@@ -72,9 +72,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>

--- a/src/platforms/java/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/java/common/enriching-events/scopes/index.mdx
@@ -73,12 +73,6 @@ made will stay isolated within the <PlatformIdentifier name="with-scope" /> call
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
 
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>
-
 ### Using Scope Callback Parameter
 
 In the following example we use the scope callback parameter that is available for all `capture` methods to attach a `level` and a `tag` to only one specific error:

--- a/src/platforms/javascript/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/javascript/common/enriching-events/scopes/index.mdx
@@ -76,9 +76,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>

--- a/src/platforms/node/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/node/common/enriching-events/scopes/index.mdx
@@ -76,9 +76,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>

--- a/src/platforms/python/enriching-events/scopes/index.mdx
+++ b/src/platforms/python/enriching-events/scopes/index.mdx
@@ -83,9 +83,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>

--- a/src/platforms/react-native/enriching-events/scopes/index.mdx
+++ b/src/platforms/react-native/enriching-events/scopes/index.mdx
@@ -76,9 +76,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>

--- a/src/platforms/rust/common/enriching-events/scopes/index.mdx
+++ b/src/platforms/rust/common/enriching-events/scopes/index.mdx
@@ -68,9 +68,3 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
-
-<Alert level="info" title="Important">
-
-Errors that occur within the callback of <PlatformIdentifier name="with-scope" /> are **not** caught and reported to Sentry.
-
-</Alert>


### PR DESCRIPTION
This is a bit confusing, as what it wants to say (probably) is "errors here are not caught and swallowed, but are captured normally by Sentry error handlers & reported to Sentry", but can be read as "errors are neither caught nor reported to sentry". Overall this is not really helpful, so just removing this.