### PR TITLE
docs(issues): Add link to browser extension filters list

### DIFF
--- a/docs/product/data-management-settings/filtering/index.mdx
+++ b/docs/product/data-management-settings/filtering/index.mdx
@@ -35,7 +35,7 @@ If you had a legacy browser filter on before the update, the old filter will app
 
 ### Browser Extension Errors
 
-Some browser extensions are known to cause errors. You can use the browser extension filter to filter these out. The filter checks the error message and the event source to see if it's a known error coming from a browser extension. To see the full list of errors filtered by the browser extension filter, see the [source code in relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/browser_extensions.rs#L9).
+Some browser extensions are known to cause errors. You can filter these out using the browser extension filter, which checks the error message and event source to see if it's a known error coming from a browser extension. To see the full list of errors filtered out by the browser extension filter, see the [source code in relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/browser_extensions.rs#L9-L76).
 
 ### Web Crawler Errors
 

--- a/docs/product/data-management-settings/filtering/index.mdx
+++ b/docs/product/data-management-settings/filtering/index.mdx
@@ -35,7 +35,7 @@ If you had a legacy browser filter on before the update, the old filter will app
 
 ### Browser Extension Errors
 
-Some browser extensions are known to cause errors. You can use the browser extension filter to filter these out. The filter checks the error message and the event source to see if it's a known error coming from a browser extension. To see the full list of errors filtered by the browser extension filter, see the [source code in relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/browser_extensions.rs#L9-L76).
+Some browser extensions are known to cause errors. You can use the browser extension filter to filter these out. The filter checks the error message and the event source to see if it's a known error coming from a browser extension. To see the full list of errors filtered by the browser extension filter, see the [source code in relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/browser_extensions.rs#L9).
 
 ### Web Crawler Errors
 

--- a/docs/product/data-management-settings/filtering/index.mdx
+++ b/docs/product/data-management-settings/filtering/index.mdx
@@ -35,7 +35,7 @@ If you had a legacy browser filter on before the update, the old filter will app
 
 ### Browser Extension Errors
 
-Some browser extensions are known to cause errors. You can use the browser extension filter to filter these out. The filter checks the error message and the event source to see if it's a known error coming from a browser extension.
+Some browser extensions are known to cause errors. You can use the browser extension filter to filter these out. The filter checks the error message and the event source to see if it's a known error coming from a browser extension. To see the full list of errors filtered by the browser extension filter, see the [source code in relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/browser_extensions.rs#L9-L76).
 
 ### Web Crawler Errors
 


### PR DESCRIPTION
People sometimes ask where they can find the list of errors being filtered out. It would be hard to keep this updated in both places so we were thinking a link to the source code would work.
