### PR TITLE
feat(metrics): Add maximum length for metric components

### DIFF
--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -49,19 +49,21 @@ Sentry allows the use of specific characters for the components of a metric:
 
 - **Metric Name**: Supports all word characters including `_`, `-`, `.`. Any unsupported characters will be replaced by `_`.
 
+- **Metric Unit**:  Custom units must consist of ASCII alphanumeric characters, underscores, and digits.
+
 - **Metric Tag Keys**: Supports all word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
 
 - **Metric Tag Values**: Supports all Unicode characters.
 
-- **Custom Metric Units**:  Custom units must consist of ASCII alphanumeric characters, underscores, and digits.
-
 More information about the normalization of unsupported characters can be found [here](https://develop.sentry.dev/sdk/metrics/#normalization).
 
-### Metric Tags Length
+### Maximum Lengths
 
-Metric tags have a maximum length:
-- Tag Keys: 32 characters.
-- Tag Values: 200 characters.
+Sentry sets a maximum length for the components of a metric:
+- **Metric Name**: 150 characters.
+- **Metric Unit**: 15 characters.
+- **Metric Tag Keys**: 32 characters.
+- **Metric Tag Values**: 200 characters.
 
 ### Retention
 

--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -47,13 +47,13 @@ Sentry incorporates protection mechanisms that will drop metrics if their cardin
 
 Sentry allows the use of specific characters for the components of a metric:
 
-- **Metric Name**: Supports all word characters including `_`, `-`, `.`. Any unsupported characters will be replaced by `_`.
+- **Metric Name**: All word characters including `_`, `-`, `.`. Any unsupported characters will be replaced by `_`.
 
-- **Metric Unit**:  Custom units must consist of ASCII alphanumeric characters, underscores, and digits.
+- **Metric Unit**: ASCII alphanumeric characters, underscores, and digits.
 
-- **Metric Tag Keys**: Supports all word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
+- **Metric Tag Keys**: All word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
 
-- **Metric Tag Values**: Supports all Unicode characters.
+- **Metric Tag Values**: All Unicode characters.
 
 More information about the normalization of unsupported characters can be found [here](https://develop.sentry.dev/sdk/metrics/#normalization).
 

--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -53,7 +53,7 @@ Sentry allows the use of specific characters for the components of a metric:
 
 - **Metric Tag Key**: All word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
 
-- **Metric Tag Values**: All Unicode characters.
+- **Metric Tag Value**: All Unicode characters.
 
 More information about the normalization of unsupported characters can be found [here](https://develop.sentry.dev/sdk/metrics/#normalization).
 

--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -62,8 +62,8 @@ More information about the normalization of unsupported characters can be found 
 Sentry sets a maximum length for the components of a metric:
 - **Metric Name**: 150 characters.
 - **Metric Unit**: 15 characters.
-- **Metric Tag Keys**: 32 characters.
-- **Metric Tag Values**: 200 characters.
+- **Metric Tag Key**: 32 characters.
+- **Metric Tag Value**: 200 characters.
 
 ### Retention
 

--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -51,7 +51,7 @@ Sentry allows the use of specific characters for the components of a metric:
 
 - **Metric Unit**: ASCII alphanumeric characters, underscores, and digits.
 
-- **Metric Tag Keys**: All word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
+- **Metric Tag Key**: All word characters including `_`, `-`, `.`, `/`. Any unsupported characters will be removed from the tag key.
 
 - **Metric Tag Values**: All Unicode characters.
 


### PR DESCRIPTION
This PR updates our develop docs with the updated limits for metric name and unit lengths.

Related to: https://github.com/getsentry/relay/pull/3628