### PR TITLE
doc(Xamarin): Add privacy info page for Xamarin

### DIFF
--- a/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
@@ -29,6 +29,45 @@ First, you need to create a privacy manifest file in your iOS project. This file
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
         <dict>

--- a/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
@@ -14,7 +14,7 @@ Sentry's SDKs provide error and performance monitoring for mobile applications r
 The information and steps in this guide are still being worked on and might change because of new tools or updated [Apple requirements](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 </Note>
 
-The SDK will provide to your project a privacy manifest file during the build proccess only containing the required information used by the SDK. If you are providing your own privacyinfo.xcprivacy, you'll need to include the below rules on your privacyinfo.xcprivacy file. This guide will help you create the privacy manifest for your Xamarin applications.
+The SDK will provide to your project a privacy manifest file during the build process only containing the required information used by the SDK. If you are providing your own privacyinfo.xcprivacy, you'll need to include the below rules on your privacyinfo.xcprivacy file. This guide will help you create the privacy manifest for your Xamarin applications.
 
 ## Before You Start
 
@@ -58,7 +58,7 @@ After adding the privacy manifest file, don't forget to alter the file propertie
 
 - For more information about generating the privacy manifest using Xamarin, read the [Privacy manifests](https://devblogs.microsoft.com/dotnet/apple-privacy-manifest-support/) guide by Microsoft.
 
-- The listed APIs are required for the SDK to function corectly and there is no way to opt-out of them.
+- The listed APIs are required for the SDK to function correctly and there is no way to opt-out of them.
 
 - If you are using an older version of the SDK, you may need to update to version [2.1.0](https://github.com/getsentry/sentry-xamarin/releases/tag/2.1.0) or later to automatically include the privacy manifest if you haven't provided one.
 

--- a/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
@@ -1,0 +1,65 @@
+---
+title: Apple Privacy Manifest
+description: "Troubleshoot and resolve common issues with the Apple Privacy Manifest and Sentry Xamarin SDK."
+sidebar_order: 50
+---
+
+<Note>
+This guide requires [@sentry/xamarin@2.1.0](https://github.com/getsentry/sentry-xamarin/releases/tag/2.1.0) or newer.
+</Note>
+
+Sentry's SDKs provide error and performance monitoring for mobile applications running on Apple devices. To do this, the SDK needs to access certain information about the device and the application. Some of the APIs required for this are considered privacy-relevant by Apple. In order to submit apps to the App Store, Apple requires all apps - and libraries used within these apps - to provide privacy manifest files stating which APIs are used under which allowed reasons. For more details, read Apple's guidelines on [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+
+<Note>
+The information and steps in this guide are still being worked on and might change because of new tools or updated [Apple requirements](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+</Note>
+
+The SDK will provide to your project a privacy manifest file during the build proccess only containing the required information used by the SDK. If you are providing your own privacyinfo.xcprivacy, you'll need to include the below rules on your privacyinfo.xcprivacy file. This guide will help you create the privacy manifest for your Xamarin applications.
+
+## Before You Start
+
+Note that the application privacy manifest covers all data usages (via `NSPrivacyCollectedDataTypes`) and API usages (via `NSPrivacyAccessedAPITypes`) for the *whole application* and *all included libraries*. The examples below reflect the current requirements for the Sentry SDKs alone. If you are using other libraries that access privacy-relevant APIs, you need to include them in the privacy manifest as well.
+
+## Create Privacy Manifest in your Editor
+
+First, you need to create a privacy manifest file in your iOS project. This file should be named `PrivacyInfo.xcprivacy` and should be placed in the root of your Xcode project. Follow the [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#4284009) guide by Apple to create the file.
+
+```xml {filename:PrivacyInfo.xcprivacy}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>
+```
+
+After adding the privacy manifest file, don't forget to alter the file properties to `bundle resource` and `Copy to Output Directory` as `Copy if newer`
+
+## Troubleshooting
+
+- For more information about generating the privacy manifest using Xamarin, read the [Privacy manifests](https://devblogs.microsoft.com/dotnet/apple-privacy-manifest-support/) guide by Microsoft.
+
+- The listed APIs are required for the SDK to function corectly and there is no way to opt-out of them.
+
+- If you are using an older version of the SDK, you may need to update to version [2.1.0](https://github.com/getsentry/sentry-xamarin/releases/tag/2.1.0) or later to automatically include the privacy manifest if you haven't provided one.
+
+- To verify the privacy manifest is included in your app correctly, build and submit your app to the App Store or TestFlight for external testing. If the manifest is missing, you will receive an email from Apple with the subject, "The uploaded build for YourAppName has one or more issues", that lists the missing API declarations.

--- a/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/dotnet/guides/xamarin/data-management/apple-privacy-manifest.mdx
@@ -14,13 +14,13 @@ Sentry's SDKs provide error and performance monitoring for mobile applications r
 The information and steps in this guide are still being worked on and might change because of new tools or updated [Apple requirements](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 </Note>
 
-The SDK will provide to your project a privacy manifest file during the build process only containing the required information used by the SDK. If you are providing your own privacyinfo.xcprivacy, you'll need to include the below rules on your privacyinfo.xcprivacy file. This guide will help you create the privacy manifest for your Xamarin applications.
+During the build process, the SDK will provide your project a privacy manifest file containing only the required information used by the SDK. If you are providing your own privacy manifest, you'll need to include the below rules in your `privacyinfo.xcprivacy` file. This guide will help you create the privacy manifest for your Xamarin applications.
 
 ## Before You Start
 
 Note that the application privacy manifest covers all data usages (via `NSPrivacyCollectedDataTypes`) and API usages (via `NSPrivacyAccessedAPITypes`) for the *whole application* and *all included libraries*. The examples below reflect the current requirements for the Sentry SDKs alone. If you are using other libraries that access privacy-relevant APIs, you need to include them in the privacy manifest as well.
 
-## Create Privacy Manifest in your Editor
+## Create a Privacy Manifest
 
 First, you need to create a privacy manifest file in your iOS project. This file should be named `PrivacyInfo.xcprivacy` and should be placed in the root of your Xcode project. Follow the [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#4284009) guide by Apple to create the file.
 
@@ -52,7 +52,7 @@ First, you need to create a privacy manifest file in your iOS project. This file
 </plist>
 ```
 
-After adding the privacy manifest file, don't forget to alter the file properties to `bundle resource` and `Copy to Output Directory` as `Copy if newer`
+After adding the privacy manifest file, don't forget to alter the file properties to `bundle resource` and `Copy to Output Directory` as `Copy if newer`.
 
 ## Troubleshooting
 

--- a/docs/platforms/dotnet/guides/xamarin/data-management/index.mdx
+++ b/docs/platforms/dotnet/guides/xamarin/data-management/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Data Management
+description: Manage your events by pre-filtering, scrubbing sensitive information, and forwarding them to other systems.
+sidebar_order: 4000
+---
+
+<PageGrid />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Apple now requires the user projects to include a Privacy manifest file on their project, this PR aids the user on how to add this information on an Xamarin project and also informs the required fields when using Sentry.

## Legal Boilerplate

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
