### PR TITLE
feat(js): Add new onboarding for all JavaScript guides

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -41,10 +41,29 @@ If you prefer to follow video instructions, see [How to Install the Sentry Next.
 
 </PlatformSection>
 
-
 <PlatformSection notSupported={["javascript.deno"]}>
 
 ## Install
+
+<PlatformCategorySection notSupported={["server"]}>
+  <PlatformSection notSupported={["javascript", 'javascript.cordova']}>
+    <OnboardingOptionButtons
+      options={["error-monitoring", "performance", "session-replay"]}
+    />
+  </PlatformSection>
+</PlatformCategorySection>
+
+<PlatformCategorySection notSupported={["browser"]}>
+  <PlatformSection notSupported={["javascript.bun"]}>
+    <OnboardingOptionButtons
+      options={["error-monitoring", "performance", "profiling"]}
+    />
+  </PlatformSection>
+
+  <PlatformSection supported={["javascript.bun"]}>
+    <OnboardingOptionButtons options={["error-monitoring", "performance"]} />
+  </PlatformSection>
+</PlatformCategorySection>
 
 Sentry captures data by using an SDK within your application’s runtime.
 

--- a/docs/platforms/javascript/common/performance/index.mdx
+++ b/docs/platforms/javascript/common/performance/index.mdx
@@ -17,13 +17,22 @@ If you’re adopting Performance in a high-throughput environment, we recommend 
 
 </PlatformCategorySection>
 
+<PlatformContent supported={['javascript']}>
 ## Enable Tracing
 
 <PlatformContent includePath="performance/enable-tracing" />
 
+</PlatformContent>
+
 ## Configure
 
+<PlatformSection supported={['javascript']}>
 First, enable tracing and configure the sampling rate for transactions. Set the sample rate for your transactions by either:
+</PlatformSection>
+
+<PlatformSection notSupported={['javascript']}>
+First, configure the sampling rate for transactions. Set the sample rate for your transactions by either:
+</PlatformSection>
 
 - Setting a uniform sample rate for all transactions using the <PlatformIdentifier name="traces-sample-rate" /> option in your SDK config to a number between `0` and `1`. (For example, to send 20% of transactions, set <PlatformIdentifier name="traces-sample-rate" /> to `0.2`.)
 - Controlling the sample rate based on the transaction itself and the context in which it's captured, by providing a function to the <PlatformIdentifier name="traces-sampler" /> config option.

--- a/docs/platforms/javascript/guides/aws-lambda/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/index.mdx
@@ -19,62 +19,25 @@ Before you begin, note:
 - You need to have experience with AWS console and a basic understanding of Lambda.
 - You'll need an AWS account and you have to create an [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).
 
-<Note>
-  This guide is for version 8.0.0 and up of `@sentry/aws-serverless`.
-</Note>
+<Note>This guide is for version 8.0.0 and up of `@sentry/aws-serverless`.</Note>
+
+## Install
+
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "profiling"]}
+/>
 
 Create a deployment package on your local machine and install the required dependencies in the deployment package. For more information, see [Building an AWS Lambda deployment package for Node.js](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-deployment-package-nodejs/).
 
-Add `@sentry/aws-serverless` as a dependency:
-
-```bash {tabTitle:npm}
-npm install --save @sentry/aws-serverless
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/aws-serverless
-```
+<PlatformContent includePath="getting-started-install" />
 
 We also support [installing Sentry as a Container Image](/platforms/javascript/guides/aws-lambda/container-image/) and [installing Sentry in Lambda Layer](/platforms/javascript/guides/aws-lambda/layer/).
 
+## Configure
+
 You can use the AWS Lambda integration for the Node like this:
 
-<SignInNote />
-
-```javascript {tabTitle:async}
-const Sentry = require("@sentry/aws-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // Add Performance Monitoring by setting tracesSampleRate and adding integration
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-});
-
-exports.handler = Sentry.wrapHandler(async (event, context) => {
-  // Your handler code
-});
-```
-
-```javascript {tabTitle:sync}
-const Sentry = require("@sentry/aws-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 1.0,
-});
-
-exports.handler = Sentry.wrapHandler((event, context, callback) => {
-  // Your handler code
-});
-```
-
-{/* <!-- TODO-ADD-VERIFICATION-EXAMPLE --> */}
+<PlatformContent includePath="getting-started-config" />
 
 ## Enable Timeout Warning
 

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -7,46 +7,21 @@ categories:
   - serverless
 ---
 
