### PR TITLE
chore(java): Add SDK names for Java integrations

### DIFF
--- a/docs/platforms/java/common/performance/instrumentation/apollo.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/apollo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apollo Integration
 sidebar_order: 30
+sdk: sentry.java.apollo
 description: "Learn how to capture the performance of Apollo GraphQL client."
 notSupported:
   - java.logback

--- a/docs/platforms/java/common/performance/instrumentation/apollo3.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/apollo3.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apollo3 Integration
 sidebar_order: 31
+sdk: sentry.java.apollo-3
 description: "Learn how to capture the performance of Apollo GraphQL client."
 notSupported:
   - java.logback

--- a/docs/platforms/java/common/performance/instrumentation/jdbc.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/jdbc.mdx
@@ -1,6 +1,7 @@
 ---
 title: JDBC Instrumentation
 sidebar_order: 40
+sdk: sentry.java.jdbc
 description: "Learn how to capture the performance of database queries executed with JDBC."
 notSupported:
   - java.logback

--- a/docs/platforms/java/common/performance/instrumentation/okhttp.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/okhttp.mdx
@@ -1,6 +1,7 @@
 ---
 title: OkHttp Integration
 sidebar_order: 35
+sdk: sentry.java.okhttp
 description: "Learn how to capture the performance of OkHttp client."
 notSupported:
   - java.logback

--- a/docs/platforms/java/common/performance/instrumentation/open-feign.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/open-feign.mdx
@@ -1,6 +1,7 @@
 ---
 title: OpenFeign Integration
 sidebar_order: 50
+sdk: sentry.java.openfeign
 description: "Learn how to capture the performance of OpenFeign-based HTTP clients."
 notSupported:
   - java.logback

--- a/docs/platforms/java/common/performance/instrumentation/opentelemetry.mdx
+++ b/docs/platforms/java/common/performance/instrumentation/opentelemetry.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Support
+sdk: sentry.java.opentelemetry-agent
 description: "Using OpenTelemetry with Sentry Performance."
 sidebar_order: 20
 ---


### PR DESCRIPTION
now that the package sidebar shows correct info for integrations, it's worthwhile to set the correct SDK names for integrations in the docs. as a followup, we may want to add more specific info (e.g. repo or api docs links) to the relevant [release registry](https://github.com/getsentry/sentry-release-registry) items.