### PR TITLE
ref(v8/sveltekit): Adjust manual setup for Vite plugin 2.x bump

### DIFF
--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -66,7 +66,7 @@ Sentry.init({
 
 3. Add the `handleErrorWithSentry` function to the [`handleError` hook](https://kit.svelte.dev/docs/hooks#shared-hooks-handleerror):
 
-```javascript {filename:hooks.client.js}
+```javascript {filename:hooks.client.js} {5}
 const myErrorHandler = ({ error, event }) => {
   console.error("An error occurred on the client side:", error, event);
 };
@@ -77,7 +77,7 @@ export const handleError = Sentry.handleErrorWithSentry(myErrorHandler);
 // export const handleError = handleErrorWithSentry();
 ```
 
-```typescript {filename:hooks.client.ts}
+```typescript {filename:hooks.client.ts} {5}
 const myErrorHandler = ({ error, event }) => {
   console.error("An error occurred on the client side:", error, event);
 };
@@ -122,7 +122,7 @@ Sentry.init({
 
 3. Add the `handleErrorWithSentry` function to the [`handleError` hook](https://kit.svelte.dev/docs/hooks#shared-hooks-handleerror):
 
-```javascript {filename:hooks.server.js}
+```javascript {filename:hooks.server.js} {5}
 const myErrorHandler = ({ error, event }) => {
   console.error("An error occurred on the server side:", error, event);
 };
@@ -132,7 +132,7 @@ export const handleError = Sentry.handleErrorWithSentry(myErrorHandler);
 // export const handleError = handleErrorWithSentry();
 ```
 
-```typescript {filename:hooks.server.ts}
+```typescript {filename:hooks.server.ts} {5}
 const myErrorHandler = ({ error, event }) => {
   console.error("An error occurred on the server side:", error, event);
 };
@@ -162,7 +162,7 @@ export const handle = Sentry.sentryHandle();
 Add the `sentrySvelteKit` plugins to your `vite.config.(js|ts)` file so the Sentry SDK can apply build-time features.
 Make sure that it is added _before_ the sveltekit plugin:
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {2,5}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -172,7 +172,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts} {2,5}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -210,7 +210,7 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 
 <SignInNote />
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {7-11}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -221,9 +221,6 @@ export default {
         org: "___ORG_SLUG___",
         project: "___PROJECT_SLUG___",
         authToken: process.env.SENTRY_AUTH_TOKEN,
-        url: "https://sentry.my-company.com",
-        cleanArtifacts: true,
-        rewrite: false,
       },
     }),
     sveltekit(),
@@ -232,7 +229,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts} {7-11}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -243,7 +240,6 @@ export default {
         org: "___ORG_SLUG___",
         project: "___PROJET_SLUG___",
         authToken: process.env.SENTRY_AUTH_TOKEN,
-        cleanArtifacts: true,
       },
     }),
     sveltekit(),
@@ -259,7 +255,7 @@ Using the `sourceMapsUploadOptions` object is useful if the default source maps 
 By default, `sentrySvelteKit` will try to detect your SvelteKit adapter to configure source maps upload correctly.
 If you're not using one of the [supported adapters](../#compatibility) or the wrong one is detected, you can override the adapter detection by passing the `adapter` option to `sentrySvelteKit`:
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {7}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -274,7 +270,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts} {7}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -293,7 +289,7 @@ export default {
 
 You can disable automatic source maps upload in your Vite config:
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {7}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -308,7 +304,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts} {7}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -342,7 +338,7 @@ If you have custom Sentry code in these files, you'll have to [manually](#instru
 
 By passing the `autoInstrument` option to `sentrySvelteKit` you can disable auto-instrumentation entirely, or customize which `load` functions should be instrumented:
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {7-10}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -360,7 +356,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts} {7-10}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
 
