### PR TITLE
ref(javascript): Revert `lastEventId` removal (v8) and deprecation (v7) in migration docs

### DIFF
--- a/includes/migration/javascript-v8/general-other-changes.mdx
+++ b/includes/migration/javascript-v8/general-other-changes.mdx
@@ -105,10 +105,6 @@ changes compared to the v7 where the property `framesToPop` was used to remove t
 
 In `8.x`, we are no longer exporting the `Span` class from SDK packages. Internally, this class is now called `SentrySpan`, and it is no longer meant to be used by users directly.
 
-### Removal of `lastEventId()` method
-
-The `lastEventId` function has been removed. See [below](./MIGRATION.md#deprecate-lasteventid) for more details.
-
 ### Removal of `void` from transport return types
 
 The `send` method on the `Transport` interface now always requires a `TransportMakeRequestResponse` to be returned in

--- a/includes/migration/javascript-v8/v7-deprecation/general.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/general.mdx
@@ -37,7 +37,6 @@ If you are using the `Hub` right now, see the following table on how to migrate 
 | captureException()     | `Sentry.captureException()`                                                          |
 | captureMessage()       | `Sentry.captureMessage()`                                                            |
 | captureEvent()         | `Sentry.captureEvent()`                                                              |
-| lastEventId()          | REMOVED - Use event processors or beforeSend instead                                 |
 | addBreadcrumb()        | `Sentry.addBreadcrumb()`                                                             |
 | setUser()              | `Sentry.setUser()`                                                                   |
 | setTags()              | `Sentry.setTags()`                                                                   |
@@ -92,27 +91,6 @@ const client = new Client();
 const scope = new Scope();
 scope.setClient(client);
 scope.captureException();
-```
-
-### Deprecate `Sentry.lastEventId()` and `hub.lastEventId()`
-
-_Deprecation introduced in `7.93.0`._
-
-Instead, if you need the ID of a recently captured event, we recommend using `beforeSend` instead:
-
-```JavaScript
-import * as Sentry from '@sentry/browser';
-
-Sentry.init({
-  dsn: '__DSN__',
-  beforeSend(event, hint) {
-    const lastCapturedEventId = event.event_id;
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
 ```
 
 ### Deprecate `addGlobalEventProcessor` in favor of `addEventProcessor`


### PR DESCRIPTION
Looks like we missed this in https://github.com/getsentry/sentry-javascript/issues/11951

This PR removes the deprecation and removal message in the migration guide of our `lastEventId` API (which we decided to bring back in version 8.1.0).