### PR TITLE
Fix mistake in tabTitle

### DIFF
--- a/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -20,12 +20,12 @@ If you want to configure source maps upload with webpack manually, follow the st
 
 Install the Sentry webpack plugin:
 
-```bash {tabTitle:npm}
-npm install @sentry/webpack-plugin --save-dev
-```
-
 ```bash {tabTitle:Yarn}
 yarn add @sentry/webpack-plugin --dev
+```
+
+```bash {tabTitle:npm}
+npm install @sentry/webpack-plugin --save-dev
 ```
 
 ### Configuration


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Description of changes

Fixed a mistake with the yarn/npm switch on the webpack source-maps docs

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
