### PR TITLE
feat(js) Update primers & headers for JS

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -1,9 +1,13 @@
 <PlatformContent includePath="getting-started-primer" />
 
-<PlatformSection notSupported={["javascript.astro", "javascript.capacitor"]}>
+<PlatformSection notSupported={["javascript.capacitor"]}>
 
-If you're seeing deprecation warnings in your code, please note that we're currently working on version 8 of the JavaScript SDKs. In v8, some methods and properties will be removed or renamed. Check out the [Migration docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
-and learn how to update your code to be compatible with v8.
+<Note>
+  We have recently released v8 of the JavaScript SDKs. If you're using version
+  7.x, we recommend upgrading to the latest version. Check out the [Migration
+  docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+  to learn how to update your code to be compatible with v8.
+</Note>
 
 </PlatformSection>
 

--- a/platform-includes/getting-started-primer/javascript.bun.mdx
+++ b/platform-includes/getting-started-primer/javascript.bun.mdx
@@ -1,5 +1,0 @@
-<Note>
-
-The Bun SDK is currently in Beta.
-
-</Note>

--- a/platform-includes/getting-started-primer/javascript.svelte.mdx
+++ b/platform-includes/getting-started-primer/javascript.svelte.mdx
@@ -3,5 +3,3 @@
 Sentry's Svelte SDK enables automatic reporting of errors and exceptions, as well as performance monitoring for your client-side Svelte apps.
 
 </Note>
-
-Sentry's Svelte SDK was introduced with version `7.10.0`.


### PR DESCRIPTION
We can remove these beta warnings for bun & deno I believe, and also I updated the primer about the migration warnings.