### PR TITLE
[Python] Describe precedence of `release` and `environment` configuration

### DIFF
--- a/docs/platforms/python/configuration/environments.mdx
+++ b/docs/platforms/python/configuration/environments.mdx
@@ -10,6 +10,6 @@ Environments are case-sensitive. The environment name can't contain newlines, sp
 
 <PlatformContent includePath="set-environment" />
 
-The `environment` can also be set by the environment variable, `SENTRY_ENVIRONMENT`. If no `environment` is set, it will default to `production`.
+If you do not set `environment` in `init()` the SDK will check for the environment variable `SENTRY_ENVIRONMENT`. If this is not set, `environment` will default to `production`.
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).

--- a/docs/platforms/python/configuration/environments.mdx
+++ b/docs/platforms/python/configuration/environments.mdx
@@ -10,6 +10,6 @@ Environments are case-sensitive. The environment name can't contain newlines, sp
 
 <PlatformContent includePath="set-environment" />
 
-If you do not set `environment` in `init()` the SDK will check for the environment variable, `SENTRY_ENVIRONMENT`. If this is not set, `environment` will default to `production`.
+If you do not set `environment` in `init()`, the Sentry SDK will check for the environment variable, `SENTRY_ENVIRONMENT`. If this is not set, `environment` will default to `production`.
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).

--- a/docs/platforms/python/configuration/environments.mdx
+++ b/docs/platforms/python/configuration/environments.mdx
@@ -10,6 +10,6 @@ Environments are case-sensitive. The environment name can't contain newlines, sp
 
 <PlatformContent includePath="set-environment" />
 
-If you do not set `environment` in `init()` the SDK will check for the environment variable `SENTRY_ENVIRONMENT`. If this is not set, `environment` will default to `production`.
+If you do not set `environment` in `init()` the SDK will check for the environment variable, `SENTRY_ENVIRONMENT`. If this is not set, `environment` will default to `production`.
 
 Environments help you better filter issues, releases, and user feedback in the Issue Details page of sentry.io, which you learn more about in our [documentation that covers using environments](/product/sentry-basics/environments/).

--- a/docs/platforms/python/configuration/releases.mdx
+++ b/docs/platforms/python/configuration/releases.mdx
@@ -36,7 +36,7 @@ We automatically detect whether a project is using semantic or time-based versio
 
 How you make the `release` available to your code is up to you. For example, you could use an environment variable that is set during the build process or during initial start-up.
 
-If no `release` is set, the Sentry SDK will try to guess it. The SDK will first check for the environment variable, `SENTRY_RELEASE`. If this environment variable is not set the SDK will check if a Git repository is present, and will take the Git SHA from the latest commit. If this did not work, the SDK will check some environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
+If you do not set `release` in `init()`, the Sentry SDK will try to guess it. The SDK will first check for the environment variable, `SENTRY_RELEASE`. If this environment variable is not set the SDK will check if a Git repository is present, and will take the Git SHA from the latest commit. If this did not work, the SDK will check some environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
 
 ## Unlocking More Release Features
 

--- a/docs/platforms/python/configuration/releases.mdx
+++ b/docs/platforms/python/configuration/releases.mdx
@@ -36,7 +36,7 @@ We automatically detect whether a project is using semantic or time-based versio
 
 How you make the `release` available to your code is up to you. For example, you could use an environment variable that is set during the build process or during initial start-up.
 
-If you do not set `release` in `init()`, the Sentry SDK will try to guess it. The SDK will first check for the environment variable, `SENTRY_RELEASE`. If this environment variable is not set the SDK will check if a Git repository is present, and will take the Git SHA from the latest commit. If this did not work, the SDK will check some environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
+If you do not set `release` in `init()`, the Sentry SDK will try to guess it. The SDK will first check for the environment variable, `SENTRY_RELEASE`. If this environment variable is not set, the SDK will then check if a Git repository is present and, if so, will take the Git SHA from the latest commit. If this doesn't work, the SDK will check for environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
 
 ## Unlocking More Release Features
 

--- a/docs/platforms/python/configuration/releases.mdx
+++ b/docs/platforms/python/configuration/releases.mdx
@@ -36,9 +36,7 @@ We automatically detect whether a project is using semantic or time-based versio
 
 How you make the `release` available to your code is up to you. For example, you could use an environment variable that is set during the build process or during initial start-up.
 
-The `release` can also be set using the environment variable, `SENTRY_RELEASE`.
-
-If no `release` is set, the Sentry SDK will try to guess it. If a Git repository is present, it will take the Git SHA from the latest commit. If this did not work, the SDK will check some environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
+If no `release` is set, the Sentry SDK will try to guess it. The SDK will first check for the environment variable, `SENTRY_RELEASE`. If this environment variable is not set the SDK will check if a Git repository is present, and will take the Git SHA from the latest commit. If this did not work, the SDK will check some environment variables used by hosting providers like `HEROKU_SLUG_COMMIT`, `SOURCE_VERSION`, `CODEBUILD_RESOLVED_SOURCE_VERSION`, `CIRCLE_SHA1`, and `GAE_DEPLOYMENT_ID`.
 
 ## Unlocking More Release Features
 


### PR DESCRIPTION
Make it clear how the configuration of `release` and `environment` can be set and in what order the SDK tries the different ways to set those options. 