### PR TITLE
ref: Make "js" codeblocks --> "javascript"

### DIFF
--- a/src/docs/product/performance/resources.md
+++ b/src/docs/product/performance/resources.md
@@ -47,7 +47,7 @@ If you've manually instrumented Sentry, you'll need to make sure that your spans
 
 Here's an example snippet of creating a resource span manually with the SDK.
 
-```js
+```javascript
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
 const resources = performance.getEntriesByType("resource");
 resources.forEach((entry) => {

--- a/src/includes/platforms/configuration/integrations/requestdata.mdx
+++ b/src/includes/platforms/configuration/integrations/requestdata.mdx
@@ -12,7 +12,7 @@ This integration adds data from incoming requests to transaction and error event
 
 Controls what types of data are added to the event:
 
-```js
+```javascript
 {
   cookies: boolean  // default: true,
   data: boolean  // default: true,

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -1,7 +1,7 @@
 If you're using our Astro SDK, distributed tracing will work out of the box for the client and server runtimes.
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` on the client-side.
 
-```js
+```javascript
 // sentry.client.config.js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -1,6 +1,6 @@
 If you're using the current version of our JavaScript SDK and have enabled the `BrowserTracing` integration, distributed tracing will work out of the box. To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, define your `tracePropagationTargets`.
 
-```js
+```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.BrowserTracing()],

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -2,7 +2,7 @@ If you're using the current version of our Next.js SDK, distributed tracing will
 
 For client-side you might have to define `tracePropagationTargets` to get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues.
 
-```js
+```javascript
 // sentry.client.config.js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -1,6 +1,6 @@
 If you're using the current version of our SvelteKit SDK, distributed tracing will work out of the box for the client and server runtimes. To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` for client-side.
 
-```js
+```javascript
 // hooks.client.js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/platform-includes/distributed-tracing/how-to-use/node.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/node.mdx
@@ -2,7 +2,7 @@ If you're using version `7.58.0` or above of our Node SDK and have the HTTP inte
 
 <SignInNote />
 
-```js
+```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.Integrations.Http({ tracing: true })],
@@ -11,7 +11,7 @@ Sentry.init({
 
 If you're using Express or an Express-compatible framework, you'll also need to use Sentry middleware:
 
-```js
+```javascript
 const app = express();
 
 // RequestHandler creates a separate execution context, so that all

--- a/src/platform-includes/distributed-tracing/how-to-use/react-native.mdx
+++ b/src/platform-includes/distributed-tracing/how-to-use/react-native.mdx
@@ -1,6 +1,6 @@
 If you're using the current version of our React Native SDK distributed tracing will work out of the box.
 
-```js
+```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracePropagationTargets: ["https://myproject.org", /^\/api\//],

--- a/src/platform-includes/performance/opentelemetry-setup/node.mdx
+++ b/src/platform-includes/performance/opentelemetry-setup/node.mdx
@@ -2,7 +2,7 @@ There are a few steps necessary in order to ensure that your OpenTelemetry setup
 
 <SignInNote />
 
-```js
+```javascript
 // Sentry dependencies
 const Sentry = require("@sentry/node");
 const {
@@ -75,7 +75,7 @@ You can either create spans via `tracer.startActiveSpan()`,
 or use the `startSpan()` / `startInactiveSpan()` methods exported from `@sentry/opentelemetry`,
 which are just thin wrappers around the OpenTelemetry API:
 
-```js
+```javascript
 import { startSpan, startInactiveSpan } from "@sentry/opentelemetry";
 
 startSpan({ name: "my span" }, (span) => {

--- a/src/platform-includes/profiling/automatic-instrumentation-headers/_default.mdx
+++ b/src/platform-includes/profiling/automatic-instrumentation-headers/_default.mdx
@@ -1,6 +1,6 @@
 How you do this will depend on your server. If you're using a server like Express, you'll be able to use the [response.set](https://expressjs.com/en/4x/api.html#res.set) function.
 
-```js
+```javascript
 app.get("/", (request, response) => {
   response.set("Document-Policy", "js-profiling");
   response.sendFile("index.html");

--- a/src/platform-includes/profiling/automatic-instrumentation-headers/javascript.electron.mdx
+++ b/src/platform-includes/profiling/automatic-instrumentation-headers/javascript.electron.mdx
@@ -1,6 +1,6 @@
 In the Electron main process, you can enable injection of this header by setting the `enableRendererProfiling` option to `true`:
 
-```js
+```javascript
 import * as Sentry from "@sentry/electron/main";
 
 Sentry.init({

--- a/src/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -41,7 +41,7 @@ public throwTestError(): void {
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -35,7 +35,7 @@ setTimeout(() => {
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -35,7 +35,7 @@ setTimeout(() => {
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -40,7 +40,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -36,7 +36,7 @@ setTimeout(() => {
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -42,7 +42,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.react.mdx
@@ -40,7 +40,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -42,7 +42,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -40,7 +40,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -42,7 +42,7 @@ You can verify this by adding the following button to your app and pressing it:
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -44,7 +44,7 @@ export default {
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```js
+```javascript
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],

--- a/src/platform-includes/user-feedback/sdk-api-example/javascript.mdx
+++ b/src/platform-includes/user-feedback/sdk-api-example/javascript.mdx
@@ -1,6 +1,6 @@
 _Requires JS SDK version v7.47.0 or higher._
 
-```js
+```javascript
 import * as Sentry from "@sentry/browser";
 
 const eventId = Sentry.captureMessage("User Feedback");
@@ -19,7 +19,7 @@ You could also collect feedback and send it when an error occurs via the SDK's `
 
 <SignInNote />
 
-```js
+```javascript
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
   beforeSend: event => {

--- a/src/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/src/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -116,7 +116,7 @@ When this happens, the Replay can't capture the response body because the reques
 
 To avoid this, disable this behavior of Apollo Client by configuring your own abort signal:
 
-```js
+```javascript
 const abortController = new AbortController();
 
 const httpLink = createHttpLink({

--- a/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/src/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -177,7 +177,7 @@ navigation.addEventListener("navigate", (event) => {
 When using `replaysOnErrorSampleRate`, we "roll the dice" on any Error that is captured & sent to Sentry.
 If you want to skip capturing a Replay for certain errors, you can use the `beforeErrorSampling` callback:
 
-```js
+```javascript
 new Replay({
   beforeErrorSampling: (error) => {
     return error.message?.includes("drop me");

--- a/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
+++ b/src/platforms/javascript/guides/capacitor/troubleshooting.mdx
@@ -9,7 +9,7 @@ sidebar_order: 1000
 
 If you see the following error during build time, the sibling SDKs installed in your app have mismatched versions:
 
-```js
+```javascript
   node_modules/@sentry/types/types/globals.d.ts:2:11 - error TS2451: Cannot redeclare block-scoped variable '__DEBUG_BUILD__'.
 ```
 

--- a/src/platforms/node/common/configuration/async-context.mdx
+++ b/src/platforms/node/common/configuration/async-context.mdx
@@ -6,7 +6,7 @@ description: "Learn more about how to isolate Sentry scope and breadcrumbs acros
 
 You can use the `runWithAsyncContext` method to isolate Sentry scope and breadcrumbs to a single request if you are using SDK v7.48.0 or higher. This is useful if you are finding that breadcrumbs and scope are leaking across requests.
 
-```js
+```javascript
 const Sentry = require("@sentry/node");
 
 function requestHandlerMiddleware(req, res, next) {
@@ -21,7 +21,7 @@ Under the hood, the SDK uses Node's [AsyncLocalStorage API](https://nodejs.org/a
 
 On lower SDK versions you'll have to use [domains](https://nodejs.org/api/domain.html) to isolate Sentry scope and breadcrumbs to a single request.
 
-```js
+```javascript
 const domain = require("domain");
 
 function myRequestHandler(req, res, next) {

--- a/src/platforms/node/guides/express/performance/index.mdx
+++ b/src/platforms/node/guides/express/performance/index.mdx
@@ -53,7 +53,7 @@ app.listen(3000);
 
 You can also manually create transactions in your app:
 
-```js
+```javascript
 const Sentry = require("@sentry/node");
 const http = require("http");
 

--- a/src/platforms/react-native/migration/sentry-expo.mdx
+++ b/src/platforms/react-native/migration/sentry-expo.mdx
@@ -81,7 +81,7 @@ Sentry.init({
 
 Expo-specific tags are no longer added by default. If you were using them, you can add them manually:
 
-```js
+```javascript
 import Constants from "expo-constants";
 import * as Device from "expo-device";
 import * as Updates from "expo-updates";

--- a/src/platforms/react-native/performance/instrumentation/user-interaction-instrumentation.mdx
+++ b/src/platforms/react-native/performance/instrumentation/user-interaction-instrumentation.mdx
@@ -22,7 +22,7 @@ Transaction names are composed from a combination of displayed screen names, (fo
 
 UI instrumentation tracing is disabled by default, but you can enable it by setting the `enableUserInteractionTracing` options to `true` and wrapping your root component:
 
-```js
+```javascript
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
@@ -43,7 +43,7 @@ export default Sentry.wrap(App);
 
 The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, `sentry-label` will be used instead. If an element can't be identified, the transaction won't be captured.
 
-```js
+```javascript
 export default Sentry.wrap(App, {
   touchEventBoundaryProps: { labelName: "my-label" },
 });
@@ -68,7 +68,7 @@ To create UI transactions from React Native Gesture Handler, you need to wrap in
   is supported.
 </Note>
 
-```js
+```javascript
 import React from "react";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { sentryTraceGesture } from "@sentry/react-native";

--- a/src/platforms/react-native/troubleshooting/index.mdx
+++ b/src/platforms/react-native/troubleshooting/index.mdx
@@ -31,7 +31,7 @@ If you use a polyfilling library that patches the global `Promise` instance, you
 
 <SignInNote />
 
-```js
+```javascript
 import allSettled from "promise.allsettled";
 
 Sentry.init({
@@ -216,7 +216,7 @@ If your build is failing because of outdated fields in the `react-native.config.
 
 _Old_:
 
-```js
+```javascript
 module.exports = {
   dependency: {
     platforms: {
@@ -239,7 +239,7 @@ module.exports = {
 
 _New_:
 
-```js
+```javascript
 module.exports = {
   dependency: {
     platforms: {


### PR DESCRIPTION
This was a bit inconsistent, but the majority (800+ instances) of codeblocks were "javascript" vs 40 or so of "js"
