### PR TITLE
chore(native): Add snippets to strip sensitive data with set_tag and set_user

### DIFF
--- a/platform-includes/sensitive-data/set-tag/native.mdx
+++ b/platform-includes/sensitive-data/set-tag/native.mdx
@@ -1,0 +1,7 @@
+The Native SDK maintains all data in a single global scope.
+
+```c
+#include <sentry.h>
+
+sentry_set_tag("birthday", checksum_or_hash("08/12/1990"));
+```

--- a/platform-includes/sensitive-data/set-user/native.mdx
+++ b/platform-includes/sensitive-data/set-user/native.mdx
@@ -1,0 +1,11 @@
+The Native SDK maintains all data in a single global scope.
+
+```c
+#include <sentry.h>
+
+sentry_value_t user = sentry_value_new_object();
+sentry_value_set_by_key(user, "id", client_user->id);
+// OR
+sentry_value_set_by_key(user, "username", client_user->username));
+sentry_set_user(user);
+```

--- a/platform-includes/sensitive-data/set-user/native.mdx
+++ b/platform-includes/sensitive-data/set-user/native.mdx
@@ -4,8 +4,8 @@ The Native SDK maintains all data in a single global scope.
 #include <sentry.h>
 
 sentry_value_t user = sentry_value_new_object();
-sentry_value_set_by_key(user, "id", client_user->id);
+sentry_value_set_by_key(user, "id", sentry_value_new_int32(client_user->id));
 // OR
-sentry_value_set_by_key(user, "username", client_user->username));
+sentry_value_set_by_key(user, "username", sentry_value_new_string(client_user->username));
 sentry_set_user(user);
 ```


### PR DESCRIPTION
Adds snippets to strip sensitive data with set_tag and set_user. Tried to keep the examples in line with the other platforms (e.g. `checksum_or_hash`)

cc @supervacuus 