### PR TITLE
feat(native): advanced usage section to explain OS error handling

### DIFF
--- a/docs/platforms/native/advanced-usage/index.mdx
+++ b/docs/platforms/native/advanced-usage/index.mdx
@@ -3,12 +3,10 @@ title: Advanced Usage
 description: "Learn how the Native SDK backends handle errors on their supported platforms and how that affects your usage."
 sidebar_order: 6000
 ---
-This section details recurring topics where the knowledge beyond what the SDK boundary can abstract away from its users no longer holds.
+This section discusses recurring topics that go beyond what the SDK can abstract away from users. 
 
-These will include operating system specifics regarding error handling or how some platforms deviate from established standards.
+While not a complete reference, this section covers topics like how different operating systems handle errors and where some platforms don't follow usual standards. Here, we also offer solutions to help users deal with specific platform quirks. 
 
-This section is not a conclusive reference documentation but will cover solutions that a user should understand to adapt to particular platform behavior.
-
-While we try to keep the content light, due to the in-depth nature of the topics following the text might require more effort than the other parts of the documentation.
+Due to the in-depth and nuanced nature of these topics, users may need a more advanced level of expertise. 
 
 <PageGrid />

--- a/docs/platforms/native/advanced-usage/index.mdx
+++ b/docs/platforms/native/advanced-usage/index.mdx
@@ -10,3 +10,5 @@ These will include operating system specifics regarding error handling or how so
 This section is not a conclusive reference documentation but will cover solutions that a user should understand to adapt to particular platform behavior.
 
 While we try to keep the content light, due to the in-depth nature of the topics following the text might require more effort than the other parts of the documentation.
+
+<PageGrid />

--- a/docs/platforms/native/advanced-usage/index.mdx
+++ b/docs/platforms/native/advanced-usage/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Advanced Usage
+description: "Learn how the Native SDK backends handle errors on their supported platforms and how that affects your usage."
+sidebar_order: 6000
+---
+This section details recurring topics where the knowledge beyond what the SDK boundary can abstract away from its users no longer holds.
+
+These will include operating system specifics regarding error handling or how some platforms deviate from established standards.
+
+This section is not a conclusive reference documentation but will cover solutions that a user should understand to adapt to particular platform behavior.
+
+While we try to keep the content light, due to the in-depth nature of the topics following the text might require more effort than the other parts of the documentation.

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -14,7 +14,7 @@ The topic of signal handling is vast, and this documentation can only guide you 
 * We recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/) if you want a book-length treatment.
  
 
-## Signals of interest
+## Signals of Interest
 
 ## Signal Handling Conflicts
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -31,7 +31,7 @@ In the context of the Native SDK, we are only interested in signals that will re
 * `SIGABRT`: Raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
 * `SIGFPE`: An erroneous arithmetic operation occurred in the CPU.
 * `SIGILL`: The process attempted to execute an illegal (often privileged) processor instruction.
