### PR TITLE
add privacy section to session replays

### DIFF
--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -37,7 +37,7 @@ Personally identifiable information (PII), and privacy are important considerati
 - [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
 - Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
-While we have certain privacy considerations in place, Sentry's session replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking settings.
+While we have certain privacy considerations in place, Sentry's Session Replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other types of private data, you can opt out of the default text masking and image blocking settings.
 To learn more about session replay privacy, [read our docs.](/platforms/javascript/session-replay/privacy/)
 
 ### Lazy-loading Replay

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -34,7 +34,7 @@ setTimeout(() => {
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:
-- [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else (the default behavior being to replace each character with a *).
+- [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else. (The default behavior being to replace each character with a *.)
 - Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
 While we have certain privacy considerations in place, Sentry's Session Replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other types of private data, you can opt out of the default text masking and image blocking settings.

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -31,6 +31,14 @@ setTimeout(() => {
   throw new Error("Sentry Test Error");
 });
 ```
+### PII & Privacy Considerations
+
+Personally identifiable information (PII), and privacy are important considerations when enabling session replays. There are several ways in which Sentry helps you avoid collecting PII:
+- [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
+- Making [Network request and response bodies and headers](/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
+
+Sentry's session replays allow you to set up the [privacy configuration]() that makes the most sense for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking options.
+To learn more about session replay privateDecrypt, [read our docs.](/platforms/javascript/session-replay/privacy/)
 
 ### Lazy-loading Replay
 

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -35,7 +35,7 @@ setTimeout(() => {
 
 Personally identifiable information (PII), and privacy are important considerations when enabling session replays. There are several ways in which Sentry helps you avoid collecting PII:
 - [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
-- Making [Network request and response bodies and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
+- Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
 While we have certain privacy considerations in place, Sentry's session replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking settings.
 To learn more about session replay privacy, [read our docs.](/platforms/javascript/session-replay/privacy/)

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -33,7 +33,7 @@ setTimeout(() => {
 ```
 ### PII & Privacy Considerations
 
-Personally identifiable information (PII), and privacy are important considerations when enabling session replays. There are several ways in which Sentry helps you avoid collecting PII:
+Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are several ways in which Sentry helps you avoid collecting PII:
 - [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
 - Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -34,7 +34,7 @@ setTimeout(() => {
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are several ways in which Sentry helps you avoid collecting PII:
-- [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
+- [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else (the default behavior being to replace each character with a *).
 - Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
 While we have certain privacy considerations in place, Sentry's Session Replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other types of private data, you can opt out of the default text masking and image blocking settings.

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -35,10 +35,10 @@ setTimeout(() => {
 
 Personally identifiable information (PII), and privacy are important considerations when enabling session replays. There are several ways in which Sentry helps you avoid collecting PII:
 - [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
-- Making [Network request and response bodies and headers](/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
+- Making [Network request and response bodies and headers](/javascript/session-replay/privacy//javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers/) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
-Sentry's session replays allow you to set up the [privacy configuration]() that makes the most sense for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking options.
-To learn more about session replay privateDecrypt, [read our docs.](/platforms/javascript/session-replay/privacy/)
+While we have certain privacy considerations in place, Sentry's session replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking settings.
+To learn more about session replay privacy, [read our docs.](/platforms/javascript/session-replay/privacy/)
 
 ### Lazy-loading Replay
 

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -35,7 +35,7 @@ setTimeout(() => {
 
 Personally identifiable information (PII), and privacy are important considerations when enabling session replays. There are several ways in which Sentry helps you avoid collecting PII:
 - [Masking](/platforms/javascript/session-replay/privacy/#masking) which replaces the text content with something else (the default behavior being to replace each character with a *).
-- Making [Network request and response bodies and headers](/javascript/session-replay/privacy//javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers/) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
+- Making [Network request and response bodies and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
 While we have certain privacy considerations in place, Sentry's session replays allow you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other type of private data, you can opt out of the default text masking and image blocking settings.
 To learn more about session replay privacy, [read our docs.](/platforms/javascript/session-replay/privacy/)

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -33,7 +33,7 @@ setTimeout(() => {
 ```
 ### PII & Privacy Considerations
 
-Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are several ways in which Sentry helps you avoid collecting PII:
+Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:
 - [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else (the default behavior being to replace each character with a *).
 - Making [Network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 


### PR DESCRIPTION
Add a note about privacy to session replay set up docs.

closes: https://github.com/getsentry/sentry-docs/issues/8878