### PR TITLE
fix(rn): Remove unsafe `authToken` option from the Expo setup page

### DIFF
--- a/includes/react-native-expo-plugin-code-snippet.mdx
+++ b/includes/react-native-expo-plugin-code-snippet.mdx
@@ -6,8 +6,7 @@
         "@sentry/react-native/expo",
         {
           "url": "https://sentry.io/",
-          "warning": "DO NOT COMMIT YOUR AUTH TOKEN",
-          "authToken": "___ORG_AUTH_TOKEN___",
+          "note": "Use SENTRY_AUTH_TOKEN env to authenticate with Sentry.",
           "project": "___PROJECT_SLUG___",
           "organization": "___ORG_SLUG___"
         }
@@ -27,8 +26,7 @@ const config = {
 
 module.exports = withSentry(config, {
   url: "https://sentry.io/",
-  // DO NOT COMMIT YOUR AUTH TOKEN
-  authToken: "___ORG_AUTH_TOKEN___",
+  // Use SENTRY_AUTH_TOKEN env to authenticate with Sentry.
   project: "___PROJECT_SLUG___s",
   organization: "___ORG_SLUG___",
 });
@@ -45,9 +43,15 @@ const config: ExpoConfig = {
 
 export default withSentry(config, {
   url: "https://sentry.io/",
-  // DO NOT COMMIT YOUR AUTH TOKEN
-  authToken: "___ORG_AUTH_TOKEN___",
+  // Use SENTRY_AUTH_TOKEN env to authenticate with Sentry.
   project: "___PROJECT_SLUG___",
   organization: "___ORG_SLUG___",
 });
+```
+
+Add auth token to your environment:
+
+```bash
+# DO NOT COMMIT YOUR AUTH TOKEN
+export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```


### PR DESCRIPTION
- related to https://github.com/getsentry/sentry-react-native/pull/3630

This PR removed the `authToken` option example as using it is not safe to use (the token can be easily exposed).