### PR TITLE
feat(js): Add all relevant deprecations and expand breaking changes for next.js

### DIFF
--- a/docs/platforms/javascript/common/migration/index.mdx
+++ b/docs/platforms/javascript/common/migration/index.mdx
@@ -2,6 +2,8 @@
 title: Migration Guide
 description: "Migrate from an older version of our Sentry JavaScript SDK."
 sidebar_order: 8000
+notSupported:
+  - javascript.electron
 ---
 
 Here's a list of guides on migrating to a newer version of the Sentry JavaScript SDK.

--- a/docs/platforms/javascript/common/migration/index.mdx
+++ b/docs/platforms/javascript/common/migration/index.mdx
@@ -3,6 +3,8 @@ title: Migration Guide
 description: "Migrate from an older version of our Sentry JavaScript SDK."
 sidebar_order: 8000
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
+++ b/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
@@ -2,6 +2,8 @@
 title: Migrate from 4.x to 5.x/6.x
 sidebar_order: 8930
 description: "Learn about migrating from Sentry JavaScript SDK 4.x to 5.x/6.x"
+notSupported:
+  - javascript.electron
 ---
 
 We recommend upgrading from `4.x` to `6.x` directly. Migrating from `5.x` to `6.x` has no breaking changes to the SDK's

--- a/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
+++ b/docs/platforms/javascript/common/migration/v4-to-v5_v6.mdx
@@ -3,6 +3,8 @@ title: Migrate from 4.x to 5.x/6.x
 sidebar_order: 8930
 description: "Learn about migrating from Sentry JavaScript SDK 4.x to 5.x/6.x"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/docs/platforms/javascript/common/migration/v6-to-v7.mdx
+++ b/docs/platforms/javascript/common/migration/v6-to-v7.mdx
@@ -2,6 +2,8 @@
 title: Migrate from 6.x to 7.x
 sidebar_order: 8920
 description: "Learn about migrating from Sentry JavaScript SDK 6.x to 7.x"
+notSupported:
+  - javascript.electron
 ---
 
 The v7 version of the JavaScript SDK requires a self-hosted version of Sentry `20.6.0` or higher.

--- a/docs/platforms/javascript/common/migration/v6-to-v7.mdx
+++ b/docs/platforms/javascript/common/migration/v6-to-v7.mdx
@@ -3,6 +3,8 @@ title: Migrate from 6.x to 7.x
 sidebar_order: 8920
 description: "Learn about migrating from Sentry JavaScript SDK 6.x to 7.x"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -10,13 +10,13 @@ dependencies on OpenTelemetry.
 
 ## Migration Codemod
 
-Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix all deprecations on `7.x`, you can use the `@sentry/migr8` codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
+Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix most of the deprecations on `7.x`, you can use the [`@sentry/migr8`](https://www.npmjs.com/package/@sentry/migr8) codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
 
 ```bash
 npx @sentry/migr8@latest
 ```
 
-Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`!
+Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`! For more details on the deprecations, see our docs on [Deprecations in 7.x](./v7-deprecations).
 
 ## Migration Guide
 
@@ -30,7 +30,7 @@ Please see our [detailed migration guide](https://github.com/getsentry/sentry-ja
 
 <PlatformContent includePath="migration/javascript-v8/intro" />
 
-We recommend you read through all the [Important Changes](#important-changes) as they affect all Next.js SDK users. The [Other Changes](#other-changes) linked below only affect users who have very custom instrumentation. There is also a [Troubleshooting](#troubleshooting) section for common issues.
+We recommend you read through all the [Important Changes](#important-changes) as they affect all Next.js SDK users. The [Other Changes](#other-changes) linked below only affect users who have more customized instrumentation. There is also a [Troubleshooting](#troubleshooting) section for common issues.
 
 ## Important Changes
 
@@ -42,9 +42,11 @@ We recommend you read through all the [Important Changes](#important-changes) as
 
 <PlatformContent includePath="migration/javascript-v8/integrations-package-removal" />
 
-### Removal of `@sentry/hub`
+### Deprecation of `Hub` and `getCurrentHub()`
 
-`@sentry/hub` has been removed and will no longer be published. All of the @sentry/hub exports have moved to `@sentry/core` or other related SDKs.
+The `Hub` has been a very important part of the Sentry SDK API up until now. Hubs were the SDK's "unit of concurrency" to keep track of data across threads and to scope data to certain parts of your code. Because it is overly complicated and confusing to power users, it is going to be replaced by a set of new APIs: the "new Scope API". For now `Hub` and `getCurrentHub` are still available, but it will be removed in the next major version.
+
+As such, `@sentry/hub` has been removed and will no longer be published. All of the @sentry/hub exports have moved to `@sentry/core` or other related SDKs.
 
 <PlatformContent includePath="migration/javascript-v8/tracing-package-removal" />
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -3,6 +3,8 @@ title: Migrate from 7.x to 8.x
 sidebar_order: 8910
 description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -2,6 +2,8 @@
 title: Migrate from 7.x to 8.x
 sidebar_order: 8910
 description: "Learn about migrating from Sentry JavaScript SDK 7.x to 8.x"
+notSupported:
+  - javascript.electron
 ---
 
 The main goal of version 8 is to improve our performance monitoring APIs, integrations API, and ESM support. This

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
@@ -2,6 +2,8 @@
 title: Deprecations in 7.x
 sidebar_order: 8940
 description: "Learn about deprecations in Sentry JavaScript SDK 7.x and how to address them"
+notSupported:
+  - javascript.electron
 ---
 
 To fix most of the deprecations on `7.x`, you can use the [`@sentry/migr8`](https://www.npmjs.com/package/@sentry/migr8) codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
@@ -3,6 +3,8 @@ title: Deprecations in 7.x
 sidebar_order: 8940
 description: "Learn about deprecations in Sentry JavaScript SDK 7.x and how to address them"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 
@@ -14,6 +16,8 @@ npx @sentry/migr8@latest
 
 Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`!
 
-See our [detailed migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x) on GitHub for more details.
+## List of Deprecations
+
+The following is a list of the most important deprecations that happened in `7.x`. Please see the [detailed migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x) on GitHub for a comprehensive list of all deprecations.
 
 <PlatformContent includePath="migration/javascript-v8/v7-deprecation" />

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v7-deprecations.mdx
@@ -1,0 +1,17 @@
+---
+title: Deprecations in 7.x
+sidebar_order: 8940
+description: "Learn about deprecations in Sentry JavaScript SDK 7.x and how to address them"
+---
+
+To fix most of the deprecations on `7.x`, you can use the [`@sentry/migr8`](https://www.npmjs.com/package/@sentry/migr8) codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.
+
+```bash
+npx @sentry/migr8@latest
+```
+
+Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`!
+
+See our [detailed migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x) on GitHub for more details.
+
+<PlatformContent includePath="migration/javascript-v8/v7-deprecation" />

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
@@ -2,6 +2,8 @@
 title: New Performance Monitoring APIs
 sidebar_order: 8920
 description: "Learn about new Performance Monitoring APIs in Sentry JavaScript SDK 8.x"
+notSupported:
+  - javascript.electron
 ---
 
 The SDK `8.x` release introduces new APIs for performance monitoring. These APIs are designed to provide more control over how performance data is collected and reported to Sentry.

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: New Performance Monitoring APIs
-sidebar_order: 8997
+sidebar_order: 8920
 description: "Learn about new Performance Monitoring APIs in Sentry JavaScript SDK 8.x"
 ---
 
@@ -201,7 +201,7 @@ In addition, a transaction has this API:
 
 ### Attributes vs. Data vs. Tags vs. Context
 
-Previously, the model had the concepts of **Data**, **Tags**, and **Context**, which could be used for different things. However, this had two main downsides: Firstly, it was not always clear which concept should be used in a given situation. Secondly, these concepts were not displayed the same way for transactions or spans.  
+Previously, the model had the concepts of **Data**, **Tags**, and **Context**, which could be used for different things. However, this had two main downsides: Firstly, it was not always clear which concept should be used in a given situation. Secondly, these concepts were not displayed the same way for transactions or spans.
 
 To address these issues, the new model only has **Attributes** that can be set on spans. Broadly speaking, they map to what was formerly known as Data.
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-new-performance-api.mdx
@@ -3,6 +3,8 @@ title: New Performance Monitoring APIs
 sidebar_order: 8920
 description: "Learn about new Performance Monitoring APIs in Sentry JavaScript SDK 8.x"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
@@ -2,6 +2,8 @@
 title: OpenTelemetry Support
 sidebar_order: 8930
 description: "Learn OpenTelemetry support in SDK 8.x"
+notSupported:
+  - javascript.electron
 ---
 
 In `8.x`, the Performance Monitoring APIs for the SDK been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood.

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry Support
-sidebar_order: 8998
+sidebar_order: 8930
 description: "Learn OpenTelemetry support in SDK 8.x"
 ---
 

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
@@ -3,6 +3,8 @@ title: OpenTelemetry Support
 sidebar_order: 8930
 description: "Learn OpenTelemetry support in SDK 8.x"
 notSupported:
+  - javascript.capacitor
+  - javascript.cordova
   - javascript.electron
 ---
 

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -14,6 +14,52 @@ The `@sentry/replay` package is no longer required. Instead you can import the r
  });
 ```
 
+### Change of Replay default options (`unblock` and `unmask`)
+
+The Replay options `unblock` and `unmask` now have `[]` as default value. This means that if you want to use these
+options, you have to explicitly set them like this:
+
+```JavaScript
+Sentry.init({
+  integrations: [
+    Sentry.replayIntegration({
+      unblock: [".sentry-unblock, [data-sentry-unblock]"],
+      unmask: [".sentry-unmask, [data-sentry-unmask]"],
+    }),
+  ],
+});
+```
+
 ### Removal of makeXHRTransport transport
 
 The xhr transport via `makeXHRTransport` transport has been removed. Only `makeFetchTransport` is available now. This means that the Sentry SDK requires the `fetch` API to be available in the environment.
+
+### Removal of the `Offline` integration
+
+The `Offline` integration has been removed in favor of the <PlatformLink to="/configuration/transports/#offline-caching/">offline transport wrapper</PlatformLink>
+
+### Removal of `wrap` export
+
+The `Sentry.wrap` export has been removed. There is no replacement API.
+
+### Updated behaviour of `tracePropagationTargets` in the browser
+
+We updated the behaviour of the SDKs when no `tracePropagationTargets` option was defined. As a reminder, you can
+provide a list of strings or RegExes that will be matched against URLs to tell the SDK, to which outgoing requests
+tracing HTTP headers should be attached to. These tracing headers are used for distributed tracing.
+
+Previously, on the browser, when `tracePropagationTargets` were not defined, they defaulted to the following:
+`['localhost', /^\/(?!\/)/]`. This meant that all request targets to that had "localhost" in the URL, or started with a
+`/` were equipped with tracing headers. This default was chosen to prevent CORS errors in your browser applications.
+However, this default had a few flaws.
+
+Going forward, when the `tracePropagationTargets` option is not set, tracing headers will be attached to all outgoing
+requests on the same origin. For example, if you're on `https://example.com/` and you send a request to
+`https://example.com/api`, the request will be traced (ie. will have trace headers attached). Requests to
+`https://api.example.com/` will not, because it is on a different origin. The same goes for all applications running on
+`localhost`.
+
+When you provide a `tracePropagationTargets` option, all of the entries you defined will now be matched be matched
+against the full URL of the outgoing request. Previously, it was only matched against what you called request APIs with.
+For example, if you made a request like `fetch("/api/posts")`, the provided `tracePropagationTargets` were only compared
+against `"/api/posts"`.

--- a/includes/migration/javascript-v8/general-other-changes.mdx
+++ b/includes/migration/javascript-v8/general-other-changes.mdx
@@ -1,0 +1,153 @@
+### Deprecation of `Hub` and `getCurrentHub()`
+
+The `Hub` has been a very important part of the Sentry SDK API up until now. Hubs were the SDK's "unit of concurrency"
+to keep track of data across threads and to scope data to certain parts of your code. Because it is overly complicated
+and confusing to power users, it is going to be replaced by a set of new APIs: the "new Scope API". For now `Hub` and
+`getCurrentHub` are still available, but it will be removed in the next major version.
+
+See [Deprecate Hub](./v7-deprecations#deprecate-hub) for details on how to replace existing usage of the Hub APIs.
+
+### Removal of class-based integrations
+
+In v7, integrations are classes and can be added as e.g. `integrations: [new Sentry.Replay()]`. In v8, integrations will
+not be classes anymore, but instead functions. Both the use as a class, as well as accessing integrations from the
+`Integrations.XXX` hash, is deprecated in favor of using the new functional integrations. For example,
+`new Integrations.LinkedErrors()` becomes `linkedErrorsIntegration()`.
+
+For a list of integrations and their replacements, see [the `7.x` deprecation documentation](./v7-deprecations#deprecate-class-based-integrations).
+
+### Removal of `Sentry.configureScope` method
+
+The top level `Sentry.configureScope` function has been removed. Instead, you should use the `Sentry.getCurrentScope()`
+to access and mutate the current scope.
+
+```JavaScript diff
+- Sentry.configureScope((scope) => {
+-  scope.setTag("key", "value");
+- });
++ Sentry.getCurrentScope().setTag("key", "value");
+```
+
+### `tracingOrigins` has been replaced by `tracePropagationTargets`
+
+`tracingOrigins` is now removed in favor of the `tracePropagationTargets` option. The `tracePropagationTargets` option
+should be set in the `Sentry.init()` options, or in your custom `Client`s option if you create them.
+
+```TypeScript
+Sentry.init({
+  dsn: "__DSN__",
+  integrations: [Sentry.browserTracingIntegration()],
+  tracePropagationTargets: ["localhost", "example.com"],
+});
+```
+
+### Simplification of Metrics Configuration
+
+In `7.x`, you had to enable the metrics aggregator by setting the `_experiments` option to `{ metricsAggregator: true }`. In addition for browser environments you had to add the `metricsAggregatorIntegration` to the `integrations` array.
+
+```TypeScript
+// v7 - Server (Node/Deno/Bun)
+Sentry.init({
+  dsn: "__PUBLIC_DSN__",
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+
+// v7 - Browser
+Sentry.init({
+  dsn: "__PUBLIC_DSN__",
+  integrations: [Sentry.metricsAggregatorIntegration()],
+});
+
+Sentry.metrics.increment("my_metric");
+```
+
+In `8.x` no additional configuration is needed to use metrics APIs.
+
+```ts
+// v8
+Sentry.init({
+  dsn: "__PUBLIC_DSN__",
+});
+
+Sentry.metrics.increment("my_metric");
+```
+
+### Removal of Severity Enum
+
+In `7.x` we deprecated the `Severity` enum in favor of using the `SeverityLevel` type as this helps save bundle size, and
+this has been removed in `8.x`. You should now use the `SeverityLevel` type directly.
+
+```JavaScript diff
+- import { Severity } from '@sentry/types';
++ import { SeverityLevel } from '@sentry/types';
+
+- const level = Severity.error;
++ const level: SeverityLevel = "error";
+```
+
+#### Removal of `spanStatusfromHttpCode` in favour of `getSpanStatusFromHttpCode`
+
+In `8.x`, we are removing the `spanStatusfromHttpCode` function in favor of `getSpanStatusFromHttpCode`.
+
+```JavaScript diff
+- const spanStatus = spanStatusfromHttpCode(200);
++ const spanStatus = getSpanStatusFromHttpCode(200);
+```
+
+### `framesToPop` applies to parsed frames
+
+Errors with `framesToPop` property will have the specified number of frames removed from the top of the stack. This
+changes compared to the v7 where the property `framesToPop` was used to remove top n lines from the stack string.
+
+### Removal of `Span` class export from SDK packages
+
+In `8.x`, we are no longer exporting the `Span` class from SDK packages. Internally, this class is now called `SentrySpan`, and it is no longer meant to be used by users directly.
+
+### Removal of `lastEventId()` method
+
+The `lastEventId` function has been removed. See [below](./MIGRATION.md#deprecate-lasteventid) for more details.
+
+### Removal of `void` from transport return types
+
+The `send` method on the `Transport` interface now always requires a `TransportMakeRequestResponse` to be returned in
+the promise. This means that the `void` return type is no longer allowed.
+
+```TypeScript diff
+// v7
+ interface Transport {
+-  send(event: Event): Promise<void | TransportMakeRequestResponse>;
++  send(event: Event): Promise<TransportMakeRequestResponse>;
+ }
+```
+
+### `extraErrorDataIntegration` changes
+
+The `extraErrorDataIntegration` integration now looks at
+[`error.cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) by
+default.
+
+### `transactionContext` no longer passed to `tracesSampler`
+
+Instead of an `transactionContext` being passed to the `tracesSampler` callback, the callback will directly receive
+`name` and `attributes` going forward. Note that the `attributes` are only the attributes at span creation time, and
+some attributes may only be set later during the span lifecycle (and thus not be available during sampling).
+
+### `getClient()` always returns a client
+
+`getClient()` now always returns a client if `Sentry.init()` was called. For cases where this may be used to check if
+Sentry was actually initialized, using `getClient()` will thus not work anymore. Instead, you should use the new
+`Sentry.isInitialized()` utility to check this.
+
+### Removal of `addGlobalEventProcessor` in favour of `addEventProcessor`
+
+In `8.x`, we are removing the `addGlobalEventProcessor` function in favor of `addEventProcessor`.
+
+```JavaScript diff
+- Sentry.addGlobalEventProcessor((event) => {
++ Sentry.getGlobalScope().addEventProcessor((event) => {
+   delete event.extra;
+   return event;
+ });
+```

--- a/includes/migration/javascript-v8/node-other-changes.mdx
+++ b/includes/migration/javascript-v8/node-other-changes.mdx
@@ -10,3 +10,17 @@ Sentry.init({
   ],
 });
 ```
+
+### Removal of `Sentry.Handlers.trpcMiddleware()` in favor of `Sentry.trpcMiddleware()`
+
+The Sentry tRPC middleware got moved from `Sentry.Handlers.trpcMiddleware()` to `Sentry.trpcMiddleware()`.
+
+### Behaviour in combination with `onUncaughtException` handlers in Node.js
+
+Previously the SDK exited the process by default, even though additional `onUncaughtException` may have been registered,
+that would have prevented the process from exiting. You could opt out of this behaviour by setting the
+`exitEvenIfOtherHandlersAreRegistered: false` in the `onUncaughtExceptionIntegration` options. Up until now the value
+for this option defaulted to `true`.
+
+Going forward, the default value for `exitEvenIfOtherHandlersAreRegistered` will be `false`, meaning that the SDK will
+not exit your process when you have registered other `onUncaughtException` handlers.

--- a/includes/migration/javascript-v8/server-other-changes.mdx
+++ b/includes/migration/javascript-v8/server-other-changes.mdx
@@ -1,3 +1,9 @@
 ### Removal of `deepReadDirSync` method
 
 The `deepReadDirSync` method has been removed as an export from the SDK. There is no replacement API.
+
+#### Removal of Client-Side health check transaction filters
+
+The SDK no longer filters out health check transactions by default. Instead, they are sent to Sentry but still dropped
+by the Sentry backend by default. You can disable dropping them in your Sentry project settings. If you still want to
+drop specific transactions within the SDK you can either use the `ignoreTransactions` SDK option.

--- a/includes/migration/javascript-v8/v7-deprecation/browser-tracing.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/browser-tracing.mdx
@@ -1,4 +1,6 @@
-## Deprecated `BrowserTracing` integration (since 7.100.0)
+### Deprecated `BrowserTracing` integration
+
+_Deprecation introduced in `7.100.0`._
 
 The `BrowserTracing` integration, together with the custom routing instrumentations passed to it, are deprecated in v8.
 

--- a/includes/migration/javascript-v8/v7-deprecation/browser-tracing.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/browser-tracing.mdx
@@ -1,0 +1,5 @@
+## Deprecated `BrowserTracing` integration (since 7.100.0)
+
+The `BrowserTracing` integration, together with the custom routing instrumentations passed to it, are deprecated in v8.
+
+Instead, you should use `Sentry.browserTracingIntegration()`.

--- a/includes/migration/javascript-v8/v7-deprecation/class-based-integrations.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/class-based-integrations.mdx
@@ -1,0 +1,11 @@
+### Deprecate class-based integrations
+
+_Deprecation introduced in `7.100.0`._
+
+In v7, integrations are classes and can be added as e.g. `integrations: [new Sentry.Integrations.ContextLines()]`. In
+v8, integrations will not be classes anymore, but instead functions. Both the use as a class, as well as accessing
+integrations from the `Integrations.XXX` hash, is deprecated in favor of using the new functional integrations
+
+- for example, `new Integrations.LinkedErrors()` becomes `linkedErrorsIntegration()`.
+
+The following list shows how integrations should be migrated:

--- a/includes/migration/javascript-v8/v7-deprecation/general.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/general.mdx
@@ -1,0 +1,196 @@
+### Deprecate `getIntegration()` and `getIntegrationById()`
+
+_Deprecation introduced in `7.94.0`._
+
+This deprecates `getIntegrationById()` and `getIntegration()` on the client. Instead, use `getIntegrationByName()`. You can optionally pass an integration generic to make it easier to work with.
+
+```TypeScript
+const replay = getClient().getIntegrationByName<Replay>("Replay");
+```
+
+### Deprecate `Hub`
+
+_Deprecation introduced in `7.110.0`._
+
+The `Hub` has been a very important part of the Sentry SDK API up until now. Hubs were the SDK's "unit of concurrency"
+to keep track of data across threads and to scope data to certain parts of your code. Because it is overly complicated
+and confusing to power users, it is going to be replaced by a set of new APIs: the "new Scope API".
+
+`Scope`s have existed before in the SDK but we are now expanding on them because we have found them powerful enough to
+fully cover the `Hub` API.
+
+If you are using the `Hub` right now, see the following table on how to migrate to the new API:
+
+| Old `Hub` API          | New `Scope` API                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `new Hub()`            | `withScope()`, `withIsolationScope()` or `new Scope()`                               |
+| hub.isOlderThan()      | REMOVED - Was used to compare `Hub` instances, which are gonna be removed            |
+| hub.bindClient()       | A combination of `scope.setClient()` and `client.init()`                             |
+| hub.pushScope()        | `Sentry.withScope()`                                                                 |
+| hub.popScope()         | `Sentry.withScope()`                                                                 |
+| hub.withScope()        | `Sentry.withScope()`                                                                 |
+| getClient()            | `Sentry.getClient()`                                                                 |
+| getScope()             | `Sentry.getCurrentScope()` to get the currently active scope                         |
+| getIsolationScope()    | `Sentry.getIsolationScope()`                                                         |
+| getStack()             | REMOVED - The stack used to hold scopes. Scopes are used directly now                |
+| getStackTop()          | REMOVED - The stack used to hold scopes. Scopes are used directly now                |
+| captureException()     | `Sentry.captureException()`                                                          |
+| captureMessage()       | `Sentry.captureMessage()`                                                            |
+| captureEvent()         | `Sentry.captureEvent()`                                                              |
+| lastEventId()          | REMOVED - Use event processors or beforeSend instead                                 |
+| addBreadcrumb()        | `Sentry.addBreadcrumb()`                                                             |
+| setUser()              | `Sentry.setUser()`                                                                   |
+| setTags()              | `Sentry.setTags()`                                                                   |
+| setExtras()            | `Sentry.setExtras()`                                                                 |
+| setTag()               | `Sentry.setTag()`                                                                    |
+| setExtra()             | `Sentry.setExtra()`                                                                  |
+| setContext()           | `Sentry.setContext()`                                                                |
+| configureScope()       | REMOVED - Scopes are now the unit of concurrency                                     |
+| run()                  | `Sentry.withScope()` or `Sentry.withIsolationScope()`                                |
+| getIntegration()       | `client.getIntegration()`                                                            |
+| startTransaction()     | `Sentry.startSpan()`, `Sentry.startInactiveSpan()` or `Sentry.startSpanManual()`     |
+| traceHeaders()         | REMOVED - The closest equivalent is now `spanToTraceHeader(getActiveSpan())`         |
+| captureSession()       | `Sentry.captureSession()`                                                            |
+| startSession()         | `Sentry.startSession()`                                                              |
+| endSession()           | `Sentry.endSession()`                                                                |
+| shouldSendDefaultPii() | REMOVED - The closest equivalent is `Sentry.getClient().getOptions().sendDefaultPii` |
+
+The `Hub` constructor is also deprecated and will be removed in the next major version. If you are creating Hubs for
+multi-client use like so:
+
+```TypeScript
+// OLD
+const hub = new Hub();
+hub.bindClient(client);
+makeMain(hub);
+```
+
+instead initialize the client as follows:
+
+```TypeScript
+// NEW
+Sentry.withIsolationScope(() => {
+  Sentry.setCurrentClient(client);
+  client.init();
+});
+```
+
+If you are using the Hub to capture events like so:
+
+```TypeScript
+// OLD
+const client = new Client();
+const hub = new Hub(client);
+hub.captureException();
+```
+
+instead capture isolated events as follows:
+
+```TypeScript
+// NEW
+const client = new Client();
+const scope = new Scope();
+scope.setClient(client);
+scope.captureException();
+```
+
+### Deprecate `Sentry.lastEventId()` and `hub.lastEventId()`
+
+_Deprecation introduced in `7.93.0`._
+
+Instead, if you need the ID of a recently captured event, we recommend using `beforeSend` instead:
+
+```JavaScript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '__DSN__',
+  beforeSend(event, hint) {
+    const lastCapturedEventId = event.event_id;
+
+    // Do something with `lastCapturedEventId` here
+
+    return event;
+  },
+});
+```
+
+### Deprecate `addGlobalEventProcessor` in favor of `addEventProcessor`
+
+_Deprecation introduced in `7.85.0`._
+
+Instead of using `addGlobalEventProcessor`, you should use `addEventProcessor` which does not add the event processor
+globally, but to the current client.
+
+For the vast majority of cases, the behavior of these should be the same. Only in the case where you have multiple
+clients will this differ - but you'll likely want to add event processors per-client then anyhow, not globally.
+
+In v8, we will remove the global event processors overall, as that allows us to avoid keeping global state that is not
+necessary.
+
+### Deprecate `configureScope` in favor of using `getCurrentScope()`
+
+_Deprecation introduced in `7.89.0`._
+
+Instead of updating the scope in a callback via `configureScope()`, you should access it via `getCurrentScope()` and
+configure it directly:
+
+```js
+Sentry.getCurrentScope().setTag("xx", "yy");
+```
+
+### Deprecate `pushScope` & `popScope` in favor of `withScope`
+
+_Deprecation introduced in `7.89.0`._
+
+Instead of manually pushing/popping a scope, you should use `Sentry.withScope(callback: (scope: Scope))` instead.
+
+### Deprecate arguments for `startSpan()` APIs
+
+_Deprecation introduced in `7.93.0`._
+
+In v8, the API to start a new span will be reduced from the currently available options. Going forward, only these
+arguments will be passable to `startSpan()`, `startSpanManual()` and `startInactiveSpan()`:
+
+- `name`
+- `attributes`
+- `origin`
+- `op`
+- `startTime`
+- `scope`
+
+### Deprecate `startTransaction()` & `span.startChild()`
+
+_Deprecation introduced in `7.93.0`._
+
+In v8, the old performance API `startTransaction()` (and `hub.startTransaction()`), as well as `span.startChild()`, will
+be removed. Instead, use the new performance APIs:
+
+- `startSpan()`
+- `startSpanManual()`
+- `startInactiveSpan()`
+
+### Deprecated `transactionContext` passed to `tracesSampler`
+
+_Deprecation introduced in `7.100.0`._
+
+Instead of an `transactionContext` being passed to the `tracesSampler` callback, the callback will directly receive `name` and `attributes` going forward. You can use these to make your sampling decisions, while `transactionContext` will be removed in `8.x`. Note that the `attributes` are only the attributes at span creation time, and some attributes may only be set later during the span lifecycle (and thus not be available during sampling).
+
+### Deprecate `scope.getSpan()` and `scope.setSpan()`
+
+_Deprecation introduced in `7.93.0`._
+
+Instead, you can get the currently active span via `Sentry.getActiveSpan()`. Setting a span on the scope happens
+automatically when you use the new performance APIs `startSpan()` and `startSpanManual()`.
+
+### Deprecate `scope.setTransactionName()`
+
+_Deprecation introduced in `7.93.0`._
+
+Instead, either set this as attributes or tags, or use an event processor to set `event.transaction`.
+
+### Deprecate `scope.getTransaction()` and `getActiveTransaction()`
+
+_Deprecation introduced in `7.93.0`._
+
+Instead, you should not rely on the active transaction, but just use `startSpan()` APIs, which handle this for you.

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
@@ -115,8 +115,26 @@ If you were previously using the `@sentry/opentelemetry-node`, it is no longer r
 
 To customize your OpenTelemetry setup, see the docs on [OpenTelemetry instrumentation in `8.0`](./v8-opentelemetry/#custom-opentelemetry-setup).
 
+### Performance Monitoring Integrations
+
+As we added support for OpenTelemetry, we have expanded the automatic instrumentation for our Next.js SDK.
+
+We now support the following integrations out of the box without extra configuration for server-side Next.js:
+
+- `httpIntegration`: Automatically instruments Node `http` and `https` standard libraries
+- `nativeNodeFetchIntegration`: Automatically instruments top level fetch and undici
+- `graphqlIntegration`: Automatically instruments GraphQL
+- `mongoIntegration`: Automatically instruments MongoDB
+- `mongooseIntegration`: Automatically instruments Mongoose
+- `mysqlIntegration`: Automatically instruments MySQL
+- `mysql2Integration`: Automatically instruments MySQL2
+- `postgresIntegration`: Automatically instruments PostgreSQL
+- `prismaIntegration`: Automatically instruments Prisma
+
 <Include name="migration/javascript-v8/node-other-changes" />
 
 <Include name="migration/javascript-v8/server-other-changes" />
 
 <Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
@@ -1,3 +1,30 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript diff
@@ -13,3 +40,5 @@
 +  integrations: [Sentry.browserTracingIntegration({ router })],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
@@ -1,0 +1,15 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript diff
+ import * as Sentry from "@sentry/angular";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.routingInstrumentation(router),
+-    })
+-  ],
++  integrations: [Sentry.browserTracingIntegration({ router })],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
@@ -1,3 +1,60 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
+Server-side Integrations:
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new LocalVariables()`       | `localVariablesIntegration()`       |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new ProfilingIntegration()` | `nodeProfilingIntegration()`        |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
@@ -11,3 +68,5 @@ Browser tracing is automatically set up for you in these packages so you do not 
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
@@ -1,0 +1,13 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
+
+```JavaScript {sentry.client.config.js} diff
+ import * as Sentry from "@sentry/astro";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.bun.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.bun.mdx
@@ -1,0 +1,27 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.deno.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.deno.mdx
@@ -1,0 +1,30 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new DenoContext()`          | `denoContextIntegration()`          |
+| `new DenoCron()`             | `denoCronIntegration()`             |
+| `new NormalizePaths()`       | `normalizePathsIntegration()`       |
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.gatsby.mdx
@@ -1,0 +1,11 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript diff
+ import * as Sentry from "@sentry/gatsby";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.gatsby.mdx
@@ -1,3 +1,32 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript diff
@@ -9,3 +38,5 @@
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
@@ -1,0 +1,36 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript {tabTitle: npm} diff
+ import * as Sentry from "@sentry/browser";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```
+
+```JavaScript {tabTitle: Loader} diff
+ // Configure sentryOnLoad before adding the Loader Script
+ window.sentryOnLoad = function () {
+   Sentry.init({
+     // you only need to add this if you are customizing the SDK setup
+-    integrations: [new Sentry.BrowserTracing()],
++    integrations: [Sentry.browserTracingIntegration()],
+   });
+ };
+```
+
+```JavaScript {tabTitle: CDN}
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
++  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```
+
+<Note>
+
+You only need to add the `integrations` configuration for the loader if you were previously explicitly using the `BrowserTracing` integration.
+
+</Note>

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
@@ -1,3 +1,32 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript {tabTitle: npm} diff
@@ -34,3 +63,5 @@
 You only need to add the `integrations` configuration for the loader if you were previously explicitly using the `BrowserTracing` integration.
 
 </Note>
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
@@ -21,7 +21,7 @@
  };
 ```
 
-```JavaScript {tabTitle: CDN}
+```JavaScript {tabTitle: CDN} diff
  Sentry.init({
    dsn: "___PUBLIC_DSN___",
 +  integrations: [new Sentry.BrowserTracing()],

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
@@ -1,3 +1,60 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
+Server-side Integrations:
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new LocalVariables()`       | `localVariablesIntegration()`       |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new ProfilingIntegration()` | `nodeProfilingIntegration()`        |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
@@ -11,3 +68,5 @@ Browser tracing is automatically set up for you in these packages so you do not 
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
@@ -1,0 +1,13 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
+
+```JavaScript {sentry.client.config.js} diff
+ import * as Sentry from "@sentry/nextjs";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.node.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.node.mdx
@@ -1,0 +1,29 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new LocalVariables()`       | `localVariablesIntegration()`       |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new ProfilingIntegration()` | `nodeProfilingIntegration()`        |
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
@@ -1,0 +1,86 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+For react, we provide multiple integrations to cover different router integrations:
+
+### React Router v6
+
+```JavaScript diff
+ import * as Sentry from '@sentry/react';
+
+ Sentry.init({
+   integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.reactRouterV6Instrumentation({
+-        useEffect,
+-        useLocation,
+-        useNavigationType,
+-        createRoutesFromChildren,
+-        matchRoutes,
+-        stripBasename,
+-      }),
+-    }),
++    Sentry.reactRouterV6BrowserTracingIntegration({
++      useEffect,
++      useLocation,
++      useNavigationType,
++      createRoutesFromChildren,
++      matchRoutes,
++      stripBasename,
++    }),
+   ],
+ });
+```
+
+### React Router v4/v5
+
+```JavaScript diff
+ import * as Sentry from '@sentry/react';
+
+ Sentry.init({
+   integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.reactRouterV5Instrumentation({
+-        history,
+-      }),
+-    }),
++    Sentry.reactRouterV5BrowserTracingIntegration({
++      history,
++    }),
+   ],
+ });
+```
+
+### React Router v3
+
+```JavaScript diff
+ import * as Sentry from '@sentry/react';
+
+ Sentry.init({
+   integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.reactRouterV3Instrumentation({
+-        history,
+-        routes,
+-        match,
+-      }),
+-    }),
++    Sentry.reactRouterV3BrowserTracingIntegration({
++      history,
++      routes,
++      match,
++    }),
+   ],
+ });
+```
+
+### No React Router
+
+```JavaScript diff
+ import * as Sentry from "@sentry/svelte";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
@@ -1,3 +1,30 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 For react, we provide multiple integrations to cover different router integrations:
@@ -84,3 +111,5 @@ For react, we provide multiple integrations to cover different router integratio
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.remix.mdx
@@ -1,3 +1,60 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
+Server-side Integrations:
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new LocalVariables()`       | `localVariablesIntegration()`       |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new ProfilingIntegration()` | `nodeProfilingIntegration()`        |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript diff
@@ -13,3 +70,5 @@
 +  integrations: [Sentry.browserTracingIntegration({ useEffect, useLocation, useMatches })],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.remix.mdx
@@ -1,0 +1,15 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript diff
+ import * as Sentry from "@sentry/remix";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.remixRouterInstrumentation(useEffect, useLocation, useMatches),
+-    })
+-  ],
++  integrations: [Sentry.browserTracingIntegration({ useEffect, useLocation, useMatches })],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.svelte.mdx
@@ -1,0 +1,11 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript diff
+ import * as Sentry from "@sentry/svelte";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.svelte.mdx
@@ -1,3 +1,30 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript diff
@@ -9,3 +36,5 @@
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
@@ -1,3 +1,60 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+Client-side Integrations:
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
+Server-side Integrations:
+
+| Old                          | New                                 |
+| ---------------------------- | ----------------------------------- |
+| `new InboundFilters()`       | `inboundFiltersIntegration()`       |
+| `new FunctionToString()`     | `functionToStringIntegration()`     |
+| `new LinkedErrors()`         | `linkedErrorsIntegration()`         |
+| `new RequestData()`          | `requestDataIntegration()`          |
+| `new CaptureConsole()`       | `captureConsoleIntegration()`       |
+| `new Debug()`                | `debugIntegration()`                |
+| `new Dedupe()`               | `dedupeIntegration()`               |
+| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       |
+| `new RewriteFrames()`        | `rewriteFramesIntegration()`        |
+| `new SessionTiming()`        | `sessionTimingIntegration()`        |
+| `new Console()`              | `consoleIntegration()`              |
+| `new Context()`              | `nodeContextIntegration()`          |
+| `new Modules()`              | `modulesIntegration()`              |
+| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  |
+| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` |
+| `new ContextLines()`         | `contextLinesIntegration()`         |
+| `new LocalVariables()`       | `localVariablesIntegration()`       |
+| `new Spotlight()`            | `spotlightIntegration()`            |
+| `new Anr()`                  | `anrIntegration()`                  |
+| `new Hapi()`                 | `hapiIntegration()`                 |
+| `new Undici()`               | `nativeNodeFetchIntegration()`      |
+| `new Http()`                 | `httpIntegration()`                 |
+| `new ProfilingIntegration()` | `nodeProfilingIntegration()`        |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
@@ -11,3 +68,5 @@ Browser tracing is automatically set up for you in these packages so you do not 
 +  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
@@ -1,0 +1,13 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
+
+```JavaScript {hooks.client.js} diff
+ import * as Sentry from "@sentry/sveltekit";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [new Sentry.BrowserTracing()],
++  integrations: [Sentry.browserTracingIntegration()],
+ });
+```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
@@ -1,3 +1,30 @@
+<Include name="migration/javascript-v8/v7-deprecation/class-based-integrations" />
+
+| Old                                 | New                              |
+| ----------------------------------- | -------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`    |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`    |
+| `new FunctionToString()`            | `functionToStringIntegration()`  |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`      |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`    |
+| `new Replay()`                      | `replayIntegration()`            |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`      |
+| `new Feedback()`                    | `feedbackIntegration()`          |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`    |
+| `new Debug()`                       | `debugIntegration()`             |
+| `new Dedupe()`                      | `dedupeIntegration()`            |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`    |
+| `new ReportingObserver()`           | `reportingObserverIntegration()` |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`     |
+| `new SessionTiming()`               | `sessionTimingIntegration()`     |
+| `new HttpClient()`                  | `httpClientIntegration()`        |
+| `new ContextLines()`                | `contextLinesIntegration()`      |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`    |
+| `new HttpContext()`                 | `httpContextIntegration()`       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`  |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`  |
+
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
 ```JavaScript diff
@@ -13,3 +40,5 @@
 +  integrations: [Sentry.browserTracingIntegration({ router })],
  });
 ```
+
+<Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
@@ -1,0 +1,15 @@
+<Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
+
+```JavaScript diff
+ import * as Sentry from "@sentry/vue";
+
+ Sentry.init({
+   dsn: "___PUBLIC_DSN___",
+-  integrations: [
+-    new Sentry.BrowserTracing({
+-      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+-    })
+-  ],
++  integrations: [Sentry.browserTracingIntegration({ router })],
+ });
+```


### PR DESCRIPTION
This builds upon https://github.com/getsentry/sentry-docs/pull/9796, porting the `7.x` deprecations to the docs, and adding the rest of the behaviour changes to the docs as well.

Next up - Node frameworks!