### PR TITLE
docs(python): Document `set_tags` function

### DIFF
--- a/docs/platforms/python/enriching-events/tags/index.mdx
+++ b/docs/platforms/python/enriching-events/tags/index.mdx
@@ -13,9 +13,17 @@ _Tag values_ have a maximum length of 200 characters and they cannot contain the
 
 Defining tags is easy, and will bind them to the [current scope](../scopes/) ensuring all future events within scope contain the same tags.
 
-Define the tag:
+Tags can be set with the `set_tag` function:
 
 <PlatformContent includePath="enriching-events/set-tag" />
+
+Alternatively, multiple tags can be set at once with the `set_tags` function:
+
+```python
+from sentry_sdk import set_tags
+
+set_tags({"page.locale": "de-at", "page.type": "article"})
+```
 
 <Note>
 


### PR DESCRIPTION
Add documentation for the [new `set_tags` function](https://github.com/getsentry/sentry-python/pull/2978) in the Python SDK.

Closes GH-9703

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)