### PR TITLE
fix: cache_spans are False by default

### DIFF
--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -128,9 +128,9 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 - `cache_spans`:
 
-  Create spans and track performance of all read operations to configured caches. The spans also include information if the cache access was a hit or a miss. Set to `False` to disable.
+  Create spans and track performance of all read operations to configured caches. The spans also include information if the cache access was a hit or a miss. Set to `True` to enable.
 
-  The default is `True`.
+  The default is `False`.
 
 ## Supported Versions
 


### PR DESCRIPTION
Correct the issue in the docs which state that `cache_spans` is enabled by defaults. This is not the case, it's actually disabled by default.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
