### PR TITLE
Update webhook docs for issues

### DIFF
--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -15,7 +15,7 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
 ### action
 
 - type: string
-- description: can be `created`, `resolved`, `assigned`, or `archived`
+- description: can be `created`, `resolved`, `assigned`, `archived` or `unresolved`
 
 ### data['issue']
 
@@ -38,6 +38,14 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
 - description: the api url to the project the issue is a part of
 
 ## Payload
+
+Payload includes additional information about the issue. Some important fields to pay attention to are:
+
+### status
+Some issue webhooks are getting triggered on status change of an issue. An issue status can be `resolved`, `unresolved` or `ignored` (archived).
+
+### substatus
+Substatus of an issue is giving more details about a status, specially if one status can mean multiple things. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.
 
 ```json
 {
@@ -81,6 +89,7 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
       "status": "unresolved",
       "statusDetails": {},
       "subscriptionDetails": null,
+      "substatus": "escalating",
       "title": "ReferenceError: blooopy is not defined",
       "type": "error",
       "userCount": 1

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -15,7 +15,7 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
 ### action
 
 - type: string
-- description: can be `created`, `resolved`, `assigned`, `archived` or `unresolved`
+- description: can be `created`, `resolved`, `assigned`, `archived`, or `unresolved`
 
 ### data['issue']
 

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -52,11 +52,11 @@ A status can mean multiple things, so substatus gives more details about the sta
 * `inRelease`: The release that the resolution is in (for example, `latest`)
 * `inNextRelease`: `True` if the resolution will be in the next release
 * `inCommit`: Includes information about the resolution commit (such as `repository` and `commit`)
-* `ignoreDuration`: The duration (in minutes) that an archived issue should be ignored before it gets escalated.
 * `ignoreCount`: Maximum number of occurences in for an archived issue before it gets escalated 
 * `ignoreWindow`: Used with `ignoreCount` indicating the number of minutes that `ignoreCount` occurences will be ignored
 * `ignoreUserCount`: Maximun number of users who are affected by an archived issue before it gets escalated
 * `ignoreUserWindow`: Used with `ignoreUserCount` indicating the number of minutes that `ignoreUserCount` affected users will be ignored 
+* `ignoreDuration`: The duration (in minutes) that an archived issue should be ignored before it gets escalated. Increase in the number of users affected or the number of occurences will not escalate before this duration has passed unless there is a spike. To learn more about how this works, see [Escalating Issues Algorithm](https://docs.sentry.io/product/issues/states-triage/escalating-issues/).
 
 ```json
 {

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -48,7 +48,7 @@ Some issue webhooks are triggered on status change of an issue. An issue status 
 A status can mean multiple things, so substatus gives more details about the status. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.
 
 ### statusDetails
-`statusDetails` includes more detailed information about the action being done on the issue, for example is the issue is being resolved or archived. These details are:
+`statusDetails` includes more detailed information about `resolved` and `archived` status changes on an issue. These details can include:
 * `inRelease`: The release that the resolution is in for example `latest`
 * `inNextRelease`: `True` if the resolution will be in the next release
 * `inCommit`: Includes information about the resolution commit, for example `repository` and `commit`

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -53,8 +53,10 @@ A status can mean multiple things, so substatus gives more details about the sta
 * `inNextRelease`: `True` if the resolution will be in the next release
 * `inCommit`: Includes information about the resolution commit, for example `repository` and `commit`
 * `ignoreDuration`: Duration for an archived issue before it's turns to escalated in minutes
-* `ignoreCount`: Maximum number of occurences in `ignoreWindow` minutes for an archived issue before it gets escalated                                 
-* `ignoreUserCount`: Maximun number of users in `ignoreUserWindow` minutes who are affected by an archived issue before it gets escalated
+* `ignoreCount`: Maximum number of occurences in for an archived issue before it gets escalated 
+* `ignoreWindow`: Used with `ignoreCount` indicating the number of minutes that `ignoreCount` occurences will be ignored
+* `ignoreUserCount`: Maximun number of users who are affected by an archived issue before it gets escalated
+* `ignoreUserWindow`: Used with `ignoreUserCount` indicating the number of minutes that `ignoreUserCount` affected users will be ignored 
 
 ```json
 {

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -49,10 +49,10 @@ A status can mean multiple things, so substatus gives more details about the sta
 
 ### statusDetails
 `statusDetails` includes more detailed information about `resolved` and `archived` status changes on an issue. These details can include:
-* `inRelease`: The release that the resolution is in for example `latest`
+* `inRelease`: The release that the resolution is in (for example, `latest`)
 * `inNextRelease`: `True` if the resolution will be in the next release
-* `inCommit`: Includes information about the resolution commit, for example `repository` and `commit`
-* `ignoreDuration`: Duration for an archived issue before it's turns to escalated in minutes
+* `inCommit`: Includes information about the resolution commit (such as `repository` and `commit`)
+* `ignoreDuration`: The duration (in minutes) that an archived issue should be ignored before it gets escalated.
 * `ignoreCount`: Maximum number of occurences in for an archived issue before it gets escalated 
 * `ignoreWindow`: Used with `ignoreCount` indicating the number of minutes that `ignoreCount` occurences will be ignored
 * `ignoreUserCount`: Maximun number of users who are affected by an archived issue before it gets escalated

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -42,7 +42,7 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
 Payload includes additional information about the issue. Some important fields to pay attention to are:
 
 ### status
-Some issue webhooks are getting triggered on status change of an issue. An issue status can be `resolved`, `unresolved` or `ignored` (archived).
+Some issue webhooks are triggered on status change of an issue. An issue status can be `resolved`, `unresolved`, or `ignored` (archived).
 
 ### substatus
 Substatus of an issue is giving more details about a status, specially if one status can mean multiple things. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -45,7 +45,7 @@ Payload includes additional information about the issue. Some important fields t
 Some issue webhooks are triggered on status change of an issue. An issue status can be `resolved`, `unresolved`, or `ignored` (archived).
 
 ### substatus
-Substatus of an issue is giving more details about a status, specially if one status can mean multiple things. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.
+A status can mean multiple things, so substatus gives more details about the status. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.
 
 ### statusDetails
 `statusDetails` includes more detailed information about the action being done on the issue, for example is the issue is being resolved or archived. These details are:

--- a/docs/organization/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks/issues.mdx
@@ -47,6 +47,15 @@ Some issue webhooks are getting triggered on status change of an issue. An issue
 ### substatus
 Substatus of an issue is giving more details about a status, specially if one status can mean multiple things. For example, an issue status can change to `unresolved` because it is now `escalating` or because a resolved issue is `regressed`. Possible substatuses are: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`, `escalating`, `ongoing`, `regressed` and `new`.
 
+### statusDetails
+`statusDetails` includes more detailed information about the action being done on the issue, for example is the issue is being resolved or archived. These details are:
+* `inRelease`: The release that the resolution is in for example `latest`
+* `inNextRelease`: `True` if the resolution will be in the next release
+* `inCommit`: Includes information about the resolution commit, for example `repository` and `commit`
+* `ignoreDuration`: Duration for an archived issue before it's turns to escalated in minutes
+* `ignoreCount`: Maximum number of occurences in `ignoreWindow` minutes for an archived issue before it gets escalated                                 
+* `ignoreUserCount`: Maximun number of users in `ignoreUserWindow` minutes who are affected by an archived issue before it gets escalated
+
 ```json
 {
   "action": "created",


### PR DESCRIPTION
We're launching a new status: `unresolved` and I also think we need to explain what `substatus` is for that to make sense.
https://sentry-docs-git-athena-webhook-docs.sentry.dev/product/integrations/integration-platform/webhooks/issues/