### PR TITLE
Bring back /platform-redirect endpoint

### DIFF
--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -1,0 +1,62 @@
+import {redirect} from 'next/navigation';
+
+import {DocPage} from 'sentry-docs/components/docPage';
+import {PlatformIcon} from 'sentry-docs/components/platformIcon';
+import {SmartLink} from 'sentry-docs/components/smartLink';
+import {extractPlatforms, getDocsRootNode} from 'sentry-docs/docTree';
+import {setServerContext} from 'sentry-docs/serverContext';
+
+import 'sentry-docs/styles/screen.scss';
+
+export default async function Page({
+  searchParams: {next, platform},
+}: {
+  searchParams: {[key: string]: string | string[] | undefined};
+}) {
+  const rootNode = await getDocsRootNode();
+  const platformList = (rootNode && extractPlatforms(rootNode)) ?? [];
+
+  const requestedPlatform = Array.isArray(platform) ? platform[0] : platform;
+  if (requestedPlatform) {
+    const isValidPlatform = platformList.some(
+      p => p.key === requestedPlatform?.toLowerCase()
+    );
+    if (isValidPlatform) {
+      return redirect(`/platforms/${requestedPlatform}${next}`);
+    }
+  }
+
+  const frontMatter = {
+    title: 'Platform Specific Content',
+  };
+
+  // TODO(mjq): This is a hack to get the <ServerSidebar> component to use the
+  // <ProductSidebar>. The sidebar components should be rejigged so that
+  // <ProductSidebar> can be passed into DocPage's sidebar prop below.
+  setServerContext({rootNode, path: ['platform-redirect']});
+
+  return (
+    <DocPage frontMatter={frontMatter}>
+      <p>
+        The page you are looking for is customized for each platform. Select your platform
+        below and we&apos;ll direct you to the most specific documentation on it.
+      </p>
+
+      <ul>
+        {platformList.map(p => (
+          <li key={p.key}>
+            <SmartLink to={`/platforms/${p.key}${next}`}>
+              <PlatformIcon
+                size={16}
+                platform={p.icon ?? p.key}
+                style={{marginRight: '0.5rem'}}
+                format="sm"
+              />
+              <h4 style={{display: 'inline-block'}}>{p.title}</h4>
+            </SmartLink>
+          </li>
+        ))}
+      </ul>
+    </DocPage>
+  );
+}

--- a/src/components/docPage.tsx
+++ b/src/components/docPage.tsx
@@ -29,7 +29,7 @@ export function DocPage({
   const {rootNode, path} = serverContext();
   const platformOrGuide = rootNode && getCurrentPlatformOrGuide(rootNode, path);
   const hasToc = (!notoc && !frontMatter.notoc) || !!platformOrGuide;
-  const hasGithub = path?.length && path[0] !== 'api';
+  const hasGithub = !!path?.length && path[0] !== 'api';
 
   return (
     <div className="document-wrapper">

--- a/src/components/serverSidebar.tsx
+++ b/src/components/serverSidebar.tsx
@@ -60,7 +60,7 @@ export function ServerSidebar() {
     } else {
       return null;
     }
-  } else if (path.indexOf('product') === 0) {
+  } else if (path.indexOf('product') === 0 || path.indexOf('platform-redirect') === 0) {
     return productSidebar(rootNode);
   } else if (path.indexOf('api') === 0) {
     return <ApiSidebar />;


### PR DESCRIPTION
This endpoint is given a path (via the `next` query string param) and, optionally, a `platform` param. If a valid platform is given, a redirect happens immediately. Otherwise, a list of platform-specific links to the given path is rendered.

See [the Gatsby version](https://github.com/getsentry/sentry-docs/blob/405170000995bd8d98bd155f4e8d38ce4c19275a/src/pages/platform-redirect.tsx).