### PR TITLE
feat: Update browser getting started docs to explain loader vs npm config

### DIFF
--- a/src/platform-includes/configuration/capture-console/javascript.mdx
+++ b/src/platform-includes/configuration/capture-console/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { CaptureConsole } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/contextlines/javascript.mdx
+++ b/src/platform-includes/configuration/contextlines/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { ContextLines } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/debug/javascript.mdx
+++ b/src/platform-includes/configuration/debug/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { Debug } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/dedupe/javascript.mdx
+++ b/src/platform-includes/configuration/dedupe/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { Dedupe } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/src/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/src/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { ExtraErrorData } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/http-client/javascript.mdx
+++ b/src/platform-includes/configuration/http-client/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { HttpClient } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/module-metadata/javascript.mdx
+++ b/src/platform-includes/configuration/module-metadata/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/src/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/src/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { ReportingObserver } from "@sentry/integrations";
 

--- a/src/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/src/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: ESM}
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 import { RewriteFrames } from "@sentry/integrations";
 

--- a/src/platform-includes/getting-started-config/javascript.bun.mdx
+++ b/src/platform-includes/getting-started-config/javascript.bun.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle:ESM}
+```javascript
 import * as Sentry from "@sentry/bun";
 
 Sentry.init({

--- a/src/platform-includes/getting-started-config/javascript.mdx
+++ b/src/platform-includes/getting-started-config/javascript.mdx
@@ -1,8 +1,10 @@
 Once this is done, Sentry's JavaScript SDK captures all unhandled exceptions, transactions, and Session Replays, based on the sample rates set.
 
+Note that configuration differs slightly depending on how you installed the Sentry SDK. Make sure to follow the instructions in the correct tab, depending on if you installed the Sentry SDK via NPM, using the Loader Script, or via CDN.
+
 <SignInNote />
 
-```javascript
+```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({
@@ -26,4 +28,70 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 });
+```
+
+```html {tabTitle: Loader}
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+
+<script>
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+
+      // Alternatively, use `process.env.npm_package_version` for a dynamic release version
+      // if your build tool supports it.
+      release: "my-project-name@2.3.12",
+      integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+
+      // Set tracesSampleRate to 1.0 to capture 100%
+      // of transactions for performance monitoring.
+      // We recommend adjusting this value in production
+      tracesSampleRate: 1.0,
+
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+
+      // Capture Replay for 10% of all sessions,
+      // plus for 100% of sessions with an error
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    });
+  };
+</script>
+```
+
+```html {tabTitle: CDN}
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/bundle.tracing.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'bundle.tracing.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<script>
+  Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+
+      // Alternatively, use `process.env.npm_package_version` for a dynamic release version
+      // if your build tool supports it.
+      release: "my-project-name@2.3.12",
+      integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+
+      // Set tracesSampleRate to 1.0 to capture 100%
+      // of transactions for performance monitoring.
+      // We recommend adjusting this value in production
+      tracesSampleRate: 1.0,
+
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+
+      // Capture Replay for 10% of all sessions,
+      // plus for 100% of sessions with an error
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    });
+  }
+</script>
 ```


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/8880

It was brought up in that issue, that while we point to the Loader setup first, we show the non-loader config below on the "Getting Started" page for Browser JS. This is a bit confusing...  I updated this to specifically call out that config differs for the loader, adding tabs for npm/loader/cdn for clarity.

While at it, I also renamed the tabs from "ESM" to `npm` in the integration pages, which is IMHO clearer for there.