### PR TITLE
ref(javascript): Streamline custom http request instrumenation guide

### DIFF
--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
@@ -27,17 +27,17 @@ async function makeRequest(method, url) {
     async (span) => {
       const parsedURL = new URL(url, location.origin);
 
-      span?.setAttribute("http.request.method", method);
+      span.setAttribute("http.request.method", method);
 
-      span?.setAttribute("server.address", parsedURL.hostname);
-      span?.setAttribute("server.port", parsedURL.port || undefined);
+      span.setAttribute("server.address", parsedURL.hostname);
+      span.setAttribute("server.port", parsedURL.port || undefined);
 
       const response = await fetch(url, {
         method,
       });
 
-      span?.setAttribute("http.response.status_code", response.status);
-      span?.setAttribute(
+      span.setAttribute("http.response.status_code", response.status);
+      span.setAttribute(
         "http.response_content_length",
         Number(response.headers.get("content-length"))
       );

--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
@@ -4,7 +4,7 @@ sidebar_order: 2000
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests](/product/performance/requests/), you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, follow this guide to manually instrument your requests.
+As a prerequisite to setting up [Requests](/product/performance/requests/), you'll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, follow this guide to manually instrument your requests.
 
 ## Custom Instrumentation
 

--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
@@ -4,42 +4,42 @@ sidebar_order: 2000
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
 
-As a prerequisite to setting up [Requests](/product/performance/requests/), you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, you can set up using [custom instrumentation](#custom-instrumentation).
+As a prerequisite to setting up [Requests](/product/performance/requests/), you’ll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, follow this guide to manually instrument your requests.
 
 ## Custom Instrumentation
 
 For detailed information about which data can be set, see the [Requests Module developer specifications](https://develop.sentry.dev/sdk/performance/modules/requests/).
 
-### Initialize Sentry
-
-<PlatformContent includePath="getting-started-config" />
-
 ### Wrap The HTTP Requests in a Span
 
-NOTE: Refer to [HTTP Span Data Conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/#http) for a full list of the span data attributes.
+<Note>
+
+Refer to [HTTP Span Data Conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/#http) for a full list of the span data attributes.
+
+</Note>
 
 Here is an example of an instrumented function that makes HTTP requests:
 
-```javascript
+```javascript {filename: my-request.js}
 async function makeRequest(method, url) {
   return await Sentry.startSpan(
-    {op: 'http.client', name: `${method} ${url}`},
-    async span => {
+    { op: "http.client", name: `${method} ${url}` },
+    async (span) => {
       const parsedURL = new URL(url, location.origin);
+
+      span?.setAttribute("http.request.method", method);
+
+      span?.setAttribute("server.address", parsedURL.hostname);
+      span?.setAttribute("server.port", parsedURL.port || undefined);
 
       const response = await fetch(url, {
         method,
       });
 
-      span?.setAttribute('http.request.method', method);
-
-      span?.setAttribute('server.address', parsedURL.hostname);
-      span?.setAttribute('server.port', parsedURL.port || undefined);
-
-      span?.setAttribute('http.response.status_code', response.status);
+      span?.setAttribute("http.response.status_code", response.status);
       span?.setAttribute(
-        'http.response_content_length',
-        Number(response.headers.get('content-length'))
+        "http.response_content_length",
+        Number(response.headers.get("content-length"))
       );
 
       // A good place to set other span attributes

--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/requests-module.mdx
@@ -6,11 +6,9 @@ description: "Learn how to manually instrument your code to use Sentry's Request
 
 As a prerequisite to setting up [Requests](/product/performance/requests/), you'll need to first <PlatformLink to="/performance/">set up performance monitoring</PlatformLink>. Once this is done, the JavaScript SDK will automatically instrument outgoing HTTP requests. If that doesn't fit your use case, follow this guide to manually instrument your requests.
 
-## Custom Instrumentation
-
 For detailed information about which data can be set, see the [Requests Module developer specifications](https://develop.sentry.dev/sdk/performance/modules/requests/).
 
-### Wrap The HTTP Requests in a Span
+## Wrap HTTP Requests in a Span
 
 <Note>
 


### PR DESCRIPTION
- Remove SDK init section as it's covered extensively in higher-level guides
- Some wording and code adjustments
