### PR TITLE
fix: show results from other Sentry sites when user clicks corresponding button

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -74,7 +74,14 @@ export function Search({path, autoFocus, platforms = []}: Props) {
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
-  const handleClickOutside = useCallback(() => {
+  const handleClickOutside = useCallback((ev: MouseEvent) => {
+    // don't close the search results if the user is clicking the expand button
+    if (
+      (ev.target as HTMLButtonElement).classList.contains('sgs-expand-results-button')
+    ) {
+      return;
+    }
+
     setInputFocus(false);
     setShowOffsiteResults(false);
   }, []);


### PR DESCRIPTION
…ing button

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Closes #9034 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
