### PR TITLE
Fix missing header platforms dropdown on 404 page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -4,11 +4,16 @@ import {Header} from 'sentry-docs/components/header';
 import {Navbar} from 'sentry-docs/components/navbar';
 import {productSidebar} from 'sentry-docs/components/serverSidebar';
 import {getDocsRootNode} from 'sentry-docs/docTree';
+import {setServerContext} from 'sentry-docs/serverContext';
 
 import 'sentry-docs/styles/screen.scss';
 
 export default async function NotFound() {
   const rootNode = await getDocsRootNode();
+  setServerContext({
+    rootNode,
+    path: [],
+  });
 
   const sidebar = rootNode && productSidebar(rootNode);
   return (


### PR DESCRIPTION
The `<Navbar>` component expects server context to be set. That's normally done in the `Page` - since `NotFound` acts as an alternative to the `Page` component it must set it too.

Fixes #9000.