### PR TITLE
chore(apple): Add Apple Privacy Manifest guide

### DIFF
--- a/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
@@ -1,0 +1,108 @@
+---
+title: Apple Privacy Manifest
+description: "Troubleshoot and resolve common issues with the Apple Privacy Manifest and Sentry Cocoa SDK."
+sidebar_order: 50
+---
+
+<Note>
+This guide requires [sentry-cocoa@8.21.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.21.0) or newer.
+</Note>
+
+Sentry's SDKs provide error and performance monitoring for mobile applications running on Apple devices. To do this, the SDK needs to access certain information about the device and the application. Some of the APIs required for this are considered privacy-relevant by Apple. In order to submit apps to the App Store, Apple requires all apps - and libraries used within these apps - to provide privacy manifest files stating which APIs are used under which allowed reasons. For more details, read Apple's guidelines on [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+
+<Note>
+The information and steps in this guide are still being worked on and might change because of new tools or updated [Apple requirements](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+</Note>
+
+If you are using dynamically linked frameworks, Apple will automatically process the SDK's privacy manifest. If you are using statically linked libraries, you need to provide the privacy manifest yourself. This guide will help you create the privacy manifest for your applications.
+
+## Before You Start
+
+Note that the application privacy manifest covers all data usages (via `NSPrivacyCollectedDataTypes`) and API usages (via `NSPrivacyAccessedAPITypes`) for the *whole application* and *all included libraries*. The examples below reflect the current requirements for the Sentry SDKs alone. If you are using other libraries that access privacy-relevant APIs, you need to include them in the privacy manifest as well.
+
+## Create Privacy Manifest in Xcode
+
+Create a privacy manifest file in your Xcode project. This file should be named `PrivacyInfo.xcprivacy` and should be placed in the root of your Xcode project. Follow the [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#4284009) guide by Apple to create the file.
+
+```xml {filename:PrivacyInfo.xcprivacy}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>
+```
+
+## Troubleshooting
+
+- The listed APIs are required for the SDK to function corectly and there is no way to opt-out of them.
+
+- If you are using an older version of the SDK, you may need to update to version [8.21.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.21.0) or later to automatically include the privacy manifest for dynamically linked frameworks.
+
+- To verify the privacy manifest is included in your app correctly, build and submit your app to the App Store or TestFlight for external testing. If the manifest is missing, you will receive an email from Apple with the subject, "The uploaded build for YourAppName has one or more issues", that lists the missing API declarations.

--- a/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
@@ -16,13 +16,11 @@ The information and steps in this guide are still being worked on and might chan
 
 If you are using dynamically linked frameworks, Apple will automatically process the SDK's privacy manifest. If you are using statically linked libraries, you need to provide the privacy manifest yourself. This guide will help you create the privacy manifest for your applications.
 
-## Before You Start
-
-Note that the application privacy manifest covers all data usages (via `NSPrivacyCollectedDataTypes`) and API usages (via `NSPrivacyAccessedAPITypes`) for the *whole application* and *all included libraries*. The examples below reflect the current requirements for the Sentry SDKs alone. If you are using other libraries that access privacy-relevant APIs, you need to include them in the privacy manifest as well.
-
 ## Create Privacy Manifest in Xcode
 
 Create a privacy manifest file in your Xcode project. This file should be named `PrivacyInfo.xcprivacy` and should be placed in the root of your Xcode project. Follow the [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#4284009) guide by Apple to create the file.
+
+Note that the application privacy manifest covers all data usages (via `NSPrivacyCollectedDataTypes`) and API usages (via `NSPrivacyAccessedAPITypes`) for the *whole application* and *all included libraries*. The example below reflects the current requirements for the Sentry SDK alone. If you are using other libraries that access privacy-relevant APIs, you need to include them in the privacy manifest as well.
 
 ```xml {filename:PrivacyInfo.xcprivacy}
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -4,6 +4,10 @@ description: "Troubleshoot and resolve common issues with the Cocoa SDK."
 sidebar_order: 9000
 ---
 
+## "Missing API declaration" after App Store review
+
+Starting May 1, 2024, Apple requires all apps submitted to the App Store to provide a list of privacy-related APIs they use, including the reaasons under which they use it. If you received an email from Apple with the message "ITMS-91053: Missing API declaration", your app doesn't fulfill the requirements. To solve this, follow our [Apple Privacy Manifest](/platforms/apple/data-management/apple-privacy-manifest) guide.
+
 ## Wrong App Start Data
 
 Starting with iOS 15, the system might [pre-warm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In such cases, we can't reliably measure the app start, so we drop it as of [sentry-cocoa 7.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.18.0). We are working on a fix for this. Follow the [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/1897) for more details.


### PR DESCRIPTION
Adds a new page to explain what APIs need to be listed in the Apple Privacy Manifest for apps with Sentry SDK to be published in the App Store. https://github.com/getsentry/sentry-docs/pull/9752 for Apple

related: https://github.com/getsentry/team-mobile/issues/183