### PR TITLE
ref(js/bun): Remove global unhandled errors warning from bun

### DIFF
--- a/platform-includes/getting-started-primer/javascript.bun.mdx
+++ b/platform-includes/getting-started-primer/javascript.bun.mdx
@@ -3,9 +3,3 @@
 The Bun SDK is currently in Beta.
 
 </Note>
-
-<Alert level="warning" title="Note">
-
-The Bun SDK can't currently capture global unhandled exceptions and unhandled promise rejections. Bun is working on adding support to enable this. See this [Github issue](https://github.com/oven-sh/bun/issues/5091) for more information.
-
-</Alert>


### PR DESCRIPTION
Fix landed: https://github.com/oven-sh/bun/issues/5091

v7: https://github.com/getsentry/sentry-javascript/pull/11959
v8: https://github.com/getsentry/sentry-javascript/pull/11960