### PR TITLE
Improve build times

### DIFF
--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -4,6 +4,8 @@
 
 import {promises as fs} from 'fs';
 
+import {cache} from 'react';
+
 import {DeRefedOpenAPI} from './open-api/types';
 
 // SENTRY_API_SCHEMA_SHA is used in the sentry-docs GHA workflow in getsentry/sentry-api-schema.
@@ -30,8 +32,6 @@ async function resolveOpenAPI(): Promise<DeRefedOpenAPI> {
   );
   return await response.json();
 }
-
-export default resolveOpenAPI;
 
 export type APIParameter = {
   description: string;
@@ -77,7 +77,7 @@ function slugify(s: string): string {
     .toLowerCase();
 }
 
-export async function apiCategories(): Promise<APICategory[]> {
+export const apiCategories = cache(async (): Promise<APICategory[]> => {
   const data = await resolveOpenAPI();
 
   const categoryMap: {[name: string]: APICategory} = {};
@@ -142,7 +142,7 @@ export async function apiCategories(): Promise<APICategory[]> {
     c.apis.sort((a, b) => a.name.localeCompare(b.name));
   });
   return categories;
-}
+});
 
 function getBodyParameters(apiData): APIParameter[] {
   const content = apiData.requestBody?.content;

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import {cache} from 'react';
 import matter from 'gray-matter';
 import {s} from 'hastscript';
 import yaml from 'js-yaml';
@@ -34,7 +35,7 @@ export type FrontMatter = {[key: string]: any};
 
 export const allDocsFrontMatter = getAllFilesFrontMatter();
 
-export async function getDocsFrontMatter(): Promise<FrontMatter[]> {
+export const getDocsFrontMatter = cache(async (): Promise<FrontMatter[]> => {
   const frontMatter = [...allDocsFrontMatter];
 
   const categories = await apiCategories();
@@ -53,7 +54,7 @@ export async function getDocsFrontMatter(): Promise<FrontMatter[]> {
   });
 
   return frontMatter;
-}
+});
 
 export function getAllFilesFrontMatter(folder: string = 'docs'): FrontMatter[] {
   const docsPath = path.join(root, folder);


### PR DESCRIPTION
Debugged the load times using commit c8d5391d, which more than tripled local build times and more than doubled Vercel build times compared to the previous commit (baf391b1).

Initially, c8d5391d took 9:35 locally.

After caching the `apiCategories` function, the time dropped to 6:34. This method makes a `fetch` call to retrieve our OpenAPI specs - I'm suspicious that Next's fetch cache isn't working properly on this call. We only need this to run once per build anyway.

Further, caching the `getDocsFrontMatter` function dropped the build time to 5:19. This function defensively copies a large array, but the result only needs to be calculated once per build.

There's still work to be done to get all the way back down to baf391b1's build time (2:47 locally), but it's a start.

See #9020.
