### PR TITLE
fix(mobile-vitals): Link to TTFD from screens module page

### DIFF
--- a/docs/product/performance/mobile-vitals/screen-loads.mdx
+++ b/docs/product/performance/mobile-vitals/screen-loads.mdx
@@ -8,7 +8,7 @@ description: "Learn how to monitor your mobile application's performance by usin
 
 The **Screen Loads** page shows an overview of the amount of time it takes for your application to load its screens. It helps you identify slow or regressed screens and gives additional information so you can better understand the factors contributing to the slowness of both time to initial display (TTID) and time to full display (TTFD).
 
-Sentry tracks TTID automatically, but [TTFD](#time-to-initial-display-and-time-to-full-display) requires that the `reportFullyDisplayed()` API be manually called to report that the screen has loaded all of its content and is fully displayed.
+Sentry tracks TTID automatically, but [TTFD](/product/performance/mobile-vitals/#time-to-initial-display-and-time-to-full-display) requires that the `reportFullyDisplayed()` API be manually called to report that the screen has loaded all of its content and is fully displayed.
 
 ### Minimum SDK Requirements:
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This link was missed when the new page was created. The section that it intends to link to is up a level in the Mobile Vitals docs.
