### PR TITLE
feat(js): Add browser sdk migration docs for v8

### DIFF
--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -28,13 +28,13 @@ Please see our [detailed migration guide](https://github.com/getsentry/sentry-ja
 
 {/* Make sure to update the PlatformSection below when new fully fleshed out migration guides are added */}
 
-<PlatformSection supported={["javascript.nextjs"]}>
+<PlatformSection supported={["javascript.angular", "javascript.astro", "javascript.gatsby", "javascript.nextjs", "javascript.react", "javascript.svelte", "javascript.sveltekit", "javascript.vue"]}>
 
 ## Upgrading to `8.x`
 
 <PlatformContent includePath="migration/javascript-v8/intro" />
 
-We recommend you read through all the [Important Changes](#important-changes) as they affect all Next.js SDK users. The [Other Changes](#other-changes) linked below only affect users who have more customized instrumentation. There is also a [Troubleshooting](#troubleshooting) section for common issues.
+We recommend you read through all the [Important Changes](#important-changes) as they affect all SDK users. The [Other Changes](#other-changes) linked below only affect users who have more customized instrumentation. There is also a [Troubleshooting](#troubleshooting) section for common issues.
 
 ## Important Changes
 
@@ -60,7 +60,7 @@ As such, `@sentry/hub` has been removed and will no longer be published. All of 
 
 </PlatformSection>
 
-<PlatformSection notSupported={["javascript.nextjs"]}>
+<PlatformSection notSupported={["javascript.angular", "javascript.astro", "javascript.gatsby", "javascript.nextjs", "javascript.react", "javascript.svelte", "javascript.sveltekit", "javascript.vue"]}>
 
 {/* TODO: Remove the generic summary */}
 

--- a/includes/migration/javascript-v8/compatible-browsers.mdx
+++ b/includes/migration/javascript-v8/compatible-browsers.mdx
@@ -1,0 +1,10 @@
+The SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.

--- a/includes/migration/javascript-v8/general-other-changes.mdx
+++ b/includes/migration/javascript-v8/general-other-changes.mdx
@@ -48,7 +48,7 @@ In `7.x`, you had to enable the metrics aggregator by setting the `_experiments`
 ```TypeScript
 // v7 - Server (Node/Deno/Bun)
 Sentry.init({
-  dsn: "__PUBLIC_DSN__",
+  dsn: "___PUBLIC_DSN___",
   _experiments: {
     metricsAggregator: true,
   },
@@ -56,7 +56,7 @@ Sentry.init({
 
 // v7 - Browser
 Sentry.init({
-  dsn: "__PUBLIC_DSN__",
+  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.metricsAggregatorIntegration()],
 });
 
@@ -68,7 +68,7 @@ In `8.x` no additional configuration is needed to use metrics APIs.
 ```ts
 // v8
 Sentry.init({
-  dsn: "__PUBLIC_DSN__",
+  dsn: "___PUBLIC_DSN___",
 });
 
 Sentry.metrics.increment("my_metric");

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
@@ -1,0 +1,16 @@
+### Supported versions
+
+Sentry Angular SDK `8.x` supports Angular Ivy by default and supports Angular version `14.0.0` or higher.
+
+As a result, `@sentry/angular-ivy` has been removed in favor of `@sentry/angular`. If you are using Angular 13 or lower, we suggest upgrading your Angular version before migrating to `8.x`. If you can't upgrade your Angular version to at least Angular 14, you can also continue using the `7.x` of `@sentry/angular-ivy` SDK.
+
+In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
@@ -4,13 +4,4 @@ Sentry Angular SDK `8.x` supports Angular Ivy by default and supports Angular ve
 
 As a result, `@sentry/angular-ivy` has been removed in favor of `@sentry/angular`. If you are using Angular 13 or lower, we suggest upgrading your Angular version before migrating to `8.x`. If you can't upgrade your Angular version to at least Angular 14, you can also continue using the `7.x` of `@sentry/angular-ivy` SDK.
 
-In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
@@ -7,16 +7,7 @@ Sentry Astro SDK `8.x` supports:
 
 If you need to support older versions of Node.js, please use Sentry Astro SDK `7.x`.
 
-The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />
 
 ### Removal of `trackHeaders` option for Astro middleware
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
@@ -1,0 +1,35 @@
+### Supported versions
+
+Sentry Astro SDK `8.x` supports:
+
+- Astro version `3.0.0` or higher
+- Node `14.18.0` or higher
+
+If you need to support older versions of Node.js, please use Sentry Astro SDK `7.x`.
+
+The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+
+### Removal of `trackHeaders` option for Astro middleware
+
+Instead of opting-in via the middleware config, you can configure if headers should be captured via `requestDataIntegration` options, which defaults to `true` but can be disabled like this:
+
+```JavaScript
+Sentry.init({
+  integrations: [
+    Sentry.requestDataIntegration({
+      include: {
+        headers: false,
+      },
+    }),
+  ],
+});
+```

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -10,9 +10,9 @@ If you need to support older versions of React, please use Sentry Gatsby SDK `7.
 
 In `8.x`, we are removing the ability to initialize the Gatsby SDK via plugin options.
 
-Previously you had to use the `gatsby-config.js` file to initialize the SDK like this:
+Previously you could use the `gatsby-config.js` file to initialize the SDK like this:
 
-```JavaScript {gatsby-config.js}
+```JavaScript {filename:gatsby-config.js}
 module.exports = {
   // ...
   plugins: [
@@ -29,7 +29,7 @@ module.exports = {
 
 Now you still use the `gatsby-config.js`:
 
-```JavaScript {gatsby-config.js}
+```JavaScript {filename:gatsby-config.js}
 module.exports = {
   // ...
   plugins: [
@@ -43,10 +43,10 @@ module.exports = {
 
 But you should also create a `sentry.config.js` file in the root of your project and initialize the SDK there:
 
-```JavaScript {sentry.config.js}
+```JavaScript {filename:sentry.config.js}
 import * as Sentry from '@sentry/gatsby';
 
 Sentry.init({
-  dsn: '__PUBLIC_DSN__',
+  dsn: '___PUBLIC_DSN___',
 });
 ```

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -4,16 +4,7 @@ Sentry Gatsby SDK `8.x` supports React version `16.0.0` or higher.
 
 If you need to support older versions of React, please use Sentry Gatsby SDK `7.x`.
 
-In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />
 
 ### Removal of Gatsby Initialization via plugin options
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -50,24 +50,3 @@ Sentry.init({
   dsn: '__PUBLIC_DSN__',
 });
 ```
-
-### Automatic adding of `browserTracingIntegration` for Gatsby
-
-The Gatsby SDK no longer adds the `browserTracingIntegration` automatically when you specify a `tracesSampleRate`. If you want to enable tracing in the browser, you need to add it manually. Make sure to also configured a `tracePropagationTargets` value.
-
-```JavaScript {sentry.config.js}
-import * as Sentry from '@sentry/gatsby';
-
-Sentry.init({
-  dsn: '__PUBLIC_DSN__',
-  integrations: [Sentry.browserTracingIntegration()],
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-
-  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-});
-```

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -1,0 +1,82 @@
+### Supported versions
+
+Sentry Gatsby SDK `8.x` supports React version `16.0.0` or higher.
+
+If you need to support older versions of React, please use Sentry Gatsby SDK `7.x`.
+
+In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+
+### Removal of Gatsby Initialization via plugin options
+
+In `8.x`, we are removing the ability to initialize the Gatsby SDK via plugin options.
+
+Previously you had to use the `gatsby-config.js` file to initialize the SDK like this:
+
+```JavaScript {gatsby-config.js}
+module.exports = {
+  // ...
+  plugins: [
+    {
+      resolve: '@sentry/gatsby',
+      options: {
+        dsn: process.env.SENTRY_DSN,
+      },
+    },
+    // ...
+  ],
+};
+```
+
+Now you still use the `gatsby-config.js`:
+
+```JavaScript {gatsby-config.js}
+module.exports = {
+  // ...
+  plugins: [
+    {
+      resolve: '@sentry/gatsby',
+    },
+    // ...
+  ],
+};
+```
+
+But you should also create a `sentry.config.js` file in the root of your project and initialize the SDK there:
+
+```JavaScript {sentry.config.js}
+import * as Sentry from '@sentry/gatsby';
+
+Sentry.init({
+  dsn: '__PUBLIC_DSN__',
+});
+```
+
+### Automatic adding of `browserTracingIntegration` for Gatsby
+
+The Gatsby SDK no longer adds the `browserTracingIntegration` automatically when you specify a `tracesSampleRate`. If you want to enable tracing in the browser, you need to add it manually. Make sure to also configured a `tracePropagationTargets` value.
+
+```JavaScript {sentry.config.js}
+import * as Sentry from '@sentry/gatsby';
+
+Sentry.init({
+  dsn: '__PUBLIC_DSN__',
+  integrations: [Sentry.browserTracingIntegration()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
+});
+```

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
@@ -18,7 +18,7 @@ To start using the Next.js built-in hooks, follow these steps:
 
 1. First, enable the Next.js instrumentation hook by setting the [`experimental.instrumentationHook`](https://nextjs.org/docs/app/api-reference/next-config-js/instrumentationHook) to true in your `next.config.js`.
 
-```JavaScript {next.config.js} {2-4}
+```JavaScript {filename:next.config.js} {2-4}
 module.exports = {
   experimental: {
     instrumentationHook: true,
@@ -30,7 +30,7 @@ module.exports = {
 
 3. Now, export a register function from the `instrumentation.ts|js` file and call `Sentry.init()` inside of it:
 
-```JavaScript {instrumentation.js}
+```JavaScript {filename:instrumentation.js}
 import * as Sentry from '@sentry/nextjs';
 
 export function register() {
@@ -68,7 +68,7 @@ The Custom Instrumentation API for Performance Monitoring has been revamped in `
 
 With `8.x` of the Sentry Next.js SDK, `withSentryConfig` will no longer accept 3 arguments. The second argument (holding options for the Sentry Webpack plugin) and the third argument (holding options for SDK build-time configuration) should now be passed as one:
 
-```JavaScript {next.config.js} diff
+```JavaScript {filename:next.config.js} diff
 const nextConfig = {
   // Your Next.js options...
 };
@@ -90,7 +90,7 @@ const nextConfig = {
 
 As part of this change the SDK will no longer support passing Next.js options with a `sentry` property to `withSentryConfig`. Please use the second argument of `withSentryConfig` to configure the SDK instead.
 
-```JavaScript {next.config.js} diff
+```JavaScript {filename:next.config.js} diff
  const nextConfig = {
    // Your Next.js options...
 -

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
@@ -8,16 +8,7 @@ Sentry Next.js SDK `8.x` supports:
 
 If you need to support older versions of Node.js or Next.js, please use Sentry Next.js SDK `7.x`.
 
-The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />
 
 ### Updated SDK initialization
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
@@ -6,7 +6,7 @@ Sentry Next.js SDK `8.x` supports:
 - Webpack `5.0.0` or higher
 - Node `14.18.0` or higher
 
-If you need to support older versions of Next.js, please use Sentry Next.js SDK `7.x`.
+If you need to support older versions of Node.js or Next.js, please use Sentry Next.js SDK `7.x`.
 
 The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
@@ -1,0 +1,16 @@
+### Supported versions
+
+Sentry React SDK `8.x` supports React version `16.0.0` or higher.
+
+If you need to support older versions of React, please use Sentry Next.js SDK `7.x`.
+
+In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
@@ -4,13 +4,4 @@ Sentry React SDK `8.x` supports React version `16.0.0` or higher.
 
 If you need to support older versions of React, please use Sentry Next.js SDK `7.x`.
 
-In addition the SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.svelte.mdx
@@ -1,0 +1,12 @@
+### Supported versions
+
+The Sentry Svelte SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.svelte.mdx
@@ -1,12 +1,3 @@
 ### Supported versions
 
-The Sentry Svelte SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
@@ -6,6 +6,24 @@ If you need to support older versions of Node.js, please use Sentry SvelteKit SD
 
 <Include name="migration/javascript-v8/compatible-browsers" />
 
+### Updated SDK initialization
+
+With `8.x` the Server-side Setup of the SvelteKit SDK now needs to be initialized before anything else runs in `hooks.server.js|ts`. Make sure to move `Sentry.init` to the top of the file.
+
+```JavaScript
+import * as Sentry from "@sentry/sveltekit";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+});
+
+// rest of your code and imports
+```
+
 ### Breaking `sentrySvelteKit()` changes
 
 Under the hood, the SvelteKit SDK uses [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin) to upload sourcemaps and automatically associate add releases to your events. In `8.x`, the SDK now uses `2.x` of the Sentry Vite Plugin which brings many improvements and bug fixes. Sourcemaps uploading with the SvelteKit SDK now uses <Link to="/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/">Debug IDs</Link>.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
@@ -4,16 +4,7 @@ Sentry SvelteKit SDK `8.x` supports Node `14.18.0` or higher
 
 If you need to support older versions of Node.js, please use Sentry SvelteKit SDK `7.x`.
 
-The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />
 
 ### Breaking `sentrySvelteKit()` changes
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
@@ -1,0 +1,86 @@
+### Supported versions
+
+Sentry SvelteKit SDK `8.x` supports Node `14.18.0` or higher
+
+If you need to support older versions of Node.js, please use Sentry SvelteKit SDK `7.x`.
+
+The client-side SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+
+### Breaking `sentrySvelteKit()` changes
+
+Under the hood, the SvelteKit SDK uses [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin) to upload sourcemaps and automatically associate add releases to your events. In `8.x`, the SDK now uses `2.x` of the Sentry Vite Plugin which brings many improvements and bug fixes. Sourcemaps uploading with the SvelteKit SDK now uses <Link to="/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/">Debug IDs</Link>.
+
+To allow future upgrades of the Vite plugin without breaking stable and public APIs in `sentrySvelteKit`, we modified the `sourceMapsUploadOptions` to remove the hard dependency on the API of the plugin. While you previously could specify all [version 0.x Vite plugin options](https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1), we now reduced them to a subset of [2.x options](https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#options).
+
+Previously configuring your options looked like this:
+
+```JavaScript {vite.config.js}
+// SvelteKit SDK 7.x
+sentrySvelteKit({
+  sourceMapsUploadOptions: {
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    release: '1.0.1',
+    injectRelease: true,
+    include: ['./build/*/**/*'],
+    ignore: ['**/build/client/**/*']
+  },
+}),
+```
+
+Now they look like this:
+
+```JavaScript {vite.config.js}
+// SvelteKit SDK 8.x
+sentrySvelteKit({
+  sourceMapsUploadOptions: {
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    release: {
+	    name: '1.0.1',
+	    inject: true
+    },
+    sourcemaps: {
+	    assets: ['./build/*/**/*'],
+	    ignore: ['**/build/client/**/*'],
+	    filesToDeleteAfterUpload: ['./build/**/*.map']
+    },
+  },
+}),
+```
+
+In the future, we might add additional [options](https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#options)
+from the Vite plugin but if you would like to specify some of them directly, you can do this by passing in an
+`unstable_sentryVitePluginOptions` object:
+
+```JavaScript {vite.config.js}
+sentrySvelteKit({
+  sourceMapsUploadOptions: {
+    // ...
+    release: {
+	    name: '1.0.1',
+    },
+    unstable_sentryVitePluginOptions: {
+      release: {
+        setCommits: {
+          auto: true
+        }
+      }
+    }
+  },
+}),
+```
+
+Important: we DO NOT guarantee stability of `unstable_sentryVitePluginOptions`. They can be removed or updated at any
+time, including breaking changes within the same major version of the SDK.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
@@ -14,7 +14,7 @@ To allow future upgrades of the Vite plugin without breaking stable and public A
 
 Previously configuring your options looked like this:
 
-```JavaScript {vite.config.js}
+```JavaScript {filename:vite.config.js}
 // SvelteKit SDK 7.x
 sentrySvelteKit({
   sourceMapsUploadOptions: {
@@ -31,7 +31,7 @@ sentrySvelteKit({
 
 Now they look like this:
 
-```JavaScript {vite.config.js}
+```JavaScript {filename:vite.config.js}
 // SvelteKit SDK 8.x
 sentrySvelteKit({
   sourceMapsUploadOptions: {
@@ -55,7 +55,7 @@ In the future, we might add additional [options](https://www.npmjs.com/package/@
 from the Vite plugin but if you would like to specify some of them directly, you can do this by passing in an
 `unstable_sentryVitePluginOptions` object:
 
-```JavaScript {vite.config.js}
+```JavaScript {filename:vite.config.js}
 sentrySvelteKit({
   sourceMapsUploadOptions: {
     // ...

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.vue.mdx
@@ -1,0 +1,12 @@
+### Supported versions
+
+The Sentry Vue SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
+
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
+
+For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.vue.mdx
@@ -1,12 +1,3 @@
 ### Supported versions
 
-The Sentry Vue SDK now only works with ES2018 compatible browsers. The minimum supported browser versions are:
-
-- Chrome 63
-- Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
-
-For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
+<Include name="migration/javascript-v8/compatible-browsers" />

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.angular.mdx
@@ -1,0 +1,17 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/angular`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/angular` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.astro.mdx
@@ -1,0 +1,20 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/astro`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/astro` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+
+Integrations that are now exported from `@sentry/astro` for client-side and server-side init:
+
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.gatsby.mdx
@@ -1,0 +1,17 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/gatsby`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/gatsby` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.react.mdx
@@ -1,0 +1,17 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/react`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/react` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.svelte.mdx
@@ -1,0 +1,17 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/svelte`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/svelte` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.sveltekit.mdx
@@ -1,0 +1,20 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/sveltekit`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/sveltekit` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+
+Integrations that are now exported from `@sentry/sveltekit` for client-side and server-side init:
+
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.vue.mdx
@@ -1,0 +1,17 @@
+### Removal of `@sentry/integrations` package
+
+`@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/vue`. In addition they are now functions instead of classes.
+
+Integrations that are now exported from `@sentry/vue` for client-side init:
+
+- `httpClientIntegration` (`HTTPClient`)
+- `contextLinesIntegration` (`ContextLines`)
+- `reportingObserverIntegration` (`ReportingObserver`)
+- `captureConsoleIntegration` (`CaptureConsole`)
+- `debugIntegration` (`Debug`)
+- `extraErrorDataIntegration` (`ExtraErrorData`)
+- `rewriteFramesIntegration` (`RewriteFrames`)
+- `sessionTimingIntegration` (`SessionTiming`)
+- `dedupeIntegration` (`Dedupe`) - Note: enabled by default, not pluggable
+
+The `Transaction` integration has been removed from `@sentry/integrations`. There is no replacement API.

--- a/platform-includes/migration/javascript-v8/intro/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/intro/javascript.astro.mdx
@@ -1,0 +1,1 @@
+`8.x` simplifies Sentry Astro SDK initialization and leverages OpenTelemetry instrumentation for performance monitoring.

--- a/platform-includes/migration/javascript-v8/intro/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/intro/javascript.mdx
@@ -1,0 +1,1 @@
+`8.x` simplifies Sentry SDK initialization and makes several internal improvements.

--- a/platform-includes/migration/javascript-v8/intro/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/intro/javascript.sveltekit.mdx
@@ -1,0 +1,1 @@
+`8.x` simplifies Sentry SvelteKit SDK initialization and leverages OpenTelemetry instrumentation for performance monitoring.

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.angular.mdx
@@ -1,0 +1,25 @@
+### Renaming Angular Tracing Decorator
+
+The usage of `TraceClassDecorator` and the `TraceMethodDecorator` already implies that those are decorators. The word Decorator is now removed from the names to avoid multiple mentioning.
+
+Additionally, the `TraceClass` and `TraceMethod` decorators accept an optional name parameter to set the transaction name. This was added because Angular minifies class and method names, and you might want to set a more descriptive name. If nothing provided, the name defaults to 'unnamed'.
+
+```TypeScript
+// Before (7.x)
+@Sentry.TraceClassDecorator()
+export class HeaderComponent {
+  @Sentry.TraceMethodDecorator()
+  ngOnChanges(changes: SimpleChanges) {}
+}
+
+// After (8.x)
+@Sentry.TraceClass({ name: 'HeaderComponent' })
+export class HeaderComponent {
+  @Sentry.TraceMethod({ name: 'ngOnChanges' })
+  ngOnChanges(changes: SimpleChanges) {}
+}
+```
+
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.astro.mdx
@@ -1,0 +1,7 @@
+<Include name="migration/javascript-v8/node-other-changes" />
+
+<Include name="migration/javascript-v8/server-other-changes" />
+
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.astro.mdx
@@ -1,5 +1,21 @@
 <Include name="migration/javascript-v8/node-other-changes" />
 
+### Performance Monitoring Integrations
+
+As we added support for OpenTelemetry, we have expanded the automatic instrumentation for our Astro SDK.
+
+We now support the following integrations out of the box without extra configuration for server-side Astro:
+
+- `httpIntegration`: Automatically instruments Node `http` and `https` standard libraries
+- `nativeNodeFetchIntegration`: Automatically instruments top level fetch and undici
+- `graphqlIntegration`: Automatically instruments GraphQL
+- `mongoIntegration`: Automatically instruments MongoDB
+- `mongooseIntegration`: Automatically instruments Mongoose
+- `mysqlIntegration`: Automatically instruments MySQL
+- `mysql2Integration`: Automatically instruments MySQL2
+- `postgresIntegration`: Automatically instruments PostgreSQL
+- `prismaIntegration`: Automatically instruments Prisma
+
 <Include name="migration/javascript-v8/server-other-changes" />
 
 <Include name="migration/javascript-v8/browser-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
@@ -1,0 +1,3 @@
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
@@ -1,3 +1,24 @@
+### Automatic adding of `browserTracingIntegration` for Gatsby
+
+The Gatsby SDK no longer adds the `browserTracingIntegration` automatically when you specify a `tracesSampleRate`. If you want to enable tracing in the browser, you need to add it manually. Make sure to also configured a `tracePropagationTargets` value.
+
+```JavaScript {sentry.config.js}
+import * as Sentry from '@sentry/gatsby';
+
+Sentry.init({
+  dsn: '__PUBLIC_DSN__',
+  integrations: [Sentry.browserTracingIntegration()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
+});
+```
+
 <Include name="migration/javascript-v8/browser-other-changes" />
 
 <Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.gatsby.mdx
@@ -2,11 +2,11 @@
 
 The Gatsby SDK no longer adds the `browserTracingIntegration` automatically when you specify a `tracesSampleRate`. If you want to enable tracing in the browser, you need to add it manually. Make sure to also configured a `tracePropagationTargets` value.
 
-```JavaScript {sentry.config.js}
+```JavaScript {filename:sentry.config.js}
 import * as Sentry from '@sentry/gatsby';
 
 Sentry.init({
-  dsn: '__PUBLIC_DSN__',
+  dsn: '___PUBLIC_DSN___',
   integrations: [Sentry.browserTracingIntegration()],
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
@@ -115,6 +115,8 @@ If you were previously using the `@sentry/opentelemetry-node`, it is no longer r
 
 To customize your OpenTelemetry setup, see the docs on [OpenTelemetry instrumentation in `8.0`](./v8-opentelemetry/#custom-opentelemetry-setup).
 
+<Include name="migration/javascript-v8/node-other-changes" />
+
 ### Performance Monitoring Integrations
 
 As we added support for OpenTelemetry, we have expanded the automatic instrumentation for our Next.js SDK.
@@ -130,8 +132,6 @@ We now support the following integrations out of the box without extra configura
 - `mysql2Integration`: Automatically instruments MySQL2
 - `postgresIntegration`: Automatically instruments PostgreSQL
 - `prismaIntegration`: Automatically instruments Prisma
-
-<Include name="migration/javascript-v8/node-other-changes" />
 
 <Include name="migration/javascript-v8/server-other-changes" />
 

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.nextjs.mdx
@@ -8,7 +8,7 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 
 - `nextRouterInstrumentation` has been removed in favour of `browserTracingIntegration`.
 
-```JavaScript {sentry.client.config.js} diff
+```JavaScript {filename:sentry.client.config.js} diff
  import * as Sentry from '@sentry/nextjs';
 
  Sentry.init({
@@ -25,7 +25,7 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 
 - `withSentryApi` has been removed in favour of `wrapApiHandlerWithSentry`.
 
-```JavaScript {pages/api/*} diff
+```JavaScript {filename:pages/api/*} diff
 -import { withSentryApi } from "@sentry/nextjs";
 +import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
 
@@ -39,7 +39,7 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 
 - `withSentryGetServerSideProps` has been removed in favour of `wrapGetServerSidePropsWithSentry`.
 
-```JavaScript {pages/index.js} diff
+```JavaScript {filename:pages/index.js} diff
 -import { withSentryGetServerSideProps } from "@sentry/nextjs";
 +import { wrapGetServerSidePropsWithSentry } from "@sentry/nextjs";
 
@@ -53,7 +53,7 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 
 - `withSentryGetStaticProps` has been removed in favour of `wrapGetStaticPropsWithSentry`.
 
-```JavaScript {pages/index.js} diff
+```JavaScript {filename:pages/index.js} diff
 -import { withSentryGetStaticProps } from "@sentry/nextjs";
 +import { wrapGetStaticPropsWithSentry } from "@sentry/nextjs";
 
@@ -67,7 +67,7 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 
 - `withSentryServerSideGetInitialProps` has been removed in favour of `wrapGetInitialPropsWithSentry`.
 
-```JavaScript {pages/index.js} diff
+```JavaScript {filename:pages/index.js} diff
 -import { withSentryServerSideGetInitialProps } from "@sentry/nextjs";
 +import { wrapGetInitialPropsWithSentry } from "@sentry/nextjs";
 
@@ -102,7 +102,7 @@ If you were previously using the `@sentry/opentelemetry-node`, it is no longer r
 
 2. Remove `instrumenter: "otel",` from your `Sentry.init` call for your server-side SDK initialization.
 
-```JavaScript {sentry.server.config.js} diff
+```JavaScript {filename:sentry.server.config.js} diff
  import * as Sentry from '@sentry/nextjs';
 
  Sentry.init({

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.react.mdx
@@ -1,0 +1,3 @@
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.svelte.mdx
@@ -2,7 +2,7 @@
 
 The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure component tracking.
 
-```JavaScript {svelte.config.js} diff
+```JavaScript {filename:svelte.config.js} diff
 // v7 - svelte.config.js
 -import { componentTrackingPreprocessor } from '@sentry/svelte';
 +import { withSentryConfig } from "@sentry/svelte";

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.svelte.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.svelte.mdx
@@ -1,0 +1,24 @@
+### Removal of `componentTrackingPreprocessor` export
+
+The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure component tracking.
+
+```JavaScript {svelte.config.js} diff
+// v7 - svelte.config.js
+-import { componentTrackingPreprocessor } from '@sentry/svelte';
++import { withSentryConfig } from "@sentry/svelte";
+
+ const config = {
+  preprocess: [
+-   componentTrackingPreprocessor(),
+     // ...
+  ],
+   // ...
+ };
+
+-export default config;
++export default withSentryConfig(config);
+```
+
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
@@ -1,0 +1,28 @@
+### Removal of `componentTrackingPreprocessor` export
+
+The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure component tracking.
+
+```JavaScript {svelte.config.js} diff
+// v7 - svelte.config.js
+-import { componentTrackingPreprocessor } from '@sentry/svelte';
++import { withSentryConfig } from "@sentry/svelte";
+
+ const config = {
+  preprocess: [
+-   componentTrackingPreprocessor(),
+     // ...
+  ],
+   // ...
+ };
+
+-export default config;
++export default withSentryConfig(config);
+```
+
+<Include name="migration/javascript-v8/node-other-changes" />
+
+<Include name="migration/javascript-v8/server-other-changes" />
+
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
@@ -2,7 +2,7 @@
 
 The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure component tracking.
 
-```JavaScript {svelte.config.js} diff
+```JavaScript {filename:svelte.config.js} diff
 // v7 - svelte.config.js
 -import { componentTrackingPreprocessor } from '@sentry/svelte';
 +import { withSentryConfig } from "@sentry/svelte";

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
@@ -19,6 +19,22 @@ The `componentTrackingPreprocessor` export has been removed. You should instead 
 +export default withSentryConfig(config);
 ```
 
+### Performance Monitoring Integrations
+
+As we added support for OpenTelemetry, we have expanded the automatic instrumentation for our SvelteKit SDK.
+
+We now support the following integrations out of the box without extra configuration for server-side SvelteKit:
+
+- `httpIntegration`: Automatically instruments Node `http` and `https` standard libraries
+- `nativeNodeFetchIntegration`: Automatically instruments top level fetch and undici
+- `graphqlIntegration`: Automatically instruments GraphQL
+- `mongoIntegration`: Automatically instruments MongoDB
+- `mongooseIntegration`: Automatically instruments Mongoose
+- `mysqlIntegration`: Automatically instruments MySQL
+- `mysql2Integration`: Automatically instruments MySQL2
+- `postgresIntegration`: Automatically instruments PostgreSQL
+- `prismaIntegration`: Automatically instruments Prisma
+
 <Include name="migration/javascript-v8/node-other-changes" />
 
 <Include name="migration/javascript-v8/server-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.vue.mdx
@@ -1,0 +1,3 @@
+<Include name="migration/javascript-v8/browser-other-changes" />
+
+<Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.astro.mdx
@@ -59,7 +59,7 @@ Server-side Integrations:
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
 
-```JavaScript {sentry.client.config.js} diff
+```JavaScript {filename:sentry.client.config.js} diff
  import * as Sentry from "@sentry/astro";
 
  Sentry.init({

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.nextjs.mdx
@@ -59,7 +59,7 @@ Server-side Integrations:
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
 
-```JavaScript {sentry.client.config.js} diff
+```JavaScript {filename:sentry.client.config.js} diff
  import * as Sentry from "@sentry/nextjs";
 
  Sentry.init({

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.sveltekit.mdx
@@ -59,7 +59,7 @@ Server-side Integrations:
 
 Browser tracing is automatically set up for you in these packages so you do not need to change you code unless you were using the `BrowserTracing` class directly.
 
-```JavaScript {hooks.client.js} diff
+```JavaScript {filename:hooks.client.js} diff
  import * as Sentry from "@sentry/sveltekit";
 
  Sentry.init({


### PR DESCRIPTION
Building on top of https://github.com/getsentry/sentry-docs/pull/9796 and https://github.com/getsentry/sentry-docs/pull/9817, this adds detailed migration docs for all browser based SDKs. All that is left now is Node!