### PR TITLE
feat: append platform or guide name to page title

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -10,10 +10,15 @@ import {DocPage} from 'sentry-docs/components/docPage';
 import {Home} from 'sentry-docs/components/home';
 import {Include} from 'sentry-docs/components/include';
 import {PlatformContent} from 'sentry-docs/components/platformContent';
-import {getDocsRootNode, nodeForPath} from 'sentry-docs/docTree';
+import {
+  getCurrentPlatformOrGuide,
+  getDocsRootNode,
+  nodeForPath,
+} from 'sentry-docs/docTree';
 import {getDocsFrontMatter, getFileBySlug} from 'sentry-docs/mdx';
 import {mdxComponents} from 'sentry-docs/mdxComponents';
 import {setServerContext} from 'sentry-docs/serverContext';
+import {capitilize} from 'sentry-docs/utils';
 
 export async function generateStaticParams() {
   const docs = await getDocsFrontMatter();
@@ -112,10 +117,14 @@ export async function generateMetadata({params}: MetadataProps): Promise<Metadat
   const images = [{url: `${domain}/meta.png`, width: 1200, height: 630}];
 
   const rootNode = await getDocsRootNode();
+
   if (rootNode && params.path) {
     const pageNode = nodeForPath(rootNode, params.path);
     if (pageNode) {
-      title = pageNode.frontmatter.title;
+      const guideOrPlatform = getCurrentPlatformOrGuide(rootNode, params.path);
+      title =
+        pageNode.frontmatter.title +
+        (guideOrPlatform ? ` | Sentry for ${capitilize(guideOrPlatform.name)}` : '');
       description = pageNode.frontmatter.description;
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,10 @@ export function sortBy<A>(arr: A[], comp: (v: A) => number): A[] {
   });
 }
 
+export const capitilize = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
 type Page = {
   context: {
     sidebar_order?: number;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

Append ` | Sentry for "Platform"` on page titles

Closes #9311 

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
