### PR TITLE
docs(integrations): Add environment information to integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.electron
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.breadcrumbsIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).

--- a/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.fastify
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.browserTracingIntegration`_
 
 With [performance monitoring](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services.

--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.consoleIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.consoleIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.fastify
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.globalHandlersIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.httpIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.httpIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/httpclient.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpclient.mdx
@@ -12,6 +12,10 @@ notSupported:
   - javascript.fastify
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.httpClientIntegration`_
 
 This integration captures errors on failed requests from Fetch and XHR and attaches request and response information.

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.fastify
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.httpContextIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).

--- a/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.localVariablesIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.localVariablesIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/modulemetadata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modulemetadata.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.koa
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.moduleMetadataIntegration`_
 
 Metadata can be injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.

--- a/docs/platforms/javascript/common/configuration/integrations/modules.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modules.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.modulesIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/modules.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modules.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.modulesIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.nodeContextIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.nodeContextIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.nativeNodeFetchIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.nativeNodeFetchIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.onUncaughtExceptionIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.onUncaughtExceptionIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/replay.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replay.mdx
@@ -16,6 +16,10 @@ notSupported:
   - javascript.koa
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.replayIntegration`_
 
 [Session Replay](/product/session-replay/) helps you get to the root cause of an error or latency issue faster by providing you with a video-like reproduction of what was happening in the user's browser before, during, and after the issue. You can rewind and replay your application's DOM state and see key user interactions, like mouse clicks, scrolls, network requests, and console entries, in a single combined UI inspired by your browser's DevTools.

--- a/docs/platforms/javascript/common/configuration/integrations/reportingobserver.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/reportingobserver.mdx
@@ -12,6 +12,10 @@ notSupported:
   - javascript.koa
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.reportingObserverIntegration`_
 
 This integration hooks into the ReportingObserver API and sends captured events through to Sentry. It can be configured to handle specific issue types only.

--- a/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
@@ -14,9 +14,13 @@ supported:
   - javascript.koa
   - javascript.nextjs
   - javascript.sveltekit
-  - javascript.astro
   - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.requestDataIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
@@ -19,7 +19,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.requestDataIntegration`_

--- a/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/trycatch.mdx
@@ -13,6 +13,10 @@ notSupported:
   - javascript.koa
 ---
 
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
 _Import name: `Sentry.browserApiErrorsIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).

--- a/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
@@ -11,7 +11,15 @@ supported:
   - javascript.gcp-functions
   - javascript.koa
   - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
 ---
+
+<Alert level="info">
+  This integration only works inside a Node.js environment.
+</Alert>
 
 _Import name: `Sentry.onUnhandledRejectionIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
@@ -18,7 +18,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a Node.js environment.
+  This integration only works inside server environments (Node.js, Bun, Deno).
 </Alert>
 
 _Import name: `Sentry.onUnhandledRejectionIntegration`_


### PR DESCRIPTION
## Description of changes

To also show Node.js integrations in meta-frameworks like Next.js or SvelteKit.
