### PR TITLE
add alpha note

### DIFF
--- a/docs/platforms/dotnet/metrics/index.mdx
+++ b/docs/platforms/dotnet/metrics/index.mdx
@@ -4,6 +4,8 @@ description: "Learn how to measure the data points you care about by configuring
 sidebar_order: 9000
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
+
 <Note>
 
 Metrics for .NET are supported with Sentry .NET SDK version `4.0.0` and above.

--- a/docs/platforms/javascript/common/metrics/index.mdx
+++ b/docs/platforms/javascript/common/metrics/index.mdx
@@ -7,6 +7,8 @@ notSupported:
   - javascript.cordova
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
+
 <PlatformContent includePath="metrics/version-support-note" />
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.

--- a/docs/platforms/php/common/metrics/index.mdx
+++ b/docs/platforms/php/common/metrics/index.mdx
@@ -5,6 +5,8 @@ notSupported:
   - php.symfony
 ---
 
+
+<Include name="feature-stage-alpha-metrics.mdx" />
 <Note>
 
 Metrics for PHP are supported with Sentry PHP SDK version `4.5.0` and above.

--- a/docs/platforms/php/guides/laravel/metrics/index.mdx
+++ b/docs/platforms/php/guides/laravel/metrics/index.mdx
@@ -3,6 +3,8 @@ title: Set Up Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Laravel app."
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
+
 <Note>
 
 Metrics for Laravel are supported with Sentry Laravel SDK version `4.2.0` and above.

--- a/docs/platforms/python/common/metrics/index.mdx
+++ b/docs/platforms/python/common/metrics/index.mdx
@@ -3,6 +3,7 @@ title: Set Up Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Python app."
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
 <Note>
 
 Metrics for Python are supported with Sentry Python SDK version `1.40.0` and above.

--- a/docs/platforms/react-native/metrics/index.mdx
+++ b/docs/platforms/react-native/metrics/index.mdx
@@ -3,6 +3,7 @@ title: Set Up Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your React Native app."
 ---
 
+<Include name="feature-stage-alpha-metrics.mdx" />
 <PlatformContent includePath="metrics/version-support-note" />
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.


### PR DESCRIPTION
A user pointed out that he was confused when he tried to add metrics and was taken to a waiting list. It's definitely a good call to add the note about this being an alpha release to the SDK set up docs! :)

PS - I didn't edit the node docs because the user who pointed this out already created his own PR for this.
