### PR TITLE
docs(releases): Update cli examples

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -74,17 +74,12 @@ sentry-cli releases set-commits "$VERSION" --auto
 In case you are deploying without access to the git repository, you can manually specify the commits instead. To do this, pass the `--commit` parameter to the `set-commits` command in the format `REPO_NAME@REVISION`. You can repeat this for as many repositories as you have:
 
 ```bash {tabTitle:bash (one repo)}
-sentry-cli releases set-commits "$VERSION" --commit "my-repo@deadbeef"
+sentry-cli releases set-commits "$VERSION" --commit "repo-owner/repo-name@deadbeef"
 ```
 
 ```bash {tabTitle:bash (many repos)}
-sentry-cli releases set-commits "$VERSION" --commit "my-repo@deadbeef" --commit "my-repo@deadbeef2" --commit "my-repo@deadbeef3"
+sentry-cli releases set-commits "$VERSION" --commit "repo-owner/repo-name@deadbeef" --commit "repo-owner/repo-name@deadbeef2" --commit "repo-owner/repo-name@deadbeef3"
 ```
-
-<Note>
-  The repository name `my-repo` should match the name you entered when linking
-  the repo, and should be in the form `owner-name/repo-name`.
-</Note>
 
 To see which repos are available for the organization, you can run `sentry-cli repos list` which will return a list of configured repositories.
 
@@ -93,7 +88,7 @@ Note that you need to refer to releases you need to use the actual full commit S
 If you also want to set a previous commit instead of letting the server use the previous release as the base point you can do that by setting a commit range:
 
 ```bash
-sentry-cli releases set-commits "$VERSION" --commit "my-repo@from..to"
+sentry-cli releases set-commits "$VERSION" --commit "repo-owner/repo-name@from..to"
 ```
 
 ### Alternatively: Without a Repository Integration


### PR DESCRIPTION
## DESCRIBE YOUR PR
Replace `my-repo` with `repo-owner/repo-name` in the cli examples so that users don't accidently only use the repo name.

Fixes GH-10044

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)