### PR TITLE
build: Use Accept:application/vnd.github.VERSION.sha to get the latest sha of sentry-api-schema repo

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -20,6 +20,8 @@ jobs:
           # kick off for the PR we're about to create.
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: |
+          set -euo pipefail
+          set -x
           git config user.email "bot@getsentry.com"
           git config user.name "openapi-getsentry-bot"
 

--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -21,13 +21,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: |
           set -euo pipefail
-          set -x
+
           git config user.email "bot@getsentry.com"
           git config user.name "openapi-getsentry-bot"
 
           filepath="src/build/resolveOpenAPI.ts"
+
           sha="$(curl -sSl -H 'Accept: application/vnd.github.VERSION.sha' 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main')"
+          echo "Latest commit to 'getsentry/sentry-api-schema' is $sha"
+
           sed -i -e "s|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = '$sha';|g" "$filepath"
+          echo "Updated $filepath"
 
           branch="bot/bump-api-schema-to-${sha:0:8}"
           git checkout -b "$branch"

--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -24,7 +24,7 @@ jobs:
           git config user.name "openapi-getsentry-bot"
 
           filepath="src/build/resolveOpenAPI.ts"
-          sha="$(curl -sSL 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main' | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "sha" { print $4 }')"
+          sha="$(curl -sSl -H 'Accept: application/vnd.github.VERSION.sha' 'https://api.github.com/repos/getsentry/sentry-api-schema/commits/main')"
           sed -i -e "s|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = '$sha';|g" "$filepath"
 
           branch="bot/bump-api-schema-to-${sha:0:8}"


### PR DESCRIPTION
This is following up on: https://github.com/getsentry/sentry-docs/pull/9086 (reverted in https://github.com/getsentry/sentry-docs/pull/9102)

The reason that initial attempt didn't work isn't clear to me, i think it's because the api response included funky data (sometimes) that would cause two sha's to be returned instead of the one that we expected. I'm not 100% sure exactly, but the logs for failing runs clearly show unexpected things happened like `Switched to a new branch 'bot/bump-api-schema-to-'` where no sha is suffixed to the branch name.

So this takes a different approach: ask for the sha only, and skip all the rest of the parsing business.