### PR TITLE
Update deprecated option names and attachStacktrace value

### DIFF
--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -67,7 +67,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.
 
-This option is turned off by default.
+This option is turned on by default.
 
 Grouping in Sentry is different for events with stack traces and without. As a result, you will get new groups as you enable or disable this flag for certain events.
 
@@ -315,13 +315,13 @@ Set this boolean to `true` to automatically attach all threads to all logged eve
 
 </ConfigKey>
 
-<ConfigKey name="enableAutoPerformanceTracking">
+<ConfigKey name="enableAutoPerformanceTracing">
 
 Set this boolean to `false` to disable auto [performance monitoring](/product/performance/) tracking.
 
 </ConfigKey>
 
-<ConfigKey name="enableOutOfMemoryTracking">
+<ConfigKey name="enableWatchdogTerminationTracking">
 
 Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/ios/configuration/out-of-memory/) tracking on iOS.
 


### PR DESCRIPTION
Update options for performance tracing and watchdog termination to reflect their new names in the v5 versions of React Native.

attachStacktrace is also On by default in React Native, whereas the docs currently listed it as Off.