### PR TITLE
Fix: extra line breaks upon copying code snippets

### DIFF
--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -28,7 +28,8 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
       return;
     }
 
-    let code = codeRef.current.textContent || codeRef.current.innerText.replace(/\n\n/g, '\n');
+    let code =
+      codeRef.current.textContent || codeRef.current.innerText.replace(/\n\n/g, '\n');
 
     // don't copy leading prompt for bash
     if (language === 'bash' || language === 'shell') {

--- a/src/components/codeBlock.tsx
+++ b/src/components/codeBlock.tsx
@@ -28,7 +28,7 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
       return;
     }
 
-    let code = codeRef.current.innerText;
+    let code = codeRef.current.textContent || codeRef.current.innerText.replace(/\n\n/g, '\n');
 
     // don't copy leading prompt for bash
     if (language === 'bash' || language === 'shell') {

--- a/src/styles/_includes/code-blocks.scss
+++ b/src/styles/_includes/code-blocks.scss
@@ -81,7 +81,10 @@
 .code-line {
   display: block;
   float: left;
+  // fallback for browsers that don't support calc
+  // yes it should come before the calc
   min-width: 100%;
+  min-width: calc(100% + 24px);
   padding-left: 8px;
   margin-left: -12px;
   box-sizing: border-box;
@@ -97,8 +100,6 @@
 .code-line.diff-inserted,
 .code-line.inserted {
   background-color: rgba(16, 185, 129, 0.2); /* Set inserted line (+) color */
-  float: left;
-  min-width: 100%;
 }
 
 .code-line.diff-deleted,


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This was due to the nuance how browsers handle `.textContent` vs `.innerText` and `display: block;` on individual lines that was necessary for the diff/line highlighting.

I can't believe I overlooked it earlier 🙈 

Closes #9384, #9380

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
