### PR TITLE
fix: Config option typo in `attachViewhierarchy`

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -155,7 +155,7 @@ _(New in version 6.0.0)_
 
 </ConfigKey>
 
-<ConfigKey name="attach-viewhierarchy">
+<ConfigKey name="attach-view-hierarchy">
 
 Renders a JSON representation of the entire view hierarchy of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with the view hierarchy in our <PlatformLink to="/enriching-events/viewhierarchy/">View Hierarchy documentation</PlatformLink>.

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -168,7 +168,7 @@ Learn more about enriching events with screenshots in our <PlatformLink to="/enr
 
 </ConfigKey>
 
-<ConfigKey name="attach-viewhierarchy" supported={["apple.ios"]}>
+<ConfigKey name="attach-view-hierarchy" supported={["apple.ios"]}>
 
 Renders a JSON representation of the entire view hierarchy of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with the view hierarchy in our <PlatformLink to="/enriching-events/viewhierarchy/">View Hierarchy documentation</PlatformLink>.

--- a/docs/platforms/flutter/configuration/options.mdx
+++ b/docs/platforms/flutter/configuration/options.mdx
@@ -161,7 +161,7 @@ The quality of the attached screenshot. It can be set to `full`, `high`, `medium
 
 </ConfigKey>
 
-<ConfigKey name="attach-viewhierarchy">
+<ConfigKey name="attach-view-hierarchy">
 
 Renders a JSON representation of the entire view hierarchy of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with the view hierarchy in our <PlatformLink to="/enriching-events/viewhierarchy/">View Hierarchy documentation</PlatformLink>.

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -146,7 +146,7 @@ _(New in version 4.11.0)_
 
 </ConfigKey>
 
-<ConfigKey name="attach-viewhierarchy">
+<ConfigKey name="attach-view-hierarchy">
 
 Renders a JSON representation of the entire view hierarchy of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with the view hierarchy in our <PlatformLink to="/enriching-events/viewhierarchy/">View Hierarchy documentation</PlatformLink>.


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-docs/issues/8794
for all applicable platforms