### PR TITLE
Documented request tracing requirement for an active transaction on the scope to the .NET docs

### DIFF
--- a/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -33,7 +33,11 @@ To avoid depleting performance quota, Sentry will only create request spans when
 ```csharp
   var transaction = SentrySdk.StartTransaction("tutorial", "example");
   SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
+  
+  // The SentryHttpMessageHandler will automatically create a span for the request
   var response = await httpClient.GetStringAsync("https://example.com");
+  
+  transaction.Finish();
 ```
 
 Additionally, `SentryHttpMessageHandler` also inherits from `DelegatingHandler` which allows you to chain it together with other handlers. For example:

--- a/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -28,7 +28,7 @@ Upon sending a request to `https://example.com`, the instrumented HTTP client wi
 - Populate the `sentry-trace` header on the request. This allows peer service to start a transaction by linking it to the current (assuming it's also instrumented with Sentry).
 - Start a span named `GET https://example.com` which will track the corresponding HTTP operation on the current transaction.
 
-To avoid depleting performance quota, Sentry will only create request spans when there is an active transaction on the scope. If there is no active transaction then you will need to create one before making an HTTP request, for request tracing to work:
+To avoid depleting performance quota, Sentry will only create request spans if there's an active transaction on the scope. If there's no active transaction, you'll need to create one before making an HTTP request for request tracing to work:
 
 ```csharp
   var transaction = SentrySdk.StartTransaction("tutorial", "example");

--- a/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/dotnet/common/performance/instrumentation/automatic-instrumentation.mdx
@@ -28,6 +28,14 @@ Upon sending a request to `https://example.com`, the instrumented HTTP client wi
 - Populate the `sentry-trace` header on the request. This allows peer service to start a transaction by linking it to the current (assuming it's also instrumented with Sentry).
 - Start a span named `GET https://example.com` which will track the corresponding HTTP operation on the current transaction.
 
+To avoid depleting performance quota, Sentry will only create request spans when there is an active transaction on the scope. If there is no active transaction then you will need to create one before making an HTTP request, for request tracing to work:
+
+```csharp
+  var transaction = SentrySdk.StartTransaction("tutorial", "example");
+  SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
+  var response = await httpClient.GetStringAsync("https://example.com");
+```
+
 Additionally, `SentryHttpMessageHandler` also inherits from `DelegatingHandler` which allows you to chain it together with other handlers. For example:
 
 ```csharp


### PR DESCRIPTION
## DESCRIBE YOUR PR

Added docs explaining that transactions/spans don't get created for outbound HTTP requests when there is an active transaction on the scope, when using the .NET SDK.

Resolves https://github.com/getsentry/sentry-dotnet/issues/3370

## IS YOUR CHANGE URGENT?  

- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
CC: @bitsandfoxes for review

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
