### PR TITLE
fix(capacitor): correct min version  for Sentry Capacitor

### DIFF
--- a/platform-includes/session-replay/pre-requisites/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/pre-requisites/javascript.capacitor.mdx
@@ -1,4 +1,4 @@
-For the sentry-replay integration to work, you must have the [Sentry Capacitor SDK package](https://www.npmjs.com/package/@sentry/capacitor) installed. The minimum version required for the SDK is `0.12.3`.
+For the sentry-replay integration to work, you must have the [Sentry Capacitor SDK package](https://www.npmjs.com/package/@sentry/capacitor) installed. The minimum version required for the SDK is `0.11.0`.
 If you're on an older version of the SDK, please check the [troubleshooting
 document to help on
 migration](/platforms/javascript/guides/capacitor/troubleshooting/).

--- a/platform-includes/session-replay/setup/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/setup/javascript.capacitor.mdx
@@ -1,7 +1,7 @@
 Several options are supported and passable using the integration constructor. See the [configuration documentation](/platforms/javascript/guides/capacitor/session-replay/configuration/) for more details. To set up the integration, add the following to your Sentry initialization:
 
 <Note>
-  The minimal supported version of Sentry's SDK for Capacitor is 0.11.1.
+  The minimal supported version of Sentry's SDK for Capacitor is 0.11.0.
 </Note>
 
 <SignInNote />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Just a nit here the minimum version that supports Replay on Capacitor is 0.11.0

It can be validated here: https://github.com/getsentry/sentry-capacitor/blob/main/CHANGELOG.md#0110 
## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
