### PR TITLE
Remove references to Percentiles

### DIFF
--- a/docs/product/metrics/metrics-explorer-page.mdx
+++ b/docs/product/metrics/metrics-explorer-page.mdx
@@ -23,7 +23,7 @@ Once you've started sending metrics to Sentry, you can explore them in the produ
   ></iframe>
 </div>
 
-You can use the dropdowns at the top of the page as a query editor for your metrics. Select the metric you want to plot from a list of available metrics in your project, the aggregate operation you'd like to perform (such as avg, min, max, percentiles, and so on), and, optionally, any tags you'd like to group by. In the image above, the p95 values of the metric, `gibpotato.potatoes.event_processing_time`, is queried and shown, grouped by `event_type`.
+You can use the dropdowns at the top of the page as a query editor for your metrics. Select the metric you want to plot from a list of available metrics in your project, the aggregate operation you'd like to perform (such as avg, min, max, and so on), and, optionally, any tags you'd like to group by. In the image above the metric `gibpotato.potatoes.event_processing_time`, is queried and shown, grouped by `event_type`.
 
 Optionally, you can also use the search bar to filter for specific tag values. In addition to custom metrics that are defined by your team, you can also explore any tags that Sentry offers out-of-the-box.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Remove references to Percentiles, since we removed them from distributions in the product already.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): The feature has already been removed from the product, we missed these references in docs. It's a minor change, so hopefully we can merge it soon 🙏 
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)