### PR TITLE
feat(api): Remove "API Guides" from Sidebar

### DIFF
--- a/docs/api/guides/index.mdx
+++ b/docs/api/guides/index.mdx
@@ -1,5 +1,0 @@
----
-title: API Guides
----
-
-<PageGrid />


### PR DESCRIPTION
This PR Removed "API Guides" from the sidebar. Currently the section lives between other endpoint documentation, which is out of place.
<img width="286" alt="image" src="https://github.com/getsentry/sentry-docs/assets/33237075/ad23b4d4-8f79-47b9-a7f0-4d85a3913bab">

The docs are already linked under the main API Reference page:
<img width="724" alt="image" src="https://github.com/getsentry/sentry-docs/assets/33237075/bd8198b0-9dc9-4aac-abf1-3881ce1f43a5">

so it is safe to remove them from the sidebar.

How it looks now:
<img width="188" alt="image" src="https://github.com/getsentry/sentry-docs/assets/33237075/e35b321d-6e12-4841-8cb6-35d4cb2de2ad">


## IS YOUR CHANGE URGENT?  
Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+