### PR TITLE
fix codeBlock overflow on short lines

### DIFF
--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -19,7 +19,21 @@
     border: 0;
     border-radius: 4px;
     margin: 0 0 1rem;
-    padding: 1rem;
+  }
+
+  pre[class^='language-']:has(:global(.code-diff)) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  pre[class^='language-']:has(:global(.highlight-line)) {
+    padding-left: 0;
+    padding-right: 0;
+
+    & :global(.code-line) {
+      padding-left: 12px;
+      padding-right: 12px;
+    }
   }
 
   /**
@@ -35,19 +49,10 @@
     min-width: 100%;
   }
 
-  /* Counter the 12px padding on the left side of the code block on the pre tag
-  * and the 4px border on the left side of the line + the 8px padding bring it
-  * back visually to the left side of the code block with "12px" of padding.
-  */
   :global(.code-line) {
     display: block;
     float: left;
-    // fallback for browsers that don't support calc
-    // yes it should come before the calc
     min-width: 100%;
-    min-width: calc(100% + 24px);
-    padding-left: 8px;
-    margin-left: -12px;
     box-sizing: border-box;
     // Set placeholder for highlight accent border color to transparent
     border-left: 4px solid rgba(0, 0, 0, 0);


### PR DESCRIPTION
fix this
<img width="532" alt="Screenshot 2024-05-09 at 11 41 35" src="https://github.com/getsentry/sentry-docs/assets/17055517/1023b6d7-f2ef-474b-8abb-1b0cf948d425">
