### PR TITLE
fix(csp): migrate to new `report-to` directive

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io vercel.live; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io reload.getsentry.net storage.googleapis.com; img-src * 'self' data: www.google.com www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com; worker-src blob:; report-uri https://o1.ingest.sentry.io/api/1267915/security/?sentry_key=ad63ba38287245f2803dc220be959636"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io vercel.live; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io reload.getsentry.net storage.googleapis.com; img-src * 'self' data: www.google.com www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com; worker-src blob:; report-to csp"
         },
         {
           "key": "NEL",
@@ -25,7 +25,7 @@
         },
         {
           "key": "Report-To",
-          "value": "{\"group\":\"nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://o1.ingest.sentry.io/api/1267915/nel/?sentry_key=ad63ba38287245f2803dc220be959636\"}]}"
+          "value": "{\"group\":\"nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://o1.ingest.sentry.io/api/1267915/nel/?sentry_key=ad63ba38287245f2803dc220be959636\"}]},{\"group\":\"csp\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://o1.ingest.sentry.io/api/1267915/security/?sentry_key=ad63ba38287245f2803dc220be959636\"}]}"
         }
       ]
     }


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Migrating away from deprecated `report-uri` to the new `report-to` keyword (ingestion implemented in https://github.com/getsentry/relay/pull/3277).

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
