### PR TITLE
Move plausible off Google Tag manager

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -101,5 +101,12 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({setHeadComponents}) => 
       src="https://www.googletagmanager.com/gtm.js?id=GTM-N72TJRH"
       async
     />,
+    // Plausible
+    <script 
+      defer 
+      data-domain="docs.sentry.io" 
+      data-api="https://plausible.io/api/event"
+      src="https://plausible.io/js/script.tagged-events.js">
+    </script>,
   ]);
 };

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -104,7 +104,7 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({setHeadComponents}) => 
     // Plausible
     <script 
       defer 
-      data-domain="docs.sentry.io" 
+      data-domain="docs.sentry.io,rollup.sentry.io" 
       data-api="https://plausible.io/api/event"
       src="https://plausible.io/js/script.tagged-events.js">
     </script>,

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io *.plausible.io; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io *.plausible.io reload.getsentry.net; img-src * 'self' data: www.google.com www.googletagmanager.com plausible.io *.plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com; worker-src blob:; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io reload.getsentry.net; img-src * 'self' data: www.google.com www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com; worker-src blob:; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
         }
       ]
     }


### PR DESCRIPTION
We are moving away from Google Tag Manager and hosting the script we needed directly on our site, as a follow up to our cookie blog.