### PR TITLE
Fix spacing on custom performance instrumentation

### DIFF
--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation.mdx
@@ -16,7 +16,7 @@ If you're using one of Sentry's SDK integrations, transactions will be created f
 
 </Note>
 
-The following example creates a transaction for an expensive operation (in this case,`eat_pizza`), and then sends the result to Sentry:
+The following example creates a transaction for an expensive operation (in this case, `eat_pizza`), and then sends the result to Sentry:
 
 ```python
 import sentry_sdk


### PR DESCRIPTION
adds a space in on the performance instrumentation page for Python.  