### PR TITLE
chore(okhttp): Update Android OkHttp integration docs to sentry.okhttp

### DIFF
--- a/docs/platforms/android/integrations/okhttp/index.mdx
+++ b/docs/platforms/android/integrations/okhttp/index.mdx
@@ -2,25 +2,25 @@
 title: OkHttp
 caseStyle: camelCase
 supportLevel: production
-sdk: sentry.java.android.okhttp
+sdk: sentry.java.okhttp
 description: "Learn more about the Sentry OkHttp integration for the Android SDK."
 categories:
   - mobile
 ---
 
-The `sentry-android-okhttp` library provides [OkHttp](https://github.com/square/okhttp) support for Sentry via the [OkHttp Interceptor](https://github.com/square/okhttp/blob/a2059dedc0b1d4a977480834ae4ed9ea576a3eb8/okhttp/src/main/kotlin/okhttp3/Interceptor.kt). The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/main/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp).
+The `sentry-okhttp` library provides [OkHttp](https://github.com/square/okhttp) support for Sentry via the [OkHttp Interceptor](https://github.com/square/okhttp/blob/a2059dedc0b1d4a977480834ae4ed9ea576a3eb8/okhttp/src/main/kotlin/okhttp3/Interceptor.kt).
 
 On this page, we get you up and running with Sentry's OkHttp Integration, so that it will automatically add a breadcrumb and start a span out of the active span bound to the scope for each HTTP Request.
 
 <Note>
 
-The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilities](https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce) with Android versions below 5.0. However, you are free to adapt our [SentryOkHttpInterceptor](https://github.com/getsentry/sentry-java/blob/main/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt) if you're using an older `okhttp` version.
+The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilities](https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce) with Android versions below 5.0. However, you are free to adapt our [SentryOkHttpInterceptor](https://github.com/getsentry/sentry-java/blob/main/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt) if you're using an older `okhttp` version.
 
 </Note>
 
 ## Auto-Installation With the Sentry Android Gradle Plugin
 
-Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-android-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-android-okhttp` dependency if an `okhttp` dependency was discovered on the classpath.
+Starting from version `3.1.0`, the Sentry Android Gradle plugin will automatically add the `sentry-okhttp` dependency and instrument all of your `OkHttpClient` instances through bytecode manipulation. The plugin will only add the `sentry-okhttp` dependency if an `okhttp` dependency was discovered on the classpath.
 Starting from version `3.11.0`, the Sentry Android Gradle plugin will also automatically add the `SentryOkHttpEventListener` to your `OkHttpClient` instances through bytecode manipulation.
 
 ### Install
@@ -78,11 +78,11 @@ Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/and
 
 ### Install
 
-Sentry captures data by adding an `OkHttp Interceptor` and an `OkHttp EventListener`. To add the OkHttp integration, initialize the [Android SDK](/platforms/android/), then add the `sentry-android-okhttp` dependency using Gradle:
+Sentry captures data by adding an `OkHttp Interceptor` and an `OkHttp EventListener`. To add the OkHttp integration, initialize the [Android SDK](/platforms/android/), then add the `sentry-okhttp` dependency using Gradle:
 
 ```groovy
 implementation 'io.sentry:sentry-android:{{@inject packages.version('sentry.java.android', '5.0.0') }}'
-implementation 'io.sentry:sentry-android-okhttp:{{@inject packages.version('sentry.java.android.okhttp', '5.0.0') }}'
+implementation 'io.sentry:sentry-okhttp:{{@inject packages.version('sentry.java.okhttp', '5.0.0') }}'
 ```
 
 ### Configure
@@ -97,8 +97,8 @@ Configuration should happen once you create your `OkHttpClient` instance.
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 
 private val client = OkHttpClient.Builder()
   .addInterceptor(SentryOkHttpInterceptor())
@@ -108,8 +108,8 @@ private val client = OkHttpClient.Builder()
 
 ```java
 import okhttp3.OkHttpClient;
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor;
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor;
 
 private final OkHttpClient client = new OkHttpClient.Builder()
   .addInterceptor(new SentryOkHttpInterceptor())
@@ -125,8 +125,8 @@ The SDK can give more in-depth information through the `SentryOkHttpEventListene
 This snippet includes a HTTP Request and captures an intentional message, so you can test that everything is working as soon as you set it up:
 
 ```kotlin
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 import io.sentry.Sentry
 import java.io.IOException
 import okhttp3.OkHttpClient
@@ -150,8 +150,8 @@ fun run(url: String): String? {
 ```
 
 ```java
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor;
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor;
 import io.sentry.Sentry
 import java.io.IOException;
 import okhttp3.OkHttpClient;
@@ -190,7 +190,7 @@ The captured span can be customized or dropped with a `BeforeSpanCallback`:
 
 ```kotlin
 import io.sentry.ISpan
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpInterceptor
 import okhttp3.Request
 import okhttp3.Response
 
@@ -207,7 +207,7 @@ class CustomBeforeSpanCallback : SentryOkHttpInterceptor.BeforeSpanCallback {
 
 ```java
 import io.sentry.ISpan;
-import io.sentry.android.okhttp.SentryOkHttpInterceptor;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -226,8 +226,8 @@ The callback instance must be set on the `SentryOkHttpInterceptor` once you crea
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 
 private val client = OkHttpClient.Builder()
   .eventListener(SentryOkHttpEventListener())
@@ -237,8 +237,8 @@ private val client = OkHttpClient.Builder()
 
 ```java
 import okhttp3.OkHttpClient;
-import io.sentry.android.okhttp.SentryOkHttpEventListener;
-import io.sentry.android.okhttp.SentryOkHttpInterceptor;
+import io.sentry.okhttp.SentryOkHttpEventListener;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
 
 private final OkHttpClient client = new OkHttpClient.Builder()
   .eventListener(new SentryOkHttpEventListener())
@@ -252,8 +252,8 @@ The event listener can propagate calls to another `EventListener` or `EventListe
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 
 private val client = OkHttpClient.Builder()
   .eventListener(SentryOkHttpEventListener(MyEventListener()))
@@ -263,8 +263,8 @@ private val client = OkHttpClient.Builder()
 
 ```java
 import okhttp3.OkHttpClient;
-import io.sentry.android.okhttp.SentryOkHttpEventListener;
-import io.sentry.android.okhttp.SentryOkHttpInterceptor;
+import io.sentry.okhttp.SentryOkHttpEventListener;
+import io.sentry.okhttp.SentryOkHttpInterceptor;
 
 private final OkHttpClient client = new OkHttpClient.Builder()
   .eventListener(new SentryOkHttpEventListener(new MyEventListener()))
@@ -280,8 +280,8 @@ Starting with SDK version `7.0.0`, HTTP client error capturing is enabled by def
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 
 private val client = OkHttpClient.Builder()
   .eventListener(SentryOkHttpEventListener())
@@ -293,8 +293,8 @@ By default, only HTTP client errors with a response code between `500` and `599`
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 import io.sentry.HttpStatusCodeRange
 
 private val client = OkHttpClient.Builder()
@@ -309,8 +309,8 @@ HTTP client errors from every target (`.*` regular expression) are automatically
 
 ```kotlin
 import okhttp3.OkHttpClient
-import io.sentry.android.okhttp.SentryOkHttpEventListener
-import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import io.sentry.okhttp.SentryOkHttpEventListener
+import io.sentry.okhttp.SentryOkHttpInterceptor
 import io.sentry.HttpStatusCodeRange
 
 private val client = OkHttpClient.Builder()


### PR DESCRIPTION
[Android OkHttp integration docs still refer](https://docs.sentry.io/platforms/android/integrations/okhttp/) to the deprecated `sentry-android-okhttp` package. The [Java page](https://docs.sentry.io/platforms/java/performance/instrumentation/okhttp/) has already been updated.