### PR TITLE
feat: Add JavaScript SDK migration docs to Sentry docs site

### DIFF
--- a/docs/platforms/javascript/common/migration/index.mdx
+++ b/docs/platforms/javascript/common/migration/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Migration Guide
+description: "Migrate from an older version of our Sentry JavaScript SDK."
+sidebar_order: 8000
+---
+
+Here's a list of guides on migrating to a newer version of the Sentry JavaScript SDK.
+
+<PageGrid />

--- a/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
+++ b/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 4.x to 5.x/6.x
-sidebar_order: 8996
+sidebar_order: 8930
 description: "Learn about migrating from Sentry JavaScript SDK 4.x to 5.x/6.x"
 ---
 

--- a/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
+++ b/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
@@ -1,10 +1,10 @@
 ---
-title: Migrate from Sentry JavaScript SDK 4.x to 5.x/6.x
-sidebar_order: 8997
+title: Migrate from 4.x to 5.x/6.x
+sidebar_order: 8996
 description: "Learn about migrating from Sentry JavaScript SDK 4.x to 5.x/6.x"
 ---
 
 We recommend upgrading from `4.x` to `6.x` directly. Migrating from `5.x` to `6.x` has no breaking changes to the SDK's
 API.
 
-Please see our detailed migration guide for more information on migrating from `4.x` to `5.x`/`6.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v4-to-v5_v6.md)
+Please see our [detailed migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v4-to-v5_v6.md) for more information on migrating from `4.x` to `5.x`/`6.x`.

--- a/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
+++ b/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
@@ -1,0 +1,10 @@
+---
+title: Migrate from Sentry JavaScript SDK 4.x to 5.x/6.x
+sidebar_order: 8997
+description: "Learn about migrating from Sentry JavaScript SDK 4.x to 5.x/6.x"
+---
+
+We recommend upgrading from `4.x` to `6.x` directly. Migrating from `5.x` to `6.x` has no breaking changes to the SDK's
+API.
+
+Please see our detailed migration guide for more information on migrating from `4.x` to `5.x`/`6.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v4-to-v5_v6.md)

--- a/docs/platforms/javascript/common/migration/v6-to-v7.mdx
+++ b/docs/platforms/javascript/common/migration/v6-to-v7.mdx
@@ -1,6 +1,6 @@
 ---
-title: Migrate from Sentry JavaScript SDK 6.x to 7.x
-sidebar_order: 8998
+title: Migrate from 6.x to 7.x
+sidebar_order: 8997
 description: "Learn about migrating from Sentry JavaScript SDK 6.x to 7.x"
 ---
 
@@ -12,13 +12,13 @@ should consider when upgrading.
 
 **TL;DR** If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
 
-- If you installed additional Sentry packages, such as`@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make sure to upgrade all of them to version 7.
+- If you installed additional Sentry packages, such as `@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make sure to upgrade all of them to version 7.
 - Our CDN bundles are now ES6 - you will need to reconfigure your script tags if you want to
   keep supporting ES5 and IE11 on the new SDK version.
 - Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
-- We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.
+- We bumped the TypeScript version we generate our types with to `3.8.3`. Please check if your TypeScript projects using TypeScript version `3.7` or lower still compile. Otherwise, upgrade your TypeScript version.
 - `whitelistUrls` and `blacklistUrls` have been renamed to `allowUrls` and `denyUrls` in the `Sentry.init()` options.
 - The `UserAgent` integration is now called `HttpContext`.
 - If you are using Performance Monitoring and with tracing enabled, you might have to make adjustments to your server's CORS settings.
 