-* `SIGTRAP`: This is typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
+* `SIGTRAP`: This is typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.). Instrumentation tools and sanitizers also sometimes issue breakpoints.
 
 If you use the `crashpad` backend, in addition to the above, on Linux, you will also get crash reports for:
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -10,7 +10,6 @@ A (POSIX) signal is a way for an operating system kernel to inform an applicatio
 The topic of signal handling is vast, and this documentation can only guide you in the context of the Native SDK. If you are interested in more general documentation on the topic, we can recommend the following:
 
 * The [main Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview and links to many signal details.
-* [The signal handling chapter](https://beej.us/guide/bgc/html/split/signal-handling.html) of "Beej's Guide to C Programming" provides a concise but practical introduction.
 * The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.
 * We recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/) if you want a book-length treatment.
  

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -7,7 +7,7 @@ The Native SDK uses signal handling on all supported platforms. On Linux (and An
 
 A (POSIX) signal is a way for an operating system kernel to inform an application about an exceptional event and provide a mechanism for the application to react to that event. The operating system delivers this information by interrupting the current execution of the affected  application with a "handler" function that the application registered before.
 
-The topic of signal handling is vast, and this documentation can only guide you in the context of the Native SDK. If you are interested in more general documentation on the topic, we can recommend the following:
+This document provides guidance on signal handling in the Native SDK. If you'd like to learn more about signal handling in general, we recommend the following resources:
 
 * The [Signal (IPC) Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview of signals and describes many POSIX signals.
 * The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -51,7 +51,7 @@ Since signal handlers can interrupt the running process at any time (and even ea
 
 Our ["develop" docs provide guidelines for writing signal handlers](https://develop.sentry.dev/sdk/signal-handlers/), which also apply to the hooks if you run on Linux or Android. Please take them seriously.
 
-## Stack size in the signal handler
+## Stack Size in the Signal Handler
 
 In addition to the above guidelines, you must consider the signal handler's stack usage. Because a stack overflow (where the process stack is exhausted) can be one reason to end up in a signal handler, we typically reserve a separate signal handler stack (`sigaltstack()`) so that we can continue to run the handler when it gets executed.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -46,7 +46,7 @@ The callback that you register as an `on_crash` hook runs in the context of a si
 
 Since signal handlers can interrupt the running process (and even each other) at any time, take special care when writing them. 
 
-Our ["develop" docs provide guidelines for writing signal handlers](https://develop.sentry.dev/sdk/signal-handlers/), which also apply to the hooks if you run on Linux or Android. Please take them seriously.
+Our developer documentation provides [guidelines for writing signal handlers](https://develop.sentry.dev/sdk/signal-handlers/). If you run on Linux or Android, these guidelines also apply to hooks. Signal handlers are notoriously difficult to work with, so it is crucial to follow these guidelines in order to avoid causing severe faults (like crashes and deadlocks), which can prevent terminating programs and sending reports.```
 
 ## Stack Size in the Signal Handler
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -21,9 +21,9 @@ The topic of signal handling is vast, and this documentation can only guide you 
 Sentry's Native SDK comes with its own set of signal handlers. There may be conflicts if your application currently installs handlers for any [signals of interest](#signals-of-interest) (listed below) that can result in a crash. To avoid this, do the following:
 
 * Refrain from registering a conflicting signal handler in your application.
-* If you have to, register this handler after `sentry_init()` and let it invoke the previously installed handler (ours) after it finishes or you won't get a report.
-* If you or one of your dependencies register a handler for the signals listed below _before_ you call `sentry_init()`, we will reinstall the previous handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes the previously installed handler at the end of its handler.
-* If you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash).
+* If you have to, register your handler after `sentry_init()` and let it invoke Sentry's handler after it finishes, or you won't get a report.
+* If you or one of your dependencies register a handler for the signals listed below _before_ you call `sentry_init()`, we will reinstall that handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes your installed handler at the end of Sentry's handler.
+* If you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash) instead of registering a signal handler.
 
 ### Signals of Interest
 
@@ -34,7 +34,7 @@ In the context of the Native SDK, we are only interested in signals that will re
 * `SIGABRT`: Raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
 * `SIGFPE`: An erroneous arithmetic operation that occurred in the CPU.
 * `SIGILL`: The process attempted to execute an illegal (often privileged) processor instruction.
-* `SIGTRAP`: Typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
+* `SIGTRAP`: This is typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
 
 If you use the `crashpad` backend, in addition to the above, on Linux, you will also get crash reports for:
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -55,7 +55,7 @@ Our ["develop" docs provide guidelines for writing signal handlers](https://deve
 
 In addition to the above guidelines, you must consider the signal handler's stack usage. Because a stack overflow (where the process stack is exhausted) can be one reason to end up in a signal handler, we typically reserve a separate signal handler stack (`sigaltstack()`) so that we can continue to run the handler when it gets executed.
 
-This stack is 64KiB on Linux. On Android, it is 16KiB on 32-bit and 32KiB on 64-bit devices.
+This stack is 64KiB on Linux. On Android, it is 16KiB on 32-bit devices and 32KiB on 64-bit devices.
 
 Further, it is crucial to understand that this signal handler stack configuration affects only a single thread and that the Native SDK on Linux can only initialize the stack for the thread on which you called `sentry_init()`. No configuration provides an alternate signal stack if the kernel interrupts another thread to handle a signal.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -3,7 +3,7 @@ title: Signal Handling
 description: "Learn about error handling common to all POSIX platforms."
 sidebar_order: 1000
 ---
-The Native SDK uses signal handling on all supported platforms. On Linux (and Android), it is the primary mechanism to detect errors, while on macOS and Windows, signal handlers detect specific errors that other mechanisms do not detect or in lightweight backends that don't support the lower-level error handling mechanisms (for instance `inproc` on macOS).
+The Native SDK uses signal handling on all supported platforms. On Linux (and Android), it is the primary mechanism to detect errors. On macOS and Windows, signal handlers detect specific errors that other mechanisms do not detect.
 
 A (POSIX) signal is a way for an operating system kernel to inform an application about an exceptional event and provide a mechanism for the application to react to that event. The operating system delivers this information by interrupting the current execution of the affected  application with a "handler" function that the application registered before.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -16,30 +16,32 @@ The topic of signal handling is vast, and this documentation can only guide you 
 
 ## Signals of interest
 
-Signals can support many events, not all of which signify an error or terminate the application (like `SIGCONT`, `SIGUSR1`, or `SIGUSR2`).
+## Signal Handling Conflicts
+
+Sentry's Native SDK comes with its own set of signal handlers. There may be conflicts if your application currently installs handlers for any [signals of interest](#signals-of-interest) (listed below) that can result in a crash. To avoid this, do the following:
+
+* Refrain from registering a conflicting signal handler in your application.
+* If you have to, register this handler after `sentry_init()` and let it invoke the previously installed handler (ours) after it finishes or you won't get a report.
+* If you or one of your dependencies register a handler for the signals listed below _before_ you call `sentry_init()`, we will reinstall the previous handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes the previously installed handler at the end of its handler.
+* If you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash).
+
+### Signals of Interest
 
 In the context of the Native SDK, we are only interested in signals that will result in the application's unexpected termination (crashes). These typically include:
 
-* `SIGSEGV`: the process tried to access an invalid virtual memory "segment".
-* `SIGBUS`: the process tried to access an invalid physical address or a VM page failed to "page-in".
-* `SIGABRT`: raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
-* `SIGFPE`: an erroneous arithmetic operation that occurred in the CPU.
-* `SIGILL`: the process attempted to execute an illegal (often privileged) processor instruction.
-* `SIGTRAP`: typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
+* `SIGSEGV`: The process tried to access an invalid virtual memory "segment".
+* `SIGBUS`: The process tried to access an invalid physical address or a VM page failed to "page-in".
+* `SIGABRT`: Raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
+* `SIGFPE`: An erroneous arithmetic operation that occurred in the CPU.
+* `SIGILL`: The process attempted to execute an illegal (often privileged) processor instruction.
+* `SIGTRAP`: Typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
 
 If you use the `crashpad` backend, in addition to the above, on Linux, you will also get crash reports for:
 
-* `SIGSYS`: the kernel received a system call with an invalid argument.
-* `SIGEMT`: an emulator trap occurred.
-* `SIGXCPU`: the process exceeded a previously specified CPU [rlimit](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html).
-* `SIGXFSZ`: similar to `SIGXCPU`, raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
-
-If your application currently installs handlers for any of the above signals, that can result in a potential conflict. Expressly
-
-* refrain from registering a conflicting signal handler in your application.
-* if you have to, register this handler after `sentry_init()` and let it invoke the previously installed handler (ours) after it finished or you won't get a report.
-* if you or one of your dependencies register a handler for the above signals _before_ you call `sentry_init()`, we will reinstall the previous handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes the previously installed handler at the end of its handler.
-* if you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash).
+* `SIGSYS`: The kernel received a system call with an invalid argument.
+* `SIGEMT`: An emulator trap occurred.
+* `SIGXCPU`: The process exceeded a previously specified CPU [rlimit](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html).
+* `SIGXFSZ`: Similar to `SIGXCPU`, raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
 
 ## What to consider when writing `on_crash` hooks
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Signal Handling
+description: "Learn about error handling common to all POSIX platforms."
+sidebar_order: 1000
+---
+The Native SDK uses signal handling on all supported platforms. On Linux (and Android), it is the primary mechanism to detect errors, while on macOS and Windows, signal handlers detect specific errors that other mechanisms do not detect or in lightweight backends that don't support the lower-level error handling mechanisms (for instance `inproc` on macOS).
+
+A (POSIX) signal is a way for an operating system kernel to inform an application about an exceptional event and provide a mechanism for the application to react to that event. The operating system delivers this information by interrupting the current execution of the affected  application with a "handler" function that the application registered before.
+
+The topic of signal handling is vast, and this documentation can only guide you in the context of the Native SDK. If you are interested in more general documentation on the topic, we can recommend the following:
+
+* The [main Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview and links to many signal details.
+* [The signal handling chapter](https://beej.us/guide/bgc/html/split/signal-handling.html) of "Beej's Guide to C Programming" provides a concise but practical introduction.
+* The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.
+* We recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/) if you want a book-length treatment.
+ 
+
+## Signals of interest
+
+Signals can support many events, not all of which signify an error or terminate the application (like `SIGCONT`, `SIGUSR1`, or `SIGUSR2`).
+
+In the context of the Native SDK, we are only interested in signals that will result in the application's unexpected termination (crashes). These typically include:
+
+* `SIGSEGV`: the process tried to access an invalid virtual memory "segment".
+* `SIGBUS`: the process tried to access an invalid physical address or a VM page failed to "page-in".
+* `SIGABRT`: raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
+* `SIGFPE`: an erroneous arithmetic operation that occurred in the CPU.
+* `SIGILL`: the process attempted to execute an illegal (often privileged) processor instruction.
+* `SIGTRAP`: typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
+
+If you use the `crashpad` backend, in addition to the above, on Linux, you will also get crash reports for:
+
+* `SIGSYS`: the kernel received a system call with an invalid argument.
+* `SIGEMT`: an emulator trap occurred.
+* `SIGXCPU`: the process exceeded a previously specified CPU [rlimit](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html).
+* `SIGXFSZ`: similar to `SIGXCPU`, raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
+
+If your application currently installs handlers for any of the above signals, that can result in a potential conflict. Expressly
+
+* refrain from registering a conflicting signal handler in your application.
+* if you have to, register this handler after `sentry_init()` and let it invoke the previously installed handler (ours) after it finished or you won't get a report.
+* if you or one of your dependencies register a handler for the above signals _before_ you call `sentry_init()`, we will reinstall the previous handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes the previously installed handler at the end of its handler.
+* if you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash).
+
+## What to consider when writing `on_crash` hooks
+
+The callback that you register as an `on_crash` hook (and `before_send` if you didn't turn it off for crashes) runs in the context of a signal handler.
+
+Since signal handlers can interrupt the running process at any time (and even each other), take  special care when writing them. 
+
+Our ["develop" docs provide guidelines for writing signal handlers](https://develop.sentry.dev/sdk/signal-handlers/), which also apply to the hooks if you run on Linux or Android. Please take them seriously.
+
+## Stack size in the signal handler
+
+In addition to the above guidelines, you must consider the signal handler's stack usage. Because a stack overflow (where the process stack is exhausted) can be one reason to end up in a signal handler, we typically reserve a separate signal handler stack (`sigaltstack()`) so that we can continue to run the handler when it gets executed.
+
+This stack is 64KiB on Linux. On Android, it is 16KiB on 32-bit and 32KiB on 64-bit devices.
+
+Further, it is crucial to understand that this signal handler stack configuration affects only a single thread and that the Native SDK on Linux can only initialize the stack for the thread on which you called `sentry_init()`. No configuration provides an alternate signal stack if the kernel interrupts another thread to handle a signal.
+
+This differs from the situation on Android, where the `Bionic libc` `pthread` implementation initializes each thread with a separate signal handler stack. `Bionic` sets the Android stack sizes from above, and the Android Runtime Team recommends _not_ overwriting these settings.
+
+In this scenario, most of the above-defined stack sizes will be fully available to your defined `on_crash` hook. Still, be considerate of stack usage. If you need to fill any large data structures within the hook, we recommend pre-allocating them at initialization and only filling the values within the hook.

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -38,7 +38,7 @@ If you use the `crashpad` backend, in addition to the above, on Linux, you will 
 * `SIGSYS`: The kernel received a system call with an invalid argument.
 * `SIGEMT`: An emulator trap occurred.
 * `SIGXCPU`: The process exceeded a previously specified CPU [rlimit](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html).
-* `SIGXFSZ`: Similar to `SIGXCPU`, raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
+* `SIGXFSZ`: Raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
 
 ## What to Consider When Writing `on_crash` Hooks
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -19,7 +19,7 @@ Sentry's Native SDK comes with its own set of signal handlers. There may be conf
 
 * Refrain from registering a conflicting signal handler in your application.
 * If you have to, register your handler after `sentry_init()` and let it invoke Sentry's handler after it finishes, or you won't get a report.
-* If you or one of your dependencies register a handler for the signals listed below _before_ you call `sentry_init()`, we will reinstall that handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes your installed handler at the end of Sentry's handler.
+* If you or one of your dependencies register a handler for the signals listed below _before_ you call `sentry_init()`, Sentry will reinstall that handler as soon as you call `sentry_close()`. Only the `inproc` backend invokes your installed handler at the end of Sentry's handler.
 * If you want to act on any crash and not consider specific signals, [register an `on_crash()` hook](https://docs.sentry.io/platforms/native/configuration/filtering/#using-on_crash) instead of registering a signal handler.
 
 ### Signals of Interest

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -13,9 +13,6 @@ This document provides guidance on signal handling in the Native SDK. If you'd l
 * The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.
 * If you want a book-length treatment, we recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/).
  
-
-## Signals of Interest
-
 ## Signal Handling Conflicts
 
 Sentry's Native SDK comes with its own set of signal handlers. There may be conflicts if your application currently installs handlers for any [signals of interest](#signals-of-interest) (listed below) that can result in a crash. To avoid this, do the following:

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -29,7 +29,7 @@ In the context of the Native SDK, we are only interested in signals that will re
 * `SIGSEGV`: The process tried to access an invalid virtual memory "segment".
 * `SIGBUS`: The process tried to access an invalid physical address or a VM page failed to "page-in".
 * `SIGABRT`: Raised when `abort()` was called. This is the only signal handled on Windows (and only by the `crashpad` backend) because calling `abort()` bypasses Structured Exception Handling ([`SEH`](https://learn.microsoft.com/en-us/windows/win32/debug/structured-exception-handling)).
-* `SIGFPE`: An erroneous arithmetic operation that occurred in the CPU.
+* `SIGFPE`: An erroneous arithmetic operation occurred in the CPU.
 * `SIGILL`: The process attempted to execute an illegal (often privileged) processor instruction.
 * `SIGTRAP`: This is typically used to inform debuggers when execution hits a breakpoint instruction (`int 3`, `brk`, etc.), which instrumentation tools and sanitizers sometimes also issue.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -42,7 +42,7 @@ If you use the `crashpad` backend, in addition to the above, on Linux, you will 
 
 ## What to Consider When Writing `on_crash` Hooks
 
-The callback that you register as an `on_crash` hook (and `before_send` if you didn't turn it off for crashes) runs in the context of a signal handler.
+The callback that you register as an `on_crash` hook runs in the context of a signal handler. (`before_send` also runs in the context of a signal handler, unless you turned it off for crashes.)
 
 Since signal handlers can interrupt the running process at any time (and even each other), take  special care when writing them. 
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -11,7 +11,7 @@ The topic of signal handling is vast, and this documentation can only guide you 
 
 * The [Signal (IPC) Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview of signals and describes many POSIX signals.
 * The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.
-* We recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/) if you want a book-length treatment.
+* If you want a book-length treatment, we recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/).
  
 
 ## Signals of Interest

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -44,7 +44,7 @@ If you use the `crashpad` backend, in addition to the above, on Linux, you will 
 
 The callback that you register as an `on_crash` hook runs in the context of a signal handler. (`before_send` also runs in the context of a signal handler, unless you turned it off for crashes.)
 
-Since signal handlers can interrupt the running process at any time (and even each other), take  special care when writing them. 
+Since signal handlers can interrupt the running process (and even each other) at any time, take special care when writing them. 
 
 Our ["develop" docs provide guidelines for writing signal handlers](https://develop.sentry.dev/sdk/signal-handlers/), which also apply to the hooks if you run on Linux or Android. Please take them seriously.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -43,7 +43,7 @@ If you use the `crashpad` backend, in addition to the above, on Linux, you will 
 * `SIGXCPU`: The process exceeded a previously specified CPU [rlimit](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html).
 * `SIGXFSZ`: Similar to `SIGXCPU`, raised when a process grows a file beyond a maximum allowed size ([`RLIMIT_FSIZE`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)). 
 
-## What to consider when writing `on_crash` hooks
+## What to Consider When Writing `on_crash` Hooks
 
 The callback that you register as an `on_crash` hook (and `before_send` if you didn't turn it off for crashes) runs in the context of a signal handler.
 

--- a/docs/platforms/native/advanced-usage/signal-handling/index.mdx
+++ b/docs/platforms/native/advanced-usage/signal-handling/index.mdx
@@ -9,7 +9,7 @@ A (POSIX) signal is a way for an operating system kernel to inform an applicatio
 
 The topic of signal handling is vast, and this documentation can only guide you in the context of the Native SDK. If you are interested in more general documentation on the topic, we can recommend the following:
 
-* The [main Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview and links to many signal details.
+* The [Signal (IPC) Wikipedia article](https://en.wikipedia.org/wiki/Signal_(IPC)) provides an overview of signals and describes many POSIX signals.
 * The [glibc-docs](https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html) and [the man pages](https://man7.org/linux/man-pages/man7/signal.7.html) offer reference details for the signal vocabulary.
 * We recommend chapters 20-22 of Michael Kerrisk's [The Linux Programming Interface](https://man7.org/tlpi/) if you want a book-length treatment.
  


### PR DESCRIPTION
This PR introduces a new section, "Advanced usage," which allows us to go into much more detail when describing how operating systems behave and how this affects users of the Native SDK.

This section should house topics that our users repeatedly encounter, which we cannot hide behind a nice facade and which runtime developers do not abstract away from our responsibility (as is the case for most other SDKs).

While this section will soon see additions like

- [WER module usage ](https://github.com/getsentry/sentry-native/issues/875#issuecomment-1689564967)
- Debugging & resolving `UnhandledExceptionFilter` overwrites
- [Stackoverflow handling on Windows](https://github.com/getsentry/sentry-native/issues/977)
- [Trade-offs in determining which backend to use](https://github.com/getsentry/sentry-native/issues/908#issuecomment-1830031091)

The current driver for the section and content of this PR is the use of POSIX signal handling on Linux and Android and the issues users need to be aware of: https://github.com/getsentry/sentry-native/issues/960.

@kahest, can I ask you for a first review of whether this level of detail makes sense? It is really hard to reduce this further without linking every other word. I tried to balance this and removed a lot of detail already. I adapted it also to the future content in expected tone and level of detail.