### PR TITLE
fix(native): clarify android support

### DIFF
--- a/platform-includes/getting-started-install/native.mdx
+++ b/platform-includes/getting-started-install/native.mdx
@@ -1,4 +1,4 @@
-The Native SDK currently supports **Windows**, **macOS**, and **Linux**. The Native SDK also acts as an **Android** NDK support library in downstream SDKs via the [Android SDK](/platforms/android/configuration/using-ndk/) but currently does not directly support the platform.
+The Native SDK currently supports **Windows**, **macOS**, and **Linux**. The Native SDK also acts as an **Android** NDK support library in downstream SDKs via the [Android SDK](/platforms/android/configuration/using-ndk/), but currently does not directly support the platform.
 
 To build the SDK, download the latest sources from the [Releases page](https://github.com/getsentry/sentry-native/releases). The SDK is managed as a [CMake] project, which additionally supports several configuration options, such as the backend to use.
 

--- a/platform-includes/getting-started-install/native.mdx
+++ b/platform-includes/getting-started-install/native.mdx
@@ -1,4 +1,4 @@
-The Native SDK currently supports **Windows**, **macOS**, **Linux**, and **Android**.
+The Native SDK currently supports **Windows**, **macOS**, and **Linux**. The Native SDK also acts as an **Android** NDK support library in downstream SDKs via the [Android SDK](/platforms/android/configuration/using-ndk/) but currently does not directly support the platform.
 
 To build the SDK, download the latest sources from the [Releases page](https://github.com/getsentry/sentry-native/releases). The SDK is managed as a [CMake] project, which additionally supports several configuration options, such as the backend to use.
 

--- a/platform-includes/getting-started-install/native.qt.mdx
+++ b/platform-includes/getting-started-install/native.qt.mdx
@@ -1,5 +1,5 @@
 The Qt integration is part of the [`sentry-native`](https://github.com/getsentry/sentry-native/) SDK,
-which currently supports Windows, macOS, Linux, and Android. Both Qt 5 and Qt 6 are supported.
+which currently supports Windows, macOS, and Linux. Both Qt 5 and Qt 6 are supported.
 
 To build the SDK, download the latest sources from the [Releases page](https://github.com/getsentry/sentry-native/releases). The SDK is managed as a [CMake] project, which additionally supports several configuration options, such as the backend to use.
 


### PR DESCRIPTION
The Native SDK doesn't support Android directly but acts as a support library for downstream SDKs. The formulation in the documentation needs to be clarified so users can understand the level at which we can support their use cases, which often deviate severely from anything we currently implement, build, or test.

In particular, Qt for Android as a combined supported scenario can easily misinterpreted even though it is not explicitly mentioned. It is better to remove "Android" from the "Getting Started" layer for Qt altogether.

cc: @kahest 
