### PR TITLE
add caches walkthrough arcade

### DIFF
--- a/docs/product/performance/caches/cache-page.mdx
+++ b/docs/product/performance/caches/cache-page.mdx
@@ -20,6 +20,20 @@ By default, this table is sorted by most time spent. This means that endpoints a
 
 To investigate a specific endpoint, click on it to open a sidebar showing some sample events and additional duration metrics.
 
+<div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
+  <iframe
+    src="https://demo.arcade.software/wWxTT19VRB7pkyV3oHwm?embed&show_copy_link=true"
+    frameborder="0"
+    loading="lazy"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{"colorScheme":"light","height":"100%","left":"0px","position":"absolute","top":"0px","width":"100%"}}
+    title="Performance -> Caches Module Walkthrough"
+  ></iframe>
+</div>
+
+
 ## Sample List
 
 To help you compare the performances of cache hits (where a value was found in the cache) versus misses (where no value corresponding to the key was found in the cache) over time, Sentry automatically surfaces a distribution of both samples for the timeframe selected from the **Caches** page.

--- a/docs/product/performance/caches/cache-page.mdx
+++ b/docs/product/performance/caches/cache-page.mdx
@@ -6,20 +6,7 @@ description: "Learn more about Sentry's Cache page, which provides insights into
 
 The **Caches** page gives an overview of cache performance across all endpoints for currently selected backend projects with summary graphs for **Miss Rate** and **Requests Per Minute** (throughput). You can use these as a starting point to see if there are any potential cache performance issues, for example, a higher than expected Miss Rate percentage.
 
- If you see an anomaly or want to investigate a time range further, click and drag to select a range directly in the graph and data will be filtered for that specific time range only.
-
-The transaction table shows a list of endpoints that contain at least one `cache.get` span along with:
-
-- Its average value size (the bytes being fetched from cache)
-- Throughput
-- Average transaction duration
-- Miss rate percentage (how often did a lookup did not return a value)
-- Time spent (total time your application spent on a given transaction)
-
-By default, this table is sorted by most time spent. This means that endpoints at the top are usually really slow, requested very frequently, or both. You can change the sort order to view top transactions by throughput, miss rate percentage, average value size, or average transaction duration.
-
-To investigate a specific endpoint, click on it to open a sidebar showing some sample events and additional duration metrics.
-
+The gif below demonstrates how to use performance monitoring for caches.
 <div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
   <iframe
     src="https://demo.arcade.software/wWxTT19VRB7pkyV3oHwm?embed&show_copy_link=true"
@@ -33,6 +20,20 @@ To investigate a specific endpoint, click on it to open a sidebar showing some s
   ></iframe>
 </div>
 
+
+ If you see an anomaly or want to investigate a time range further, click and drag to select a range directly in the graph and data will be filtered for that specific time range only.
+
+The transaction table shows a list of endpoints that contain at least one `cache.get` span along with:
+
+- Its average value size (the bytes being fetched from cache)
+- Throughput
+- Average transaction duration
+- Miss rate percentage (how often did a lookup did not return a value)
+- Time spent (total time your application spent on a given transaction)
+
+By default, this table is sorted by most time spent. This means that endpoints at the top are usually really slow, requested very frequently, or both. You can change the sort order to view top transactions by throughput, miss rate percentage, average value size, or average transaction duration.
+
+To investigate a specific endpoint, click on it to open a sidebar showing some sample events and additional duration metrics.
 
 ## Sample List
 

--- a/docs/product/performance/caches/cache-page.mdx
+++ b/docs/product/performance/caches/cache-page.mdx
@@ -6,21 +6,6 @@ description: "Learn more about Sentry's Cache page, which provides insights into
 
 The **Caches** page gives an overview of cache performance across all endpoints for currently selected backend projects with summary graphs for **Miss Rate** and **Requests Per Minute** (throughput). You can use these as a starting point to see if there are any potential cache performance issues, for example, a higher than expected Miss Rate percentage.
 
-The gif below demonstrates how to use performance monitoring for caches.
-<div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
-  <iframe
-    src="https://demo.arcade.software/wWxTT19VRB7pkyV3oHwm?embed&show_copy_link=true"
-    frameborder="0"
-    loading="lazy"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{"colorScheme":"light","height":"100%","left":"0px","position":"absolute","top":"0px","width":"100%"}}
-    title="Performance -> Caches Module Walkthrough"
-  ></iframe>
-</div>
-
-
  If you see an anomaly or want to investigate a time range further, click and drag to select a range directly in the graph and data will be filtered for that specific time range only.
 
 The transaction table shows a list of endpoints that contain at least one `cache.get` span along with:

--- a/docs/product/performance/caches/index.mdx
+++ b/docs/product/performance/caches/index.mdx
@@ -14,6 +14,20 @@ Sentry's cache monitoring provides insights into cache utilization and latency s
 
 Starting with the [Cache page](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/), you get an overview of the transactions within your application that are making at least one lookup against a cache. From there, you can dig into specific cache span operations by clicking a transaction and viewing its sample list.
 
