### PR TITLE
add extra clarity to start span snippet

### DIFF
--- a/platform-includes/performance/start-span/javascript.mdx
+++ b/platform-includes/performance/start-span/javascript.mdx
@@ -1,4 +1,4 @@
-You can use the `Sentry.startSpan` method to wrap a callback in a span to measure how long it will take. The span will automatically be finished when the callback finishes. This works with both synchronous and async callbacks.
+You can use the `Sentry.startSpan` method to wrap a callback in a span to measure how long it will take. The span will automatically be finished when the callback finishes. This works with both synchronous and async callbacks, but automatically finishes async callbacks based on the promise that is returned from the callback. In cases where you need to manually finish the span (because you don't return anything), you can use `Sentry.startSpanManual`, documented below this snippet.
 
 ```javascript
 const result = Sentry.startSpan({ name: "Important Function" }, () => {


### PR DESCRIPTION
Add extra note about `startSpanManual`, and clarify start span behaviour around returning callbacks.