### PR TITLE
fix: Alert level colors

### DIFF
--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -4,7 +4,7 @@ type Props = {
   children?: any;
   deepLink?: string;
   dismiss?: boolean;
-  level?: 'info' | 'warning' | 'danger' | 'success' | "";
+  level?: 'info' | 'warning' | 'danger' | 'success' | '';
   title?: string;
 };
 

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -4,7 +4,7 @@ type Props = {
   children?: any;
   deepLink?: string;
   dismiss?: boolean;
-  level?: string;
+  level?: 'info' | 'warning' | 'danger' | 'success' | "";
   title?: string;
 };
 

--- a/src/styles/_includes/bootstrap-overrides.scss
+++ b/src/styles/_includes/bootstrap-overrides.scss
@@ -46,8 +46,10 @@ $cyan: $jewel1;
 $primary: $purple;
 
 $theme-colors: (
-  'info': $brandLink,
-  'warning': $brandPink,
+  'info': $blue,
+  'warning': $orange,
+  'danger': $red,
+  'success': $green,
 );
 
 $code-color: $codeColor;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Brand pink on `info` level `Alert`s looks like an error.

I gave it the traditional Bootstrap colors (using the our theme) and added some types for better autocomplete.

This PR closes #9049 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
