### PR TITLE
ref: Don't use Image for rewrite

### DIFF
--- a/app/changelog/header.tsx
+++ b/app/changelog/header.tsx
@@ -1,12 +1,10 @@
-import Image from 'next/image';
-
 export default function Header({loading}) {
   return (
     <div className="w-full mx-auto h-96 relative bg-darkPurple">
       <div className="relative w-full lg:max-w-7xl mx-auto px-4 lg:px-8 pt-8 grid grid-cols-12 items-center">
-        <Image
+        <img
           className={`justify-self-center col-span-10 z-20 hidden lg:block ${loading ? 'animate-fade-in-left' : ''}`}
-          src="/changelog/assets/hero.png"
+          src="https://docs.sentry.io/changelog/assets/hero.png"
           alt="Sentry Changelog"
           height={273}
           width={450}

--- a/src/components/changelog/article.tsx
+++ b/src/components/changelog/article.tsx
@@ -1,5 +1,4 @@
 import {ReactNode} from 'react';
-import Image from 'next/image';
 
 import Date from './date';
 import Tag from './tag';
@@ -31,15 +30,11 @@ export default function Article({
   return (
     <article className={`bg-white rounded-lg shadow-lg mb-8 ${className}`}>
       {image && (
-        <div className="relative w-full h-64">
-          <Image
-            className="object-cover rounded-lg rounded-b-none"
-            src={image}
-            fill
-            alt={title}
-            sizes="(max-width: 768px) 100vw"
-          />
-        </div>
+        <img
+          className="object-cover relative w-full h-64 rounded-lg rounded-b-none"
+          src={image}
+          alt={title}
+        />
       )}
       <div className="p-6">
         <h3 className="text-3xl text-primary font-semibold mb-2">{title}</h3>


### PR DESCRIPTION
For our rewrite from sentry.io/changelog the Next.js Image component doesn't seem to work