### PR TITLE
Speed up the build a little more

### DIFF
--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -1,3 +1,5 @@
+import {cache} from 'react';
+
 import {type FrontMatter, getDocsFrontMatter} from 'sentry-docs/mdx';
 
 import {platformsData} from './platformsData';
@@ -21,9 +23,9 @@ function slugWithoutIndex(slug: string): string[] {
   return parts;
 }
 
-export async function getDocsRootNode(): Promise<DocNode | undefined> {
+export const getDocsRootNode = cache(async (): Promise<DocNode | undefined> => {
   return frontmatterToTree(await getDocsFrontMatter());
-}
+});
 
 function frontmatterToTree(frontmatter: FrontMatter[]): DocNode | undefined {
   if (frontmatter.length === 0) {


### PR DESCRIPTION
Caching `getDocsRootNode` improves local build times from 5:19 to 4:39, and also gets rid of a bunch of waiting (the CPU utilization during build according to `time` goes from 74% to 531%).

In Vercel this translated to an improvement from ~26 minutes to ~21 minutes - not huge, but seems worthwhile given the small size of the change.

See #9020.