### PR TITLE
fix brand name for platform

### DIFF
--- a/docs/product/session-replay/getting-started.mdx
+++ b/docs/product/session-replay/getting-started.mdx
@@ -59,7 +59,7 @@ Currently, replays for backend errors is supported for the following SDK version
 - Python [1.20.0](https://github.com/getsentry/sentry-python/releases/tag/1.20.0)
 - Node [7.48.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.48.0)
 - PHP [3.18.0](https://github.com/getsentry/sentry-php/releases/tag/3.18.0)
-- NET [3.31.0](https://github.com/getsentry/sentry-dotnet/releases/tag/3.31.0)
+- .NET [3.31.0](https://github.com/getsentry/sentry-dotnet/releases/tag/3.31.0)
 - Java [6.17.0](https://github.com/getsentry/sentry-java/releases/tag/6.17.0)
 - Ruby [5.9.0](https://github.com/getsentry/sentry-ruby/releases/tag/5.9.0)
 - Go [0.21.0](https://github.com/getsentry/sentry-go/releases/tag/v0.21.0)


### PR DESCRIPTION
literally just a `.`