### PR TITLE
fix(apple):No screenshot and view hierarchy for app hangs

### DIFF
--- a/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
@@ -14,6 +14,10 @@ When a user experiences an error, an exception or a crash, Sentry provides the a
 
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, taking a screenshot requires the UI thread and in the event of a crash, that might not be available. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 
+<Note>
+App hang events will not have a screenshot because the main thread is blocked and we can't interact with UI elements in a background view.
+</Note>
+
 ## Enabling Screenshots
 
 Screenshots may contain <PlatformLink to="/data-management/sensitive-data/">PII</PlatformLink> and is an opt-in feature. You can enable it as shown below:

--- a/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
@@ -15,7 +15,7 @@ When a user experiences an error, an exception or a crash, Sentry provides the a
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, taking a screenshot requires the UI thread and in the event of a crash, that might not be available. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 
 <Note>
-App hang events will not have a screenshot because the main thread is blocked and we can't interact with UI elements in a background view.
+App hang events will not have a screenshot because the main thread is blocked and Sentry can't interact with UI elements in a background view.
 </Note>
 
 ## Enabling Screenshots

--- a/docs/platforms/apple/common/enriching-events/viewhierarchy/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/viewhierarchy/index.mdx
@@ -15,7 +15,7 @@ Sentry makes it possible to render a JSON representation of the view hierarchy o
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, rendering the view hierarchy requires the UI thread and in the event of a crash, that might not be available. Another example where the view hierarchy might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 
 <Note>
-App hang events will not have view hierarchy because the main thread is blocked and we can't interact with UI elements in a background view.
+App hang events will not have view hierarchy because the main thread is blocked and Sentry can't interact with UI elements in a background view.
 </Note>
 
 <Note>

--- a/docs/platforms/apple/common/enriching-events/viewhierarchy/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/viewhierarchy/index.mdx
@@ -15,6 +15,10 @@ Sentry makes it possible to render a JSON representation of the view hierarchy o
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, rendering the view hierarchy requires the UI thread and in the event of a crash, that might not be available. Another example where the view hierarchy might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 
 <Note>
+App hang events will not have view hierarchy because the main thread is blocked and we can't interact with UI elements in a background view.
+</Note>
+
+<Note>
 
 Deobfuscation for view hierarchies is fully supported for native SDKs, and React Native, but is currently not supported for Flutter. View hierarchies are not supported for SwiftUI.
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Updated screenshot and view hierarchy docs to reflect changes in the app hang not having those informations.