### PR TITLE
feat(replay): Document how to connect Replay with support software

### DIFF
--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -224,7 +224,7 @@ Sentry.init({
 /**
  * Your widget will need to have an event/hook to trigger flushing the replay to
  * Sentry.
- /
+ */
 MySupportWidget.on('open', () => {
   const replay = Sentry.getReplay();
   // Send replay to Sentry

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -195,3 +195,50 @@ replayIntegration({
 
 If you return `false` from this method for a given error, we will not check the error sample rate for this error.
 If you return `true`, we will continue to check the error sample rate as normal.
+
+
+### Connect Replays with Support Software
+
+Replays does not need to be connected to an application error, it can also be used to supplement your support software
+as well. Depending on the level of customization provided by your support widget, it is possible to send a replay to
+Sentry when your users open the support widget. Note that Sentry's [User Feedback](https://docs.sentry.io/product/user-feedback/#user-feedback-widget)
+provides this functionality by default! You can then send the ID of the replay along with the support ticket that your
+user submits. The ID can then be used to reference the replay inside of Sentry. Alternatively, you can search for
+replays by a user identifier such as email.
+
+The below is a hypothetical scenario of how you can connect Replay to your support widget.
+
+```javascript
+/**
+ * Initialize the Sentry SDK as normal.
+ *
+ * `replaysOnErrorSampleRate` needs to be > 0 so that replays are always buffering and only sent when necessary
+ */
+Sentry.init({
+  dsn: "...",
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 0.5,
+  integrations: [Sentry.replayIntegration()],
+});
+
+/**
+ * Your widget will need to have an event/hook to trigger flushing the replay to
+ * Sentry.
+ /
+MySupportWidget.on('open', () => {
+  const replay = Sentry.getReplay();
+  // Send replay to Sentry
+  replay.flush();
+  // Retrieve the replay id that was saved and attach it to your support widget
+  const replayId = replay.getReplayId();
+  MySupportWidget.setTag('replayId', replayId);
+});
+
+/**
+ * Now determine if your support application allows you to use custom data to generate a link directly to the
+ * replay in Sentry. Replay URLs have the following format:
+ *
+ *   https://<org-slug>.sentry.io/replays/<replay-id>/
+ *
+ */
+```

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -199,14 +199,14 @@ If you return `true`, we will continue to check the error sample rate as normal.
 
 ### Connect Replays with Support Software
 
-Replays do not need to be connected to an application error, it can also be used to supplement your support tickets
-as well. Depending on the level of customization provided by your support widget, it is possible to send a replay to
+Replays do not need to be connected to an application error, they can also be used to supplement your support tickets.
+Depending on the level of customization provided by your support widget, it is possible to send a replay to
 Sentry when your users open the support widget. Note that Sentry's [User Feedback](https://docs.sentry.io/product/user-feedback/#user-feedback-widget)
 provides this functionality by default! You can then send the ID of the replay along with the support ticket that your
-user submits. The ID can then be used to reference the replay inside of Sentry. Alternatively, you can search for
+user submits. The ID can be used to reference the replay in Sentry. Alternatively, you can search for
 replays by a user identifier such as email.
 
-The below is a hypothetical scenario of how you can connect Replay to your support widget.
+The example below provides a template for how you might connect Replay to your support widget.
 
 ```javascript
 /**

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -236,7 +236,7 @@ MySupportWidget.on('open', () => {
 
 /**
  * Now determine if your support application allows you to use custom data to generate a link directly to the
- * replay in Sentry. Replay URLs have the following format:
+ * replay in Sentry from within your Support software. Replay URLs have the following format:
  *
  *   https://<org-slug>.sentry.io/replays/<replay-id>/
  *

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -235,8 +235,10 @@ MySupportWidget.on('open', () => {
 });
 
 /**
- * Now determine if your support application allows you to use custom data to generate a link directly to the
- * replay in Sentry from within your Support software. Replay URLs have the following format:
+ * If your support application allows you to send custom data with the support
+ * ticket, you may want to include a link to the replay URL in Sentry. That
+ * way, you'll be able to open the replay directly from the ticket itself.
+ * Replay URLs have the following format:
  *
  *   https://<org-slug>.sentry.io/replays/<replay-id>/
  *

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -199,7 +199,7 @@ If you return `true`, we will continue to check the error sample rate as normal.
 
 ### Connect Replays with Support Software
 
-Replays does not need to be connected to an application error, it can also be used to supplement your support software
+Replays do not need to be connected to an application error, it can also be used to supplement your support tickets
 as well. Depending on the level of customization provided by your support widget, it is possible to send a replay to
 Sentry when your users open the support widget. Note that Sentry's [User Feedback](https://docs.sentry.io/product/user-feedback/#user-feedback-widget)
 provides this functionality by default! You can then send the ID of the replay along with the support ticket that your


### PR DESCRIPTION
Adds a hypothetical example of how you can send a replay when a user opens a support widget.

Closes https://github.com/getsentry/sentry-docs/issues/9037
