### PR TITLE
feat(canvas): Remove EA requirement for replay-canvas

### DIFF
--- a/src/docs/product/accounts/early-adopter-features/index.mdx
+++ b/src/docs/product/accounts/early-adopter-features/index.mdx
@@ -25,6 +25,3 @@ Limitations:
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
 - [Open PR Comments](/product/integrations/source-code-mgmt/github/#open-pull-request-comments)
 - [Investigation Mode](/product/performance/retention-priorities/#investigation-mode) for retention priorities in Performance Monitoring
-- <PlatformLink to="/session-replay/#canvas-recording">
-    Replay Canvas Recording
-  </PlatformLink>

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -49,13 +49,12 @@ Sentry.addIntegration(replayIntegration());
 
 ### Canvas Recording
 
-<Alert level="warning">
-  There is currently no PII scrubbing in canvas recordings!
+<Alert level="">
+  Canvas recording is currently in beta. Please submit an issue on [GitHub](https://github.com/getsentry/sentry-javascript) if you encounter any bugs.
 </Alert>
 
-<Alert level="">
-  Canvas recording is in beta and currently only available to{" "}
-  <a href="/product/accounts/early-adopter-features/">early adopters</a>
+<Alert level="warning">
+  There is currently no PII scrubbing in canvas recordings!
 </Alert>
 
 If you want to record HTML canvas elements, you'll need to add an additional integration in your Sentry configuration. The canvas integration is exported from the browser SDK, so no additional package is required. Canvas recording is opt-in and will be tree-shaken from your bundle if it's not being used:

--- a/src/platform-includes/session-replay/setup/javascript.mdx
+++ b/src/platform-includes/session-replay/setup/javascript.mdx
@@ -50,7 +50,9 @@ Sentry.addIntegration(replayIntegration());
 ### Canvas Recording
 
 <Alert level="">
-  Canvas recording is currently in beta. Please submit an issue on [GitHub](https://github.com/getsentry/sentry-javascript) if you encounter any bugs.
+  Canvas recording is currently in beta. Please submit an issue on
+  [GitHub](https://github.com/getsentry/sentry-javascript) if you encounter any
+  bugs.
 </Alert>
 
 <Alert level="warning">


### PR DESCRIPTION
This should actually be open beta rather than limited to EA.
