### PR TITLE
fix(code-mappings): Add Go to list of languages that have support for Automatic Code mappings

### DIFF
--- a/docs/product/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/product/integrations/source-code-mgmt/github/index.mdx
@@ -296,7 +296,7 @@ By default, this feature is automatically enabled once your GitHub integration h
 
 <Note>
 
-Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, and PHP projects for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually. Support for other languages and other source code integrations is being worked on.
+Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, PHP, and Go projects for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually. Support for other languages and other source code integrations is being worked on.
 
 </Note>
 

--- a/docs/product/issues/suspect-commits/index.mdx
+++ b/docs/product/issues/suspect-commits/index.mdx
@@ -51,7 +51,7 @@ In [sentry.io](https://sentry.io):
 
 <Note>
 
-Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, and PHP projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
+Sentry will automatically try to set up code mappings on Python, JavaScript, Node.js, Ruby, PHP, and Go projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
 
 </Note>
 


### PR DESCRIPTION
Automatic Code Mapping support for Go has just been GA'd today! This PR updates the docs to reflect that 