### PR TITLE
fix(ruby): Use new meta helper in rails view

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/ruby.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/ruby.mdx
@@ -50,8 +50,7 @@ To propagate tracing information into JavaScript running in rendered HTML, you h
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta name="sentry-trace" content=<%= Sentry.get_traceparent %>>
-    <meta name="baggage" content=<%= Sentry.get_baggage %>>
+    <%= Sentry.get_trace_propagation_meta.html_safe %>
   </head>
   <body>
     <p>This is a website.</p>


### PR DESCRIPTION
merge after https://github.com/getsentry/sentry-ruby/pull/2314 is released