### PR TITLE
Added a guide for how to add a new platform icon to the docs

### DIFF
--- a/docs/contributing/approach/sdk-docs/common_content.mdx
+++ b/docs/contributing/approach/sdk-docs/common_content.mdx
@@ -11,7 +11,7 @@ For SDKs that have framework-specific docs (which we call guides or children), c
 
 ## Hierarchy
 
-What displays for the user relies upon the hierarchy of content as detailed in our content discussing [Platform Portals](/contributing/platforms/). In short, a guide's content displays if provided. If not provided, then the platform content displays.
+What displays for the user relies upon the hierarchy of content as detailed in our content discussing [Platforms & Guides](/contributing/platforms/). In short, a guide's content displays if provided. If not provided, then the platform content displays.
 
 ## Tuning Common Content
 

--- a/docs/contributing/platforms/index.mdx
+++ b/docs/contributing/platforms/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Platform Portals
+title: Platforms & Guides
 noindex: true
 sidebar_order: 3
 ---
@@ -111,7 +111,7 @@ There are a number of components that aid the development of platform specific p
 
 ## Delineation
 
-We separate platform portals by the main way or mechanism that developers interact with the platform and with Sentry.
+We separate platforms by the main way or mechanism that developers interact with the platform and with Sentry.
 
 In general, use this decision tree:
 

--- a/docs/contributing/platforms/index.mdx
+++ b/docs/contributing/platforms/index.mdx
@@ -111,7 +111,7 @@ There are a number of components that aid the development of platform specific p
 
 ## Delineation
 
-We separate platforms by the main way or mechanism that developers interact with the platform and with Sentry.
+We differentiate platforms by language and developer interaction. A top-level SDK is considered a platform. A platform may have guides for frameworks that it supports, and these guides often inherit much of their content from their parent platform.
 
 In general, use this decision tree:
 

--- a/docs/contributing/platforms/platform-icons/index.mdx
+++ b/docs/contributing/platforms/platform-icons/index.mdx
@@ -3,33 +3,32 @@ title: Platform Icons
 sidebar_order: 1
 ---
 
-To have consistent icons for all supported platforms over all of Sentry (the product, the docs, landing pages, etc) we created a repo for managing those icons, it is called [platformicons](https://github.com/getsentry/platformicons).
+To have consistent icons for all supported platforms across all of Sentry (the product, the docs, landing pages, etc.) we created a repo for managing those icons, called [platformicons](https://github.com/getsentry/platformicons).
 
-If there is a new platform we support, there are several steps to be done, so the new icon can be used in the docs:
+If a new platform is added, follow these steps to add a new icon that can be used in the docs:
 
 1. **Add the new icon to `platformicons`:**
 
-    Create a [new issue on the platformicons repository](https://github.com/getsentry/platformicons/issues) and specify how the icon should be named and a link to the website of the platform you want to add. Also, make sure to describe whether it is a top level icon (like `python`) or a subitem that is only available in one specific platform (like `python.celery`).
+    Create a [new issue in the platformicons repository](https://github.com/getsentry/platformicons/issues) that specifies how the icon should be named and includes a link to the platform's website. Also, make sure to specify whether it is a top-level icon (like `python`) or a subitem that is only available in one specific platform (like `python.celery`).
 
-    You can also create a PR in the repository where you add two versions of the icon. See [README.md](https://github.com/getsentry/platformicons) for the format.
+    You can also create a PR in the `platformicons` repository where you add two versions of the icon. See the [README](https://github.com/getsentry/platformicons) for more info on formatting.```
 
 2. **Release a new version of `platformicons` to NPM.**
 
-    If you are a Sentry employee follow the [README.md](https://github.com/getsentry/platformicons) on how to do a release.
+    If you are a Sentry employee, follow the [README.md](https://github.com/getsentry/platformicons) on how to do a release.
 
-    If you are not a Sentry employee ask on our [Discord server](https://discord.com/invite/Ww9hbqr) so someone can review your contribution and trigger the release.
+    If you are not a Sentry employee, ask on our [Discord server](https://discord.com/invite/Ww9hbqr) so someone can review your contribution and trigger the release.
 
-3. **Update the `platformicons` version used in docs repository.**
+3. **Update the `platformicons` version used in the docs repository.**
 
     Update the version of your newly released `platformicons` in `package.json` and run `yarn install` to also have the new version in `yarn.lock`.
 
 4. **Make it available as a component in the docs repository.**
 
-    Update [platformIcon.tsx](https://github.com/getsentry/sentry-docs/blob/master/src/components/platformIcon.tsx) to have your new icon.
+    Update [platformIcon.tsx](https://github.com/getsentry/sentry-docs/blob/master/src/components/platformIcon.tsx) to include your new icon. Make sure to:
 
-    You need to:
-    - add two imports (one for each version of the icon)
-    - add it to `formatToSVG`
-    - add it to `PLATFORM_TO_ICON`
+    - Add two imports (one for each version of the icon).
+    - Add the icons to `formatToSVG`.
+    - Add a mapping for the platform and icon to `PLATFORM_TO_ICON`.
 
-4. **Now the new Icon is available in the docs and will be used wherever icons are rendered!**
+Now the new icon is available in the docs and will be used wherever icons are rendered!

--- a/docs/contributing/platforms/platform-icons/index.mdx
+++ b/docs/contributing/platforms/platform-icons/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Platform Icons
+sidebar_order: 1
+---
+
+To have consistent icons for all supported platforms over all of Sentry (the product, the docs, landing pages, etc) we created a repo for managing those icons, it is called [platformicons](https://github.com/getsentry/platformicons).
+
+If there is a new platform we support, there are several steps to be done, so the new icon can be used in the docs:
+
+1. **Add the new icon to `platformicons`:**
+
+    Create a [new issue on the platformicons repository](https://github.com/getsentry/platformicons/issues) and specify how the icon should be named and a link to the website of the platform you want to add. Also, make sure to describe whether it is a top level icon (like `python`) or a subitem that is only available in one specific platform (like `python.celery`).
+
+    You can also create a PR in the repository where you add two versions of the icon. See [README.md](https://github.com/getsentry/platformicons) for the format.
+
+2. **Release a new version of `platformicons` to NPM.**
+
+    If you are a Sentry employee follow the [README.md](https://github.com/getsentry/platformicons) on how to do a release.
+
+    If you are not a Sentry employee ask on our [Discord server](https://discord.com/invite/Ww9hbqr) so someone can review your contribution and trigger the release.
+
+3. **Update the `platformicons` version used in docs repository.**
+
+    Update the version of your newly released `platformicons` in `package.json` and run `yarn install` to also have the new version in `yarn.lock`.
+
+4. **Make it available as a component in the docs repository.**
+
+    Update [platformIcon.tsx](https://github.com/getsentry/sentry-docs/blob/master/src/components/platformIcon.tsx) to have your new icon.
+
+    You need to:
+    - add two imports (one for each version of the icon)
+    - add it to `formatToSVG`
+    - add it to `PLATFORM_TO_ICON`
+
+4. **Now the new Icon is available in the docs and will be used wherever icons are rendered!**


### PR DESCRIPTION
Because there are several steps that one must do to make a new platform icon to work in docs. 

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
