### PR TITLE
feat(js): Add profiling integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
@@ -1,0 +1,29 @@
+---
+title: BrowserProfiling
+description: "Collect & view performance insights for JavaScript programs with Sentry’s JavaScript Profiling integration."
+notSupported:
+  - javascript.cordova
+  - javascript.wasm
+  - javascript.bun
+  - javascript.deno
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+---
+
+<Alert level="info">
+  This integration only works inside a browser environment.
+</Alert>
+
+_Import name: `Sentry.browserProfilingIntegration`_
+
+[Profiling](/product/profiling/) offers a deeper level of visibility on top of traditional tracing, removing the need for custom instrumentation and enabling precise code-level visibility into your application in a production environment.
+
+Read more about <PlatformLink to='/profiling'>setting up Profiling</PlatformLink>.

--- a/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
@@ -1,0 +1,29 @@
+---
+title: ProfilingIntegration
+description: "Collect & view performance insights for JavaScript programs with Sentry’s JavaScript Profiling integration."
+supported:
+  - javascript.cordova
+  - javascript.wasm
+  - javascript.bun
+  - javascript.deno
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+---
+
+<Alert level="info">
+  This integration only works inside a node environment.
+</Alert>
+
+_Import name: `Sentry.nodeProfilingIntegration`_
+
+[Profiling](/product/profiling/) offers a deeper level of visibility on top of traditional tracing, removing the need for custom instrumentation and enabling precise code-level visibility into your application in a production environment.
+
+Read more about <PlatformLink to='/profiling'>setting up Profiling</PlatformLink>.

--- a/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
@@ -1,6 +1,6 @@
 ---
 title: ProfilingIntegration
-description: "Collect & view performance insights for JavaScript programs with Sentry’s JavaScript Profiling integration."
+description: "Collect & view performance insights for JavaScript Node programs with Sentry’s Node Profiling integration."
 supported:
   - javascript.cordova
   - javascript.wasm
@@ -19,7 +19,7 @@ supported:
 ---
 
 <Alert level="info">
-  This integration only works inside a node environment.
+  This integration only works inside a Node environment.
 </Alert>
 
 _Import name: `Sentry.nodeProfilingIntegration`_


### PR DESCRIPTION
This adds the browser & node profiling integrations to the list of integrations, streamlining this a bit.
it mostly links out to the relevant page, but should still make it easier to find this.