### PR TITLE
Revert "Add Changelog Maintence (#9236)"

### DIFF
--- a/app/changelog/%5Fadmin/[id]/edit/page.tsx
+++ b/app/changelog/%5Fadmin/[id]/edit/page.tsx
@@ -7,7 +7,7 @@ import {ForwardRefEditor} from 'sentry-docs/components/changelog/forwardRefEdito
 import {TitleSlug} from 'sentry-docs/components/changelog/titleSlug';
 import {Button} from 'sentry-docs/components/changelog/ui/Button';
 import {Select} from 'sentry-docs/components/changelog/ui/Select';
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 export default async function ChangelogCreatePage({params}) {
   const categories = await prisma.category.findMany({

--- a/app/changelog/%5Fadmin/[id]/edit/page.tsx
+++ b/app/changelog/%5Fadmin/[id]/edit/page.tsx
@@ -1,0 +1,96 @@
+import {Fragment, Suspense} from 'react';
+import Link from 'next/link';
+
+import {editChangelog} from 'sentry-docs/actions/changelog';
+import {FileUpload} from 'sentry-docs/components/changelog/fileUpload';
+import {ForwardRefEditor} from 'sentry-docs/components/changelog/forwardRefEditor';
+import {TitleSlug} from 'sentry-docs/components/changelog/titleSlug';
+import {Button} from 'sentry-docs/components/changelog/ui/Button';
+import {Select} from 'sentry-docs/components/changelog/ui/Select';
+import {prisma} from 'sentry-docs/prisma';
+
+export default async function ChangelogCreatePage({params}) {
+  const categories = await prisma.category.findMany({
+    orderBy: {
+      name: 'asc',
+    },
+  });
+  const changelog = await prisma.changelog.findUnique({
+    where: {id: params.id},
+    include: {
+      author: true,
+      categories: true,
+    },
+  });
+
+  if (!changelog) {
+    return (
+      <Fragment>
+        <header>
+          <h2>Changelog not found</h2>
+        </header>
+        <footer>
+          <Link href="/changelogs">Return to Changelogs list</Link>
+        </footer>
+      </Fragment>
+    );
+  }
+
+  return (
+    <section className="overflow-x-auto col-start-3 col-span-8">
+      <form action={editChangelog} className="px-2 w-full">
+        <input type="hidden" name="id" value={changelog.id} />
+        <TitleSlug defaultSlug={changelog.slug} defaultTitle={changelog.title} />
+        <FileUpload defaultFile={changelog.image || ''} />
+        <div className="my-6">
+          <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
+            Summary
+            <Fragment>
+              &nbsp;<span className="font-bold text-secondary">*</span>
+            </Fragment>
+          </label>
+          <textarea name="summary" className="w-full" required>
+            {changelog.summary}
+          </textarea>
+          <span className="text-xs text-gray-500 italic">
+            This will be shown in the list
+          </span>
+        </div>
+        <div>
+          <Select
+            name="categories"
+            className="mt-1 mb-6"
+            label="Category"
+            placeholder="Select Category"
+            defaultValue={changelog.categories.map(category => ({
+              label: category.name,
+              value: category.name,
+            }))}
+            options={categories.map(category => ({
+              label: category.name,
+              value: category.name,
+            }))}
+            isMulti
+          />
+        </div>
+
+        <Suspense fallback={null}>
+          <ForwardRefEditor
+            name="content"
+            defaultValue={changelog.content || ''}
+            className="w-full"
+          />
+        </Suspense>
+
+        <footer className="flex items-center justify-between mt-2 mb-8">
+          <Link href="/changelog/_admin" className="underline text-gray-500">
+            Return to Changelogs list
+          </Link>
+          <div>
+            <Button type="submit">Update</Button>
+          </div>
+        </footer>
+      </form>
+    </section>
+  );
+}

--- a/app/changelog/%5Fadmin/confirm.tsx
+++ b/app/changelog/%5Fadmin/confirm.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+export default function Confirm({changelog, action, children}) {
+  return (
+    <form
+      action={action}
+      className="inline-block"
+      onSubmit={e => {
+        e.preventDefault();
+        // eslint-disable-next-line no-alert
+        if (confirm('Are you sure?')) {
+          action(new FormData(e.currentTarget));
+        }
+      }}
+    >
+      <input type="hidden" name="id" value={changelog.id} />
+      <button
+        type="submit"
+        className="text-indigo-600 hover:bg-indigo-100 rounded-md px-1 py-2 text-xs whitespace-nowrap"
+      >
+        {children}
+      </button>
+    </form>
+  );
+}

--- a/app/changelog/%5Fadmin/create/page.tsx
+++ b/app/changelog/%5Fadmin/create/page.tsx
@@ -7,7 +7,7 @@ import {ForwardRefEditor} from 'sentry-docs/components/changelog/forwardRefEdito
 import {TitleSlug} from 'sentry-docs/components/changelog/titleSlug';
 import {Button} from 'sentry-docs/components/changelog/ui/Button';
 import {Select} from 'sentry-docs/components/changelog/ui/Select';
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 export default async function ChangelogCreatePage() {
   const categories = await prisma.category.findMany({

--- a/app/changelog/%5Fadmin/create/page.tsx
+++ b/app/changelog/%5Fadmin/create/page.tsx
@@ -1,0 +1,65 @@
+import {Fragment} from 'react';
+import Link from 'next/link';
+
+import {createChangelog} from 'sentry-docs/actions/changelog';
+import {FileUpload} from 'sentry-docs/components/changelog/fileUpload';
+import {ForwardRefEditor} from 'sentry-docs/components/changelog/forwardRefEditor';
+import {TitleSlug} from 'sentry-docs/components/changelog/titleSlug';
+import {Button} from 'sentry-docs/components/changelog/ui/Button';
+import {Select} from 'sentry-docs/components/changelog/ui/Select';
+import {prisma} from 'sentry-docs/prisma';
+
+export default async function ChangelogCreatePage() {
+  const categories = await prisma.category.findMany({
+    orderBy: {
+      name: 'asc',
+    },
+  });
+
+  return (
+    <section className="overflow-x-auto col-start-3 col-span-8">
+      <form action={createChangelog} className="px-2 w-full">
+        <TitleSlug />
+        <FileUpload />
+        <div className="my-6">
+          <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
+            Summary
+            <Fragment>
+              &nbsp;<span className="font-bold text-secondary">*</span>
+            </Fragment>
+          </label>
+          <textarea name="summary" className="w-full" required />
+          <span className="text-xs text-gray-500 italic">
+            This will be shown in the list
+          </span>
+        </div>
+        <div>
+          <Select
+            name="categories"
+            className="mt-1 mb-6"
+            label="Category"
+            placeholder="Select Category"
+            options={categories.map(category => ({
+              label: category.name,
+              value: category.name,
+            }))}
+            isMulti
+          />
+        </div>
+
+        <ForwardRefEditor name="content" className="w-full" />
+
+        <footer className="flex items-center justify-between mt-2">
+          <Link href="/changelog/_admin" className="underline text-gray-500">
+            Return to Changelogs list
+          </Link>
+          <div>
+            <Button type="submit">Create (not published yet)</Button>
+            <br />
+            <span className="text-xs text-gray-500 italic">You can publish it later</span>
+          </div>
+        </footer>
+      </form>
+    </section>
+  );
+}

--- a/app/changelog/%5Fadmin/layout.tsx
+++ b/app/changelog/%5Fadmin/layout.tsx
@@ -1,0 +1,33 @@
+import {type ReactNode, Suspense} from 'react';
+import {GET} from 'app/changelog/api/auth/[...nextauth]/route';
+import type {Metadata} from 'next';
+import {getServerSession} from 'next-auth/next';
+
+import LoginButton from 'sentry-docs/components/changelog/loginButton';
+import NextAuthSessionProvider from 'sentry-docs/components/nextAuthSessionProvider';
+
+export const metadata: Metadata = {
+  robots: 'noindex, nofollow',
+};
+
+export default async function Layout({children}: {children: ReactNode}) {
+  const session = await getServerSession(GET);
+  let content = (
+    <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto bg-gray-200 pt-16 grid grid-cols-12">
+      {children}
+      <div className="fixed top-3 right-4 z-50">
+        <Suspense fallback={null}>
+          <LoginButton />
+        </Suspense>
+      </div>
+    </div>
+  );
+  if (!session) {
+    content = (
+      <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto bg-gray-200 pt-16 flex items-center justify-center">
+        <LoginButton />
+      </div>
+    );
+  }
+  return <NextAuthSessionProvider>{content}</NextAuthSessionProvider>;
+}

--- a/app/changelog/%5Fadmin/loading.tsx
+++ b/app/changelog/%5Fadmin/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center">
+      <h3 className="text-2xl text-primary font-semibold">
+        <div
+          className="mx-auto mb-8 h-16 w-16 animate-spin rounded-full border-4 border-solid border-current border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]"
+          role="status"
+        />{' '}
+        Loading...
+      </h3>
+    </div>
+  );
+}

--- a/app/changelog/%5Fadmin/page.tsx
+++ b/app/changelog/%5Fadmin/page.tsx
@@ -8,7 +8,7 @@ import {
   publishChangelog,
   unpublishChangelog,
 } from 'sentry-docs/actions/changelog';
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 import Confirm from './confirm';
 

--- a/app/changelog/%5Fadmin/page.tsx
+++ b/app/changelog/%5Fadmin/page.tsx
@@ -1,0 +1,121 @@
+import {Fragment} from 'react';
+import {PlusIcon} from '@radix-ui/react-icons';
+import {Button, Text} from '@radix-ui/themes';
+import Link from 'next/link';
+
+import {
+  deleteChangelog,
+  publishChangelog,
+  unpublishChangelog,
+} from 'sentry-docs/actions/changelog';
+import {prisma} from 'sentry-docs/prisma';
+
+import Confirm from './confirm';
+
+export default async function ChangelogsListPage() {
+  const changelogs = await prisma.changelog.findMany({
+    include: {
+      categories: true,
+      author: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  return (
+    <Fragment>
+      <header className="mb-4 col-start-2 col-span-2 text-left">
+        <Button>
+          <PlusIcon />
+          <Link href="/changelog/_admin/create">New Changelog</Link>
+        </Button>
+      </header>
+      <section className="overflow-x-auto col-start-2 col-span-10 shadow-md rounded-lg">
+        <table className="w-full text-sm text-left text-gray-500">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-50">
+            <tr>
+              <th className="whitespace-nowrap px-4 py-2">Title</th>
+              <th className="whitespace-nowrap px-4 py-2">Categories</th>
+              <th className="whitespace-nowrap px-4 py-2">Published by</th>
+              <th className="px-4 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white border-b hover:bg-gray-50 dark:hover:bg-gray-600">
+            {changelogs.length === 0 && (
+              <tr>
+                <td
+                  colSpan={10}
+                  className="text-center font-medium text-gray-900 whitespace-nowrap"
+                >
+                  No changelogs found
+                </td>
+              </tr>
+            )}
+
+            {changelogs.map(changelog => (
+              <tr key={changelog.id} className="bg-white border-b hover:bg-gray-50">
+                <td className="px-6 py-4 font-medium text-gray-900">{changelog.title}</td>
+
+                <td className="px-4 py-2">
+                  {changelog.categories.map(category => (
+                    <div
+                      key={category.id}
+                      className="inline whitespace-nowrap p-2 uppercase shadow-sm no-underline rounded-full text-red text-xs mr-1 bg-gray-100"
+                    >
+                      {category.name}
+                    </div>
+                  ))}
+                </td>
+                <td className="px-4 py-2 text-center">
+                  {changelog.published && (
+                    <span className="text-gray-500">
+                      <Text size="1">
+                        {' '}
+                        {new Date(changelog.publishedAt || '').toLocaleDateString(
+                          undefined,
+                          {month: 'long', day: 'numeric'}
+                        )}
+                      </Text>
+                      <br />
+                    </span>
+                  )}
+                  <Text size="1">{changelog.author?.name}</Text>
+                </td>
+
+                <td className="px-4 py-2">
+                  <div className="flex h-full justify-end">
+                    <Link
+                      href={`/changelog/${changelog.slug}`}
+                      className="text-indigo-600 hover:bg-indigo-100 rounded-md px-1 py-2 text-xs whitespace-nowrap"
+                    >
+                      👀 Show
+                    </Link>
+                    <Link
+                      href={`/changelog/_admin/${changelog.id}/edit`}
+                      className="text-indigo-600 hover:bg-indigo-100 rounded-md px-1 py-2 text-xs whitespace-nowrap"
+                    >
+                      📝 Edit
+                    </Link>
+                    {changelog.published ? (
+                      <Confirm action={unpublishChangelog} changelog={changelog}>
+                        ⛔️ Unpublish?
+                      </Confirm>
+                    ) : (
+                      <Confirm action={publishChangelog} changelog={changelog}>
+                        ✅ Publish?
+                      </Confirm>
+                    )}
+                    <Confirm action={deleteChangelog} changelog={changelog}>
+                      💀 Delete?
+                    </Confirm>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </Fragment>
+  );
+}

--- a/app/changelog/%5Fadmin/upload/route.tsx
+++ b/app/changelog/%5Fadmin/upload/route.tsx
@@ -1,0 +1,44 @@
+import crypto from 'crypto';
+
+import {Storage} from '@google-cloud/storage';
+import {GET as sessionHandler} from 'app/changelog/api/auth/[...nextauth]/route';
+import {NextRequest} from 'next/server';
+import {getServerSession} from 'next-auth/next';
+
+const handler = async function handler(req: NextRequest) {
+  const session = await getServerSession(sessionHandler);
+
+  if (!session) {
+    return Response.json({error: 'Unauthorized'}, {status: 401});
+  }
+
+  const {method} = req;
+  const {searchParams} = new URL(req.url);
+  if (method !== 'GET') {
+    return Response.json({error: 'Method not allowed'}, {status: 405});
+  }
+  const file = searchParams.get('file');
+
+  const storage = new Storage({
+    projectId: process.env.GOOGLE_PROJECT_ID,
+    credentials: {
+      client_email: process.env.GOOGLE_CLIENT_EMAIL,
+      private_key: `${process.env.GOOGLE_PRIVATE_KEY}`.split(String.raw`\n`).join('\n'),
+    },
+  });
+  const bucket = storage.bucket(`${process.env.GOOGLE_BUCKET_NAME}`);
+  const randomFilename = `${crypto.randomBytes(5).toString('base64url')}-${file}`;
+  const gcsFile = bucket.file(randomFilename as string);
+
+  const options = {
+    expires: Date.now() + 5 * 60 * 1000, //  5 minutes,
+    fields: {'x-goog-meta-source': `${process.env.GOOGLE_PROJECT_ID}`},
+    destination: randomFilename,
+  };
+
+  const [response] = await gcsFile.generateSignedPostPolicyV4(options);
+
+  return Response.json({response, options});
+};
+
+export {handler as GET, handler as POST};

--- a/app/changelog/[slug]/loading.tsx
+++ b/app/changelog/[slug]/loading.tsx
@@ -1,0 +1,13 @@
+import Article from 'sentry-docs/components/changelog/article';
+
+export default function Loading() {
+  return (
+    <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200">
+      <div className="col-span-12 md:col-start-3 md:col-span-8">
+        <div className="max-w-3xl mx-auto px-4 p-4 sm:px-6 lg:px-8 mt-16">
+          <Article loading />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/changelog/[slug]/page.tsx
+++ b/app/changelog/[slug]/page.tsx
@@ -1,0 +1,120 @@
+import {Fragment, Suspense} from 'react';
+import {type Category, type Changelog} from '@prisma/client';
+import * as Sentry from '@sentry/nextjs';
+import {GET} from 'app/changelog/api/auth/[...nextauth]/route';
+import type {Metadata, ResolvingMetadata} from 'next';
+import Link from 'next/link';
+import {getServerSession} from 'next-auth/next';
+import {MDXRemote} from 'next-mdx-remote/rsc';
+
+import Article from 'sentry-docs/components/changelog/article';
+import {mdxOptions} from 'sentry-docs/mdxOptions';
+import {prisma} from 'sentry-docs/prisma';
+
+type ChangelogWithCategories = Changelog & {
+  categories: Category[];
+};
+
+type Props = {
+  params: {slug: string};
+};
+
+export async function generateMetadata(
+  {params}: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  let changelog: Changelog | null = null;
+  try {
+    changelog = await prisma.changelog.findUnique({
+      where: {
+        slug: params.slug,
+      },
+    });
+  } catch (e) {
+    return {title: (await parent).title};
+  }
+
+  return {
+    title: changelog?.title,
+    description: changelog?.summary,
+    alternates: {
+      canonical: `https://sentry.io/changelog/${params.slug}`,
+    },
+    openGraph: {
+      images: changelog?.image || (await parent).openGraph?.images,
+    },
+    other: {
+      'sentry-trace': `${Sentry.getActiveSpan()?.toTraceparent()}`,
+    },
+  };
+}
+
+export default async function ChangelogEntry({params}) {
+  let changelog: ChangelogWithCategories | null = null;
+  const session = await getServerSession(GET);
+  let published: boolean | undefined = undefined;
+  if (!session) {
+    published = true;
+  }
+  try {
+    changelog = await prisma.changelog.findUnique({
+      where: {
+        slug: params.slug,
+        published,
+      },
+      include: {
+        categories: true,
+      },
+    });
+  } catch (e) {
+    return <div>Not found</div>;
+  }
+
+  return (
+    <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200">
+      <div className="col-span-12 md:col-start-3 md:col-span-8">
+        <div className="max-w-3xl mx-auto px-4 p-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center space-x-4 py-3">
+            <Link href="/changelog/">
+              <button
+                className="flex items-center gap-2 px-6 py-3 font-bold text-center text-primary uppercase align-middle transition-all rounded-lg select-none hover:bg-gray-900/10 active:bg-gray-900/20"
+                type="button"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="2"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                  className="w-4 h-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                  />
+                </svg>
+                Back
+              </button>
+            </Link>
+          </div>
+          <Article
+            title={changelog?.title}
+            image={changelog?.image}
+            date={changelog?.publishedAt}
+          >
+            <Suspense fallback={<Fragment>Loading...</Fragment>}>
+              <MDXRemote
+                source={changelog?.content || 'No content found.'}
+                options={{
+                  mdxOptions,
+                }}
+              />
+            </Suspense>
+          </Article>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/changelog/[slug]/page.tsx
+++ b/app/changelog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nextjs';
 import {GET} from 'app/changelog/api/auth/[...nextauth]/route';
 import type {Metadata, ResolvingMetadata} from 'next';
 import Link from 'next/link';
+import {notFound} from 'next/navigation';
 import {getServerSession} from 'next-auth/next';
 import {MDXRemote} from 'next-mdx-remote/rsc';
 
@@ -67,7 +68,7 @@ export default async function ChangelogEntry({params}) {
       },
     });
   } catch (e) {
-    return <div>Not found</div>;
+    return notFound();
   }
 
   return (

--- a/app/changelog/[slug]/page.tsx
+++ b/app/changelog/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {MDXRemote} from 'next-mdx-remote/rsc';
 
 import Article from 'sentry-docs/components/changelog/article';
 import {mdxOptions} from 'sentry-docs/mdxOptions';
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 type ChangelogWithCategories = Changelog & {
   categories: Category[];

--- a/app/changelog/api/auth/[...nextauth]/route.ts
+++ b/app/changelog/api/auth/[...nextauth]/route.ts
@@ -2,7 +2,7 @@ import {PrismaAdapter} from '@auth/prisma-adapter';
 import NextAuth from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 const handler = NextAuth({
   adapter: PrismaAdapter(prisma),

--- a/app/changelog/api/auth/[...nextauth]/route.ts
+++ b/app/changelog/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,20 @@
+import {PrismaAdapter} from '@auth/prisma-adapter';
+import NextAuth from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+
+import {prisma} from 'sentry-docs/prisma';
+
+const handler = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+});
+
+export {handler as GET, handler as POST};

--- a/app/changelog/error.tsx
+++ b/app/changelog/error.tsx
@@ -1,0 +1,39 @@
+'use client'; // Error components must be Client Components
+
+import {Fragment, useEffect} from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & {digest?: string};
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <Fragment>
+      <div className="w-full mx-auto h-96 relative bg-darkPurple">
+        <div className="flex flex-col w-full h-64 lg:max-w-7xl mx-auto px-4 lg:px-8 pt-24 items-center">
+          <h1 className="justify-self-center text-white font-bold text-4xl text-center">
+            ಠ_ಠ Something went wrong!
+          </h1>
+          <a
+            className="text-gold font-bold text-xl cursor-pointer hover:underline"
+            onClick={
+              // Attempt to recover by trying to re-render the segment
+              () => reset()
+            }
+          >
+            Try again
+          </a>
+        </div>
+        <div className="hero-bottom-left-down-slope absolute bottom-0 w-full h-10 bg-gray-200" />
+      </div>
+      <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200" />
+    </Fragment>
+  );
+}

--- a/app/changelog/not-found.tsx
+++ b/app/changelog/not-found.tsx
@@ -1,0 +1,23 @@
+import {Fragment} from 'react';
+
+export default function NotFound() {
+  return (
+    <Fragment>
+      <div className="w-full mx-auto h-96 relative bg-darkPurple">
+        <div className="flex flex-col w-full h-64 lg:max-w-7xl mx-auto px-4 lg:px-8 pt-24 items-center">
+          <h1 className="justify-self-center text-white font-bold text-4xl text-center">
+            Not found!
+          </h1>
+          <a
+            className="text-gold font-bold text-xl cursor-pointer hover:underline"
+            href="/changelog/"
+          >
+            Go back home
+          </a>
+        </div>
+        <div className="hero-bottom-left-down-slope absolute bottom-0 w-full h-10 bg-gray-200" />
+      </div>
+      <div className="relative min-h-[calc(100vh-8rem)] w-full mx-auto grid grid-cols-12 bg-gray-200" />
+    </Fragment>
+  );
+}

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -9,7 +9,7 @@ import Months from 'sentry-docs/components/changelog/months';
 import Pagination from 'sentry-docs/components/changelog/pagination';
 import Search from 'sentry-docs/components/changelog/search';
 import Tags from 'sentry-docs/components/changelog/tags';
-import {prisma} from 'sentry-docs/prisma';
+import prisma from 'sentry-docs/prisma';
 
 import Header from './header';
 

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,30 +1,185 @@
-import {Fragment} from 'react';
+import {Fragment, Suspense} from 'react';
 import * as Sentry from '@sentry/nextjs';
 import type {Metadata} from 'next';
+import Link from 'next/link';
 
 import Article from 'sentry-docs/components/changelog/article';
+import List from 'sentry-docs/components/changelog/list';
+import Months from 'sentry-docs/components/changelog/months';
+import Pagination from 'sentry-docs/components/changelog/pagination';
+import Search from 'sentry-docs/components/changelog/search';
+import Tags from 'sentry-docs/components/changelog/tags';
+import {prisma} from 'sentry-docs/prisma';
 
 import Header from './header';
 
-export default function ChangelogList() {
+const ENTRIES_PER_PAGE = 10;
+
+export default async function ChangelogList({
+  searchParams,
+}: {
+  searchParams?: {
+    before?: string;
+    page?: string;
+    query?: string;
+    tags?: string;
+  };
+}) {
+  const query = searchParams?.query || '';
+  const currentPage = Number(searchParams?.page) || 1;
+  const selectedCategories = searchParams?.tags?.split(',') || [];
+  const before = searchParams?.before || '';
+
+  const filtered = query || selectedCategories.length || before;
+
+  const categoryOR: any = [];
+  if (selectedCategories.length) {
+    categoryOR.push({
+      name: {
+        in: selectedCategories,
+      },
+    });
+  }
+  if (query) {
+    categoryOR.push({
+      name: {
+        contains: query,
+      },
+    });
+  }
+
+  const matchingCategories = await prisma.category.findMany({
+    where: {
+      OR: categoryOR,
+    },
+  });
+  const matchingCategoryIds = matchingCategories.map(category => category.id);
+
+  const changelogOR: any = [];
+  if (selectedCategories.length) {
+    changelogOR.push({categories: {some: {id: {in: matchingCategoryIds}}}});
+  }
+  if (query) {
+    changelogOR.push({title: {contains: query}});
+    changelogOR.push({summary: {contains: query}});
+    changelogOR.push({content: {contains: query}});
+  }
+
+  const where: any = {
+    published: true,
+  };
+  if (before) {
+    const date = new Date(Date.parse(`${before}`));
+    date.setMonth(date.getMonth() + 1);
+    date.setDate(0);
+    where.publishedAt = {
+      lte: date,
+    };
+  }
+  if (changelogOR.length) {
+    where.OR = changelogOR;
+  }
+
+  const totalCount = await prisma.changelog.count({where});
+  const categories = await prisma.category.findMany();
+  const changelogs = await prisma.changelog.findMany({
+    include: {
+      categories: true,
+    },
+    where,
+    orderBy: {
+      publishedAt: 'desc',
+    },
+    skip: (currentPage - 1) * ENTRIES_PER_PAGE,
+    take: 10,
+  });
+
+  const reduceMonths = (changelog: any) => {
+    return changelog.reduce((allMonths: any, post: any) => {
+      const date = post.publishedAt as Date;
+      const year = date.getFullYear();
+      const month = date.toLocaleString('default', {
+        month: 'long',
+      });
+      const monthYear = `${month} ${year}`;
+      return [...new Set([...allMonths, monthYear])];
+    }, []);
+  };
+
+  // iterate over all posts and create a list of months & years
+  const months = reduceMonths(changelogs);
+
+  const allMonths = reduceMonths(
+    await prisma.changelog.findMany({
+      select: {publishedAt: true},
+      orderBy: {
+        publishedAt: 'desc',
+      },
+    })
+  );
+
+  const pagination = {
+    currentPage,
+    totalPages: totalCount / ENTRIES_PER_PAGE,
+  };
+
   return (
     <Fragment>
       <Header loading={false} />
       <div className="w-full mx-auto grid grid-cols-12 bg-gray-200">
-        <div className="hidden md:block md:col-span-2 pl-5 pt-10" />
-        <div className="col-span-12 md:col-span-8">
-          <div className="max-w-3xl mx-auto px-4 pb-4 sm:px-6 md:px-8">
-            <div className="flex justify-between items-center py-6 space-x-4" />
-
-            <Article title="Be right back">
-              <a href="https://changelog.getsentry.com">
-                We're currently updating our changelog. Please visit our changelog page
-                for the latest updates.
-              </a>
-            </Article>
+        <div className="hidden md:block md:col-span-2 pl-5 pt-10">
+          <h3 className="text-2xl text-primary font-semibold mb-2">Categories:</h3>
+          <div className="flex flex-wrap gap-1 py-1">
+            <Suspense key={query + searchParams}>
+              <Tags categories={categories} />
+            </Suspense>
           </div>
         </div>
-        <div className="hidden md:block md:col-span-2 pl-5 pt-10" />
+        <div className="col-span-12 md:col-span-8">
+          <div className="max-w-3xl mx-auto px-4 pb-4 sm:px-6 md:px-8">
+            <div className="flex justify-between items-center py-6 space-x-4">
+              <Search placeholder="Search..." />
+              <div className="flex space-x-4">
+                <Link
+                  className={`${filtered ? 'text-purple font-medium' : 'text-gray-500'} hover:text-gray-700`}
+                  href="/changelog/"
+                >
+                  Reset
+                </Link>
+              </div>
+            </div>
+
+            <Suspense
+              fallback={
+                <Fragment>
+                  <Article loading />
+                </Fragment>
+              }
+              key={query + searchParams + months + pagination}
+            >
+              <List changelogs={changelogs} />
+              {pagination && pagination.totalPages > 1 && (
+                <Pagination
+                  currentPage={pagination.currentPage}
+                  totalPages={pagination.totalPages}
+                />
+              )}
+            </Suspense>
+
+            {!changelogs.length && (
+              <div className="flex items-center my-4">
+                <div className="flex-1 border-t-[1px] border-gray-400" />
+                <span className="px-3 text-gray-500">No posts found.</span>
+                <div className="flex-1 border-t-[1px] border-gray-400" />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="hidden md:block md:col-span-2 pl-5 pt-10">
+          <Suspense key={query + searchParams}>
+            <Months months={allMonths} />
+          </Suspense>
+        </div>
       </div>
     </Fragment>
   );

--- a/src/actions/changelog.ts
+++ b/src/actions/changelog.ts
@@ -1,0 +1,132 @@
+'use server';
+
+import {GET as handler} from 'app/changelog/api/auth/[...nextauth]/route';
+import {revalidatePath} from 'next/cache';
+import {redirect} from 'next/navigation';
+import {getServerSession} from 'next-auth/next';
+
+import {prisma} from '../prisma';
+
+export async function unpublishChangelog(formData: FormData) {
+  const session = await getServerSession(handler);
+  if (!session) {
+    return {message: 'Unauthorized'};
+  }
+  const id = formData.get('id') as string;
+  try {
+    await prisma.changelog.update({
+      where: {id},
+      data: {published: false, publishedAt: null},
+    });
+  } catch (error) {
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to unpublish changelog'};
+  }
+
+  return revalidatePath(`/changelog/_admin`);
+}
+
+export async function publishChangelog(formData: FormData) {
+  const session = await getServerSession(handler);
+  if (!session) {
+    return {message: 'Unauthorized'};
+  }
+  const id = formData.get('id') as string;
+  try {
+    await prisma.changelog.update({
+      where: {id},
+      data: {published: true, publishedAt: new Date().toISOString()},
+    });
+  } catch (error) {
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to publish changelog'};
+  }
+
+  return revalidatePath(`/changelog/_admin`);
+}
+
+export async function createChangelog(formData: FormData) {
+  const session = await getServerSession(handler);
+  if (!session) {
+    return {message: 'Unauthorized'};
+  }
+  const categories = formData.getAll('categories');
+  await prisma.category.createMany({
+    data: categories.map(category => ({name: category as string})),
+    skipDuplicates: true,
+  });
+  const connect = categories.map(category => {
+    return {name: category as string};
+  });
+  const user = await prisma.user.findUnique({
+    // @ts-ignore
+    where: {email: session?.user?.email as string},
+  });
+  const data = {
+    title: formData.get('title') as string,
+    content: formData.get('content') as string,
+    summary: formData.get('summary') as string,
+    image: formData.get('image') as string,
+    slug: formData.get('slug') as string,
+    author: {connect: {id: user?.id as string}},
+    categories: formData.get('categories') !== '' ? {connect} : {},
+  };
+
+  await prisma.changelog.create({data});
+
+  return redirect(`/changelog/_admin`);
+}
+
+export async function editChangelog(formData: FormData) {
+  const session = await getServerSession(handler);
+  if (!session) {
+    return {message: 'Unauthorized'};
+  }
+  const id = formData.get('id') as string;
+  const categories = formData.getAll('categories');
+  await prisma.category.createMany({
+    data: categories.map(category => ({name: category as string})),
+    skipDuplicates: true,
+  });
+  const connect = categories.map(category => {
+    return {name: category as string};
+  });
+  try {
+    const data = {
+      title: formData.get('title') as string,
+      content: formData.get('content') as string,
+      summary: formData.get('summary') as string,
+      image: formData.get('image') as string,
+      slug: formData.get('slug') as string,
+      categories: formData.get('categories') !== '' ? {set: [...connect]} : {set: []},
+    };
+
+    await prisma.changelog.update({
+      where: {id},
+      data,
+    });
+  } catch (error) {
+    console.error('EDIT ACTION ERROR:', error);
+    return {message: error};
+  }
+
+  return redirect(`/changelog/_admin`);
+}
+
+export async function deleteChangelog(formData: FormData) {
+  const session = await getServerSession(handler);
+  if (!session) {
+    return {message: 'Unauthorized'};
+  }
+  const id = formData.get('id') as string;
+  try {
+    await prisma.changelog.delete({
+      where: {id},
+    });
+  } catch (error) {
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to delete changelog'};
+  }
+
+  return revalidatePath(`/changelog/_admin`);
+}

--- a/src/actions/changelog.ts
+++ b/src/actions/changelog.ts
@@ -5,7 +5,7 @@ import {revalidatePath} from 'next/cache';
 import {redirect} from 'next/navigation';
 import {getServerSession} from 'next-auth/next';
 
-import {prisma} from '../prisma';
+import prisma from '../prisma';
 
 export async function unpublishChangelog(formData: FormData) {
   const session = await getServerSession(handler);

--- a/src/components/changelog/article.tsx
+++ b/src/components/changelog/article.tsx
@@ -46,7 +46,7 @@ export default function Article({
           <div className="prose max-w-none text-gray-700 py-2">{children}</div>
           <dl>
             <dd className="text-xs leading-6 text-gray-400">
-              <Date date={date} />
+              {date && <Date date={date} />}
             </dd>
           </dl>
         </div>

--- a/src/components/changelog/article.tsx
+++ b/src/components/changelog/article.tsx
@@ -46,7 +46,7 @@ export default function Article({
           <div className="prose max-w-none text-gray-700 py-2">{children}</div>
           <dl>
             <dd className="text-xs leading-6 text-gray-400">
-              {date && <Date date={date} />}
+              <Date date={date} />
             </dd>
           </dl>
         </div>

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,9 +1,16 @@
+// using the code from https://github.com/vercel/examples/blob/main/storage/postgres-prisma/lib/prisma.ts
+// eventho it's basically the same as it was before
 import {PrismaClient} from '@prisma/client';
 
-const globalForPrisma = globalThis as unknown as {prisma: PrismaClient};
-
-export const prisma = globalForPrisma.prisma || new PrismaClient();
-
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
 }
+
+const prisma = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV === 'development') {
+  global.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
Setting `&connection_limit=1` in the postgres url in the environment.
See: https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections#the-serverless-challenge

At least locally when there was an error the page constantly refreshed - adding the error page fixed this. Also added proper not found page while at it.

So I am still not certain this will prevent it from exploding again, I hope the connection limits are properly set now (there are only two functions running the changelog).