### PR TITLE
fix: Format some inline styles as strings to try and avoid hydration errors

### DIFF
--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -18,7 +18,7 @@ export function Breadcrumbs() {
   }
 
   return (
-    <ul className="breadcrumb" style={{margin: 0}}>
+    <ul className="breadcrumb" style={{margin: '0px'}}>
       {nodes.map(n => {
         const to = n.path === '/' ? n.path : `/${n.path}/`;
         return (

--- a/src/components/navbarClient.tsx
+++ b/src/components/navbarClient.tsx
@@ -31,7 +31,7 @@ export function NavbarClient({platforms, currentPlatform}: Props) {
         <Search path={pathname} platforms={searchPlatforms} />
       </div>
       <div className="collapse navbar-collapse content-max" id="navbar-menu">
-        <Nav className="justify-content-end" style={{flex: 1}}>
+        <Nav className="justify-content-end" style={{flex: '1 1 0%'}}>
           <NavbarPlatformDropdown
             platforms={platforms}
             currentPlatform={currentPlatform}

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -33,7 +33,7 @@ export function PageGrid({header}: Props) {
           .filter(c => c.frontmatter.title)
           .map(n => (
             <li key={n.path} style={{marginBottom: '1rem'}}>
-              <h4 style={{marginBottom: 0}}>
+              <h4 style={{marginBottom: '0px'}}>
                 <Link href={'/' + n.path}>{n.frontmatter.title}</Link>
               </h4>
               {n.frontmatter.description && <p>{n.frontmatter.description}</p>}


### PR DESCRIPTION
In Sentry->Session Replay we're seeing some diffs using the hydration error tool, i'm trying to fix them and see if we can improve, but this won't address all sources of hydration errors.

The diffs are:
![SCR-20240416-mbfc](https://github.com/getsentry/sentry-docs/assets/187460/1ea232ba-7798-4287-a1d0-50ffb1a84ead)
![SCR-20240416-mbdu](https://github.com/getsentry/sentry-docs/assets/187460/ebbf6ebd-642b-4853-8879-27175557bfaa)
![SCR-20240416-mbcj](https://github.com/getsentry/sentry-docs/assets/187460/37f191f4-fe3f-4f8c-842e-e743d47850ed)

I was looking at this replay: https://sentry.sentry.io/replays/3585f82981d74dc5a2bc464525272d6d/?project=1267915&query=&referrer=%2Freplays%2F&statsPeriod=24h&yAxis=count%28%29

initial url was https://docs.sentry.io/product/issues/
