### PR TITLE
fix: empty bullet item on PageGrid

### DIFF
--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -28,14 +28,17 @@ export function PageGrid({header}: Props) {
     <nav>
       {header && <h2>{header}</h2>}
       <ul>
-        {parentNode.children.map(n => (
-          <li key={n.path} style={{marginBottom: '1rem'}}>
-            <h4 style={{marginBottom: 0}}>
-              <Link href={'/' + n.path}>{n.frontmatter.title}</Link>
-            </h4>
-            {n.frontmatter.description ?? <p>{n.frontmatter.description}</p>}
-          </li>
-        ))}
+        {parentNode.children
+          /* NOTE: temp fix while we figure out the reason why some nodes have empty front matter */
+          .filter(c => c.frontmatter.title)
+          .map(n => (
+            <li key={n.path} style={{marginBottom: '1rem'}}>
+              <h4 style={{marginBottom: 0}}>
+                <Link href={'/' + n.path}>{n.frontmatter.title}</Link>
+              </h4>
+              {n.frontmatter.description && <p>{n.frontmatter.description}</p>}
+            </li>
+          ))}
       </ul>
     </nav>
   );


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Don't render nodes with not front matter on `PageGrid`

Closes #9324 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
