### PR TITLE
Update type in null object for ruby performance transaction

### DIFF
--- a/src/platform-includes/performance/retrieve-transaction/ruby.mdx
+++ b/src/platform-includes/performance/retrieve-transaction/ruby.mdx
@@ -1,6 +1,6 @@
 ## Retrieve a Transaction
 
-In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.get_current_scope.get_transaction`. This property will return a `Transaction` in case there is a running Transaction otherwise it returns `None`.
+In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry.get_current_scope.get_transaction`. This property will return a `Transaction` in case there is a running Transaction otherwise it returns `nil`.
 
 ```ruby
 transaction = Sentry.get_current_scope.get_transaction || Sentry.start_transaction(name: "task")


### PR DESCRIPTION
- [ ] Checked Vercel preview for correctness, including links 
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This fixes the null object representation in a ruby dedicated example in Performance's « retrieve a transaction » paragraph.

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
