### PR TITLE
fix(python): Fix migration guide

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -55,7 +55,7 @@ The API function `last_event_id()` was removed. The last event ID is still retur
 
 ## Custom Instrumentation
 
-You no longer have to use `configure_scope` to mutate a transaction. Instead, you simply get the current scope to mutate the transaction. Here is a recipe on how to change your code to make it work:
+Hub-based APIs as well as some scope-based APIs (like `configure_scope()` and `push_scope()`) are now deprecated as a consequence of [reworking](/platforms/python/enriching-events/scopes/) the way the SDK saves and propagates data internally. Instead, SDK 2.0 introduces the concept of a global, isolation and current scope. In short:
 
 - The **global scope** holds data that doesn't change as long as your app is running (for example, the current release).
 - The **isolation scope** follows a single basic unit of your program, such as a single request-response cycle or one task in a task queue, and holds data pertaining to it. In most cases, the lifecycle of an isolation scope maps to the lifecycle of a transaction.
@@ -101,7 +101,7 @@ If you want your scope change to affect the whole transaction, use the isolation
 + # do something with scope
 ```
 
-Additionally, you can no longer mutate a manually-created transaction in a `configure_scope` block. Instead, you need to get the current scope to mutate the transaction. Here is a recipe on how to change your code to make it work:
+Additionally, you no longer have to use `configure_scope` to mutate a transaction. Instead, you simply get the current scope to mutate the transaction. Here is a recipe on how to change your code to make it work:
 
 ```python diff
 transaction = sentry_sdk.transaction(...)


### PR DESCRIPTION


## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Messed up the last [migration guide merge](https://github.com/getsentry/sentry-docs/pull/9182/commits/e672fca4613684cd59f6669b7c8dc3606ece7b0c). Fixing.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
