### PR TITLE
Fix caching during build

### DIFF
--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -1,5 +1,3 @@
-import {cache} from 'react';
-
 import {type FrontMatter, getDocsFrontMatter} from 'sentry-docs/mdx';
 
 import {platformsData} from './platformsData';
@@ -23,9 +21,19 @@ function slugWithoutIndex(slug: string): string[] {
   return parts;
 }
 
-export const getDocsRootNode = cache(async (): Promise<DocNode | undefined> => {
+let getDocsRootNodeCache: Promise<DocNode | undefined> | undefined;
+
+export function getDocsRootNode(): Promise<DocNode | undefined> {
+  if (getDocsRootNodeCache) {
+    return getDocsRootNodeCache;
+  }
+  getDocsRootNodeCache = getDocsRootNodeUncached();
+  return getDocsRootNodeCache;
+}
+
+async function getDocsRootNodeUncached(): Promise<DocNode | undefined> {
   return frontmatterToTree(await getDocsFrontMatter());
-});
+}
 
 function frontmatterToTree(frontmatter: FrontMatter[]): DocNode | undefined {
   if (frontmatter.length === 0) {

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import {cache} from 'react';
 import matter from 'gray-matter';
 import {s} from 'hastscript';
 import yaml from 'js-yaml';
@@ -56,10 +55,18 @@ const isSupported = (
 
 export type FrontMatter = {[key: string]: any};
 
-export const allDocsFrontMatter = getAllFilesFrontMatter();
+let getDocsFrontMatterCache: Promise<FrontMatter[]> | undefined;
 
-export const getDocsFrontMatter = cache(async (): Promise<FrontMatter[]> => {
-  const frontMatter = [...allDocsFrontMatter];
+export function getDocsFrontMatter(): Promise<FrontMatter[]> {
+  if (getDocsFrontMatterCache) {
+    return getDocsFrontMatterCache;
+  }
+  getDocsFrontMatterCache = getDocsFrontMatterUncached();
+  return getDocsFrontMatterCache;
+}
+
+async function getDocsFrontMatterUncached(): Promise<FrontMatter[]> {
+  const frontMatter = getAllFilesFrontMatter();
 
   const categories = await apiCategories();
   categories.forEach(category => {
@@ -77,7 +84,7 @@ export const getDocsFrontMatter = cache(async (): Promise<FrontMatter[]> => {
   });
 
   return frontMatter;
-});
+}
 
 export function getAllFilesFrontMatter(folder: string = 'docs'): FrontMatter[] {
   const docsPath = path.join(root, folder);

--- a/src/platformsData.ts
+++ b/src/platformsData.ts
@@ -1,12 +1,21 @@
 import fs from 'fs';
 import path from 'path';
 
-import {cache} from 'react';
 import yaml from 'js-yaml';
 
 const root = process.cwd();
 
-export const platformsData = cache(() => {
+let platformsDataCache: {} | undefined;
+
+export function platformsData(): {} {
+  if (platformsDataCache) {
+    return platformsDataCache;
+  }
+  platformsDataCache = platformsDataUncached();
+  return platformsDataCache;
+}
+
+function platformsDataUncached(): {} {
   try {
     const data = yaml.load(
       // @ts-ignore
@@ -22,4 +31,4 @@ export const platformsData = cache(() => {
     console.error('failed to read platforms.yml:', e);
     return {};
   }
-});
+}


### PR DESCRIPTION
React's `cache` function does not work the way I expected, and actually wasn't caching properly. Replace usages of it with memoization, which is more verbose but definitely works.

Locally, this sped up `yarn build` to 201 seconds, which is much faster than the previous local build time.
