### PR TITLE
dotnet: mention key features

### DIFF
--- a/platform-includes/getting-started-primer/dotnet.mdx
+++ b/platform-includes/getting-started-primer/dotnet.mdx
@@ -5,6 +5,9 @@ This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with th
 **Features:**
 
 - Multiple integrations with additional features such as <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#sqlclient-integration">SQL Client</PlatformLink>, Serilog, log4net, ASP.NET Core, EntityFramework, <PlatformLink to="/performance/instrumentation/automatic-instrumentation/#entity-framework-core-integration">EntityFramework Core</PlatformLink>, Xamarin
+- [Native AOT](https://sentry.engineering/blog/should-you-could-you-aot) with native crash in release for Windows, macOS and Linux
+- Bindings to Sentry's native iOS and Android SDKs. Line numbers for C# exceptions in release builds.
+- Server side symbolication with [automated symbol upload via MSBuild](https://docs.sentry.io/platforms/dotnet/configuration/msbuild/). 
 - <PlatformLink to="/enriching-events/breadcrumbs/#automatic-breadcrumbs">Breadcrumbs automatically</PlatformLink> captured
 - [Release health](/product/releases/health/) tracks crash free users and sessions
 - <PlatformLink to="/enriching-events/attachments/">Attachments</PlatformLink> enrich


### PR DESCRIPTION
Came up today from Gene if we supported native crash reporting for .NET on Android and iOS (outside MAUI).
I noticed we don't mention AOT, Portable PDB/server-side symbolication nor native crash reporting on desktop 

@jamescrosswell 