### PR TITLE
fix typo

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
     })
   ],
   build: {
-    sourcemaps: true,
+    sourcemap: true,
     // ... rest of your Vite build options
   }
 


### PR DESCRIPTION
fix sourceMap option for vite plugin: https://vitejs.dev/config/build-options.html#build-sourcemap

it is saying `sourcemaps`, while the correct option in the Vite documentation (and other sentry pages) is `sourcemap`