### PR TITLE
docs(product-profiling): typos

### DIFF
--- a/docs/product/profiling/differential-flamegraphs.mdx
+++ b/docs/product/profiling/differential-flamegraphs.mdx
@@ -30,7 +30,7 @@ Let's look at another example:
 
 The above differential flamegraph shows that new function calls to `OrganizationTeamsEndpoint.dispatch` were introduced, which made the code run slower, while calls to `ChunkUploadEndpoint.get` decreased.
 
-If you look closely, you'll notice that the top right corner has a `Before -> After` and `After -> Before` toggle. This is because by default, differential flamegraphs draw the aggregate flamegraph from after a regression has occured as the source of truth. This means that any code that may have been removed, will no longer be drawn (after all, it's not there anymore). This is why negating the view is useful, as it allows us to compare the data from before and peek into the future of how our code will change.
+If you look closely, you'll notice that the top right corner has a `Before -> After` and `After -> Before` toggle. This is because by default, differential flamegraphs draw the aggregate flamegraph from after a regression has occurred as the source of truth. This means that any code that may have been removed, will no longer be drawn (after all, it's not there anymore). This is why negating the view is useful, as it allows us to compare the data from before and peek into the future of how our code will change.
 
 ``
 Here's an example of what our module lock problem looks like when using the profiling data from after the regression has occurred as the source of truth:

--- a/docs/product/profiling/index.mdx
+++ b/docs/product/profiling/index.mdx
@@ -22,7 +22,7 @@ description: "Profiling offers a deeper level of visibility on top of traditiona
 
 </Note>
 
-Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. Profiling provides context at a deeper level than traditional tracing, enabling you to visualize the precise details of the call stack without the need for custom instrumentation. With Profiilng you can quickly identify hot paths in your code and understand potential performance bottlenecks, enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one.
+Sentry's profiling feature builds upon our established [Performance Monitoring](/product/performance) capabilities to provide precise code-level visibility into application execution in a production environment. Profiling provides context at a deeper level than traditional tracing, enabling you to visualize the precise details of the call stack without the need for custom instrumentation. With Profiling you can quickly identify hot paths in your code and understand potential performance bottlenecks, enabling you to build in [performance as a feature](https://blog.codinghorror.com/performance-is-a-feature/) from day one.
 
 Sentry profiling supports common platforms for both Mobile and Backend applications:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Just correcting typos in profiling docs

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
