### PR TITLE
Rename Metrics to Profiling Metrics

### DIFF
--- a/docs/product/profiling/mobile-app-profiling/metrics.mdx
+++ b/docs/product/profiling/mobile-app-profiling/metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: Profiling Metrics
 sidebar_order: 50
-description: "Measurements taken by the Sentry profiler that help us contextualize the work your mobile app does and detect possible issues impacting performance."
+description: "Learn about the measurements taken by the Sentry profiler that help us contextualize the work your mobile app does and detect possible issues impacting performance."
 ---
 
 The Sentry profiler records several system measurements to help analyze the backtraces it gathers. Some, like CPU and heap usage, are taken on a regular sampling interval using functions from `mach/mach.h`, albeit with a lower frequency than backtrace sampling. Others, like GPU information, are taken from `CADisplayLink` callback invocations, as they're received.

--- a/docs/product/profiling/mobile-app-profiling/metrics.mdx
+++ b/docs/product/profiling/mobile-app-profiling/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Metrics
+title: Profiling Metrics
 sidebar_order: 50
 description: "Measurements taken by the Sentry profiler that help us contextualize the work your mobile app does and detect possible issues impacting performance."
 ---


### PR DESCRIPTION
To distinguish [profiling metrics](https://docs.sentry.io/product/profiling/mobile-app-profiling/metrics/) from [performance metrics](https://docs.sentry.io/product/performance/metrics/) and [custom metrics](https://docs.sentry.io/product/metrics/)