### PR TITLE
feat(apple): Recommend installing via SPM

### DIFF
--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -3,7 +3,7 @@ title: Cocoapods
 description: "Learn about installing the Sentry SDK with CocoaPods."
 ---
 
-We recommend installing the SDK with CocoaPods. To integrate Sentry into your Xcode project, specify it in your _Podfile_:
+To integrate Sentry into your Xcode project using CocoaPods, specify it in your _Podfile_:
 
 ```ruby
 platform :ios, '11.0'

--- a/platform-includes/getting-started-install/apple.macos.mdx
+++ b/platform-includes/getting-started-install/apple.macos.mdx
@@ -1,14 +1,7 @@
 The minimum version for macOS is 10.10.
 
-We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with Swift Package Manager (SPM), but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:
 
-```ruby {filename:Podfile}
-platform :macos, '10.10'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
 ```
-
-Then run `pod install`.
+https://github.com/getsentry/sentry-cocoa.git
+```

--- a/platform-includes/getting-started-install/apple.mdx
+++ b/platform-includes/getting-started-install/apple.mdx
@@ -1,12 +1,5 @@
-We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with Swift Package Manager (SPM), but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:
 
-```ruby {filename:Podfile}
-platform :ios, '11.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
 ```
-
-Then run `pod install`.
+https://github.com/getsentry/sentry-cocoa.git
+```

--- a/platform-includes/getting-started-install/apple.tvos.mdx
+++ b/platform-includes/getting-started-install/apple.tvos.mdx
@@ -1,14 +1,7 @@
 The minimum version for tvOS is 9.0.
 
-We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with Swift Package Manager (SPM), but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:
 
-```ruby {filename:Podfile}
-platform :tvos, '9.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
 ```
-
-Then run `pod install`.
+https://github.com/getsentry/sentry-cocoa.git
+```

--- a/platform-includes/getting-started-install/apple.watchos.mdx
+++ b/platform-includes/getting-started-install/apple.watchos.mdx
@@ -1,14 +1,7 @@
 The minimum version for watchOS is 2.0. Our SDK has limited symbolication support and no crash or app hang detection for watchOS.
 
-We recommend installing the SDK with CocoaPods, but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, specify it in your `Podfile`:
+We recommend installing the SDK with Swift Package Manager (SPM), but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:
 
-```ruby
-platform :watchos, '2.0'
-use_frameworks! # This is important
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
 ```
-
-Then run `pod install`.
+https://github.com/getsentry/sentry-cocoa.git
+```


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We already recommend installing the Cocoa SDK via SPM [in the wizard](https://github.com/getsentry/sentry/blob/master/static/app/gettingStartedDocs/apple/apple-macos.tsx#L79). Let's also change it in the docs to align.
