### PR TITLE
feat(tracing): Add link to `tracesSampler` example

### DIFF
--- a/docs/platforms/android/performance/index.mdx
+++ b/docs/platforms/android/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/apple/common/performance/index.mdx
+++ b/docs/platforms/apple/common/performance/index.mdx
@@ -19,7 +19,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/dart/performance/index.mdx
+++ b/docs/platforms/dart/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/dotnet/common/performance/index.mdx
+++ b/docs/platforms/dotnet/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/dotnet/common/performance/index.mdx
+++ b/docs/platforms/dotnet/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">TracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/flutter/performance/index.mdx
+++ b/docs/platforms/flutter/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/go/common/performance/index.mdx
+++ b/docs/platforms/go/common/performance/index.mdx
@@ -25,7 +25,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/go/common/performance/index.mdx
+++ b/docs/platforms/go/common/performance/index.mdx
@@ -25,7 +25,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">TracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/java/common/performance/index.mdx
+++ b/docs/platforms/java/common/performance/index.mdx
@@ -37,7 +37,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/javascript/common/performance/index.mdx
+++ b/docs/platforms/javascript/common/performance/index.mdx
@@ -35,7 +35,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/native/common/performance/index.mdx
+++ b/docs/platforms/native/common/performance/index.mdx
@@ -34,7 +34,7 @@ The Native SDK doesn't currently support sampling functions (<PlatformIdentifier
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/node/common/performance/index.mdx
+++ b/docs/platforms/node/common/performance/index.mdx
@@ -29,7 +29,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/php/common/performance/index.mdx
+++ b/docs/platforms/php/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/php/common/performance/index.mdx
+++ b/docs/platforms/php/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">traces_sampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/powershell/performance/index.mdx
+++ b/docs/platforms/powershell/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/powershell/performance/index.mdx
+++ b/docs/platforms/powershell/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">TracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/python/performance/index.mdx
+++ b/docs/platforms/python/performance/index.mdx
@@ -18,7 +18,7 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Next Steps
 

--- a/docs/platforms/python/performance/index.mdx
+++ b/docs/platforms/python/performance/index.mdx
@@ -18,7 +18,7 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">traces_sampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Next Steps
 

--- a/docs/platforms/react-native/performance/index.mdx
+++ b/docs/platforms/react-native/performance/index.mdx
@@ -21,7 +21,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/ruby/common/performance/index.mdx
+++ b/docs/platforms/ruby/common/performance/index.mdx
@@ -25,7 +25,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/ruby/common/performance/index.mdx
+++ b/docs/platforms/ruby/common/performance/index.mdx
@@ -25,7 +25,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">traces_sampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/rust/common/performance/index.mdx
+++ b/docs/platforms/rust/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/rust/common/performance/index.mdx
+++ b/docs/platforms/rust/common/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/unity/performance/index.mdx
+++ b/docs/platforms/unity/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 

--- a/docs/platforms/unity/performance/index.mdx
+++ b/docs/platforms/unity/performance/index.mdx
@@ -23,7 +23,7 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 <PlatformContent includePath="performance/configure-sample-rate" />
 
-Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+Learn more about performance monitoring <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">TracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
 ## Verify
 


### PR DESCRIPTION
## Description of changes

The `tracesSampler` function is mentioned in the performance docs, but no example is provided. Added a link to an respective example.
