### PR TITLE
Revert "build: Trim the sha list we get back from github"

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -24,7 +24,7 @@ jobs:
           git config user.name "openapi-getsentry-bot"
 
           filepath="src/build/resolveOpenAPI.ts"
-          sha="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main')" | jq --raw-output .sha
+          sha="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
           sed -i -e "s|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = '$sha';|g" "$filepath"
 
           branch="bot/bump-api-schema-to-${sha:0:8}"


### PR DESCRIPTION
Reverts getsentry/sentry-docs#9086

Seems like builds are not happy with this:
<img width="1121" alt="SCR-20240209-jgyi" src="https://github.com/getsentry/sentry-docs/assets/187460/18ebed47-1430-4cad-9da8-e8dcd0341606">
