### PR TITLE
fix(apple): Return nil in beforeSend

### DIFF
--- a/docs/platforms/apple/common/configuration/http-client-errors.mdx
+++ b/docs/platforms/apple/common/configuration/http-client-errors.mdx
@@ -91,7 +91,7 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.beforeSend = { event in
-        // modify event here or return NULL to discard the event
+        // modify event here or return nil to discard the event
         return event
     }
 }
@@ -103,7 +103,7 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.beforeSend = ^SentryEvent * _Nullable(SentryEvent * _Nonnull event) {
-        // modify event here or return NULL to discard the event
+        // modify event here or return nil to discard the event
         return event;
     }
 }];

--- a/platform-includes/configuration/before-send/apple.mdx
+++ b/platform-includes/configuration/before-send/apple.mdx
@@ -6,7 +6,7 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.beforeSend = { event in
-        // modify event here or return NULL to discard the event
+        // modify event here or return nil to discard the event
         return event
     }
 }
@@ -18,7 +18,7 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.beforeSend = ^SentryEvent * _Nullable(SentryEvent * _Nonnull event) {
-        // modify event here or return NULL to discard the event
+        // modify event here or return nil to discard the event
         return event;
     }
 }];


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Change code comment to return nil instead of NULL.

