### PR TITLE
Include a warning about alpha on node metrics integration docs

### DIFF
--- a/docs/platforms/node/common/metrics/index.mdx
+++ b/docs/platforms/node/common/metrics/index.mdx
@@ -3,6 +3,8 @@ title: Set Up Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your JavaScript app."
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
+
 <PlatformContent includePath="metrics/version-support-note" />
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.


### PR DESCRIPTION
I spent time implementing this and being confused by nothing showing up in my dashboards. I didn't realize Sentry Metrics was _another product_, with a waitlist and all that.

## Pre-merge checklist

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.