### PR TITLE
chore(open-pr-comments): Note About Ruby SDK Version

### DIFF
--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -276,7 +276,7 @@ Sentry will comment on the pull request with up to five issues per file that wer
 
 This feature requires [code mappings](/product/issues/suspect-commits/#2-set-up-code-mappings) and is currently only supported for Python, Javascript/Typescript, and PHP files. For Javascript/Typescript, please ensure that you've unminified your code by [setting up source maps](/platforms/javascript/sourcemaps/).
 
-<Note> This feature is also supported in Ruby for early adopters. To opt in, make sure your organization's [Early Adopter status](/product/accounts/early-adopter-features/) is on. </Note>
+<Note> This feature is also supported in Ruby for early adopters. To opt in, make sure your organization's [Early Adopter status](/product/accounts/early-adopter-features/) is on and your `sentry-ruby` SDK version is >= 5.17.2  </Note>
 
 ### Missing Member Detection
 


### PR DESCRIPTION
Added note specifying what version the Ruby SDK needs to be in order for comments to work