### PR TITLE
fix(feedback docs): make Astro setup docs consistent

### DIFF
--- a/platform-includes/user-feedback/install/javascript.astro.mdx
+++ b/platform-includes/user-feedback/install/javascript.astro.mdx
@@ -1,6 +1,6 @@
 The User Feedback integration is already included with the Sentry Astro SDK.
 
-```bash {tabTitle:npx}
+```bash {tabTitle:Bash}
 npx astro add @sentry/astro
 ```
 


### PR DESCRIPTION
The Astro code snippet header said `npx` but every other guide says `Bash`:
<img width="589" alt="SCR-20240206-jwpv" src="https://github.com/getsentry/sentry-docs/assets/56095982/4ece9610-5f8b-4a36-b5e6-6ab05da9c7e5">

ex. 
<img width="583" alt="SCR-20240206-jwri" src="https://github.com/getsentry/sentry-docs/assets/56095982/adc172d2-a69f-443e-914b-94fe8156e781">

