### PR TITLE
Update extraerrordata.mdx

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
@@ -21,6 +21,6 @@ a primitive value.
 
 ### `captureErrorCause`
 
-_Type: `boolean`
+_Type: `boolean`_
 
 Indicates if the serializer should catch the `cause` of the error. For more information, see the [Error: cause MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).

--- a/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
@@ -18,3 +18,9 @@ _Type: `number`_
 Limit of how deep the object serializer should go. The default is 3. Anything deeper than the set limit will
 be replaced with standard Node.js REPL notation of [Object], [Array], [Function], or
 a primitive value.
+
+### `captureErrorCause`
+
+_Type: `boolean`
+
+Indicates if the serializer catch the `cause` of the error. More information: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

--- a/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/extraerrordata.mdx
@@ -23,4 +23,4 @@ a primitive value.
 
 _Type: `boolean`
 
-Indicates if the serializer catch the `cause` of the error. More information: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+Indicates if the serializer should catch the `cause` of the error. For more information, see the [Error: cause MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).


### PR DESCRIPTION
Updating doc to reflect the `captureErrorCause` option in the ExtraErrorData Integration.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
I've updated the ExtraErrorData documentation to also includes its second option (`captureErrorCause`).

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
