### PR TITLE
ref(crons): Simplify example, add async note

### DIFF
--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -30,4 +30,4 @@ The SDK might be experiencing network issues. Learn more about <PlatformLink to=
 
 ### Can I Monitor Async Tasks as Well?
 
-Yes, just make sure you're using SDK version `1.45.0` or higher since that's when support for monitoring async functions was added.
+Yes, just make sure you're using SDK version `1.44.1` or higher since that's when support for monitoring async functions was added.

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -30,4 +30,4 @@ The SDK might be experiencing network issues. Learn more about <PlatformLink to=
 
 ### Can I Monitor Async Tasks as Well?
 
-Yes, just make sure you're using SDK version `1.44` or higher since that's when support for monitoring async functions was added.
+Yes, just make sure you're using SDK version `1.45.0` or higher since that's when support for monitoring async functions was added.

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -30,4 +30,4 @@ The SDK might be experiencing network issues. Learn more about <PlatformLink to=
 
 ### Can I Monitor Async Tasks as Well?
 
-Yes, just make sure you're using SDK version 1.44 or higher since that's when support for monitoring async functions was added.
+Yes, just make sure you're using SDK version `1.44` or higher since that's when support for monitoring async functions was added.

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -27,3 +27,7 @@ Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedb
 ### Why Are My Monitors Showing Up as Failed?
 
 The SDK might be experiencing network issues. Learn more about <PlatformLink to="/troubleshooting/#network-issues">troubleshooting network issues</PlatformLink>.
+
+### Can I Monitor Async Tasks as Well?
+
+Yes, support for monitoring asynchronous functions was added in SDK version 1.44.

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -30,4 +30,4 @@ The SDK might be experiencing network issues. Learn more about <PlatformLink to=
 
 ### Can I Monitor Async Tasks as Well?
 
-Yes, support for monitoring asynchronous functions was added in SDK version 1.44.
+Yes, just make sure you're using SDK version 1.44 or higher since that's when support for monitoring async functions was added.

--- a/platform-includes/crons/setup/python.mdx
+++ b/platform-includes/crons/setup/python.mdx
@@ -15,7 +15,7 @@ from sentry_sdk.crons import monitor
 # Add the @monitor decorator to your task
 @monitor(monitor_slug='<monitor-slug>')
 def tell_the_world():
-    print("My scheduled task...")
+    print('My scheduled task...')
 ```
 
 Alternatively, `monitor` can be used as a context manager:
@@ -26,12 +26,12 @@ from sentry_sdk.crons import monitor
 
 def tell_the_world():
     with monitor(monitor_slug='<monitor-slug>'):
-        print("My scheduled task...")
+        print('My scheduled task...')
 ```
 
 <Note>
 
-Since version `1.44` of the SDK you can use `monitor` to annotate asynchronous
+Since version `1.45.0` of the SDK you can use `monitor` to annotate asynchronous
 functions as well.
 
 </Note>

--- a/platform-includes/crons/setup/python.mdx
+++ b/platform-includes/crons/setup/python.mdx
@@ -31,7 +31,7 @@ def tell_the_world():
 
 <Note>
 
-Since version `1.45.0` of the SDK you can use `monitor` to annotate asynchronous
+Since version `1.44.1` of the SDK you can use `monitor` to annotate asynchronous
 functions as well.
 
 </Note>

--- a/platform-includes/crons/setup/python.mdx
+++ b/platform-includes/crons/setup/python.mdx
@@ -31,7 +31,7 @@ def tell_the_world():
 
 <Note>
 
-Since version 1.44 of the SDK you can use `monitor` to annotate asynchronous
+Since version `1.44` of the SDK you can use `monitor` to annotate asynchronous
 functions as well.
 
 </Note>

--- a/platform-includes/crons/setup/python.mdx
+++ b/platform-includes/crons/setup/python.mdx
@@ -6,19 +6,32 @@ If you're using **Celery Beat** to run your periodic tasks, have a look at our [
 
 Use the Python SDK to monitor and notify you if your periodic task is missed (or doesn't start when expected), if it fails due to a problem in the runtime (such as an error), or if it fails by exceeding its maximum runtime.
 
+Use the `monitor` decorator to wrap your tasks:
+
 ```python
 import sentry_sdk
 from sentry_sdk.crons import monitor
 
 # Add the @monitor decorator to your task
 @monitor(monitor_slug='<monitor-slug>')
-def tell_the_world(msg):
-    # Scheduled task here...
-    print(msg)
-
-# monitor can also be used as a context manager
-def tell_the_world_contextmanager(msg):
-    with monitor(monitor_slug='<monitor-slug>'):
-        # Scheduled task here...
-        print(msg)
+def tell_the_world():
+    print("My scheduled task...")
 ```
+
+Alternatively, `monitor` can be used as a context manager:
+
+```python
+import sentry_sdk
+from sentry_sdk.crons import monitor
+
+def tell_the_world():
+    with monitor(monitor_slug='<monitor-slug>'):
+        print("My scheduled task...")
+```
+
+<Note>
+
+Since version 1.44 of the SDK you can use `monitor` to annotate asynchronous
+functions as well.
+
+</Note>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We'll be adding support for monitoring async functions in https://github.com/getsentry/sentry-python/pull/2912:
* added a note about the minimal version to the main Python crons page
* simplified the examples on the crons page into more digestible code snippets
* added a note to the crons troubleshooting page as well since we had customers asking about this

Direct link to preview:
* https://sentry-docs-git-ivana-python-async-crons.sentry.dev/platforms/python/crons/
* https://sentry-docs-git-ivana-python-async-crons.sentry.dev/platforms/python/crons/troubleshooting/

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
