### PR TITLE
Fix `supported`/`notSupported` frontmatter logic

### DIFF
--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -30,6 +30,29 @@ const root = process.cwd();
 function formatSlug(slug) {
   return slug.replace(/\.(mdx|md)/, '');
 }
+const isSupported = (
+  frontmatter: any,
+  platformName: string,
+  guideName?: string
+): boolean => {
+  const canonical = guideName ? `${platformName}.${guideName}` : platformName;
+  if (frontmatter.supported && frontmatter.supported.length) {
+    if (frontmatter.supported.indexOf(canonical) !== -1) {
+      return true;
+    }
+    if (frontmatter.supported.indexOf(platformName) === -1) {
+      return false;
+    }
+  }
+  if (
+    frontmatter.notSupported &&
+    (frontmatter.notSupported.indexOf(canonical) !== -1 ||
+      frontmatter.notSupported.indexOf(platformName) !== -1)
+  ) {
+    return false;
+  }
+  return true;
+};
 
 export type FrontMatter = {[key: string]: any};
 
@@ -113,12 +136,7 @@ export function getAllFilesFrontMatter(folder: string = 'docs'): FrontMatter[] {
     });
 
     commonFiles.forEach(f => {
-      const supported =
-        (!f.frontmatter.supported?.length ||
-          f.frontmatter.supported.includes(platformName)) &&
-        (!f.frontmatter.notSupported?.length ||
-          !f.frontmatter.notSupported.includes(platformName));
-      if (!supported) {
+      if (!isSupported(f.frontmatter, platformName)) {
         return;
       }
 
@@ -158,13 +176,7 @@ export function getAllFilesFrontMatter(folder: string = 'docs'): FrontMatter[] {
       }
 
       commonFiles.forEach(f => {
-        const guideKey = `${platformName}.${guideName}`;
-        const supported =
-          (!f.frontmatter.supported?.length ||
-            f.frontmatter.supported.includes(guideKey)) &&
-          (!f.frontmatter.notSupported?.length ||
-            !f.frontmatter.notSupported.includes(guideKey));
-        if (!supported) {
+        if (!isSupported(f.frontmatter, platformName, guideName)) {
           return;
         }
 


### PR DESCRIPTION
The previous logic for whether `common` guide pages were applicable based on `supported` and `notSupported` tags was not the same as the old site. It was a little too strict, expecting `supported` to act as an allowlist and `notSupported` as a separate blocklist. Instead, the logic combined the two.

Copied the logic from the old Gatsby site exactly (just renaming the method): https://github.com/getsentry/sentry-docs/blob/405170000995bd8d98bd155f4e8d38ce4c19275a/src/gatsby/createPages/createPlatformPages.ts#L138-L161

Fixes a reported issue where some JavaScript guides were missing Automatic Instrumentation pages.

---

⚠️ Please note that #9056 created Automatic Instrumentation pages for many of the platforms that were missing as a result of this bug. However, the new pages are missing a lot of content.

Gatsby version of Ember Automatic Instrumentation: https://sentry-docs-6x97536mr.sentry.dev/platforms/javascript/guides/ember/performance/instrumentation/automatic-instrumentation/

Current prod version of Ember Automatic Instrumentation: https://sentry-docs-hd1o5x0zq.sentry.dev/platforms/javascript/guides/ember/performance/instrumentation/automatic-instrumentation/

I'm not sure this was intended. cc @lizokm, @mydea ⚠️ 