### PR TITLE
feat(alers): Update note about filtering out archived issues

### DIFF
--- a/docs/product/alerts/alert-types.mdx
+++ b/docs/product/alerts/alert-types.mdx
@@ -41,7 +41,7 @@ Metric alerts monitor macro-level metrics for both error and transaction events.
 
 <Note>
 
-Metric alerts aren’t affected by [archived issues](/product/issues/states-triage/#archive), so events from those issues are counted if they match the filters of your metric alert rule. Events from archived and resolved issues can be filtered out by using the `is:unresolved` filter in your metric alert rule filter.
+Metric alerts may include [archived issues](/product/issues/states-triage/#archive) if events from those issues match the filters of your metric alert rule. Events from archived and resolved issues can be filtered out by using the `is:unresolved` filter in your metric alert rule. This filter is added by default when creating a new metric alert, but you may need to manually add it to older metric alerts if you want them to exclude archived issues.
 
 </Note>
 

--- a/docs/product/alerts/alert-types.mdx
+++ b/docs/product/alerts/alert-types.mdx
@@ -41,7 +41,7 @@ Metric alerts monitor macro-level metrics for both error and transaction events.
 
 <Note>
 
-Metric alerts aren’t affected by [archived issues](/product/issues/states-triage/#archive), so events from those issues are counted if they match the filters of your metric alert rule.
+Metric alerts aren’t affected by [archived issues](/product/issues/states-triage/#archive), so events from those issues are counted if they match the filters of your metric alert rule. Events from archived and resolved issues can be filtered out by using the `is:unresolved` filter in your metric alert rule filter.
 
 </Note>
 

--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -11,7 +11,7 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 <Note>
-By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events from archived issues. If you want your metric alerts to include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
+When creating new metric alerts, the `is:unresolved` filter is added by default. This filter excludes events from archived and resolved issues. If you want your metric alerts to include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
 </Note>
 
 ### Metrics Types for Alerting

--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -11,7 +11,7 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 <Note>
-By default, metric alerts exclude archived issues. For instance, an alert for "Number of Errors" does not count errors from archived issues. If you want your metric alerts include archived issues, you can manually add `is:archived` to your [filters](#filters).
+By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events archived issues. If you want your metric alerts include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
 </Note>
 
 ### Metrics Types for Alerting

--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -11,7 +11,7 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 <Note>
-By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events archived issues. If you want your metric alerts include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
+By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events from archived issues. If you want your metric alerts include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
 </Note>
 
 ### Metrics Types for Alerting

--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -11,7 +11,7 @@ Sentry provides several configuration options to create a metric alert based on 
 To create a metric alert you first need to choose a metric type. For some alert types the function is built into the alert and for others you can choose functions and parameters to apply to it. For example, if you select “Users Experiencing Errors”, that translates to the function, `count_unique(user.id)`. Since editing this function would change the nature of the alert, it is not editable and thus hidden. On the other hand, if you select “Largest Contentful Paint” the measurement used is `measurement.lcp`, you also need to choose a function, e.g. `p75()`, for a combined metric function of `p75(measurement.lcp)`.
 
 <Note>
-By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events from archived issues. If you want your metric alerts include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
+By default, the "Number of Errors" metric alert filters by `is:unresolved` which excludes events from archived issues. If you want your metric alerts to include archived issues, you can manually remove `is:unresolved` from your [filters](#filters).
 </Note>
 
 ### Metrics Types for Alerting


### PR DESCRIPTION
Adds a note about filtering archived issues from metric alerts. See changelog https://changelog.getsentry.com/announcements/removing-archived-issues-from-metric-alerts
