### PR TITLE
feat(replay): Replay canvas troubleshooting docs

### DIFF
--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -19,7 +19,7 @@ Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to
 
 ## My `canvas` has been tainted
 
-Set `crossorigin="anonymous"` on your images. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin.
+Set `crossorigin="anonymous"` on your images. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin. See the [CORS documention](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image) for more information about this error.
 
 ## Replay is slowing down my `canvas`
 

--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -17,7 +17,7 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> to get started with canvas recordings.
 
-If you are on a supported SDK version and your `canvas` elements still aren't getting captured, check if you have images or videos loaded from foreign origins inside your `canvas`. Additionally, check for a `SecurityError` being thrown when trying to use the replay canvas integration. If these apply, set `crossorigin="anonymous"` to your images or videos. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin. See the [CORS documention](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases) for more information about this.
+If you are on a supported SDK version and your `canvas` elements still aren't getting captured, check if you have images or videos loaded from foreign origins inside your `canvas`. Any data loaded from an origin without CORS approval is not considered secure and will throw a `SecurityError` when trying to use the replay canvas integration. To fix this issue, set `crossorigin="anonymous"` to your images or videos. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin. See the [CORS documention](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases) for more information about cross-origin access.
 
 ## Replay is slowing down my `canvas`
 

--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -17,9 +17,7 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> to get started with canvas recordings.
 
-## My `canvas` has been tainted
-
-Set `crossorigin="anonymous"` on your images. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin. See the [CORS documention](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image) for more information about this error.
+If you are on a supported SDK version and your `canvas` elements still aren't getting captured, check if you have images or videos loaded from foreign origins inside your `canvas`. Additionally, check for a `SecurityError` being thrown when trying to use the replay canvas integration. If these apply, set `crossorigin="anonymous"` to your images or videos. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin. See the [CORS documention](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases) for more information about this.
 
 ## Replay is slowing down my `canvas`
 

--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -17,6 +17,10 @@ This guide aims to extend the <PlatformLink to="/troubleshooting/">main troubles
 
 Canvas is supported in SDK versions >= `7.98.0`. Please see the <PlatformLink to="/session-replay/#canvas-recording">canvas setup documention</PlatformLink> to get started with canvas recordings.
 
+## My `canvas` has been tainted
+
+Set `crossorigin="anonymous"` on your images. This will allow images that are loaded from foreign origins to be used in `canvas` as if they have been loaded from the current origin.
+
 ## Replay is slowing down my `canvas`
 
 The integration needs to enable `preserveDrawingBuffer` to export images from 3D and WebGL canvases. This can negatively affect canvas performance. If your canvas application is impacted by enabling `preserveDrawingBuffer`, you'll need to <PlatformLink to="/session-replay/#canvas-recording-performance">enable manual snapshotting</PlatformLink> and call a `snapshot()` method inside of your re-paint loop.


### PR DESCRIPTION
Adds troubleshooting section for canvas being tainted
<img width="793" alt="image" src="https://github.com/getsentry/sentry-docs/assets/55311782/e5c3dd9f-d2df-48e5-9e7f-f37a7fbb831c">

Fixes https://github.com/getsentry/sentry-docs/issues/9515
