### PR TITLE
[Python] Guide for Manual Queues Insights Module Instrumenation

### DIFF
--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation/caches-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: Instrument Caches
 sidebar_order: 1000
-description: "Learn how to manually instrument your code to use Sentrys Cache module. "
+description: "Learn how to manually instrument your code to use Sentry's Caches module. "
 ---
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 

--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation/queues-module.mdx
@@ -1,0 +1,134 @@
+---
+title: Instrument Queues
+sidebar_order: 3000
+description: "Learn how to manually instrument your code to use Sentry's Queues module. "
+---
+To ensure that you have performance data about your messaging queues, you'll need to instrument custom spans and transactions around your queue producers and consumers.
+
+## Producer Instrumentation
+
+To start capturing performance metrics, use the `sentry_sdk.start_span()` function to wrap your queue producer events. Your span `op` must be set to `queue.publish`. Include the following span data to enrich your producer spans with queue metrics:
+
+| Data Attribute | Type | Description |
+|:--|:--|:--|
+| `messaging.message.id ` | string | The message identifier |
+| `messaging.destination.name` | string | The queue or topic name |
+| `messaging.message.body.size` | int | Size of the message body in bytes |
+
+Your `queue.publish` span must exist inside a transaction in order to be recognized as a producer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink> the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
+
+You must also include trace headers (`sentry-trace` and `baggage`) in your message so that your consumers can continue your trace once your message is picked up.
+
+
+```python
+from datetime import datetime, timezone
+
+import sentry_sdk
+import my_custom_queue
+
+# Initialize Sentry
+sentry_sdk.init(...)
+
+connection = my_custom_queue.connect()
+
+# The message you want to send to the queue
+queue = "messages"
+message = "Hello World!"
+message_id = "abc123"
+
+# Create transaction
+# If you are using a web framework, the framework integration
+# will create this for you and you can omit this.
+with sentry_sdk.start_transaction(
+    op="function",
+    name="queue_producer_transaction",
+):
+    # Create the span
+    with sentry_sdk.start_span(
+        op="queue.publish",
+        description="queue_producer",
+    ) as span:
+        # Set span data
+        span.set_data("messaging.message.id", message_id)
+        span.set_data("messaging.destination.name", queue)
+        span.set_data("messaging.message.body.size", len(message.encode("utf-8")))
+
+        # Publish the message to the queue (including trace information and current time stamp)
+        now = int(datetime.now(timezone.utc).timestamp())
+        connection.publish(
+            queue=queue,
+            body=message,
+            timestamp=now,
+            headers = {
+                "sentry-trace": sentry_sdk.get_traceparent(),
+                "baggage": sentry_sdk.get_baggage(),
+            },
+        )
+```
+
+
+## Consumer Instrumentation
+
+To start capturing performance metrics, use the `sentry_sdk.start_span()` function to wrap your queue consumers. Your span `op` must be set to `queue.process`. Include the following span data to enrich your consumer spans with queue metrics:
+
+| Data Attribute | Type | Description |
+|:--|:--|:--|
+| `messaging.message.id ` | string | The message identifier |
+| `messaging.destination.name` | string | The queue or topic name |
+| `messaging.message.body.size` | number | Size of the message body in bytes |
+| `messaging.message.retry.count ` | number | The number of times a message was attempted to be processed |
+| `messaging.message.receive.latency ` | number | The time in milliseconds that a message awaited processing in queue |
+
+Your `queue.process` span must exist inside a transaction in order to be recognized as a consumer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink> the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
+
+Use `sentry_sdk.continue_trace()` to connect your consumer spans to their associated producer spans, and `span.set_status()` to mark the trace of your message as success or failed.
+
+
+```python
+from datetime import datetime, timezone
+
+import sentry_sdk
+import my_custom_queue
+
+# Initialize Sentry
+sentry_sdk.init(...)
+
+connection = my_custom_queue.connect()
+
+# Pick up message from queues
+queue = "messages"
+message = connection.consume(queue=queue)
+
+# Calculate latency (optional, but valuable)
+now = datetime.now(timezone.utc)
+message_time = datetime.fromtimestamp(message["timestamp"], timezone.utc)
+latency =  now - message_time
+
+# Continue the trace started in the producer
+# If you are using a web framework, the framework integration
+# will create this for you and you can omit this.
+transaction = sentry_sdk.continue_trace(
+    message["headers"],
+    op="function",
+    name="queue_consumer_transaction",
+)
+with sentry_sdk.start_transaction(transaction):
+    # Create the span
+    with sentry_sdk.start_span(
+        op="queue.process",
+        description="queue_consumer",
+    ) as span:
+        # Set span data
+        span.set_data("messaging.message.id", message["message_id"])
+        span.set_data("messaging.destination.name", queue)
+        span.set_data("messaging.message.body.size", message["body"])
+        span.set_data("messaging.message.receive.latency", latency)
+        span.set_data("messaging.message.retry.count", 0)
+
+        try:
+            # Process the message
+            process_message(message)
+        except Exception:
+            # In case of an error set the status to "internal_error"
+            span.set_status("internal_error")
+```

