### PR TITLE
docs(feedback): Add notes about async loading the Feedback integration

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -310,7 +310,7 @@ document
 Because the `feedbackIntegration` is a user-facing integration, we offer two loading strategies that have implications on bundle size.
 
 <Note>
-In every case, we recommend using `feedbackIntegration` in your `Sentry.init` call.
+For most users, we recommend using `feedbackIntegration` in your `Sentry.init` call. This will set up user feedback with good defaults matching the environment.
 </Note>
 
 All of the code examples on this page use `feedbackIntegration` as a default because it is available whether you have chosen the CDN or NPM installation method. However, the implementation of `feedbackIntegration` is different depending on the installation method. For NPM users `feedbackIntegration` is an alias of `feedbackSyncIntegration`. For CDN users, `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
@@ -319,13 +319,13 @@ All of the code examples on this page use `feedbackIntegration` as a default bec
 
 If you have installed the SDK with NPM, this loading strategy is used by default. This strategy is not available if you have installed the SDK via the CDN.
 
-This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to open when the user interacts with it, but in either case network connectivity is required to send the feedback message.
+This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest upfront bundle size in your application. The benefit of this is that the feedback widget is guaranteed to open when the user interacts with it, but in either case network connectivity is required to send the feedback message.
 
 #### `feedbackAsyncIntegration`
 
 If you installed the SDK with the CDN, this loading strategy is used by default. If you used NPM, you can still choose to use this loading strategy by adding this integration to your `Sentry.init` call.
 
-This integration includes the minimum amount of code needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button, the integration will asynchronously load internal integrations from `https://js.sentry-cdn.com` that show the form and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asynchronous loading can fail if, for example, the user has an ad-blocker.
+This integration includes the minimum amount of code upfront needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button, the integration will asynchronously load internal integrations from `https://browser.sentry-cdn.com` that show the form and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asynchronous loading can fail if, for example, the user has an ad-blocker.
 
 #### When Installed via CDN
 

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -307,7 +307,7 @@ document
 
 ### Loading Strategies
 
-Because the `feedbackIntegration` is a user-facing integration, we offer two loading strategies that have implications on bundle size.
+Because the `feedbackIntegration` is a user-facing integration, we offer two loading strategies that have bundle size implications.
 
 <Note>
 For most users, we recommend using `feedbackIntegration` in your `Sentry.init` call. This will set up user feedback with good defaults matching the environment.

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -305,6 +305,109 @@ document
 
 </PlatformSection>
 
+### Loading Strategies
+
+The `feedbackIntegration` is special among our integrations because it is a user-facing integration. Therefore, we have two strategies available to help you control bundle size. What strategies are available depend on how you have installed the SDK into your application.
+
+All of the code examples on this page use `feedbackIntegration` as a default because it is available whether you have chosen the CDN or NPM installation method.
+
+<Note>
+In every case, we recommend using `feedbackIntegration` in your `Sentry.init` call.
+</Note>
+
+1. `feedbackSyncIntegration`
+
+    This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to work when the user interacts with it.
+
+    This loading strategy is not available if you have installed the SDK via the CDN.
+
+2. `feedbackAsyncIntegration`
+
+    This integration includes the minimum amount of code needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button the integration will asynchronously load inrernal integrations that show the form, and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asyncronous loading can fail when the user interacts with the button.
+
+#### When Installed via CDN
+
+For CDN users `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
+
+```javascript {tabTitle: Default Strategy}
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    // Use the default strategy, an alias for `feedbackAsyncIntegration`
+    Sentry.feedbackIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: 'system',
+    }),
+  ]
+});
+```
+
+```javascript {tabTitle: Async Strategy}
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    // Use the async strategy so everything is bundled for page load
+    Sentry.feedbackAsyncIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: 'system',
+    }),
+  ]
+});
+```
+
+#### When Installed via NPM
+
+For NPM users `feedbackIntegration` is an alias of `feedbackSyncIntegration`.
+
+```javascript {tabTitle: Default Strategy}
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    // Use the default strategy, an alias for `feedbackSyncIntegration`
+    Sentry.feedbackIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: 'system',
+    }),
+  ]
+});
+```
+
+```javascript {tabTitle: Sync Strategy}
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    // Use the sync strategy so everything is bundled for page load
+    Sentry.feedbackSyncIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: 'system',
+    }),
+  ]
+});
+```
+
+```javascript {tabTitle: Async Strategy}
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___PUBLIC_DSN___',
+  integrations: [
+    // Use the async strategy to keep bundle size lower
+    Sentry.feedbackAsyncIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: 'system',
+    }),
+  ]
+});
+```
+
 ## Crash-Report Modal
 
 You can customize the Crash-Report modal to your organization's needs, for example, for localization purposes. All options can be passed through the `Sentry.showReportDialog` call.

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -319,7 +319,7 @@ All of the code examples on this page use `feedbackIntegration` as a default bec
 
 If you have installed the SDK with NPM, this loading strategy is used by default. This strategy is not available if you have installed the SDK via the CDN.
 
-This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to work when the user interacts with it.
+This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to open when the user interacts with it, but in either case network connectivity is required to send the feedback message.
 
 #### `feedbackAsyncIntegration`
 

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -307,23 +307,25 @@ document
 
 ### Loading Strategies
 
-The `feedbackIntegration` is special among our integrations because it is a user-facing integration. Therefore, we have two strategies available to help you control bundle size. What strategies are available depend on how you have installed the SDK into your application.
-
-All of the code examples on this page use `feedbackIntegration` as a default because it is available whether you have chosen the CDN or NPM installation method.
+Because the `feedbackIntegration` is a user-facing integration, we offer two loading strategies that have implications on bundle size.
 
 <Note>
 In every case, we recommend using `feedbackIntegration` in your `Sentry.init` call.
 </Note>
 
-1. `feedbackSyncIntegration`
+All of the code examples on this page use `feedbackIntegration` as a default because it is available whether you have chosen the CDN or NPM installation method. However, the implementation of `feedbackIntegration` is different depending on the installation method. For NPM users `feedbackIntegration` is an alias of `feedbackSyncIntegration`. For CDN users, `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
 
