### PR TITLE
ref(open-pr-comments): remove from EA list and add javascript/typescript

### DIFF
--- a/docs/product/accounts/early-adopter-features/index.mdx
+++ b/docs/product/accounts/early-adopter-features/index.mdx
@@ -21,5 +21,4 @@ Limitations:
 - [Priority Sort](/product/issues#issue-sort) algorithm improvements
 - [Issue Reprocessing](/product/issues/reprocessing/)
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
-- [Open PR Comments](/product/integrations/source-code-mgmt/github/#open-pull-request-comments)
 - [Investigation Mode](/product/performance/retention-priorities/#investigation-mode) for retention priorities in Performance Monitoring

--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -267,7 +267,7 @@ When a pull request is opened, Sentry will parse the filenames and function name
 
 Sentry will comment on the pull request with up to five issues per file that were first seen within the past 90 days and were last seen within the past 14 days.
 
-This feature requires [code mappings](/product/issues/suspect-commits/#2-set-up-code-mappings) and is currently only supported for Python and Javascript/Typescript files. For Javascript/Typescript, please ensure that you've unminified your code in Sentry.
+This feature requires [code mappings](/product/issues/suspect-commits/#2-set-up-code-mappings) and is currently only supported for Python and Javascript/Typescript files. For Javascript/Typescript, please ensure that you've unminified your code by [setting up source maps](/platforms/javascript/sourcemaps/).
 
 ### Missing Member Detection
 

--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -261,15 +261,13 @@ Sentry will only comment on pull requests less than two weeks old that are assoc
 
 #### Open Pull Request Comments
 
-<Include name="feature-available-for-user-group-early-adopter.mdx" />
-
 When a pull request is opened, Sentry will parse the filenames and function names modified in the pull request from the PR diff to find recent unhandled, unresolved issues associated with your pull request.
 
 ![Sentry comment on open pull request in GitHub](/product/integrations/source-code-mgmt/github/sentry-github-open-pr-comment.png)
 
 Sentry will comment on the pull request with up to five issues per file that were first seen within the past 90 days and were last seen within the past 14 days.
 
-This feature requires [code mappings](/product/issues/suspect-commits/#2-set-up-code-mappings) and is currently only supported for Python files.
+This feature requires [code mappings](/product/issues/suspect-commits/#2-set-up-code-mappings) and is currently only supported for Python and Javascript/Typescript files. For Javascript/Typescript, please ensure that you've unminified your code in Sentry.
 
 ### Missing Member Detection
 


### PR DESCRIPTION
- Removes EA banner and Open PR Comments from the list of EA features
- Adds note about Javascript/Typescript