### PR TITLE
Feat: Persist code block tab selection to locaStorage

### DIFF
--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -307,7 +307,6 @@ export function CodeContextProvider({children}: {children: React.ReactNode}) {
   );
 
   // Maintains the global selection for which code block tab is selected
-  // const sharedCodeSelection = useState<SeledtedCodeTabs>(storedSelections);
   const sharedCodeSelection = useReducer(
     (tabs: SelectedCodeTabs, [groupId, value]: [string, string]) => {
       return {...tabs, [groupId]: value};

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -308,9 +308,12 @@ export function CodeContextProvider({children}: {children: React.ReactNode}) {
 
   // Maintains the global selection for which code block tab is selected
   // const sharedCodeSelection = useState<SeledtedCodeTabs>(storedSelections);
-  const sharedCodeSelection = useReducer((tabs: SeledtedCodeTabs, [groupId, value]: [string, string]) => {
-    return {...tabs, [groupId]: value};
-  }, storedSelections)
+  const sharedCodeSelection = useReducer(
+    (tabs: SeledtedCodeTabs, [groupId, value]: [string, string]) => {
+      return {...tabs, [groupId]: value};
+    },
+    storedSelections
+  );
 
   const result: CodeContextType = {
     codeKeywords,

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {createContext, useEffect, useState} from 'react';
+import {createContext, useEffect, useReducer, useState} from 'react';
 import Cookies from 'js-cookie';
 
 type ProjectCodeKeywords = {
@@ -88,10 +88,12 @@ export const DEFAULTS: CodeKeywords = {
   USER: undefined,
 };
 
+type SeledtedCodeTabs = Record<string, string | undefined>;
+
 type CodeContextType = {
   codeKeywords: CodeKeywords;
   isLoading: boolean;
-  sharedCodeSelection: [string | null, React.Dispatch<string | null>];
+  sharedCodeSelection: [SeledtedCodeTabs, React.Dispatch<[string, string]>];
   sharedKeywordSelection: [
     Record<string, number>,
     React.Dispatch<Record<string, number>>,
@@ -297,8 +299,18 @@ export function CodeContextProvider({children}: {children: React.ReactNode}) {
   // that is the only namespace that actually has a list
   const sharedKeywordSelection = useState<Record<string, number>>({});
 
+  const storedSelections = Object.fromEntries(
+    Object.entries(
+      // default to an empty object if localStorage is not available on the server
+      typeof localStorage === 'undefined' ? {} : localStorage
+    ).filter(([key]) => key.startsWith('Tabgroup:'))
+  );
+
   // Maintains the global selection for which code block tab is selected
-  const sharedCodeSelection = useState<string | null>(null);
+  // const sharedCodeSelection = useState<SeledtedCodeTabs>(storedSelections);
+  const sharedCodeSelection = useReducer((tabs: SeledtedCodeTabs, [groupId, value]: [string, string]) => {
+    return {...tabs, [groupId]: value};
+  }, storedSelections)
 
   const result: CodeContextType = {
     codeKeywords,

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -88,12 +88,12 @@ export const DEFAULTS: CodeKeywords = {
   USER: undefined,
 };
 
-type SeledtedCodeTabs = Record<string, string | undefined>;
+type SelectedCodeTabs = Record<string, string | undefined>;
 
 type CodeContextType = {
   codeKeywords: CodeKeywords;
   isLoading: boolean;
-  sharedCodeSelection: [SeledtedCodeTabs, React.Dispatch<[string, string]>];
+  sharedCodeSelection: [SelectedCodeTabs, React.Dispatch<[string, string]>];
   sharedKeywordSelection: [
     Record<string, number>,
     React.Dispatch<Record<string, number>>,
@@ -309,7 +309,7 @@ export function CodeContextProvider({children}: {children: React.ReactNode}) {
   // Maintains the global selection for which code block tab is selected
   // const sharedCodeSelection = useState<SeledtedCodeTabs>(storedSelections);
   const sharedCodeSelection = useReducer(
-    (tabs: SeledtedCodeTabs, [groupId, value]: [string, string]) => {
+    (tabs: SelectedCodeTabs, [groupId, value]: [string, string]) => {
       return {...tabs, [groupId]: value};
     },
     storedSelections

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -86,10 +86,14 @@ export function CodeTabs({children}: CodeTabProps) {
     }
   });
 
-  const [sharedSelection, setSharedSelection] = codeContext?.sharedCodeSelection ?? [];
+  // The groupId is used to store the selection in localStorage.
+  // It is a unique identifier based on the tab titles.
+  const groupId = 'Tabgroup:' + possibleChoices.sort().join('|');
 
-  const sharedSelectionChoice = sharedSelection
-    ? possibleChoices.find(x => x === sharedSelection)
+  const [sharedSelections, setSharedSelections] = codeContext?.sharedCodeSelection ?? [];
+
+  const sharedSelectionChoice = sharedSelections
+    ? possibleChoices.find(x => x === sharedSelections[groupId])
     : null;
   const localSelectionChoice = localSelection
     ? possibleChoices.find(x => x === localSelection)
@@ -98,6 +102,11 @@ export function CodeTabs({children}: CodeTabProps) {
   // Prioritize sharedSelectionChoice over the local selection
   const finalSelection =
     sharedSelectionChoice ?? localSelectionChoice ?? possibleChoices[0];
+
+  // Save the selected tab for Tabgroup to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem(groupId, finalSelection);
+  }, [finalSelection]);
 
   // Whenever local selection and the final selection are not in sync, the local
   // selection is updated from the final one.  This means that when the shared
@@ -117,7 +126,7 @@ export function CodeTabs({children}: CodeTabProps) {
           // see useEffect above.
           setLastScrollOffset(containerRef.current.getBoundingClientRect().y);
         }
-        setSharedSelection?.(choice);
+        setSharedSelections?.([groupId, choice]);
         setLocalSelection(choice);
       }}
     >


### PR DESCRIPTION
This comes at the expense of some inevitable hydration errors

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This is useful for platforms like Java/Kotlin where it makes more sense to have the selection survive a page reload

**Caveat**: this introduces a jump after hydration if the stored selection is different from the default (first one)

Ideally this info should be stored in a cookie, but we can't do it since the pages are statically generated.

Closes #3051

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
