### PR TITLE
fix{website}: startSpan returns void

### DIFF
--- a/platform-includes/performance/start-span/node.mdx
+++ b/platform-includes/performance/start-span/node.mdx
@@ -1,11 +1,11 @@
 You can use the `Sentry.startSpan` method to wrap a callback in a span to measure how long it will take. The span will automatically be finished when the callback finishes. This works with both synchronous and async callbacks.
 
 ```javascript
-const result = Sentry.startSpan({ name: "Important Function" }, () => {
+Sentry.startSpan({ name: "Important Function" }, () => {
   return expensiveFunction();
 });
 
-const result2 = await Sentry.startSpan(
+await Sentry.startSpan(
   { name: "Important Function" },
   async () => {
     const res = await Sentry.startSpan({ name: "Child Span" }, () => {
@@ -16,14 +16,14 @@ const result2 = await Sentry.startSpan(
   }
 );
 
-const result3 = Sentry.startSpan({ name: "Important Function" }, (span) => {
+Sentry.startSpan({ name: "Important Function" }, (span) => {
   // You can access the span to add attributes or set specific status.
   // The span may be undefined if the span was not sampled or if performance monitoring is disabled.
   span?.setAttribute("foo", "bar");
   return expensiveFunction();
 });
 
-const result4 = Sentry.startSpan(
+Sentry.startSpan(
   {
     name: "Important Function",
     // You can also pass attributes directly to `startSpan`:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Removed result consts, since SentrystartSpan() returns null

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