-    This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to work when the user interacts with it.
+#### `feedbackSyncIntegration`
 
-    This loading strategy is not available if you have installed the SDK via the CDN.
+If you have installed the SDK with NPM, this loading strategy is used by default. This strategy is not available if you have installed the SDK via the CDN.
 
-2. `feedbackAsyncIntegration`
+This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest bundle size in your application. The benefit of this is that the feedback widget is guaranteed to work when the user interacts with it.
 
-    This integration includes the minimum amount of code needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button the integration will asynchronously load inrernal integrations that show the form, and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asyncronous loading can fail when the user interacts with the button.
+#### `feedbackAsyncIntegration`
+
+If you installed the SDK with the CDN, this loading strategy is used by default. If you used NPM, you can still choose to use this loading strategy by adding this integration to your `Sentry.init` call.
+
+This integration includes the minimum amount of code needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button, the integration will asynchronously load internal integrations from `https://js.sentry-cdn.com` that show the form and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asynchronous loading can fail if, for example, the user has an ad-blocker.
 
 #### When Installed via CDN
 

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -310,24 +310,24 @@ document
 Because the `feedbackIntegration` is a user-facing integration, we offer two loading strategies that have bundle size implications.
 
 <Note>
-For most users, we recommend using `feedbackIntegration` in your `Sentry.init` call. This will set up user feedback with good defaults matching the environment.
+For most users, we recommend using `feedbackIntegration` in your `Sentry.init` call. This will set up user feedback with good defaults, matching the environment.
 </Note>
 
-All of the code examples on this page use `feedbackIntegration` as a default because it is available whether you have chosen the CDN or NPM installation method. However, the implementation of `feedbackIntegration` is different depending on the installation method. For NPM users `feedbackIntegration` is an alias of `feedbackSyncIntegration`. For CDN users, `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
+All of the code examples on this page use `feedbackIntegration` as a default because it's available regardless of whether you've chosen the CDN or NPM installation method. However, the implementation of `feedbackIntegration` is different for the two installation methods. For NPM users, `feedbackIntegration` is an alias of `feedbackSyncIntegration`. For CDN users, `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
 
 #### `feedbackSyncIntegration`
 
-If you have installed the SDK with NPM, this loading strategy is used by default. This strategy is not available if you have installed the SDK via the CDN.
+If you've installed the SDK with NPM, this loading strategy is used by default. The strategy isn't available if you've installed the SDK via the CDN.
 
-This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest upfront bundle size in your application. The benefit of this is that the feedback widget is guaranteed to open when the user interacts with it, but in either case network connectivity is required to send the feedback message.
+This integration includes all the code needed to render the "Send Feedback" button, as well as the form that is triggered when the button is clicked. Choosing this loading strategy means accepting the largest upfront bundle size in your application. The benefit of this is that the feedback widget is guaranteed to open when the user interacts with it, but in either case, network connectivity is required to send the feedback message.
 
 #### `feedbackAsyncIntegration`
 
 If you installed the SDK with the CDN, this loading strategy is used by default. If you used NPM, you can still choose to use this loading strategy by adding this integration to your `Sentry.init` call.
 
-This integration includes the minimum amount of code upfront needed to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button, the integration will asynchronously load internal integrations from `https://browser.sentry-cdn.com` that show the form and let the user type out their feedback message. This has the benefit of being the lowest bundle size. The drawback is that asynchronous loading can fail if, for example, the user has an ad-blocker.
+This integration includes the minimum amount of code needed upfront to show the "Send Feedback" button on the screen when the page is loaded. When the user clicks on that button, the integration will asynchronously load internal integrations from `https://browser.sentry-cdn.com` that show the form and let the user type out their feedback message. This has the benefit of being the smallest bundle size. The drawback is that asynchronous loading can fail if, for example, the user has an ad-blocker.
 
-#### When Installed via CDN
+#### When Installed Via CDN
 
 For CDN users `feedbackIntegration` is an alias of `feedbackAsyncIntegration`.
 
@@ -361,7 +361,7 @@ Sentry.init({
 });
 ```
 
-#### When Installed via NPM
+#### When Installed Via NPM
 
 For NPM users `feedbackIntegration` is an alias of `feedbackSyncIntegration`.
 


### PR DESCRIPTION
This adds documentation for a new feature/behavior within the User Feedback SDK -> different strategies for bundling the SDK code within your app.

I tried to be verbose about what's available, and what the defaults are. I hope it makes sense. 

Relates to https://github.com/getsentry/sentry/issues/70862