### PR TITLE
ref(astro): Add Netlify adapter compatibility note

### DIFF
--- a/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -19,3 +19,4 @@ Before we get started, make sure you have the following:
 - A Node runtime:
   - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions).
     Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
+- If you're using Astro's Netflify adapter (`@astrojs/netlify`), only version 5.0.0 or newer is supported.

--- a/platform-includes/getting-started-primer/javascript.astro.mdx
+++ b/platform-includes/getting-started-primer/javascript.astro.mdx
@@ -19,4 +19,4 @@ Before we get started, make sure you have the following:
 - A Node runtime:
   - This SDK currently only works on Node runtimes (e.g. Node adapter, Vercel with Lambda functions).
     Non-Node runtimes, like Vercel's Edge runtime or Cloudflare Pages, are currently not supported.
-- If you're using Astro's Netflify adapter (`@astrojs/netlify`), only version 5.0.0 or newer is supported.
+- If you're using Astro's Netflify adapter (`@astrojs/netlify`), you need version `5.0.0` or newer.


### PR DESCRIPTION
We were notified that the Astro SDK cause runtime errors when an Astro app is deployed to Netlify using the  Netlify adapter <5.0.0. There seems to be a bug in the adapter that causes `@sentry/cli` to be bundled and required at runtime which shouldn't happen.  
The issues are resolved after upgrading to version 5.x of the adapter, so let's set this as a minimum version.