### PR TITLE
docs(feedback): Link to migration guide for feedback from SDK v7 to v8

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/v7/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/v7/index.mdx
@@ -6,7 +6,7 @@ description: "Learn about general User Feedback configuration fields for version
 
 <Alert level="warning" title="Deprecation Warning">
 
-In version 7 of our JavaScript SDK, User Feedback was released as a Beta integration. We recommend updating your SDK to <PlatformLink to="/user-feedback/configuration/">version 8</PlatformLink>.
+In version 7 of our JavaScript SDK, User Feedback was released as a Beta integration. We recommend following the [migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/docs/migration/feedback.md) and updating your SDK to <PlatformLink to="/user-feedback/configuration/">version 8</PlatformLink>.
 
 </Alert>
 


### PR DESCRIPTION
Add a link in the docs pages so people can find the migration steps as they're reading about feedback in the v7 sdk.

Fixes https://github.com/getsentry/sentry-javascript/issues/12015