### PR TITLE
ref: Use default prettier config for formatting code blocks instead of repository config

### DIFF
--- a/src/remark-format-code.js
+++ b/src/remark-format-code.js
@@ -1,8 +1,6 @@
 import {format} from 'prettier';
 import {visit} from 'unist-util-visit';
 
-import * as prettierConfig from '../prettier.config.js';
-
 export default function remarkFormatCodeBlocks() {
   return async tree => {
     const codeNodes = [];
@@ -44,9 +42,8 @@ async function formatCode(node) {
 
   try {
     const formattedCode = await format(node.value, {
-      ...prettierConfig,
+      printWidth: 75, // The code blocks in the docs have around 77 characters available on desktop
       ...parserConfig,
-      printWidth: 80,
     });
     // get rid of the trailing newline
     node.value = formattedCode.trimEnd();


### PR DESCRIPTION
We do not want "our" (as in, the docs developers) prettier config to be what dictates the content of code blocks, but rather we want to stick to the default prettier config as much as possible because that is what people are used to.