### PR TITLE
FIx: Right Sidebar(Table of contents) anchor url fixed

### DIFF
--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -75,10 +75,11 @@ export function TableOfContents({guideGrid}: Props) {
       const tocItems: TocItem[] = [];
       elements?.forEach(e => {
         const title = e.textContent?.trim();
-        if (title) {
+        const {id} = e;
+        if (title && id) {
           tocItems.push({
             depth: e.tagName === 'H2' ? 2 : 3,
-            url: `#${slug(title)}`,
+            url: `#${slug(id)}`,
             value: title,
           });
         }

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {ReactElement, useEffect, useState} from 'react';
-import {slug} from 'github-slugger';
 
 interface TocItem {
   depth: number;
@@ -79,7 +78,7 @@ export function TableOfContents({guideGrid}: Props) {
         if (title && id) {
           tocItems.push({
             depth: e.tagName === 'H2' ? 2 : 3,
-            url: `#${slug(id)}`,
+            url: `#${id}`,
             value: title,
           });
         }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

fixes: #9115  #9012 #9068 

For every link in mdx, there is ConfigKey defined with the `name` attribute which is used in the anchor tag.
Utilized same in table of contents