### PR TITLE
fix: hide non functioning copy button on slow connections

### DIFF
--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {Clipboard} from 'react-feather';
 
 import {makeKeywordsClickable} from './codeKeywords';
@@ -15,6 +15,13 @@ export interface CodeBlockProps {
 export function CodeBlock({filename, language, children}: CodeBlockProps) {
   const [showCopied, setShowCopied] = useState(false);
   const codeRef = useRef<HTMLDivElement>(null);
+
+  // Show the copy button after js has loaded
+  // otherwise the copy button will not work
+  const [showCopyButton, setShowCopyButton] = useState(false);
+  useEffect(() => {
+    setShowCopyButton(true);
+  }, []);
 
   async function copyCode() {
     if (codeRef.current === null) {
@@ -39,9 +46,11 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
     <div className="code-block">
       <div className="code-actions">
         <code className="filename">{filename}</code>
-        <button className="copy" onClick={() => copyCode()}>
-          <Clipboard size={16} />
-        </button>
+        {showCopyButton && (
+          <button className="copy" onClick={() => copyCode()}>
+            <Clipboard size={16} />
+          </button>
+        )}
       </div>
       <div className="copied" style={{opacity: showCopied ? 1 : 0}}>
         Copied


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Hide the copy button on code blocks until it is interactive

This PR closes #8139

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
