### PR TITLE
Toggle performance for Java SDK

### DIFF
--- a/platform-includes/getting-started-config/java.mdx
+++ b/platform-includes/getting-started-config/java.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```java {tabTitle: Java}
+```java {tabTitle: Java} {"onboardingOptions": {"performance": "5-9"}}
 import io.sentry.Sentry;
 
 Sentry.init(options -> {

--- a/platform-includes/getting-started-config/java.mdx
+++ b/platform-includes/getting-started-config/java.mdx
@@ -13,7 +13,7 @@ Sentry.init(options -> {
 });
 ```
 
-```kotlin {tabTitle: Kotlin}
+```kotlin {tabTitle: Kotlin} {"onboardingOptions": {"performance": "5-9"}}
 import io.sentry.Sentry
 
 Sentry.init { options ->

--- a/platform-includes/getting-started-config/java.spring-boot.mdx
+++ b/platform-includes/getting-started-config/java.spring-boot.mdx
@@ -4,7 +4,7 @@ Provide a `sentry.dsn` property using either `application.properties` or `applic
 
 <SignInNote />
 
-```properties {filename:application.properties}
+```properties {filename:application.properties} {"onboardingOptions": {"performance": "2-6"}}
 sentry.dsn=___PUBLIC_DSN___
 
 # Set traces_sample_rate to 1.0 to capture 100%

--- a/platform-includes/getting-started-config/java.spring-boot.mdx
+++ b/platform-includes/getting-started-config/java.spring-boot.mdx
@@ -13,7 +13,7 @@ sentry.dsn=___PUBLIC_DSN___
 sentry.traces-sample-rate=1.0
 ```
 
-```yaml {filename:application.yml}
+```yaml {filename:application.yml} {"onboardingOptions": {"performance": "3-7"}}
 sentry:
   dsn: ___PUBLIC_DSN___
 

--- a/platform-includes/getting-started-install/java.mdx
+++ b/platform-includes/getting-started-install/java.mdx
@@ -1,3 +1,7 @@
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance"]}
+/>
+
 ```groovy {filename:build.gradle}
 plugins {
   id "io.sentry.jvm.gradle" version "{{@inject packages.version('sentry.java.android.gradle-plugin', '3.12.0') }}"

--- a/platform-includes/getting-started-install/java.spring-boot.mdx
+++ b/platform-includes/getting-started-install/java.spring-boot.mdx
@@ -1,3 +1,7 @@
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance"]}
+/>
+
 ```xml {tabTitle:Maven (Spring Boot 2)}
 <dependency>
     <groupId>io.sentry</groupId>


### PR DESCRIPTION
Didn't allow me to toggle locally, now trying to deploy here and check this way.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
