### PR TITLE
feat(js): Remove `@sentry/integrations` recommendation

### DIFF
--- a/platform-includes/configuration/capture-console/javascript.mdx
+++ b/platform-includes/configuration/capture-console/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { captureConsoleIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [captureConsoleIntegration()],
+  integrations: [Sentry.captureConsoleIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/capture-console/javascript.node.mdx
+++ b/platform-includes/configuration/capture-console/javascript.node.mdx
@@ -1,13 +1,10 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { captureConsoleIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [captureConsoleIntegration()],
+  integrations: [Sentry.captureConsoleIntegration()],
 });
 ```

--- a/platform-includes/configuration/contextlines/javascript.mdx
+++ b/platform-includes/configuration/contextlines/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { contextLinesIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [contextLinesIntegration()],
+  integrations: [Sentry.contextLinesIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/debug/javascript.mdx
+++ b/platform-includes/configuration/debug/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { debugIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [debugIntegration()],
+  integrations: [Sentry.debugIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/debug/javascript.node.mdx
+++ b/platform-includes/configuration/debug/javascript.node.mdx
@@ -1,13 +1,10 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { debugIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [debugIntegration()],
+  integrations: [Sentry.debugIntegration()],
 });
 ```

--- a/platform-includes/configuration/dedupe/javascript.mdx
+++ b/platform-includes/configuration/dedupe/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { dedupeIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [dedupeIntegration()],
+  integrations: [Sentry.dedupeIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/dedupe/javascript.node.mdx
+++ b/platform-includes/configuration/dedupe/javascript.node.mdx
@@ -1,13 +1,10 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { dedupeIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [dedupeIntegration()],
+  integrations: [Sentry.dedupeIntegration()],
 });
 ```

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -2,13 +2,12 @@
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { reportingObserverIntegration } from "@sentry/integrations";
 
 Sentry.init({
   integrations: [],
 });
 
-Sentry.addIntegration(reportingObserverIntegration());
+Sentry.addIntegration(Sentry.reportingObserverIntegration());
 ```
 
 ```html {tabTitle: Loader}

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.node.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.node.mdx
@@ -2,10 +2,9 @@
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { captureConsoleIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [captureConsoleIntegration()],
+  integrations: [Sentry.captureConsoleIntegration()],
 });
 ```

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -2,11 +2,10 @@
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { reportingObserverIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [reportingObserverIntegration()],
+  integrations: [Sentry.reportingObserverIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.node.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.node.mdx
@@ -2,12 +2,11 @@
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { captureConsoleIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
   integrations: [],
 });
 
-Sentry.addIntegration(captureConsoleIntegration());
+Sentry.addIntegration(Sentry.captureConsoleIntegration());
 ```

--- a/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { extraErrorDataIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [extraErrorDataIntegration()],
+  integrations: [Sentry.extraErrorDataIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/extra-error-data/javascript.node.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.node.mdx
@@ -1,13 +1,10 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { extraErrorDataIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [extraErrorDataIntegration()],
+  integrations: [Sentry.extraErrorDataIntegration()],
 });
 ```

--- a/platform-includes/configuration/http-client/javascript.mdx
+++ b/platform-includes/configuration/http-client/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { httpClientIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [httpClientIntegration()]
+  integrations: [Sentry.httpClientIntegration()]
 
   // This option is required for capturing headers and cookies.
   sendDefaultPii: true,

--- a/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { reportingObserverIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [reportingObserverIntegration()],
+  integrations: [Sentry.reportingObserverIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { rewriteFramesIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [rewriteFramesIntegration()],
+  integrations: [Sentry.rewriteFramesIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/rewrite-frames/javascript.node.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.node.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { rewriteFramesIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [rewriteFramesIntegration(
+  integrations: [Sentry.rewriteFramesIntegration(
     {
       // root path that will be stripped from the current frame's filename by the default iteratee if the filename is an absolute path
       root: string;

--- a/platform-includes/configuration/sessiontiming/javascript.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.mdx
@@ -1,14 +1,11 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: npm}
 import * as Sentry from "@sentry/browser";
-import { sessionTimingIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [sessionTimingIntegration()],
+  integrations: [Sentry.sessionTimingIntegration()],
 });
 ```
 

--- a/platform-includes/configuration/sessiontiming/javascript.node.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.node.mdx
@@ -1,13 +1,10 @@
-This integration requires you to install `@sentry/integrations` next to your main SDK package.
-
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/node";
-import { sessionTimingIntegration } from "@sentry/integrations";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [sessionTimingIntegration()],
+  integrations: [Sentry.sessionTimingIntegration()],
 });
 ```


### PR DESCRIPTION
This is not needed anymore since 7.112.0, and will be removed in v8. By updating this docs work both for v7 and v8.