### PR TITLE
chore(grammar): change "the" to "your" in suspect commits page

### DIFF
--- a/docs/product/issues/suspect-commits/index.mdx
+++ b/docs/product/issues/suspect-commits/index.mdx
@@ -162,6 +162,6 @@ If an issue has already been assigned manually, new events will not change the c
 
 ## Limitations
 
-- If auto-assignment is enabled but the suspect commit author is not in the Sentry organization, we will not be able to auto-assign the issue to them.
+- If auto-assignment is enabled but the suspect commit author is not in your Sentry organization, we will not be able to auto-assign the issue to them.
 
 - Auto-assignment may be skipped if a project is creating too many new issues at a given time due to rate limits. We'll try to auto-assign it the next time an event comes in for those skipped issues. If you are encountering this limit with non-recurring issues, you may want to take a look at [issue grouping](/product/data-management-settings/event-grouping/) strategies.


### PR DESCRIPTION
super small nit clarifying that we're talking about the reader's Sentry org and not _the_ Sentry org 