### PR TITLE
feat(js): Update supported browsers based on v8

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/supported-browsers.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/supported-browsers.mdx
@@ -16,49 +16,15 @@ notSupported:
   - javascript.nestjs
 ---
 
-Sentry's JavaScript SDK supports the following browsers:
+Sentry's JavaScript SDKs support ES2018 compatible browsers. The minimum supported browser versions are:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <strong>Android</strong>
-      </td>
-      <td>
-        <strong>Firefox</strong>
-      </td>
-      <td>
-        <strong>Chrome</strong>
-      </td>
-      <td>
-        <strong>IE</strong>
-      </td>
-      <td>
-        <strong>iPhone</strong>
-      </td>
-      <td>
-        <strong>Edge</strong>
-      </td>
-      <td>
-        <strong>Safari</strong>
-      </td>
-    </tr>
-    <tr>
-      <td>4.4</td>
-      <td>latest</td>
-      <td>latest</td>
-      <td>IE 11</td>
-      <td>iOS12</td>
-      <td>latest</td>
-      <td>latest</td>
-    </tr>
-  </tbody>
-</table>
+- Chrome 63
+- Edge 79
+- Safari/iOS Safari 12
+- Firefox 58
+- Opera 50
+- Samsung Internet 8.2
 
 ## Support for IE11 / ES5
 
-The Sentry JavaScript SDK uses ES6 syntax and functionality to provide the best possible user experience. If you want to support IE11 (or other environments that do not support ES6), you need to transpile your code using a bundler like webpack, Vite, Rollup, etc.
-
-We do use some ES6-only features. If you want to use them in ES5, you'll need to provide polyfills. [Here is an example](https://github.com/getsentry/sentry-javascript/blob/9307308e4b3fed18645889838983083315697b9b/dev-packages/rollup-utils/polyfills/es5.js) of how to do this.
-
-Alternatively, you can use our [ES5 CDN bundles](/platforms/javascript/install/loader/#available-bundles).
+The Sentry JavaScript SDK uses ES2018 syntax and functionality to provide the best possible user experience and lowest bundle size. If you want to support IE11 (or other environments that do not support ES6), you need to transpile your code using a bundler like webpack, Vite, Rollup, etc and add polyfills for ES5 functionality.


### PR DESCRIPTION
Copying over https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#supported-versions