### PR TITLE
feat(node): Add fallback guide

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/index.mdx
@@ -2,6 +2,7 @@
 title: AWS Lambda
 description: "Learn about Sentry's integration with AWS Lambda."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - serverless
 ---

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -2,6 +2,7 @@
 title: Azure Functions
 description: "Learn about using Sentry with Azure Functions."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - serverless
 ---

--- a/docs/platforms/javascript/guides/connect/index.mdx
+++ b/docs/platforms/javascript/guides/connect/index.mdx
@@ -2,6 +2,7 @@
 title: Connect
 description: "Learn about using Sentry with Connect."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - server
 ---

--- a/docs/platforms/javascript/guides/express/index.mdx
+++ b/docs/platforms/javascript/guides/express/index.mdx
@@ -2,6 +2,7 @@
 title: Express
 description: "Learn about using Sentry with Express."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - server
 ---

--- a/docs/platforms/javascript/guides/fastify/index.mdx
+++ b/docs/platforms/javascript/guides/fastify/index.mdx
@@ -2,6 +2,7 @@
 title: Fastify
 description: "Learn about using Sentry with Fastify."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - server
 ---

--- a/docs/platforms/javascript/guides/gcp-functions/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/index.mdx
@@ -2,6 +2,7 @@
 title: Google Cloud Functions
 description: "Learn about using Sentry with Google Cloud Functions."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - serverless
 ---

--- a/docs/platforms/javascript/guides/koa/index.mdx
+++ b/docs/platforms/javascript/guides/koa/index.mdx
@@ -2,6 +2,7 @@
 title: Koa
 description: "Learn about using Sentry with Koa."
 sdk: sentry.javascript.node
+fallbackGuide: javascript.node
 categories:
   - server
 ---

