### PR TITLE
ref(python): remove initialize sentry section in python

### DIFF
--- a/docs/platforms/python/performance/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/python/performance/instrumentation/custom-instrumentation/caches-module.mdx
@@ -19,10 +19,6 @@ For detailed information about which data can be set, see the [Cache Module Deve
 
 If you're using anything other than <PlatformLink to="/integrations/django/">Django</PlatformLink>, <PlatformLink to="/integrations/redis/">Redis</PlatformLink>,  memcached (comming soon), you'll need to manually instrument the [Cache Module]((https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/)) by following the steps below.
 
-### Initialize Sentry
-
-<PlatformContent includePath="getting-started-config" />
-
 ### Add Span When Putting Data Into the Cache
 
 If the cache you’re using isn’t supported by auto instrumentation mentioned above, you can use the custom instrumentation instructions below to emit cache spans:


### PR DESCRIPTION
Complements https://github.com/getsentry/sentry-docs/pull/10121/
Removes the section about initializing sentry as it's documented throughly throughout our docs