### PR TITLE
feat(js): Add lazy loading docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/index.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/index.mdx
@@ -47,11 +47,48 @@ You can add additional integrations in your `init` call:
 
 <PlatformContent includePath="configuration/enable-pluggable-integrations" />
 
-Alternatively, you can add integrations lazily via `Sentry.addIntegration()`.
-This is useful if you only want to enable an integration in a specific environment or if you want to lazy-load an integration.
+Alternatively, you can add integrations via `Sentry.addIntegration()`.
+This is useful if you only want to enable an integration in a specific environment or if you want to load an integration later.
 For all other cases, we recommend you use the `integrations` option.
 
 <PlatformContent includePath="configuration/enable-pluggable-integrations-lazy" />
+
+<PlatformCategorySection supported={['browser']}>
+
+## Lazy Loading Integrations
+
+You can lazy load pluggable integrations via `Sentry.lazyLoadIntegration()`. This will try to load the integration from the CDN, allowing you to add an integration without increasing the initial bundle size.
+
+```javascript
+async function loadHttpClient() {
+  const httpClientIntegration = await Sentry.lazyLoadIntegration('httpClientIntegration');
+  Sentry.addIntegration(httpClientIntegration());
+}
+```
+
+Note that this function will reject if it fails to load the integration from the CDN, which can happen e.g. if a user has an ad-blocker or if there is a network problem. You should always make sure to handle rejections for this function in your application.
+
+Lazy loading is available for the following integrations:
+
+- `replayIntegration`
+- `replayCanvasIntegration`
+- `feedbackIntegration`
+- `feedbackModalIntegration`
+- `feedbackScreenshotIntegration`
+- `captureConsoleIntegration`
+- `contextLinesIntegration`
+- `linkedErrorsIntegration`
+- `debugIntegration`
+- `dedupeIntegration`
+- `extraErrorDataIntegration`
+- `httpClientIntegration`
+- `reportingObserverIntegration`
+- `rewriteFramesIntegration`
+- `sessionTimingIntegration`
+- `browserProfilingIntegration`
+
+
+</PlatformCategorySection>
 
 ## Removing a Default Integration
 

--- a/platform-includes/configuration/capture-console/javascript.mdx
+++ b/platform-includes/configuration/capture-console/javascript.mdx
@@ -13,19 +13,18 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.captureConsoleIntegration()],
-    });
+    Sentry.init({});
+
+    Sentry.lazyLoadIntegration("captureConsoleIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/captureconsole.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'captureconsole.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/contextlines/javascript.mdx
+++ b/platform-includes/configuration/contextlines/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.contextLinesIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("contextLinesIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/contextlines.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'contextlines.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/debug/javascript.mdx
+++ b/platform-includes/configuration/debug/javascript.mdx
@@ -13,19 +13,15 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.debugIntegration()],
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("debugIntegration").then((integration) => {
+      Sentry.addIntegration(integration());
     });
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/debug.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'debug.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/dedupe/javascript.mdx
+++ b/platform-includes/configuration/dedupe/javascript.mdx
@@ -13,19 +13,15 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.dedupeIntegration()],
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("dedupeIntegration").then((integration) => {
+      Sentry.addIntegration(integration());
     });
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/dedupe.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'dedupe.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -24,18 +24,17 @@ Sentry.addIntegration(Sentry.reportingObserverIntegration());
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
 ></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
 
 <script>
   // Later in your application
   // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
   window.Sentry &&
     Sentry.onLoad(function () {
-      Sentry.addIntegration(Sentry.reportingObserverIntegration());
+      Sentry.lazyLoadIntegration("reportingObserverIntegration").then(
+        (integration) => {
+          Sentry.addIntegration(integration());
+        }
+      );
     });
 </script>
 ```

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.reportingObserverIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("reportingObserverIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.extraErrorDataIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("extraErrorDataIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/extraerrordata.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'extraerrordata.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/http-client/javascript.mdx
+++ b/platform-includes/configuration/http-client/javascript.mdx
@@ -17,21 +17,20 @@ Sentry.init({
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
     Sentry.init({
-      integrations: [Sentry.httpClientIntegration()],
-
       // This option is required for capturing headers and cookies.
       sendDefaultPii: true,
     });
+
+    Sentry.lazyLoadIntegration("httpClientIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/httpclient.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'httpclient.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.reportingObserverIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("reportingObserverIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.rewriteFramesIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("rewriteFramesIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/rewriteframes.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'rewriteframes.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```

--- a/platform-includes/configuration/sessiontiming/javascript.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.mdx
@@ -13,19 +13,17 @@ Sentry.init({
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
-    Sentry.init({
-      integrations: [Sentry.sessionTimingIntegration()],
-    });
+    Sentry.init({});
+    Sentry.lazyLoadIntegration("sessionTimingIntegration").then(
+      (integration) => {
+        Sentry.addIntegration(integration());
+      }
+    );
   };
 </script>
 
 <script
   src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/sessiontiming.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'debug.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 ```


### PR DESCRIPTION
This adds docs on how to lazy load (browser) integrations. It also updates all loader docs to use this instead of adding a CDN bundle, as the latter method has fundamental problems because versions will stop aligning.