### PR TITLE
[DO-NOT-MERGE] feat(404): Improved 404 page for sentry docs

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -30,9 +30,10 @@ export async function generateStaticParams() {
   return paths;
 }
 
-// Only render paths returned by generateStaticParams
+// To allow dynamic params to support custom not-found page
 export const dynamicParams = true;
-export const dynamic = 'force-static';
+// ref: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic
+export const dynamic = 'auto';
 
 const mdxComponentsWithWrapper = mdxComponents(
   {Include, PlatformContent},

--- a/docs/notFound.mdx
+++ b/docs/notFound.mdx
@@ -1,0 +1,3 @@
+## Page Not Found
+
+We couldn't find the page you were looking for.

--- a/src/components/docPage.tsx
+++ b/src/components/docPage.tsx
@@ -28,10 +28,10 @@ export function DocPage({
   notoc = false,
   sidebar = <ServerSidebar />,
 }: Props) {
-  const {rootNode, path} = serverContext();
+  const {rootNode, path, isOriginalPathBroken} = serverContext();
   const platformOrGuide = rootNode && getCurrentPlatformOrGuide(rootNode, path);
   const hasToc = (!notoc && !frontMatter.notoc) || !!platformOrGuide;
-  const hasGithub = !!path?.length && path[0] !== 'api';
+  const hasGithub = !!path?.length && path[0] !== 'api' && !isOriginalPathBroken;
 
   return (
     <div className="document-wrapper">
@@ -61,7 +61,7 @@ export function DocPage({
             </div>
             <div className="row">
               <div className={hasToc ? 'col-sm-8 col-md-12 col-lg-8 col-xl-9' : 'col-12'}>
-                <h1 className="mb-3">{frontMatter.title}</h1>
+                {!isOriginalPathBroken && <h1 className="mb-3">{frontMatter.title}</h1>}
                 <div id="main">
                   <CodeContextProvider>{children}</CodeContextProvider>
                 </div>

--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -215,7 +215,7 @@ export function getAllFilesFrontMatter(folder: string = 'docs') {
   return allFrontMatter;
 }
 
-export async function getFileBySlug(slug: string) {
+export async function getFileBySlug(slug: string, showNotFoundSource = false) {
   const configPath = path.join(root, slug, 'config.yml');
 
   let configFrontmatter: PlatformConfig | undefined;
@@ -256,6 +256,7 @@ export async function getFileBySlug(slug: string) {
 
   const sourcePath = [mdxPath, mdxIndexPath, mdPath].find(fs.existsSync) ?? mdIndexPath;
   const source = fs.readFileSync(sourcePath, 'utf8');
+  const notFoundSource = fs.readFileSync(path.join(root, 'docs/notFound.mdx'), 'utf8');
 
   process.env.ESBUILD_BINARY_PATH = path.join(
     root,
@@ -271,7 +272,7 @@ export async function getFileBySlug(slug: string) {
   const cwd = path.dirname(sourcePath);
 
   const result = await bundleMDX<Platform>({
-    source,
+    source: showNotFoundSource ? notFoundSource : source,
     cwd,
     mdxOptions(options) {
       // this is the recommended way to add custom remark/rehype plugins:

--- a/src/serverContext.tsx
+++ b/src/serverContext.tsx
@@ -6,12 +6,14 @@ import {DocNode} from 'sentry-docs/docTree';
 
 interface ServerContext {
   path: string[];
+  isOriginalPathBroken?: boolean;
   rootNode?: DocNode;
 }
 
 export const serverContext = cache(() => {
   const context: ServerContext = {
     path: [],
+    isOriginalPathBroken: false,
   };
   return context;
 });
@@ -19,4 +21,5 @@ export const serverContext = cache(() => {
 export const setServerContext = (data: ServerContext) => {
   serverContext().rootNode = data.rootNode;
   serverContext().path = data.path;
+  serverContext().isOriginalPathBroken = data.isOriginalPathBroken;
 };


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

#9656 

Approach:
- To accept dynamic params, to accept the params other than the slugs defined in docsFrontMatter.
- While rendering the pageNode if it's undefined (means other than what is defined in docsFrontMatter), pop it from path array and check the last one again. This will set the pageNode as the node of the first valid path from right.
- Set the serverContext for the first valid path, but also set a boolean in the context that the originalpath is broken.
- MDX source returned to docs page is also from custom defined notFound mdx.


Earlier
![image](https://github.com/getsentry/sentry-docs/assets/43654389/82ef2458-68fc-46f3-bc8e-64dbe39829b6)



Now

path- `/platforms/javascript/test/`
![image](https://github.com/getsentry/sentry-docs/assets/43654389/63b1a605-2aac-4e9e-b783-cc3b96e8709b)



path - `/platforms/test/`
![image](https://github.com/getsentry/sentry-docs/assets/43654389/be64e419-dec0-4517-a079-dd9f0c820077)



path- `/test`
![image](https://github.com/getsentry/sentry-docs/assets/43654389/c2d9efe1-4f31-4ecb-8186-ad748246ad6c)

