### PR TITLE
feat(django): Add `signals_denylist` as new option

### DIFF
--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -85,6 +85,8 @@ By adding `DjangoIntegration` explicitly to your `sentry_sdk.init()` call you ca
 <SignInNote />
 
 ```python
+import django.db.models.signals
+
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -95,7 +97,11 @@ sentry_sdk.init(
         DjangoIntegration(
             transaction_style='url',
             middleware_spans=True,
-            signals_spans=False,
+            signals_spans=True,
+            signals_denylist=[
+                django.db.models.signals.pre_init, 
+                django.db.models.signals.post_init,
+            ],
             cache_spans=False,
         ),
     ],
@@ -124,6 +130,12 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
   Create spans and track performance of all synchronous [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/) receiver functions in your Django project. Set to `False` to disable.
 
   The default is `True`.
+
+- `signals_denylist`:
+
+  If you're tracking signal performance with `signals_spans`, `signals_denylist` can be set to a list of signals to exclude from performance monitoring.
+
+  The default is `[]`.
 
 - `cache_spans`:
 

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -133,7 +133,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 - `signals_denylist`:
 
-  If you're tracking signal performance with `signals_spans`, `signals_denylist` can be set to a list of signals to exclude from performance monitoring.
+  A list of signals to exclude from performance tracking. No spans will be created for these.
 
   The default is `[]`.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

We'll be adding a new option to the Django integration in https://github.com/getsentry/sentry-python/pull/2758 -- documenting it here.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
