### PR TITLE
feat(webvitals): More browser support performance score details, and Firefox LCP support

### DIFF
--- a/src/docs/product/performance/web-vitals.mdx
+++ b/src/docs/product/performance/web-vitals.mdx
@@ -147,6 +147,8 @@ The **Performance Score** is comprised of 5 individual **Web Vital** components.
 | [First Contentful Paint](#first-contentful-paint-fcp) (FCP)     | [900ms](https://www.desmos.com/calculator/gcxbiypuuh)  | [1600ms](https://www.desmos.com/calculator/gcxbiypuuh) | 15%    |
 | [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)           | [200ms](https://www.desmos.com/calculator/ykzahw9goi)  | [400ms](https://www.desmos.com/calculator/ykzahw9goi)  | 10%    |
 
+Find out which Web Vitals are required to calculate Performance Scores in the [Browser Support](#browser-support) table.
+
 ## Opportunity
 
 **Opportunity** scores are number values associated with each page and are meant to give you a sense of which pages are most valuable to improve. The Opportunity score is the maximum possible increase to your application's overall Performance Score if you were to raise a page's score to 100. If a page in your application already has a score of 100, the Opportunity score would be 0, since there's no way to further optimize this page.
@@ -171,9 +173,11 @@ If you wish to see all of the data available, open the dropdown and click "View 
 
 | Web Vital                                                       | Chrome | Edge | Opera | Firefox | Safari | IE  |
 | --------------------------------------------------------------- | ------ | ---- | ----- | ------- | ------ | --- |
-| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP) | ✓      | ✓    | ✓     |         |        |     |
+| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP) | ✓\*    | ✓\*  | ✓\*   | ✓       |        |     |
 | [First Input Delay](#first-input-delay-fid) (FID)               | ✓      | ✓    | ✓     | ✓       | ✓      | ✓   |
-| [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)   | ✓      | ✓    | ✓     |         |        |     |
+| [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)   | ✓\*    | ✓\*  | ✓\*   |         |        |     |
 | [First Paint](#first-paint-fp) (FP)                             | ✓      | ✓    | ✓     |         |        |     |
-| [First Contentful Paint](#first-contentful-paint-fcp) (FCP)     | ✓      | ✓    | ✓     | ✓       | ✓      |     |
-| [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)           | ✓      | ✓    | ✓     | ✓       | ✓      | ✓   |
+| [First Contentful Paint](#first-contentful-paint-fcp) (FCP)     | ✓\*    | ✓\*  | ✓\*   | ✓\*     | ✓\*    |     |
+| [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)           | ✓\*    | ✓\*  | ✓\*   | ✓\*     | ✓\*    | ✓   |
+
+\* These Web Vitals are required to calculate [Performance Scores](#performance-score), based on the clients browser. Some browsers may not always send all Web Vitals depending on the web page and/or browser version. Page loads that are missing required Web Vitals are not scored due to low data quality.


### PR DESCRIPTION
Add some more content around required browser support for performance score calculations. Also update firefox to include lcp support in the browser support table. (Firefox supports lcp as of version 122 released on Jan 23, 2024)