### PR TITLE
feat(code-mappings): Add PHP to supported platforms for automatic code amppings

### DIFF
--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -296,13 +296,13 @@ By default, this feature is automatically enabled once your GitHub integration h
 
 <Note>
 
-Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, and Ruby projects for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually. Support for other languages and other source code integrations is being worked on.
+Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, and PHP projects for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually. Support for other languages and other source code integrations is being worked on.
 
 </Note>
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
-1. Navigate to **Settings > Integrations > GitHub > Configurations**.
+ > GitHub > Configurations**.
 
 1. Click the "Configure" button next to your GitHub Instance.
 

--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -302,7 +302,7 @@ Sentry will automatically try to set up code mappings on Python, JavaScript, Nod
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 
- > GitHub > Configurations**.
+1. Navigate to **Settings > Integrations > GitHub > Configurations**.
 
 1. Click the "Configure" button next to your GitHub Instance.
 

--- a/docs/product/issues/suspect-commits/index.mdx
+++ b/docs/product/issues/suspect-commits/index.mdx
@@ -51,7 +51,7 @@ In [sentry.io](https://sentry.io):
 
 <Note>
 
-Sentry will automatically try to set up code mappings on Python and JavaScript projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
+Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, and PHP projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
 
 </Note>
 


### PR DESCRIPTION
**Adds PHP to the list of platforms which have automatic stack trace linking enabled in the Github integration page and the suspect commit page.**  

### Github Integration Page: (/product/integrations/source-code-mgmt/github/)
**Before:**
![image](https://github.com/getsentry/sentry-docs/assets/55160142/5b6a5b38-ab76-4345-b372-58f1e09898e4)!
**After:**
![image](https://github.com/getsentry/sentry-docs/assets/55160142/1b249089-ee72-4225-b016-2c687a21116a)



### Suspect Commit Page: (/product/issues/suspect-commits/)
**Before:**
![image](https://github.com/getsentry/sentry-docs/assets/55160142/e39779f5-5b97-45e6-98af-0e33e831aa96)
**After:**
![image](https://github.com/getsentry/sentry-docs/assets/55160142/f1f9499a-f87b-4b86-95bd-fd4e3877c7f6)
