### PR TITLE
ref(js): Add deprecation note to `startTransaction` documentation

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/custom-instrumentation.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/custom-instrumentation.mdx
@@ -38,7 +38,15 @@ Sentry maintains a [list of well known span operations](https://develop.sentry.d
 
 <PlatformContent includePath="performance/span-operations" />
 
-## Start Transaction
+## (Deprecated) Start Transaction
+
+<Alert level="warning" title="Deprecation">
+
+The `startTransaction` function is deprecated and will be removed in version 8 of the SDK.
+
+To migrate, use the span starting functions documented above as a replacement.
+
+</Alert>
 
 The root span (the span that is the parent of all other spans) is known as a **transaction** in Sentry. Transactions can be accessed and created separately if you need more control over your timing data or if you use a version of the SDK that doesn't support the top-level span APIs.
 


### PR DESCRIPTION
`startTransaction` will be removed in v8 of the JS SDK in favour of the startSpan functions. We already 
deprecated the function in out changelog, migration guide and code documentation. This PR also adds a 
deprecation note to the docs, given this is a quite prominent API.

closes https://github.com/getsentry/sentry-docs/issues/8946