### PR TITLE
feat: Add deprecation info to JS docs

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -36,6 +36,15 @@ If you prefer to follow video instructions, see [How to Install the Sentry Next.
 
 </PlatformSection>
 
+<Alert level="warning" title="Seeing deprecation warnings in your code?">
+
+We are currently preparing version 8 of the JavaScript SDKs.
+In v8, some methods and properties will be removed or renamed.
+You can refer to the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+to see how you can update your code to be compatible with v8.
+
+</Alert>
+
 <PlatformSection notSupported={["javascript.deno"]}>
 
 ## Install

--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -4,6 +4,9 @@
 
 On this page, we get you up and running with Sentry's SDK.
 
+If you're seeing deprecation warnings in your code, please note that we're currently working on version 8 of the JavaScript SDKs. In v8, some methods and properties will be removed or renamed. Check out the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+and learn how to update your code to be compatible with v8.
+
 </PlatformSection>
 
 <PlatformSection noGuides>
@@ -36,14 +39,6 @@ If you prefer to follow video instructions, see [How to Install the Sentry Next.
 
 </PlatformSection>
 
-<Alert level="warning" title="Seeing deprecation warnings in your code?">
-
-We are currently preparing version 8 of the JavaScript SDKs.
-In v8, some methods and properties will be removed or renamed.
-You can refer to the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
-to see how you can update your code to be compatible with v8.
-
-</Alert>
 
 <PlatformSection notSupported={["javascript.deno"]}>
 

--- a/docs/platforms/node/common/index.mdx
+++ b/docs/platforms/node/common/index.mdx
@@ -2,20 +2,14 @@
 
 On this page, we get you up and running with Sentry's SDK.
 
+If you're seeing deprecation warnings in your code, please note that we're currently working on version 8 of the JavaScript SDKs. In v8, some methods and properties will be removed or renamed. Check out the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+and learn how to update your code to be compatible with v8.
+
 <PlatformContent includePath="alert-using-a-framework" noGuides />
 
 Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
 If you prefer to follow video instructions, see [How to Install the Sentry Node SDK in 60 Seconds](https://vimeo.com/899368543).
-
-<Alert level="warning" title="Seeing deprecation warnings in your code?">
-
-We are currently preparing version 8 of the JavaScript SDKs.
-In v8, some methods and properties will be removed or renamed.
-You can refer to the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
-to see how you can update your code to be compatible with v8.
-
-</Alert>
 
 ## Install
 

--- a/docs/platforms/node/common/index.mdx
+++ b/docs/platforms/node/common/index.mdx
@@ -8,6 +8,15 @@ Don't already have an account and Sentry project established? Head over to [sent
 
 If you prefer to follow video instructions, see [How to Install the Sentry Node SDK in 60 Seconds](https://vimeo.com/899368543).
 
+<Alert level="warning" title="Seeing deprecation warnings in your code?">
+
+We are currently preparing version 8 of the JavaScript SDKs.
+In v8, some methods and properties will be removed or renamed.
+You can refer to the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+to see how you can update your code to be compatible with v8.
+
+</Alert>
+
 ## Install
 
 Sentry captures data by using an SDK within your application’s runtime.


### PR DESCRIPTION
This adds an explicit callout to the getting started page of all JS SDKs pointing them to the migration docs. They are maybe not super intuitive to find right now, if you go search for them on the docs... We can eventually remove them again.

Note that they shouldn't actually look like errors, this is due to https://github.com/getsentry/sentry-docs/issues/9049.