### PR TITLE
Updated Python AWS Lambda docs ...

### DIFF
--- a/docs/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -7,7 +7,15 @@ sidebar_order: 3000
 <Alert level="warning" title="Deprecation Notice">
 
 The Python AWS Lambda Container Image is deprecated.
-Instead, please either use the <PlatformLink to="/integrations/aws-lambda/manual-layer/">Sentry AWS Lambda Layer</PlatformLink> or set up <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">Manual AWS Lambda Instrumentation</PlatformLink>.
+
+Instead, please use one of these ways:
+
+- **Without touching your code.**
+    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer manually to your function.**
+    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+- **By manually adding Sentry in your function code.**
+    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
 
 </Alert>
 

--- a/docs/platforms/python/integrations/aws-lambda/container-image/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/container-image/index.mdx
@@ -8,14 +8,14 @@ sidebar_order: 3000
 
 The Python AWS Lambda Container Image is deprecated.
 
-Instead, please use one of these ways:
+Please instrument your AWS Lambda function in one of the following ways instead:
 
-- **Without touching your code.**
-    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
-- **By adding the Sentry Lambda Layer manually to your function.**
-    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
-- **By manually adding Sentry in your function code.**
-    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
+- **Without touching your code:**
+    This method can be instrumented from the Sentry product by those who have access to the AWS infrastructure and doesn't require that you make any direct updates to the code. See the [AWS Lambda guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer to your function manually:**
+    While this is a quick way to add Sentry to your AWS Lambda function, it gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+- **By manually adding Sentry to your function code:**
+    This method requires that you install the Sentry SDK into your AWS Lambda function packages. While it takes more effort to set up, it gives you full control of your setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda manual instrumentation</PlatformLink>.
 
 </Alert>
 

--- a/docs/platforms/python/integrations/aws-lambda/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/index.mdx
@@ -5,9 +5,9 @@ description: "Learn about using Sentry with AWS Lambda."
 
 You can instrument your AWS Lambda functions in several different ways:
 
-- **Without touching your code.**
-    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
-- **By adding the Sentry Lambda Layer manually to your function.**
-    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
-- **By manually adding Sentry in your function code.**
-    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
+- **Without touching your code:**
+    This method can be instrumented from the Sentry product by those who have access to the AWS infrastructure and doesn't require that you make any direct updates to the code. See the [AWS Lambda guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer to your function manually:**
+    While this is a quick way to add Sentry to your AWS Lambda function, it gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+- **By manually adding Sentry to your function code:**
+    This method requires that you install the Sentry SDK into your AWS Lambda function packages. While it takes more effort to set up, it gives you full control of your setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda manual instrumentation</PlatformLink>.

--- a/docs/platforms/python/integrations/aws-lambda/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/index.mdx
@@ -5,7 +5,9 @@ description: "Learn about using Sentry with AWS Lambda."
 
 You can instrument your AWS Lambda functions in several different ways:
 
-- **Without touching your code.** This is configurable from within the Sentry product. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
-- **By adding the Sentry Lambda Layer manually to your function.** See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
-- **By manually adding Sentry in your function code.** See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
-- **By adding Sentry to your AWS Lambda container image.** See <PlatformLink to="/integrations/aws-lambda/container-image/">AWS Lambda Container Image</PlatformLink>.
+- **Without touching your code.**
+    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer manually to your function.**
+    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+- **By manually adding Sentry in your function code.**
+    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.

--- a/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
@@ -4,18 +4,17 @@ description: "Learn about instrumenting your AWS lambda function manually using 
 sidebar_order: 2000
 ---
 
-This guide describes how you manually add Sentry to your AWS Lambda function. You will need to install the Sentry SDK into your AWS Lambda function packages. This is the most work to set up, but it gives you full control of your Sentry setup and manual instrumentation.
+This guide walks you through how to manually add Sentry to your AWS Lambda function by installing the Sentry SDK into your AWS Lambda function packages. While this method takes more effort, it gives you full control of your Sentry setup and manual instrumentation.
 
-<Note>
 
-**Sentry has several ways to add Sentry to your AWS Lambda function:**
 
-- **Without touching your code.**
-    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
-- **By adding the Sentry Lambda Layer manually to your function.**
-    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
-- **By manually adding Sentry in your function code. (This Guide)**
-</Note>
+You can also configure this function in one of the two ways described below: 
+
+
+- **Without touching your code:**
+    This method can be instrumented from the Sentry product by those who have access to the AWS infrastructure and doesn't require that you make any direct updates to the code. See the [AWS Lambda guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer to your function manually:**
+    While this is a quick way to add Sentry to your AWS Lambda function, it gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
 
 ## Install
 

