### PR TITLE
update project permissions

### DIFF
--- a/docs/product/accounts/membership.mdx
+++ b/docs/product/accounts/membership.mdx
@@ -13,7 +13,7 @@ Permissions in Sentry are broadly handled using [organization-level roles](#orga
 All users and their organization-level roles are listed in **Settings > Members**. Users can hold any of the following org-level roles:
 
 - **Billing** users can manage payment and compliance details.
-- **Org Members** can view most data in the organization and act on issues. They can join and leave teams, and access projects their teams own.
+- **Org Members** can view most data in the organization and act on issues. They can join and leave teams, and access projects their teams own.  For Business and Enterprise plans, members can also create personal projects.
 - **Org Admins** can edit global integrations, manage projects, and add/remove teams. They automatically assume the Team Admin role for teams they join. **Note**: This role can no longer be assigned in Business and Enterprise plans.
 - **Org Managers** have full management access to all teams and projects. They can also manage the organization's membership. Org Managers can perform Team Admin actions without needing to join the team.
 - **Org Owners** have full access to the organization, its data, and settings. Org Owners can perform Team Admin actions without needing to join the team.
@@ -37,7 +37,7 @@ Organization-level roles enable broad access to the entire organization, as desc
 | Can add repositories (through GitHub integrations)                              |             | ✓          | ✓         | ✓           | ✓         |
 | Can create and remove teams from the organization                               |             |            | ✓         | ✓           | ✓         |
 | Can change project settings                                                     |             |            | ✓         | ✓           | ✓         |
-| Can create and remove projects for the organization                             |             |            | ✓         | ✓           | ✓         |
+| Can create and remove projects for the organization                             |             | ✓\*        | ✓         | ✓           | ✓         |
 | Can edit Global Integrations                                                    |             |            | ✓         | ✓           | ✓         |
 | Can remove repositories                                                         |             |            | ✓         | ✓           | ✓         |
 | Can add, remove, and change Org Members                                         |             |            |           | ✓           | ✓         |
@@ -48,6 +48,8 @@ Organization-level roles enable broad access to the entire organization, as desc
 | Can remove projects from teams                                                  |             |            |           | ✓           | ✓         |
 | Can transfer projects to another organization                                   |             |            |           |             | ✓         |
 | Can remove an organization                                                      |             |            |           |             | ✓         |
+
+\*For Business and Enterprise plans, Org Members who are not a Team Admin for any team can create a new personal project. When creating this project, the member can add a new personal team that they will become a Team Admin for. [Team Admin permissions](#permissions-1) will then apply for this team.
 
 ## Team-level Roles
 
@@ -64,7 +66,11 @@ Only Org Admins, Managers, and Owners can add new teams to an organization. User
 - **Team Contributors** can view and act on issues. Depending on the organization rules, they can also add members to the team.
 - **Team Admins** have additional permissions to manage their team's membership and projects. These permissions are granted at the team-level, and don't apply to teams where they're not a Team Admin.
 
-Org Members can be Team Admins for specific teams, but they can't add new teams. Org Admins automatically become Team Admins when they join a team. Org Managers and Owners can perform Team Admin actions for all teams without needing to join.
+Org Members can join teams as a Team Contributor and be assigned Team Admin for specific teams. Org Members who are not a Team Admin for any team can create a new personal project and personal team once, and become Team Admin for that team.
+
+Org Admins automatically become Team Admins when they join a team.
+
+Org Managers and Owners can perform Team Admin actions for all teams without needing to join.
 
 ### Permissions
 

--- a/docs/product/accounts/membership.mdx
+++ b/docs/product/accounts/membership.mdx
@@ -13,7 +13,7 @@ Permissions in Sentry are broadly handled using [organization-level roles](#orga
 All users and their organization-level roles are listed in **Settings > Members**. Users can hold any of the following org-level roles:
 
 - **Billing** users can manage payment and compliance details.
-- **Org Members** can view most data in the organization and act on issues. They can join and leave teams, and access projects their teams own.  For Business and Enterprise plans, members can also create personal projects.
+- **Org Members** can view most data in the organization and act on issues. They can join and leave teams, and access projects their teams own. For Business and Enterprise plans, members can also create personal projects.
 - **Org Admins** can edit global integrations, manage projects, and add/remove teams. They automatically assume the Team Admin role for teams they join. **Note**: This role can no longer be assigned in Business and Enterprise plans.
 - **Org Managers** have full management access to all teams and projects. They can also manage the organization's membership. Org Managers can perform Team Admin actions without needing to join the team.
 - **Org Owners** have full access to the organization, its data, and settings. Org Owners can perform Team Admin actions without needing to join the team.

--- a/docs/product/accounts/membership.mdx
+++ b/docs/product/accounts/membership.mdx
@@ -49,7 +49,7 @@ Organization-level roles enable broad access to the entire organization, as desc
 | Can transfer projects to another organization                                   |             |            |           |             | ✓         |
 | Can remove an organization                                                      |             |            |           |             | ✓         |
 
-\*For Business and Enterprise plans, Org Members who are not a Team Admin for any team can create a new personal project. When creating this project, the member can add a new personal team that they will become a Team Admin for. [Team Admin permissions](#permissions-1) will then apply for this team.
+\*For Business and Enterprise plans, even Org Members who are not a Team Admin for any team can create a new personal project. When creating this project, the member will get assigned a new personal team that they will become a Team Admin for. [Team Admin permissions](#permissions-1) will then apply for this team.
 
 ## Team-level Roles
 


### PR DESCRIPTION
Update docs to reflect how org members can create a new project

replaces https://github.com/getsentry/sentry-docs/pull/8725 due to migration and removes mention or org settings which haven't been implemented yet.