### PR TITLE
feat: Avoid using deprecated `getTransaction()` in JS

### DIFF
--- a/platform-includes/performance/custom-performance-metrics/javascript.mdx
+++ b/platform-includes/performance/custom-performance-metrics/javascript.mdx
@@ -1,14 +1,12 @@
 Adding custom metrics is supported in Sentry's JavaScript SDK version `7.0.0` and above.
 
 ```javascript
-const transaction = Sentry.getCurrentScope().getTransaction();
-
 // Record amount of memory used
-transaction.setMeasurement("memoryUsed", 123, "byte");
+Sentry.setMeasurement("memoryUsed", 123, "byte");
 
 // Record time when Footer component renders on page
-transaction.setMeasurement("ui.footerComponent.render", 1.3, "second");
+Sentry.setMeasurement("ui.footerComponent.render", 1.3, "second");
 
 // Record amount of times localStorage was read
-transaction.setMeasurement("localStorageRead", 4);
+Sentry.setMeasurement("localStorageRead", 4);
 ```


### PR DESCRIPTION
Replacement for https://github.com/getsentry/sentry-docs/pull/9015 that actually updates the code snippet.