### PR TITLE
Remove `sentry-expo` note and link new Sentry Expo guide

### DIFF
--- a/platform-includes/getting-started-install/react-native.mdx
+++ b/platform-includes/getting-started-install/react-native.mdx
@@ -29,13 +29,7 @@ The following tasks will be performed by the Sentry Wizard:
 
 ### Expo
 
-If you're using Expo, read about [How to Add Sentry to Your Expo Project](https://docs.expo.io/guides/using-sentry/). This SDK works for both managed and bare projects.
-
-<Note>
-
-Make sure that the version of `@sentry/react-native` matches what `sentry-expo` depends on, [read more in Expo documentation](https://docs.expo.io/guides/using-sentry/).
-
-</Note>
+If you're using Expo, read about [How to Add Sentry to Your Expo Project](/platforms/react-native/manual-setup/expo/). This SDK works for both managed and bare projects.
 
 ### iOS Specifics
 


### PR DESCRIPTION
The main RN page still included a note about deprecated `sentry-expo`.

