### PR TITLE
fix(typo): import capitalization typo

### DIFF
--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -128,7 +128,7 @@ The only exception is `sourceMapsUploadOptions` which **always** needs to be set
 Here's an example of a custom client-side SDK setup:
 
 ```javascript {filename:sentry.client.config.js}
-import * as sentry from "@sentry/astro";
+import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/src/platforms/javascript/guides/astro/manual-setup.mdx
@@ -157,7 +157,7 @@ Sentry.init({
 Here's an example of a custom server-side SDK setup:
 
 ```javascript {filename:sentry.server.config.js}
-import * as sentry from "@sentry/astro";
+import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Found a typo in Astro's "Manual Setup" code blocks.

**Also:** I noticed we're using `process.env` to access environment variables in the `astro.config.mjs` file. If we define our variables in `.env` file(s), it won't work because [Astro evaluates the config file before `.env`](https://docs.astro.build/en/guides/configuring-astro/#environment-variables) so the values are always going to be `undefined`. A suggested solution is to use the `loadEnv` method from the `vite` package (which if you use `pnpm` you explicitly need to install it):

```javascript
import { loadEnv } from "vite";

const { SENTRY_DSN, SENTRY_AUTH_TOKEN } = loadEnv(
  process.env.NODE_ENV,
  process.cwd(),
  "",
);
```

Do you think we should specify that in our docs? I know it has nothing to do with Sentry, it's just for correctness? 😅 Copy-pasting the configure block won't work, but it also won't show any issues. Maybe we could add a "heads up" blockquote and a link to Astro's docs on [using environment variables in config files](https://docs.astro.build/en/guides/configuring-astro/#environment-variables)?

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
