### PR TITLE
feat(python): Append OpenTelemetry propagators instead of replace

### DIFF
--- a/platform-includes/performance/opentelemetry-setup/python.mdx
+++ b/platform-includes/performance/opentelemetry-setup/python.mdx
@@ -20,14 +20,14 @@ Next, configure OpenTelemetry as you need and hook in the Sentry span processor 
 
 ```python
 from opentelemetry import trace
-from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagate import propagators
 from opentelemetry.sdk.trace import TracerProvider
 from sentry_sdk.integrations.opentelemetry import SentrySpanProcessor, SentryPropagator
 
 provider = TracerProvider()
 provider.add_span_processor(SentrySpanProcessor())
 trace.set_tracer_provider(provider)
-set_global_textmap(SentryPropagator())
+propagators.append(SentryPropagator())
 ```
 
 Finally, try it out with:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
According to [documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators) OpenTelemetry provides two default propagators: `tracecontext,baggage`. It may contain user defined propagators as well. Setting up SentryPropagator using `set_global_textmap` breaks down distributed tracing. It would be better to append propagator to existing ones instead of replace them.

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