--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation/queues-module.mdx
@@ -3,7 +3,7 @@ title: Instrument Queues
 sidebar_order: 3000
 description: "Learn how to manually instrument your code to use Sentry's Queues module. "
 ---
-To ensure that you have performance data about your messaging queues, you'll need to instrument custom spans and transactions around your queue producers and consumers.
+Sentry comes with automatic instrumentation for the most common messaging queue systems. In case yours isn't supported, you can still instrument custom spans and transactions around your queue producers and consumers to ensure that you have performance data about your messaging queues.
 
 ## Producer Instrumentation
 
@@ -15,7 +15,7 @@ To start capturing performance metrics, use the `sentry_sdk.start_span()` functi
 | `messaging.destination.name` | string | The queue or topic name |
 | `messaging.message.body.size` | int | Size of the message body in bytes |
 
-Your `queue.publish` span must exist inside a transaction in order to be recognized as a producer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink> the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
+Your `queue.publish` span must exist inside a transaction in order to be recognized as a producer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink>, the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
 
 You must also include trace headers (`sentry-trace` and `baggage`) in your message so that your consumers can continue your trace once your message is picked up.
 
@@ -59,7 +59,7 @@ with sentry_sdk.start_transaction(
             queue=queue,
             body=message,
             timestamp=now,
-            headers = {
+            headers={
                 "sentry-trace": sentry_sdk.get_traceparent(),
                 "baggage": sentry_sdk.get_baggage(),
             },
@@ -79,7 +79,7 @@ To start capturing performance metrics, use the `sentry_sdk.start_span()` functi
 | `messaging.message.retry.count ` | number | The number of times a message was attempted to be processed |
 | `messaging.message.receive.latency ` | number | The time in milliseconds that a message awaited processing in queue |
 
-Your `queue.process` span must exist inside a transaction in order to be recognized as a consumer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink> the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
+Your `queue.process` span must exist inside a transaction in order to be recognized as a consumer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink>, the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
 
 Use `sentry_sdk.continue_trace()` to connect your consumer spans to their associated producer spans, and `span.set_status()` to mark the trace of your message as success or failed.
 
@@ -102,7 +102,7 @@ message = connection.consume(queue=queue)
 # Calculate latency (optional, but valuable)
 now = datetime.now(timezone.utc)
 message_time = datetime.fromtimestamp(message["timestamp"], timezone.utc)
-latency =  now - message_time
+latency = now - message_time
 
 # Continue the trace started in the producer
 # If you are using a web framework, the framework integration


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
A guide on how to manually instrument spans so they are eligible for the Queues Insighs Module. 

Preview: https://sentry-docs-git-antonpirker-python-queues-module-manual-533d53.sentry.dev/platforms/python/performance/instrumentation/custom-instrumentation/queues-module/

## IS YOUR CHANGE URGENT?     

Help us prioritize incoming PRs by letting us know when the change needs to go live. 
- [X] Urgent deadline (GA date, etc.): EA: 2024-05-20 / GA: 2024-06-05
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs. 
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it. 
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
