### PR TITLE
adding scopes to sentry-cli explain command

### DIFF
--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -280,6 +280,12 @@ To troubleshoot your source maps set up, you can either:
 
 To use the automated verification process, install and configure the Sentry [Command Line Interface](/product/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
 
+<Alert title="Note" level="warning">
+
+The `sourcemaps explain` command requires an auth token with the following scopes: `project:admin`, `release:admin`, `event:read`, `organisation:read`. We recomend creating an [internal integration token](https://docs.sentry.io/product/integrations/integration-platform/internal-integration/) over a personal token.  
+
+</Alert>
+
 For example, "Event ID: c2ad049f":
 
 ![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)

--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -282,7 +282,7 @@ To use the automated verification process, install and configure the Sentry [Com
 
 <Alert title="Note" level="warning">
 
-The `sourcemaps explain` command requires an auth token with the following scopes: `project:admin`, `release:admin`, `event:read`, `organisation:read`. We recomend creating an [internal integration token](https://docs.sentry.io/product/integrations/integration-platform/internal-integration/) over a personal token.  
+The `sourcemaps explain` command requires an auth token with the following scopes: `project:admin`, `release:admin`, `event:read`, and `organization:read`. We recommend creating an [internal integration token](/product/integrations/integration-platform/internal-integration/) over a personal token.  
 
 </Alert>
 


### PR DESCRIPTION
This change adds the required scopes to authenticate the sentry-cli in order to run sourcemaps explain and upload the files to sentry. 

Which is not supported by org tokens with scope `org:cli`