### PR TITLE
Codeblock highlight callouts and diffs

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -24,37 +24,32 @@ The `profiles_sample_rate` and `profiler_mode` options are not experimental anym
 
 The deprecated `with_locals` and `request_bodies` options have been removed in favor of their new counterparts: `include_local_variables` and `max_request_body_size`, respectively.
 
-**Old**:
+**These are all potential changes you need to apply to your init**:
 
 <SignInNote />
 
-```python
+```python diff
 import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    with_locals=False,
-    request_bodies="always",
-    _experiments={
-        "profiles_sample_rate": 1.0,
-        "profiler_mode": "thread",
-    },
-)
-```
 
-**New**:
+    # Replace with_locals
+-   with_locals=False,
++   include_local_variables=False,
 
-<SignInNote />
+    # Replace request_bodies
+-   request_bodies="always",
++   max_request_body_size="always",
 
-```python
-import sentry_sdk
-
-sentry_sdk.init(
-    dsn="___PUBLIC_DSN___",
-    include_local_variables=False,  # replaces with_locals
-    max_request_body_size="always",  # replaces request_bodies
-    profiles_sample_rate=1.0,  # replaces _experiments["profiles_sample_rate"]
-    profiler_mode="thread",  # replaces _experiments["profiler_mode"]
+    # Replace _experiments["profiles_sample_rate"]
+    # Replace _experiments["profiler_mode"]
+-   _experiments={
+-       "profiles_sample_rate": 1.0,
+-       "profiler_mode": "thread",
+-   },
++   profiles_sample_rate=1.0,
++   profiler_mode="thread",
 )
 ```
 
@@ -66,30 +61,19 @@ The API function `last_event_id()` was removed. The last event ID is still retur
 
 You can no longer mutate a manually-created transaction in a `configure_scope` block. Instead, you need to get the current scope to mutate the transaction. Here is a recipe on how to change your code to make it work:
 
-**Old**:
-
 <SignInNote />
 
-```python
+```python diff
 transaction = sentry_sdk.transaction(...)
 
 # later in the code execution:
 
-with sentry_sdk.configure_scope() as scope:
-    scope.set_transaction_name("new-transaction-name")
-```
+-with sentry_sdk.configure_scope() as scope:
+-    scope.set_transaction_name("new-transaction-name")
 
-**New**:
++scope = sentry_sdk.Scope.get_current_scope()
++scope.set_transaction_name("new-transaction-name")
 
-<SignInNote />
-
-```python
-transaction = sentry_sdk.transaction(...)
-
-# later in the code execution:
-
-scope = sentry_sdk.Scope.get_current_scope()
-scope.set_transaction_name("new-transaction-name")
 ```
 
 ## Self-Hosted

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-textarea-autosize": "^8.5.3",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-preset-minify": "^7.0.0",
+    "rehype-prism-diff": "^1.1.2",
     "rehype-prism-plus": "^1.6.3",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.0",

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -11,6 +11,7 @@ import rehypePresetMinify from 'rehype-preset-minify';
 import rehypePrismPlus from 'rehype-prism-plus';
 // Rehype packages
 import rehypeSlug from 'rehype-slug';
+import rehypePrismDiff from 'rehype-prism-diff';
 // Remark packages
 import remarkGfm from 'remark-gfm';
 
@@ -333,6 +334,7 @@ export async function getFileBySlug(slug) {
           },
         ],
         [rehypePrismPlus, {ignoreMissing: true}],
+        [rehypePrismDiff, {remove: true}],
         rehypePresetMinify,
       ];
       return options;

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -2,16 +2,15 @@ import fs from 'fs';
 import path from 'path';
 
 import matter from 'gray-matter';
-import {toString} from 'hast-util-to-string';
-import {h, s} from 'hastscript';
+import {s} from 'hastscript';
 import yaml from 'js-yaml';
 import {bundleMDX} from 'mdx-bundler';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypePresetMinify from 'rehype-preset-minify';
+import rehypePrismDiff from 'rehype-prism-diff';
 import rehypePrismPlus from 'rehype-prism-plus';
 // Rehype packages
 import rehypeSlug from 'rehype-slug';
-import rehypePrismDiff from 'rehype-prism-diff';
 // Remark packages
 import remarkGfm from 'remark-gfm';
 
