### PR TITLE
Adding `sentryTag` in compose docs

### DIFF
--- a/docs/platforms/android/integrations/jetpack-compose/index.mdx
+++ b/docs/platforms/android/integrations/jetpack-compose/index.mdx
@@ -112,7 +112,7 @@ SentryAndroid.init(this) { options ->
 
 #### Capture Composables
 
-The Sentry SDK requires to have the `Modifier.sentryTag("<tag>")` on each Composable you want to capture to determine its identifier. 
+The Sentry SDK requires you to have either `Modifier.sentryTag("<tag>")` or `Modifier.testTag("<tag>")` applied on each `@Composable` you want to capture to determine its identifier.
 Here's an example:
 
 ```kotlin
@@ -133,7 +133,7 @@ fun LoginScreen() {
 
 <Note>
 
-If a `@Composable` doesn't have a `sentryTag` modifier applied, both breadcrumbs and transactions won't be captured because they can't be uniquely identified. 
+If a `@Composable` doesn't have a `.sentryTag` or a `.testTag` modifier applied, both breadcrumbs and transactions won't be captured because they can't be uniquely identified.
 To automatically generate tags, refer to the docs about our <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink>.
 
 </Note>

--- a/docs/platforms/android/integrations/jetpack-compose/index.mdx
+++ b/docs/platforms/android/integrations/jetpack-compose/index.mdx
@@ -38,7 +38,7 @@ Once performance metrics have been enabled, you'll see two spans inside your tra
 - `ui.compose.composition`, describing the time it took to execute your `@Composable`
 - `ui.compose.rendering`, describing the time it took to render your `@Composable` to the canvas
 
-The `SentryTraced` function also provides an `enableUserInteractionTracing` argument, which automatically applies a `Modifier.testTag()` and enables the _User Interactions_ feature mentioned below.
+The `SentryTraced` function also provides an `enableUserInteractionTracing` argument, which automatically applies a `Modifier.sentryTag()` and enables the _User Interactions_ feature mentioned below.
 
 ### Installation
 
@@ -110,17 +110,20 @@ SentryAndroid.init(this) { options ->
 }
 ```
 
-The Sentry SDK utilizes the built-in `Modifier.testTag("<tag>")` of a Composable to determine its identifier. Here's an example:
+#### Capture Composables
+
+The Sentry SDK requires to have the `Modifier.sentryTag("<tag>")` on each Composable you want to capture to determine its identifier. 
+Here's an example:
 
 ```kotlin
-import androidx.compose.ui.platform.testTag
+import io.sentry.compose.sentryTag
 
 @Composable
 fun LoginScreen() {
   Column {
     // ...
     Button(
-        modifier = Modifier.testTag("button_login"),
+        modifier = Modifier.sentryTag("button_login"),
         onClick = { TODO() }) {
         Text(text = "Login")
     }
@@ -130,7 +133,8 @@ fun LoginScreen() {
 
 <Note>
 
-If a `@Composable` doesn't have a `testTag` modifier applied, both breadcrumbs and transactions won't be captured because they can't be uniquely identified. To automatically generate tags, refer to the docs about our <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink>.
+If a `@Composable` doesn't have a `sentryTag` modifier applied, both breadcrumbs and transactions won't be captured because they can't be uniquely identified. 
+To automatically generate tags, refer to the docs about our <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink>.
 
 </Note>
 

--- a/docs/platforms/android/performance/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/android/performance/instrumentation/automatic-instrumentation.mdx
@@ -278,17 +278,18 @@ If the view doesn't have the `id` assigned, the transaction won't be captured be
 
 _(New in version 6.10.0)_
 
-The SDK composes the transaction name out of the host `Activity` and the `tag` set by way of the `Modifier.testTag("<tag>")` of the `Composable` (for example, `LoginActivity.login_button`). The transaction operation is set to `ui.action` plus the interaction type (one of `click`, `scroll`, or `swipe`).
+The SDK composes the transaction name out of the host `Activity` and the `tag` set by way of the `Modifier.sentryTag("<tag>")` of the `Composable` (for example, `LoginActivity.login_button`). 
+The transaction operation is set to `ui.action` plus the interaction type (one of `click`, `scroll`, or `swipe`).
 
 ```kotlin
-import androidx.compose.ui.platform.testTag
+import io.sentry.compose.sentryTag
 
 @Composable
 fun LoginScreen() {
   Column {
     // ...
     Button(
-        modifier = Modifier.testTag("button_login"),
+        modifier = Modifier.sentryTag("button_login"),
         onClick = { TODO() }) {
         Text(text = "Login")
     }
@@ -298,7 +299,8 @@ fun LoginScreen() {
 
 <Note>
 
-If the `@Composable` doesn't have a `testTag` modifier applied, the transaction won't be captured because it can't be uniquely identified. To capture a transaction for the `@Composable`, you must either add a `testTag` modifier or enable automatic `@Composable` tagging.
+If the `@Composable` doesn't have a `sentryTag` modifier applied, the transaction won't be captured because it can't be uniquely identified. 
+To capture a transaction for the `@Composable`, you must either add a `sentryTag` modifier or enable automatic `@Composable` tagging.
 
 </Note>
 
@@ -310,7 +312,9 @@ The Sentry Kotlin Compiler plugin is considered _experimental_. Give it a try an
 
 </Note>
 
-The <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink> can automatically enrich your `@Composable` functions during compilation with a tag name, based on the function name of your `@Composable`. In order to use this feature, the Sentry Kotlin Compiler plugin needs to be applied to all modules, which contain `@Composable` elements.
+The <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink> can automatically enrich your `@Composable` functions during compilation with a tag name, 
+based on the function name of your `@Composable`. 
+In order to use this feature, the Sentry Kotlin Compiler plugin needs to be applied to all modules, which contain `@Composable` elements.
 
 ```groovy {filename:app/build.gradle}
 plugins {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Changed the docs from mentioning `Modifier.testTag` to `Modifier.sentryTag`.
I'm not sure why the `testTag` thing is there, if this was changed to your own tag or what.. 
I just found out that you actually use a custom `sentryTag` and not the `testTag`.
See https://github.com/getsentry/sentry-android-gradle-plugin/blob/1c15d184114b41058f3c0803c8675b79073f0d0a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt#L92

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
