### PR TITLE
Use report-to with group which configured in the separate header

### DIFF
--- a/docs/product/security-policy-reporting.mdx
+++ b/docs/product/security-policy-reporting.mdx
@@ -19,7 +19,9 @@ To configure CSP reports in Sentry, you’ll need to send a header from your ser
 ```
 Content-Security-Policy: ...;
     report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
-    report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
+    report-to csp-endpoint
+
+Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 
 <Alert level="note" title="Compatibility Recommendation">
@@ -35,7 +37,9 @@ Alternatively you can setup CSP reports to simply send reports rather than actua
 ```
 Content-Security-Policy-Report-Only: ...;
     report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
-    report-to {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
+    report-to csp-endpoint
+
+Report-To: {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 
 When defining your policy it is important to ensure that `sentry.io` or your self-hosted Sentry domain is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.

--- a/docs/product/security-policy-reporting.mdx
+++ b/docs/product/security-policy-reporting.mdx
@@ -39,7 +39,7 @@ Content-Security-Policy-Report-Only: ...;
     report-uri https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___;
     report-to csp-endpoint
 
-Report-To: {"group":"default","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
+Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 
 When defining your policy it is important to ensure that `sentry.io` or your self-hosted Sentry domain is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
>The Content-Security-Policy Report-To HTTP response header field instructs the user agent to store reporting endpoints for an origin.

 the `report-to` directive seems need to be configured as following 
```
Content-Security-Policy: …; report-to groupname
```
and then  `Report-To` header contains the definition of the group with the above defined name

fix: https://github.com/getsentry/sentry-docs/issues/9199
fix: https://github.com/getsentry/sentry/issues/52794
related to: https://github.com/getsentry/sentry/issues/38940 and https://github.com/getsentry/relay/issues/2645

@oioki  just to double check if that makes sense. 

We also use the `report-to` configuration with similar config for NEL and that seems like it works as expected.  