### PR TITLE
fix(flutter): Flutter migration docs missing _flutter

### DIFF
--- a/docs/platforms/flutter/migration.mdx
+++ b/docs/platforms/flutter/migration.mdx
@@ -3,7 +3,7 @@ title: Migration Guide
 sidebar_order: 8000
 ---
 
-## Migrating From `sentry_flutter` `6.18.x` to `sentry` `7.0.0`
+## Migrating From `sentry_flutter` `6.18.x` to `sentry_flutter` `7.0.0`
 
 In addition to the changes introduced in [sentry](/platforms/dart/migration/):
 
@@ -19,11 +19,11 @@ API changes:
   - `autoSessionTrackingIntervalMillis` replaced with `autoSessionTrackingInterval`.
 - The `enableNdkScopeSync` feature is now enabled by default.
 
-## Migrating From `sentry_flutter` `6.12.x` to `sentry` `6.13.x`
+## Migrating From `sentry_flutter` `6.12.x` to `sentry_flutter` `6.13.x`
 
 The SDK already runs your init `callback` on an error handler, such as [`runZonedGuarded`](https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html) on Flutter versions prior to `3.3`, or [`PlatformDispatcher.onError`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html) on Flutter versions 3.3 and higher, so that errors are automatically captured. No code changes are needed on your part.
 
-## Migrating From `sentry_flutter` `6.5.x` to `sentry` `6.6.x`
+## Migrating From `sentry_flutter` `6.5.x` to `sentry_flutter` `6.6.x`
 
 There are no Flutter-specific breaking changes. However, there are some in [sentry](/platforms/dart/migration/) for Dart.
 


### PR DESCRIPTION
as discussed on discord