### PR TITLE
docs(lambda): Add AWS Lambda layer for v7 node sdk

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/layer/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/layer/index.mdx
@@ -26,3 +26,14 @@ Then add the Sentry Layer by navigating to your Lambda function. Select **Layers
 Finally, set the region and copy the provided ARN value into the input.
 
 <LambdaLayerDetail canonical="aws-layer:node" />
+
+<br/>
+
+## Lambda layer for v7
+
+You can also install a v7 version of the Sentry Lambda layer in case you cannot upgrade to v8.
+Modify and copy the provided ARN value for your region into the input, e.g. for region `us-west-1` and the current v7 Lambda layer version `1`:
+
+```
+arn:aws:lambda:us-west-1:943013980633:layer:SentryNodeServerlessSDKv7:1
+```


### PR DESCRIPTION
Ideally we would want to have another dropdown for v7 that automatically spits out the latest ARN for v7, but this is a change that needs to be carefully evaluated in `craft` and `sentry-release-registry`. For now we'll have to live with a hard-coded ARN for v7.

ref: https://github.com/getsentry/sentry-javascript/issues/12098