### PR TITLE
Cleanup Astro upload page

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -30,20 +30,7 @@ export default defineConfig({
 
 ### Disable Source Maps Upload
 
-You can disable automatic source maps upload in your Astro config:
-
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentry({
-      // Other Sentry options
-      sourceMapsUploadOptions: {
-        enabled: false,
-      },
-    }),
-  ],
-});
-```
+You can disable automatic source maps upload in your Astro configuration with `enabled: false` under `sourceMapsUploadOptions`
 
 ### Setting the Source Maps Assets Directory
 
@@ -88,17 +75,5 @@ export default defineConfig({
 The Astro SDK uses the Sentry Vite plugin to upload source maps.
 This plugin collects telemetry data to help us improve the source map uploading experience.
 Read more about this in our [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin#telemetry).
-You can disable telemetry collection by setting `telemetry` to `false`:
+You can disable telemetry collection by setting `telemetry:`false` under `sourceMapsUploadOptions`.
 
-```javascript {filename:astro.config.mjs}
-export default defineConfig({
-  integrations: [
-    sentry({
-      // Other Sentry options
-      sourceMapsUploadOptions: {
-        telemetry: false,
-      },
-    }),
-  ],
-});
-```


### PR DESCRIPTION
Astro's source map uploads includes a lot of snippet variations. I think this is distracting and we can stick what we promtoe and reduce the rest, and move the legacy token to the legacy uploading methods