--- a/platform-includes/capture-error/javascript.aws-lambda.mdx
+++ b/platform-includes/capture-error/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.azure-functions.mdx
+++ b/platform-includes/capture-error/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.connect.mdx
+++ b/platform-includes/capture-error/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.express.mdx
+++ b/platform-includes/capture-error/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.fastify.mdx
+++ b/platform-includes/capture-error/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.gcp-functions.mdx
+++ b/platform-includes/capture-error/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/capture-error/javascript.koa.mdx
+++ b/platform-includes/capture-error/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.connect.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.express.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/auto-session-tracking/javascript.koa.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.connect.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.express.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/breadcrumb-hints/javascript.koa.mdx
+++ b/platform-includes/configuration/breadcrumb-hints/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/capture-console/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/capture-console/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.connect.mdx
+++ b/platform-includes/configuration/capture-console/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.express.mdx
+++ b/platform-includes/configuration/capture-console/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.fastify.mdx
+++ b/platform-includes/configuration/capture-console/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/capture-console/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/capture-console/javascript.koa.mdx
+++ b/platform-includes/configuration/capture-console/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/contextlines/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/contextlines/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.connect.mdx
+++ b/platform-includes/configuration/contextlines/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.express.mdx
+++ b/platform-includes/configuration/contextlines/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.fastify.mdx
+++ b/platform-includes/configuration/contextlines/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/contextlines/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/contextlines/javascript.koa.mdx
+++ b/platform-includes/configuration/contextlines/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/debug/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/debug/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.connect.mdx
+++ b/platform-includes/configuration/debug/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.express.mdx
+++ b/platform-includes/configuration/debug/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.fastify.mdx
+++ b/platform-includes/configuration/debug/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/debug/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/debug/javascript.koa.mdx
+++ b/platform-includes/configuration/debug/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/dedupe/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/dedupe/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.connect.mdx
+++ b/platform-includes/configuration/dedupe/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.express.mdx
+++ b/platform-includes/configuration/dedupe/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.fastify.mdx
+++ b/platform-includes/configuration/dedupe/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/dedupe/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/dedupe/javascript.koa.mdx
+++ b/platform-includes/configuration/dedupe/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/drain-example/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/drain-example/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.connect.mdx
+++ b/platform-includes/configuration/drain-example/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.express.mdx
+++ b/platform-includes/configuration/drain-example/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/drain-example/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/drain-example/javascript.koa.mdx
+++ b/platform-includes/configuration/drain-example/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.connect.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.express.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.fastify.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.koa.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.connect.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.express.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.fastify.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.koa.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.connect.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.express.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.fastify.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/extra-error-data/javascript.koa.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.connect.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.express.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.fastify.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/rewrite-frames/javascript.koa.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.azure-functions.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.connect.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.express.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.fastify.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/configuration/sessiontiming/javascript.koa.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.aws-lambda.mdx
+++ b/platform-includes/crons/setup/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.azure-functions.mdx
+++ b/platform-includes/crons/setup/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.connect.mdx
+++ b/platform-includes/crons/setup/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.express.mdx
+++ b/platform-includes/crons/setup/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.fastify.mdx
+++ b/platform-includes/crons/setup/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.gcp-functions.mdx
+++ b/platform-includes/crons/setup/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/crons/setup/javascript.koa.mdx
+++ b/platform-includes/crons/setup/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.aws-lambda.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.azure-functions.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.connect.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.express.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.fastify.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.gcp-functions.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/how-to-use/javascript.koa.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.aws-lambda.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.azure-functions.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.connect.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.express.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.gcp-functions.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/distributed-tracing/limiting-traces/javascript.koa.mdx
+++ b/platform-includes/distributed-tracing/limiting-traces/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.aws-lambda.mdx
+++ b/platform-includes/enriching-events/import/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.azure-functions.mdx
+++ b/platform-includes/enriching-events/import/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.connect.mdx
+++ b/platform-includes/enriching-events/import/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.express.mdx
+++ b/platform-includes/enriching-events/import/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.fastify.mdx
+++ b/platform-includes/enriching-events/import/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.gcp-functions.mdx
+++ b/platform-includes/enriching-events/import/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/enriching-events/import/javascript.koa.mdx
+++ b/platform-includes/enriching-events/import/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-config/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-install/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.azure-functions.mdx
+++ b/platform-includes/getting-started-install/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.connect.mdx
+++ b/platform-includes/getting-started-install/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.express.mdx
+++ b/platform-includes/getting-started-install/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-install/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-install/javascript.koa.mdx
+++ b/platform-includes/getting-started-install/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-verify/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-verify/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-verify/javascript.azure-functions.mdx
+++ b/platform-includes/getting-started-verify/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/getting-started-verify/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-verify/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.aws-lambda.mdx
+++ b/platform-includes/metrics/configure/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.azure-functions.mdx
+++ b/platform-includes/metrics/configure/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.connect.mdx
+++ b/platform-includes/metrics/configure/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.express.mdx
+++ b/platform-includes/metrics/configure/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.gcp-functions.mdx
+++ b/platform-includes/metrics/configure/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/metrics/configure/javascript.koa.mdx
+++ b/platform-includes/metrics/configure/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.azure-functions.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.connect.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.express.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.fastify.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/configure-sample-rate/javascript.koa.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/connect-services/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.azure-functions.mdx
+++ b/platform-includes/performance/connect-services/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.connect.mdx
+++ b/platform-includes/performance/connect-services/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.express.mdx
+++ b/platform-includes/performance/connect-services/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/connect-services/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/connect-services/javascript.koa.mdx
+++ b/platform-includes/performance/connect-services/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.azure-functions.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.connect.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.express.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/custom-sampling-context/javascript.koa.mdx
+++ b/platform-includes/performance/custom-sampling-context/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.azure-functions.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.connect.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.express.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/enable-tracing/javascript.koa.mdx
+++ b/platform-includes/performance/enable-tracing/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.azure-functions.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.connect.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.express.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/group-transaction-example/javascript.koa.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.azure-functions.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.connect.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.express.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-install/javascript.koa.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.azure-functions.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.connect.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.express.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/opentelemetry-setup/javascript.koa.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.aws-lambda.mdx
+++ b/platform-includes/performance/span-operations/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.azure-functions.mdx
+++ b/platform-includes/performance/span-operations/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.connect.mdx
+++ b/platform-includes/performance/span-operations/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.express.mdx
+++ b/platform-includes/performance/span-operations/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.gcp-functions.mdx
+++ b/platform-includes/performance/span-operations/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/performance/span-operations/javascript.koa.mdx
+++ b/platform-includes/performance/span-operations/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.aws-lambda.mdx
+++ b/platform-includes/set-environment/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.azure-functions.mdx
+++ b/platform-includes/set-environment/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.connect.mdx
+++ b/platform-includes/set-environment/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.express.mdx
+++ b/platform-includes/set-environment/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.fastify.mdx
+++ b/platform-includes/set-environment/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.gcp-functions.mdx
+++ b/platform-includes/set-environment/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/set-environment/javascript.koa.mdx
+++ b/platform-includes/set-environment/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.aws-lambda.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.aws-lambda.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.azure-functions.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.azure-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.connect.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.connect.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.express.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.express.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.fastify.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.fastify.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.gcp-functions.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.gcp-functions.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/platform-includes/user-feedback/sdk-api-example/javascript.koa.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.koa.mdx
@@ -1,1 +1,0 @@
-javascript.node.mdx