--- a/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
@@ -4,14 +4,17 @@ description: "Learn about instrumenting your AWS lambda function manually using 
 sidebar_order: 2000
 ---
 
+This guide describes how you manually add Sentry to your AWS Lambda function. You will need to install the Sentry SDK into your AWS Lambda function packages. This is the most work to set up, but it gives you full control of your Sentry setup and manual instrumentation.
+
 <Note>
 
-We also support:
+**Sentry has several ways to add Sentry to your AWS Lambda function:**
 
-- [Adding Sentry without modifying your code](/product/integrations/cloud-monitoring/aws-lambda/)
-- [Installing Sentry in the Lambda Layer](/platforms/python/integrations/aws-lambda/manual-layer/)
-- [Installing Sentry as a container image](/platforms/python/integrations/aws-lambda/container-image/)
-
+- **Without touching your code.**
+    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer manually to your function.**
+    A quick way to add Sentry to your AWS Lambda function. Gets you started quickly but gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+- **By manually adding Sentry in your function code. (This Guide)**
 </Note>
 
 ## Install

--- a/docs/platforms/python/integrations/aws-lambda/manual-layer/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-layer/index.mdx
@@ -4,7 +4,21 @@ description: "Learn how to manually set up Sentry with a Layer"
 sidebar_order: 1000
 ---
 
-You can add Sentry to your AWS Lambda function by adding the Sentry AWS Lambda Layer to your function.
+This guide describes how to add Sentry to your AWS Lambda function by adding the Sentry AWS Lambda layer. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure.
+
+<Note>
+
+**Sentry has several ways to add Sentry to your AWS Lambda function:**
+
+- **Without touching your code.**
+    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer manually to your function. (This Guide)**
+
+- **By manually adding Sentry in your function code.**
+    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
+
+
+</Note>
 
 ## Install The Layer
 

--- a/docs/platforms/python/integrations/aws-lambda/manual-layer/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-layer/index.mdx
@@ -4,21 +4,16 @@ description: "Learn how to manually set up Sentry with a Layer"
 sidebar_order: 1000
 ---
 
-This guide describes how to add Sentry to your AWS Lambda function by adding the Sentry AWS Lambda layer. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure.
-
-<Note>
-
-**Sentry has several ways to add Sentry to your AWS Lambda function:**
-
-- **Without touching your code.**
-    This is configurable from within the Sentry product. This way is probably the easiest for admin kind of people that have access to the AWS infrastructure. See the [AWS Lambda Cloud Monitoring Product Guide](/product/integrations/cloud-monitoring/aws-lambda/).
-- **By adding the Sentry Lambda Layer manually to your function. (This Guide)**
-
-- **By manually adding Sentry in your function code.**
-    You need to install the Sentry SDK into your AWS Lambda function packages. This is most work to set up, but it gives you full control of your Sentry setup and manual instrumentation. See <PlatformLink to="/integrations/aws-lambda/manual-instrumentation/">AWS Lambda Manual Instrumentation</PlatformLink>.
+This guide walks you through how to add Sentry to your AWS Lambda function by adding the Sentry AWS Lambda layer. This method can be instrumented from the Sentry product by those who have access to the AWS infrastructure and doesn't require that you make any direct updates to the code.  
 
 
-</Note>
+You can also configure this function in one of the two ways described below: 
+
+- **Without touching your code:**
+    This method can be instrumented from the Sentry product by those who have access to the AWS infrastructure and doesn't require that you make any direct updates to the code. See the [AWS Lambda guide](/product/integrations/cloud-monitoring/aws-lambda/).
+- **By adding the Sentry Lambda Layer to your function manually:**
+    While this is a quick way to add Sentry to your AWS Lambda function, it gives you limited configuration possibilities with environment vars. See <PlatformLink to="/integrations/aws-lambda/manual-layer/">AWS Lambda Layer</PlatformLink>.
+
 
 ## Install The Layer
 


### PR DESCRIPTION
... to make less confusing which way to choose to instrument your Python based AWS Lambda functions.

Previews:

Index: https://sentry-docs-git-antonpirker-python-awslambda-less-confusting.sentry.dev/platforms/python/integrations/aws-lambda/
- Lambda layer: https://sentry-docs-git-antonpirker-python-awslambda-less-confusting.sentry.dev/platforms/python/integrations/aws-lambda/manual-layer/
- Lambda manual instrumentation: https://sentry-docs-git-antonpirker-python-awslambda-less-confusting.sentry.dev/platforms/python/integrations/aws-lambda/manual-instrumentation/
- Lambda container image: https://sentry-docs-git-antonpirker-python-awslambda-less-confusting.sentry.dev/platforms/python/integrations/aws-lambda/container-image/
