### PR TITLE
fix: Path to RN Module for Debug Files upload

### DIFF
--- a/docs/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/docs/platforms/react-native/manual-setup/manual-setup.mdx
@@ -90,7 +90,7 @@ By default, uploading of source maps for debug simulator builds is disabled for 
 To upload debug symbols to Sentry, create a new Run Script build phase using the following script:
 
 ```bash {filename:Upload Debug Symbols to Sentry}
-/bin/sh ../../scripts/sentry-xcode-debug-files.sh
+/bin/sh ../node_modules/@sentry/react-native/scripts/sentry-xcode-debug-files.sh
 ```
 
 To change the default behavior, you can pass the following environment variables in `.xcode.env` or in the Build Phase script:


### PR DESCRIPTION
Tiny fix for the Debug Files upload, adding full path to the Sentry RN SDK module.