### PR TITLE
feat(js/deno): Remove options `xhr`, `history` and `dom` from deno breadcrumbs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -9,10 +9,10 @@ notSupported:
 
 _Import name: `Sentry.breadcrumbsIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
-This integration wraps native APIs to capture breadcrumbs. By default, the Sentry SDK wraps all APIs.
-You can opt-out of capturing breadcrumbs for specific parts of your application (e.g. do not capture `console.log` calls as breadcrumbs) via the options below.
+The `breadcrumbsIntegration` wraps native APIs to capture breadcrumbs.
+By default, the Sentry SDK wraps all APIs. You can opt out of capturing breadcrumbs for specific parts of your application (for example, you could say don't capture `console.log` calls as breadcrumbs) via the options below.
 
 ## Options
 
@@ -20,7 +20,7 @@ You can opt-out of capturing breadcrumbs for specific parts of your application 
 
 _Type: `boolean`_
 
-Log calls to `console.log`, `console.debug`, etc.
+Log calls to `console.log`, `console.debug`, and so on.
 
 ### `dom`
 

--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.breadcrumbsIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 The `breadcrumbsIntegration` wraps native APIs to capture breadcrumbs.
 By default, the Sentry SDK wraps all APIs. You can opt out of capturing breadcrumbs for specific parts of your application (for example, you could say don't capture `console.log` calls as breadcrumbs) via the options below.
@@ -34,7 +34,7 @@ When an object with a `serializeAttribute` key is provided, the Breadcrumbs inte
 
 _Type: `boolean`_
 
-Log HTTP requests done with the Fetch API
+Log HTTP requests done with the Fetch API.
 
 ### `history`
 

--- a/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
@@ -1,20 +1,16 @@
 ---
 title: Breadcrumbs
 excerpt: ""
-description: "Wraps native APIs to capture breadcrumbs. (default)"
+description: "Learn how Sentry wraps native APIs of Deno to capture breadcrumbs."
 sidebar_order: 1
-notSupported:
-  - javascript.electron
 ---
 
 _Import name: `Sentry.breadcrumbsIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
-This integration wraps native APIs to capture breadcrumbs. By default, the Sentry SDK wraps all APIs.
-You can opt-out of capturing breadcrumbs for specific parts of your application (e.g. do not capture `console.log` calls as breadcrumbs) via the options below.
-
-In
+The `breadcrumbsIntegration` wraps native APIs to capture breadcrumbs.
+By default, the Sentry SDK wraps all APIs. You can opt out of capturing breadcrumbs for specific parts of your application (for example, you could say don't capture `console.log` calls as breadcrumbs) via the options below.
 
 ## Options
 
@@ -22,7 +18,7 @@ In
 
 _Type: `boolean`_
 
-Log calls to `console.log`, `console.debug`, etc.
+Log calls to `console.log`, `console.debug`, and so on.
 
 ### `fetch`
 

--- a/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
@@ -1,0 +1,38 @@
+---
+title: Breadcrumbs
+excerpt: ""
+description: "Wraps native APIs to capture breadcrumbs. (default)"
+sidebar_order: 1
+notSupported:
+  - javascript.electron
+---
+
+_Import name: `Sentry.breadcrumbsIntegration`_
+
+This integration is [enabled by default](./../#modifying-default-integrations).
+
+This integration wraps native APIs to capture breadcrumbs. By default, the Sentry SDK wraps all APIs.
+You can opt-out of capturing breadcrumbs for specific parts of your application (e.g. do not capture `console.log` calls as breadcrumbs) via the options below.
+
+In
+
+## Options
+
+### `console`
+
+_Type: `boolean`_
+
+Log calls to `console.log`, `console.debug`, etc.
+
+### `fetch`
+
+_Type: `boolean`_
+
+Log HTTP requests done with the Fetch API
+
+### `sentry`
+
+_Type: `boolean`_
+
+Log whenever we send an event to the server.
+

--- a/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/guides/deno/configuration/integrations/breadcrumbs.mdx
@@ -24,7 +24,7 @@ Log calls to `console.log`, `console.debug`, and so on.
 
 _Type: `boolean`_
 
-Log HTTP requests done with the Fetch API
+Log HTTP requests done with the Fetch API.
 
 ### `sentry`
 


### PR DESCRIPTION
## Description of changes

In this PR https://github.com/getsentry/sentry-javascript/pull/10867, the options `xhr`, `history` and `dom` were removed from the breadcrumbs Integration for Deno. The base for the breadcrumbs docs file is located in `commons`.

