### PR TITLE
build: Update the filepath of resolveOpenAPI.ts

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -23,7 +23,7 @@ jobs:
           git config user.email "bot@getsentry.com"
           git config user.name "openapi-getsentry-bot"
 
-          filepath="src/gatsby/utils/resolveOpenAPI.ts"
+          filepath="src/build/resolveOpenAPI.ts"
           sha="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
           sed -i -e "s|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = '$sha';|g" "$filepath"
 


### PR DESCRIPTION
It looks like resolveOpenAPI.ts got moved when we switched from gastby to nextjs. This is the new path to the file.

https://github.com/getsentry/sentry-docs/blob/36ad36ada4d889a0975a4d3186aae6705fe05df5/src/build/resolveOpenAPI.ts#L13

---

I'm not sure how to test this directly, but the build is currently failing with errors like:
```
Run git config user.email "bot@getsentry.com"
sed: can't read src/gatsby/utils/resolveOpenAPI.ts: No such file or directory
Error: Process completed with exit code 2.
```
OR
```
0s
Run git config user.email "bot@getsentry.com"
sed: -e expression #[1](https://github.com/getsentry/sentry-docs/actions/runs/7723375200/job/21053336128#step:3:1), char 107: unterminated `s' command
Error: Process completed with exit code 1.
```
which i think are the same problem: the file can't be found so the `sed` command has nothing to work on. Certainly a reference to `src/gatsby/utils` is old and needs to change.