### PR TITLE
fix(apple): fixes `sdk` for apple guides + "Package" sidebar

### DIFF
--- a/docs/platforms/apple/guides/ios/config.yml
+++ b/docs/platforms/apple/guides/ios/config.yml
@@ -1,3 +1,4 @@
 title: iOS
+sdk: sentry.cocoa
 categories:
   - mobile

--- a/docs/platforms/apple/guides/macos/config.yml
+++ b/docs/platforms/apple/guides/macos/config.yml
@@ -1,3 +1,4 @@
 title: macOS
+sdk: sentry.cocoa
 categories:
   - desktop

--- a/docs/platforms/apple/guides/tvos/config.yml
+++ b/docs/platforms/apple/guides/tvos/config.yml
@@ -1,1 +1,2 @@
 title: tvOS
+sdk: sentry.cocoa

--- a/docs/platforms/apple/guides/visionos/config.yml
+++ b/docs/platforms/apple/guides/visionos/config.yml
@@ -1,2 +1,3 @@
 title: visionOS
+sdk: sentry.cocoa
 caseStyle: camelCase

--- a/docs/platforms/apple/guides/watchos/config.yml
+++ b/docs/platforms/apple/guides/watchos/config.yml
@@ -1,1 +1,2 @@
 title: watchOS
+sdk: sentry.cocoa


### PR DESCRIPTION
sets the `sdk` property for Apple platform guides, which fixes the missing `Package` sidebar when opening a guide

fixes https://github.com/getsentry/sentry-docs/issues/9365