### PR TITLE
Remove replay references under Event Properties.mdx

### DIFF
--- a/docs/product/reference/search/searchable-properties/events.mdx
+++ b/docs/product/reference/search/searchable-properties/events.mdx
@@ -11,7 +11,6 @@ You can search by event properties in the following [sentry.io](https://sentry.i
 - Discover - in the query builder
 - Dashboards - within the widget builder, depending on dataset selection
 - Performance - only in transaction summaries
-- Replay - on the **Replay** page
 - Issues - as indicated in the list below
 - Alerts - when creating a metric alert
 
@@ -307,7 +306,7 @@ Full URL of the request that caused the error, but without any parameters
 
 ### `id`
 
-The event or replay id. In **Issues**, use only the ID value without the `id` key.
+The event id. In **Issues**, use only the ID value without the `id` key.
 
 - **Type:** UUID
 


### PR DESCRIPTION
Remove Replay references under Event Properties to reduce confusion since event properties are defined as specifically errors and transactions in this document.

