### PR TITLE
ref(js): Update and fix browser profiling integration code snippets

### DIFF
--- a/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
@@ -5,8 +5,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    new Sentry.BrowserTracing(),
-    new Sentry.BrowserProfilingIntegration(),
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
@@ -1,11 +1,10 @@
-```javascript {filename:entry.client.tsx}
-import * as Sentry from "@sentry/remix";
+```javascript
+import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
     Sentry.browserProfilingIntegration(),
   ],
 

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
@@ -5,8 +5,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-   Sentry.browserTracingIntegration(),
-   Sentry.browserTracingIntegration(),
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
@@ -5,7 +5,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    new Sentry.BrowserProfilingIntegration(),
+    Sentry.browserProfilingIntegration(),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Just noticed via https://github.com/getsentry/sentry-javascript/issues/10599 that some of the browser profiling docs still mentioned the deprecated integration classes