### PR TITLE
fix: narrow down integrations properly on platformSelector

### DIFF
--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -198,6 +198,10 @@ export function PlatformSelector({
                       guides: platform.guides.filter(g =>
                         matches.some(m => m.key === g.key)
                       ),
+
+                      integrations: platform.integrations.filter(i =>
+                        matches.some(m => m.key === i.key)
+                      ),
                       isExpanded:
                         // expand search results
                         searchValue !== '' ||


### PR DESCRIPTION
platform selector didn't filter out integrations shown as guides properly