### PR TITLE
Remove EA note from Reprocessing docs

### DIFF
--- a/docs/product/issues/reprocessing/index.mdx
+++ b/docs/product/issues/reprocessing/index.mdx
@@ -7,8 +7,6 @@ description: Learn about reprocessing errors with new debug files.
 Sentry uses [debug information
 files](/platforms/native/data-management/debug-files/) only after they have been uploaded. _Reprocessing_ allows you to apply debug information files to error events that have already occurred.
 
-<Include name="feature-available-for-user-group-early-adopter.mdx" />
-
 <Include name="only-error-issues-note.mdx" />
 
 After becoming an Early Adopter, you will find a new action when viewing an issue:


### PR DESCRIPTION
We have decided to enable this feature for all customers, so lets remove the early adopter note.

Turning the feature on fully happens in https://github.com/getsentry/sentry/pull/68412.