### PR TITLE
Python SDK 1.26 is the release where tracing without performance was released

### DIFF
--- a/docs/product/session-replay/getting-started.mdx
+++ b/docs/product/session-replay/getting-started.mdx
@@ -56,7 +56,7 @@ Sentry.init({
 Currently, replays for backend errors is supported for the following SDK versions or newer:
 
 - JavaScript (or related framework) [7.51.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.51.0)
-- Python [1.25.0](https://github.com/getsentry/sentry-python/releases/tag/1.25.0)
+- Python [1.26.0](https://github.com/getsentry/sentry-python/releases/tag/1.26.0)
 - Node [7.48.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.48.0)
 - PHP [3.18.0](https://github.com/getsentry/sentry-php/releases/tag/3.18.0)
 - .NET [3.31.0](https://github.com/getsentry/sentry-dotnet/releases/tag/3.31.0)


### PR DESCRIPTION
The prev diff https://github.com/getsentry/sentry-docs/pull/9594 changed from 1.20 to 1.25. There's no functional difference between 1.20 and 1.25, so the update doesn't help users. The real benefit to users comes from v1.26 where tracing without performance was released.

See the release notes here: https://github.com/getsentry/sentry-python/releases/tag/1.26.0

fixes https://github.com/getsentry/sentry/issues/67973