--- a/src/components/platformContent.tsx
+++ b/src/components/platformContent.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import {getMDXComponent} from 'mdx-bundler/client';
 
-import {getDocsRootNode, getPlatform} from 'sentry-docs/docTree';
+import {getCurrentGuide, getDocsRootNode, getPlatform} from 'sentry-docs/docTree';
 import {getFileBySlug} from 'sentry-docs/mdx';
 import {mdxComponents} from 'sentry-docs/mdxComponents';
 import {serverContext} from 'sentry-docs/serverContext';
@@ -37,6 +37,21 @@ export async function PlatformContent({includePath, platform, noGuides}: Props) 
       doc = await getFileBySlug(`platform-includes/${includePath}/${guide}`);
     } catch (e) {
       // It's fine - keep looking.
+    }
+  }
+
+  if (!doc) {
+    const rootNode = await getDocsRootNode();
+    const guideObject = getCurrentGuide(rootNode, path);
+
+    if (guideObject?.fallbackGuide) {
+      try {
+        doc = await getFileBySlug(
+          `platform-includes/${includePath}/${guideObject.fallbackGuide}`
+        );
+      } catch (e) {
+        // It's fine - keep looking.
+      }
     }
   }
 

--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -11,7 +11,7 @@ import {
 
 export interface DocNode {
   children: DocNode[];
-  frontmatter: FrontMatter & PlatformConfig;
+  frontmatter: FrontMatter & PlatformConfig & Pick<PlatformGuide, 'fallbackGuide'>;
   missing: boolean;
   path: string;
   slug: string;
@@ -173,6 +173,7 @@ function nodeToGuide(platform: string, n: DocNode): PlatformGuide {
     platform,
     sdk: n.frontmatter.sdk || `sentry.${key}`,
     categories: n.frontmatter.categories,
+    fallbackGuide: n.frontmatter.fallbackGuide,
   };
 }
 

--- a/src/types/platform.tsx
+++ b/src/types/platform.tsx
@@ -59,6 +59,12 @@ export interface PlatformGuide
    * The relative URL to the docs for this guide
    */
   url: string;
+  /**
+   * Useful to define the "parent" guide. When specified the Guide will inherit configuration values
+   * from the parent guide. This is useful for node-based guides such as express, as their parent platform
+   * is javascript and "node" should be a guide that can be inherited from.
+   */
+  fallbackGuide?: string;
 }
 
 export interface PlatformIntegration extends Omit<PlatformGuide, 'type'> {


### PR DESCRIPTION
Adds possibility for fallback guide which is useful for e.g. node-based libraries such as express. The `PlatformContent` component will not fallback to the javascript snippets but the node snippets (as node is just a guide in the JS platform). Currently, this is solved by using symlinks to the node code snippets to keep the snippets the same as node.
