### PR TITLE
Update performance-metrics.mdx (missing info about method deprecation)

### DIFF
--- a/src/platforms/javascript/common/performance/instrumentation/performance-metrics.mdx
+++ b/src/platforms/javascript/common/performance/instrumentation/performance-metrics.mdx
@@ -34,6 +34,12 @@ Currently, unit conversion is only supported once the data has already been stor
 
 </Note>
 
+<Note>
+
+You should not rely on the transaction (`getTransaction` is marked as deprecated), but just use `startSpan()` [APIs](https://docs.sentry.io/platforms/javascript/guides/solid/performance/instrumentation/custom-instrumentation/#start-span) instead.
+
+</Note>
+
 ## Supported Performance Metric Units
 
 Units augment metric values by giving meaning to what otherwise might be abstract numbers. Adding units also allows Sentry to offer controls &#151; unit conversions, filters, and so on &#151; based on those units. For values that are unitless, you can supply an empty string or `none`.


### PR DESCRIPTION
`getTransaction` is marked as deprecated and adviced to use `startSpan` APIs instead, but it isn't stated in the docs

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds a short note about `getTransaction` being deprecated and necessity to use `startSpan` APIs instead

Screenshot from the [official docs](https://docs.sentry.io/platforms/javascript/performance/instrumentation/performance-metrics/?original_referrer=https%3A%2F%2Fwww.google.com%2F):

![image](https://github.com/getsentry/sentry-docs/assets/8372070/1cf31da6-c7f2-41eb-bc9b-1bd2c4146bd2)

But when user will try to use example from the above, this will be shown:

![image](https://github.com/getsentry/sentry-docs/assets/8372070/1f78725b-13db-4ec5-9a38-ab170bf9ca73)


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
