### PR TITLE
Fix beforeSend signature in code snippets for dart platforms

### DIFF
--- a/platform-includes/configuration/before-breadcrumb-hint/dart.mdx
+++ b/platform-includes/configuration/before-breadcrumb-hint/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-Breadcrumb beforeBreadcrumb(Breadcrumb crumb, {Hint? hint}) {
+Breadcrumb beforeBreadcrumb(Breadcrumb crumb, Hint hint) {
   return hint is MyHint ? null : crumb;
 }
 

--- a/platform-includes/configuration/before-breadcrumb-hint/dart.mdx
+++ b/platform-includes/configuration/before-breadcrumb-hint/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-Breadcrumb beforeBreadcrumb(Breadcrumb crumb, Hint hint) {
+Breadcrumb? beforeBreadcrumb(Breadcrumb? breadcrumb, Hint hint) {
   return hint is MyHint ? null : crumb;
 }
 

--- a/platform-includes/configuration/before-send-fingerprint/dart.mdx
+++ b/platform-includes/configuration/before-send-fingerprint/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   if (event.throwable is DatabaseException) {
     event = event.copyWith(fingerprint: ['database-connection-error']);
   }

--- a/platform-includes/configuration/before-send-hint/dart.mdx
+++ b/platform-includes/configuration/before-send-hint/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   return hint is MyHint ? null : event;
 }
 

--- a/platform-includes/configuration/before-send/dart.mdx
+++ b/platform-includes/configuration/before-send/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   // Modify the event here:
   event = event.copyWith(serverName: null); // Don't send server names.
   return event;

--- a/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dart.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-Breadcrumb beforeBreadcrumb(Breadcrumb breadcrumb, {Hint? hint}) {
+Breadcrumb beforeBreadcrumb(Breadcrumb breadcrumb, Hint hint) {
   return 'a.spammy.Logger' == breadcrumb.category ? null : breadcrumb;
 }
 

--- a/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dart.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-Breadcrumb beforeBreadcrumb(Breadcrumb breadcrumb, Hint hint) {
+Breadcrumb? beforeBreadcrumb(Breadcrumb? breadcrumb, Hint hint) {
   return 'a.spammy.Logger' == breadcrumb.category ? null : breadcrumb;
 }
 

--- a/platform-includes/set-fingerprint/basic/dart.mdx
+++ b/platform-includes/set-fingerprint/basic/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   if (event.throwable is DatabaseException) {
     event = event.copyWith(fingerprint: ['database-connection-error']);
   }

--- a/platform-includes/set-fingerprint/database-connection/dart.mdx
+++ b/platform-includes/set-fingerprint/database-connection/dart.mdx
@@ -1,7 +1,7 @@
 ```dart
 import 'package:sentry/sentry.dart';
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   if (event.throwable is DatabaseException) {
     event = event.copyWith(fingerprint: ['database-connection-error']);
   }

--- a/platform-includes/set-fingerprint/rpc/dart.mdx
+++ b/platform-includes/set-fingerprint/rpc/dart.mdx
@@ -8,7 +8,7 @@ class MyRpcException implements Exception {
   MyRpcException(this.function, this.httpStatusCode);
 }
 
-FutureOr<SentryEvent?> beforeSend(SentryEvent event, {Hint? hint}) async {
+FutureOr<SentryEvent?> beforeSend(SentryEvent event, Hint hint) async {
   if (event.throwable is MyRpcException) {
     final exception = event.throwable as MyRpcException;
     event = event.copyWith(fingerprint: [


### PR DESCRIPTION
Adjust documentation to reflect a breaking change to a `beforeSend` signature introduced in v8.0.0:
- Pull Request introducing the change: https://github.com/getsentry/sentry-dart/pull/1574
- Issue with context: https://github.com/getsentry/sentry-dart/issues/1478 

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
