### PR TITLE
feat(js): Restructure tree shaking docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/docs/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -60,7 +60,7 @@ For more details, see the documentation for the specific bundler plugin you're u
 
 ### Tree Shaking With Next.js
 
-To tree shake Sentry debug code in Next.js projects, you can use webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) in your Next.js configuration.
+To tree shake Sentry debug code in Next.js projects, use webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) in your Next.js configuration like in the example below:
 
 ```javascript {filename:next.config.(js|mjs)}
 const nextConfig = {
@@ -87,32 +87,35 @@ For more information on custom webpack configurations in Next.js, see [Custom We
 
 ### Manual Tree Shaking
 
-To make optional code eligible for tree shaking, you can remove the code from your build output by replacing various flags in the Sentry SDK.
+If you want to tree shake optional code, remove the code from your build output by replacing various flags in the Sentry SDK.
 
-The following flags are available:
+**The following flags are available:**
 
 `__SENTRY_DEBUG__`
 
-Replacing this flag with `false` will tree shake all code in the SDK that is related to debug logging.
+Replacing this flag with `false` will tree shake any SDK code that's related to debug logging.
 
 `__SENTRY_TRACING__`
 
-Replacing this flag with `false` will tree shake all code in the SDK that is related to performance monitoring.
-**Attention:** `__SENTRY_TRACING__` must not be replaced with `false` when you're using any performance monitoring-related SDK features (e.g. `Sentry.startTransaction()`). This flag is intended to be used in combination with packages like `@sentry/next` or `@sentry/sveltekit`, which automatically include performance monitoring functionality.
+Replacing this flag with `false` will tree shake any SDK code that's related to performance monitoring.
+
+<Note>
+ `__SENTRY_TRACING__` must not be replaced with `false` when you're using any performance monitoring-related SDK features (for example,`Sentry.startTransaction()`). This flag is intended to be used in combination with packages like `@sentry/next` or `@sentry/sveltekit`, which automatically include the performance monitoring functionality.
+ </Note>
 
 <PlatformSection notSupported={["javascript.wasm", "javascript.cordova", "javascript.bun", "javascript.deno"]}>
 
 `__RRWEB_EXCLUDE_IFRAME__`
 
-Replacing this flag with `true` will tree shake all code in the SDK that is related capturing iframe content with Session Replay. This is only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. You can enable this flag if you don't have any iframes on your page you care to record.
+Replacing this flag with `true` will tree shake any SDK code related to capturing iframe content with Session Replay. It's only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. Enable this flag if you don't want to record any iframes.
 
 `__RRWEB_EXCLUDE_SHADOW_DOM__`
 
-Replacing this flag with `true` will tree shake all code in the SDK that's related to capturing shadow dom elements with Session Replay. This is only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. Enable this flag if you don't have any shadow dom elements on your page you want to record.
+Replacing this flag with `true` will tree shake any SDK code related to capturing shadow dom elements with Session Replay. It's only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. Enable this flag if you don't want to record any shadow dom elements.
 
 `__SENTRY_EXCLUDE_REPLAY_WORKER__`
 
-Replacing this flag with `true` will tree shake all code in the SDK that's related to the included compression web worker for Session Replay. This is only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. Enable this flag if you want to host a compression worker yourself - see <PlatformLink to="/session-replay/configuration/#using-a-custom-compression-worker">Using a Custom Compression Worker</PlatformLink> for details. **We do not recommend enabling this flag unless you provide a custom worker URL.**
+Replacing this flag with `true` will tree shake any SDK code that's related to the included compression web worker for Session Replay. It's only relevant when using <PlatformLink to="/session-replay">Session Replay</PlatformLink>. Enable this flag if you want to host a compression worker yourself. See <PlatformLink to="/session-replay/configuration/#using-a-custom-compression-worker">Using a Custom Compression Worker</PlatformLink> for details. **We don't recommend enabling this flag unless you provide a custom worker URL.**
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/tree-shaking/index.mdx
+++ b/docs/platforms/javascript/common/configuration/tree-shaking/index.mdx
@@ -23,7 +23,69 @@ The Sentry SDK ships with code that is not strictly required for it to collect y
   you use certain features.
 </Note>
 
-### List Of Flags
+
+<PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
+
+### Tree Shaking With Sentry Bundler Plugins
+
+_This configuration is available starting with v2.9.0 of the bundler plugins._
+
+If you're using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
+
+```javascript
+// For example, the @sentry/webpack-plugin passed to the webpack config
+sentryPlugin({
+  // other config
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
+    excludePerformanceMonitoring: true,
+    excludeReplayIframe: true,
+    excludeReplayShadowDom: true,
+    excludeReplayWorker: true,
+  },
+});
+```
+
+For more details, see the documentation for the specific bundler plugin you're using:
+
+- [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin)
+- [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin)
+- [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
+- [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
+
+</PlatformSection>
+
+
+<PlatformSection supported={["javascript.nextjs"]}>
+
+### Tree Shaking With Next.js
+
+To tree shake Sentry debug code in Next.js projects, you can use webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) in your Next.js configuration.
+
+```javascript {filename:next.config.(js|mjs)}
+const nextConfig = {
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        __SENTRY_DEBUG__: false,
+        __SENTRY_TRACING__: false,
+        __RRWEB_EXCLUDE_IFRAME__: true,
+        __RRWEB_EXCLUDE_SHADOW_DOM__: true,
+        __SENTRY_EXCLUDE_REPLAY_WORKER__: true,
+      })
+    );
+
+    // return the modified config
+    return config;
+  },
+};
+```
+
+For more information on custom webpack configurations in Next.js, see [Custom Webpack Config](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config) in the Next.js docs.
+
+</PlatformSection>
+
+### Manual Tree Shaking
 
 To make optional code eligible for tree shaking, you can remove the code from your build output by replacing various flags in the Sentry SDK.
 
@@ -56,38 +118,7 @@ Replacing this flag with `true` will tree shake all code in the SDK that's relat
 
 <PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 
-### Tree Shaking Optional Code With Sentry Bundler Plugins
-
-_This configuration is available starting with v2.9.0 of the bundler plugins._
-
-If you're using one of our bundler plugins, you can use the `bundleSizeOptimizations` configuration option to tree shake optional code:
-
-```javascript
-// For example, the @sentry/webpack-plugin passed to the webpack config
-sentryPlugin({
-  // other config
-  bundleSizeOptimizations: {
-    excludeDebugStatements: true,
-    excludePerformanceMonitoring: true,
-    excludeReplayIframe: true,
-    excludeReplayShadowDom: true,
-    excludeReplayWorker: true,
-  },
-});
-```
-
-For more details, see the documentation for the specific bundler plugin you're using:
-
-- [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin)
-- [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin)
-- [Sentry Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin)
-- [Sentry Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)
-
-</PlatformSection>
-
-<PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
-
-### Tree Shaking Optional Code With Webpack
+### Tree Shaking With Webpack
 
 To tree shake Sentry debug code in your webpack bundles, we recommend using webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/):
 
@@ -113,7 +144,7 @@ module.exports = {
 
 <PlatformSection notSupported={["javascript.nextjs", "javascript.sveltekit", "javascript.remix", "javascript.astro"]}>
 
-### Tree Shaking Optional Code With Rollup
+### Tree Shaking With Rollup
 
 If you're using `rollup.js`, we recommend using [Rollup's `replace` plugin](https://github.com/rollup/plugins/tree/master/packages/replace):
 
@@ -139,35 +170,6 @@ export default {
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript.nextjs"]}>
-
-### Tree Shaking Optional Code With Next.js
-
-To tree shake Sentry debug code in Next.js projects, you can use webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) in your Next.js configuration.
-
-```javascript {filename:next.config.(js|mjs)}
-const nextConfig = {
-  webpack: (config, { webpack }) => {
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        __SENTRY_DEBUG__: false,
-        __SENTRY_TRACING__: false,
-        __RRWEB_EXCLUDE_IFRAME__: true,
-        __RRWEB_EXCLUDE_SHADOW_DOM__: true,
-        __SENTRY_EXCLUDE_REPLAY_WORKER__: true,
-      })
-    );
-
-    // return the modified config
-    return config;
-  },
-};
-```
-
-For more information on custom webpack configurations in Next.js, see [Custom Webpack Config](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config) in the Next.js docs.
-
-</PlatformSection>
-
 ## Tree Shaking Default Integrations
 
 By default, the Sentry SDK sets up a list of [default integrations](../integrations) that extend your
@@ -186,7 +188,7 @@ import {
   breadcrumbsIntegration,
   dedupeIntegration,
   defaultStackParser,
-  getCurrentHub,
+  getCurrentScope,
   globalHandlersIntegration,
   makeFetchTransport,
   linkedErrorsIntegration,
@@ -207,7 +209,8 @@ const client = new BrowserClient({
   ],
 });
 
-getCurrentHub().bindClient(client);
+getCurrentScope().setClient(client);
+client.init();
 ```
 
 <Note>


### PR DESCRIPTION
This moves the sections around a bit, leading with the bundler plugins instructions now, as they are the easiest to do.

Side note: Currently we do not show the bundler plugin docs for next, sveltekit, remix and astro. For next we have dedicated docs, which seems OK. But, can/should we show bundler plugin docs for these platforms as well? Or is this not possible? cc @Lms24 & @lforst 