### PR TITLE
Updated Metrics Setup docs for the dotnet SDK to prepare for GA

### DIFF
--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -137,7 +137,7 @@ builder.WebHost.UseSentry(options =>
 
 Or, you can choose to capture only metrics from specific Instruments:
 
-```csharp
+```csharp {11}
 var HatsMeter = new Meter("HatCo.HatStore", "1.0.0");
 var HatsSold = HatsMeter.CreateCounter<int>(
     name: "hats-sold",

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -102,7 +102,7 @@ using (SentrySdk.Metrics.StartTimer("bingo"))
 
 You can configure the .NET SDK to automatically capture and send OpenTelemetry metrics to Sentry.
 
-For example, you could configure Sentry to capture all of the built-in metrics that it knows about:
+For example, you can configure Sentry to capture all the built-in metrics that it knows about:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -12,8 +12,6 @@ Metrics for .NET are supported with Sentry .NET SDK version `4.0.0` and above.
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
 
-# Custom metrics
-
 ## Initialization
 
 To enable metrics you have to opt-in the metrics feature.
@@ -98,7 +96,7 @@ using (SentrySdk.Metrics.StartTimer("bingo"))
 }
 ```
 
-# OpenTelemetry Metrics
+## OpenTelemetry Metrics
 
 You can configure the .NET SDK to automatically capture and send OpenTelemetry metrics to Sentry.
 

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -122,7 +122,7 @@ builder.WebHost.UseSentry(options =>
 });
 ```
 
-Or to capture only metrics from specific Meters:
+You can also capture only metrics from specific Meters:
 
 ```csharp
 builder.WebHost.UseSentry(options =>

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -124,7 +124,7 @@ builder.WebHost.UseSentry(options =>
 
 You can also capture only metrics from specific Meters:
 
-```csharp
+```csharp {5-6}
 builder.WebHost.UseSentry(options =>
 {
     options.dsn = "___DSN___";

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -4,8 +4,6 @@ description: "Learn how to measure the data points you care about by configuring
 sidebar_order: 5500
 ---
 
-<Include name="feature-stage-beta-metrics.mdx" />
-
 <Note>
 
 Metrics for .NET are supported with Sentry .NET SDK version `4.0.0` and above.
@@ -13,6 +11,8 @@ Metrics for .NET are supported with Sentry .NET SDK version `4.0.0` and above.
 </Note>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
+
+# Custom metrics
 
 ## Initialization
 
@@ -22,8 +22,12 @@ To enable metrics you have to opt-in the metrics feature.
 SentrySdk.Init(options =>
 {
     options.dsn = "___DSN___";
-    // Initialize some (non null) ExperimentalMetricsOptions to enable Sentry Metrics,
-    options.ExperimentalMetrics = new ExperimentalMetricsOptions { EnableCodeLocations = true };
+    // Enable Sentry Metrics,
+    options.EnableMetrics(metrics =>
+    {
+        // Send code locations with any metrics you emit manually
+        metrics.EnableCodeLocations = true;
+    });
 });
 ```
 
@@ -92,4 +96,59 @@ using (SentrySdk.Metrics.StartTimer("bingo"))
 {
     // Your code goes here
 }
+```
+
+# OpenTelemetry Metrics
+
+The Sentry SDK for .NET also allows you to configure OpenTelemetry metrics that you would like to automatically capture and send to Sentry.
+
+For example, you could configure Sentry to capture all of the built-in metrics that it knows about:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+            .AddRuntimeInstrumentation() // <-- Requires the OpenTelemetry.Instrumentation.Runtime package
+            .AddMeter(
+                "Microsoft.AspNetCore.Hosting",
+                "Microsoft.AspNetCore.Server.Kestrel",
+                "System.Net.Http")
+    );
+
+builder.WebHost.UseSentry(options =>
+{
+    options.dsn = "___DSN___";
+    options.EnableMetrics(metrics => metrics.CaptureSystemDiagnosticsMeters = BuiltInSystemDiagnosticsMeters.All);
+});
+```
+
+Or to capture only metrics from specific Meters:
+
+```csharp
+builder.WebHost.UseSentry(options =>
+{
+    options.dsn = "___DSN___";
+    metrics.CaptureSystemDiagnosticsMeters = [
+        BuiltInSystemDiagnosticsMeters.MicrosoftAspNetCoreHosting,
+        BuiltInSystemDiagnosticsMeters.SystemNetHttp,
+    ];
+});
+```
+
+Or even to capture only specific Instruments:
+
+```csharp
+var HatsMeter = new Meter("HatCo.HatStore", "1.0.0");
+var HatsSold = HatsMeter.CreateCounter<int>(
+    name: "hats-sold",
+    unit: "Hats",
+    description: "Number of hats sold"
+);
+
+SentrySdk.Init(options => {
+    options.dsn = "___DSN___";
+    options.EnableMetrics(metrics => {
+        metrics.CaptureSystemDiagnosticsInstruments = ["hats-sold"];
+    });
+});
 ```

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -100,7 +100,7 @@ using (SentrySdk.Metrics.StartTimer("bingo"))
 
 # OpenTelemetry Metrics
 
-The Sentry SDK for .NET also allows you to configure OpenTelemetry metrics that you would like to automatically capture and send to Sentry.
+You can configure the .NET SDK to automatically capture and send OpenTelemetry metrics to Sentry.
 
 For example, you could configure Sentry to capture all of the built-in metrics that it knows about:
 

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -104,7 +104,7 @@ You can configure the .NET SDK to automatically capture and send OpenTelemetry m
 
 For example, you can configure Sentry to capture all the built-in metrics that it knows about:
 
-```csharp
+```csharp {13}
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddOpenTelemetry()
     .WithMetrics(metrics => metrics

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -135,7 +135,7 @@ builder.WebHost.UseSentry(options =>
 });
 ```
 
-Or even to capture only specific Instruments:
+Or, you can choose to capture only metrics from specific Instruments:
 
 ```csharp
 var HatsMeter = new Meter("HatCo.HatStore", "1.0.0");


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Resolves https://github.com/getsentry/sentry-dotnet/issues/3245

When Metrics are GA, the syntax for enabling Metrics in the .NET SDK will change.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Other deadline: Whenever Metrics are GA

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.

@bitsandfoxes I'm having difficulty with this one. I can't work out how to change what shows in the "ON THIS PAGE" pane... this doesn't appear to update automatically when I add new H1, H2 headers etc.

Once we're happy with the content, I imagine we'll also want to update:
`docs/platforms/unity/metrics/index.mdx`

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)