### PR TITLE
[go] Condense Profiling Setup Docs

### DIFF
--- a/docs/platforms/go/common/profiling/index.mdx
+++ b/docs/platforms/go/common/profiling/index.mdx
@@ -7,23 +7,6 @@ sidebar_order: 5000
 <PlatformContent includePath="profiling/index/preface" />
 <PlatformContent includePath="profiling/index/why-profiling" />
 
-## Enable Performance Monitoring
-
-Profiling depends on Sentry’s performance monitoring product being enabled beforehand. To enable performance monitoring in the SDK:
-
-<SignInNote />
-
-```go
-err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	EnableTracing: true,
-	// We recommend adjusting this value in production:
-	TracesSampleRate: 1.0,
-})
-```
-
-Check out the <PlatformLink to="/performance/">performance setup documentation</PlatformLink> for more detailed information on how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured.
-
 ## Enable Profiling
 
 <Note>
@@ -40,9 +23,15 @@ To enable profiling, set the `ProfilesSampleRate`:
 err := sentry.Init(sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
 	EnableTracing: true,
-	// We recommend adjusting these values in production:
 	TracesSampleRate: 1.0,
-	// The sampling rate for profiling is relative to TracesSampleRate:
 	ProfilesSampleRate: 1.0,
 })
 ```
+
+<Note>
+
+The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
+
+Profiling requires Sentry’s performance monitoring to be enabled via `traces_sample_rate` in the example above. Read our <PlatformLink to="/performance/">performance setup documentation</PlatformLink> to learn how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured.
+
+</Note>

--- a/docs/platforms/go/common/profiling/index.mdx
+++ b/docs/platforms/go/common/profiling/index.mdx
@@ -32,6 +32,6 @@ err := sentry.Init(sentry.ClientOptions{
 
 The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
-Profiling requires Sentry’s performance monitoring to be enabled via `traces_sample_rate` in the example above. Read our <PlatformLink to="/performance/">performance setup documentation</PlatformLink> to learn how to configure sampling. Setting the sample rate to 1.0 means all transactions will be captured.
+For Profiling to work, you have to first enable Sentry’s performance monitoring via `traces_sample_rate` (like in the example above). Read our <PlatformLink to="/performance/">performance setup documentation</PlatformLink> to learn how to configure sampling. If you set your sample rate to 1.0, all transactions will be captured.
 
 </Note>


### PR DESCRIPTION
Combine snippets, no stand alone for enabling performance

Cleaned up some repetive info on the page and snippets

there are 2 notes for go being in alpha, should also be combined IMO, feeling lazy atm