-Add `@sentry/node` as a dependency:
+## Install
 
-```bash {tabTitle:npm}
-npm install --save @sentry/node
-```
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "profiling"]}
+/>
 
-```bash {tabTitle:Yarn}
-yarn add @sentry/node
-```
+Sentry captures data by using an SDK within your application’s runtime. This means that you have to add `@sentry/node` as a runtime dependency to your application:
+
+<PlatformContent includePath="getting-started-install" />
+
+## Configure
 
 To set up Sentry error logging for an Azure Function:
 
-<SignInNote />
-
-```javascript
-"use strict";
-
-const Sentry = require("@sentry/node");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-});
-
-module.exports = async function (context, req) {
-  try {
-    await notExistFunction();
-  } catch (e) {
-    Sentry.withScope((scope) => {
-      scope.setSDKProcessingMetadata({ request: req });
-      Sentry.captureException(e);
-    });
-    await Sentry.flush(2000);
-  }
-
-  context.res = {
-    status: 200,
-    body: "Hello from Azure Cloud Function!",
-  };
-};
-```
+<PlatformContent includePath="getting-started-config" />
 
 You can obtain the DSN using your Sentry account from your organization's _Settings > Projects > Client Keys (DSN)_ in the Sentry web UI.
 

--- a/docs/platforms/javascript/guides/bun/config.yml
+++ b/docs/platforms/javascript/guides/bun/config.yml
@@ -1,5 +1,4 @@
 title: Bun
 sdk: sentry.javascript.bun
 categories:
-  - browser
   - server

--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -10,6 +10,10 @@ categories:
 
 ## Install
 
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "session-replay"]}
+/>
+
 <PlatformContent includePath="getting-started-install" />
 
 ## Configure

--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -8,6 +8,10 @@ categories:
 
 ## Install
 
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "session-replay"]}
+/>
+
 To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK):
 
 ```bash {tabTitle:npm}
@@ -42,12 +46,15 @@ Then, configure your `Sentry.init`:
 
 <SignInNote />
 
-```javascript {filename:sentry.config.(js|ts)}
+```javascript {filename:sentry.config.(js|ts)} {"onboardingOptions": {"performance": "6, 9-13", "session-replay": "7, 14-18"}}
 import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.

--- a/docs/platforms/javascript/guides/gcp-functions/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/index.mdx
@@ -11,62 +11,21 @@ categories:
   This guide is for version 8.0.0 and up of `@sentry/google-cloud-serverless`.
 </Note>
 
+## Install
+
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "profiling"]}
+/>
+
 Add `@sentry/google-cloud-serverless` as a dependency to `package.json`:
 
-```bash
-  "@sentry/google-cloud-serverless": "^{{@inject packages.version('sentry.javascript.node') }}"
-```
+<PlatformContent includePath="getting-started-install" />
+
+## Configure
 
 To set up Sentry for a Google Cloud Function:
 
-<SignInNote />
-
-```javascript {tabTitle:Http functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // Add Performance Monitoring by setting tracesSampleRate and adding integration
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-});
-
-exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
-  throw new Error("oh, hello there!");
-});
-```
-
-```javascript {tabTitle:Background functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-});
-
-exports.helloEvents = Sentry.wrapEventFunction(
-  (data, context, callback) => {
-    throw new Error("oh, hello there!");
-  }
-);
-```
-
-```javascript {tabTitle:CloudEvent functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-});
-
-exports.helloEvents = Sentry.wrapCloudEventFunction(
-  (context, callback) => {
-    throw new Error("oh, hello there!");
-  }
-);
-```
+<PlatformContent includePath="getting-started-config" />
 
 <Alert level="warning" title="Note">
 

--- a/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/platform-includes/getting-started-config/javascript.angular.mdx
@@ -2,7 +2,7 @@ Once this is done, Sentry's Angular SDK captures all unhandled exceptions and tr
 
 <SignInNote />
 
-```typescript {filename: main.ts} {3, 6-30}
+```typescript {filename: main.ts} {3, 6-30} {"onboardingOptions": {"performance": "9-12, 17-24", "session-replay": "13-15, 25-29"}}
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 import * as Sentry from "@sentry/angular";
@@ -43,7 +43,7 @@ platformBrowserDynamic()
 
 The Sentry Angular SDK exports a couple of Angular providers that are necessary to fully instrument your application. We recommend registering them in your main `AppModule`:
 
-```typescript {filename: app.module.ts} {4, 9-22}
+```typescript {filename: app.module.ts} {4, 9-22} {"onboardingOptions": {"performance": "13-22"}}
 import { APP_INITIALIZER, ErrorHandler, NgModule } from "@angular/core";
 import { Router } from "@angular/router";
 
@@ -74,6 +74,7 @@ export class AppModule {}
 
 The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. You can also customize the behavior by setting a couple of handler [options](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
 
+<OnboardingOption optionId="performance">
 The `Sentry.TraceService` listens to the Angular router for performance monitoring and tracing. To inject `TraceService`, register the `APP_INITIALIZER` provider as shown above. Alternatively, you can also require the `TraceService` from inside your `AppModule` constructor:
 
 ```javascript {filename: app.module.ts} {5}
