### PR TITLE
Fix replaysSessionSampleRate in custom sampling example

### DIFF
--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -134,7 +134,7 @@ Sentry.init({
 // After a user has been authenticated, check if they're an employee
 // If they are, we'll call `replay.flush()` to either flush the replay as normal if it's a session-based replay, or if it's buffering due to error sampling, the flush will send the first segment of the replay.
 
-// Since `replaysOnErrorSampleRate` is > 0, we know that a replay has been buffered and `flush()` will flush the contents of that buffer. If only `replaysSessionSampleRate` is > 1, then there is a chance that a replay has not been recording/buffering.
+// Since `replaysOnErrorSampleRate` is > 0, we know that a replay has been buffered and `flush()` will flush the contents of that buffer. If only `replaysSessionSampleRate` is > 0, then there is a chance that a replay has not been recording/buffering.
 // In this case, you can check that `replay.getReplayId()` returns a value, if it does, it means replay is active and you can call `replay.flush()`, other call `replay.start()` to start recording a new replay.
 // ...
 


### PR DESCRIPTION
## Description of changes

The documentation in this case was not correct and was saying that `replaysSessionSampleRate` should be above 1 which shouldn't be the case for a sample-rate. It probably should mean that `replaysSessionSampleRate` should be above 0. Otherwise it makes no sense for me.
