### PR TITLE
Remove reference to deprecated "Sentry as a Container Image"

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/index.mdx
@@ -35,7 +35,7 @@ npm install --save @sentry/aws-serverless
 yarn add @sentry/aws-serverless
 ```
 
-We also support [installing Sentry as a Container Image](/platforms/javascript/guides/aws-lambda/container-image/) and [installing Sentry in Lambda Layer](/platforms/javascript/guides/aws-lambda/layer/).
+We also support [installing Sentry in Lambda Layer](/platforms/javascript/guides/aws-lambda/layer/).
 
 You can use the AWS Lambda integration for the Node like this:
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The page for "installing Sentry as a Container Image" specifies it is now deprecated.
```
Deprecation Notice
The Node.js AWS Lambda Container Image is deprecated. Instead, please either use the Sentry AWS Lambda Layer or use the Sentry AWS Lambda SDK directly.
```

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
