### PR TITLE
fix: Changelog Images

### DIFF
--- a/app/changelog/header.tsx
+++ b/app/changelog/header.tsx
@@ -1,14 +1,12 @@
-import Image from 'next/image';
-
 export default function Header({loading}) {
   return (
     <div className="w-full mx-auto h-96 relative bg-darkPurple">
       <div className="relative w-full lg:max-w-7xl mx-auto px-4 lg:px-8 pt-8 grid grid-cols-12 items-center">
-        <Image
+        {/* this needs to be a plain <img> next/image doesn't work here because of redirects we do */}
+        <img
           className={`justify-self-center col-span-10 hidden lg:block ${loading ? 'animate-fade-in-left' : ''}`}
           src="https://docs.sentry.io/changelog/assets/hero.png"
           alt="Sentry Changelog"
-          priority
           height={273}
           width={450}
         />

--- a/app/changelog/header.tsx
+++ b/app/changelog/header.tsx
@@ -3,6 +3,7 @@ export default function Header({loading}) {
     <div className="w-full mx-auto h-96 relative bg-darkPurple">
       <div className="relative w-full lg:max-w-7xl mx-auto px-4 lg:px-8 pt-8 grid grid-cols-12 items-center">
         {/* this needs to be a plain <img> next/image doesn't work here because of redirects we do */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className={`justify-self-center col-span-10 hidden lg:block ${loading ? 'animate-fade-in-left' : ''}`}
           src="https://docs.sentry.io/changelog/assets/hero.png"

--- a/src/components/changelog/article.tsx
+++ b/src/components/changelog/article.tsx
@@ -31,6 +31,7 @@ export default function Article({
     <article className={`bg-white rounded-lg shadow-lg mb-8 ${className}`}>
       {/* this needs to be a plain <img> next/image doesn't work here because of redirects we do */}
       {image && (
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           className="object-cover relative w-full h-64 rounded-lg rounded-b-none"
           src={image}

--- a/src/components/changelog/article.tsx
+++ b/src/components/changelog/article.tsx
@@ -1,5 +1,4 @@
 import {ReactNode} from 'react';
-import Image from 'next/image';
 
 import Date from './date';
 import Tag from './tag';
@@ -30,10 +29,10 @@ export default function Article({
 
   return (
     <article className={`bg-white rounded-lg shadow-lg mb-8 ${className}`}>
+      {/* this needs to be a plain <img> next/image doesn't work here because of redirects we do */}
       {image && (
-        <Image
+        <img
           className="object-cover relative w-full h-64 rounded-lg rounded-b-none"
-          priority
           src={image}
           alt={title}
         />


### PR DESCRIPTION
next/image doesn't work with the redirects we do and static images we serve from Google
<img width="777" alt="image" src="https://github.com/getsentry/sentry-docs/assets/363802/58c9b078-140e-499e-beaf-dc40894170da">
