### PR TITLE
Document the new Laravel SQL origin threshold option

### DIFF
--- a/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
+++ b/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
@@ -36,6 +36,9 @@ The Laravel SDK will create [breadcrumbs](../../enriching-events/breadcrumbs/) f
 
     // Capture HTTP client request information as breadcrumbs
     'http_client_requests' => env('SENTRY_BREADCRUMBS_HTTP_CLIENT_REQUESTS_ENABLED', true),
+
+    // Capture send notifications as breadcrumbs
+    'notifications' => env('SENTRY_BREADCRUMBS_NOTIFICATIONS_ENABLED', true),
 ],
 ```
 
@@ -50,7 +53,7 @@ SENTRY_TRACES_SAMPLE_RATE=1.0
 
 ### Advanced Sample Rate
 
-If you want more control over which requests are monitored, you can use the `traces_sampler` option:
+If you want more control over which requests are monitored, you can use the [`traces_sampler`](/platforms/php/guides/laravel/configuration/options/#traces-sampler) option:
 
 ```php {filename:config/sentry.php}
 'traces_sampler' => function (\Sentry\Tracing\SamplingContext $context): float {
@@ -97,6 +100,9 @@ These settings have no effect if `SENTRY_TRACES_SAMPLE_RATE` is set to `0.0` or 
     // Capture where the SQL query originated from on the SQL query spans
     'sql_origin' => env('SENTRY_TRACE_SQL_ORIGIN_ENABLED', true),
 
+    // Define a threshold in milliseconds for SQL queries to resolve their origin
+    'sql_origin_threshold_ms' => env('SENTRY_TRACE_SQL_ORIGIN_THRESHOLD_MS', 100),
+
     // Capture views rendered as spans
     'views' => env('SENTRY_TRACE_VIEWS_ENABLED', true),
 
@@ -111,6 +117,9 @@ These settings have no effect if `SENTRY_TRACES_SAMPLE_RATE` is set to `0.0` or 
 
     // Capture where the Redis command originated from on the Redis command spans
     'redis_origin' => env('SENTRY_TRACE_REDIS_ORIGIN_ENABLED', true),
+
+    // Capture send notifications as spans
+    'notifications' => env('SENTRY_TRACE_NOTIFICATIONS_ENABLED', true),
 
     // Enable tracing for requests without a matching route (404's)
     'missing_routes' => env('SENTRY_TRACE_MISSING_ROUTES_ENABLED', false),

--- a/docs/product/performance/queries.mdx
+++ b/docs/product/performance/queries.mdx
@@ -95,7 +95,7 @@ The gif below provides a detailed walkthrough of the **Query Summary** page.
 
 <Note>
 
-Query Sources are currently supported in Sentry's [Laravel](/platforms/php/guides/laravel/configuration/laravel-options/) (enabled with the `SENTRY_TRACE_SQL_ORIGIN_ENABLED` option) and [Python](/platforms/python/configuration/options/#enable-db-query-source) (enabled by default) SDKs. For Python, Sentry only attaches query sources to queries that are slower than a [configurable threshold](/platforms/python/configuration/options/#db-query-source-threshold-ms) to reduce the performance impact.
+Query Sources are currently supported in Sentry's [Laravel](/platforms/php/guides/laravel/configuration/laravel-options/#more-configuration) (enabled by default) and [Python](/platforms/python/configuration/options/#enable-db-query-source) (enabled by default) SDKs. Sentry only attaches query sources to queries that are slower than a configurable threshold ([Python](/platforms/python/configuration/options/#db-query-source-threshold-ms), [Laravel](/platforms/php/guides/laravel/configuration/laravel-options/#more-configuration)) to reduce the performance impact.
 
 </Note>
 


### PR DESCRIPTION
Can be merged after https://github.com/getsentry/sentry-laravel/pull/881 is merged and released.