@@ -382,7 +378,7 @@ export default {
 
 If you set the `autoInstrument` option to `false`, the SDK won't auto-instrument any `load` functions. You can still [manually instrument](#instrument-load-functions-manually) specific `load` functions.
 
-```javascript {filename:vite.config.js}
+```javascript {filename:vite.config.js} {7}
 import { sveltekit } from '@sveltejs/kit/vite';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 
@@ -397,7 +393,7 @@ export default {
 };
 ```
 
-```typescript {filename:vite.config.ts}
+```typescript {filename:vite.config.ts}  {7}
 import { sveltekit } from '@sveltejs/kit/vite';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 
@@ -420,19 +416,23 @@ If you don't want to use auto-instrumentation, you can also manually instrument 
 
 Use the `wrapLoadWithSentry` function to wrap universal `load` functions declared in `+page.(js|ts)` or `+layout.(js|ts)`
 
-```javascript {filename:+(page|layout).js}
+```javascript {filename:+(page|layout).js} {1,3}
 import { wrapLoadWithSentry } from "@sentry/sveltekit";
 
-export const load = wrapLoadWithSentry((event) => {
-  //... your load code
+export const load = wrapLoadWithSentry(({ fetch }) => {
+  const res = await fetch("/api/data");
+  const data = await res.json();
+  return { data };
 });
 ```
 
-```typescript {filename:+(page|layout).ts}
+```typescript {filename:+(page|layout).ts} {1,3}
 import { wrapLoadWithSentry } from "@sentry/sveltekit";
 
-export const load = wrapLoadWithSentry((event) => {
-  //... your load code
+export const load = wrapLoadWithSentry(({ fetch }) => {
+  const res = await fetch("/api/data");
+  const data = await res.json();
+  return { data };
 });
 ```
 
@@ -440,19 +440,23 @@ export const load = wrapLoadWithSentry((event) => {
 
 Or use the `wrapServerLoadWithSentry` function to wrap server-only `load` functions declared in `+page.server.(js|ts)` or `+layout.server.(js|ts)`
 
-```javascript {filename:+(page|layout).server.js}
+```javascript {filename:+(page|layout).server.js} {1,3}
 import { wrapServerLoadWithSentry } from "@sentry/sveltekit";
 
-export const load = wrapServerLoadWithSentry((event) => {
-  //... your load code
+export const load = wrapServerLoadWithSentry(({ fetch }) => {
+  const res = await fetch("/api/data");
+  const data = await res.json();
+  return { data };
 });
 ```
 
-```typescript {filename:+(page|layout).server.ts}
+```typescript {filename:+(page|layout).server.ts} {1,3}
 import { wrapServerLoadWithSentry } from "@sentry/sveltekit";
 
-export const load = wrapServerLoadWithSentry((event) => {
-  //... your load code
+export const load = wrapServerLoadWithSentry(({ event }) => {
+  const res = await fetch("/api/data");
+  const data = await res.json();
+  return { data };
 });
 ```
 
@@ -478,7 +482,7 @@ export const handle = sentryHandle({ fetchProxyScriptNonce: "<your-nonce>" });
 
 Then, adjust your [SvelteKit CSP configuration](https://kit.svelte.dev/docs/configuration#csp):
 
-```javascript {svelte.config.js}
+```javascript {svelte.config.js} {5}
 const config = {
   kit: {
     csp: {

--- a/platform-includes/getting-started-verify/javascript.sveltekit.mdx
+++ b/platform-includes/getting-started-verify/javascript.sveltekit.mdx
@@ -1,6 +1,6 @@
 Add a button to a frontend component that throws an error:
 
-```javascript {filename:src/routes/sentry/+page.svelte}
+```javascript {filename:src/routes/sentry/+page.svelte} {3}
 <button
   on:click={() => {
     throw new Error("Sentry Frontend Error");
@@ -12,7 +12,7 @@ Add a button to a frontend component that throws an error:
 
 Or throw an error in one of your `load` functions:
 
-```javascript {filename:src/routes/sentry/+page.js}
+```javascript {filename:src/routes/sentry/+page.js} {2}
 export const load = () => {
   throw new Error("Sentry Load Error");
 };
@@ -20,7 +20,7 @@ export const load = () => {
 
 Or throw an error in an API route:
 
-```javascript {filename:src/routes/sentry/+server.js}
+```javascript {filename:src/routes/sentry/+server.js} {2}
 export const GET = () => {
   throw new Error("Sentry API Error");
 };

--- a/platform-includes/sourcemaps/primer/javascript.sveltekit.mdx
+++ b/platform-includes/sourcemaps/primer/javascript.sveltekit.mdx
@@ -1,3 +1,3 @@
 `@sentry/sveltekit` will generate and upload source maps automatically, so that errors in Sentry will contain readable stack traces.
 
-The SvelteKit SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1) to upload source maps. See the [Manual Configuration](../manual-setup/#configure-source-maps-upload) page and the Sentry [Vite documentation](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1#configuration) for more details.
+The SvelteKit SDK uses the [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2) to upload source maps. See the [Manual Configuration](../manual-setup/#configure-source-maps-upload) page and the Sentry [Vite documentation](https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#configuration) for more details.


### PR DESCRIPTION
Updates SvelteKit docs to reflect Vite plugin 2.x bump. Also added a bunch of code block highlights - great stuff @a-hariti!