### PR TITLE
Bold and separate instructions for adding init code before loader script

### DIFF
--- a/docs/platforms/javascript/common/install/loader.mdx
+++ b/docs/platforms/javascript/common/install/loader.mdx
@@ -94,7 +94,7 @@ You can configure the release by adding the following to your page:
 
 The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to <PlatformLink to="/configuration/options/">configure your SDK</PlatformLink> beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. 
 
-*Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:*
+**Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:**
 
 ```html
 <script>

--- a/docs/platforms/javascript/common/install/loader.mdx
+++ b/docs/platforms/javascript/common/install/loader.mdx
@@ -92,7 +92,9 @@ You can configure the release by adding the following to your page:
 
 ### Custom Configuration
 
-The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to <PlatformLink to="/configuration/options/">configure your SDK</PlatformLink> beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:
+The loader script always includes a call to `Sentry.init` with a default configuration, including your DSN. If you want to <PlatformLink to="/configuration/options/">configure your SDK</PlatformLink> beyond that, you can configure a custom init call by defining a `window.sentryOnLoad` function. Whatever is defined inside of this function will _always_ be called first, before any other SDK method is called. 
+
+*Be sure to define this function _before_ you add the loader script, to ensure it can be called at the right time:*
 
 ```html
 <script>


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Splitting out and bolding the instruction to include the Sentry.init code _before_ the loader script for Browser JavaScript.

Note: I missed this instruction MULTIPLE times so hopefully this helps other people with my limited reading and comprehension skills. 😅

