### PR TITLE
feat(js/angualar): Update Angular docs for v8

### DIFF
--- a/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
+++ b/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
@@ -3,7 +3,7 @@ title: Track Angular Components
 description: "Learn how Sentry's Angular SDK allows you to monitor the rendering performance of your application and its components."
 ---
 
-Sentry's Angular SDK offers a feature to monitor the performance of your Angular components: component tracking. Enabling this feature provides you with spans in your transactions that show the initialization and update cycles of your Angular components. This allows you to get a drilled-down view into how your components are behaving so you can do things like identify slow initializations or frequent updates, which might have an impact on your app's performance.
+Sentry's Angular SDK offers a feature to monitor the performance of your Angular components: Component Tracking. Enabling this feature provides you with spans in your transactions that show the initialization and update cycles of your Angular components. This allows you to get a drilled-down view into how your components are behaving so you can identify slow initializations or frequent updates, which might have an impact on your app's performance.
 
 <Alert>
 
@@ -13,25 +13,14 @@ To set up component tracking, you need to configure performance monitoring. For 
 
 To track your components as part of your transactions, use any (or a combination) of the following options.
 
-## Using `TraceDirective`
+## Using the `trace` directive
 
-`TraceDirective` tracks a duration between the `OnInit` and `AfterViewInit` lifecycle hooks in your component template. It adds spans called **`ui.angular.init`** to the currently active transaction that allows you to track specific individual instances of your components. If you want to track all instances instead, use [`TraceClassDecorator`](#using-traceclassdecorator).
+Our `TraceDirective` tracks a duration between the `OnInit` and `AfterViewInit` lifecycle hooks in your component template. It adds spans called **`ui.angular.init`** to the currently active transaction that allows you to track specific individual instances of your components. If you want to track all instances instead, use [`TraceClass`](#using-traceclass).
 
 Import `TraceModule` either globally in your application's `app.module.ts` file or in the module(s) in which
 you want to track your components:
 
-```typescript {filename:app.module.ts} {tabTitle:Angular 12+}
-import * as Sentry from "@sentry/angular-ivy";
-
-@NgModule({
-  // ...
-  imports: [Sentry.TraceModule],
-  // ...
-})
-export class AppModule {}
-```
-
-```typescript {filename:app.module.ts} {tabTitle:Angular 10/11}
+```typescript {filename:app.module.ts} {1,5}
 import * as Sentry from "@sentry/angular";
 
 @NgModule({
@@ -44,44 +33,19 @@ export class AppModule {}
 
 Then, in your component's template, add the directive to all components you want to track. Remember to give the `trace` attribute a name, which will be shown in the span's description:
 
-```html {filename:app.component.ts}
-<app-header [trace]="'header'"></app-header>
-<articles-list [trace]="'articles-list'"></articles-list>
-<app-footer [trace]="'footer'"></app-footer>
+```html {filename:app.component.(ts|html)}
+<app-header trace="header"></app-header>
+<articles-list trace="articles-list"></articles-list>
+<app-footer trace="footer"></app-footer>
 ```
 
-<Alert level="info" title="Compatibility">
+## Using `TraceClass`
 
-If you're using version 6 of the Angular SDK, using `TraceDirective` or `TraceModule` causes a
-compiler error at application compile time of your Angular application. This is a [known issue](https://github.com/getsentry/sentry-javascript/issues/3282)
-of our Angular SDK v6 and it was [fixed](https://github.com/getsentry/sentry-javascript/issues/4644)
-in version 7. We recommend upgrading to the latest Angular SDK version.
-Otherwise, please use the other options (`TraceClassDecorator` and `TraceMethodDecorator`)
-below to track your Angular components.
+The `TraceClass` decorator tracks the duration between the `OnInit` and `AfterViewInit` lifecycle hooks in components. It adds spans called **`ui.angular.init`** to the currently active transaction. In contrast to the [`trace` directive](#using-the-trace-directive), `TraceClassDecorator` tracks all instances of the component(s) you add it to, creating spans for each component instance.
 
-</Alert>
+Just add `TraceClass` decorator with a component name to the components you want to track:
 
-## Using `TraceClassDecorator`
-
-`TraceClassDecorator` tracks the duration between the `OnInit` and `AfterViewInit` lifecycle hooks in components. It adds spans called **`ui.angular.init`** to the currently active transaction. In contrast to [`TraceDirective`](#using-tracedirective), `TraceClassDecorator` tracks all instances of the component(s) you add it to, creating spans for each component instance.
-
-Just add `TraceClassDecorator` to the components you want to track:
-
-```javascript {filename:header.component.ts} {tabTitle: Angular 12+}
-import { Component } from "@angular/core";
-import * as Sentry from "@sentry/angular-ivy";
-
-@Component({
-  selector: "app-header",
-  templateUrl: "./header.component.html",
-})
-@Sentry.TraceClassDecorator()
-export class HeaderComponent {
-  // ...
-}
-```
-
-```javascript {filename:header.component.ts} {tabTitle: Angular 10/11}
+```typescript {filename:header.component.ts} {2,8}
 import { Component } from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
@@ -89,31 +53,19 @@ import * as Sentry from "@sentry/angular";
   selector: "app-header",
   templateUrl: "./header.component.html",
 })
-@Sentry.TraceClassDecorator()
+@Sentry.TraceClass({ name: "Header" })
 export class HeaderComponent {
   // ...
 }
 ```
 
-## Using `TraceMethodDecorator`
+Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceClass` decorator. Otherwise, spans will refer to the component as `<unnamed>`
 
-`TraceMethodDecorator` tracks specific component lifecycle hooks as point-in-time spans. The added spans are called **`ui.angular.[methodname]`** (like, `ui.angular.ngOnChanges`). For example, you can use this decorator to track how often component changes are detected during an ongoing transaction:
+## Using `TraceMethod`
 
-```javascript {filename:login.component.ts} {tabTitle: Angular 12+}
-import { Component, OnInit } from "@angular/core";
-import * as Sentry from "@sentry/angular-ivy";
+The `TraceMethod` decorator tracks specific component lifecycle hooks as point-in-time spans. The added spans are called **`ui.angular.[methodname]`** (like, `ui.angular.ngOnChanges`). For example, you can use this decorator to track how often component changes are detected:
 
-@Component({
-  selector: "app-login",
-  templateUrl: "./login.component.html",
-})
-export class LoginComponent implements OnChanges {
-  @Sentry.TraceMethodDecorator()
-  ngOnChanges(changes: SimpleChanges) {}
-}
-```
-
-```javascript {filename:login.component.ts} {tabTitle: Angular 10/11}
+```typescript {filename:login.component.ts} {2,9}
 import { Component, OnInit } from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
@@ -122,38 +74,24 @@ import * as Sentry from "@sentry/angular";
   templateUrl: "./login.component.html",
 })
 export class LoginComponent implements OnChanges {
-  @Sentry.TraceMethodDecorator()
-  ngOnChanges(changes: SimpleChanges) {}
+  @Sentry.TraceMethod({ name: "Login.ngOnChanges" })
+  ngOnChanges(changes: SimpleChanges) {
+    // ...
+  }
 }
 ```
+
+Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceMethod` decorator. Otherwise, created spans will refer to the component as `<unnamed>`
 
 ## Advanced Usage
 
-You can combine our tracking utilities and track the bootstrapping duration of your app.
+You can combine our component tracking utilities and track the bootstrapping duration of your app.
 
 ### Combining Component Tracking Utilities
 
 To get the best insights into your components' performance, you can combine `TraceDirective`, `TraceClassDecorator`, and `TraceMethodDecorator`. This allows you to track component initialization durations as well as arbitrary lifecycle events, such as change and destroy events:
 
-```javascript {filename:user-card.component.ts} {tabTitle: Angular 12+}
-import { Component, OnInit } from "@angular/core";
-import * as Sentry from "@sentry/angular-ivy";
-
-@Component({
-  selector: "app-user-card",
-  templateUrl: "./user-card.component.html",
-})
-@Sentry.TraceClassDecorator()
-export class UserCardComponent implements OnChanges, OnDestroy {
-  @Sentry.TraceMethodDecorator()
-  ngOnChanges(changes: SimpleChanges) {}
-
-  @Sentry.TraceMethodDecorator()
-  ngOnDestroy() {}
-}
-```
-
-```javascript {filename:user-card.component.ts} {tabTitle: Angular 10/11}
+```typescript {filename:user-card.component.ts} {2,8,10,13}
 import { Component, OnInit } from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
@@ -161,19 +99,19 @@ import * as Sentry from "@sentry/angular";
   selector: "app-user-card",
   templateUrl: "./user-card.component.html",
 })
-@Sentry.TraceClassDecorator()
+@Sentry.TraceClass()
 export class UserCardComponent implements OnChanges, OnDestroy {
-  @Sentry.TraceMethodDecorator()
+  @Sentry.TraceMethod()
   ngOnChanges(changes: SimpleChanges) {}
 
-  @Sentry.TraceMethodDecorator()
+  @Sentry.TraceMethod()
   ngOnDestroy() {}
 }
 ```
 
-User `TraceDirective` if you only want to track components in certain instances or locations:
+Use the `trace` directive if you only want to track components in certain instances or locations:
 
-```html {filename: user-card.component.html}
+```html {filename: user-card.component.html} {2,5}
 <div>
   <app-icon trace="user-icon">user</app-icon>
   <label>{{ user.name }}</label>
@@ -186,10 +124,10 @@ User `TraceDirective` if you only want to track components in certain instances 
 
 You can add your own custom spans using `startSpan()`. For example, you can track the duration of the Angular bootstrapping process to find out how long your app takes to bootstrap on your users' devices:
 
-```javascript {tabTitle: Angular 12+} {filename:main.ts}
+```typescript {filename:main.ts} {3,9-20}
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import * as Sentry from "@sentry/angular-ivy";
+import * as Sentry from "@sentry/angular";
 
 import { AppModule } from "./app/app.module";
 
@@ -203,30 +141,6 @@ Sentry.startSpan(
   async () => {
     await platformBrowserDynamic()
       .bootstrapModule(AppModule)
-      .then(() => console.log(`Bootstrap success`))
-      .catch((err) => console.error(err));
-  }
-);
-```
-
-```javascript {tabTitle: Angular 10/11} {filename:main.ts}
-import { enableProdMode } from "@angular/core";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import * as Sentry from "@sentry/angular";
-
-import { AppModule } from "./app/app.module";
-
-// ...
-
-Sentry.startSpan(
-  {
-    name: "platform-browser-dynamic",
-    op: "ui.angular.bootstrap",
-  },
-  async () => {
-    await platformBrowserDynamic()
-      .bootstrapModule(AppModule)
-      .then(() => console.log(`Bootstrap success`))
       .catch((err) => console.error(err));
   }
 );

--- a/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
+++ b/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
@@ -3,7 +3,7 @@ title: Track Angular Components
 description: "Learn how Sentry's Angular SDK allows you to monitor the rendering performance of your application and its components."
 ---
 
-Sentry's Angular SDK offers a feature to monitor the performance of your Angular components: Component Tracking. Enabling this feature provides you with spans in your transactions that show the initialization and update cycles of your Angular components. This allows you to get a drilled-down view into how your components are behaving so you can identify slow initializations or frequent updates, which might have an impact on your app's performance.
+Sentry's Angular SDK offers a feature to monitor the performance of your Angular components: Component Tracking. Enabling this feature provides you with spans in your transactions that show the initialization and update cycles of your Angular components. This allows you to drill down into how your components are behaving so you can identify slow initializations or frequent updates, which might have an impact on your app's performance.
 
 <Alert>
 
@@ -59,7 +59,7 @@ export class HeaderComponent {
 }
 ```
 
-Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceClass` decorator. Otherwise, spans will refer to the component as `<unnamed>`
+Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceClass` decorator. Otherwise, spans will refer to the component as `<unnamed>`.
 
 ## Using `TraceMethod`
 
@@ -81,7 +81,7 @@ export class LoginComponent implements OnChanges {
 }
 ```
 
-Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceMethod` decorator. Otherwise, created spans will refer to the component as `<unnamed>`
+Note: Due to code minification in production builds, you need to pass a `name` property to the `TraceMethod` decorator. Otherwise, created spans will refer to the component as `<unnamed>`.
 
 ## Advanced Usage
 

--- a/platform-includes/capture-error/javascript.angular.mdx
+++ b/platform-includes/capture-error/javascript.angular.mdx
@@ -1,16 +1,6 @@
 You can pass an `Error` object to `captureException()` to get it captured as event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stack trace.
 
-```javascript {tabTitle: Angular 12+}
-import * as Sentry from "@sentry/angular-ivy";
-
-try {
-  aFunctionThatMightFail();
-} catch (err) {
-  Sentry.captureException(err);
-}
-```
-
-```javascript {tabTitle: Angular 10/11}
+```typescript {filename:some.component.ts} {1,6}
 import * as Sentry from "@sentry/angular";
 
 try {

--- a/platform-includes/enriching-events/import/javascript.angular.mdx
+++ b/platform-includes/enriching-events/import/javascript.angular.mdx
@@ -1,7 +1,3 @@
-```javascript {tabTitle: Angular 12+}
-import * as Sentry from "@sentry/angular-ivy";
-```
-
-```javascript {tabTitle: Angular 10/11}
+```javascript
 import * as Sentry from "@sentry/angular";
 ```

--- a/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/platform-includes/getting-started-config/javascript.angular.mdx
@@ -2,10 +2,10 @@ Once this is done, Sentry's Angular SDK captures all unhandled exceptions and tr
 
 <SignInNote />
 
-```javascript {tabTitle: Angular 12+}{filename: main.ts}
+```typescript {filename: main.ts} {3, 6-30}
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import * as Sentry from "@sentry/angular-ivy";
+import * as Sentry from "@sentry/angular";
 import { AppModule } from "./app/app.module";
 
 Sentry.init({
@@ -36,65 +36,17 @@ Sentry.init({
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
-  .then(success => console.log(`Bootstrap success`))
-  .catch(err => console.error(err));
+  .catch((err) => console.error(err));
 ```
 
-```javascript {tabTitle: Angular 10/11}{filename: main.ts}
-import { enableProdMode } from "@angular/core";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import * as Sentry from "@sentry/angular";
-import { AppModule } from "./app/app.module";
+### Register Sentry Providers
 
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Registers and configures the Tracing integration,
-    // which automatically instruments your application to monitor its
-    // performance, including custom Angular routing instrumentation
-    Sentry.browserTracingIntegration()
-  ],
+The Sentry Angular SDK exports a couple of Angular providers that are necessary to fully instrument your application. We recommend registering them in your main `AppModule`:
 
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
+```typescript {filename: app.module.ts} {4, 9-22}
+import { APP_INITIALIZER, ErrorHandler, NgModule } from "@angular/core";
+import { Router } from "@angular/router";
 
-  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-});
-
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .then(success => console.log(`Bootstrap success`))
-  .catch(err => console.error(err));
-```
-
-### Automatically Send Errors with `ErrorHandler`
-
-The Angular SDK exports a function to instantiate an `ErrorHandler` provider that will automatically send JavaScript errors captured by Angular's error handler.
-
-```javascript {tabTitle: Angular 12+}{filename: app.module.ts}
-import { NgModule, ErrorHandler } from "@angular/core";
-import * as Sentry from "@sentry/angular-ivy";
-
-@NgModule({
-  // ...
-  providers: [
-    {
-      provide: ErrorHandler,
-      useValue: Sentry.createErrorHandler({
-        showDialog: true,
-      }),
-    },
-  ],
-  // ...
-})
-export class AppModule {}
-```
-
-```javascript {tabTitle: Angular 10/11}{filename: app.module.ts}
-import { NgModule, ErrorHandler } from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
 @NgModule({
@@ -102,76 +54,12 @@ import * as Sentry from "@sentry/angular";
   providers: [
     {
       provide: ErrorHandler,
-      useValue: Sentry.createErrorHandler({
-        showDialog: true,
-      }),
+      useValue: Sentry.createErrorHandler(),
     },
-  ],
-  // ...
-})
-export class AppModule {}
-```
-
-You can configure the behavior of `createErrorHandler`. For more details see the `ErrorHandlerOptions` interface in [our repository](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
-
-### Register `TraceService`
-
-For performance monitoring, register `TraceService` as a provider with a `Router` as its dependency:
-
-```javascript {tabTitle: Angular 12+}{filename: app.module.ts}
-import { NgModule } from "@angular/core";
-import { Router } from "@angular/router";
-import * as Sentry from "@sentry/angular-ivy";
-
-@NgModule({
-  // ...
-  providers: [
     {
       provide: Sentry.TraceService,
       deps: [Router],
     },
-  ],
-  // ...
-})
-export class AppModule {}
-```
-
-```javascript {tabTitle: Angular 10/11}{filename: app.module.ts}
-import { NgModule } from "@angular/core";
-import { Router } from "@angular/router";
-import * as Sentry from "@sentry/angular";
-
-@NgModule({
-  // ...
-  providers: [
-    {
-      provide: Sentry.TraceService,
-      deps: [Router],
-    },
-  ],
-  // ...
-})
-export class AppModule {}
-```
-
-Then, either require the `TraceService` from inside `AppModule` or use `APP_INITIALIZER` to force instantiate Tracing.
-
-```javascript {filename: app.module.ts}
-@NgModule({
-  // ...
-})
-export class AppModule {
-  constructor(trace: Sentry.TraceService) {}
-}
-```
-
-or
-
-```javascript {filename: app.module.ts}
-import { APP_INITIALIZER } from "@angular/core";
-@NgModule({
-  // ...
-  providers: [
     {
       provide: APP_INITIALIZER,
       useFactory: () => () => {},
@@ -182,4 +70,17 @@ import { APP_INITIALIZER } from "@angular/core";
   // ...
 })
 export class AppModule {}
+```
+
+The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. You can also customize the behavior by setting a couple of handler [options](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
+
+The `Sentry.TraceService` listens to the Angular router for performance monitoring and tracing. To inject `TraceService`, register the `APP_INITIALIZER` provider as shown above. Alternatively, you can also require the `TraceService` from inside your `AppModule` constructor:
+
+```javascript {filename: app.module.ts} {5}
+@NgModule({
+  // ...
+})
+export class AppModule {
+  constructor(trace: Sentry.TraceService) {}
+}
 ```

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -4,8 +4,7 @@ Then forward the `init` method from the sibling Sentry SDK for the framework you
 
 ```typescript {tabTitle: Angular} {filename: app.module.ts}
 import * as Sentry from "@sentry/capacitor";
-// Use @sentry/angular-ivy for Angular 12+ or `@sentry/angular` from Angular 10 and 11
-import * as SentryAngular from "@sentry/angular-ivy";
+import * as SentryAngular from "@sentry/angular";
 
 Sentry.init(
   {

--- a/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/platform-includes/getting-started-install/javascript.angular.mdx
@@ -1,37 +1,35 @@
 ```bash {tabTitle:npm}
-# Angular 12 and newer:
-npm install --save @sentry/angular-ivy
-
-# Angular 10 and 11:
 npm install --save @sentry/angular
 ```
 
 ```bash {tabTitle:Yarn}
-# Angular 12 and newer:
-yarn add @sentry/angular-ivy
-
-# Angular 10 and 11:
 yarn add @sentry/angular
 ```
 
 ### Angular Version Compatibility
 
-Because of the way Angular libraries are compiled, you need to use a specific version of the Sentry SDK for each corresponding version of Angular as shown below:
+The Sentry Angular SDK supports Angular 14 and newer in its current major version.
 
-| Angular version | Recommended Sentry SDK |
-| --------------- | ---------------------- |
-| 12 and newer    | `@sentry/angular-ivy`  |
-| 10, 11          | `@sentry/angular`      |
-| Older versions  | See note below         |
+If you're using an older version of Angular, you also need to use an older version of the SDK:
 
-<Alert level="warning">
-
-Support for any Angular version below 10 was discontinued in version 7 of the SDK. If you need to use Angular 9 or older, try version 6 (`@sentry/angular@^6.x`) of the SDK. For AngularJS/1.x, use `@sentry/browser@^6.x` and our [AngularJS integration](/platforms/javascript/guides/angular/angular1). Note, that these versions of the SDK are no longer maintained or tested.
-
-</Alert>
+| Angular version | Recommended Sentry SDK                                            |
+| --------------- | ----------------------------------------------------------------- |
+| 14 and newer    | `@sentry/angular`                                                 |
+| 12 or 13        | `@sentry/angular-ivy@^7` (see [Note](#what-is-sentryangular-ivy)) |
+| 10 or 11        | `@sentry/angular@^7`                                              |
 
 <Alert level="warning">
 
-If you are using Angular 16 or newer, `@sentry/angular` will no longer work as it doesn't support Angular's rendering engine Ivy natively. Please use `@sentry/angular-ivy` instead.
+Support for Angular versions below 14 was discontinued in version 8 of the SDK.
+If you need to use Angular 13 or older, you can continue using version 7 of the SDK (see table above).
+If you need to use Angular 9 or older, you can continue using version 6 of the SDK.
+For AngularJS/1.x, use `@sentry/browser@^6` and our [AngularJS integration](/platforms/javascript/guides/angular/angular1).
+Please note, that these versions of the SDK are no longer maintained or tested.
 
 </Alert>
+
+#### What is `@sentry/angular-ivy`?
+
+The `@sentry/angular-ivy` package is an Ivy-compatible version of `@sentry/angular` in version 7 of the SDK. It's recommended to use this package if you're using Angular 12 or 13 to avoid build-time warnings.
+Functionality-wise, it's identical to `@sentry/angular` and you can simply replace all imports of `@sentry/angular` with `@sentry/angular-ivy` in our docs.
+Since version 8, the Sentry Angular SDK is Ivy-compatible by default.

--- a/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/platform-includes/getting-started-install/javascript.angular.mdx
@@ -8,9 +8,9 @@ yarn add @sentry/angular
 
 ### Angular Version Compatibility
 
-The Sentry Angular SDK supports Angular 14 and newer in its current major version.
+In its current major version, the Sentry Angular SDK only supports Angular 14 and newer.
 
-If you're using an older version of Angular, you also need to use an older version of the SDK:
+If you're using an older version of Angular, you also need to use an older version of the SDK. See the table below for compatibility guidance:
 
 | Angular version | Recommended Sentry SDK                                            |
 | --------------- | ----------------------------------------------------------------- |

--- a/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/platform-includes/getting-started-install/javascript.angular.mdx
@@ -32,4 +32,4 @@ Please note, that these versions of the SDK are no longer maintained or tested.
 
 The `@sentry/angular-ivy` package is an Ivy-compatible version of `@sentry/angular` in version 7 of the SDK. It's recommended to use this package if you're using Angular 12 or 13 to avoid build-time warnings.
 Functionality-wise, it's identical to `@sentry/angular` and you can simply replace all imports of `@sentry/angular` with `@sentry/angular-ivy` in our docs.
-Since version 8, the Sentry Angular SDK is Ivy-compatible by default.
+Since version 8, the `@sentry/angular-ivy` was [removed and merged](./migration/v7-to-v8/#supported-versions) with `@sentry/angular` which is now Ivy-compatible by default.

--- a/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/platform-includes/getting-started-install/javascript.angular.mdx
@@ -12,21 +12,15 @@ In its current major version, the Sentry Angular SDK only supports Angular 14 an
 
 If you're using an older version of Angular, you also need to use an older version of the SDK. See the table below for compatibility guidance:
 
-| Angular version | Recommended Sentry SDK                                            |
-| --------------- | ----------------------------------------------------------------- |
-| 14 and newer    | `@sentry/angular`                                                 |
-| 12 or 13        | `@sentry/angular-ivy@^7` (see [Note](#what-is-sentryangular-ivy)) |
-| 10 or 11        | `@sentry/angular@^7`                                              |
+| Angular version | Recommended Sentry SDK                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------ |
+| 14 and newer    | `@sentry/angular`                                                                                      |
+| 12 or 13        | `@sentry/angular-ivy@^7` (see [Note](#what-is-sentryangular-ivy)) *                                    |
+| 10 or 11        | `@sentry/angular@^7` *                                                                                 |
+| 9 and below     | `@sentry/angular@^6` *                                                                                 |
+| AngularJS/1.x   | `@sentry/browser@^6` with the [AngularJS integration](/platforms/javascript/guides/angular/angular1) * |
 
-<Alert level="warning">
-
-Support for Angular versions below 14 was discontinued in version 8 of the SDK.
-If you need to use Angular 13 or older, you can continue using version 7 of the SDK (see table above).
-If you need to use Angular 9 or older, you can continue using version 6 of the SDK.
-For AngularJS/1.x, use `@sentry/browser@^6` and our [AngularJS integration](/platforms/javascript/guides/angular/angular1).
-Please note, that these versions of the SDK are no longer maintained or tested.
-
-</Alert>
+\* These versions of the SDK are no longer maintained or tested. Version 7 might still receive bug fixes but we don't guarantee support.
 
 #### What is `@sentry/angular-ivy`?
 

--- a/platform-includes/getting-started-install/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-install/javascript.capacitor.mdx
@@ -2,10 +2,10 @@ Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the 
 
 ```bash {tabTitle:Angular}
 # npm
-npm install --save @sentry/capacitor @sentry/angular-ivy
+npm install --save @sentry/capacitor @sentry/angular
 
 # yarn
-yarn add @sentry/capacitor @sentry/angular-ivy
+yarn add @sentry/capacitor @sentry/angular
 ```
 
 ```bash {tabTitle:Other Frameworks}

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.angular.mdx
@@ -2,6 +2,6 @@
 
 Sentry Angular SDK `8.x` supports Angular Ivy by default and supports Angular version `14.0.0` or higher.
 
-As a result, `@sentry/angular-ivy` has been removed in favor of `@sentry/angular`. If you are using Angular 13 or lower, we suggest upgrading your Angular version before migrating to `8.x`. If you can't upgrade your Angular version to at least Angular 14, you can also continue using the `7.x` of `@sentry/angular-ivy` SDK.
+As a result, `@sentry/angular-ivy` has been removed in favor of `@sentry/angular`. If you are using Angular 13 or lower, we suggest upgrading your Angular version before migrating to `8.x`. If you can't upgrade your Angular version to at least Angular 14, you can also continue using the `7.x` of the `@sentry/angular-ivy` SDK.
 
 <Include name="migration/javascript-v8/compatible-browsers" />

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
@@ -1,11 +1,11 @@
-```javascript
-import * as Sentry from "@sentry/angular-ivy";
+```typescript {8} {filename:main.ts}
+import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    // Add browser profiling integration to the list of integrations
     Sentry.browserTracingIntegration(),
+    // Add browser profiling integration to the list of integrations
     Sentry.browserProfilingIntegration(),
   ],
 

--- a/platform-includes/session-replay/install/javascript.angular.mdx
+++ b/platform-includes/session-replay/install/javascript.angular.mdx
@@ -1,24 +1,15 @@
 ```bash {tabTitle:npm}
-# Angular 12 and newer:
-npm install --save @sentry/angular-ivy
-
-# Angular 10 and 11:
 npm install --save @sentry/angular
 ```
 
 ```bash {tabTitle:Yarn}
-# Angular 12 and newer:
-yarn add @sentry/angular-ivy
-
-# Angular 10 and 11:
 yarn add @sentry/angular
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/angular
 ```
 
 ### Angular Version Compatibility
 
-Because of the way Angular libraries are compiled, you need to use a specific version of the Sentry SDK for each corresponding version of Angular as shown below:
-
-| Angular version | Recommended Sentry SDK |
-| --------------- | ---------------------- |
-| 12 and newer    | `@sentry/angular-ivy`  |
-| 10, 11          | `@sentry/angular`      |
+The current major version of the Sentry Angular SDK supports Angular 14 and newer. If you're using an older Angular version, check our [Angular version compatibility](../#angular-version-compatibility) table to find the right SDK version for your project.

--- a/platform-includes/session-replay/install/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/install/javascript.capacitor.mdx
@@ -1,11 +1,11 @@
-Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the framework you're using, such as Angular in this example:
+Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the framework you're using:
 
 ```bash {tabTitle:Angular}
 # npm
-npm install --save @sentry/capacitor @sentry/angular-ivy
+npm install --save @sentry/capacitor @sentry/angular
 
 # yarn
-yarn add @sentry/capacitor @sentry/angular-ivy
+yarn add @sentry/capacitor @sentry/angular
 ```
 
 ```bash {tabTitle:React}

--- a/platform-includes/session-replay/setup-canvas/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup-canvas/javascript.angular.mdx
@@ -1,5 +1,5 @@
-```javascript {13}
-import * as Sentry from "@sentry/angular-ivy";
+```javascript {13} {filename: main.ts}
+import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -1,5 +1,5 @@
-```javascript {8,12,14-20}
-import * as Sentry from "@sentry/angular-ivy";
+```typescript {8,12,14-20} {filename: main.ts}
+import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -36,10 +36,12 @@ public throwTestError(): void {
   throw new Error("Sentry Test Error");
 }
 ```
+
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII) and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:
-- [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else -- the default behavior being to replace each character with a *.
+
+- [Masking](/platforms/javascript/session-replay/privacy/#masking), which replaces the text content with something else -- the default behavior being to replace each character with a \*.
 - Making [network request, response bodies, and headers](/platforms/javascript/session-replay/privacy/#network-request-and-response-bodies-and-headers) an opt-in feature, because the best way to avoid getting PII into Sentry is by not adding URLs of endpoints that may contain PII.
 
 While we have certain privacy considerations in place, Sentry's Session Replay allows you to set up the [privacy configurations](/platforms/javascript/session-replay/privacy/#privacy-configuration) that work best for your use case. For example, if you're working on a static website that's free of PII or other types of private data, you can opt out of the default text masking and image blocking settings.
@@ -49,13 +51,13 @@ To learn more about Session Replay privacy, [read our docs.](/platforms/javascri
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```javascript
+```javascript {filename: main.ts} {3, 7-8}
 Sentry.init({
-  // Note, Replay is NOT instantiated below:
+  // Note, replayIntegration is NOT instantiated below:
   integrations: [],
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/angular-ivy");
+const { replayIntegration } = await import("@sentry/angular");
 Sentry.addIntegration(replayIntegration());
 ```

--- a/platform-includes/user-feedback/install/javascript.angular.mdx
+++ b/platform-includes/user-feedback/install/javascript.angular.mdx
@@ -1,24 +1,15 @@
 ```bash {tabTitle:npm}
-# Angular 12 and newer:
-npm install --save @sentry/angular-ivy
-
-# Angular 10 and 11:
 npm install --save @sentry/angular
 ```
 
 ```bash {tabTitle:Yarn}
-# Angular 12 and newer:
-yarn add @sentry/angular-ivy
-
-# Angular 10 and 11:
 yarn add @sentry/angular
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/angular
 ```
 
 ### Angular Version Compatibility
 
-Because of the way Angular libraries are compiled, you need to use a specific version of the Sentry SDK for each corresponding version of Angular as shown below:
-
-| Angular version | Recommended Sentry SDK |
-| --------------- | ---------------------- |
-| 12 and newer    | `@sentry/angular-ivy`  |
-| 10, 11          | `@sentry/angular`      |
+The current major version of the Sentry Angular SDK supports Angular 14 and newer. If you're using an older Angular version, check our [Angular version compatibility](../#angular-version-compatibility) table to find the right SDK version for your project.

--- a/platform-includes/user-feedback/setup/javascript.angular.mdx
+++ b/platform-includes/user-feedback/setup/javascript.angular.mdx
@@ -1,5 +1,5 @@
-```javascript
-import * as Sentry from "@sentry/angular-ivy";
+```typescript {filename: main.ts}
+import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",


### PR DESCRIPTION
(draft until v8 is stable)

This PR updates our Angular SDK docs for the v8 major bump. Changes:

- Removed `@sentry/angular-ivy` imports and related duplicated snippets. No longer necessary as in v8, there's only one Angular package (for the moment at least)
- Renamed the `TraceClass` and `TraceMethod` decorators and slightly reworked the component tracking docs
- Re-worked the Getting Started docs to finally have _one_ code snippet that shows all providers that are necessary to set up. Previously, we had 3 different snippets which made the setup utterly complicated to follow. Technically, this is a bit out of scope but since I was looking at Angular docs, I figured I might as well improve things.
- Added highlighting to most snippets