### PR TITLE
feat(Android): Re-add features list as separate page

### DIFF
--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -4,24 +4,22 @@ sidebar_order: 0
 description: "Learn about the features of Sentry's Android SDK."
 ---
 
-
 Sentry's Android SDK enables automatic reporting of errors and exceptions, and identifies performance issues in your application. The below, is a list of features that are available as part of this SDK.
-
 
 - Native Development Kit (NDK), the set of tools that that allows you to use C and C++ with Android.
 - Events [enriched with device data](/platforms/android/enriching-events/context/).
 - Offline caching. (If a device is offline, we'll send a report once the application has been restarted.)
 - [Automatic breadcrumbs](/platforms/android/enriching-events/breadcrumbs/#automatic-breadcrumbs) for:
   - Android activity lifecycle events.
-  - Application lifecycle events. 
+  - Application lifecycle events.
   - System events such as: low battery, low storage space, airplane mode started, shutdown, changes of the configuration, and so forth.
   - Application component callbacks.
   - User Interactions such as: view click, scroll, swipe, and so on.
   - Android [fragment](/platforms/android/configuration/integrations/fragment/) lifecycle events.
-  - [OkHttp](/platforms/android/configuration/integrations/okhttp/) requests. 
-  - [Apollo](/platforms/android/configuration/integrations/apollo/) requests. 
+  - [OkHttp](/platforms/android/configuration/integrations/okhttp/) requests.
+  - [Apollo](/platforms/android/configuration/integrations/apollo/) requests.
   - [Timber logs](/platforms/android/configuration/integrations/timber/).
-  - [Navigation destination](/platforms/android/configuration/integrations/navigation/) changes. 
+  - [Navigation destination](/platforms/android/configuration/integrations/navigation/) changes.
 - [Release health](/product/releases/health/), tracking crash-free users and sessions.
 - [Attachments](/platforms/android/enriching-events/attachments/) that can enrich your event by storing additional files, such as config or log files.
 - [User Feedback](/platforms/android/enriching-events/user-feedback/), providing the ability to collect user information when an event occurs.

--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -1,14 +1,12 @@
 ---
 title: Features
 sidebar_order: 0
-description: "Learn more about Sentry's Android SDK features."
+description: "Learn about the features of Sentry's Android SDK."
 ---
 
-<Note>
 
-Sentry's Android SDK enables automatic reporting of errors and exceptions, and identifies performance issues in your application.
+Sentry's Android SDK enables automatic reporting of errors and exceptions, and identifies performance issues in your application. The below, is a list of features that are available as part of this SDK.
 
-</Note>
 
 - Native Development Kit (NDK), the set of tools that that allows you to use C and C++ with Android.
 - Events [enriched with device data](/platforms/android/enriching-events/context/).

--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -44,4 +44,4 @@ Sentry's Android SDK enables automatic reporting of errors and exceptions, and i
 - [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/)
 - [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
 - Code samples provided in both Kotlin and Java as the Android SDK uses both languages
-- We provide a [sample application](https://github.com/getsentry/sentry-java/tree/master/sentry-samples/sentry-samples-android) for our Android users
+- We provide a [sample application](https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-android) for our Android users

--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -10,38 +10,38 @@ Sentry's Android SDK enables automatic reporting of errors and exceptions, and i
 
 </Note>
 
-- The Native Development Kit (NDK), the set of tools that that allows you to use C and C++ code with Android, is packed with the SDK.
-- Events [enriched](/platforms/android/enriching-events/context/) with device data
-- Offline caching when a device is offline; we send a report once the application is restarted
-- [Breadcrumbs automatically](/platforms/android/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for:
-  - Android activity lifecycle events
-  - Application lifecycle events (lifecycle of the application process)
-  - System events (low battery, low storage space, airplane mode started, shutdown, changes of the configuration, and so forth)
-  - App. component callbacks
-  - User Interactions (view click, scroll, swipe, etc.)
-  - Android fragment lifecycle events with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
-  - OkHttp requests with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
-  - Apollo requests with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
-  - Timber logs with [Timber Integration](/platforms/android/configuration/integrations/timber/)
-  - Navigation destination changes with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
-- [Release health](/product/releases/health/) tracks crash free users and sessions
-- [Attachments](/platforms/android/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files.
-- [User Feedback](/platforms/android/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs.
-- [Performance Monitoring](/product/performance/) creates transactions for:
-    - Android activity transactions
-    - User interaction transactions (view click, scroll, swipe, and so on)
-    - Navigation transactions with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
-    - Android fragment spans with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
-    - [Cold and warm app start](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
-    - [Slow and frozen frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
-    - OkHttp request spans with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
-    - SQLite and Room query spans with [Room and SQLite Integration](/platforms/android/configuration/integrations/room-and-sqlite/)
-    - File I/O spans with [File I/O Integration](/platforms/android/configuration/integrations/file-io/)
-    - Apollo request spans with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
-    - Distributed tracing through [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Apollo](/platforms/android/configuration/integrations/apollo/) integrations
-- [Application Not Responding (ANR)](/platforms/android/configuration/app-not-respond/) reported if the application is blocked for more than five seconds
-- [HTTP Client Errors](/platforms/android/configuration/integrations/okhttp/#http-client-errors)
-- [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/)
-- [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
-- Code samples provided in both Kotlin and Java as the Android SDK uses both languages
-- We provide a [sample application](https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-android) for our Android users
+- Native Development Kit (NDK), the set of tools that that allows you to use C and C++ with Android.
+- Events [enriched with device data](/platforms/android/enriching-events/context/).
+- Offline caching. (If a device is offline, we'll send a report once the application has been restarted.)
+- [Automatic breadcrumbs](/platforms/android/enriching-events/breadcrumbs/#automatic-breadcrumbs) for:
+  - Android activity lifecycle events.
+  - Application lifecycle events. 
+  - System events such as: low battery, low storage space, airplane mode started, shutdown, changes of the configuration, and so forth.
+  - Application component callbacks.
+  - User Interactions such as: view click, scroll, swipe, and so on.
+  - Android [fragment](/platforms/android/configuration/integrations/fragment/) lifecycle events.
+  - [OkHttp](/platforms/android/configuration/integrations/okhttp/) requests. 
+  - [Apollo](/platforms/android/configuration/integrations/apollo/) requests. 
+  - [Timber logs](/platforms/android/configuration/integrations/timber/).
+  - [Navigation destination](/platforms/android/configuration/integrations/navigation/) changes. 
+- [Release health](/product/releases/health/), tracking crash-free users and sessions.
+- [Attachments](/platforms/android/enriching-events/attachments/) that can enrich your event by storing additional files, such as config or log files.
+- [User Feedback](/platforms/android/enriching-events/user-feedback/), providing the ability to collect user information when an event occurs.
+- [Performance Monitoring](/product/performance/) that can track:
+    - Android activity transactions.
+    - User interaction transactions such as: view click, scroll, swipe, and so on.
+    - [Navigation transactions](/platforms/android/configuration/integrations/navigation/).
+    - Android [fragment spans](/platforms/android/configuration/integrations/fragment/).
+    - [Cold and warm app starts](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation).
+    - [Slow and frozen frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames).
+    - [OkHttp request spans](/platforms/android/configuration/integrations/okhttp/).
+    - [SQLite and Room query spans](/platforms/android/configuration/integrations/room-and-sqlite/).
+    - [File I/O spans](/platforms/android/configuration/integrations/file-io/).
+    - [Apollo request spans](/platforms/android/configuration/integrations/apollo/).
+    - Distributed tracing through [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Apollo](/platforms/android/configuration/integrations/apollo/) integrations.
+- [Application Not Responding (ANR)](/platforms/android/configuration/app-not-respond/), reported if the application is blocked for more than five seconds.
+- [HTTP Client Errors](/platforms/android/configuration/integrations/okhttp/#http-client-errors).
+- [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/).
+- [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/).
+- Code samples provided in both Kotlin and Java (since the Android SDK uses both languages).
+- A [sample application](https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-android) for our Android users.

--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -45,4 +45,3 @@ Sentry's Android SDK enables automatic reporting of errors and exceptions, and i
 - [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
 - Code samples provided in both Kotlin and Java as the Android SDK uses both languages
 - We provide a [sample application](https://github.com/getsentry/sentry-java/tree/master/sentry-samples/sentry-samples-android) for our Android users
-- Our [video tutorial](/platforms/android/android-video/) visually demonstrates how to set up our SDK

--- a/docs/platforms/android/features/index.mdx
+++ b/docs/platforms/android/features/index.mdx
@@ -1,0 +1,48 @@
+---
+title: Features
+sidebar_order: 0
+description: "Learn more about Sentry's Android SDK features."
+---
+
+<Note>
+
+Sentry's Android SDK enables automatic reporting of errors and exceptions, and identifies performance issues in your application.
+
+</Note>
+
+- The Native Development Kit (NDK), the set of tools that that allows you to use C and C++ code with Android, is packed with the SDK.
+- Events [enriched](/platforms/android/enriching-events/context/) with device data
+- Offline caching when a device is offline; we send a report once the application is restarted
+- [Breadcrumbs automatically](/platforms/android/enriching-events/breadcrumbs/#automatic-breadcrumbs) captured for:
+  - Android activity lifecycle events
+  - Application lifecycle events (lifecycle of the application process)
+  - System events (low battery, low storage space, airplane mode started, shutdown, changes of the configuration, and so forth)
+  - App. component callbacks
+  - User Interactions (view click, scroll, swipe, etc.)
+  - Android fragment lifecycle events with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
+  - OkHttp requests with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
+  - Apollo requests with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
+  - Timber logs with [Timber Integration](/platforms/android/configuration/integrations/timber/)
+  - Navigation destination changes with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
+- [Release health](/product/releases/health/) tracks crash free users and sessions
+- [Attachments](/platforms/android/enriching-events/attachments/) enrich your event by storing additional files, such as config or log files.
+- [User Feedback](/platforms/android/enriching-events/user-feedback/) provides the ability to collect user information when an event occurs.
+- [Performance Monitoring](/product/performance/) creates transactions for:
+    - Android activity transactions
+    - User interaction transactions (view click, scroll, swipe, and so on)
+    - Navigation transactions with [Navigation Integration](/platforms/android/configuration/integrations/navigation/)
+    - Android fragment spans with [Fragment Integration](/platforms/android/configuration/integrations/fragment/)
+    - [Cold and warm app start](/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation)
+    - [Slow and frozen frames](/platforms/android/performance/instrumentation/automatic-instrumentation/#slow-and-frozen-frames)
+    - OkHttp request spans with [OkHttp Integration](/platforms/android/configuration/integrations/okhttp/)
+    - SQLite and Room query spans with [Room and SQLite Integration](/platforms/android/configuration/integrations/room-and-sqlite/)
+    - File I/O spans with [File I/O Integration](/platforms/android/configuration/integrations/file-io/)
+    - Apollo request spans with [Apollo Integration](/platforms/android/configuration/integrations/apollo/)
+    - Distributed tracing through [OkHttp](/platforms/android/configuration/integrations/okhttp/) and [Apollo](/platforms/android/configuration/integrations/apollo/) integrations
+- [Application Not Responding (ANR)](/platforms/android/configuration/app-not-respond/) reported if the application is blocked for more than five seconds
+- [HTTP Client Errors](/platforms/android/configuration/integrations/okhttp/#http-client-errors)
+- [Screenshot attachments for errors](/platforms/android/enriching-events/screenshots/)
+- [View Hierarchy attachments for errors](/platforms/android/enriching-events/viewhierarchy/)
+- Code samples provided in both Kotlin and Java as the Android SDK uses both languages
+- We provide a [sample application](https://github.com/getsentry/sentry-java/tree/master/sentry-samples/sentry-samples-android) for our Android users
+- Our [video tutorial](/platforms/android/android-video/) visually demonstrates how to set up our SDK

--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -44,4 +44,4 @@ To view and resolve the recorded error, log into [sentry.io](https://sentry.io) 
 
 ## Next Steps
 
-- <PlatformLink to="/features">Learn more about Sentry's Android SDK features</PlatformLink>
+- <PlatformLink to="/features">Learn about the features of Sentry's Android SDK</PlatformLink>

--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -20,7 +20,7 @@ Don't already have an account and Sentry project established? Head over to [sent
 
 ## Install
 
-Sentry captures data by using an SDK within your application’s runtime.
+Sentry captures data by using an SDK within your application's runtime.
 
 <PlatformContent includePath="getting-started-install" />
 
@@ -41,3 +41,7 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 </Note>
 
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+
+## Next Steps
+
+- Learn more about Sentry's <PlatformLink to="/features">Android SDK features</PlatformLink>

--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -44,4 +44,4 @@ To view and resolve the recorded error, log into [sentry.io](https://sentry.io) 
 
 ## Next Steps
 
-- Learn more about Sentry's <PlatformLink to="/features">Android SDK features</PlatformLink>
+- <PlatformLink to="/features">Learn more about Sentry's Android SDK features</PlatformLink>


### PR DESCRIPTION
We removed this a while ago from the landing page to streamline the getting started experience. Re-adding this now as separate Features page.

The list is a good reference for new and existing users.