### PR TITLE
feat(crons): Document new broken monitors UX

### DIFF
--- a/docs/product/crons/troubleshooting.mdx
+++ b/docs/product/crons/troubleshooting.mdx
@@ -7,6 +7,10 @@ sidebar_order: 3
 
 All monitors are automatically deactivated at the start of a new billing period if there's not enough [on-demand spend](/product/accounts/pricing/#on-demand-capacity) to cover all active monitors. Monitors can be manually activated based on on-demand availability. See [Manage Your Cron Monitors](/product/accounts/quotas/manage-cron-monitors) for more details.
 
+### Why Was My Monitor Environment Marked As Broken or Automatically Muted?
+
+If your monitor environment has been in a failing state for 14 days or more, we will automatically mark it as broken and notify you of this escalated failure state via email. If the monitor environment stays in this state for another 14 days, we will automatically mute it to stop it from generating additional noise through notifications or issue events.
+
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have [linked errors to your monitor](/product/crons/getting-started/http/#connecting-errors-to-cron-monitors).


### PR DESCRIPTION
Adding a section here to describe the new broken monitor UX

<img width="774" alt="image" src="https://github.com/getsentry/sentry-docs/assets/9372512/db10bee3-5306-4c6e-a91c-7a71f67ff383">

https://github.com/getsentry/team-crons/issues/157