### PR TITLE
chore: Update min versions in apple privacy docs

### DIFF
--- a/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/apple/common/data-management/apple-privacy-manifest.mdx
@@ -5,7 +5,7 @@ sidebar_order: 50
 ---
 
 <Note>
-This guide requires [sentry-cocoa@8.21.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.21.0) or newer.
+This guide requires [sentry-cocoa@8.25.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.25.0) or newer.
 </Note>
 
 Sentry's SDKs provide error and performance monitoring for mobile applications running on Apple devices. To do this, the SDK needs to access certain information about the device and the application. Some of the APIs required for this are considered privacy-relevant by Apple. In order to submit apps to the App Store, Apple requires all apps - and libraries used within these apps - to provide privacy manifest files stating which APIs are used under which allowed reasons. For more details, read Apple's guidelines on [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
@@ -101,6 +101,6 @@ Note that the application privacy manifest covers all data usages (via `NSPrivac
 
 - The listed APIs are required for the SDK to function correctly and there is no way to opt-out of them.
 
-- If you are using an older version of the SDK, you may need to update to version [8.21.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.21.0) or later to automatically include the privacy manifest for dynamically linked frameworks.
+- If you are using an older version of the SDK, you may need to update to version [8.25.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.25.0) or later to automatically include the privacy manifest for dynamically linked frameworks.
 
 - To verify the privacy manifest is included in your app correctly, build and submit your app to the App Store or TestFlight for external testing. If the manifest is missing, you will receive an email from Apple with the subject, "The uploaded build for YourAppName has one or more issues", that lists the missing API declarations.

--- a/docs/platforms/flutter/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/flutter/data-management/apple-privacy-manifest.mdx
@@ -5,7 +5,7 @@ sidebar_order: 50
 ---
 
 <Note>
-This guide requires [@sentry/dart@7.17.0](https://github.com/getsentry/sentry-dart/releases/tag/7.17.0) or newer.
+This guide requires [@sentry/dart@7.20.1](https://github.com/getsentry/sentry-dart/releases/tag/7.20.1) or newer.
 </Note>
 
 Sentry's SDKs provide error and performance monitoring for mobile applications running on Apple devices. To do this, the SDK needs to access certain information about the device and the application. Some of the APIs required for this are considered privacy-relevant by Apple. In order to submit apps to the App Store, Apple requires all apps - and libraries used within these apps - to provide privacy manifest files stating which APIs are used under which allowed reasons. For more details, read Apple's guidelines on [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
@@ -101,6 +101,6 @@ Note that the application privacy manifest covers all data usages (via `NSPrivac
 
 - The listed APIs are required for the SDK to function correctly and there is no way to opt-out of them.
 
-- If you are using an older version of the SDK, you may need to update to version [7.17.0](https://github.com/getsentry/sentry-dart/releases/tag/7.17.0) or later to automatically include the privacy manifest for dynamically linked frameworks.
+- If you are using an older version of the SDK, you may need to update to version [7.20.1](https://github.com/getsentry/sentry-dart/releases/tag/7.20.1) or later to automatically include the privacy manifest for dynamically linked frameworks.
 
 - To verify the privacy manifest is included in your app correctly, build and submit your app to the App Store or TestFlight for external testing. If the manifest is missing, you will receive an email from Apple with the subject, "The uploaded build for YourAppName has one or more issues", that lists the missing API declarations.

--- a/docs/platforms/react-native/data-management/apple-privacy-manifest.mdx
+++ b/docs/platforms/react-native/data-management/apple-privacy-manifest.mdx
@@ -5,7 +5,7 @@ sidebar_order: 50
 ---
 
 <Note>
-This guide requires [@sentry/react-native@5.19.3](https://github.com/getsentry/sentry-react-native/releases/tag/5.19.3) or newer.
+This guide requires [@sentry/react-native@5.22.1](https://github.com/getsentry/sentry-react-native/releases/tag/5.22.1) or newer.
 </Note>
 
 Sentry's SDKs provide error and performance monitoring for mobile applications running on Apple devices. To do this, the SDK needs to access certain information about the device and the application. Some of the APIs required for this are considered privacy-relevant by Apple. In order to submit apps to the App Store, Apple requires all apps - and libraries used within these apps - to provide privacy manifest files stating which APIs are used under which allowed reasons. For more details, read Apple's guidelines on [Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
@@ -101,7 +101,7 @@ First, you need to create a privacy manifest file in your Xcode project. This fi
 
 ## Create Privacy Manifest in Expo
 
-Depending on the Expo application setup, if you're using Continuous Native Generation ([CNG](https://docs.expo.dev/workflow/continuous-native-generation/)), then you may need to add the privacy manifest to the `app.json` file. Otherwise, you can add your privacy manifest using Xcode. 
+Depending on the Expo application setup, if you're using Continuous Native Generation ([CNG](https://docs.expo.dev/workflow/continuous-native-generation/)), then you may need to add the privacy manifest to the `app.json` file. Otherwise, you can add your privacy manifest using Xcode.
 
 ```json {filename:app.json}
 {
@@ -156,6 +156,6 @@ Depending on the Expo application setup, if you're using Continuous Native Gener
 
 - The listed APIs are required for the SDK to function correctly and there is no way to opt-out of them.
 
-- If you are using an older version of the SDK, you may need to update to version [5.19.3](https://github.com/getsentry/sentry-react-native/releases/tag/5.19.3) or later to automatically include the privacy manifest for dynamically linked frameworks.
+- If you are using an older version of the SDK, you may need to update to version [5.22.1](https://github.com/getsentry/sentry-react-native/releases/tag/5.22.1) or later to automatically include the privacy manifest for dynamically linked frameworks.
 
 - To verify the privacy manifest is included in your app correctly, build and submit your app to the App Store or TestFlight for external testing. If the manifest is missing, you will receive an email from Apple with the subject, "The uploaded build for YourAppName has one or more issues", that lists the missing API declarations.


### PR DESCRIPTION
updates min versions listed in apple privacy manifest docs for cocoa, RN and flutter