### PR TITLE
Fix sitemap paths

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -23,10 +23,7 @@ import {capitilize} from 'sentry-docs/utils';
 export async function generateStaticParams() {
   const docs = await getDocsFrontMatter();
   const paths = docs.map(doc => {
-    let path = doc.slug.split('/');
-    if (path[path.length - 1] === 'index') {
-      path = path.slice(0, path.length - 1);
-    }
+    const path = doc.slug.split('/');
     return {path};
   });
   paths.push({path: undefined}); // the home page

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,10 +7,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const sitemapEntries = docs.map(doc => {
     let slug = doc.slug;
-    const slugParts = slug.split('/');
-    if (slugParts[slugParts.length - 1] === 'index') {
-      slug = slugParts.slice(0, slugParts.length - 1).join('/');
-    }
     if (!slug.endsWith('/')) {
       slug += '/';
     }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,9 +4,18 @@ import {getDocsFrontMatter} from 'sentry-docs/mdx';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const docs = await getDocsFrontMatter();
-  const sitemapEntries = docs.map(doc => ({
-    url: `https://docs.sentry.io/${doc.slug}`,
-  }));
+
+  const sitemapEntries = docs.map(doc => {
+    let slug = doc.slug;
+    const slugParts = slug.split('/');
+    if (slugParts[slugParts.length - 1] === 'index') {
+      slug = slugParts.slice(0, slugParts.length - 1).join('/');
+    }
+    if (!slug.endsWith('/')) {
+      slug += '/';
+    }
+    return {url: `https://docs.sentry.io/${slug}`};
+  });
   sitemapEntries.unshift({
     url: 'https://docs.sentry.io/',
   });

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -84,6 +84,14 @@ async function getDocsFrontMatterUncached(): Promise<FrontMatter[]> {
     });
   });
 
+  // Remove a trailing /index, since that is also removed from the path by Next.
+  frontMatter.forEach(fm => {
+    const trailingIndex = '/index';
+    if (fm.slug.endsWith(trailingIndex)) {
+      fm.slug = fm.slug.slice(0, fm.slug.length - trailingIndex.length);
+    }
+  });
+
   return frontMatter;
 }
 


### PR DESCRIPTION
@lizokm reported that only some of the pages in the sitemap.xml were being indexed properly. This was caused by an extra trailing `/index` in many of the paths. This is something that the main Page component already handles, but it was missed in the sitemap. Moved this fix up a level (into `getDocsFrontMatter()`) so that it didn't have to be duplicated into both the page and the sitemap, and so that future callers don't run into this same oversight.
