### PR TITLE
fix(app-start): Fix broken link to iOS performanceV2 flag

### DIFF
--- a/docs/product/performance/mobile-vitals/app-starts.mdx
+++ b/docs/product/performance/mobile-vitals/app-starts.mdx
@@ -28,7 +28,7 @@ SentryAndroid.init(this, options -> {
 
 - `>=8.18.0` for automatic instrumentation of [app start spans](/platforms/apple/performance/instrumentation/automatic-instrumentation/#app-start-tracing)
 - `>=8.21.0` for app start profiling
-- [PerformanceV2](platforms/apple/performance/instrumentation/automatic-instrumentation/#performance-v2) must be enabled in the SDK, e.g.:
+- [PerformanceV2](/platforms/apple/performance/instrumentation/automatic-instrumentation/#performance-v2) must be enabled in the SDK, e.g.:
 ```swift
 import Sentry
 


### PR DESCRIPTION
Missed a `/` so the link would just append to the URL instead of going to the right place