### PR TITLE
Add note to Next.js docs about `tunnelRoute` clashing with middleware

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -483,6 +483,13 @@ const nextConfig = {
 
 Setting this option will add an API endpoint to your application that is used to forward Sentry events to the Sentry servers.
 
+<Alert title={<>Using <code>tunnelRoute</code> with Next.js Middleware</>}>
+
+Recording client-side events will fail if the route configured with `tunnelRoute` is intercepted by your Next.js middleware.
+You can exclude the tunnel route by adding a negative matcher to your middleware: `(?!monitoring-tunnel)`
+
+</Alert>
+
 Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.
 
 The `tunnelRoute` option does currently not work with self-hosted Sentry instances.

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -483,10 +483,9 @@ const nextConfig = {
 
 Setting this option will add an API endpoint to your application that is used to forward Sentry events to the Sentry servers.
 
-<Alert title={<>Using <code>tunnelRoute</code> with Next.js Middleware</>}>
+<Alert title={<>Complications when using <code>tunnelRoute</code> with Next.js Middleware</>}>
 
-Recording client-side events will fail if the route configured with `tunnelRoute` is intercepted by your Next.js middleware.
-You can exclude the tunnel route by adding a negative matcher to your middleware: `(?!monitoring-tunnel)`
+If the route configured with `tunnelRoute` is intercepted by your Next.js middleware, the client-side events recording will fail. You can exclude the tunnel route by adding a negative matcher to your middleware like this: `(?!monitoring-tunnel)`
 
 </Alert>
 


### PR DESCRIPTION
Adds a note to Next.js docs about tunnelRoute being incompatible with Next.js middleware and how to resolve.