### PR TITLE
fix: added params for filters on changelog listing page

### DIFF
--- a/src/components/changelog/list.tsx
+++ b/src/components/changelog/list.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {type Category, type Changelog} from '@prisma/client';
 import Link from 'next/link';
+import {usePathname, useRouter, useSearchParams} from 'next/navigation';
 
 import Article from 'sentry-docs/components/changelog/article';
 import Pagination from 'sentry-docs/components/changelog/pagination';
@@ -19,12 +20,32 @@ export default function Changelogs({
 }: {
   changelogs: ChangelogWithCategories[];
 }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   const [pageNumber, setPageNumber] = useState(1);
   const [searchValue, setSearchValue] = useState('');
-  const [selectedCategories, setSelectedCategory] = useState<Category[]>([]);
-  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
+  const [selectedCategoriesIds, setSelectedCategoriesIds] = useState<string[]>(
+    searchParams?.get('categories')?.split(',') || []
+  );
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(
+    searchParams?.get('month') || null
+  );
 
-  const filtered = selectedCategories.length || searchValue || selectedMonth;
+  useEffect(() => {
+    const params: string[] = [];
+    if (selectedCategoriesIds.length > 0) {
+      params.push(`categories=${selectedCategoriesIds.join(',')}`);
+    }
+    if (selectedMonth) {
+      params.push(`month=${selectedMonth}`);
+    }
+    router.push(pathname + '?' + params.join('&'));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCategoriesIds, selectedMonth]);
+
+  const filtered = selectedCategoriesIds.length || searchValue || selectedMonth;
 
   const filteredChangelogs = changelogs
     .filter((changelog: ChangelogWithCategories) => {
@@ -42,11 +63,9 @@ export default function Changelogs({
       const searchContent = changelog.title + changelog.summary + categories;
       return (
         searchContent.toLowerCase().includes(searchValue.toLowerCase()) &&
-        (!selectedCategories.length ||
-          selectedCategories.some(selectedCategory =>
-            changelog.categories.some(
-              changelogCategory => changelogCategory.id === selectedCategory.id
-            )
+        (!selectedCategoriesIds.length ||
+          selectedCategoriesIds.some(catId =>
+            changelog.categories.some(changelogCategory => changelogCategory.id === catId)
           )) &&
         (!selectedMonth || selectedMonth === postMonthYear)
       );
@@ -127,17 +146,19 @@ export default function Changelogs({
             return (
               <a
                 onClick={() => {
-                  if (selectedCategories.includes(category)) {
-                    setSelectedCategory(selectedCategories.filter(c => c !== category));
+                  if (selectedCategoriesIds.includes(category.id)) {
+                    setSelectedCategoriesIds(
+                      selectedCategoriesIds.filter(cat => cat !== category.id)
+                    );
                   } else {
-                    setSelectedCategory([...selectedCategories, category]);
+                    setSelectedCategoriesIds([...selectedCategoriesIds, category.id]);
                   }
                 }}
                 key={category.name}
               >
                 <Tag
                   text={category.name}
-                  active={selectedCategories.includes(category)}
+                  active={selectedCategoriesIds.includes(category.id)}
                   pointer
                 />
               </a>
@@ -161,7 +182,7 @@ export default function Changelogs({
                 className={`${filtered ? 'text-purple font-medium cursor-pointer' : 'text-gray-500 cursor-not-allowed'} hover:text-gray-700`}
                 onClick={() => {
                   setSearchValue('');
-                  setSelectedCategory([]);
+                  setSelectedCategoriesIds([]);
                   setSelectedMonth(null);
                 }}
               >
@@ -196,7 +217,6 @@ export default function Changelogs({
             <li key={index}>
               <a
                 className={`text-primary hover:text-purple-900 hover:font-extrabold ${selectedMonth === month ? 'underline' : ''}`}
-                href={`#${month}`}
                 onClick={e => {
                   e.preventDefault();
                   if (selectedMonth === month) {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
#9410 

Added params for both date and categories that'll help in sharing the changelog filtered blogs.