### PR TITLE
[Python] Updated the environment configuration

### DIFF
--- a/docs/platforms/python/configuration/environments.mdx
+++ b/docs/platforms/python/configuration/environments.mdx
@@ -10,6 +10,6 @@ Environments are case-sensitive. The environment name can't contain newlines, sp
 
 <PlatformContent includePath="set-environment" />
 
-The `environment` can also be set by an environment variable `SENTRY_ENVIRONMENT`. If no `environment` is set it will default to `production`.
+The `environment` can also be set by the environment variable, `SENTRY_ENVIRONMENT`. If no `environment` is set, it will default to `production`.
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).

--- a/docs/platforms/python/configuration/environments.mdx
+++ b/docs/platforms/python/configuration/environments.mdx
@@ -6,10 +6,10 @@ description: "Learn how to configure your SDK to tell Sentry about your environm
 
 Environments tell you where an error occurred, whether that's in your production system, your staging server, or elsewhere.
 
-Sentry automatically creates an environment when it receives an event with the `environment` parameter set.
-
 Environments are case-sensitive. The environment name can't contain newlines, spaces or forward slashes, can't be the string "None", or exceed 64 characters. You can't delete environments, but you can [hide](/product/sentry-basics/environments/#hidden-environments) them.
 
 <PlatformContent includePath="set-environment" />
+
+The `environment` can also be set by an environment variable `SENTRY_ENVIRONMENT`. If no `environment` is set it will default to `production`.
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).

--- a/platform-includes/set-environment/python.mdx
+++ b/platform-includes/set-environment/python.mdx
@@ -4,6 +4,6 @@ import sentry_sdk
 sentry_sdk.init(
     # ...
 
-    environment="production",
+    environment="staging",
 )
 ```


### PR DESCRIPTION
Updated the "environments" page of the Python docs. I included the default value and the possibility to set it via env var. I also improved the code snippet by not setting the environment to the default value, which would not make sense at all. 

Preview:
https://sentry-docs-git-antonpirker-python-configuration-environment.sentry.dev/platforms/python/configuration/environments/