### PR TITLE
docs(python): Document `start_transaction` args

### DIFF
--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation.mdx
@@ -30,6 +30,8 @@ def eat_pizza(pizza):
             eat_slice(pizza.slices.pop())
 ```
 
+The [API reference](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.start_transaction) documents `start_transaction` and all its parameters.
+
 ## Add Spans to a Transaction
 
 If you want to have more fine-grained performance monitoring, you can add child spans to your transaction, which can be done by either:


### PR DESCRIPTION
## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Link to the `start_transaction` API docs, which describe all the possible arguments to `start_transaction`.

Closes GH-5082