### PR TITLE
fix(user-feedback): missing whitespace

### DIFF
--- a/platform-includes/user-feedback/example-widget/_default.mdx
+++ b/platform-includes/user-feedback/example-widget/_default.mdx
@@ -11,7 +11,7 @@ Make sure you've got the JavaScript SDK available:
 You'll then need to call `showReportDialog` and pass in the generated event ID.
 This event ID is returned from all calls to <PlatformIdentifier
 name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
-There is also a function called <PlatformIdentifier name="last-event-id" />
+There is also a function called <PlatformIdentifier name="last-event-id" /> 
 that returns the ID of the most recently sent event.
 
 <SignInNote />

--- a/platform-includes/user-feedback/example-widget/_default.mdx
+++ b/platform-includes/user-feedback/example-widget/_default.mdx
@@ -11,7 +11,7 @@ Make sure you've got the JavaScript SDK available:
 You'll then need to call `showReportDialog` and pass in the generated event ID.
 This event ID is returned from all calls to <PlatformIdentifier
 name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
-There is also a function called <PlatformIdentifier name="last-event-id" /> 
+There is also a function called {<PlatformIdentifier name="last-event-id" />}
 that returns the ID of the most recently sent event.
 
 <SignInNote />

--- a/platform-includes/user-feedback/example-widget/dotnet.mdx
+++ b/platform-includes/user-feedback/example-widget/dotnet.mdx
@@ -12,7 +12,7 @@ You'll then need to call `showReportDialog` and pass in the generated event ID.
 This event ID is returned from all calls to <PlatformIdentifier
 name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
 There is also a function called {<PlatformIdentifier name="last-event-id" />}
-that returns the ID of the most recently sent evesnt.
+that returns the ID of the most recently sent event.
 
 <SignInNote />
 

--- a/platform-includes/user-feedback/example-widget/dotnet.mdx
+++ b/platform-includes/user-feedback/example-widget/dotnet.mdx
@@ -11,7 +11,7 @@ Make sure you've got the JavaScript SDK available:
 You'll then need to call `showReportDialog` and pass in the generated event ID.
 This event ID is returned from all calls to <PlatformIdentifier
 name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
-There is also a function called <PlatformIdentifier name="last-event-id" />
+There is also a function called <PlatformIdentifier name="last-event-id" /> 
 that returns the ID of the most recently sent event.
 
 <SignInNote />

--- a/platform-includes/user-feedback/example-widget/dotnet.mdx
+++ b/platform-includes/user-feedback/example-widget/dotnet.mdx
@@ -11,8 +11,8 @@ Make sure you've got the JavaScript SDK available:
 You'll then need to call `showReportDialog` and pass in the generated event ID.
 This event ID is returned from all calls to <PlatformIdentifier
 name="capture-event" /> and <PlatformIdentifier name="capture-exception" />.
-There is also a function called <PlatformIdentifier name="last-event-id" /> 
-that returns the ID of the most recently sent event.
+There is also a function called {<PlatformIdentifier name="last-event-id" />}
+that returns the ID of the most recently sent evesnt.
 
 <SignInNote />
 


### PR DESCRIPTION
Missing whitespaces:
- https://docs.sentry.io/platforms/python/user-feedback/#integration
- https://docs.sentry.io/platforms/dotnet/user-feedback/#integration