### PR TITLE
Deno arguments are not in the correct order

### DIFF
--- a/platform-includes/getting-started-config/javascript.deno.mdx
+++ b/platform-includes/getting-started-config/javascript.deno.mdx
@@ -15,5 +15,5 @@ To ensure the SDK can send events, you should enable network access for your
 ingestion domain:
 
 ```bash
-deno run index.ts --allow-net=___ORG_INGEST_DOMAIN___
+deno run --allow-net=___ORG_INGEST_DOMAIN___ index.ts
 ```

--- a/platform-includes/getting-started-sourcemaps/javascript.deno.mdx
+++ b/platform-includes/getting-started-sourcemaps/javascript.deno.mdx
@@ -3,5 +3,5 @@
 To ensure the SDK can include your source code in stack traces, you should enable read access for your source files:
 
 ```bash
-deno run index.ts --allow-read=./src
+deno run --allow-read=./src index.ts 
 ```


### PR DESCRIPTION
When testing this Deno CLI complained about the order of arguments in the script. This is how i tried it from the docs


![image](https://github.com/getsentry/sentry-docs/assets/47563310/f0e575bb-7a82-4abb-9bf5-84df56bc4196)


```
me@me deno-edge-hello-world % deno run index.ts --allow-net=xxxxx.ingest.sentry.io

Permission flags have likely been incorrectly set after the script argument.
To grant permissions, set them before the script argument. For example:
    deno run --allow-read=. main.js
error: Module not found "file:///Users/steveneubank/Desktop/deno-edge-hello-world/index.ts".
```

Flipping the order as instructed works

