### PR TITLE
Sentry Metrics Note

### DIFF
--- a/docs/product/performance/metrics.mdx
+++ b/docs/product/performance/metrics.mdx
@@ -4,6 +4,12 @@ sidebar_order: 90
 description: "Learn more about Sentry's Performance metrics such as Apdex, failure rate, throughput, and latency, and the user experience insights about your application that they provide."
 ---
 
+<Note>
+
+There is also now Sentry metrics, currently in close beta. Learn more [here](https://docs.sentry.io/product/metrics/)
+
+</Note>
+
 Metrics provide insight about how users are experiencing your application. In [Performance](/product/performance/), we'll set you up with a few of the basic metrics to get you started. For further customizations on target thresholds, feel free to build out a query using the Discover [Query Builder](/product/discover-queries/query-builder/). By identifying useful thresholds to measure your application, you have a quantifiable measurement of your application's health. This means you can more easily identify when errors occur or if performance issues are emerging.
 
 ## Apdex

--- a/docs/product/performance/metrics.mdx
+++ b/docs/product/performance/metrics.mdx
@@ -6,7 +6,7 @@ description: "Learn more about Sentry's Performance metrics such as Apdex, failu
 
 <Note>
 
-There is also now Sentry metrics, currently in close beta. Learn more [here](https://docs.sentry.io/product/metrics/)
+If you are looking to try out custom metrics (currently in beta), you can learn more [here](https://docs.sentry.io/product/metrics/)
 
 </Note>
 


### PR DESCRIPTION
direct users to the new Sentry metric, where the signup page is

there's also [Performance Metrics](https://docs.sentry.io/platforms/javascript/performance/instrumentation/performance-metrics/) on a number of platforms with no note