### PR TITLE
feat: Replace span data with attributes in JS docs

### DIFF
--- a/docs/platforms/javascript/common/performance/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/performance/troubleshooting/index.mdx
@@ -18,11 +18,11 @@ For example:
 
 Currently, every tag has a maximum character limit of 200 characters. Tags over the 200 character limit will become truncated, losing potentially important information. To retain this data, you can split data over several tags instead.
 
-For example, a 200+ character tagged request:
+For example, a 200+ character tag like this:
 
 `https://empowerplant.io/api/0/projects/ep/setup_form/?user_id=314159265358979323846264338327&tracking_id=EasyAsABC123OrSimpleAsDoReMi&product_name=PlantToHumanTranslator&product_id=161803398874989484820458683436563811772030917980576`
 
-The 200+ character request above will become truncated to:
+...will become truncated to:
 
 `https://empowerplant.io/api/0/projects/ep/setup_form/?user_id=314159265358979323846264338327&tracking_id=EasyAsABC123OrSimpleAsDoReMi&product_name=PlantToHumanTranslator&product_id=1618033988749894848`
 

--- a/docs/platforms/node/common/performance/troubleshooting/index.mdx
+++ b/docs/platforms/node/common/performance/troubleshooting/index.mdx
@@ -18,11 +18,11 @@ For example:
 
 Currently, every tag has a maximum character limit of 200 characters. Tags over the 200 character limit will become truncated, losing potentially important information. To retain this data, you can split data over several tags instead.
 
-For example, a 200+ character tagged request:
+For example, a 200+ character tag like this:
 
 `https://empowerplant.io/api/0/projects/ep/setup_form/?user_id=314159265358979323846264338327&tracking_id=EasyAsABC123OrSimpleAsDoReMi&product_name=PlantToHumanTranslator&product_id=161803398874989484820458683436563811772030917980576`
 
-The 200+ character request above will become truncated to:
+...will become truncated to:
 
 `https://empowerplant.io/api/0/projects/ep/setup_form/?user_id=314159265358979323846264338327&tracking_id=EasyAsABC123OrSimpleAsDoReMi&product_name=PlantToHumanTranslator&product_id=1618033988749894848`
 

--- a/platform-includes/performance/add-spans-example/javascript.mdx
+++ b/platform-includes/performance/add-spans-example/javascript.mdx
@@ -46,7 +46,10 @@ function processItem(item) {
           response.on("data", () => {});
           response.on("end", () => {
             span.setTag("http.status_code", response.statusCode);
-            span.setData("http.foobarsessionid", getFoobarSessionid(response));
+            span.setAttribute(
+              "http.foobarsessionid",
+              getFoobarSessionid(response)
+            );
             resolve(response);
           });
         });
@@ -70,7 +73,7 @@ function processItem(item) {
       const json = await response.json();
 
       span.setTag("http.status_code", response.statusCode);
-      span.setData("http.foobarsessionid", getFoobarSessionid(response));
+      span.setAttribute("http.foobarsessionid", getFoobarSessionid(response));
     }
   );
 }

--- a/platform-includes/performance/control-data-truncation/javascript.mdx
+++ b/platform-includes/performance/control-data-truncation/javascript.mdx
@@ -1,4 +1,4 @@
-Instead, using `span.set_tag` and `span.set_data` preserves the details of this query using structured metadata. This could be done over `baseUrl`, `endpoint`, and `parameters`:
+Instead of using tags, it is recommended to add data to spans as attributes. Using `span.setAttribute()` allows to add data with arbitrary length to a span. You can add as many attributes to your span as you want.
 
 ```javascript
 const baseUrl = "https://empowerplant.io";
@@ -10,15 +10,23 @@ const parameters = {
   product_id: 161803398874989484820458683436563811772030917980576,
 };
 
-const span = transaction.startChild({
-  op: "http.client",
-  description: "setup form",
-});
+startSpan(
+  {
+    op: "http.client",
+    name: "setup form",
+    // you can add attributes when starting the span
+    attributes: {
+      baseUrl,
+      endpoint,
+    },
+  },
+  (span) => {
+    // or you can add attributes to an existing span
+    for (const key of parameters) {
+      span.setAttribute(`parameters.${key}`, parameters[key]);
+    }
 
-span.setTag("baseUrl", baseUrl);
-span.setTag("endpoint", endpoint);
-span.setData("parameters", parameters);
-// you may also find some parameters to be valuable as tags
-span.setData("user_id", parameters.user_id);
-http.get(`${base_url}/${endpoint}/`, (data = parameters));
+    // do something to be measured
+  }
+);
 ```

