### PR TITLE
feat(otel): Add docs for manual tracing in fastify

### DIFF
--- a/docs/platforms/javascript/guides/fastify/performance/instrumentation/opentelemetry.mdx
+++ b/docs/platforms/javascript/guides/fastify/performance/instrumentation/opentelemetry.mdx
@@ -72,3 +72,21 @@ const provider = new BasicTracerProvider({
   sampler: new SentrySampler(Sentry.getClient()),
 });
 ```
+
+## Using an OpenTelemetry Tracer
+
+While using `Sentry.startSpan()` and related APIs remains the recommended way to create spans, you can also use native OpenTelemetry APIs to create spans.
+
+You can access the tracer Sentry uses via `client.tracer`, like this:
+
+```js
+const Sentry = require("@sentry/node");
+
+const tracer = Sentry.getClient()?.tracer;
+// Now you can use native APIs on the tracer:
+tracer.startActiveSpan("span name", () => {
+  // measure something
+});
+```
+
+You can also use any other tracer, all OpenTelemetry spans will be picked up by Sentry automatically.


### PR DESCRIPTION
Adding docs for the v8 beta fastify docs about how to use otel-native tracing.