### PR TITLE
fix: permissive regex

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -57,7 +57,7 @@ const search = new SentryGlobalSearch([
 ]);
 
 function relativizeUrl(url: string) {
-  return url.replace(/^.*:\/\/docs\.sentry\.io/, '');
+  return url.replace(/^(https?:\/\/docs\.sentry\.io)(?=\/|$)/, '');
 }
 
 type Props = {


### PR DESCRIPTION
## Pre-merge checklist

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

Fix the `relativizeUrl` function's permissive regex. The original pattern could match any domain name that contains "docs.sentry.io" in it. For example, it would match `http://docs.sentry.io.malicious-site.com`.

Resolves CodeQL scanning alert: https://github.com/getsentry/sentry-docs/security/code-scanning/2
