### PR TITLE
fix(scrubbing): Mention default data scrubbing settings

### DIFF
--- a/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -75,7 +75,7 @@ Sentry does not know if a local variable that looks like a credit card number ac
 
 Selectors allow you to restrict rules to certain parts of the event. This is useful to unconditionally remove certain data by event attribute, and can also be used to conservatively test rules on real data. A few examples:
 
-- `**` to scrub everything
+- `**` to scrub [almost every field](/product/data-management-settings/scrubbing/server-side-scrubbing/event-pii-fields/) (other fields require specific selectors)
 - `$error.value` to scrub in the exception message
 - `$message` to scrub the event-level log message
 - `extra.'My Value'` to scrub the key `My Value` in "Additional Data"

--- a/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -75,7 +75,7 @@ Sentry does not know if a local variable that looks like a credit card number ac
 
 Selectors allow you to restrict rules to certain parts of the event. This is useful to unconditionally remove certain data by event attribute, and can also be used to conservatively test rules on real data. A few examples:
 
-- `**` to scrub [all default event PII fields](/product/data-management-settings/scrubbing/server-side-scrubbing/event-pii-fields/) (other fields require specific selectors)
+- `**` to scrub [all default event PII fields](/product/data-management-settings/scrubbing/server-side-scrubbing/event-pii-fields/) (other fields, like `span.description`, require specific selectors)
 - `$error.value` to scrub in the exception message
 - `$message` to scrub the event-level log message
 - `extra.'My Value'` to scrub the key `My Value` in "Additional Data"

--- a/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/product/data-management-settings/scrubbing/advanced-datascrubbing.mdx
@@ -75,7 +75,7 @@ Sentry does not know if a local variable that looks like a credit card number ac
 
 Selectors allow you to restrict rules to certain parts of the event. This is useful to unconditionally remove certain data by event attribute, and can also be used to conservatively test rules on real data. A few examples:
 
-- `**` to scrub [almost every field](/product/data-management-settings/scrubbing/server-side-scrubbing/event-pii-fields/) (other fields require specific selectors)
+- `**` to scrub [all default event PII fields](/product/data-management-settings/scrubbing/server-side-scrubbing/event-pii-fields/) (other fields require specific selectors)
 - `$error.value` to scrub in the exception message
 - `$message` to scrub the event-level log message
 - `extra.'My Value'` to scrub the key `My Value` in "Additional Data"


### PR DESCRIPTION
Link to the default scrubbed filters from the `**` selector in the data scrubbing sources docs.

Resolves https://github.com/getsentry/sentry/issues/66932.