### PR TITLE
feat: fail production build process upon @Inject variable interpolation failure

### DIFF
--- a/src/remark-variables.js
+++ b/src/remark-variables.js
@@ -63,7 +63,15 @@ export default function remarkVariables(options) {
             throw err;
           }
 
+          // replace the match with the result (even if it's empty)
           node.value = node.value.replace(match[0], result);
+          if (!result) {
+            console.error(new Error(`Failed to interpolate expression: "${expr}"`));
+            // fail the build process in production
+            if (process.env.NODE_ENV === 'production') {
+              process.exit(1);
+            }
+          }
         });
       }
     );


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This prevents showing empty code blocks when `@inject` variables interpolation fails.

An error is logged to the console in development mode, and the build fails in prod.

Closes #3004 

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
