### PR TITLE
fix(native): provide an example for the breadcrumb data property

### DIFF
--- a/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/native.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/native.mdx
@@ -5,4 +5,17 @@ sentry_value_t crumb = sentry_value_new_breadcrumb("default", "Authenticated use
 sentry_value_set_by_key(crumb, "category", sentry_value_new_string("auth"));
 sentry_value_set_by_key(crumb, "level", sentry_value_new_string("info"));
 sentry_add_breadcrumb(crumb);
+
+// to add `data` to a breadcrumb you must create a wrapping `object` which maps
+// to the expected dictionary structure:
+sentry_value_t http_data = sentry_value_new_object();
+sentry_value_set_by_key(http_data, "url", sentry_value_new_string("https://example.com/api/1.0/users"));
+sentry_value_set_by_key(http_data, "method", sentry_value_new_string("GET"));
+sentry_value_set_by_key(http_data, "status_code", sentry_value_new_int32(200));
+sentry_value_set_by_key(http_data, "reason", sentry_value_new_string("OK"));
+
+sentry_value_t http_crumb = sentry_value_new_breadcrumb("http", NULL);
+sentry_value_set_by_key(http_crumb, "category", sentry_value_new_string("xhr"));
+sentry_value_set_by_key(http_crumb, "data", http_data);
+sentry_add_breadcrumb(http_crumb);
 ```


### PR DESCRIPTION
In the same vein as this: https://github.com/getsentry/sentry-native/pull/951

There is currently no example in the docs that clarifies the necessity of a wrapping object for the `data` property in breadcrumbs. Users tried to assign JSON as a string for instance.

The example is straight out of the develop docs: https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types. Not sure if we should mention this, because the surroundings docs already do.

cc: @kahest 