### PR TITLE
docs(apple): Add snippet for new Fastlane plugin DIF upload action

### DIFF
--- a/platform-includes/debug-symbols-apple/_default.mdx
+++ b/platform-includes/debug-symbols-apple/_default.mdx
@@ -44,7 +44,16 @@ Sentry can display snippets of your code next to event stack traces. This featur
 
 <OrgAuthTokenNote />
 
-```ruby
+```ruby {tabTitle:Current Fastlane plugin}
+sentry_debug_files_upload(
+  auth_token: '___ORG_AUTH_TOKEN___',
+  org_slug: '___ORG_SLUG___',
+  project_slug: '___PROJECT_SLUG___',
+  include_sources: true, # Optional. For source context.
+)
+```
+
+```ruby {tabTitle:Fastlane plugin before 1.20.0}
 sentry_upload_dif(
   auth_token: '___ORG_AUTH_TOKEN___',
   org_slug: '___ORG_SLUG___',

--- a/platform-includes/source-context/apple.mdx
+++ b/platform-includes/source-context/apple.mdx
@@ -23,7 +23,16 @@ to upload your source to Sentry by adding `include_sources: true` to the plugin 
 
 <OrgAuthTokenNote />
 
-```ruby
+```ruby {tabTitle:Current Fastlane plugin}
+sentry_debug_files_upload(
+  auth_token: '___ORG_AUTH_TOKEN___',
+  org_slug: '___ORG_SLUG___',
+  project_slug: '___PROJECT_SLUG___',
+  include_sources: true, # Optional. For source context.
+)
+```
+
+```ruby {tabTitle:Fastlane plugin before 1.20.0}
 sentry_upload_dif(
   auth_token: '___ORG_AUTH_TOKEN___',
   org_slug: '___ORG_SLUG___',


### PR DESCRIPTION
Add snippet for new Fastlane plugin DIF upload action, keeping the old (pre v1.20.0) snippet as second tab

related: 
- https://github.com/getsentry/sentry-fastlane-plugin/pull/234
- https://github.com/getsentry/sentry-fastlane-plugin/issues/245

cc: @denrase 