### PR TITLE
ref(fastify): Recommend the default export of fastify over named export

### DIFF
--- a/platform-includes/getting-started-add-top-level-import/javascript.fastify.mdx
+++ b/platform-includes/getting-started-add-top-level-import/javascript.fastify.mdx
@@ -2,9 +2,9 @@
 // Ensure to require this before requiring any other modules!
 require('./instrument.js')
 
-const { fastify } = require("fastify");
+const Fastify = require("fastify");
 const Sentry = require("@sentry/node");
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 
@@ -17,9 +17,9 @@ app.listen({ port: 3030 });
 // Ensure to import this before importing any other modules!
 import './instrument.js'
 
-import { fastify } from "fastify";
+import Fastify from "fastify";
 import * as Sentry from "@sentry/node";
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 

--- a/platform-includes/getting-started-use/javascript.fastify.mdx
+++ b/platform-includes/getting-started-use/javascript.fastify.mdx
@@ -3,10 +3,10 @@
 require("./instrument");
 
 // Now require other modules
-const { fastify } = require("fastify");
+const Fastify = require("fastify");
 const Sentry = require("@sentry/node");
 
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 
@@ -20,10 +20,10 @@ app.listen({ port: 3030 });
 import "./instrument";
 
 // Now import other modules
-import { fastify } from "fastify";
+import Fastify from "fastify";
 import * as Sentry from "@sentry/node";
 
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.fastify.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.fastify.mdx
@@ -12,9 +12,9 @@ Here's an example of instrumentating a Fastify application with Sentry Node SDK 
 
 ```javascript {tabTitle:CommonJS}
 require("./instrument");
-const { fastify } = require("fastify");
+const Fastify = require("fastify");
 const Sentry = require("@sentry/node");
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 
@@ -25,9 +25,9 @@ app.listen({ port: 3030 });
 
 ```javascript {tabTitle:ESM}
 import "./instrument";
-import { fastify } from "fastify";
+import Fastify from "fastify";
 import * as Sentry from "@sentry/node";
-const app = fastify();
+const app = Fastify();
 
 Sentry.setupFastifyErrorHandler(app);
 
@@ -79,16 +79,16 @@ We now support the following integrations out of the box with 0 configuration:
 
 ```JavaScript diff {tabTitle:CommonJS}
 +require('./instrument');
- const { fastify } = require("fastify");
+ const Fastify = require("fastify");
  const Sentry = require("@sentry/node");
- const app = fastify();
+ const app = Fastify();
 ```
 
 ```JavaScript diff {tabTitle:ESM}
 +import './instrument';
- import { fastify } from "fastify";
+ import Fastify from "fastify";
  import * as Sentry from "@sentry/node";
- const app = fastify();
+ const app = Fastify();
 ```
 
 <Alert level="warning" title="Running with ESM">


### PR DESCRIPTION
Reference: https://github.com/getsentry/sentry-javascript/issues/12119#issuecomment-2122228817

Also, this now lines up with the code snippet in sentry ui.
