### PR TITLE
fix: Remove community fastify sdk

### DIFF
--- a/docs/platforms/index.mdx
+++ b/docs/platforms/index.mdx
@@ -34,7 +34,6 @@ These SDKs are maintained and supported by [the Sentry community](https://open.s
 - [_ColdFusion_](https://github.com/coldbox-modules/sentry)
 - [_Crystal_](https://github.com/Sija/raven.cr)
 - [_Defold_](https://github.com/indiesoftby/defold-sentinel)
-- [_Fastify_](https://github.com/zentered/fastify-sentry)
 - [_Grails_](https://github.com/agorapulse/grails-sentry)
 - [_Kubernetes_](https://github.com/alekitto/sentry-kubernetes)
 - [_Lua_](https://github.com/cloudflare/raven-lua)


### PR DESCRIPTION
We now have a 1st party fastify sdk - we should recommend that!
