### PR TITLE
Add basic automated exception capturing for Ruby

### DIFF
--- a/platform-includes/getting-started-config/ruby.mdx
+++ b/platform-includes/getting-started-config/ruby.mdx
@@ -16,3 +16,14 @@ Sentry.init do |config|
   end
 end
 ```
+
+Note that this will only set up Sentry, but **not** capture any exceptions automatically.
+Setting up automatic exception capturing is usually done by adding the Sentry extension
+corresponding to your framework. If you cannot find a Sentry extension which meets your needs,
+you can add the following code.
+
+```ruby
+at_exit do
+  Sentry.capture_exception($!) if $!
+end
+```

--- a/platform-includes/getting-started-config/ruby.mdx
+++ b/platform-includes/getting-started-config/ruby.mdx
@@ -17,10 +17,10 @@ Sentry.init do |config|
 end
 ```
 
-Note that this will only set up Sentry, but **not** capture any exceptions automatically.
+The code above will only set up Sentry, **not** capture any exceptions automatically.
 Setting up automatic exception capturing is usually done by adding the Sentry extension
 corresponding to your framework. If you cannot find a Sentry extension which meets your needs,
-you can add the following code.
+you can add the following code:
 
 ```ruby
 at_exit do


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Most developers are used to adding Sentry's Ruby gems to a Rails application where it starts to capture
any unrescued exception _out of the box_. This is not the case when writing a bare-bones Ruby application from scratch.
This commit adds a suggestion how to add automatic exception capturing for such minimal applications.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
