### PR TITLE
Remove crons-feedback email

### DIFF
--- a/docs/platforms/elixir/crons/troubleshooting.mdx
+++ b/docs/platforms/elixir/crons/troubleshooting.mdx
@@ -29,5 +29,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/platforms/java/common/crons/troubleshooting.mdx
+++ b/docs/platforms/java/common/crons/troubleshooting.mdx
@@ -33,5 +33,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/platforms/javascript/common/crons/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/crons/troubleshooting.mdx
@@ -49,5 +49,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/platforms/php/common/crons/troubleshooting.mdx
+++ b/docs/platforms/php/common/crons/troubleshooting.mdx
@@ -29,5 +29,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/platforms/python/crons/troubleshooting.mdx
+++ b/docs/platforms/python/crons/troubleshooting.mdx
@@ -41,5 +41,3 @@ Currently, we only support crontab expressions with five fields.
 Yes, just make sure you're using SDK version `1.44.1` or higher since that's when support for monitoring async functions was added.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/platforms/ruby/common/crons/troubleshooting.mdx
+++ b/docs/platforms/ruby/common/crons/troubleshooting.mdx
@@ -29,5 +29,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/docs/product/crons/troubleshooting.mdx
+++ b/docs/product/crons/troubleshooting.mdx
@@ -39,7 +39,3 @@ Our current data retention policy is 90 days.
 Currently, we only support crontab expressions with five fields.
 
 </Expandable>
-
-### Additional Help
-
-Still having trouble? Reach out to [crons-feedback@sentry.io](mailto:crons-feedback@sentry.io).

--- a/includes/feature-stage-beta-crons.mdx
+++ b/includes/feature-stage-beta-crons.mdx
@@ -1,5 +1,0 @@
-<Alert level="warning" title="Important">
-
-Sentry Cron Monitoring is currently in open beta and subject to change. Help us make it better by letting us know what you think. Respond on [GitHub](https://github.com/getsentry/sentry/discussions/42283) or write to us at crons-feedback@sentry.io.
-
-</Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR
Since Crons is not in beta any longer, I'm removing the crons-feedback email from our docs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)