@@ -84,3 +85,4 @@ export class AppModule {
   constructor(trace: Sentry.TraceService) {}
 }
 ```
+</OnboardingOption>

--- a/platform-includes/getting-started-config/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-config/javascript.aws-lambda.mdx
@@ -1,1 +1,50 @@
-javascript.node.mdx
+
+<SignInNote />
+
+```javascript {tabTitle:async} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/aws-serverless");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+exports.handler = Sentry.wrapHandler(async (event, context) => {
+  // Your handler code
+});
+```
+
+```javascript {tabTitle:sync} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/aws-serverless");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+exports.handler = Sentry.wrapHandler((event, context, callback) => {
+  // Your handler code
+});
+```

--- a/platform-includes/getting-started-config/javascript.azure-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.azure-functions.mdx
@@ -1,1 +1,38 @@
-javascript.node.mdx
+<SignInNote />
+
+```javascript {tabTitle:async} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/node");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+module.exports = async function (context, req) {
+  try {
+    await notExistFunction();
+  } catch (e) {
+    Sentry.withScope((scope) => {
+      scope.setSDKProcessingMetadata({ request: req });
+      Sentry.captureException(e);
+    });
+    await Sentry.flush(2000);
+  }
+
+  context.res = {
+    status: 200,
+    body: "Hello from Azure Cloud Function!",
+  };
+};
+```

--- a/platform-includes/getting-started-config/javascript.bun.mdx
+++ b/platform-includes/getting-started-config/javascript.bun.mdx
@@ -1,10 +1,14 @@
 <SignInNote />
 
-```javascript
+```javascript {"onboardingOptions": {"performance": "5-9"}}
 import * as Sentry from "@sentry/bun";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
   tracesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -2,7 +2,7 @@ Then forward the `init` method from the sibling Sentry SDK for the framework you
 
 <SignInNote />
 
-```typescript {tabTitle: Angular} {filename: app.module.ts}
+```typescript {tabTitle: Angular} {filename: app.module.ts} {"onboardingOptions": {"performance": "13-18, 23-27, 45-54", "session-replay": "19-21, 28-32"}}
 import * as Sentry from "@sentry/capacitor";
 import * as SentryAngular from "@sentry/angular";
 
@@ -21,11 +21,20 @@ Sentry.init(
       SentryAngular.browserTracingIntegration({
         tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
       }),
+      // Registers the Replay integration,
+      // which automatically captures Session Replays
+      Sentry.replayIntegration(),
     ],
+
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
+
+    // Capture Replay for 10% of all sessions,
+    // plus for 100% of sessions with an error
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
   },
   // Forward the init method from @sentry/angular
   SentryAngular.init

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -2,7 +2,7 @@ Then forward the `init` method from the sibling Sentry SDK for the framework you
 
 <SignInNote />
 
-```typescript {tabTitle: Angular} {filename: app.module.ts} {"onboardingOptions": {"performance": "13-18, 23-27, 45-54", "session-replay": "19-21, 28-32"}}
+```typescript {tabTitle: Angular} {filename: app.module.ts} {"onboardingOptions": {"performance": "13-16, 21-28, 46-55", "session-replay": "17-19, 29-33"}}
 import * as Sentry from "@sentry/capacitor";
 import * as SentryAngular from "@sentry/angular";
 
@@ -18,9 +18,7 @@ Sentry.init(
       // Registers and configures the Tracing integration,
       // which automatically instruments your application to monitor its
       // performance, including custom Angular routing instrumentation
-      SentryAngular.browserTracingIntegration({
-        tracePropagationTargets: ["localhost", "https://yourserver.io/api"],
-      }),
+      SentryAngular.browserTracingIntegration(),
       // Registers the Replay integration,
       // which automatically captures Session Replays
       Sentry.replayIntegration(),
@@ -30,6 +28,9 @@ Sentry.init(
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
+
+    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+    tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
 
     // Capture Replay for 10% of all sessions,
     // plus for 100% of sessions with an error

--- a/platform-includes/getting-started-config/javascript.deno.mdx
+++ b/platform-includes/getting-started-config/javascript.deno.mdx
@@ -1,17 +1,28 @@
-```javascript {tabTitle: Deno}
+<OnboardingOptionButtons options={["error-monitoring", "performance"]} />
+
+```javascript {tabTitle: Deno}  {"onboardingOptions": {"performance": "5-9" }}
 import * as Sentry from "https://deno.land/x/sentry/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // ...
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
 });
 ```
