### PR TITLE
fix(python): Clarify how to set up tracing in older SDK

### DIFF
--- a/platform-includes/performance/configure-sample-rate/python.mdx
+++ b/platform-includes/performance/configure-sample-rate/python.mdx
@@ -1,4 +1,10 @@
-Activate performance monitoring by setting `enable_tracing` to `True`. Performance Monitoring is available for the Sentry Python SDK version ≥ 0.11.2.
+Activate performance monitoring by setting `enable_tracing` to `True`.
+
+<Note>
+
+`enable_tracing` is available in Sentry Python SDK version ≥ 1.16.0. To enable tracing in older SDK versions (≥ 0.11.2), use `traces_sample_rate=1.0`.
+
+</Note>
 
 <SignInNote />
 
@@ -7,6 +13,6 @@ import sentry_sdk
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    enable_tracing=True
+    enable_tracing=True,
 )
 ```

--- a/platform-includes/performance/configure-sample-rate/python.mdx
+++ b/platform-includes/performance/configure-sample-rate/python.mdx
@@ -1,10 +1,10 @@
 Activate performance monitoring by setting `enable_tracing` to `True`.
 
-<Note>
 
-`enable_tracing` is available in Sentry Python SDK version ≥ 1.16.0. To enable tracing in older SDK versions (≥ 0.11.2), use `traces_sample_rate=1.0`.
 
-</Note>
+Note that `enable_tracing` is available in Sentry Python SDK **version ≥ 1.16.0**. To enable tracing in older SDK versions (≥ 0.11.2), use `traces_sample_rate=1.0`.
+
+
 
 <SignInNote />
 


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

See https://github.com/getsentry/sentry-docs/issues/8771

We say that performance monitoring is available since version 0.11.2, but then use an option that was only added in version 1.16 in the setup example.

Adding a note to clarify.

**Direct link to preview:** https://sentry-docs-git-ivana-enable-tracing-not-available-in-old-sdk.sentry.dev/platforms/python/performance/#configure

Fixes https://github.com/getsentry/sentry-docs/issues/8771

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
