### PR TITLE
Clarify error boundary react behaviour

### DIFF
--- a/docs/platforms/javascript/guides/react/features/error-boundary.mdx
+++ b/docs/platforms/javascript/guides/react/features/error-boundary.mdx
@@ -28,7 +28,7 @@ Sentry.withErrorBoundary(Example, { fallback: <p>an error has occurred</p> });
 
 <Alert level="warning" title="Note">
 
-In development mode, React will rethrow errors caught within an error boundary. This will result in errors being reported twice to Sentry with the above setup, but this won't occur in your production build.
+In development mode, React will rethrow errors caught within an error boundary to the global error handler. This will result in Sentry only reporting an error from the global error handler, but not from the error boundary itself. We recommend testing the error boundary with a production build of React.
 
 </Alert>
 


### PR DESCRIPTION
Based on a slack convo: https://sentry.slack.com/archives/C28MX5WAJ/p1712172008252529

Q from slack: This is interesting.. so in a non-prod environment, should 2 issues appear in the issue stream then? Because the expected eventID (__EVENT_ID__) did not reach their Org even though there's a sampleRate of 1.

A: It doesn't because of how react dev mode works. This docs change should make that more clear.

