### PR TITLE
ref(crons): Remove mentions of attachments (deprecated)

### DIFF
--- a/docs/platforms/elixir/crons/troubleshooting.mdx
+++ b/docs/platforms/elixir/crons/troubleshooting.mdx
@@ -4,8 +4,6 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 500
 ---
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -14,7 +12,7 @@ You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">l
 
 You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monitor</PlatformLink>.
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/platforms/java/common/crons/troubleshooting.mdx
+++ b/docs/platforms/java/common/crons/troubleshooting.mdx
@@ -4,8 +4,6 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 500
 ---
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -14,7 +12,7 @@ You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">l
 
 You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monitor</PlatformLink>.
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/platforms/javascript/common/crons/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/crons/troubleshooting.mdx
@@ -21,8 +21,6 @@ supported:
 
 <PlatformCategorySection supported={['server', 'serverless']}>
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -33,7 +31,7 @@ You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monito
 
 </PlatformCategorySection>
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/platforms/php/common/crons/troubleshooting.mdx
+++ b/docs/platforms/php/common/crons/troubleshooting.mdx
@@ -4,8 +4,6 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 500
 ---
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -14,7 +12,7 @@ You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">l
 
 You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monitor</PlatformLink>.
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -4,8 +4,6 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 500
 ---
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -14,7 +12,7 @@ You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">l
 
 You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monitor</PlatformLink>.
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/platforms/ruby/common/crons/troubleshooting.mdx
+++ b/docs/platforms/ruby/common/crons/troubleshooting.mdx
@@ -4,8 +4,6 @@ description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 500
 ---
 
-<PlatformContent includePath="crons/troubleshooting" />
-
 ### Why Aren't Recurring Job Errors Showing Up on My Monitor Details Page?
 
 You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">linked errors to your monitor</PlatformLink>.
@@ -14,7 +12,7 @@ You may not have <PlatformLink to="/crons/#connecting-errors-to-cron-monitors">l
 
 You may not have <PlatformLink to="/crons/#alerts">set up alerts for your monitor</PlatformLink>.
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/docs/product/crons/troubleshooting.mdx
+++ b/docs/product/crons/troubleshooting.mdx
@@ -19,7 +19,7 @@ You may not have [linked errors to your monitor](/product/crons/getting-started/
 
 You may not have [set up alerts for your monitor](/product/crons/getting-started/http/#alerts).
 
-### What Is the Crons Data Retention Policy for Check-ins and Attachments?
+### What Is the Crons Data Retention Policy for Check-ins?
 
 Our current data retention policy is 90 days.
 

--- a/platform-includes/crons/troubleshooting/elixir.mdx
+++ b/platform-includes/crons/troubleshooting/elixir.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by our Elixir SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/platform-includes/crons/troubleshooting/java.mdx
+++ b/platform-includes/crons/troubleshooting/java.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by our Java SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/platform-includes/crons/troubleshooting/javascript.mdx
+++ b/platform-includes/crons/troubleshooting/javascript.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by the SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/platform-includes/crons/troubleshooting/php.mdx
+++ b/platform-includes/crons/troubleshooting/php.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by our PHP SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/platform-includes/crons/troubleshooting/python.mdx
+++ b/platform-includes/crons/troubleshooting/python.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by our Python SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).

--- a/platform-includes/crons/troubleshooting/ruby.mdx
+++ b/platform-includes/crons/troubleshooting/ruby.mdx
@@ -1,3 +1,0 @@
-### How Do I Send an Attachment With a Check-in (Such as a Log Output)?
-
-Attachments aren't supported by our Ruby SDK yet. For now, you can use the [check-in attachments API](/product/crons/getting-started/http/#check-in-attachment-optional).


### PR DESCRIPTION
Removes mentions of attachments in troubleshooting docs for crons.