### PR TITLE
feat(perf): Requests module SDK instrumentation documentation

### DIFF
--- a/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
@@ -1,0 +1,51 @@
+---
+title: Custom Instrumentation for Requests Module
+sidebar_order: 9999
+description: "Learn how to manually instrument your code to use Sentry's Requests module."
+---
+
+As a prerequisite to setting up [Requests](/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use-case, you can also set up [custom instrumentation](#custom-instrumentation).
+
+## Custom Instrumentation
+
+For detailed information about which data can be set, see the [Requests Module Developer Specification](https://develop.sentry.dev/sdk/performance/modules/requests/).
+
+### Initialize Sentry
+
+<PlatformContent includePath="getting-started-config" />
+
+### Wrap The HTTP Requests in a Span
+
+NOTE: Refer to [HTTP Span Data Conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/#http) for a full list of the span data attributes.
+
+Here is an example of an instrumented function that makes HTTP requests:
+
+```javascript
+async function makeRequest(method, url) {
+  return await Sentry.startSpan(
+    {op: 'http.client', name: `${method} ${url}`},
+    async span => {
+      const parsedURL = new URL(url, location.origin);
+
+      const response = await fetch(url, {
+        method,
+      });
+
+      span?.setAttribute('http.request.method', method);
+
+      span?.setAttribute('server.address', parsedURL.hostname);
+      span?.setAttribute('server.port', parsedURL.port || undefined);
+
+      span?.setAttribute('http.response.status_code', response.status);
+      span?.setAttribute(
+        'http.response_content_length',
+        Number(response.headers.get('content-length'))
+      );
+
+      // A good place to set other span attributes
+
+      return response;
+    }
+  );
+}
+```

--- a/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
@@ -8,7 +8,7 @@ As a prerequisite to setting up [Requests](/product/performance/requests/) youâ€
 
 ## Custom Instrumentation
 
-For detailed information about which data can be set, see the [Requests Module Developer Specification](https://develop.sentry.dev/sdk/performance/modules/requests/).
+For detailed information about which data can be set, see the [Requests Module developer specifications](https://develop.sentry.dev/sdk/performance/modules/requests/).
 
 ### Initialize Sentry
 

--- a/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
@@ -4,7 +4,7 @@ sidebar_order: 9999
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests](/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use-case, you can also set up [custom instrumentation](#custom-instrumentation).
+As a prerequisite to setting up [Requests],(/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
 
 ## Custom Instrumentation
 

--- a/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/requests-module.mdx
@@ -4,7 +4,7 @@ sidebar_order: 9999
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests],(/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
+As a prerequisite to setting up [Requests](/product/performance/requests/), you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
 
 ## Custom Instrumentation
 

--- a/docs/platforms/python/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/requests-module.mdx
@@ -8,7 +8,7 @@ As a prerequisite to setting up [Requests],(/product/performance/requests/) youâ
 
 ## Custom Instrumentation
 
-For detailed information about which data can be set, see the [Requests Module Developer Specification](https://develop.sentry.dev/sdk/performance/modules/requests/).
+For detailed information about which data can be set, see the [Requests Module developer specifications](https://develop.sentry.dev/sdk/performance/modules/requests/).
 
 ### Initialize Sentry
 

--- a/docs/platforms/python/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/requests-module.mdx
@@ -1,0 +1,49 @@
+---
+title: Custom Instrumentation for Requests Module
+sidebar_order: 9999
+description: "Learn how to manually instrument your code to use Sentry's Requests module."
+---
+
+As a prerequisite to setting up [Requests](/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection`. If that doesn't fit your use-case, you can also set up [custom instrumentation](#custom-instrumentation).
+
+## Custom Instrumentation
+
+For detailed information about which data can be set, see the [Requests Module Developer Specification](https://develop.sentry.dev/sdk/performance/modules/requests/).
+
+### Initialize Sentry
+
+<PlatformContent includePath="getting-started-config" />
+
+### Wrap The HTTP Requests in a Span
+
+NOTE: Refer to [HTTP Span Data Conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/#http) for a full list of the span data attributes.
+
+Here is an example of an instrumented function that makes HTTP requests:
+
+```python
+from urllib.parse import urlparse
+import requests
+
+def make_request(method, url):
+    span = sentry_sdk.start_span(
+        op="http.client",
+        description="%s %s" % (method, url),
+    )
+
+    span.set_data("http.request.method", method)
+
+    parsed_url = urlparse(url)
+    span.set_data("url", url)
+    span.set_data("server.address", parsed_url.hostname)
+    span.set_data("server.port", parsed_url.port)
+
+    response = requests.request(method=method, url=url)
+
+    span.set_data("http.response.status_code", response.status_code)
+    span.set_data("http.response_content_length", response.headers["content-length"])
+
+    span.finish()
+
+    return response
+
+```

--- a/docs/platforms/python/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/requests-module.mdx
@@ -4,7 +4,7 @@ sidebar_order: 9999
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests],(/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection`. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
+As a prerequisite to setting up [Requests](/product/performance/requests/), you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection`. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
 
 ## Custom Instrumentation
 

--- a/docs/platforms/python/performance/instrumentation/requests-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/requests-module.mdx
@@ -4,7 +4,7 @@ sidebar_order: 9999
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests](/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection`. If that doesn't fit your use-case, you can also set up [custom instrumentation](#custom-instrumentation).
+As a prerequisite to setting up [Requests],(/product/performance/requests/) you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection`. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
 
 ## Custom Instrumentation
 

--- a/docs/product/performance/requests.mdx
+++ b/docs/product/performance/requests.mdx
@@ -21,7 +21,7 @@ On the [**Requests** page](#requests-page), you get an overview of the domains t
   ></iframe>
 </div>
 
-## Prerequisites
+## Prerequisites and Limitations
 
 <Note>
 Network requests using non-HTTP protocols (FTP, WebSocket, etc.) are not supported at this time.
@@ -29,16 +29,7 @@ Network requests using non-HTTP protocols (FTP, WebSocket, etc.) are not support
 
 Availability of HTTP request monitoring depends on the SDK your application uses. In most cases, Sentry's SDKs automatically enable HTTP request tracking. You can check your SDK's <PlatformLink to="/performance/instrumentation/automatic-instrumentation">automatic instrumentation documentation</PlatformLink> to see if it includes tracking HTTP requests.
 
-### Span Eligibility
-
-If the SDK you are using doesn't automatically instrument HTTP requests, you can use <PlatformLink to="/performance/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink>. For best results, follow these guidelines for your custom spans:
-
-- The `op` field is set to `"http.client"`.
-- The `description` field contains the HTTP method and the full URL of the request (e.g., `"GET http://my.service.io/some-data"`).
-- If the request is to a relative URL (e.g., `"GET /data.json"`), the `server.address` span data value should be set to the server address (e.g., `"my.service.io"`).
-- The `http.response.status_code` contains the HTTP response status code (e.g., `"200"`).
-
-See the [Span Data Conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/#http) page for more information.
+If the SDK you are using doesn't automatically instrument HTTP requests, you can use <PlatformLink to="/performance/instrumentation/requests-module/">custom instrumentation</PlatformLink> instructions to instrument your application. If your platform doesn't have dedicated custom instrumentation instructions, try adapting the code from another platform, since all the concepts are the same.
 
 ## Requests Page
 

--- a/docs/product/performance/requests.mdx
+++ b/docs/product/performance/requests.mdx
@@ -29,7 +29,7 @@ Network requests using non-HTTP protocols (FTP, WebSocket, etc.) are not support
 
 Availability of HTTP request monitoring depends on the SDK your application uses. In most cases, Sentry's SDKs automatically enable HTTP request tracking. You can check your SDK's <PlatformLink to="/performance/instrumentation/automatic-instrumentation">automatic instrumentation documentation</PlatformLink> to see if it includes tracking HTTP requests.
 
-If the SDK you are using doesn't automatically instrument HTTP requests, you can use <PlatformLink to="/performance/instrumentation/requests-module/">custom instrumentation</PlatformLink> instructions to instrument your application. If your platform doesn't have dedicated custom instrumentation instructions, try adapting the code from another platform, since all the concepts are the same.
+If the SDK you're using doesn't automatically instrument HTTP requests, you can instrument your application by following the <PlatformLink to="/performance/instrumentation/requests-module/">custom instrumentation</PlatformLink> instructions. Because all the concepts are the same, if your platform doesn't have dedicated custom instrumentation instructions, you can try adapting the code from another platform.
 
 ## Requests Page
 


### PR DESCRIPTION
I'm following the template set up for the Caches documentation! Adding manual instrumentation docs for JavaScript and Python, and linking to the snippets from the module documentation. Very similar to https://github.com/getsentry/sentry-docs/pull/9926/
