### PR TITLE
misc(expo): EAS Update source maps has no release associated note

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -46,7 +46,7 @@ npx sentry-expo-upload-sourcemaps dist
 #### Notes
 
 - `dist` is the default output directory of `eas update`.
-- Uploaded source maps have no released associated. This is expected as updates can apply to multiple releases at once.
+- Uploaded source maps have no associated releases. This is expected as updates can apply to multiple releases.
 
 ## Notes
 

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -46,6 +46,7 @@ npx sentry-expo-upload-sourcemaps dist
 #### Notes
 
 - `dist` is the default output directory of `eas update`.
+- Uploaded source maps have no released associated. This is expected as updates can apply to multiple releases at once.
 
 ## Notes
 


### PR DESCRIPTION
- context https://github.com/getsentry/sentry-react-native/issues/3659