### PR TITLE
feat(webvitals): Moves overall perf score explainer up and add min latency for inp

### DIFF
--- a/docs/product/performance/web-vitals/index.mdx
+++ b/docs/product/performance/web-vitals/index.mdx
@@ -78,6 +78,12 @@ At the center of the **Page Overview**, Web Vital p75 values and scores are disp
 
 **Performance Score** is a rating from 0 to 100 that summarizes the perceived performance of your web application. Page loads and Interactions on your web application are scored based on their **Web Vitals**. Each **Web Vital** is given a rating from 0 to 100 through a [Log-Normal Distribution](https://www.desmos.com/calculator/o98tbeyt1t), which is then weighed and aggregated by page and overall for your entire web application.
 
+The overall **Performance Score** of your web application is the weighted average of your **Page Load** and **Interaction** scores. If your web application has far more Page Load scores than Interaction scores, your overall **Performance Score** will be biased towards Page Loads, and vice versa. An equal number of Page Load and Interaction scores produces an overall **Performance Score** comprised of a 50/50 average.
+
+<Note>
+Performance Scores are currently only supported on desktop web browsers.
+</Note>
+
 A **Page Load Performance Score** is comprised of up to 4 individual **Web Vital** components found on each event. The default weights and rating thresholds for each **Web Vital** can be found in the table below.
 
 | Page Load Web Vital                                             | P90 (Good)                                             | P50 (Meh)                                              | Weight |
@@ -99,10 +105,8 @@ An **Interaction Performance Score** is based off a single **Web Vital** compone
 | --------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ | ------ |
 | [Interaction to Next Paint](/product/performance/web-vitals/web-vitals-concepts/#interaction-to-next-paint-inp) (INP)   | [200ms](https://www.desmos.com/calculator/jaqxodpx8d)  | [500ms](https://www.desmos.com/calculator/jaqxodpx8d)  | 100%   |
 
-The overall **Performance Score** of your web application is the weighted average of your **Page Load** and **Interaction** scores. If your web application has far more Page Load scores than Interaction scores, your overall **Performance Score** will be biased towards Page Loads, and vice versa. An equal number of Page Load and Interaction scores produces an overall **Performance Score** comprised of a 50/50 average.
-
 <Note>
-Performance Scores are currently only supported on desktop web browsers.
+For an interaction to be considered an INP candidate, it must have a latency of at least [40ms](https://github.com/GoogleChrome/web-vitals/blob/v3.5.2/src/onINP.ts#L209).
 </Note>
 
 ## Opportunity


### PR DESCRIPTION
Moves up the explainer for the overall performance score and adds note about minimum latency for INP candidates which links out to the google webvitals library
![image](https://github.com/getsentry/sentry-docs/assets/83961295/020fd004-236d-4868-9ddc-30a0ebcf75db)
