### PR TITLE
Removing sourcemap header reference

### DIFF
--- a/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/src/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -289,8 +289,6 @@ Some CDNs automatically strip comments from static files, including JavaScript f
 
 Double-check that your deployed, final JavaScript files have `sourceMappingURL` present.
 
-Alternately, instead of `sourceMappingURL`, you can set a `SourceMap` HTTP header on your minified file. If this header is present, Sentry will use it to discover the location of your source map.
-
 <PlatformSection notSupported={["javascript.electron"]}>
 
 ### Verify artifact distribution value matches value configured in your SDK


### PR DESCRIPTION
Sentry no longer supports finding the sourcemap file using the Sourcemap header added to files. Removing the line that explains how to use it.