### PR TITLE
add 'javascript.remix.mdx' file to reflect correct import source in docs

### DIFF
--- a/platform-includes/enriching-events/import/javascript.remix.mdx
+++ b/platform-includes/enriching-events/import/javascript.remix.mdx
@@ -1,0 +1,3 @@
+```javascript
+import * as Sentry from "@sentry/remix";
+```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Adds a new file `(platform-includes/enriching-events/import/javascript.remix.mdx`) so that the `PlatformContent` component resolves with the correct markdown demonstrating an import from the `@sentry/remix` SDK.

Before:
<img width="770" alt="before" src="https://github.com/getsentry/sentry-docs/assets/43189095/e83cbb40-02a2-4816-95b7-ab0cd89f1637">

After:
<img width="773" alt="after" src="https://github.com/getsentry/sentry-docs/assets/43189095/903cbaa4-b28b-4127-b692-2ca62700554c">


## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
