### PR TITLE
fix(native): clarify use of crashpad in macOS sandbox

### DIFF
--- a/docs/platforms/native/configuration/backends/crashpad.mdx
+++ b/docs/platforms/native/configuration/backends/crashpad.mdx
@@ -46,3 +46,5 @@ locking in place.
 ## Known Limitations
 
 When using the Crashpad backend on macOS, the status of crashed sessions can not be reliably determined, and may be classified as [`abnormal`](/product/releases/health/release-details/) exits instead.
+
+If you want to deploy your application to the macOS App Store or distribute it "sandboxed" outside, the crashpad client will fail to start the `crashpad_handler` executable (due to sandbox restrictions). For these deployment targets, we recommend using the `breakpad` backend.


### PR DESCRIPTION
This an outcome of a recent support discussion with one of our users: https://github.com/getsentry/sentry-native/discussions/881#discussioncomment-8640854

cc: @kahest 