### PR TITLE
feat(crons): Add Redbeat as supported scheduler

### DIFF
--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -62,7 +62,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-In addition to the default Celery Beat scheduler we also support Redbeat.
+In addition to the default Celery Beat scheduler, we also support Redbeat.
 
 <Note>
 

--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -62,7 +62,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-In addition to the default Celery Beat scheduler we also support the Redbeat scheduler.
+In addition to the default Celery Beat scheduler we also support Redbeat.
 
 <Note>
 

--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -62,7 +62,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-Currently, only the default scheduler of Celery Beat is officially supported. Other schedulers (like `RedBeat`) are not supported.
+In addition to the default Celery Beat scheduler we also support the Redbeat scheduler.
 
 <Note>
 

--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -62,7 +62,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-In addition to the default Celery Beat scheduler, we also support Redbeat.
+In addition to the default Celery Beat scheduler, we also support [https://redbeat.readthedocs.io/en/latest](Redbeat).
 
 <Note>
 

--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -62,7 +62,7 @@ Once Sentry Crons is set up, tasks in your Celery beat schedule will be auto-dis
 
 Start your Celery beat and worker services and see your tasks being monitored at [https://sentry.io/crons/](https://sentry.io/crons/).
 
-In addition to the default Celery Beat scheduler, we also support [https://redbeat.readthedocs.io/en/latest](Redbeat).
+In addition to the default Celery Beat scheduler, we also support [Redbeat](https://redbeat.readthedocs.io/en/latest).
 
 <Note>
 


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

With https://github.com/getsentry/sentry-python/issues/2616 and https://github.com/getsentry/sentry-python/pull/2643 we'll be adding support for a new Celery Beat scheduler (Redbeat).

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
