### PR TITLE
dotnet profiling doesnt need prerelease

### DIFF
--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -26,7 +26,7 @@ To enable profiling, set the `ProfilesSampleRate`.
 Additionally, for all platforms except iOS/Mac Catalyst, you need to add a dependency on the `Sentry.Profiling` NuGet package.
 
 ```shell {tabTitle:.NET CLI}
-dotnet add package Sentry.Profiling --prerelease
+dotnet add package Sentry.Profiling
 ```
 
 Profiling depends on Sentry’s performance monitoring product being enabled beforehand. To enable performance monitoring in the SDK, set the `TracesSampleRate` option to the desired value.


### PR DESCRIPTION
Relates to:
* https://github.com/getsentry/sentry-dotnet/issues/3336