-```javascript {tabTitle: npm}
+
+```javascript {tabTitle: npm} {"onboardingOptions": {"performance": "5-9" }}
 import * as Sentry from "npm:@sentry/deno";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // ...
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
 });
 ```
 

--- a/platform-includes/getting-started-config/javascript.electron.mdx
+++ b/platform-includes/getting-started-config/javascript.electron.mdx
@@ -3,15 +3,34 @@ You should `init` the SDK in the `main` process and every `renderer` process you
 <SignInNote />
 
 In the Electron `main` process:
+
 ```javascript
 import * as Sentry from "@sentry/electron/main";
 
-Sentry.init({ dsn: "___PUBLIC_DSN___" });
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+});
 ```
 
 In the Electron `renderer` process:
-```javascript
+
+```javascript {"onboardingOptions": {"performance": "5, 8-12", "session-replay": "6, 13-17"}}
 import * as Sentry from "@sentry/electron/renderer";
 
-Sentry.init();
+Sentry.init({
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Capture Replay for 10% of all sessions,
+  // plus for 100% of sessions with an error
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
 ```

--- a/platform-includes/getting-started-config/javascript.ember.mdx
+++ b/platform-includes/getting-started-config/javascript.ember.mdx
@@ -2,7 +2,7 @@ This snippet includes automatic instrumentation to monitor the performance of yo
 
 <SignInNote />
 
-```javascript
+```javascript {"onboardingOptions": {"performance": "11-15", "session-replay": "10, 16-20"}}
 import Application from "@ember/application";
 import Resolver from "ember-resolver";
 import loadInitializers from "ember-load-initializers";

--- a/platform-includes/getting-started-config/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.gcp-functions.mdx
@@ -1,0 +1,77 @@
+<SignInNote />
+
+```javascript {tabTitle:Http functions} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/google-cloud-serverless");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
+  throw new Error("oh, hello there!");
+});
+```
+
+```javascript {tabTitle:Background functions} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/google-cloud-serverless");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+exports.helloEvents = Sentry.wrapEventFunction(
+  (data, context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
+```
+
+```javascript {tabTitle:CloudEvent functions} {"onboardingOptions": {"performance": "9-13", "profiling": "2, 6-8, 14-16"}}
+const Sentry = require("@sentry/google-cloud-serverless");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  // Add Performance Monitoring by setting tracesSampleRate
+  // Set tracesSampleRate to 1.0 to capture 100% of transactions
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Set sampling rate for profiling - this is relative to tracesSampleRate
+  profilesSampleRate: 1.0,
+});
+
+exports.helloEvents = Sentry.wrapCloudEventFunction(
+  (context, callback) => {
+    throw new Error("oh, hello there!");
+  }
+);
+```