+The gif below demonstrates how to use performance monitoring for caches.
+<div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
+  <iframe
+    src="https://demo.arcade.software/wWxTT19VRB7pkyV3oHwm?embed&show_copy_link=true"
+    frameborder="0"
+    loading="lazy"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{"colorScheme":"light","height":"100%","left":"0px","position":"absolute","top":"0px","width":"100%"}}
+    title="Performance -> Caches Module Walkthrough"
+  ></iframe>
+</div>
+
 ## Instrumentation
 
 Cache monitoring currently supports [auto instrumentation](/platform-redirect/?next=%2Fperformance%2Finstrumentation%2Fautomatic-instrumentation) for [Django's cache framework](https://docs.djangoproject.com/en/5.0/topics/cache/) when the [cache_spans option](https://docs.sentry.io/platforms/python/integrations/django/#options) is set to `True`. Other frameworks require custom instrumentation.

--- a/docs/product/performance/caches/index.mdx
+++ b/docs/product/performance/caches/index.mdx
@@ -14,7 +14,6 @@ Sentry's cache monitoring provides insights into cache utilization and latency s
 
 Starting with the [Cache page](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/), you get an overview of the transactions within your application that are making at least one lookup against a cache. From there, you can dig into specific cache span operations by clicking a transaction and viewing its sample list.
 
-The gif below demonstrates how to use performance monitoring for caches.
 <div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
   <iframe
     src="https://demo.arcade.software/wWxTT19VRB7pkyV3oHwm?embed&show_copy_link=true"

--- a/docs/product/performance/queue-monitoring/index.mdx
+++ b/docs/product/performance/queue-monitoring/index.mdx
@@ -14,7 +14,6 @@ Queue monitoring allows you to monitor both the performance and error rates of y
 
 The **Queues** page gives you a high-level overview so that you can see where messages are being written to. (You may see topic names or actual queue names, depending on the messaging system.) If you click on a transaction, you'll see the **Destination Summary** page, which provides metrics about specific endpoints within your applications that either write to, or read from the destination. You can also dig into individual endpoints within your application representing producers creating messages, and consumers reading messages. You'll see actual traces representing messages processed by your application.
 
-The gif below demonstrates how to use performance monitoring for queues.
 <div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
   <iframe
     src="https://demo.arcade.software/GC3MZ7jwiuXGlVCkXSFt?embed&show_copy_link=true"

--- a/docs/product/performance/queue-monitoring/index.mdx
+++ b/docs/product/performance/queue-monitoring/index.mdx
@@ -14,6 +14,20 @@ Queue monitoring allows you to monitor both the performance and error rates of y
 
 The **Queues** page gives you a high-level overview so that you can see where messages are being written to. (You may see topic names or actual queue names, depending on the messaging system.) If you click on a transaction, you'll see the **Destination Summary** page, which provides metrics about specific endpoints within your applications that either write to, or read from the destination. You can also dig into individual endpoints within your application representing producers creating messages, and consumers reading messages. You'll see actual traces representing messages processed by your application.
 
+The gif below demonstrates how to use performance monitoring for queues.
+<div style={{"height":"0px","paddingBottom":"calc(56.8359% + 41px)","position":"relative","width":"100%"}}>
+  <iframe
+    src="https://demo.arcade.software/GC3MZ7jwiuXGlVCkXSFt?embed&show_copy_link=true"
+    frameborder="0"
+    loading="lazy"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{"colorScheme":"light","height":"100%","left":"0px","position":"absolute","top":"0px","width":"100%"}}
+    title="Performance -> Caches Module Walkthrough"
+  ></iframe>
+</div>
+
 ### Prerequisites and Limitations
 
 Queue monitoring currently supports [auto instrumentation](/platform-redirect/?next=%2Fperformance%2Finstrumentation%2Fautomatic-instrumentation) for the [Celery Distributed Task Queue](https://docs.celeryq.dev/en/stable/) in Python. Other messaging systems can be monitored using custom instrumentation.

--- a/docs/product/performance/queue-monitoring/index.mdx
+++ b/docs/product/performance/queue-monitoring/index.mdx
@@ -24,7 +24,7 @@ The gif below demonstrates how to use performance monitoring for queues.
     mozallowfullscreen
     allowfullscreen
     style={{"colorScheme":"light","height":"100%","left":"0px","position":"absolute","top":"0px","width":"100%"}}
-    title="Performance -> Caches Module Walkthrough"
+    title="Performance -> Queues Module Walkthrough"
   ></iframe>
 </div>
 


### PR DESCRIPTION
Adds cache module arcade to caches documentation and queue module arcade.

I added it in a location consistent to the other modules, for examples requests shows the arcade just after the quick blurb on how to use the module
https://docs.sentry.io/product/performance/requests/
