### PR TITLE
Add Node 22 to profiling docs

### DIFF
--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -85,9 +85,9 @@ We recommend you have your own CPU resource-monitoring in place, because the act
 
 Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles binaries for a number of common architectures. This minimizes the tooling required to run the package and avoids compiling the package from source in most cases, which speeds up installation. Currently, we ship prebuilt binaries for the following architectures and Node versions:
 
-- macOS x64: Node v16, v18, v20
-- Linux ARM64 (musl): Node v16, v18, v20
-- Linux x64 (glibc): Node v16, v18, v20
-- Windows x64: Node v16, v18, v20
+- macOS x64: Node v16, v18, v20, v22
+- Linux ARM64 (musl): Node v16, v18, v20, v22
+- Linux x64 (glibc): Node v16, v18, v20, v22
+- Windows x64: Node v16, v18, v20, v22
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/11455 was released, so we can update the profiling docs!