### PR TITLE
fix: DSN selector not working sometimes

### DIFF
--- a/src/components/codeKeywords.tsx
+++ b/src/components/codeKeywords.tsx
@@ -11,7 +11,6 @@ import {ArrowDown} from 'react-feather';
 import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
-import memoize from 'lodash/memoize';
 
 import {useOnClickOutside} from 'sentry-docs/clientUtils';
 
@@ -95,7 +94,7 @@ function runRegex(
   }
 }
 
-const getPortal = memoize((): HTMLElement | null => {
+const getPortal = (): HTMLElement | null => {
   if (typeof document === 'undefined') {
     return null;
   }
@@ -107,7 +106,7 @@ const getPortal = memoize((): HTMLElement | null => {
     document.body.appendChild(portal);
   }
   return portal;
-});
+};
 
 type KeywordSelectorProps = {
   group: string;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The DSN selector didn't work due to a race condition. Removing the memoization of the `getPortal()` function fixes it.

The performance impact is probably negligible as `getElementById()` is pretty fast and `getPortal()` is not in a hot path.

This PR closes #9092 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
