### PR TITLE
Add `failureIssueThreshold` and `recoveryThreshold` to js cron docs

### DIFF
--- a/includes/javascript-crons-upsert.mdx
+++ b/includes/javascript-crons-upsert.mdx
@@ -148,3 +148,15 @@ The amount of time (in minutes) your job is allowed to run before it's considere
 `timezone`:
 
 The `tz` where your job is running. This is usually your server's timezone, (such as `America/Los_Angeles`). See [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Optional.
+
+`failureIssueThreshold`:
+
+_requires SDK version `8.6.0` or higher_
+
+The number of consecutive failed check-ins it takes before an issue is created. Optional.
+
+`recoveryThreshold`:
+
+_requires SDK version `8.6.0` or higher_
+
+The number of consecutive OK check-ins it takes before an issue is resolved. Optional.

--- a/includes/javascript-crons-upsert.mdx
+++ b/includes/javascript-crons-upsert.mdx
@@ -151,12 +151,12 @@ The `tz` where your job is running. This is usually your server's timezone, (suc
 
 `failureIssueThreshold`:
 
-_requires SDK version `8.6.0` or higher_
+_requires SDK version `8.7.0` or higher_
 
-The number of consecutive failed check-ins it takes before an issue is created. Optional.
+The number of consecutive failed check-ins required before an issue can be created. Optional.
 
 `recoveryThreshold`:
 
-_requires SDK version `8.6.0` or higher_
+_requires SDK version `8.7.0` or higher_
 
-The number of consecutive OK check-ins it takes before an issue is resolved. Optional.
+The number of consecutive successful check-ins required for an issue to be considered resolved. Optional.


### PR DESCRIPTION
Note: Only merge after `8.6.0` gets merged in!

Documents https://github.com/getsentry/sentry-javascript/pull/12248