### PR TITLE
ref(python): Add a warning about uWSGI to all WSGI frameworks

### DIFF
--- a/docs/platforms/python/integrations/bottle/index.mdx
+++ b/docs/platforms/python/integrations/bottle/index.mdx
@@ -56,13 +56,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 - The Sentry Python SDK will install the Bottle integration for all of your apps. The integration hooks into base Bottle class.
 

--- a/docs/platforms/python/integrations/bottle/index.mdx
+++ b/docs/platforms/python/integrations/bottle/index.mdx
@@ -56,6 +56,14 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 - The Sentry Python SDK will install the Bottle integration for all of your apps. The integration hooks into base Bottle class.
 
 - All exceptions leading to an Internal Server Error are reported.

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -55,13 +55,7 @@ urlpatterns = [
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 ### Issue Reporting
 

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -55,6 +55,14 @@ urlpatterns = [
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 ### Issue Reporting
 
 - If you use `django.contrib.auth` and you've set `send_default_pii=True` in your call to `init`, user data (such as current user id, email address, username) will be attached to error events.

--- a/docs/platforms/python/integrations/falcon/index.mdx
+++ b/docs/platforms/python/integrations/falcon/index.mdx
@@ -58,6 +58,14 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 - The Sentry Python SDK will install the Falcon integration for all of your apps. The integration hooks into the base `falcon.API` class via monkey patching.
 
 - All exceptions leading to an Internal Server Error are reported.

--- a/docs/platforms/python/integrations/falcon/index.mdx
+++ b/docs/platforms/python/integrations/falcon/index.mdx
@@ -58,13 +58,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 - The Sentry Python SDK will install the Falcon integration for all of your apps. The integration hooks into the base `falcon.API` class via monkey patching.
 

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -58,6 +58,14 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 After initialization:
 
 - If you use `flask-login` and set `send_default_pii=True` in your call to `init`, user data (current user id, email address, username) will be attached to the event.

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -58,13 +58,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 After initialization:
 

--- a/docs/platforms/python/integrations/pyramid/index.mdx
+++ b/docs/platforms/python/integrations/pyramid/index.mdx
@@ -60,13 +60,7 @@ When you point your browser to [http://localhost:6543/](http://localhost:6543/) 
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 - The Sentry Python SDK will install the Pyramid integration for all of your apps. The integration hooks into Pyramid itself, not any of your apps specifically.
 

--- a/docs/platforms/python/integrations/pyramid/index.mdx
+++ b/docs/platforms/python/integrations/pyramid/index.mdx
@@ -60,6 +60,14 @@ When you point your browser to [http://localhost:6543/](http://localhost:6543/) 
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 - The Sentry Python SDK will install the Pyramid integration for all of your apps. The integration hooks into Pyramid itself, not any of your apps specifically.
 
 - The SDK will report all exceptions leading to an Internal Server Error. These two kinds of exceptions are:

--- a/docs/platforms/python/integrations/wsgi/index.mdx
+++ b/docs/platforms/python/integrations/wsgi/index.mdx
@@ -60,13 +60,7 @@ make_server('', 8000, app).serve_forever()
 
 ## Behavior
 
-<Alert level="warning" title="uWSGI and Sentry SDK">
-
-If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
-
-To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
-
-</Alert>
+<Include name="python-uwsgi-warning.mdx" />
 
 - Request data is attached to all events: **HTTP method, URL, headers**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 

--- a/docs/platforms/python/integrations/wsgi/index.mdx
+++ b/docs/platforms/python/integrations/wsgi/index.mdx
@@ -60,6 +60,14 @@ make_server('', 8000, app).serve_forever()
 
 ## Behavior
 
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>
+
 - Request data is attached to all events: **HTTP method, URL, headers**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
 Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.

--- a/includes/python-uwsgi-warning.mdx
+++ b/includes/python-uwsgi-warning.mdx
@@ -1,0 +1,7 @@
+<Alert level="warning" title="uWSGI and Sentry SDK">
+
+If you're using uWSGI, note that it doesn't support threads by default. This might lead to unexpected behavior when using the Sentry SDK, from features not working properly to uWSGI workers crashing.
+
+To enable threading support in uWSGI, make sure you have both `--enable-threads` and `--py-call-uwsgi-fork-hooks` on.
+
+</Alert>


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We've had bug reports from folks in the Python SDK that were due to incorrect uWSGI server setup. Since the impact of such misconfiguration can be severe (uWSGI workers crashing), we should call this out in the docs of all integrations that can be used with uWSGI.

See https://github.com/getsentry/sentry-python/pull/2738

Note to the docs team: If there's a way to reuse the same warning on multiple pages, please let me know!