@@ -306,29 +305,25 @@ export async function getFileBySlug(slug) {
         [
           rehypeAutolinkHeadings,
           {
-            behavior: 'wrap',
+            behavior: 'append',
             properties: {
-              className: 'anchor',
+              className: 'autolink-header inline-flex ml-2',
               ariaHidden: true,
               tabIndex: -1,
             },
-            content: node => [
-              h(
-                'span.anchor-text',
-                s(
-                  'svg.anchor-icon',
-                  {
-                    xmlns: 'http://www.w3.org/2000/svg',
-                    width: 16,
-                    height: 16,
-                    fill: 'currentColor',
-                    viewBox: '0 0 24 24',
-                  },
-                  s('path', {
-                    d: 'M9.199 13.599a5.99 5.99 0 0 0 3.949 2.345 5.987 5.987 0 0 0 5.105-1.702l2.995-2.994a5.992 5.992 0 0 0 1.695-4.285 5.976 5.976 0 0 0-1.831-4.211 5.99 5.99 0 0 0-6.431-1.242 6.003 6.003 0 0 0-1.905 1.24l-1.731 1.721a.999.999 0 1 0 1.41 1.418l1.709-1.699a3.985 3.985 0 0 1 2.761-1.123 3.975 3.975 0 0 1 2.799 1.122 3.997 3.997 0 0 1 .111 5.644l-3.005 3.006a3.982 3.982 0 0 1-3.395 1.126 3.987 3.987 0 0 1-2.632-1.563A1 1 0 0 0 9.201 13.6zm5.602-3.198a5.99 5.99 0 0 0-3.949-2.345 5.987 5.987 0 0 0-5.105 1.702l-2.995 2.994a5.992 5.992 0 0 0-1.695 4.285 5.976 5.976 0 0 0 1.831 4.211 5.99 5.99 0 0 0 6.431 1.242 6.003 6.003 0 0 0 1.905-1.24l1.723-1.723a.999.999 0 1 0-1.414-1.414L9.836 19.81a3.985 3.985 0 0 1-2.761 1.123 3.975 3.975 0 0 1-2.799-1.122 3.997 3.997 0 0 1-.111-5.644l3.005-3.006a3.982 3.982 0 0 1 3.395-1.126 3.987 3.987 0 0 1 2.632 1.563 1 1 0 0 0 1.602-1.198z',
-                  })
-                ),
-                toString(node)
+            content: [
+              s(
+                'svg.autolink-svg',
+                {
+                  xmlns: 'http://www.w3.org/2000/svg',
+                  width: 16,
+                  height: 16,
+                  fill: 'currentColor',
+                  viewBox: '0 0 24 24',
+                },
+                s('path', {
+                  d: 'M9.199 13.599a5.99 5.99 0 0 0 3.949 2.345 5.987 5.987 0 0 0 5.105-1.702l2.995-2.994a5.992 5.992 0 0 0 1.695-4.285 5.976 5.976 0 0 0-1.831-4.211 5.99 5.99 0 0 0-6.431-1.242 6.003 6.003 0 0 0-1.905 1.24l-1.731 1.721a.999.999 0 1 0 1.41 1.418l1.709-1.699a3.985 3.985 0 0 1 2.761-1.123 3.975 3.975 0 0 1 2.799 1.122 3.997 3.997 0 0 1 .111 5.644l-3.005 3.006a3.982 3.982 0 0 1-3.395 1.126 3.987 3.987 0 0 1-2.632-1.563A1 1 0 0 0 9.201 13.6zm5.602-3.198a5.99 5.99 0 0 0-3.949-2.345 5.987 5.987 0 0 0-5.105 1.702l-2.995 2.994a5.992 5.992 0 0 0-1.695 4.285 5.976 5.976 0 0 0 1.831 4.211 5.99 5.99 0 0 0 6.431 1.242 6.003 6.003 0 0 0 1.905-1.24l1.723-1.723a.999.999 0 1 0-1.414-1.414L9.836 19.81a3.985 3.985 0 0 1-2.761 1.123 3.975 3.975 0 0 1-2.799-1.122 3.997 3.997 0 0 1-.111-5.644l3.005-3.006a3.982 3.982 0 0 1 3.395-1.126 3.987 3.987 0 0 1 2.632 1.563 1 1 0 0 0 1.602-1.198z',
+                })
               ),
             ],
           },

--- a/src/styles/_includes/code-blocks.scss
+++ b/src/styles/_includes/code-blocks.scss
@@ -62,3 +62,33 @@
     transition: opacity 150ms;
   }
 }
+
+/**
+ * Line highlighting in code blocks
+ *
+ * 1. Make the element just wide enough to fit its content.
+ * 2. Always fill the visible space in .code-highlight.
+ */
+.code-highlight {
+  float: left; /* 1 */
+  min-width: 100%; /* 2 */
+}
+
+/* Counter the 12px padding on the left side of the code block on the pre tag
+* and the 4px border on the left side of the line + the 8px padding bring it
+* back visually to the left side of the code block with "12px" of padding.
+*/
+.code-line {
+  display: block;
+  float: left;
+  min-width: 100%;
+  padding-left: 8px;
+  margin-left: -12px;
+  box-sizing: border-box;
+  border-left: 4px solid rgba(0, 0, 0, 0); /* Set placeholder for highlight accent border color to transparent */
+}
+
+.highlight-line {
+  background-color: rgba(239, 239, 239, 0.06); /* Set highlight bg color */
+  border-left: 4px solid $brandPink;
+}

--- a/src/styles/_includes/code-blocks.scss
+++ b/src/styles/_includes/code-blocks.scss
@@ -92,3 +92,16 @@
   background-color: rgba(239, 239, 239, 0.06); /* Set highlight bg color */
   border-left: 4px solid $brandPink;
 }
+
+/* Diff highlighting, classes provided by rehype-prism-plus */
+.code-line.diff-inserted,
+.code-line.inserted {
+  background-color: rgba(16, 185, 129, 0.2); /* Set inserted line (+) color */
+  float: left;
+  min-width: 100%;
+}
+
+.code-line.diff-deleted,
+.code-line.deleted {
+  background-color: rgba(239, 68, 68, 0.2); /* Set deleted line (-) color */
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,6 +5089,13 @@ hast-util-from-parse5@^8.0.0:
     vfile-location "^5.0.0"
     web-namespaces "^2.0.0"
 
+hast-util-from-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-from-string/-/hast-util-from-string-2.0.0.tgz#a04c2805d4511d47c0fdea7545985f272ee0f5c6"
+  integrity sha512-9JlBGWh+RXbT8PDrdwYZloN6poib8xg7Vq+LgN5TTqnaMDO0YqfX4EyZd3Myel6yIXlDsgysiRB1CTjH2K+1Dg==
+  dependencies:
+    "@types/hast" "^2.0.0"
+
 hast-util-from-string@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-from-string/-/hast-util-from-string-3.0.0.tgz#03d7fa95e3c868e7365b0f3be45e852adfbd80c6"
@@ -8790,6 +8797,15 @@ rehype-preset-minify@^7.0.0:
     rehype-sort-attributes "^5.0.0"
     unified "^11.0.0"
 
+rehype-prism-diff@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rehype-prism-diff/-/rehype-prism-diff-1.1.2.tgz#e6a4dc951d5db9a0eb18eb289844221052b2553d"
+  integrity sha512-ETKbxHy8dTOBhIjBOa+hCpG5NJ7RNHi2CMyl9BMXE+xNEFwGjBbt0tQYJ0wKOEg+8ywwVZIcC9eMkjfzdOlE2Q==
+  dependencies:
+    hast-util-from-string "^2.0.0"
+    hast-util-to-string "^2.0.0"
+    unist-util-visit "^4.1.0"
+
 rehype-prism-plus@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rehype-prism-plus/-/rehype-prism-plus-1.6.3.tgz#8bf23a4cfc3419349770bb9064a91bdab04fae86"
@@ -10036,7 +10052,7 @@ unist-util-visit-parents@^6.0.0:
     "@types/unist" "^3.0.0"
     unist-util-is "^6.0.0"
 
-unist-util-visit@^4.0.0:
+unist-util-visit@^4.0.0, unist-util-visit@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
   integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR adds:
1. styles for specific line callouts on code blocks using the `{lineNuber}` syntax or `{from-to}` thanks to [`rehype-prism-plus`](https://github.com/timlrx/rehype-prism-plus)
2. Inline diffs support by prepending `+` or `-` to the lines and adding `diff` to the code block metatdata using [`rehype-prism-diff`](https://github.com/enpitsuLin/rehype-prism-diff/tree/master?tab=readme-ov-file#rehypre-prism-diff) (new dependency)

The inline diffs keep the foreign symbols upon selection and copying although it shouldn't in theory (as per the package docs), we can investigate this further if necessary.

Example, this snippet:

<pre>
```javascript {tabTitle:ESM} {3-4} diff
import * as Sentry from "@sentry/node";

Sentry.init({
  dsn: "___PUBLIC_DSN___",

  // We recommend adjusting this value in production, or using tracesSampler
  // for finer control

+  tracesSampleRate: 2.0,
-  tracesSampleRate: 1.0,
});
```
</pre>

results in:
![image](https://github.com/getsentry/sentry-docs/assets/17055517/b6e42d3b-f05d-429a-8e1b-490335026d53)

Example Diff:

<pre>
```diff
+ this is added
+ this is added
- this is removed
+ this is added
```
</pre>

results in:
![image](https://github.com/getsentry/sentry-docs/assets/17055517/3a8afcdb-89d2-4b6e-9d05-1964b06d4082)


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
