### PR TITLE
fix: sort platforms dropdown in alphabetical order

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -54,6 +54,15 @@ export async function Home() {
     (a, b) => HIGHLIGHTED_PLATFORMS.indexOf(a.key) - HIGHLIGHTED_PLATFORMS.indexOf(b.key)
   );
 
+  // this regex deals with names like .NET that would otherwise be sorted at the top
+  const leadingNonAlphaRegex = /^[^\w]/;
+
+  platformList.sort((a, b) =>
+    (a.title ?? a.name)
+      .replace(leadingNonAlphaRegex, '')
+      .localeCompare((b.title ?? b.name).replace(leadingNonAlphaRegex, ''))
+  );
+
   return (
     <HomeClient
       visiblePlatforms={visiblePlatforms}


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Bring back the alphabetical platform sorting from the Gatsby docs.

This PR closes #9219

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
