### PR TITLE
Suggest to still read the js v8 changelog despite having `@sentry/migr8`

### DIFF
--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -20,7 +20,7 @@ Before updating to `8.x` of the SDK, we recommend upgrading to the latest versio
 npx @sentry/migr8@latest
 ```
 
-Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`! For more details on the deprecations, see our docs on [Deprecations in 7.x](./v7-deprecations).
+Our migration tool will let you select which updates to run, and automatically update your code. In some cases, we cannot automatically change code for you. These will be marked with a `TODO(sentry)` comment instead. Make sure to review all code changes after running `@sentry/migr8`! For more details on the deprecations, see our docs on [Deprecations in 7.x](./v7-deprecations). Despite having `@sentry/migr8`, we still recommend reading the migration guide, since `@sentry/migr8` does not cover all of the changes needed to migrate.
 
 ## Upgrading to `8.x`
 


### PR DESCRIPTION
I have seen people confused about that migr8 does not change Next.js configuration for example.