### PR TITLE
Adds more information about how to use fingerprint variables

### DIFF
--- a/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
+++ b/docs/product/data-management-settings/event-grouping/fingerprint-rules.mdx
@@ -6,7 +6,7 @@ description: "Learn about fingerprint rules, matchers for fingerprinting, how to
 
 <Include name="only-error-issues-note.mdx" />
 
-Fingerprint rules (previously known as _server-side fingerprinting_) are also configured with a config similar to [stack trace rules](../stack-trace-rules/), but the syntax is slightly different. The matchers are the same, but instead of flipping flags, a fingerprint is assigned and it overrides the default grouping entirely.
+Fingerprint rules (previously known as _server-side fingerprinting_) are also configured with a config similar to [stack trace rules](../stack-trace-rules/), but the syntax is slightly different. The matchers are the same, but instead of flipping flags, a fingerprint is assigned and it overrides the default grouping entirely. Assigning a fingerprint can also refine the default grouping rather than overriding it, if the fingerprint includes the value `{{ default }}`.
 
 These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Fingerprint Rules**. This setting has input fields where you can write custom fingerprinting rules. To update a rule:
 
@@ -172,7 +172,7 @@ error.type:ConnectionError stack.function:"connect" stack.module:"bot" -> bot-er
 
 ## Variables
 
-On the right-hand side of the fingerprint, you can use constant values and variables. Variables are substituted automatically and have the same name as matchers, but they might be filled in differently.
+On the right-hand side of the fingerprint, you can use constant values and variables. Variables are substituted automatically and have the same name as matchers, but they might be filled in differently. These variables can also be used when assigning fingerprints using Sentry SDKs.
 
 Variables are enclosed in double braces (`{{ variable_name }}`).
 


### PR DESCRIPTION
Problem
--------

- It was not clear from the documentation that variables in fingerprints would be interpreted for fingerprints set on the client side, outside of fingerprint rules.
- The documentation hinted that fingerprints disable default grouping.

Solution
--------

- Add context to the statement about overriding default grouping that makes it clear that you can still opt in to default grouping when using fingerprinting.
- Make it clear that fingerprint variables are not only evaluated on the right hand side of server-side rules, but also when included in fingerprints set via Sentry SDKs.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
