### PR TITLE
fix: overlapping sub when text is too long

### DIFF
--- a/docs/product/session-replay/performance-overhead.mdx
+++ b/docs/product/session-replay/performance-overhead.mdx
@@ -70,11 +70,9 @@ We measured the overhead of the Replay SDK on Sentry's web UI using the methodol
 | Network Download                 | 8.06 MB        | 8.09 MB         | 8.07 MB             |
 
 <p>
-  <sub>
-    * The standard deviation for LCP was 386, 511, and 354 ms, respectively.
-    This means that the LCP values are quite spread out and explains why the
-    Sentry standalone LCP value is higher than the Sentry with Replay value.
-  </sub>
+<sub> \* The standard deviation for LCP was 386, 511, and 354 ms, respectively.
+  This means that the LCP values are quite spread out and explains why the
+  Sentry standalone LCP value is higher than the Sentry with Replay value.</sub>
 </p>
 
 <p>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

The `sub` seemed to not wrap text properly.

The issue comes from the way MDX interpreted the the markdown to HTML conversion with a weird `p` and `ul` tags inside the `sub`

Escaping the `*` and keeping the opening and closing `sub`s inline with the text fixes it.

This PR closes #9028 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
