### PR TITLE
ref(JS/integrations): Slightly change info about default integration

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.breadcrumbsIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration wraps native APIs to capture breadcrumbs. By default, the Sentry SDK wraps all APIs.
 You can opt-out of capturing breadcrumbs for specific parts of your application (e.g. do not capture `console.log` calls as breadcrumbs) via the options below.

--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.breadcrumbsIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration wraps native APIs to capture breadcrumbs. By default, the Sentry SDK wraps all APIs.
 You can opt-out of capturing breadcrumbs for specific parts of your application (e.g. do not capture `console.log` calls as breadcrumbs) via the options below.
@@ -34,7 +34,7 @@ When an object with a `serializeAttribute` key is provided, the Breadcrumbs inte
 
 _Type: `boolean`_
 
-Log HTTP requests done with the Fetch API
+Log HTTP requests done with the Fetch API.
 
 ### `history`
 

--- a/docs/platforms/javascript/common/configuration/integrations/dedupe.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/dedupe.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.dedupeIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration deduplicates certain events. It can be helpful if you're receiving many duplicate errors. Note, that Sentry only compares stack traces and fingerprints.
 

--- a/docs/platforms/javascript/common/configuration/integrations/dedupe.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/dedupe.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.dedupeIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration deduplicates certain events. It can be helpful if you're receiving many duplicate errors. Note, that Sentry only compares stack traces and fingerprints.
 

--- a/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
@@ -7,6 +7,6 @@ sidebar_order: 1
 
 _Import name: `Sentry.functionToStringIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration allows the SDK to provide original functions and method names, even when those functions or methods are wrapped by our error or breadcrumb handlers.

--- a/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
@@ -7,6 +7,6 @@ sidebar_order: 1
 
 _Import name: `Sentry.functionToStringIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration allows the SDK to provide original functions and method names, even when those functions or methods are wrapped by our error or breadcrumb handlers.

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.globalHandlersIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration attaches global handlers to capture uncaught exceptions and unhandled rejections. It captures errors and unhandled promise rejections by default.
 

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.globalHandlersIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration attaches global handlers to capture uncaught exceptions and unhandled rejections. It captures errors and unhandled promise rejections by default.
 

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.httpContextIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration attaches HTTP request information, such as URL, user-agent, referrer, and other headers, to the event.
 It allows us to correctly catalog and tag events with specific OS, browser, and version information.

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.httpContextIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration attaches HTTP request information, such as URL, user-agent, referrer, and other headers, to the event.
 It allows us to correctly catalog and tag events with specific OS, browser, and version information.

--- a/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
@@ -7,7 +7,7 @@ sidebar_order: 1
 
 _Import name: `Sentry.inboundFiltersIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration allows you to ignore specific errors based on the type,
 message, or URLs in a given exception.

--- a/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
@@ -7,7 +7,7 @@ sidebar_order: 1
 
 _Import name: `Sentry.inboundFiltersIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration allows you to ignore specific errors based on the type,
 message, or URLs in a given exception.

--- a/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.linkedErrorsIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration allows you to configure linked errors. They’ll be recursively read up to a specified limit, then lookup will be performed by a specific key. By default, the Sentry SDK sets the limit to five and the key used is `"cause"`.
 

--- a/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
@@ -9,7 +9,7 @@ notSupported:
 
 _Import name: `Sentry.linkedErrorsIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration allows you to configure linked errors. They’ll be recursively read up to a specified limit, then lookup will be performed by a specific key. By default, the Sentry SDK sets the limit to five and the key used is `"cause"`.
 

--- a/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
@@ -9,6 +9,6 @@ notSupported:
 
 _Import name: `Sentry.browserApiErrorsIntegration`_
 
-This integration is [enabled by default](./../#modifying-default-integrations).
+This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
 
 This integration wraps native time and event APIs (`setTimeout`, `setInterval`, `requestAnimationFrame`, `addEventListener/removeEventListener`) in `try/catch` blocks to handle async exceptions.

--- a/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
@@ -9,6 +9,6 @@ notSupported:
 
 _Import name: `Sentry.browserApiErrorsIntegration`_
 
-This integration is enabled by default. You can also [modify default integrations](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration wraps native time and event APIs (`setTimeout`, `setInterval`, `requestAnimationFrame`, `addEventListener/removeEventListener`) in `try/catch` blocks to handle async exceptions.


### PR DESCRIPTION
## Description of changes

This PR changes the wording of the first line in default integrations. The link is now called "modify default integrations" to make it more clear where the link navigates to.

ref https://github.com/getsentry/sentry-docs/pull/9295
