### PR TITLE
Add a "good to know" note to JS Basic Options docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -15,8 +15,8 @@ The list of common options across SDKs. These work more or less the same in all 
 
 <Note>
 
-If you are using a framework or runtime that requires a prefix to expose environment variables to the client, these options will not be read into the client side automatically and must be set via the `init()` function.
-(For example, `NEXT_PUBLIC_` in [Next.js](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) or `VITE_` in [Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).)
+If you are using a framework or runtime that requires a prefix to expose environment variables to the client, you must set these options in the `init()` function. These options will not be read into the client side automatically.
+This applies to `NEXT_PUBLIC_` in [Next.js](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) and `VITE_` in [Vite](https://vitejs.dev/guide/env-and-mode.html#env-files), among others.
 
 </Note>
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -13,6 +13,13 @@ initialized.
 
 The list of common options across SDKs. These work more or less the same in all SDKs, but some subtle differences will exist to better support the platform. Options that can be read from an environment variable (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`) are read automatically.
 
+<Note>
+
+If you are using a framework or runtime that requires a prefix to expose environment variables to the client, these options will not be read into the client side automatically and must be set via the `init()` function.
+(For example, `NEXT_PUBLIC_` in [Next.js](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) or `VITE_` in [Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).)
+
+</Note>
+
 <ConfigKey name="dsn">
 
 The _DSN_ tells the SDK where to send the events. If this value is not provided, the SDK will try to read it from the `SENTRY_DSN` environment variable. If that variable also does not exist, the SDK will just not send any events.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adds a note to the JS Basic Options docs calling out a potential "gotcha" when working in frameworks that require an environmental variable prefix to expose their value to the client.

This PR resolves issue #9441 

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
