### PR TITLE
Add .NET to list supporting AzureDevOps stack trace linking

### DIFF
--- a/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -94,7 +94,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with re
 
 <Note>
 
-This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
+This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, .NET, Go and Elixir.
 
 </Note>
 

--- a/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -94,7 +94,7 @@ When Sentry sees this, we’ll automatically annotate the matching issue with re
 
 <Note>
 
-This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, .NET, Go and Elixir.
+This feature is currently only supported for Ruby, Python, PHP, Node, JavaScript, .NET, Go and Elixir.
 
 </Note>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

See https://github.com/getsentry/sentry-dotnet/issues/1902

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
