### PR TITLE
 Add React Native to metrics SDKs list

### DIFF
--- a/docs/product/metrics/metrics-set-up.mdx
+++ b/docs/product/metrics/metrics-set-up.mdx
@@ -24,3 +24,4 @@ Metrics are currently available on the following platforms:
 - [Remix](/platforms/javascript/guides/remix/metrics/)
 - [Astro](/platforms/javascript/guides/astro/metrics/)
 - [Electron](/platforms/javascript/guides/electron/metrics/)
+- [React Native](/platforms/react-native/metrics/)


### PR DESCRIPTION
- RN metrics added in https://github.com/getsentry/sentry-docs/pull/9119
- This PR adds only the link