### PR TITLE
docs(react): correct import in React v8 migration docs

### DIFF
--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.react.mdx
@@ -103,7 +103,7 @@ For react, we provide multiple integrations to cover different router integratio
 ### No React Router
 
 ```JavaScript diff
- import * as Sentry from "@sentry/svelte";
+ import * as Sentry from "@sentry/react";
 
  Sentry.init({
    dsn: "___PUBLIC_DSN___",


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
<!-- *Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.* -->

Very minor, but I encountered this issue when upgrading to `@sentry/react@8`. The import incorrectly refers to the `/svelte` package when in the React docs context

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
