### PR TITLE
feat(js): Add JS metrics docs

### DIFF
--- a/src/platform-includes/metrics/configure/javascript.astro.mdx
+++ b/src/platform-includes/metrics/configure/javascript.astro.mdx
@@ -1,0 +1,25 @@
+To use metrics with astro, first [manually setup up the SDK as per the Astro SDK docs](/platforms/javascript/guides/astro/manual-setup/#manual-sdk-initialization).
+
+To configure metrics for your client-side code, add the `metricsAggregratorIntegration` to your `Sentry.init` call in your `sentry.client.config.js` file.
+
+```JavaScript
+// sentry.client.config.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    Sentry.metrics.metricsAggregratorIntegration(),
+  ],
+});
+```
+
+To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `sentry.server.config.js` file.
+
+```JavaScript
+// sentry.server.config.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.bun.mdx
+++ b/src/platform-includes/metrics/configure/javascript.bun.mdx
@@ -1,0 +1,10 @@
+To configure metrics, add the `metricsAggregator` experimental option to your `Sentry.init` call.
+
+```JavaScript
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.deno.mdx
+++ b/src/platform-includes/metrics/configure/javascript.deno.mdx
@@ -1,0 +1,10 @@
+To configure metrics, add the `metricsAggregator` experimental option to your `Sentry.init` call.
+
+```JavaScript
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.electron.mdx
+++ b/src/platform-includes/metrics/configure/javascript.electron.mdx
@@ -1,0 +1,12 @@
+To configure metrics, add the `metricsAggregator` experimental option to your `Sentry.init` call in your main process.
+
+```JavaScript
+import * as Sentry from '@sentry/electron/main';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.mdx
+++ b/src/platform-includes/metrics/configure/javascript.mdx
@@ -1,0 +1,10 @@
+To configure metrics, add the `metricsAggregratorIntegration` to your `Sentry.init` call.
+
+```JavaScript
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    Sentry.metrics.metricsAggregratorIntegration(),
+  ],
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.nextjs.mdx
+++ b/src/platform-includes/metrics/configure/javascript.nextjs.mdx
@@ -1,0 +1,23 @@
+To configure metrics for your client-side code, add the `metricsAggregratorIntegration` to your `Sentry.init` call in your `sentry.client.config.js` file.
+
+```JavaScript
+// sentry.client.config.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    Sentry.metrics.metricsAggregratorIntegration(),
+  ],
+});
+```
+
+To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `sentry.server.config.js` and `sentry.edge.config.js` files.
+
+```JavaScript
+// sentry.server.config.js AND/OR sentry.edge.config.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.remix.mdx
+++ b/src/platform-includes/metrics/configure/javascript.remix.mdx
@@ -1,0 +1,23 @@
+To configure metrics for your client-side code, add the `metricsAggregratorIntegration` to your `Sentry.init` call in your `entry.client.tsx` file.
+
+```JavaScript
+// entry.client.tsx
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    Sentry.metrics.metricsAggregratorIntegration(),
+  ],
+});
+```
+
+To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `entry.server.tsx` file.
+
+```JavaScript
+// entry.server.tsx
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/javascript.sveltekit.mdx
+++ b/src/platform-includes/metrics/configure/javascript.sveltekit.mdx
@@ -1,0 +1,23 @@
+To configure metrics for your client-side code, add the `metricsAggregratorIntegration` to your `Sentry.init` call in your `hooks.client.js` file.
+
+```JavaScript
+// hooks.client.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    Sentry.metrics.metricsAggregratorIntegration(),
+  ],
+});
+```
+
+To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `hooks.server.js` file.
+
+```JavaScript
+// hooks.server.js
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/configure/node.mdx
+++ b/src/platform-includes/metrics/configure/node.mdx
@@ -1,0 +1,10 @@
+To configure metrics, add the `metricsAggregator` experimental option to your `Sentry.init` call.
+
+```JavaScript
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+```

--- a/src/platform-includes/metrics/counter-snippet/javascript.mdx
+++ b/src/platform-includes/metrics/counter-snippet/javascript.mdx
@@ -1,0 +1,6 @@
+```JavaScript
+// Increment a counter by one for each button click.
+Sentry.metrics.increment("button_click", 1, {
+  tags: { browser: "Firefox", app_version: "1.0.0" },
+});
+```

--- a/src/platform-includes/metrics/distribution-snippet/javascript.mdx
+++ b/src/platform-includes/metrics/distribution-snippet/javascript.mdx
@@ -1,0 +1,7 @@
+```JavaScript
+// Add '15.0' to a distribution used for tracking the loading times for component.
+Sentry.metrics.distribution("component_load_time", 15.0, {
+  tags: { type: "important" },
+  unit: "millisecond",
+});
+```

--- a/src/platform-includes/metrics/gauge-snippet/javascript.mdx
+++ b/src/platform-includes/metrics/gauge-snippet/javascript.mdx
@@ -1,0 +1,7 @@
+```JavaScript
+// Add 2 to a gauge tracking CPU usage.
+Sentry.metrics.gauge("cpu_usage", 34, {
+  tags: { os: "MacOS" },
+  unit: "percent",
+});
+```

--- a/src/platform-includes/metrics/set-snippet/javascript.mdx
+++ b/src/platform-includes/metrics/set-snippet/javascript.mdx
@@ -1,0 +1,4 @@
+```JavaScript
+// Add 'jane' to a set used for tracking the number of users that viewed a page.
+Sentry.metrics.distribution("user_view", "jane");
+```

--- a/src/platform-includes/metrics/version-support-note/javascript.electron.mdx
+++ b/src/platform-includes/metrics/version-support-note/javascript.electron.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+Metrics for JavaScript are supported with Sentry Electron SDK version `4.17.0` and above.
+
+</Note>

