### PR TITLE
chore: update dotnet profiling package version

### DIFF
--- a/src/platforms/dotnet/profiling/index.mdx
+++ b/src/platforms/dotnet/profiling/index.mdx
@@ -26,7 +26,7 @@ To enable profiling, set the `ProfilesSampleRate`.
 Additionally, for all platforms except iOS/Mac Catalyst, you need to add a dependency on the `Sentry.Profiling` NuGet package.
 
 ```shell {tabTitle:.NET CLI}
-dotnet add package Sentry.Profiling -v {{@inject packages.version('sentry.dotnet', '4.0.0-beta.8') }}
+dotnet add package Sentry.Profiling --prerelease
 ```
 
 Profiling depends on Sentry’s performance monitoring product being enabled beforehand. To enable performance monitoring in the SDK, set the `TracesSampleRate` option to the desired value.


### PR DESCRIPTION
Follow up for #8862 - for now, before the final 4.0 release is out, we need to instruct users to instruct the latest prerelease version instead 3.*.*