### PR TITLE
doc(feedback): remove beta banners and 'associated error event' mentions

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -1,10 +1,8 @@
 ---
 title: Set Up User Feedback
-description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
+description: "Learn how to enable User Feedback in your app if it is not already set up."
 sidebar_order: 6000
 ---
-
-<Include name="feature-stage-beta-user-feedback.mdx" />
 
 The User Feedback feature allows you to collect user feedback from anywhere inside your application, without requiring an error event to occur. This requires a minimum SDK version of [7.85.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.85.0). The [Crash-Report Modal](#crash-report-modal) feature still exists to handle user feedback associated with an error event.
 

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set Up User Feedback
-description: "Learn how to enable User Feedback in your app if it is not already set up."
+description: "Learn how to enable User Feedback in your app."
 sidebar_order: 6000
 ---
 

--- a/docs/product/user-feedback/index.mdx
+++ b/docs/product/user-feedback/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: User Feedback
 sidebar_order: 65
-description: "Learn how you can view user feedback submissions which, paired with the original event, give you additional insight into issues."
+description: "Learn how you can view and triage user feedback submissions."
 ---
 
 Sentry automatically detects errors thrown by your application, such as performance issues and user experience problems like rage clicks. But there are other frustrations your users may encounter (broken permission flows, broken links, typos, misleading UX, business logic flaws, and so on).

--- a/docs/product/user-feedback/setup.mdx
+++ b/docs/product/user-feedback/setup.mdx
@@ -4,8 +4,6 @@ sidebar_order: 12
 description: "Get started with Sentry's User Feedback, which allows you to collect feedback from your users."
 ---
 
-<Include name="feature-stage-beta-user-feedback.mdx" />
-
 With User Feedback, you can collect feedback from your users via two methods: a Feedback Widget that can be displayed anywhere in your web application and/or a Crash-Report Modal that appears when your users are experiencing crashes.
 
 To get instructions for how to set it up and start collecting feedback, click a link for one of the supported SDKs below.

--- a/includes/feature-stage-beta-user-feedback.mdx
+++ b/includes/feature-stage-beta-user-feedback.mdx
@@ -1,5 +1,0 @@
-<Note title="A Wild User Feedback Appears!">
-
-Sentry released a new version of User Feedback that supports collecting feedback at any time from your users, without requiring an error event. It is currently in open beta and subject to change.
-
-</Note>


### PR DESCRIPTION
As of this week User Feedback has been GA'd and is the primary way of submitting feedback!

The old method, user reports, required an associated error event but this method does not. So when describing the widget/overall product, the mentions of associating events are incorrect. 


---



<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## Pre-merge checklist

*If you work at Sentry, you're able to merge your own PR without review, but please don't unless there's a good reason.*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Description of changes

*Describe your changes here. If your PR relates to or resolves an issue, add a link to that too.*

## Legal Boilerplate

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## Extra resources

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
