### PR TITLE
Change viewed_by_id->viewed_by_me in replay search props

### DIFF
--- a/docs/concepts/search/searchable-properties/session-replay.mdx
+++ b/docs/concepts/search/searchable-properties/session-replay.mdx
@@ -249,7 +249,7 @@ Version of the Sentry SDK that sent the event.
 Whether you've seen this replay.
 Alias: `viewed_by_me`
 
-- **Type:** number
+- **Type:** boolean
 
 ### `trace`
 

--- a/docs/concepts/search/searchable-properties/session-replay.mdx
+++ b/docs/concepts/search/searchable-properties/session-replay.mdx
@@ -244,10 +244,10 @@ Version of the Sentry SDK that sent the event.
 
 - **Type:** string
 
-### `seen_by_id`
+### `seen_by_me`
 
-Sentry user IDs who have seen this Replay.
-Alias: `viewed_by_id`
+Whether you've seen this replay, true or false.
+Alias: `viewed_by_me`
 
 - **Type:** number
 

--- a/docs/concepts/search/searchable-properties/session-replay.mdx
+++ b/docs/concepts/search/searchable-properties/session-replay.mdx
@@ -246,7 +246,7 @@ Version of the Sentry SDK that sent the event.
 
 ### `seen_by_me`
 
-Whether you've seen this replay, true or false.
+Whether you've seen this replay.
 Alias: `viewed_by_me`
 
 - **Type:** number


### PR DESCRIPTION
Update after https://github.com/getsentry/sentry/pull/70967

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