--- a/platform-includes/getting-started-config/javascript.react.mdx
+++ b/platform-includes/getting-started-config/javascript.react.mdx
@@ -2,7 +2,7 @@ It is important to initialize Sentry as early as possible in your application. W
 
 <SignInNote />
 
-```javascript {filename:instrument.js}
+```javascript {filename:instrument.js} {"onboardingOptions": {"performance": "3-8, 13-21, 25-31", "session-replay": "22, 32-35"}}
 import { useEffect } from "react";
 import * as Sentry from "@sentry/react";
 import {

--- a/platform-includes/getting-started-config/javascript.react.mdx
+++ b/platform-includes/getting-started-config/javascript.react.mdx
@@ -2,7 +2,7 @@ It is important to initialize Sentry as early as possible in your application. W
 
 <SignInNote />
 
-```javascript {filename:instrument.js} {"onboardingOptions": {"performance": "3-8, 13-21, 25-31", "session-replay": "22, 32-35"}}
+```javascript {filename:instrument.js} {"onboardingOptions": {"performance": "3-8, 13-21, 24-30", "session-replay": "22, 31-35"}}
 import { useEffect } from "react";
 import * as Sentry from "@sentry/react";
 import {

--- a/platform-includes/getting-started-config/javascript.solid.mdx
+++ b/platform-includes/getting-started-config/javascript.solid.mdx
@@ -2,7 +2,7 @@ To use the SDK, initialize it in your Solid entry point before bootstrapping you
 
 <SignInNote />
 
-```javascript {filename: render-client.jsx}
+```javascript {filename: render-client.jsx} {"onboardingOptions": {"performance": "11, 14-21", "session-replay": "12, 22-26"}}
 import { render } from "solid-js/web";
 import App from "./app";
 import * as Sentry from "@sentry/browser";
@@ -12,7 +12,10 @@ import { DEV } from "solid-js";
 if (!DEV) {
   Sentry.init({
     dsn: "<Sentry DSN>",
-    integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
 
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.

--- a/platform-includes/getting-started-config/javascript.svelte.mdx
+++ b/platform-includes/getting-started-config/javascript.svelte.mdx
@@ -2,7 +2,7 @@ To use the SDK, initialize it in your Svelte entry point before bootstrapping yo
 
 <SignInNote />
 
-```javascript {filename: main.js}
+```javascript {filename: main.js} {"onboardingOptions": {"performance": "10, 13-20", "session-replay": "11, 21-25"}}
 import "./app.css";
 import App from "./App.svelte";
 
@@ -10,8 +10,11 @@ import * as Sentry from "@sentry/svelte";
 
 // Initialize the Sentry SDK here
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+  dsn: "<Sentry DSN>",
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+  ],
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
@@ -22,7 +25,7 @@ Sentry.init({
   tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
 
   // Capture Replay for 10% of all sessions,
-  // plus for 100% of sessions with an error
+  // plus 100% of sessions with an error
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 });

--- a/platform-includes/getting-started-config/javascript.vue.mdx
+++ b/platform-includes/getting-started-config/javascript.vue.mdx
@@ -4,7 +4,7 @@ To initialize Sentry in your Vue application, add the following code snippet to 
 
 <SignInNote />
 
-```javascript {filename:main.js}
+```javascript {filename:main.js} {"onboardingOptions": {"performance": "16, 19-26", "session-replay": "17, 27-31"}}
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -46,7 +46,7 @@ app.mount("#app");
 
 <SignInNote />
 
-```javascript {filename:main.js}
+```javascript {filename:main.js} {"onboardingOptions": {"performance": "15, 18-25", "session-replay": "16, 26-30"}}
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";

--- a/platform-includes/getting-started-install/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-install/javascript.aws-lambda.mdx
@@ -1,11 +1,11 @@
 <OnboardingOption optionId="profiling" hideForThisOption>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node
+npm install --save @sentry/aws-serverless
 ```
 
 ```bash {tabTitle:Yarn}
-yarn add @sentry/node
+yarn add @sentry/aws-serverless
 ```
 
 </OnboardingOption>
@@ -13,11 +13,11 @@ yarn add @sentry/node
 <OnboardingOption optionId="profiling">
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install --save @sentry/aws-serverless @sentry/profiling-node
 ```
 
 ```bash {tabTitle:Yarn}
-yarn add @sentry/node @sentry/profiling-node
+yarn add @sentry/aws-serverless @sentry/profiling-node
 ```
 
 </OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-install/javascript.gcp-functions.mdx
@@ -1,0 +1,16 @@
+<OnboardingOption optionId="profiling" hideForThisOption>
+
+```bash
+  "@sentry/google-cloud-serverless": "^{{@inject packages.version('sentry.javascript.node') }}"
+```
+
+</OnboardingOption>
+
+<OnboardingOption optionId="profiling">
+
+```bash
+  "@sentry/google-cloud-serverless": "^{{@inject packages.version('sentry.javascript.node') }}",
+  "@sentry/profiling-node": "^{{@inject packages.version('sentry.javascript.node') }}"
+```
+
+</OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.solid.mdx
+++ b/platform-includes/getting-started-install/javascript.solid.mdx
@@ -1,0 +1,7 @@
+```bash {tabTitle:npm}
+npm install --save @sentry/browser
+```
+
+```bash {tabTitle:Yarn}
+yarn add @sentry/browser
+```

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -10,29 +10,7 @@ Don't already have an account and Sentry project established? Head over to [sent
 
 Sentry captures data by using an SDK within your application’s runtime. This means that you have to add `@sentry/node` as a runtime dependency to your application:
 
-<OnboardingOption optionId="profiling" hideForThisOption>
-
-```bash {tabTitle:npm}
-npm install --save @sentry/node
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/node
-```
-
-</OnboardingOption>
-
-<OnboardingOption optionId="profiling">
-
-```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
-```
-
-```bash {tabTitle:Yarn}
-yarn add @sentry/node @sentry/profiling-node
-```
-
-</OnboardingOption>
+<PlatformContent includePath="getting-started-install" />
 
 ## Configure
 

--- a/src/components/platformCategorySection.tsx
+++ b/src/components/platformCategorySection.tsx
@@ -5,26 +5,40 @@ import {Platform, PlatformGuide} from 'sentry-docs/types';
 type Props = {
   children?: React.ReactNode;
   noGuides?: boolean;
+  notSupported?: string[];
   platform?: string;
   supported?: string[];
 };
 
 const isSupported = (
   platformOrGuide: Platform | PlatformGuide,
-  supported: string[]
+  supported: string[],
+  notSupported: string[]
 ): boolean => {
   if (platformOrGuide.categories === null) {
     return false;
   }
 
   // @ts-ignore
-  const categories = Object.values(platformOrGuide.categories);
+  const categories = Object.values(platformOrGuide.categories) as string[];
 
-  // @ts-ignore
-  return supported.length > 0 && supported.filter(v => categories.includes(v)).length > 0;
+  if (supported.length && !supported.some(v => categories.includes(v))) {
+    return false;
+  }
+
+  if (notSupported.length && notSupported.some(v => categories.includes(v))) {
+    return false;
+  }
+
+  return true;
 };
 
-export function PlatformCategorySection({supported = [], noGuides, children}: Props) {
+export function PlatformCategorySection({
+  supported = [],
+  notSupported = [],
+  noGuides,
+  children,
+}: Props) {
   const {rootNode, path} = serverContext();
   const currentPlatformOrGuide = getCurrentPlatformOrGuide(rootNode, path);
 
@@ -36,7 +50,7 @@ export function PlatformCategorySection({supported = [], noGuides, children}: Pr
     return null;
   }
 
-  if (isSupported(currentPlatformOrGuide, supported)) {
+  if (isSupported(currentPlatformOrGuide, supported, notSupported)) {
     return children;
   }
 


### PR DESCRIPTION
Except for base browser JS, which still uses the loader-based onboarding for now.

This changes quite a few things, but hopefully for the better!

I did not touch cordova, but this should be fine for now...

Meta SDKs are also not touched by this because they use the wizard.

Two other changes that were necessary to make this work:

1. I added `notSupported` to `<PlatformCategorySection>`, in order to properly be able to skip meta frameworks
2. I updated bun to count as "server" SDK, not both server + browser