### PR TITLE
flutter(user-feedback): document `lastEventId`

### DIFF
--- a/docs/platforms/dart/user-feedback/index.mdx
+++ b/docs/platforms/dart/user-feedback/index.mdx
@@ -10,7 +10,10 @@ When a user experiences an error, Sentry provides the ability to collect additio
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>} the return value of the method capturing an event. You can also access the id of the latest sent event via `Sentry.lastEventId`.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. There are several ways to get the `eventId`:
+- use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>}
+- use the return value of any method capturing an event.
+- use `Sentry.lastEventId` to get the ID of the last event sent.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
 

--- a/docs/platforms/dart/user-feedback/index.mdx
+++ b/docs/platforms/dart/user-feedback/index.mdx
@@ -10,7 +10,7 @@ When a user experiences an error, Sentry provides the ability to collect additio
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> or the return value of the method capturing an event.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>} the return value of the method capturing an event. You can also access the id of the latest sent event via `Sentry.lastEventId`.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
 

--- a/docs/platforms/flutter/user-feedback/index.mdx
+++ b/docs/platforms/flutter/user-feedback/index.mdx
@@ -10,7 +10,10 @@ When a user experiences an error, Sentry provides the ability to collect additio
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>} the return value of the method capturing an event. You can also access the id of the latest sent event via `Sentry.lastEventId`.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. There are several ways to get the `eventId`:
+- use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>}
+- use the return value of any method capturing an event.
+- use `Sentry.lastEventId` to get the ID of the last event sent.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
 

--- a/docs/platforms/flutter/user-feedback/index.mdx
+++ b/docs/platforms/flutter/user-feedback/index.mdx
@@ -10,7 +10,7 @@ When a user experiences an error, Sentry provides the ability to collect additio
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> or the return value of the method capturing an event.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use {<PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>} the return value of the method capturing an event. You can also access the id of the latest sent event via `Sentry.lastEventId`.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
 

--- a/platform-includes/user-feedback/sdk-api-example/dart.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/dart.mdx
@@ -2,6 +2,7 @@
 import 'package:sentry/sentry.dart';
 
 SentryId sentryId = Sentry.captureMessage("My message");
+// or use Sentry.lastEventId;
 
 final userFeedback = SentryUserFeedback(
     eventId: sentryId,

--- a/platform-includes/user-feedback/sdk-api-example/dart.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/dart.mdx
@@ -1,8 +1,21 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
+// Option 1: Retrieving SentryId from beforeSend
+SentryId sentryId = SentryId.empty();
+
+await Sentry.init((options) {
+  options.beforeSend = (event, {hint}) async {
+    sentryId = event.eventId;
+    return event;
+  };
+});
+
+// Option 2: Retrieving SentryId from the method capturing the event
 SentryId sentryId = Sentry.captureMessage("My message");
-// or use Sentry.lastEventId;
+
+// Option 3: Retrieving SentryId from the beforeSend callback
+SentryId sentryId = Sentry.lastEventId;
 
 final userFeedback = SentryUserFeedback(
     eventId: sentryId,


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-dart/issues/1902

Adds `lastEventId` reference to user feedback page