### PR TITLE
feat(replay): Remove "canvas is in beta" notice

### DIFF
--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -42,12 +42,6 @@ To set up the integration, add the following to your Sentry initialization. Ther
 <PlatformSection notSupported={["javascript.deno", "javascript.bun", "javascript.wasm", "javascript.capacitor", "javascript.electron"]}>
 ### Canvas Recording
 
-<Alert level="">
-  Canvas recording is currently in beta. Please submit an issue on
-  [GitHub](https://github.com/getsentry/sentry-javascript) if you encounter any
-  bugs.
-</Alert>
-
 <Alert level="warning">
   There is currently no PII scrubbing in canvas recordings!
 </Alert>


### PR DESCRIPTION
Canvas has been in GA for a few weeks now, time to remove the beta notice.
