### PR TITLE
fix: Reverse logic to explicitly just check for IS_PRODUCTION

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 const createMDX = require('@next/mdx');
 const remarkPrism = require('remark-prism');
 
-const isProd = process.env.NODE_ENV === 'production' && !process.env.IS_PREVIEW;
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   headers() {
@@ -13,7 +11,7 @@ const nextConfig = {
       },
     ];
   },
-  assetPrefix: isProd ? 'https://docs.sentry.io' : undefined,
+  assetPrefix: process.env.IS_PRODUCTION ? 'https://docs.sentry.io' : undefined,
 
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
 


### PR DESCRIPTION
This is to fix preview builds and asset loading - we only want to load assets with absolute URL in production