### PR TITLE
chore(ios): Updates `enableAppLaunchProfiling` option name

### DIFF
--- a/docs/platforms/apple/common/profiling/index.mdx
+++ b/docs/platforms/apple/common/profiling/index.mdx
@@ -52,7 +52,7 @@ SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.tracesSampleRate = 1.0 // tracing must be enabled for profiling
     options.profilesSampleRate = 1.0 // see also `profilesSampler` if you need custom sampling logic
-    options.profileAppLaunches = true // experimental new feature to start profiling in the pre-main launch phase
+    options.enableAppLaunchProfiling = true // experimental new feature to start profiling in the pre-main launch phase
 }
 ```
 
@@ -63,7 +63,7 @@ SentrySDK.start { options in
     options.dsn = @"___PUBLIC_DSN___";
     options.tracesSampleRate = @1.0; // tracing must be enabled for profiling
     options.profilesSampleRate = @1.0; // see also `profilesSampler` if you need custom sampling logic
-    options.profileAppLaunches = YES; // experimental new feature to start profiling in the pre-main launch phase
+    options.enableAppLaunchProfiling = YES; // experimental new feature to start profiling in the pre-main launch phase
 }];
 ```
 
@@ -85,7 +85,7 @@ _(New in version 8.21.0)_
 
 Normally, a profile can only be taken during a trace span after the SDK has been initialized. Now, you can configure the SDK to automatically profile certain app launches.
 
-To set up launch profiling, configure the sample rates for traces and profiles with `SentrySDK.startWithOptions` to determine if the subsequent app launch should be automatically profiled. This allows you to gather information on what is going on in your app even before `main` is called, making it easier to diagnose issues with slow app launches.
+To set up launch profiling, use the `enableAppLaunchProfiling` option and configure the sample rates for traces and profiles with `SentrySDK.startWithOptions` to determine if the subsequent app launch should be automatically profiled. This allows you to gather information on what is going on in your app even before `main` is called, making it easier to diagnose issues with slow app launches.
 
 If you use `SentryOptions.tracesSampler` or `SentryOptions.profilesSampler`, it will be invoked after you call `SentrySDK.startWithOptions`, with `SentryTransactionContext.forNextAppLaunch` set to `true` indicating that it's evaluating a launch profile sampling decision. If instead you simply set `SentryOptions.tracesSampleRate` and `SentryOptions.profilesSampleRate`, those numerical rates will be used directly.
 

--- a/platform-includes/getting-started-config/basic-config/apple.mdx
+++ b/platform-includes/getting-started-config/basic-config/apple.mdx
@@ -15,7 +15,7 @@ SentrySDK.start { options in
     options.enableMetricKit = true
     options.enableTimeToFullDisplayTracing = true
     options.swiftAsyncStacktraces = true
-    options.profileAppLaunches = true
+    options.enableAppLaunchProfiling = true
 }
 ```
 
@@ -30,7 +30,7 @@ SentrySDK.start { options in
     options.enableMetricKit = YES;
     options.enableTimeToFullDisplayTracing = YES;
     options.swiftAsyncStacktraces = YES;
-    options.profileAppLaunches = YES;
+    options.enableAppLaunchProfiling = YES;
 }];
 ```
 


### PR DESCRIPTION
Updates `enableAppLaunchProfiling` option name in code snippets and adds a mention the option in the relevant docs section