--- a/platform-includes/performance/start-span/javascript.mdx
+++ b/platform-includes/performance/start-span/javascript.mdx
@@ -5,36 +5,51 @@ const result = Sentry.startSpan({ name: "Important Function" }, () => {
   return expensiveFunction();
 });
 
-const result = await Sentry.startSpan(
+const result2 = await Sentry.startSpan(
   { name: "Important Function" },
   async () => {
-    const res = Sentry.startSpan({ name: "Child Span" }, () => {
-      return expensiveFunction();
+    const res = await Sentry.startSpan({ name: "Child Span" }, () => {
+      return expensiveAsyncFunction();
     });
 
     return updateRes(res);
   }
 );
 
-const result = Sentry.startSpan({ name: "Important Function" }, (span) => {
-  // You can access the span to add data or set specific status.
+const result3 = Sentry.startSpan({ name: "Important Function" }, (span) => {
+  // You can access the span to add attributes or set specific status.
   // The span may be undefined if the span was not sampled or if performance monitoring is disabled.
-  span?.setData("foo", "bar");
+  span?.setAttribute("foo", "bar");
   return expensiveFunction();
 });
+
+const result4 = Sentry.startSpan(
+  {
+    name: "Important Function",
+    // You can also pass attributes directly to `startSpan`:
+    attributes: {
+      foo: "bar",
+      count: 1,
+    },
+  },
+  () => {
+    return expensiveFunction();
+  }
+);
 ```
 
 In this example, the span named `Important Function` will become the active span for the duration of the callback.
 
-If you need to override when the span finishes, you can use `Sentry.startSpanManual`. This is useful for creating parallel spans that are not related to each other.
+If you need to override when the span finishes, you can use `Sentry.startSpanManual`. This is useful if you don't want to finish the span when the callback ends, or if you want to finish the span at a specific time.
 
 ```javascript
 // Start a span that tracks the duration of middleware
 function middleware(_req, res, next) {
-  return Sentry.startSpanManual({ name: "middleware" }, (span, finish) => {
+  return Sentry.startSpanManual({ name: "middleware" }, (span) => {
     res.once("finish", () => {
       span?.setHttpStatus(res.status);
-      finish();
+      // manually tell the span when to end
+      span?.end();
     });
     return next();
   });

--- a/platform-includes/performance/start-span/node.mdx
+++ b/platform-includes/performance/start-span/node.mdx
@@ -5,23 +5,37 @@ const result = Sentry.startSpan({ name: "Important Function" }, () => {
   return expensiveFunction();
 });
 
-const result = await Sentry.startSpan(
+const result2 = await Sentry.startSpan(
   { name: "Important Function" },
   async () => {
-    const res = Sentry.startSpan({ name: "Child Span" }, () => {
-      return expensiveFunction();
+    const res = await Sentry.startSpan({ name: "Child Span" }, () => {
+      return expensiveAsyncFunction();
     });
 
     return updateRes(res);
   }
 );
 
-const result = Sentry.startSpan({ name: "Important Function" }, (span) => {
-  // You can access the span to add data or set specific status.
+const result3 = Sentry.startSpan({ name: "Important Function" }, (span) => {
+  // You can access the span to add attributes or set specific status.
   // The span may be undefined if the span was not sampled or if performance monitoring is disabled.
-  span?.setData("foo", "bar");
+  span?.setAttribute("foo", "bar");
   return expensiveFunction();
 });
+
+const result4 = Sentry.startSpan(
+  {
+    name: "Important Function",
+    // You can also pass attributes directly to `startSpan`:
+    attributes: {
+      foo: "bar",
+      count: 1,
+    },
+  },
+  () => {
+    return expensiveFunction();
+  }
+);
 ```
 
 In this example, the span named `Important Function` will become the active span for the duration of the callback.


### PR DESCRIPTION
`data` is deprecated, instead users should use `attributes` for spans.
Remaining is a replacement for `span.setTag()`, I'll update this once we published https://github.com/getsentry/sentry-javascript/pull/10475 (next week).