### PR TITLE
fix(js): Fix dead link

### DIFF
--- a/docs/platforms/javascript/common/configuration/transports.mdx
+++ b/docs/platforms/javascript/common/configuration/transports.mdx
@@ -23,7 +23,7 @@ You can change the transport by setting the `transport` option in the `init` cal
 
 ## `makeBrowserOfflineTransport`
 
-The `makeBrowserOfflineTransport` transport is a built-in transport that uses the `IndexedDB` API to store events when the browser is offline. When the browser comes back online, the transport sends the stored events to Sentry. <PlatformLink to="/best-pracises/offline-caching">Read more about how to use it.</PlatformLink>
+The `makeBrowserOfflineTransport` transport is a built-in transport that uses the `IndexedDB` API to store events when the browser is offline. When the browser comes back online, the transport sends the stored events to Sentry. <PlatformLink to="/best-practices/offline-caching/">Read more about how to use it.</PlatformLink>
 
 ## Custom transport
 

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -36,7 +36,7 @@ The xhr transport via `makeXHRTransport` transport has been removed. Only `makeF
 
 ### Removal of the `Offline` integration
 
-The `Offline` integration has been removed in favor of the <PlatformLink to="/configuration/transports/#offline-caching/">offline transport wrapper</PlatformLink>
+The `Offline` integration has been removed in favor of the <PlatformLink to="/configuration/transports/#makebrowserofflinetransport">offline transport wrapper</PlatformLink>
 
 ### Removal of `wrap` export
 


### PR DESCRIPTION
There was a typo in the link, oops.