### PR TITLE
fix(codetabs): removed sorting of tabs in codetabs

### DIFF
--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -88,7 +88,7 @@ export function CodeTabs({children}: CodeTabProps) {
 
   // The groupId is used to store the selection in localStorage.
   // It is a unique identifier based on the tab titles.
-  const groupId = 'Tabgroup:' + possibleChoices.sort().join('|');
+  const groupId = 'Tabgroup:' + possibleChoices.join('|');
 
   const [sharedSelections, setSharedSelections] = codeContext?.sharedCodeSelection ?? [];
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

fixes: #9486 

for making a unique key name of tabs, the tabs were sorted causing the issue.
right now, I removed the sorting of tab names.
But if sorting is needed, please comment.
Thanks