### PR TITLE
Fix: Rename IUserFactory to ISentryUserFactory

### DIFF
--- a/docs/platforms/dotnet/guides/aspnetcore/index.mdx
+++ b/docs/platforms/dotnet/guides/aspnetcore/index.mdx
@@ -190,18 +190,18 @@ The lifetime used will be respected by the SDK. For example, when registering a 
 
 When opting-in to [SendDefaultPii](#senddefaultpii), the SDK will automatically read the user from the request by inspecting `HttpContext.User`. Default claim values like `NameIdentifier` for the _Id_ will be used.
 
-If you wish to change the behavior of how to read the user from the request, you can register a new `IUserFactory` into the container:
+If you wish to change the behavior of how to read the user from the request, you can register a new `ISentryUserFactory` into the container:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddSingleton<IUserFactory, MyUserFactory>();
+    services.AddSingleton<ISentryUserFactory, MyUserFactory>();
 }
 ```
 
 ```fsharp
 member this.ConfigureServices(services: IServiceCollection) =
-    services.AddSingleton<IUserFactory, MyUserFactory>() |> ignore
+    services.AddSingleton<ISentryUserFactory, MyUserFactory>() |> ignore
 ```
 
 ### Adding event and exception processors


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The documentation on the ASP.NET Core page (https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/#capturing-the-affected-user) references `IUserFactory`, but per [#2719](https://github.com/getsentry/sentry-dotnet/pull/2719) it should be `ISentryUserFactory`

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
