### PR TITLE
chore(api): Created Nav Link for API Docs

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -56,6 +56,7 @@ export function Header({pathname, searchPlatforms, noSearch}: Props) {
           </div>
         )}
         <div className="hidden lg:flex justify-end flex-1 space-x-2 items-center">
+          <NavLink href="/api">API</NavLink>
           <NavLink href="/changelog">Changelog</NavLink>
           <NavLink href="https://try.sentry-demo.com/demo/start/">Sandbox</NavLink>
           <NavLink href="https://sentry.io/">Sign In</NavLink>


### PR DESCRIPTION
Our API Docs were a little hidden and had no visibility from the home page. I added the Navlink to match how our docs were before:
![image](https://github.com/getsentry/sentry-docs/assets/33237075/11d7e526-5036-4706-8354-653f28e0740b)

![image](https://github.com/getsentry/sentry-docs/assets/33237075/6b612465-9b67-4a56-bbd4-1945c49bc91d)

I don't think we should group our API docs with Product docs as they serve two different purposes.