### PR TITLE
Added links to APIdocs where the levels are listed

### DIFF
--- a/docs/platforms/python/integrations/django/http_errors.mdx
+++ b/docs/platforms/python/integrations/django/http_errors.mdx
@@ -27,6 +27,6 @@ def my_custom_page_not_found_view(*args, **kwargs):
 
 The error message you send to Sentry will have the usual request data attached.
 
-For details about `capture_message()` see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.capture_message)
+For details about `capture_message()`, see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.capture_message).
 
 Refer to [Customizing Error Views](https://docs.djangoproject.com/en/3.0/topics/http/views/#customizing-error-views) from the Django documentation for more information. You can also view our <PlatformLink to="/troubleshooting/">troubleshooting information</PlatformLink>.

--- a/docs/platforms/python/integrations/django/http_errors.mdx
+++ b/docs/platforms/python/integrations/django/http_errors.mdx
@@ -27,4 +27,6 @@ def my_custom_page_not_found_view(*args, **kwargs):
 
 The error message you send to Sentry will have the usual request data attached.
 
+For details about `capture_message()` see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.capture_message)
+
 Refer to [Customizing Error Views](https://docs.djangoproject.com/en/3.0/topics/http/views/#customizing-error-views) from the Django documentation for more information. You can also view our <PlatformLink to="/troubleshooting/">troubleshooting information</PlatformLink>.

--- a/docs/platforms/python/usage/set-level/index.mdx
+++ b/docs/platforms/python/usage/set-level/index.mdx
@@ -7,3 +7,5 @@ sidebar_order: 5
 The level - similar to logging levels - is generally added by default based on the integration. You can also override it within an event.
 
 <PlatformContent includePath="set-level" />
+
+For a list of possible levels see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.set_level)

--- a/docs/platforms/python/usage/set-level/index.mdx
+++ b/docs/platforms/python/usage/set-level/index.mdx
@@ -8,4 +8,4 @@ The level - similar to logging levels - is generally added by default based on t
 
 <PlatformContent includePath="set-level" />
 
-For a list of possible levels see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.set_level)
+For a list of possible levels, see the [API Documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.set_level).


### PR DESCRIPTION
I updated the docs to include links to the autogenerated APIdocs that list the possible values for `level`.

Fixes: #5432

There is also a PR in the Python Repo where I updated the APIdocs, that will be released soon: https://github.com/getsentry/sentry-python/pull/2828
