### PR TITLE
fix(apple): Clarify trace propagation targets

### DIFF
--- a/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
+++ b/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
@@ -42,7 +42,7 @@ headers to all outgoing requests whose destination contains a string in the list
 
 **The `tracePropagationTargets` option matches the entire request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests don't unnecessarily have additional headers attached.**
 
-The default value of `tracePropagationTargets` is `['.*']`. This means that by default, tracing headers are attached to all requests.
+Since the value of `tracePropagationTargets` is `['.*']` by default, tracing headers are attached to all requests unless otherwise specified.
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
+++ b/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
@@ -35,12 +35,14 @@ Remember that in order to propagate trace information through your whole distrib
 
 ### tracePropagationTargets
 
-Per default, the Cocoa SDK will attach the `sentry-trace` and `baggage` headers to all outgoing requests. You
-can use the allowlist `tracePropagationTargets` to specify to which URLs the Cocoa SDK should send these headers.
-You can put string or regexes into the allowlist, and the SDK then only attaches the `sentry-trace` and `baggage`
-headers to all outgoing requests whose destination contains a string in the list or matches a regex in the list.
+The Cocoa SDK will attach the `sentry-trace` and `baggage` headers to all outgoing requests by default. To narrow
+this down to only specific URLs, add those URLs to the `tracePropagationTargets` allowlist, (you can use both
+string and regexes). The SDK will then only attach the `sentry-trace` and `baggage` headers to outgoing requests
+whose destination either contains a string or matches a regex in your allowlist.
 
-**The `tracePropagationTargets` option matches the entire request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests don't unnecessarily have additional headers attached.**
+<Note>
+The `tracePropagationTargets` option matches the entire request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests don't unnecessarily have additional headers attached.
+</Note>
 
 Since the value of `tracePropagationTargets` is `['.*']` by default, tracing headers are attached to all requests unless otherwise specified.
 

--- a/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
+++ b/docs/platforms/apple/common/usage/distributed-tracing/index.mdx
@@ -32,3 +32,38 @@ If you run any JavaScript applications in your distributed system, make sure tha
 <PlatformContent includePath="distributed-tracing/how-to-use/" />
 
 Remember that in order to propagate trace information through your whole distributed system, you have to use Sentry in all of the involved services and applications. Take a look at the respective SDK documentation to learn how distributed tracing can be enabled for each platform.
+
+### tracePropagationTargets
+
+Per default, the Cocoa SDK will attach the `sentry-trace` and `baggage` headers to all outgoing requests. You
+can use the allowlist `tracePropagationTargets` to specify to which URLs the Cocoa SDK should send these headers.
+You can put string or regexes into the allowlist, and the SDK then only attaches the `sentry-trace` and `baggage`
+headers to all outgoing requests whose destination contains a string in the list or matches a regex in the list.
+
+**The `tracePropagationTargets` option matches the entire request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests don't unnecessarily have additional headers attached.**
+
+The default value of `tracePropagationTargets` is `['.*']`. This means that by default, tracing headers are attached to all requests.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.tracePropagationTargets = [
+        "https://myproject.org",
+        "https://api.otherservice.org/",
+    ]
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.tracePropagationTargets = @[
+        @"https://myproject.org",
+        @"https://api.otherservice.org/"
+    ];
+}];
+```

--- a/platform-includes/distributed-tracing/how-to-use/apple.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/apple.mdx
@@ -1,27 +1,3 @@
 If you're using the current version of our Cocoa SDK, distributed tracing will work out of the box.
 
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.tracePropagationTargets = [
-        "https://myproject.org",
-        "https://api.otherservice.org/",
-    ]
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-    options.tracePropagationTargets = @[
-        @"https://myproject.org",
-        @"https://api.otherservice.org/"
-    ];
-}];
-```
-
 If you're using version `8.10.x` or below, you'll need to have our <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#network-tracking">Network Tracking feature enabled</PlatformLink> in order for distributed tracing to work.


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The trace propagation target code sample was in the section of distributed tracing without an explanation, making the distributed tracing docs for Apple confusing. This is fixed now by adding an explanation and moving the trace propagation target below the distributed tracing section.

