### PR TITLE
fix(browser-extensions): Exclude global state integrations in browser extensions

### DIFF
--- a/docs/platforms/javascript/common/best-practices/browser-extensions.mdx
+++ b/docs/platforms/javascript/common/best-practices/browser-extensions.mdx
@@ -15,7 +15,7 @@ keywords:
 When setting up Sentry in a shared environment where multiple Sentry instances may run, for example, in a browser extension or similar, you should **not use `Sentry.init()`**, as this will pollute the global state. If your browser extension uses `Sentry.init()`, and the website the extension is running on also uses Sentry, the extension may send events to the website's Sentry project, or vice versa.
 
 For such scenarios, you have to set up a client manually as seen in the example below.
-In addition, you should also avoid adding any integrations that use global state, like `Breadcrumbs` or `TryCatch`. Furthermore, some default integrations that use the global state have to be filtered as in the example below.
+In addition, you should also avoid adding any integrations that use global state, like `Breadcrumbs` or `GlobalHandlers`. Furthermore, some default integrations that use the global state have to be filtered as in the example below.
 As a rule of thumb, it's best to avoid using any integrations and to rely on manual capture of errors only in such scenarios.
 
 <SignInNote />
@@ -31,7 +31,7 @@ import {
 
 // filter integrations that use the global variable
 const integrations = defaultIntegrations.filter(defaultIntegration => {
-  return !['BrowserApiErrors', 'Breadcrumbs', 'GlobalHandlers'].includes(defaultIntegration.name);
+  return !['BrowserApiErrors', 'TryCatch', 'Breadcrumbs', 'GlobalHandlers'].includes(defaultIntegration.name);
 });
 
 const client = new BrowserClient({

--- a/docs/platforms/javascript/common/best-practices/browser-extensions.mdx
+++ b/docs/platforms/javascript/common/best-practices/browser-extensions.mdx
@@ -15,7 +15,7 @@ keywords:
 When setting up Sentry in a shared environment where multiple Sentry instances may run, for example, in a browser extension or similar, you should **not use `Sentry.init()`**, as this will pollute the global state. If your browser extension uses `Sentry.init()`, and the website the extension is running on also uses Sentry, the extension may send events to the website's Sentry project, or vice versa.
 
 For such scenarios, you have to set up a client manually as seen in the example below.
-In addition, you should also avoid adding any integrations that use global state, like `Breadcrumbs` or `TryCatch`.
+In addition, you should also avoid adding any integrations that use global state, like `Breadcrumbs` or `TryCatch`. Furthermore, some default integrations that use the global state have to be filtered as in the example below.
 As a rule of thumb, it's best to avoid using any integrations and to rely on manual capture of errors only in such scenarios.
 
 <SignInNote />
@@ -29,11 +29,16 @@ import {
   Scope,
 } from "@sentry/browser";
 
+// filter integrations that use the global variable
+const integrations = defaultIntegrations.filter(defaultIntegration => {
+  return !['BrowserApiErrors', 'Breadcrumbs', 'GlobalHandlers'].includes(defaultIntegration.name);
+});
+
 const client = new BrowserClient({
   dsn: "___PUBLIC_DSN___",
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  integrations: defaultIntegrations,
+  integrations: integrations,
 });
 
 const scope = new Scope();


### PR DESCRIPTION
## Description of changes

Some default integrations which use the global state should not be included when using Sentry in a browser extension.

