### PR TITLE
feat(tracing): Update spans section

### DIFF
--- a/docs/concepts/key-terms/tracing/distributed-tracing.mdx
+++ b/docs/concepts/key-terms/tracing/distributed-tracing.mdx
@@ -184,12 +184,13 @@ The majority of the data in a transaction resides in the individual spans the tr
 - `op`: short string identifying the type or category of operation the span is measuring. Details on the structure of span operations can be [found in the Sentry developer documentation](https://develop.sentry.dev/sdk/performance/span-operations/).
 - `start_timestamp`: when the span was opened
 - `end_timestamp`: when the span was closed
-- `description`: longer description of the span's operation, which uniquely identifies the span but is consistent across instances of the span (optional)
-- `status`: short code indicating operation's status (optional)
-- `tags`: key-value pairs holding additional data about the span (optional)
-- `data`: arbitrarily-structured additional data about the span (optional)
+- `description`: longer description of the span's operation, which uniquely identifies the span but is consistent across instances of the span
+- `status`: short code indicating operation's status
+- `tags`: key-value pairs holding additional data about the span
+- `data`: arbitrarily-structured additional data about the span
 
 An example use of the `op` and `description` properties together is `op: db.query` and `description: SELECT * FROM users WHERE last_active < %s`. The `status` property is often used to indicate the success or failure of the span's operation, or for a response code in the case of HTTP requests. Finally, `tags` and `data` allow you to attach further contextual information to the span, such as `function: middleware.auth.is_authenticated` for a function call or `request: {url: ..., headers: ... , body: ...}` for an HTTP request.
+To search span data see [Searchable Properties](/concepts/search/searchable-properties/spans/)
 
 ### Important Information About Tracing, Spans & Transactions
 


### PR DESCRIPTION
- Updating spans section in the tracing page for some changes coming up
- Given this is user facing documentation, removing the `(optional)` text since that doesn't make sense given the public api for spans is through `sentry_sdk.start_span()`
- Linking to searchable properties (that doesn't exist yet so this PR will need to wait for that) from here if that's what the user is looking for