### PR TITLE
fix(js): Fix broken cache and queue monitoring product walkthrough links

### DIFF
--- a/docs/product/performance/caches/index.mdx
+++ b/docs/product/performance/caches/index.mdx
@@ -23,7 +23,7 @@ Cache monitoring currently supports [auto instrumentation](/platform-redirect/?n
 If available, custom instrumentation is documented on an environment-by-environment basis as listed below:
 
 - [Python SDK](/platforms/python/performance/instrumentation/custom-instrumentation/caches-module/)
-- [JavaScript SDKs](/platforms/javascript/performance/instrumentation/custom-instrumentation/caches-module/)
+- [JavaScript SDKs](/platforms/javascript/guides/node/performance/instrumentation/custom-instrumentation/caches-module/)
 - [Laravel SDK](/platforms/php/guides/laravel/performance/instrumentation/custom-instrumentation/)
 - [Java SDK](/platforms/java/performance/instrumentation/custom-instrumentation/)
 - [Ruby SDK](/platforms/ruby/performance/instrumentation/custom-instrumentation/)

--- a/docs/product/performance/queue-monitoring/index.mdx
+++ b/docs/product/performance/queue-monitoring/index.mdx
@@ -21,7 +21,7 @@ Queue monitoring currently supports [auto instrumentation](/platform-redirect/?n
 Instructions for custom instrumentation in various languages are linked to below:
 
 - [Python SDK](/platforms/python/performance/instrumentation/custom-instrumentation/queues-module/)
-- [JavaScript SDK](/platforms/javascript/performance/instrumentation/custom-instrumentation/queues-module/)
+- [JavaScript SDK](/platforms/javascript/guides/node/performance/instrumentation/custom-instrumentation/queues-module/)
 - [Laravel SDK](/platforms/php/guides/laravel/performance/instrumentation/custom-instrumentation/)
 - [Java SDK](/platforms/java/distributed-tracing/custom-instrumentation/)
 - [Ruby SDK](/platforms/ruby/)


### PR DESCRIPTION
While working on #10121 and #10123 I missed that we link to these pages in our product walkthrough docs. This PR adjusts the links. 