### PR TITLE
fix(.NET): Update Azure Functions

### DIFF
--- a/docs/platforms/dotnet/guides/azure-functions-worker/index.mdx
+++ b/docs/platforms/dotnet/guides/azure-functions-worker/index.mdx
@@ -23,7 +23,7 @@ This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extens
 
 ## Configure
 
-Sentry integration with Azure Functions is done by calling `.UseSentry()` and specifying the options. E.g.:
+Sentry integration with Azure Functions is done by calling `.UseSentry()` and specifying the options, for example:
 
 <SignInNote />
 

--- a/docs/platforms/dotnet/guides/azure-functions-worker/index.mdx
+++ b/docs/platforms/dotnet/guides/azure-functions-worker/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Azure Functions
 sdk: sentry.dotnet.azurefunctions.worker
-description: "Learn about Sentry's .NET integration with Azure Functions (Isolated Worker)."
+description: "Learn about Sentry's .NET integration with Azure Functions."
 ---
 
 Sentry provides an integration with Azure Functions through the [Sentry.Azure.Functions.Worker NuGet package](https://www.nuget.org/packages/Sentry.Azure.Functions.Worker).
@@ -23,9 +23,15 @@ This package extends [Sentry.Extensions.Logging](/platforms/dotnet/guides/extens
 
 ## Configure
 
-Sentry integration with Azure Functions (when using the Isolated Worker Process execution mode) is done by calling `.UseSentry()` and specifying the options. E.g.:
+Sentry integration with Azure Functions is done by calling `.UseSentry()` and specifying the options. E.g.:
 
 <SignInNote />
+
+<Note>
+
+If using the ASP.NET Core integration add `UseSentry` to the `ConfigureFunctionsWebApplication` call instead.
+
+</Note>
 
 ```csharp
 using Sentry.Azure.Functions.Worker;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/10041

If you (as a user) are using the ASP.NET integration use the `ConfigureFunctionsWebApplication` call instead of `ConfigureFunctionsWorkerDefaults`. It's an either/or situation, but not both.
