### PR TITLE
add zd-site-verification meta tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
   openGraph: {
     images: 'https://docs.sentry.io/changelog/assets/og.png',
   },
+  zd-site-verification {
+    content: 'ocu6mswx6pke3c6qvozr2e',  
+  },
 };
 
 export default function RootLayout({children}: {children: React.ReactNode}) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,8 +9,8 @@ export const metadata: Metadata = {
   openGraph: {
     images: 'https://docs.sentry.io/changelog/assets/og.png',
   },
-  zd-site-verification {
-    content: 'ocu6mswx6pke3c6qvozr2e',  
+  other: {
+    'zd-site-verification': 'ocu6mswx6pke3c6qvozr2e',
   },
 };
 


### PR DESCRIPTION
We need to ensure that the docs site has the following meta tag:

<meta name='zd-site-verification' content='ocu6mswx6pke3c6qvozr2e' />

This will allow Zendesk's Help Center to crawl the site and index docs content for search.

More info here: https://support.zendesk.com/hc/en-us/articles/4593564000410-Setting-up-the-search-crawler



