### PR TITLE
feat: Some adjustments of docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/async-context.mdx
+++ b/docs/platforms/javascript/common/configuration/async-context.mdx
@@ -10,7 +10,6 @@ supported:
   - javascript.express
   - javascript.gcp-functions
   - javascript.koa
-  - javascript.fastify
 ---
 
 You can use the `runWithAsyncContext` method to isolate Sentry scope and breadcrumbs to a single request if you are using SDK v7.48.0 or higher. This is useful if you are finding that breadcrumbs and scope are leaking across requests.

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -106,11 +106,6 @@ Grouping in Sentry is different for events with stack traces and without. As a r
   Most SDKs will attempt to auto-discover this value.
 </ConfigKey>
 
-<ConfigKey name="ca-certs">
-
-A path to an alternative CA bundle file in PEM-format.
-
-</ConfigKey>
 </PlatformCategorySection>
 
 <ConfigKey name="ignore-errors">
@@ -152,16 +147,6 @@ When set to `true`, the SDK will send session events to Sentry. This is supporte
 When not set to `false`, the SDK tracks sessions linked to the lifetime of the Electron main process.
 
 </ConfigKey>
-
-<PlatformCategorySection supported={['server', 'serverless']}>
-<ConfigKey name="frame-context-lines">
-The number of context lines for each frame when loading a file.
-
-#### Deprecated
-
-`frameContextLines` has moved to the <PlatformLink to="/configuration/integrations/default-integrations/#contextlines">`ContextLines` integration</PlatformLink>.
-</ConfigKey>
-</PlatformCategorySection>
 
 <ConfigKey name="initial-scope">
 

--- a/docs/platforms/javascript/guides/fastify/configuration/async-context.mdx
+++ b/docs/platforms/javascript/guides/fastify/configuration/async-context.mdx
@@ -1,0 +1,42 @@
+---
+title: Async Context
+sidebar_order: 80
+description: "Learn more about how to isolate Sentry scope and breadcrumbs across requests."
+---
+
+By default, the Sentry SDK will automatically isolate each request's scope and breadcrumbs. This means that any breadcrumbs or tags added will be isolated to the request. This is useful if you are finding that breadcrumbs and scope are leaking across requests. Take the following example:
+
+```js
+const Sentry = require("@sentry/node");
+
+app.get("/my-route", function () {
+  Sentry.addBreadcrumb({
+    message: "This breadcrumb should only be attached to this request",
+  });
+  // do something
+});
+
+app.get("/my-route-2", function () {
+  Sentry.addBreadcrumb({
+    message: "This breadcrumb should only be attached to this request",
+  });
+  // do something
+});
+```
+
+Each request will have its own breadcrumbs, and they will not be shared between requests.
+
+If you want to manually isolate some code, for example for a background job, you can use the `withIsolationScope` method. This will ensure that any breadcrumbs or tags added will be isolated inside of the provided callback:
+
+```js
+const Sentry = require("@sentry/node");
+
+async function backgroundJob() {
+  return await Sentry.withIsolationScope(async () => {
+    // Everything inside of this will be isolated
+    await doSomething();
+  });
+}
+```
+
+Under the hood, the SDK uses Node's [AsyncLocalStorage API](https://nodejs.org/api/async_context.html#class-asynclocalstorage) to perform the isolation.


### PR DESCRIPTION
Mainly, updates the Async Context docs for fastify (v8 beta), and removes the `caCerts` option (it does not exist in JS).