### PR TITLE
Add troubleshooting docs for diagnostics_channel in JS and node

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -91,7 +91,10 @@ You can work around our CDN bundles being blocked by [using our NPM packages](#u
 <Note>
   The Sentry Next.js SDK has a separate option to make setting up tunnels very
   straight-forward, allowing you to skip the setup below. See{" "}
-  <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers"> Configure Tunneling to avoid Ad-Blockers </PlatformLink>{" "}
+  <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers">
+    {" "}
+    Configure Tunneling to avoid Ad-Blockers{" "}
+  </PlatformLink>{" "}
   to learn how to set up tunneling on Next.js.
 </Note>
 
@@ -240,8 +243,8 @@ If you would like to copy and paste the snippet directly, here it is minified:
           return "flush" === e || "close" === e
             ? Promise.resolve()
             : "function" == typeof n
-            ? n(window.Sentry)
-            : window.Sentry;
+              ? n(window.Sentry)
+              : window.Sentry;
         }, n);
       },
     };
@@ -430,3 +433,7 @@ export default defineConfig({
    plugins: [react()]
 })
 ```
+
+## Missing module `diagnostics_channel`
+
+<Include name="diagnostics-channel-build-error-troubleshooting.mdx" />

--- a/docs/platforms/node/common/troubleshooting/index.mdx
+++ b/docs/platforms/node/common/troubleshooting/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Troubleshooting
+description: "Troubleshoot and resolve edge cases."
+keywords: ["build error"]
+excerpt: ""
+sidebar_order: 9000
+---
+
+If you need help solving issues with your Sentry JavaScript SDK integration, you can read the edge cases documented below. If you need additional help, you can [ask on GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose). Customers on a paid plan may also contact support.
+
+## Updating to a New Sentry SDK Version
+
+If you update your Sentry SDK to a new major version, you might encounter breaking changes that need some adaption on your end.
+Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md) to learn everything you need
+to know to get up and running again with the latest Sentry features.
+
+## Debugging Additional Data
+
+You can view the JSON payload of an event to see how Sentry stores additional data in the event. The shape of the data may not exactly match the description.
+
+![Red box highlighting where to find the JSON connected to an event](/platforms/javascript/common/troubleshooting/event_JSON.png)
+
+For more details, see the [full documentation on Event Payload](https://develop.sentry.dev/sdk/event-payloads/).
+
+## Max JSON Payload Size
+
+`maxValueLength` has a default value of 250, but you can adjust this value according to your needs if your messages are longer. Please note that not every single value is affected by this option.
+
+## Third Party Promise Libraries
+
+When you include and configure Sentry, our JavaScript SDK automatically attaches global handlers to _capture_ uncaught exceptions and unhandled promise rejections. You can disable this default behavior by changing the `onunhandledrejection` option to `false` in your GlobalHandlers integration and manually hook into each event handler, then call `Sentry.captureException` or `Sentry.captureMessage` directly.
+
+You may also need to manage your configuration if you are using a third-party library to implement promises. Also, remember that browsers often implement security measures that can block error reporting when serving script files from different origins.
+
+## Events With "Non-Error Exception"
+
+If you’re seeing errors with the message “Non-Error exception (or promise rejection) captured with keys: x, y, z.”, this happens when you a) call `Sentry.captureException()` with a plain object, b) throw a plain object, or c) reject a promise with a plain object.
+
+You can see the contents of the non-Error object in question in the `__serialized__` entry of the “Additional Data” section.
+
+To get better insight into these error events, we recommend finding where the plain object is being passed or thrown to Sentry based on the contents of the `__serialized__` data, and then turning the plain object into an Error object.
+
+## Build Errors With Vite
+
+If you're using the [Vite Bundler](https://vitejs.dev/) and a Sentry NPM package, and you see the following error:
+
+```
+Error: Could not resolve './{}.js' from node_modules/@sentry/utils/esm/index.js
+```
+
+This might be because the [`define`](https://vitejs.dev/config/shared-options.html#define) option in your Vite config is string-replacing some variable used by the Sentry SDK, like `global`, which causes build errors. Vite recommends using `define` for CONSTANTS only, and not putting `process` or `global` into the options. To fix this build error, remove or update your `define` option, as shown below:
+
+```diff {filename:vite.config.ts}
+export default defineConfig({
+   build: {
+     sourcemap: true
+   },
+-  define: {
+-    global: {}
+-  },
+   plugins: [react()]
+})
+```
+
+## Missing module `diagnostics_channel`
+
+<Include name="diagnostics-channel-build-error-troubleshooting.mdx" />

--- a/includes/diagnostics-channel-build-error-troubleshooting.mdx
+++ b/includes/diagnostics-channel-build-error-troubleshooting.mdx
@@ -1,0 +1,10 @@
+If you're getting build errors when using any of the JavaScript SDKs mentioning something along the lines of "Cannot find module diagnostics_channel", try to configure your build tool to either externalize, or ignore the `diagnostics_channel` module.
+The Sentry Node.js SDK uses this built-in module to instrument Node.js fetch requests.
+Some older Node.js versions do not have the `diagnostics_channel` API, which may lead to build errors when attemtping to bundle your code.
+
+Most bundlers have an option to externalize specific modules (like `diagnostics_channel`):
+
+- [Externals in Webpack](https://webpack.js.org/configuration/externals/)
+- [External in Vite](https://vitejs.dev/config/ssr-options.html#ssr-external)
+- [External in esbuild](https://esbuild.github.io/api/#external)
+- [External in Rollup](https://rollupjs.org/configuration-options/#external)

--- a/includes/diagnostics-channel-build-error-troubleshooting.mdx
+++ b/includes/diagnostics-channel-build-error-troubleshooting.mdx
@@ -1,6 +1,6 @@
-If you're getting build errors when using any of the JavaScript SDKs mentioning something along the lines of "Cannot find module diagnostics_channel", try to configure your build tool to either externalize, or ignore the `diagnostics_channel` module.
+If you're getting build errors when using any of the JavaScript SDKs mentioning something along the lines of "Cannot find module diagnostics_channel", try to configure your build tool to either externalize or ignore the `diagnostics_channel` module.
 The Sentry Node.js SDK uses this built-in module to instrument Node.js fetch requests.
-Some older Node.js versions do not have the `diagnostics_channel` API, which may lead to build errors when attemtping to bundle your code.
+Some older Node.js versions do not have the `diagnostics_channel` API, which may lead to build errors when attempting to bundle your code.
 
 Most bundlers have an option to externalize specific modules (like `diagnostics_channel`):
 


### PR DESCRIPTION
Adds troubleshooting docs for when diagnostics_channel is not available when building/bundling.

Also adds troubleshooting docs to the node.js platform.

Ref: https://github.com/getsentry/sentry-javascript/pull/10388