### PR TITLE
feat(python): Improve crons docs, add upserts

### DIFF
--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -12,33 +12,9 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 <PlatformContent includePath="crons/setup" />
 
-## Check-Ins
+## Configuring Cron Monitors
 
-Check-in monitoring allows you to track a job's progress by capturing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
-
-If you use the `monitor` decorator/context manager, the SDK will create check-ins for the wrapped code automatically.
-
-```python
-from sentry_sdk.crons import capture_checkin
-from sentry_sdk.crons.consts import MonitorStatus
-
-check_in_id = capture_checkin(
-    monitor_slug='<monitor-slug>',
-    status=MonitorStatus.IN_PROGRESS,
-)
-
-# Execute your task here...
-
-capture_checkin(
-    monitor_slug='<monitor-slug>',
-    check_in_id=check_in_id,
-    status=MonitorStatus.OK,
-)
-```
-
-## Upserting Cron Monitors
-
-You can create and update your Monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/).
+You can create and update your monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/). If a monitor with the defined settings doesn't exist in Sentry yet, it will be created.
 
 To create/update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
 
@@ -75,6 +51,31 @@ check_in_id = capture_checkin(
     monitor_config=monitor_config,
 )
 ```
+
+## Manual Check-Ins
+
+Check-in monitoring allows you to track a job's progress by capturing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+If you use the `monitor` decorator/context manager, the SDK will create check-ins for the wrapped code automatically.
+
+```python
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+
+check_in_id = capture_checkin(
+    monitor_slug='<monitor-slug>',
+    status=MonitorStatus.IN_PROGRESS,
+)
+
+# Execute your task here...
+
+capture_checkin(
+    monitor_slug='<monitor-slug>',
+    check_in_id=check_in_id,
+    status=MonitorStatus.OK,
+)
+```
+
 
 ## Alerts
 

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -47,13 +47,17 @@ To create/update a monitor, use `monitor` as outlined above and pass in your mon
 monitor_config = {
     "schedule": {"type": "crontab", "value": "0 0 * * *"},
     "timezone": "Europe/Vienna",
-    # If an expected check-in doesn't come in `checkin_margin` minutes, it'll be considered missed
+    # If an expected check-in doesn't come in `checkin_margin`
+    # minutes, it'll be considered missed
     "checkin_margin": 10,
-    # The check-in is allowed to run for `max_runtime` minutes before it's considered failed
+    # The check-in is allowed to run for `max_runtime` minutes
+    # before it's considered failed
     "max_runtime": 10,
-    # It'll take `failure_issue_threshold` consecutive failed check-ins to create an issue
+    # It'll take `failure_issue_threshold` consecutive failed
+    # check-ins to create an issue
     "failure_issue_threshold": 5,
-    # It'll take `recovery_threshold` OK check-ins to resolve an issue
+    # It'll take `recovery_threshold` OK check-ins to resolve
+    # an issue
     "recovery_threshold": 5,
 }
 

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -43,8 +43,18 @@ You can create and update your Monitors programmatically with code rather than [
 To create/update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
 
 ```python
+# All keys except `schedule` are optional
 monitor_config = {
-    # TODO
+    "schedule": {"type": "crontab", "value": "0 0 * * *"},
+    "timezone": "Europe/Vienna",
+    # If an expected check-in doesn't come in `checkin_margin` minutes, it'll be considered missed
+    "checkin_margin": 10,
+    # The check-in is allowed to run for `max_runtime` minutes before it's considered failed
+    "max_runtime": 10,
+    # It'll take `failure_issue_threshold` consecutive failed check-ins to create an issue
+    "failure_issue_threshold": 5,
+    # It'll take `recovery_threshold` OK check-ins to resolve an issue
+    "recovery_threshold": 5,
 }
 
 @monitor(monitor_slug='<monitor-slug>', monitor_config=monitor_config)

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -12,6 +12,56 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 <PlatformContent includePath="crons/setup" />
 
+## Check-Ins
+
+Check-in monitoring allows you to track a job's progress by capturing two check-ins: one at the start of your job and another at the end of your job. This two-step process allows Sentry to notify you if your job didn't start when expected (missed) or if it exceeded its maximum runtime (failed).
+
+If you use the `monitor` decorator/context manager, the SDK will create check-ins for the wrapped code automatically.
+
+```python
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+
+check_in_id = capture_checkin(
+    monitor_slug='<monitor-slug>',
+    status=MonitorStatus.IN_PROGRESS,
+)
+
+# Execute your task here...
+
+capture_checkin(
+    monitor_slug='<monitor-slug>',
+    check_in_id=check_in_id,
+    status=MonitorStatus.OK,
+)
+```
+
+## Upserting Cron Monitors
+
+You can create and update your Monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/).
+
+To create/update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
+
+```python
+monitor_config = {
+    # TODO
+}
+
+@monitor(monitor_slug='<monitor-slug>', monitor_config=monitor_config)
+def tell_the_world():
+    print('My scheduled task...')
+```
+
+If you're using [manual check-ins](#check-ins), you can pass your `monitor_config` to the `capture_checkin` call:
+
+```python
+check_in_id = capture_checkin(
+    monitor_slug='<monitor-slug>',
+    status=MonitorStatus.IN_PROGRESS,
+    monitor_config=monitor_config,
+)
+```
+
 ## Alerts
 
 When your recurring job fails to check in (missed), runs beyond its configured maximum runtime (failed), or manually reports a failure, Sentry will create an error event with a tag to your monitor.

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -14,9 +14,9 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 ## Configuring Cron Monitors
 
-You can create and update your monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/). If a monitor with the defined settings doesn't exist in Sentry yet, it will be created.
+You can create and update your monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/). If the monitor doesn't exist in Sentry yet, it will be created.
 
-To create/update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
+To create or update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
 
 ```python
 # All keys except `schedule` are optional

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -16,7 +16,7 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 You can create and update your monitors programmatically with code rather than [creating and configuring them in Sentry.io](https://sentry.io/crons/create/). If the monitor doesn't exist in Sentry yet, it will be created.
 
-To create or update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`:
+To create or update a monitor, use `monitor` as outlined above and pass in your monitor configuration as `monitor_config`. This requires SDK version `1.45.0` or higher.
 
 ```python
 # All keys except `schedule` are optional


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

With https://github.com/getsentry/sentry-python/pull/2929 we'll be adding cron upserts to the Python SDK.

Also documenting manual check-ins which were missing.

Direct link to preview: https://sentry-docs-git-ivana-python-cron-upsert.sentry.dev/platforms/python/crons/

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
