### PR TITLE
Explicitly state "outgoing" connections

### DIFF
--- a/docs/platforms/node/common/configuration/integrations/default-integrations.mdx
+++ b/docs/platforms/node/common/configuration/integrations/default-integrations.mdx
@@ -53,7 +53,7 @@ This integration wraps the `console` module to record all of its calls as breadc
 
 _Import name: `Sentry.httpIntegration`_
 
-This integration wraps the `http` and `https` modules to capture all network requests as breadcrumbs and/or tracing spans.
+This integration wraps the `http` and `https` modules to capture all outgoing network requests as breadcrumbs and/or tracing spans.
 
 Available options:
 
@@ -114,7 +114,7 @@ Available options:
 }
 ```
 
-To change what requests get the `sentry-trace` and `baggage` headers attached (for use in distributed tracing), use the top level `tracePropagationTargets` option.
+To change what requests get the `sentry-trace` and `baggage` headers attached (for use in distributed tracing), use the top-level `tracePropagationTargets` option.
 
 ```typescript
 Sentry.init({


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Explicitly state "outgoing" connections. Mainly because I confused myself regarding the next version's [instrumentation of incoming requests](https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-node.md#plain-node--unsupported-frameworks) versus the current integration's instrumentation of outgoing requests.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
