### PR TITLE
docs(js-profiling): Re-wording comment about startSpan

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/connect/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/connect/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/express/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/express/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/koa/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/koa/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```

--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -49,14 +49,15 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 
+// Profiling happens automatically after setting it up with `Sentry.init()`.
+// However, specific elements can be manually profiled with `startSpan`.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code executed inside this callback
-    // will now be automatically profiled.
+    // Any code in this callback will be profiled.
   }
 );
 ```


### PR DESCRIPTION
Changed the comment as wrapping in `startSpan` is not required.