### PR TITLE
fix(node): Fix performance & profiling page name & order

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/connect/performance/index.mdx
+++ b/docs/platforms/javascript/guides/connect/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/connect/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/connect/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/express/performance/index.mdx
+++ b/docs/platforms/javascript/guides/express/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/express/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/express/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/fastify/performance/index.mdx
+++ b/docs/platforms/javascript/guides/fastify/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience out of it."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/fastify/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/fastify/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/hapi/performance/index.mdx
+++ b/docs/platforms/javascript/guides/hapi/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/hapi/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/hapi/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/koa/performance/index.mdx
+++ b/docs/platforms/javascript/guides/koa/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/koa/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/koa/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/nestjs/performance/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.

--- a/docs/platforms/javascript/guides/nestjs/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_order: 5000
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 ---
 

--- a/docs/platforms/javascript/guides/node/performance/index.mdx
+++ b/docs/platforms/javascript/guides/node/performance/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: Performance Monitoring
-description: "Learn more about how to configure our Performance integrations to get the best experience."
+title: Set Up Performance
+description: "Learn how to enable performance monitoring in your app."
+sidebar_order: 4000
 ---
 
 As soon as you define a `tracesSampleRate` for your Sentry SDK, Performance Monitoring will be enabled. This will automatically instrument and monitor the performance of your application.


### PR DESCRIPTION
This kind of got messed up along the way and was not really consistent anymore.

Now we use the same label & order for all the js variants again.
