### PR TITLE
ref: Remove metrics integration

### DIFF
--- a/platform-includes/metrics/configure/javascript.astro.mdx
+++ b/platform-includes/metrics/configure/javascript.astro.mdx
@@ -1,25 +1,17 @@
 To use metrics with astro, first [manually setup up the SDK as per the Astro SDK docs](/platforms/javascript/guides/astro/manual-setup/#manual-sdk-initialization).
 
-To configure metrics for your client-side code, add the `metricsAggregatorIntegration` to your `Sentry.init` call in your `sentry.client.config.js` file.
+Metrics work out of the box by calling `Sentry.init` no further setup is required.
 
 ```JavaScript
 // sentry.client.config.js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    Sentry.metrics.metricsAggregatorIntegration(),
-  ],
 });
 ```
-
-To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `sentry.server.config.js` file.
 
 ```JavaScript
 // sentry.server.config.js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  _experiments: {
-    metricsAggregator: true,
-  },
 });
 ```

--- a/platform-includes/metrics/configure/javascript.mdx
+++ b/platform-includes/metrics/configure/javascript.mdx
@@ -1,10 +1,7 @@
-To configure metrics, add the `metricsAggregatorIntegration` to your `Sentry.init` call.
+Metrics work out of the box by calling `Sentry.init` no further setup is required.
 
 ```JavaScript
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    Sentry.metrics.metricsAggregatorIntegration(),
-  ],
 });
 ```

--- a/platform-includes/metrics/configure/javascript.nextjs.mdx
+++ b/platform-includes/metrics/configure/javascript.nextjs.mdx
@@ -1,22 +1,14 @@
-To configure metrics for your client-side code, add the `metricsAggregatorIntegration` to your `Sentry.init` call in your `sentry.client.config.js` file.
+Metrics work out of the box by calling `Sentry.init` no further setup is required.
 
 ```JavaScript
 // sentry.client.config.js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    Sentry.metrics.metricsAggregatorIntegration(),
-  ],
 });
 ```
-
-To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `instrumentation.(js|ts)` file.
 
 ```JavaScript
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  _experiments: {
-    metricsAggregator: true,
-  },
 });
 ```

--- a/platform-includes/metrics/configure/javascript.remix.mdx
+++ b/platform-includes/metrics/configure/javascript.remix.mdx
@@ -1,23 +1,15 @@
-To configure metrics for your client-side code, add the `metricsAggregatorIntegration` to your `Sentry.init` call in your `entry.client.tsx` file.
+Metrics work out of the box by calling `Sentry.init` no further setup is required.
 
 ```JavaScript
 // entry.client.tsx
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    Sentry.metrics.metricsAggregatorIntegration(),
-  ],
 });
 ```
-
-To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `entry.server.tsx` file.
 
 ```JavaScript
 // entry.server.tsx
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  _experiments: {
-    metricsAggregator: true,
-  },
 });
 ```

--- a/platform-includes/metrics/configure/javascript.sveltekit.mdx
+++ b/platform-includes/metrics/configure/javascript.sveltekit.mdx
@@ -1,23 +1,15 @@
-To configure metrics for your client-side code, add the `metricsAggregatorIntegration` to your `Sentry.init` call in your `hooks.client.js` file.
+Metrics work out of the box by calling `Sentry.init` no further setup is required.
 
 ```JavaScript
 // hooks.client.js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [
-    Sentry.metrics.metricsAggregatorIntegration(),
-  ],
 });
 ```
-
-To configure metrics for your server-side code, add the `metricsAggregator` experimental option to your `Sentry.init` call in your `hooks.server.js` file.
 
 ```JavaScript
 // hooks.server.js
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  _experiments: {
-    metricsAggregator: true,
-  },
 });
 ```


### PR DESCRIPTION
The integration in v8 is no longer needed, removing it from code snippets.