### PR TITLE
update(Capacitor): Source map docs

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.capacitor.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.capacitor.mdx
@@ -8,7 +8,7 @@ After choosing your Sentry project, the setup process will prompt you to select 
 
 ```example
 ◆  Which framework, bundler or build tool are you using?
-│  ○ Angular
+│  ● Angular
 │  ○ Create React App
 │  ○ Next.js
 │  ○ Remix
@@ -16,13 +16,14 @@ After choosing your Sentry project, the setup process will prompt you to select 
 │  ● Vite (Select this if you are using Vite and you have access to your Vite config.)
 │  ● esbuild
 │  ○ Rollup
-│  ○ tsc
+│  ● tsc
 │  ○ I use another tool
 │  ○ I don't minify, transpile or bundle my code
 └
 ```
-
-If your project uses `Ionic build` for building your project, select the `tsc` option, otherwise, select `Angular`, `Webpack`, `Vite`, or `tsc` for the build script in your `package.json` file.
+<Note>
+  If your project uses `Ionic build` for building your project, select the `tsc` option.
+</Note>
 
 ## Manual Source Maps upload
 

--- a/platform-includes/sourcemaps/overview/javascript.capacitor.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.capacitor.mdx
@@ -1,0 +1,47 @@
+## Uploading Source Maps
+
+The easiest way to configure uploading source maps is by using the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx" />
+
+After choosing your Sentry project, the setup process will prompt you to select a framework. This step is crucial for configuring Sentry correctly. Make sure to choose the appropriate framework based on your project’s requirements.
+
+```example
+◆  Which framework, bundler or build tool are you using?
+│  ○ Angular
+│  ○ Create React App
+│  ○ Next.js
+│  ○ Remix
+│  ● Webpack
+│  ● Vite (Select this if you are using Vite and you have access to your Vite config.)
+│  ● esbuild
+│  ○ Rollup
+│  ○ tsc
+│  ○ I use another tool
+│  ○ I don't minify, transpile or bundle my code
+└
+```
+
+If your project uses `Ionic build` for building your project, select the `tsc` option, otherwise, select `Angular`, `Webpack`, `Vite`, or `tsc` for the build script in your `package.json` file.
+
+## Manual Source Maps upload
+
+If you want to configure source maps upload manually, follow the guide for your bundler or build tool below.
+
+### Sentry Bundler Supporte
+
+- <PlatformLink to="/sourcemaps/uploading/webpack/">webpack</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/rollup/">Rollup</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/vite/">Vite</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/esbuild/">esbuild</PlatformLink>
+
+### Guides
+
+- <PlatformLink to="/sourcemaps/uploading/typescript/"> TypeScript (tsc) </PlatformLink>
+  <Note>
+    If you're using one of webpack, Vite, Rollup or Esbuild, use the
+    corresponding Sentry plugin instead (see section "Sentry Bundler Support").
+  </Note>
+- <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
+- [GitHub Actions](/product/releases/setup/release-automation/github-actions/)

--- a/platform-includes/sourcemaps/primer/javascript.capacitor.mdx
+++ b/platform-includes/sourcemaps/primer/javascript.capacitor.mdx
@@ -1,0 +1,3 @@
+To enable readable stack traces in your Sentry errors, you need to upload your source maps to Sentry.
+
+![Readable Stack Traces](/platform-includes/sourcemaps/primer/readable-stacktraces.png)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

This PR reuses the JavaScript source map page layout, adding an additional sample on which platform/tool to select when users are using the script `ionic build` to build their projects.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
Closes #[455](https://github.com/getsentry/sentry-capacitor/issues/455)