### PR TITLE
Fix headline link icon

### DIFF
--- a/docs/platforms/python/data-management/data-collected.mdx
+++ b/docs/platforms/python/data-management/data-collected.mdx
@@ -22,7 +22,7 @@ By default, the Sentry SDK doesn't send cookies. Sentry tries to remove any cook
 
 If you want to send cookies, set `send_default_pii=True` in the `sentry_sdk.init()` call.
 
-## Information About Logged-in User<br/>
+## Information About Logged-in User
 
 By default, the Sentry SDK doesn't send any information about the logged-in user, (such as email address, user id, or username). Even if enabled, the type of logged-in user information you'll be able to send depends on the integrations you enable in Sentry's SDK. Most integrations won't send any user information. Some will only set the user id, but there are a few that will set the user id, username, and email address.
 


### PR DESCRIPTION
Was caused by a `<br/>` at the end of the headline
