### PR TITLE
ref(alerts): Remove line about proactively disabling alerts

### DIFF
--- a/docs/product/alerts/index.mdx
+++ b/docs/product/alerts/index.mdx
@@ -60,7 +60,7 @@ Metric alerts work in the same way as Issue alerts and can be muted on the **Ale
 
 ## Disabled Alerts
 
-Sentry has disabled duplicate alerts and alerts with no actions. If a noisy alert is sent to a communication channel and receives no engagement for an extended time, Sentry will proactively disable it to reduce unnecessary noise.
+Sentry has disabled duplicate alerts and alerts with no actions.
 
 Anyone with [alert edit access](/product/accounts/membership/) can re-enable an alert by editing its conditions and re-saving it. Alerts need to pass Sentry’s checks before they can be saved. See [best practices](/product/alerts/best-practices/) for guidance on writing useful alerts.
 


### PR DESCRIPTION
Remove a line about proactively disabling alerts that refers to a project we ended up not going through with. We do not do this.