--- a/src/platform-includes/metrics/version-support-note/javascript.mdx
+++ b/src/platform-includes/metrics/version-support-note/javascript.mdx
@@ -1,0 +1,5 @@
+<Note>
+
+Metrics for JavaScript are supported with Sentry JavaScript SDK version `7.94.0` and above.
+
+</Note>

--- a/src/platforms/javascript/common/metrics/index.mdx
+++ b/src/platforms/javascript/common/metrics/index.mdx
@@ -1,0 +1,91 @@
+---
+title: Set Up Metrics
+description: "Learn how to measure the data points you care about by configuring Metrics in your JavaScript app."
+notSupported:
+  - javascript.capacitor
+  - javascript.cordova
+  - javascript.cordova
+---
+
+<PlatformContent includePath="metrics/version-support-note" />
+
+Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
+
+## Configure Metrics
+
+<PlatformContent includePath="metrics/configure" />
+
+## Emit a Counter
+
+Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
+
+To emit a counter, do the following:
+
+<PlatformContent includePath="metrics/counter-snippet" />
+
+## Emit a Distribution
+
+Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
+
+To emit a distribution, do the following:
+
+<PlatformContent includePath="metrics/distribution-snippet" />
+
+## Emit a Set
+
+Sets are useful for looking at unique occurrences and counting the unique elements you added.
+
+To emit a set, do the following:
+
+<PlatformContent includePath="metrics/set-snippet" />
+
+## Emit a Gauge
+
+Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. They can be represented in a more space-efficient way than distributions, but they can't be used to get percentiles. If percentiles aren't important to you, we recommend using gauges.
+
+To emit a gauge, do the following:
+
+<PlatformContent includePath="metrics/gauge-snippet" />
+
+## Supported Performance Metric Units
+
+You can pass a unit as a optional parameter of the third argument of the `increment`, `distribution`, `set`, and `gauge` methods.
+
+Units augment metric values by giving meaning to what otherwise might be abstract numbers. Adding units also allows Sentry to offer controls &#151; unit conversions, filters, and so on &#151; based on those units. For values that are unitless, you can supply an empty string or `none`.
+
+These following units are understood by the Sentry backend, but you can supply any arbitrary units you want.
+
+### Duration Units
+
+- `nanosecond`
+- `microsecond`
+- `millisecond`
+- `second`
+- `minute`
+- `hour`
+- `day`
+- `week`
+
+### Information Units
+
+- `bit`
+- `byte`
+- `kilobyte`
+- `kibibyte`
+- `megabyte`
+- `mebibyte`
+- `gigabyte`
+- `gibibyte`
+- `terabyte`
+- `tebibyte`
+- `petabyte`
+- `pebibyte`
+- `exabyte`
+- `exbibyte`
+
+### Fraction Units
+
+- `ratio`
+- `percent`
+
+If you want to explore further, you can find details about supported units in our [event ingestion documentation](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html).

--- a/src/platforms/node/common/metrics/index.mdx
+++ b/src/platforms/node/common/metrics/index.mdx
@@ -1,0 +1,87 @@
+---
+title: Set Up Metrics
+description: "Learn how to measure the data points you care about by configuring Metrics in your JavaScript app."
+---
+
+<PlatformContent includePath="metrics/version-support-note" />
+
+Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
+
+## Configure Metrics
+
+<PlatformContent includePath="metrics/configure" />
+
+## Emit a Counter
+
+Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
+
+To emit a counter, do the following:
+
+<PlatformContent includePath="metrics/counter-snippet" />
+
+## Emit a Distribution
+
+Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
+
+To emit a distribution, do the following:
+
+<PlatformContent includePath="metrics/distribution-snippet" />
+
+## Emit a Set
+
+Sets are useful for looking at unique occurrences and counting the unique elements you added.
+
+To emit a set, do the following:
+
+<PlatformContent includePath="metrics/set-snippet" />
+
+## Emit a Gauge
+
+Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. They can be represented in a more space-efficient way than distributions, but they can't be used to get percentiles. If percentiles aren't important to you, we recommend using gauges.
+
+To emit a gauge, do the following:
+
+<PlatformContent includePath="metrics/gauge-snippet" />
+
+## Supported Performance Metric Units
+
+You can pass a unit as a optional parameter of the third argument of the `increment`, `distribution`, `set`, and `gauge` methods.
+
+Units augment metric values by giving meaning to what otherwise might be abstract numbers. Adding units also allows Sentry to offer controls &#151; unit conversions, filters, and so on &#151; based on those units. For values that are unitless, you can supply an empty string or `none`.
+
+These following units are understood by the Sentry backend, but you can supply any arbitrary units you want.
+
+### Duration Units
+
+- `nanosecond`
+- `microsecond`
+- `millisecond`
+- `second`
+- `minute`
+- `hour`
+- `day`
+- `week`
+
+### Information Units
+
+- `bit`
+- `byte`
+- `kilobyte`
+- `kibibyte`
+- `megabyte`
+- `mebibyte`
+- `gigabyte`
+- `gibibyte`
+- `terabyte`
+- `tebibyte`
+- `petabyte`
+- `pebibyte`
+- `exabyte`
+- `exbibyte`
+
+### Fraction Units
+
+- `ratio`
+- `percent`
+
+If you want to explore further, you can find details about supported units in our [event ingestion documentation](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html).


### PR DESCRIPTION
Documents metrics for browser JS (all the frameworks), Node, Deno, Bun, and Electron.

Reference:
- Electron: https://github.com/getsentry/sentry-javascript/discussions/10110
- Browser: https://github.com/getsentry/sentry-javascript/discussions/9938
- Node/Deno/Bun: https://github.com/getsentry/sentry-javascript/discussions/9973