### PR TITLE
Add `maxCacheItems` to RN Options

### DIFF
--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -63,6 +63,12 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </ConfigKey>
 
+<ConfigKey name="max-cache-items">
+
+The maximum number of [envelopes](https://develop.sentry.dev/sdk/envelopes/) to keep in cache. The SDKs use envelopes to send data, such as events, attachments, user feedback, and sessions to sentry.io. An envelope can contain multiple items, such as an event with a session and two attachments. Depending on the usage of the SDK, the size of an envelope can differ. If the number of envelopes in the local cache exceeds `maxCacheItems`, the SDK deletes the oldest envelope and migrates the sessions to the next envelope to maintain the integrity of your release health stats. The default is `30`.
+
+</ConfigKey>
+
 <ConfigKey name="attach-stacktrace">
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.


### PR DESCRIPTION
- Implemented https://github.com/getsentry/sentry-react-native/blob/4d3618dd04096827f76057238a9f96f44abf04db/src/js/options.ts#L111

The desc is copied form the native SDKs.

- https://github.com/getsentry/sentry-docs/edit/master/docs/platforms/android/configuration/options.mdx