### PR TITLE
chore(native): add note that standalone native sdk is experimental

### DIFF
--- a/platform-includes/getting-started-primer/native.mdx
+++ b/platform-includes/getting-started-primer/native.mdx
@@ -1,5 +1,11 @@
 The Sentry Native SDK is intended for C and C++. However, since it builds as a dynamic library and exposes C-bindings, it can be used by any language that supports interoperability with C, such as the Foreign Function Interface (FFI).
 
+<Note>
+
+Using the `sentry-native` SDK in a standalone use case is currently an experimental feature. The SDK’s primary function is to fuel our other SDKs, like [`sentry-java`](https://github.com/getsentry/sentry-java) or [`sentry-unreal`](https://github.com/getsentry/sentry-unreal). Support from our side is best effort and we do what we can to respond to issues in a timely fashion, but please understand if we won’t be able to address your issues or feature suggestions.
+
+</Note>
+
 Sentry also offers higher-level SDKs for platforms with built-in support for native crashes:
 
 - [_Android_](/platforms/android/)


### PR DESCRIPTION
related: https://github.com/getsentry/sentry-native/pull/952

cc @supervacuus 