-Please see our detailed migration guide for more information on migrating from `6.x` to `7.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v6-to-v7.md)
+Please see our [detailed migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v6-to-v7.md) for more information on migrating from `6.x` to `7.x`.

--- a/docs/platforms/javascript/common/migration/v6-to-v7.mdx
+++ b/docs/platforms/javascript/common/migration/v6-to-v7.mdx
@@ -1,0 +1,24 @@
+---
+title: Migrate from Sentry JavaScript SDK 6.x to 7.x
+sidebar_order: 8998
+description: "Learn about migrating from Sentry JavaScript SDK 6.x to 7.x"
+---
+
+The v7 version of the JavaScript SDK requires a self-hosted version of Sentry `20.6.0` or higher.
+
+The main goal of version 7 is to reduce bundle size. This version is breaking because we removed deprecated APIs,
+upgraded our build tooling, and restructured npm package contents. Below we will outline all the breaking changes you
+should consider when upgrading.
+
+**TL;DR** If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
+
+- If you installed additional Sentry packages, such as`@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make sure to upgrade all of them to version 7.
+- Our CDN bundles are now ES6 - you will need to reconfigure your script tags if you want to
+  keep supporting ES5 and IE11 on the new SDK version.
+- Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
+- We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.
+- `whitelistUrls` and `blacklistUrls` have been renamed to `allowUrls` and `denyUrls` in the `Sentry.init()` options.
+- The `UserAgent` integration is now called `HttpContext`.
+- If you are using Performance Monitoring and with tracing enabled, you might have to make adjustments to your server's CORS settings.
+
+Please see our detailed migration guide for more information on migrating from `6.x` to `7.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/v6-to-v7.md)

--- a/docs/platforms/javascript/common/migration/v6-to-v7.mdx
+++ b/docs/platforms/javascript/common/migration/v6-to-v7.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 6.x to 7.x
-sidebar_order: 8997
+sidebar_order: 8920
 description: "Learn about migrating from Sentry JavaScript SDK 6.x to 7.x"
 ---
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8.mdx
@@ -1,0 +1,62 @@
+---
+title: Migrate from Sentry JavaScript SDK 7.x to 8.x
+sidebar_order: 8999
+description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
+---
+
+The main goal of version 8 is to improve our performance monitoring APIs, integrations API, and ESM support. This
+version is breaking because we removed deprecated APIs, restructured npm package contents, and introduced new
+dependencies on OpenTelemetry.
+
+If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
+
+- If you installed additional Sentry packages, such as`@sentry/profiling-node` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make sure to upgrade all of them to version 8. In addition, the `@sentry/hub`, `@sentry/tracing`, `@sentry/integrations`, `@sentry/serverless`, and `@sentry/replay` package have all been removed.
+
+- Our SDKs now generate ES2018+ compatible code. This means we now only support Node 14.18 or higher and ES2018 compatible browsers. New minimum supported browsers:
+
+  - Chrome 63
+  - Edge 79
+  - Safari/iOS Safari 12
+  - Firefox 58
+  - Opera 50
+  - Samsung Internet 8.2
+
+- Integrations are now functional instead of class based. For example, the import for session replay uses `Sentry.replayIntegration` instead of `new Sentry.Replay`.
+
+- Initializing the Node SDK has been vastly simplified. You no longer need to use `autoDiscoverNodePerformanceMonitoringIntegrations` or use `Sentry.Handlers`, as these are now automatically included by the SDK without configuration. To make this work, you now have to ensure `Sentry.init` is initialized before any other code is imported and used.
+
+```ts
+// In v7, this was fine:
+const Sentry = require("@sentry/node");
+const express = require("express");
+
+Sentry.init({
+  // ...
+});
+
+const app = express();
+
+// ...
+
+// In v8, in order to ensure express is instrumented,
+// you have to initialize before you import:
+const Sentry = require("@sentry/node");
+Sentry.init({
+  // ...
+});
+
+const express = require("express");
+const app = express();
+
+Sentry.setupExpressErrorHandler(app);
+```
+
+Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix all deprecations on `7.x`, you can use the `@sentry/migr8` codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
+
+```bash
+npx @sentry/migr8@latest
+```
+
+This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
+
+Please see our detailed migration guide for more information on migrating from `7.x` to `8.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgrading-from-7x-to-8x)

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -1,0 +1,79 @@
+---
+title: Migrate from 7.x to 8.x
+sidebar_order: 8999
+description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
+---
+
+The main goal of version 8 is to improve our performance monitoring APIs, integrations API, and ESM support. This
+version is breaking because we removed deprecated APIs, restructured npm package contents, and introduced new
+dependencies on OpenTelemetry.
+
+## Migration Codemod
+
+Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix all deprecations on `7.x`, you can use the `@sentry/migr8` codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
+
+```bash
+npx @sentry/migr8@latest
+```
+
+This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
+
+## Migration Guide
+
+Please see our [detailed migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgrading-from-7x-to-8x) for more information on migrating from `7.x` to `8.x`.
+
+{/* Make sure to update the PlatformSection below when new fully fleshed out migration guides are added */}
+
+<PlatformSection supported={["javascript.nextjs"]}>
+
+## Upgrading to `8.x`
+
+<PlatformContent includePath="migration/javascript-v8/intro" />
+
+We recommend you read through all the [Important Changes](#important-changes) as they affect all Next.js SDK users. The [Other Changes](#other-changes) linked below only affect users who have very custom instrumentation. There is also a [Troubleshooting](#troubleshooting) section for common issues.
+
+## Important Changes
+
+<PlatformContent includePath="migration/javascript-v8/important-changes" />
+
+## Other Changes
+
+<PlatformContent includePath="migration/javascript-v8/other-changes" />
+
+### Removal of `@sentry/replay` package
+
+The `@sentry/replay` package is no longer required. Instead you can import the relevant methods directly from your SDK. In addition to this, the integration is now functional instead of class based.
+
+```JavaScript diff
+-import { Replay } from '@sentry/replay';
+-
+ Sentry.init({
+   dsn: '___PUBLIC_DSN___',
+   integrations: [
+-    new Replay(),
++    new Sentry.replayIntegration(),
+   ],
+ });
+```
+
+<PlatformContent includePath="migration/javascript-v8/integrations-package-removal" />
+
+### Removal of `@sentry/hub`
+
+`@sentry/hub` has been removed and will no longer be published. All of the @sentry/hub exports have moved to `@sentry/core` or other related SDKs.
+
+<PlatformContent includePath="migration/javascript-v8/tracing-package-removal" />
+
+## Troubleshooting
+
+<PlatformContent includePath="migration/javascript-v8/troubleshooting" />
+
+</PlatformSection>
+
+<PlatformSection notSupported={["javascript.nextjs"]}>
+
+{/* TODO: Remove the generic summary */}
+
+<PlatformContent includePath="migration/javascript-v8/summary" />
+
+</PlatformSection>

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -16,7 +16,7 @@ Before updating to `8.x` of the SDK, we recommend upgrading to the latest versio
 npx @sentry/migr8@latest
 ```
 
-This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
+Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`!
 
 ## Migration Guide
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 7.x to 8.x
-sidebar_order: 8999
+sidebar_order: 8910
 description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
 ---
 
@@ -39,22 +39,6 @@ We recommend you read through all the [Important Changes](#important-changes) as
 ## Other Changes
 
 <PlatformContent includePath="migration/javascript-v8/other-changes" />
-
-### Removal of `@sentry/replay` package
-
-The `@sentry/replay` package is no longer required. Instead you can import the relevant methods directly from your SDK. In addition to this, the integration is now functional instead of class based.
-
-```JavaScript diff
--import { Replay } from '@sentry/replay';
--
- Sentry.init({
-   dsn: '___PUBLIC_DSN___',
-   integrations: [
--    new Replay(),
-+    new Sentry.replayIntegration(),
-   ],
- });
-```
 
 <PlatformContent includePath="migration/javascript-v8/integrations-package-removal" />
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
@@ -1,0 +1,253 @@
+---
+title: New Performance Monitoring APIs
+sidebar_order: 8997
+description: "Learn about new Performance Monitoring APIs in Sentry JavaScript SDK 8.x"
+---
+
+The SDK `8.x` release introduces new APIs for performance monitoring. These APIs are designed to provide more control over how performance data is collected and reported to Sentry.
+
+These APIs are also available in `7.x` so you can incrementally moveover to the new APIs before upgrading to `8.x`.
+
+Previously, there were two key APIs for adding manual performance instrumentation to your applications:
+
+- `startTransaction()`
+- `span.startChild()`
+
+This showed the underlying data model that Sentry was originally based on, which is that there is a root Transaction which can have a nested tree of Spans.
+
+In the new model, transactions are conceptually gone. Instead, you will always operate on spans, no matter where in the tree you are. Note that in the background, spans may still be grouped into a transaction for the Sentry UI. However, this happens transparently, and from an SDK perspective, all you have to think about are spans.
+
+Instead of manually starting & ending transactions and spans, the new model does not differentiate between these two. Instead, you always use the same APIs to start a new span, and it will automatically either create a new Root Span (which is just a regular span, only that it has no parent, and is thus conceptually roughly similar to a transaction) or a Child Span for whatever is the currently active span.
+
+There are three key APIs available to start spans:
+
+- `startSpan()`
+- `startSpanManual()`
+- `startInactiveSpan()`
+
+All three span APIs take `StartSpanOptions` as a first argument, which has the following shape:
+
+```ts
+interface StartSpanOptions {
+  // The only required field - the name of the span
+  name: string;
+  attributes?: SpanAttributes;
+  op?: string;
+  scope?: Scope;
+  forceTransaction?: boolean;
+}
+```
+
+### `startSpan()`
+
+This is the most common API that should be used in most circumstances. It will start a new span, make it the active span
+for the duration of a given callback, and automatically end it when the callback ends. You can use it like this:
+
+```js
+Sentry.startSpan(
+  {
+    name: "my-span",
+    attributes: {
+      attr1: "my-attribute",
+      attr2: 123,
+    },
+  },
+  (span) => {
+    // do something that you want to measure
+    // once this is done, the span is automatically ended
+  }
+);
+```
+
+You can also pass an async function:
+
+```js
+Sentry.startSpan(
+  {
+    name: "my-span",
+    attributes: {},
+  },
+  async (span) => {
+    // do something that you want to measure
+    await waitOnSomething();
+    // once this is done, the span is automatically ended
+  }
+);
+```
+
+Since `startSpan()` will make the created span the active span, any automatic or manual instrumentation that creates
+spans inside of the callback will attach new spans as children of the span we just started.
+
+Note that if an error is thrown inside of the callback, the span status will automatically be set to be errored.
+
+### `startSpanManual()`
+
+This is a variation of `startSpan()` with the only change that it does not automatically end the span when the callback
+ends, but you have to call `span.end()` yourself:
+
+```js
+Sentry.startSpanManual(
+  {
+    name: "my-span",
+  },
+  (span) => {
+    // do something that you want to measure
+
+    // Now manually end the span ourselves
+    span.end();
+  }
+);
+```
+
+In most cases, `startSpan()` should be all you need for manual instrumentation. But if you find yourself in a place
+where the automatic ending of spans, for whatever reason, does not work for you, you can use `startSpanManual()`
+instead.
+
+This function will _also_ set the created span as the active span for the duration of the callback, and will _also_
+update the span status to be errored if there is an error thrown inside of the callback.
+
+### `startInactiveSpan()`
+
+In contrast to the other two methods, this does not take a callback and this does not make the created span the active
+span. You can use this method if you want to create loose spans that do not need to have any children:
+
+```js
+Sentry.startSpan({ name: "outer" }, () => {
+  const inner1 = Sentry.startInactiveSpan({ name: "inner1" });
+  const inner2 = Sentry.startInactiveSpan({ name: "inner2" });
+
+  // do something
+
+  // manually end the spans
+  inner1.end();
+  inner2.end();
+});
+```
+
+No span will ever be created as a child span of an inactive span.
+
+### Creating a child span of a specific span
+
+You can use the `withActiveSpan` helper to create a span as a child of a specific span:
+
+```js
+Sentry.withActiveSpan(parentSpan, () => {
+  Sentry.startSpan({ name: "my-span" }, (span) => {
+    // span will be a direct child of parentSpan
+  });
+});
+```
+
+### Creating a transaction
+
+While in most cases, you shouldn't have to think about creating a span vs. a transaction (just call `startSpan()` and
+we'll do the appropriate thing under the hood), there may still be times where you _need_ to ensure you create a
+transaction (for example, if you need to see it as a transaction in the Sentry UI). For these cases, you can pass
+`forceTransaction: true` to the start-span APIs, e.g.:
+
+```js
+const transaction = Sentry.startInactiveSpan({
+  name: "transaction",
+  forceTransaction: true,
+});
+```
+
+## The Span schema
+
+Previously, spans & transactions had a bunch of properties and methods to be used. Most of these have been removed in
+favor of a slimmer, more straightforward API, which is also aligned with OpenTelemetry Spans. You can refer to the table
+below to see which things used to exist, and how they can/should be mapped going forward:
+
+The `spanToJSON`, `getRootSpan`, `setHttpStatus`, `spanToTraceHeader`, and `spanToTraceContext` are all exported by the SDK to be used.
+
+| Old name                   | Replace with                                                |
+| -------------------------- | ----------------------------------------------------------- |
+| `span.traceId`             | `span.spanContext().traceId`                                |
+| `span.spanId`              | `span.spanContext().spanId`                                 |
+| `span.parentSpanId`        | `spanToJSON(span).parent_span_id`                           |
+| `span.status`              | `spanToJSON(span).status`                                   |
+| `span.sampled`             | `spanIsSampled(span)`                                       |
+| `span.startTimestamp`      | `span.startTime` - note that this has a different format!   |
+| `span.tags`                | use attributes, or set tags on the scope                    |
+| `span.data`                | `spanToJSON(span).data`                                     |
+| `span.transaction`         | `getRootSpan(span)`                                         |
+| `span.instrumenter`        | Removed                                                     |
+| `span.finish()`            | `span.end()`                                                |
+| `span.end()`               | Same                                                        |
+| `span.setTag()`            | `span.setAttribute()`, or set tags on the scope             |
+| `span.setData()`           | `span.setAttribute()`                                       |
+| `span.setStatus()`         | `span.setStatus` - note that this has a different signature |
+| `span.setHttpStatus()`     | `setHttpStatus(span, status)`                               |
+| `span.setName()`           | `span.updateName()`                                         |
+| `span.startChild()`        | Call `Sentry.startSpan()` independently                     |
+| `span.isSuccess()`         | `spanToJSON(span).status === 'ok'`                          |
+| `span.toTraceparent()`     | `spanToTraceHeader(span)`                                   |
+| `span.toContext()`         | Removed                                                     |
+| `span.updateWithContext()` | Removed                                                     |
+| `span.getTraceContext()`   | `spanToTraceContext(span)`                                  |
+
+In addition, a transaction has this API:
+
+| Old name                    | Replace with                                     |
+| --------------------------- | ------------------------------------------------ |
+| `name`                      | `spanToJSON(span).description`                   |
+| `trimEnd`                   | Removed                                          |
+| `parentSampled`             | `spanIsSampled(span)` & `spanContext().isRemote` |
+| `metadata`                  | Use attributes instead or set on scope           |
+| `setContext()`              | Set context on scope instead                     |
+| `setMeasurement()`          | `Sentry.setMeasurement()`                        |
+| `setMetadata()`             | Use attributes instead or set on scope           |
+| `getDynamicSamplingContext` | `getDynamicSamplingContextFromSpan(span)`        |
+
+### Attributes vs. Data vs. Tags vs. Context
+
+In the old model, you had the concepts of **Data**, **Tags** and **Context** which could be used for different things.
+However, this has two main downsides: One, it is not always clear which of these should be used when. And two, not all
+of these are displayed the same way for transactions or spans.
+
+Because of this, in the new model, there are only **Attributes** to be set on spans anymore. Broadly speaking, they map
+to what Data used to be.
+
+If you still really _need_ to set tags or context, you can do so on the scope before starting a span:
+
+```JavaScript
+Sentry.withScope((scope) => {
+  scope.setTag("my-tag", "tag-value");
+  Sentry.startSpan({ name: "my-span" }, (span) => {
+    // do something here
+    // span will have the tags from the containing scope
+  });
+});
+```
+
+## Other Notable Changes
+
+In addition to generally changing the performance APIs, there are also some smaller changes that this brings with it.
+
+### Changed `SamplingContext` for `tracesSampler()`
+
+Currently, `tracesSampler()` can receive an arbitrary `SamplingContext` passed as argument. While this is not defined
+anywhere in detail, the shape of this context will change in v8. Going forward, this will mostly receive the attributes
+of the span, as well as some other relevant data of the span. Some properties we used to (sometimes) pass there, like
+`req` for node-based SDKs or `location` for browser tracing, will not be passed anymore.
+
+### No more `undefined` spans
+
+In v7, the performance APIs `startSpan()` / `startInactiveSpan()` / `startSpanManual()` would receive an `undefined`
+span if tracing was disabled or the span was not sampled.
+
+In v8, aligning with OpenTelemetry, these will _always_ return a span - _but_ the span may eb a Noop-Span, meaning a
+span that is never sent. This means you don't have to guard everywhere in your code anymore for the span to exist:
+
+```TypeScript
+Sentry.startSpan((span: Span | undefined) => {
+  // previously, in order to be type safe, you had to use optional chaining or similar
+  span?.setAttribute("attr", 1);
+});
+
+// In v8, the signature changes to:
+Sentry.startSpan((span: Span) => {
+  // no need to guard anymore!
+  span.setAttribute("attr", 1);
+});
+```

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
@@ -6,18 +6,18 @@ description: "Learn about new Performance Monitoring APIs in Sentry JavaScript S
 
 The SDK `8.x` release introduces new APIs for performance monitoring. These APIs are designed to provide more control over how performance data is collected and reported to Sentry.
 
-These APIs are also available in `7.x` so you can incrementally moveover to the new APIs before upgrading to `8.x`.
+These APIs are also available in `7.x` so you can incrementally move over to the new APIs before upgrading to `8.x`.
 
 Previously, there were two key APIs for adding manual performance instrumentation to your applications:
 
 - `startTransaction()`
 - `span.startChild()`
 
-This showed the underlying data model that Sentry was originally based on, which is that there is a root Transaction which can have a nested tree of Spans.
+Those APIs were based on the original data model of Sentry. This model was based on a root Transaction that could contain a nested tree of Spans.
 
-In the new model, transactions are conceptually gone. Instead, you will always operate on spans, no matter where in the tree you are. Note that in the background, spans may still be grouped into a transaction for the Sentry UI. However, this happens transparently, and from an SDK perspective, all you have to think about are spans.
+In the new model, transactions are conceptually gone. Now, operations are always performed on spans, regardless of their position in the tree. Note that spans may still be grouped into a transaction for the Sentry UI. However, this happens in the background and, from the SDK's point of view, all you need to be concerned about are spans.
 
-Instead of manually starting & ending transactions and spans, the new model does not differentiate between these two. Instead, you always use the same APIs to start a new span, and it will automatically either create a new Root Span (which is just a regular span, only that it has no parent, and is thus conceptually roughly similar to a transaction) or a Child Span for whatever is the currently active span.
+The new model does not differentiate between a transaction or a span when manually starting or ending them. Instead, you always use the same APIs to start a new span. This will automatically create either a new Root Span (a regular span without a parent, conceptually similar to a transaction) or a Child Span, depending on what is the currently active span.
 
 There are three key APIs available to start spans:
 
@@ -27,7 +27,7 @@ There are three key APIs available to start spans:
 
 All three span APIs take `StartSpanOptions` as a first argument, which has the following shape:
 
-```ts
+```TypeScript
 interface StartSpanOptions {
   // The only required field - the name of the span
   name: string;
@@ -40,8 +40,8 @@ interface StartSpanOptions {
 
 ### `startSpan()`
 
-This is the most common API that should be used in most circumstances. It will start a new span, make it the active span
-for the duration of a given callback, and automatically end it when the callback ends. You can use it like this:
+This is the most common API that should be used in most circumstances. It will start a new span, making it the active span
+for the duration of a given callback, and automatically ends it when the callback ends. You can use it like this:
 
 ```js
 Sentry.startSpan(
@@ -82,8 +82,8 @@ Note that if an error is thrown inside of the callback, the span status will aut
 
 ### `startSpanManual()`
 
-This is a variation of `startSpan()` with the only change that it does not automatically end the span when the callback
-ends, but you have to call `span.end()` yourself:
+This is a variation of `startSpan()` with the only difference that it does not automatically end the span when the callback
+ends. When using this, you have to call `span.end()` yourself:
 
 ```js
 Sentry.startSpanManual(
@@ -201,12 +201,9 @@ In addition, a transaction has this API:
 
 ### Attributes vs. Data vs. Tags vs. Context
 
-In the old model, you had the concepts of **Data**, **Tags** and **Context** which could be used for different things.
-However, this has two main downsides: One, it is not always clear which of these should be used when. And two, not all
-of these are displayed the same way for transactions or spans.
+Previously, the model had the concepts of **Data**, **Tags**, and **Context**, which could be used for different things. However, this had two main downsides: Firstly, it was not always clear which concept should be used in a given situation. Secondly, these concepts were not displayed the same way for transactions or spans.  
 
-Because of this, in the new model, there are only **Attributes** to be set on spans anymore. Broadly speaking, they map
-to what Data used to be.
+To address these issues, the new model only has **Attributes** that can be set on spans. Broadly speaking, they map to what was formerly known as Data.
 
 If you still really _need_ to set tags or context, you can do so on the scope before starting a span:
 
@@ -236,7 +233,7 @@ of the span, as well as some other relevant data of the span. Some properties we
 In v7, the performance APIs `startSpan()` / `startInactiveSpan()` / `startSpanManual()` would receive an `undefined`
 span if tracing was disabled or the span was not sampled.
 
-In v8, aligning with OpenTelemetry, these will _always_ return a span - _but_ the span may eb a Noop-Span, meaning a
+In v8, aligning with OpenTelemetry, these will _always_ return a span - _but_ the span may be a Noop-Span, meaning a
 span that is never sent. This means you don't have to guard everywhere in your code anymore for the span to exist:
 
 ```TypeScript

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
@@ -1,0 +1,93 @@
+---
+title: OpenTelemetry Support
+sidebar_order: 8998
+description: "Learn OpenTelemetry support in SDK 8.x"
+---
+
+In `8.x`, the Performance Monitoring APIs for the SDK been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood.
+
+You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started.
+
+If you want, you can use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
+
+### Accessing the OpenTelemetry Tracer
+
+You can access the tracer instance to add custom spans or context to your traces. This means you can rely on OpenTelemetry APIs to start spans, and Sentry will pick up everything automatically.
+
+```JavaScript
+const tracer = Sentry.getClient().tracer;
+
+const span1 = tracer.startSpan('work-1');
+// Do some work
+span1.end();
+```
+
+We recommend using the [performance monitoring APIs](./v8-new-performance-api.mdx) provided by Sentry, as they are more user-friendly and provide additional features.
+
+### Custom OpenTelemetry Instrumentation
+
+While we include some vetted OpenTelemetry instrumentation out of the box, you can also add your own instrumentation on top of that. You can do that by installing an instrumentation package and calling the `addOpenTelemetryInstrumentation` method:
+
+```JavaScript
+const { GenericPoolInstrumentation } = require('@opentelemetry/instrumentation-generic-pool');
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+});
+
+// Afterwards, you can add additional instrumentation:
+Sentry.addOpenTelemetryInstrumentation(new GenericPoolInstrumentation());
+```
+
+### Custom OpenTelemetry Setup
+
+The SDK also offers the ability to completely customize your OpenTelemetry setup.
+
+In this case, you need to set `skipOpenTelemetrySetup: true` in your `Sentry.init` config, and ensure you setup all the components that Sentry needs yourself.
+
+1. First, install the `@sentry/opentelemetry` package.
+
+```bash {tabTitle:npm}
+npm install --save @sentry/opentelemetry
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/opentelemetry
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/opentelemetry
+```
+
+```bash {tabTitle:bun}
+bun add @sentry/opentelemetry
+```
+
+2. Then add the `SentrySpanProcessor`, `SentryPropagator`, `SentryContextManager`, and `SentrySampler` to your OpenTelemetry SDK initialization.
+
+```JavaScript
+// Make sure Sentry is initialized before OpenTelemetry
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  // Make sure to set this to disable the automatic OpenTelemetry setup
+  skipOpenTelemetrySetup: true,
+});
+
+const { SentrySpanProcessor, SentryPropagator, SentryContextManager, SentrySampler } = require('@sentry/opentelemetry');
+
+// We need to add a span processor to send spans to Sentry
+provider.addSpanProcessor(new SentrySpanProcessor());
+
+// We need a custom propagator and context manager
+// This enables distributed tracing and context isolation
+provier.register({
+  propagator: new SentryPropagator(),
+  contextManager: new SentryContextManager(),
+});
+
+// Optionally, if you want to use the `tracesSamplingRate` or sampling related options from Sentry,
+// you also need to use a custom sampler when you set up your provider
+const provider = new BasicTracerProvider({
+  sampler: new SentrySampler(Sentry.getClient()),
+});
+```

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -1,3 +1,19 @@
+### Removal of `@sentry/replay` package
+
+The `@sentry/replay` package is no longer required. Instead you can import the relevant methods directly from your SDK. In addition to this, the integration is now functional instead of class based.
+
+```JavaScript diff
+-import { Replay } from '@sentry/replay';
+-
+ Sentry.init({
+   dsn: '___PUBLIC_DSN___',
+   integrations: [
+-    new Replay(),
++    new Sentry.replayIntegration(),
+   ],
+ });
+```
+
 ### Removal of makeXHRTransport transport
 
 The xhr transport via `makeXHRTransport` transport has been removed. Only `makeFetchTransport` is available now. This means that the Sentry SDK requires the `fetch` API to be available in the environment.

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -1,0 +1,3 @@
+### Removal of makeXHRTransport transport
+
+The xhr transport via `makeXHRTransport` transport has been removed. Only `makeFetchTransport` is available now. This means that the Sentry SDK requires the `fetch` API to be available in the environment.

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -1,6 +1,6 @@
 ### Removal of `@sentry/replay` package
 
-The `@sentry/replay` package is no longer required. Instead you can import the relevant methods directly from your SDK. In addition to this, the integration is now functional instead of class based.
+The `@sentry/replay` package is no longer required. Instead you can import the relevant methods directly from your SDK. In addition to this, the integration is now functional instead of class-based.
 
 ```JavaScript diff
 -import { Replay } from '@sentry/replay';

--- a/includes/migration/javascript-v8/node-other-changes.mdx
+++ b/includes/migration/javascript-v8/node-other-changes.mdx
@@ -1,0 +1,12 @@
+### Revamped Application Not Responding Detection
+
+The `enableAnrDetection` and `Anr` class exports have been removed the SDK. Instead you can now use the `Sentry.anrIntegration` to enable <Link to="/platforms/javascript/guides/node/configuration/application-not-responding">Application Not Responding detection</Link>
+
+```JavaScript {4}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.anrIntegration({ captureStackTrace: true })
+  ],
+});
+```

--- a/includes/migration/javascript-v8/server-other-changes.mdx
+++ b/includes/migration/javascript-v8/server-other-changes.mdx
@@ -1,0 +1,3 @@
+### Removal of `deepReadDirSync` method
+
+The `deepReadDirSync` method has been removed as an export from the SDK. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
@@ -1,0 +1,115 @@
+### Supported versions
+
+Sentry Next.js SDK `8.x` supports:
+
+- Next.js version `13.2.0` or higher
+- Webpack `5.0.0` or higher
+- Node `14.18.0` or higher
+
+If you need to support older versions of Next.js, please use Sentry Next.js SDK `7.x`.
+
+The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+
+### Updated SDK initialization
+
+With `8.x` the Next.js SDK will no longer support the use of `sentry.server.config.js|ts` and `sentry.edge.config.js|ts` files. Instead, please initialize the Sentry Next.js SDK for the server-side in a Next.js [instrumentation hook](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation). Usage of `sentry.client.config.ts|js` is still supported and encouraged for initializing the client-side SDK.
+
+To start using the Next.js built-in hooks, follow these steps:
+
+1. First, enable the Next.js instrumentation hook by setting the [`experimental.instrumentationHook`](https://nextjs.org/docs/app/api-reference/next-config-js/instrumentationHook) to true in your `next.config.js`.
+
+```JavaScript {next.config.js} {2-4}
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}
+```
+
+2. Next, create a `instrumentation.ts|js` file in the root directory of your project (or in the src folder if you have have one).
+
+3. Now, export a register function from the `instrumentation.ts|js` file and call `Sentry.init()` inside of it:
+
+```JavaScript {instrumentation.js}
+import * as Sentry from '@sentry/nextjs';
+
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // this is your Sentry.init call from `sentry.server.config.js|ts`
+    Sentry.init({
+      dsn: '___PUBLIC_DSN___',
+      // Your Node.js Sentry configuration...
+    });
+  }
+
+  // This is your Sentry.init call from `sentry.edge.config.js|ts`
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    Sentry.init({
+      dsn: '___PUBLIC_DSN___',
+      // Your Edge Runtime Sentry configuration...
+    });
+  }
+}
+```
+
+4. Last, you can delete the `sentry.server.config.js|ts` and `sentry.edge.config.js|ts` files. Please remember to keep your `sentry.client.config.ts|js` file for client-side SDK initialization.
+
+<Alert level="warning">
+
+If you are using a [Next.js custom server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server), the `instrumentation.ts|js` hook is not called by Next.js so SDK instrumentation will not work as expected. See the [troubleshooting section](#nextjs-custom-server) for more information.
+
+</Alert>
+
+### New Performance API
+
+The Custom Instrumentation API for Performance Monitoring has been revamped in `8.x`. New methods have been introduced, and `startTransaction` and `span.startChild` has been removed. See the [new Performance Monitoring APIs docs](./v8-new-performance-api/) for more information.
+
+### Updated `withSentryConfig` Usage
+
+With `8.x` of the Sentry Next.js SDK, `withSentryConfig` will no longer accept 3 arguments. The second argument (holding options for the Sentry Webpack plugin) and the third argument (holding options for SDK build-time configuration) should now be passed as one:
+
+```JavaScript {next.config.js} diff
+const nextConfig = {
+  // Your Next.js options...
+};
+
+-module.exports = withSentryConfig(
+-  nextConfig,
+-  {
+-    // Your Sentry Webpack Plugin Options...
+-  },
+-  {
+-    // Your Sentry SDK options...
+-  },
+-);
++module.exports = withSentryConfig(nextConfig, {
++  // Your Sentry Webpack Plugin Options...
++  // AND your Sentry SDK options...
++});
+```
+
+As part of this change the SDK will no longer support passing Next.js options with a `sentry` property to `withSentryConfig`. Please use the second argument of `withSentryConfig` to configure the SDK instead.
+
+```JavaScript {next.config.js} diff
+ const nextConfig = {
+   // Your Next.js options...
+-
+-  sentry: {
+-    // Your Sentry SDK options...
+-  },
+ };
+
+ module.exports = withSentryConfig(nextConfig, {
+   // Your Sentry Webpack Plugin Options...
++  // AND your Sentry SDK options...
+ });
+```

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.nextjs.mdx
@@ -1,0 +1,20 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/nextjs`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/nextjs` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+
+Integrations that are now exported from `@sentry/nextjs` for client-side and server-side init:
+
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/intro/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/intro/javascript.nextjs.mdx
@@ -1,0 +1,1 @@
+`8.x` simplifies Sentry Next.js SDK initialization and leverages Next.js OpenTelemetry instrumentation for performance monitoring.

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
@@ -1,0 +1,122 @@
+### Improved Source Map Uploading
+
+Under the hood, the Next.js SDK uses [Sentry Webpack Plugin](https://www.npmjs.com/package/@sentry/webpack-plugin) to upload sourcemaps and automatically associate add releases to your events. In `8.x`, the SDK now uses `2.x` of the Sentry Webpack Plugin which brings many improvements and bug fixes. Sourcemaps uploading with the Next.js SDK now uses <Link to="/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/">Debug IDs</Link>.
+
+### Removal of deprecated API
+
+The following previously deprecated API has been removed from the `@sentry/nextjs` package:
+
+- `nextRouterInstrumentation` has been removed in favour of `browserTracingIntegration`.
+
+```JavaScript {sentry.client.config.js} diff
+ import * as Sentry from '@sentry/nextjs';
+
+ Sentry.init({
+   dsn: '___PUBLIC_DSN___',
+   integrations: [
+-    new Sentry.Integrations.BrowserTracing({
+-      routingInstrumentation: Sentry.nextRouterInstrumentation
+-    }),
++    Sentry.browserTracingIntegration(),
+   ]
+ });
+
+```
+
+- `withSentryApi` has been removed in favour of `wrapApiHandlerWithSentry`.
+
+```JavaScript {pages/api/*} diff
+-import { withSentryApi } from "@sentry/nextjs";
++import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
+
+ const handler = (req, res) => {
+   res.status(200).json({ name: "John Doe" });
+ };
+
+-export default withSentryApi(handler, "/api/myRoute");
++export default wrapApiHandlerWithSentry(handler, "/api/myRoute");
+```
+
+- `withSentryGetServerSideProps` has been removed in favour of `wrapGetServerSidePropsWithSentry`.
+
+```JavaScript {pages/index.js} diff
+-import { withSentryGetServerSideProps } from "@sentry/nextjs";
++import { wrapGetServerSidePropsWithSentry } from "@sentry/nextjs";
+
+ export async function _getServerSideProps() {
+   // Fetch data from external API
+ }
+
+-export const getServerSideProps = withSentryGetServerSideProps(_getServerSideProps);
++export const getServerSideProps = wrapGetServerSidePropsWithSentry(_getServerSideProps);
+```
+
+- `withSentryGetStaticProps` has been removed in favour of `wrapGetStaticPropsWithSentry`.
+
+```JavaScript {pages/index.js} diff
+-import { withSentryGetStaticProps } from "@sentry/nextjs";
++import { wrapGetStaticPropsWithSentry } from "@sentry/nextjs";
+
+ export async function _getStaticProps() {
+   // Fetch data from external API
+ }
+
+-export const getStaticProps = withSentryGetStaticProps(_getServerSideProps);
++export const getStaticProps = wrapGetStaticPropsWithSentry(_getServerSideProps);
+```
+
+- `withSentryServerSideGetInitialProps` has been removed in favour of `wrapGetInitialPropsWithSentry`.
+
+```JavaScript {pages/index.js} diff
+-import { withSentryServerSideGetInitialProps } from "@sentry/nextjs";
++import { wrapGetInitialPropsWithSentry } from "@sentry/nextjs";
+
+ async function getInitialProps() {
+   // Fetch data from external API
+   return { data }
+ }
+
+-Page.getInitialProps = withSentryServerSideGetInitialProps(getInitialProps);
++Page.getInitialProps = wrapGetInitialPropsWithSentry(getInitialProps);
+
+ export default function Page({ data }) {
+   return data
+ }
+```
+
+Similar to the above changes, the following API has been removed:
+
+- `withSentryServerSideAppGetInitialProps` has been removed in favour of `wrapAppGetInitialPropsWithSentry`.
+- `withSentryServerSideDocumentGetInitialProps` has been removed in favour of `wrapDocumentGetInitialPropsWithSentry`.
+- `withSentryServerSideErrorGetInitialProps` has been removed in favour of `wrapErrorGetInitialPropsWithSentry`.
+
+The `IS_BUILD` and `isBuild` exports have been removed. There is no replacement for these exports.
+
+### OpenTelemetry Instrumentation
+
+The Next.js SDK now leverages Next.js OpenTelemetry instrumentation for performance monitoring. This means that the SDK will automatically capture OpenTelemetry data for your Next.js application without any additional configuration.
+
+If you were previously using the `@sentry/opentelemetry-node`, it is no longer required and can be removed from your project. To migrate from using `@sentry/opentelemetry-node` to the Next.js SDK, follow these steps:
+
+1. Make sure you've updated your SDK initialization as per the [Updated SDK initialization](#updated-sdk-initialization) section above.
+
+2. Remove `instrumenter: "otel",` from your `Sentry.init` call for your server-side SDK initialization.
+
+```JavaScript {sentry.server.config.js} diff
+ import * as Sentry from '@sentry/nextjs';
+
+ Sentry.init({
+   dsn: '___PUBLIC_DSN___',
+-  instrumenter: 'otel',
+ });
+```
+
+3. Remove the `@sentry/opentelemetry-node` package and the `instrumentation.node.js|ts` file in your project. Make sure `instrumentation.js|ts` no longer imports the `instrumentation.node.js|ts` file.
+
+To customize your OpenTelemetry setup, see the docs on [OpenTelemetry instrumentation in `8.0`](./v8-opentelemetry/#custom-opentelemetry-setup).
+
+<Include name="migration/javascript-v8/node-other-changes" />
+
+<Include name="migration/javascript-v8/server-other-changes" />
+
+<Include name="migration/javascript-v8/browser-other-changes" />

--- a/platform-includes/migration/javascript-v8/summary/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/summary/javascript.mdx
@@ -1,12 +1,4 @@
----
-title: Migrate from Sentry JavaScript SDK 7.x to 8.x
-sidebar_order: 8999
-description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
----
-
-The main goal of version 8 is to improve our performance monitoring APIs, integrations API, and ESM support. This
-version is breaking because we removed deprecated APIs, restructured npm package contents, and introduced new
-dependencies on OpenTelemetry.
+## Summary of Changes
 
 If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
 
@@ -21,11 +13,15 @@ If you only use basic features of Sentry, or you simply copy & pasted the setup 
   - Opera 50
   - Samsung Internet 8.2
 
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+
 - Integrations are now functional instead of class based. For example, the import for session replay uses `Sentry.replayIntegration` instead of `new Sentry.Replay`.
+
+- The SDK's Performance API has been revamped. More details can be found in documentation about the [new Performance Monitoring APIs](./v8-new-performance-api/)
 
 - Initializing the Node SDK has been vastly simplified. You no longer need to use `autoDiscoverNodePerformanceMonitoringIntegrations` or use `Sentry.Handlers`, as these are now automatically included by the SDK without configuration. To make this work, you now have to ensure `Sentry.init` is initialized before any other code is imported and used.
 
-```ts
+```JavaScript
 // In v7, this was fine:
 const Sentry = require("@sentry/node");
 const express = require("express");
@@ -50,13 +46,3 @@ const app = express();
 
 Sentry.setupExpressErrorHandler(app);
 ```
-
-Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix all deprecations on `7.x`, you can use the `@sentry/migr8` codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
-
-```bash
-npx @sentry/migr8@latest
-```
-
-This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
-
-Please see our detailed migration guide for more information on migrating from `7.x` to `8.x`: [link](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgrading-from-7x-to-8x)

--- a/platform-includes/migration/javascript-v8/summary/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/summary/javascript.mdx
@@ -19,7 +19,7 @@ For IE11 support please transpile your code to ES5 using babel or similar and ad
 
 - The SDK's Performance API has been revamped. More details can be found in documentation about the [new Performance Monitoring APIs](./v8-new-performance-api/)
 
-- Initializing the Node SDK has been vastly simplified. You no longer need to use `autoDiscoverNodePerformanceMonitoringIntegrations` or use `Sentry.Handlers`, as these are now automatically included by the SDK without configuration. To make this work, you now have to ensure `Sentry.init` is initialized before any other code is imported and used.
+- Initializing the Node SDK has been vastly simplified. You no longer need to use `autoDiscoverNodePerformanceMonitoringIntegrations` or use `Sentry.Handlers`, as these are now automatically included by the SDK without configuration. To make this work, you now have to ensure `Sentry.init` is initialized **before any other code is imported and used**.
 
 ```JavaScript
 // In v7, this was fine:

--- a/platform-includes/migration/javascript-v8/troubleshooting/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/troubleshooting/javascript.nextjs.mdx
@@ -1,0 +1,43 @@
+### Removal of `sentry.server.config.js|ts` and `sentry.edge.config.js|ts`
+
+`8.x` of the Next.js SDK updates enforces usage of the `instrumentation.ts` file because it is a more flexible and powerful way to initialize the SDK, and allows us to use the Next.js built-in hooks and OpenTelemetry instrumentation. In addition it helps the SDK to be more compatible with the [Turbopack](https://turbo.build/pack) which is not supported in Next.js SDK `7.x`. The Next.js team recommends to use the `instrumentation.ts` file for SDK initialization, and we are working closely with them to ensure that the SDK works seamlessly with Next.js.
+
+### Next.js Custom server
+
+If you are using a [Next.js custom server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server), the `instrumentation.ts|js` hook is not called by Next.js so you need to manually call it yourself from within your server code. It is recommended to do so as early as possible in your application lifecycle.
+
+Here's an example of adding Sentry initialization code to the custom server example as per the [Next.js documentation](https://nextjs.org/docs/advanced-features/custom-server):
+
+```JavaScript diff {server.js} {1}
+// make sure that Sentry is imported and initialized before any other imports.
+
++ const Sentry = require('@sentry/nextjs');
++
++ Sentry.init({
++   dsn: '___PUBLIC_DSN___',
++   // Your Node.js Sentry configuration...
++ })
+
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+
+const dev = process.env.NODE_ENV !== 'production'
+const hostname = 'localhost'
+const port = 3000
+
+const app = next({ dev, hostname, port })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  createServer(async (req, res) => {
+    // server code
+  })
+    .once('error', (err) => {
+      // error code
+    })
+    .listen(port, () => {
+      console.log(`> Ready on http://${hostname}:${port}`)
+    })
+})
+```


### PR DESCRIPTION
This is a start to revamped migration docs for our Sentry JavaScript SDK.

These still link to the repo readme, but contain more accessible migration guides for our users. As an example, I've added a relatively fleshed out set of instructions for migrating a `Next.js` app.

If this general approach is agree'd upon, I'm going to work toward porting the rest of the migration docs into fitting this format, and then adding docs for Node, Browser, React, and Express. With those changed (and Next.js being finished), we then incrementally tackle the other more detailed migration guides whenever we want! (we could even merge them in after v8 releases).

Top level migration docs:

![image](https://github.com/getsentry/sentry-docs/assets/18689448/3db4a3ea-ca1c-47b8-9e6c-8ef60c44fe5c)

Troubleshooting (maybe should be named FAQ?) at the bottom:

![image](https://github.com/getsentry/sentry-docs/assets/18689448/b5943fb0-bdc6-4384-a830-342b7dd3b905)

OpenTelemetry docs! 

![image](https://github.com/getsentry/sentry-docs/assets/18689448/365e3910-2f74-4e56-8bd7-c8c3ec735c22)