### PR TITLE
ref(javascript): Streamline queue instrumentation page

### DIFF
--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
@@ -87,7 +87,7 @@ Use `Sentry.continueTrace` to connect your consumer spans to their associated pr
 
 <Note>
 
-Your `queue.process` span must exist as a child within a parent span in order to be recognized as a consumer span. If you don't already have a parent for the consumer span, you can wrap the consumer span with a parent span by using `Sentry.startSpan`.
+Your `queue.process` span must exist as a child within a parent span in order to be recognized as a consumer span. If you don't have a parent span, you can create one to wrap the consumer span with by using `Sentry.startSpan`.
 
 </Note>
 

--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
@@ -2,6 +2,23 @@
 title: Instrument Queues
 description: "Learn how to manually instrument your code to use Sentry's Queues module"
 sidebar_order: 20
+supported:
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.bun
+  - javascript.deno
+  - javascript.nextjs
+  - javascript.astro
+  - javascript.sveltekit
+  - javascript.remix
 ---
 
 To ensure that you have performance data about your messaging queues, you'll need to instrument custom spans and transactions around your queue producers and consumers.
@@ -10,11 +27,11 @@ To ensure that you have performance data about your messaging queues, you'll nee
 
 To start capturing performance metrics, use the `Sentry.startSpan` function to wrap your queue producer events. Your span `op` must be set to `queue.publish`. Include the following attributes to enrich your producer spans with queue metrics:
 
-| Attribute | Type | Description |
-|:--|:--|:--|
-| `messaging.message.id ` | string | The message identifier |
-| `messaging.destination.name` | string | The queue or topic name |
-| `messaging.message.body.size` | int | Size of the message body in bytes |
+| Attribute                     | Type   | Description                       |
+| :---------------------------- | :----- | :-------------------------------- |
+| `messaging.message.id `       | string | The message identifier            |
+| `messaging.destination.name`  | string | The queue or topic name           |
+| `messaging.message.body.size` | int    | Size of the message body in bytes |
 
 You must also include trace headers in your message using `spanToTraceHeader` and `spanToBaggageHeader` so that your consumers can continue your trace once your message is picked up.
 
@@ -24,31 +41,33 @@ Your `queue.publish` span must exist as a child within a parent span in order to
 
 </Note>
 
-```javascript
-import { spanToTraceHeader, spanToBaggageHeader } from '@sentry/core';
-
-app.post('/publish', async (req, res) => { // Route handler automatically instruments a parent span
-    await Sentry.startSpan(
-        {
-            name: 'queue_producer',
-            op: 'queue.publish',
-            attributes: {
-                'messaging.message.id': messageId,
-                'messaging.destination.name': 'messages',
-                'messaging.message.body.size': messageBodySize,
-            },
-        },
-        async (span) => {
-            const traceHeader = spanToTraceHeader(span);
-            const baggageHeader = spanToBaggageHeader(span);
-            await redisClient.lPush('messages', JSON.stringify({
-                traceHeader,
-                baggageHeader,
-                timestamp: Date.now(),
-                messageId,
-            }));
-        },
-    );
+```javascript {filename:my-queue.js}
+app.post("/publish", async (req, res) => {
+  // Route handler automatically instruments a parent span
+  await Sentry.startSpan(
+    {
+      name: "queue_producer",
+      op: "queue.publish",
+      attributes: {
+        "messaging.message.id": messageId,
+        "messaging.destination.name": "messages",
+        "messaging.message.body.size": messageBodySize,
+      },
+    },
+    async (span) => {
+      const traceHeader = Sentry.spanToTraceHeader(span);
+      const baggageHeader = Sentry.spanToBaggageHeader(span);
+      await redisClient.lPush(
+        "messages",
+        JSON.stringify({
+          traceHeader,
+          baggageHeader,
+          timestamp: Date.now(),
+          messageId,
+        })
+      );
+    }
+  );
 });
 ```
 
@@ -56,16 +75,15 @@ app.post('/publish', async (req, res) => { // Route handler automatically instru
 
 To start capturing performance metrics, use the `Sentry.startSpan` function to wrap your queue consumers. Your span `op` must be set to `queue.process`. Include the following attributes to enrich your consumer spans with queue metrics:
 
-| Attribute | Type | Description |
-|:--|:--|:--|
-| `messaging.message.id ` | string | The message identifier |
-| `messaging.destination.name` | string | The queue or topic name |
-| `messaging.message.body.size` | number | Size of the message body in bytes |
-| `messaging.message.retry.count ` | number | The number of times a message was attempted to be processed |
+| Attribute                            | Type   | Description                                                         |
+| :----------------------------------- | :----- | :------------------------------------------------------------------ |
+| `messaging.message.id `              | string | The message identifier                                              |
+| `messaging.destination.name`         | string | The queue or topic name                                             |
+| `messaging.message.body.size`        | number | Size of the message body in bytes                                   |
+| `messaging.message.retry.count `     | number | The number of times a message was attempted to be processed         |
 | `messaging.message.receive.latency ` | number | The time in milliseconds that a message awaited processing in queue |
 
 Use `Sentry.continueTrace` to connect your consumer spans to their associated producer spans, and `setStatus` to mark the trace of your message as success or failed.
-
 
 <Note>
 
@@ -73,7 +91,7 @@ Your `queue.process` span must exist as a child within a parent span in order to
 
 </Note>
 
-```javascript
+```javascript {filename:my-consumer.js}
 const message = JSON.parse(await redisClient.lPop(QUEUE_KEY));
 const latency = Date.now() - message.timestamp;
 
@@ -95,7 +113,7 @@ Sentry.continueTrace(
                         'messaging.message.body.size': message.messageBodySize,
                         'messaging.message.receive.latency': latency,
                         'messaging.message.retry.count': 0,
-                    }     
+                    }
                 }, (span) => {
                     ... // Continue message processing
                     parent.setStatus({code: 1, message: 'ok'});

--- a/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/javascript/common/performance/instrumentation/custom-instrumentation/queues-module.mdx
@@ -87,7 +87,7 @@ Use `Sentry.continueTrace` to connect your consumer spans to their associated pr
 
 <Note>
 
-Your `queue.process` span must exist as a child within a parent span in order to be recognized as a consumer span. If you don't already have a parent consumer span, you can start a new one using `Sentry.startSpan`.
+Your `queue.process` span must exist as a child within a parent span in order to be recognized as a consumer span. If you don't already have a parent for the consumer span, you can wrap the consumer span with a parent span by using `Sentry.startSpan`.
 
 </Note>
 


### PR DESCRIPTION
- Only show page on server-side guides
- remove imports from `@sentry/core` - we should never tell people to import from it
  as it's only a transitive dependency from their SDK. Here, we can make use of the 
  `Sentry.` namespace import that people are familiar with from other docs. This also
  saves us the hassle of having to customize the imported package for each guide :)
- just minor formatting (prettier) and code snippet fixes
