### PR TITLE
feat(apple): Add docs for beforeCaptureScreenshot

### DIFF
--- a/platform-includes/enriching-events/attach-screenshots/apple.mdx
+++ b/platform-includes/enriching-events/attach-screenshots/apple.mdx
@@ -13,3 +13,38 @@ SentrySDK.start { options in
   options.attachScreenshot = YES;
 }];
 ```
+
+### Customize Screenshot Capturing
+
+<Note>
+
+Requires Cocoa SDK version `8.27.0` or higher.
+
+</Note>
+
+
+The `beforeCaptureCallback` also allows you to customize the behavior based on event data, so you can decide when to capture a screenshot and when not to. The callback doesn't work for crash events.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.beforeCaptureScreenshot = { event in
+        // Return false to not capture a screenshot for the event.
+        return false
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.beforeCaptureScreenshot = ^BOOL(SentryEvent * _Nonnull event) {
+        // Return NO to not capture a screenshot for the event.
+        return NO;
+    };
+}];
+```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds docs for the `beforeCaptureScreenshot` callback for the Cocoa SDK; see https://github.com/getsentry/sentry-cocoa/pull/4016. We have to wait until we release Cocoa `8.27.0` to merge this.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

