### PR TITLE
Add fill_extra_context option to the symfony documentation

### DIFF
--- a/docs/platforms/php/guides/symfony/index.mdx
+++ b/docs/platforms/php/guides/symfony/index.mdx
@@ -85,7 +85,7 @@ class SentryTestController extends AbstractController
     public function testLog()
     {
         // the following code will test if monolog integration logs to sentry
-        $this->logger->error('My custom logged error.');
+        $this->logger->error('My custom logged error.', ['some' => 'Context Data']);
 
         // the following code will test if an uncaught exception logs to sentry
         throw new \RuntimeException('Example exception.');

--- a/docs/platforms/php/guides/symfony/index.mdx
+++ b/docs/platforms/php/guides/symfony/index.mdx
@@ -42,7 +42,7 @@ monolog:
             type: sentry
             level: !php/const Monolog\Logger::ERROR
             hub_id: Sentry\State\HubInterface
-            fill_extra_context: true # Enables to send the monolog context also to Sentry
+            fill_extra_context: true # Enables sending monolog context to Sentry
 ```
 
 Additionally, you can register the `PsrLogMessageProcessor` to resolve PSR-3 placeholders in reported messages:

--- a/docs/platforms/php/guides/symfony/index.mdx
+++ b/docs/platforms/php/guides/symfony/index.mdx
@@ -42,6 +42,7 @@ monolog:
             type: sentry
             level: !php/const Monolog\Logger::ERROR
             hub_id: Sentry\State\HubInterface
+            fill_extra_context: true # Enables to send the monolog context also to Sentry
 ```
 
 Additionally, you can register the `PsrLogMessageProcessor` to resolve PSR-3 placeholders in reported messages:


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Add fill_extra_context option to the symfony documentation. https://github.com/getsentry/sentry-php/blob/master/src/Monolog/Handler.php

See also comment from @nuryagdym https://github.com/getsentry/sentry-php/issues/870#issuecomment-1833319890

Thx @cviniciussdias for the hint.

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
