### PR TITLE
fix(js): Remove redundant otel note from migration

### DIFF
--- a/includes/migration/javascript-v8/node-other-changes.mdx
+++ b/includes/migration/javascript-v8/node-other-changes.mdx
@@ -11,10 +11,6 @@ Sentry.init({
 });
 ```
 
-### Removal of `Sentry.Handlers.trpcMiddleware()` in favor of `Sentry.trpcMiddleware()`
-
-The Sentry tRPC middleware got moved from `Sentry.Handlers.trpcMiddleware()` to `Sentry.trpcMiddleware()`.
-
 ### Behaviour in combination with `onUncaughtException` handlers in Node.js
 
 Previously the SDK exited the process by default, even though additional `onUncaughtException` may have been registered,

--- a/includes/migration/javascript-v8/server-other-changes.mdx
+++ b/includes/migration/javascript-v8/server-other-changes.mdx
@@ -2,6 +2,10 @@
 
 The `deepReadDirSync` method has been removed as an export from the SDK. There is no replacement API.
 
+### Removal of `Sentry.Handlers.trpcMiddleware()` in favor of `Sentry.trpcMiddleware()`
+
+The Sentry tRPC middleware got moved from `Sentry.Handlers.trpcMiddleware()` to `Sentry.trpcMiddleware()`.
+
 #### Removal of Client-Side health check transaction filters
 
 The SDK no longer filters out health check transactions by default. Instead, they are sent to Sentry but still dropped

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.astro.mdx
@@ -25,8 +25,6 @@ We now support the following integrations out of the box with 0 configuration:
 - `postgresIntegration`: Automatically instruments PostgreSQL
 - `prismaIntegration`: Automatically instruments Prisma
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 ### Removal of `trackHeaders` option for Astro middleware
 
 Instead of opting-in via the middleware config, you can configure if headers should be captured via `requestDataIntegration` options, which defaults to `true` but can be disabled like this:

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.aws-lambda.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.aws-lambda.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Serverless S
 
 With 8.x, the Sentry Serverless SDK for AWS Lambda has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 With this change, `@sentry/serverless` has been removed and will no longer be published. The AWS related code now lives in `@sentry/aws-serverless`.
 
 Here's an example of instrumentating your AWS Lambda with Sentry Serverless SDK `8.x`:

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.azure-functions.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.azure-functions.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Node SDK `7.
 
 With 8.x, @sentry/node has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 Here's an example of instrumentating your Azure Function with Sentry Node SDK `8.x`:
 
 ```JavaScript

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.connect.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.connect.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Node SDK `7.
 
 With 8.x, @sentry/node has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 Here's an example of instrumentating a Connect application with Sentry Node SDK `8.x`:
 
 ```JavaScript

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.express.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.express.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Node SDK `7.
 
 With 8.x, @sentry/node has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 Here's an example of instrumentating an Express application with Sentry Node SDK `8.x`:
 
 ```JavaScript

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gcp-functions.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gcp-functions.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Serverless S
 
 With 8.x, the Sentry Serverless SDK for Google Cloud Functions has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 With this change, `@sentry/serverless` has been removed and will no longer be published. The GCP related code now lives in `@sentry/google-cloud-serverless`.
 
 Here's an example of instrumentating your Google Cloud Function with Sentry Serverless SDK `8.x`:

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.koa.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.koa.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Node SDK `7.
 
 With 8.x, @sentry/node has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 Here's an example of instrumentating a Koa application with Sentry Node SDK `8.x`:
 
 ```JavaScript

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.nextjs.mdx
@@ -74,8 +74,6 @@ We now support the following integrations out of the box with 0 configuration:
 - `postgresIntegration`: Automatically instruments PostgreSQL
 - `prismaIntegration`: Automatically instruments Prisma
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 ### Updated `withSentryConfig` Usage
 
 With `8.x` of the Sentry Next.js SDK, `withSentryConfig` will no longer accept 3 arguments. The second argument (holding options for the Sentry Webpack plugin) and the third argument (holding options for SDK build-time configuration) should now be passed as one:

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.node.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.node.mdx
@@ -8,8 +8,6 @@ If you need to support older versions of Node.js, please use Sentry Node SDK `7.
 
 With 8.x, @sentry/node has been completely overhauled. It is now powered by [OpenTelemetry](https://opentelemetry.io/) under the hood. You do not need to know or understand what OpenTelemetry is in order to use Sentry. We set up OpenTelemetry under the hood, no knowledge of it is required in order to get started, though if you use OpenTelemetry-native APIs to start spans, and Sentry will pick up everything automatically.
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 To migrate your Node.js app to Sentry Node SDK `8.x`, you need to make the following changes:
 
 1. Move your `Sentry.init` call so that it is called before any other `require`/`import` statements.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
@@ -54,8 +54,6 @@ We now support the following integrations out of the box with 0 configuration:
 - `postgresIntegration`: Automatically instruments PostgreSQL
 - `prismaIntegration`: Automatically instruments Prisma
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 3. Move your client-side `Sentry.init` call so that it is called before any other `require`/`import` statements in `entry.client.tsx`.
 
 ```JavaScript diff

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.sveltekit.mdx
@@ -35,8 +35,6 @@ We now support the following integrations out of the box with 0 configuration:
 - `postgresIntegration`: Automatically instruments PostgreSQL
 - `prismaIntegration`: Automatically instruments Prisma
 
-If you want to customize the OpenTelemetry setup, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
-
 ### Breaking `sentrySvelteKit()` changes
 
 Under the hood, the SvelteKit SDK uses [Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin) to upload sourcemaps and automatically associate add releases to your events. In `8.x`, the SDK now uses `2.x` of the Sentry Vite Plugin which brings many improvements and bug fixes. Sourcemaps uploading with the SvelteKit SDK now uses <Link to="/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/">Debug IDs</Link>.

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.bun.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.bun.mdx
@@ -2,8 +2,6 @@
 
 If you want to customize the OpenTelemetry setup with your Bun SDK in `8.x`, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
 
-<Include name="migration/javascript-v8/node-other-changes" />
-
 <Include name="migration/javascript-v8/server-other-changes" />
 
 <Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.deno.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.deno.mdx
@@ -2,8 +2,6 @@
 
 If you want to customize the OpenTelemetry setup with your Bun SDK in `8.x`, see the docs about using [OpenTelemetry with `8.x`](./v8-opentelemetry)
 
-<Include name="migration/javascript-v8/node-other-changes" />
-
 <Include name="migration/javascript-v8/server-other-changes" />
 
 <Include name="migration/javascript-v8/general-other-changes" />

--- a/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
+++ b/platform-includes/migration/javascript-v8/other-changes/javascript.sveltekit.mdx
@@ -1,24 +1,3 @@
-### Removal of `componentTrackingPreprocessor` export
-
-The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure component tracking.
-
-```JavaScript {filename:svelte.config.js} diff
-// v7 - svelte.config.js
--import { componentTrackingPreprocessor } from '@sentry/svelte';
-+import { withSentryConfig } from "@sentry/svelte";
-
- const config = {
-  preprocess: [
--   componentTrackingPreprocessor(),
-     // ...
-  ],
-   // ...
- };
-
--export default config;
-+export default withSentryConfig(config);
-```
-
 <Include name="migration/javascript-v8/node-other-changes" />
 
 <Include name="migration/javascript-v8/server-other-changes" />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
