### PR TITLE
feat(performance): adds note about webvitals samples

### DIFF
--- a/docs/product/performance/web-vitals/index.mdx
+++ b/docs/product/performance/web-vitals/index.mdx
@@ -60,6 +60,10 @@ The **Page Overview** page displays a "Page Loads" chart in the right sidebar of
 
 ### Samples List
 
+<Note>
+The samples list only shows page loads with web vitals and performance score. If a page load is missing a required web vital, it will not be shown in the samples list.
+</Note>
+
 At the center of the **Page Overview**, Web Vital p75 values and scores are displayed. Clicking a Web Vital score will open a slideout panel containing a variety of **Page Load** samples with good to poor scores. Each sample contains an **Event ID** that can be clicked to open the [Trace Details](/concepts/key-terms/tracing/trace-view/#product-walkthrough-trace-details-page) page for further investigation. If there is a [Replay](/product/session-replay/) or [Profile](/product/profiling/) associated with the sample page load, links will be included in the associated table columns.
 
 <div style={{"height":"0px","paddingBottom":"calc(56.9796% + 41px)","position":"relative"}}>

--- a/docs/product/performance/web-vitals/index.mdx
+++ b/docs/product/performance/web-vitals/index.mdx
@@ -61,7 +61,7 @@ The **Page Overview** page displays a "Page Loads" chart in the right sidebar of
 ### Samples List
 
 <Note>
-The samples list only shows page loads with web vitals and performance score. If a page load is missing a required web vital, it will not be shown in the samples list.
+The samples list only shows page loads with web vitals and performance score. If a page load is missing a required web vital, it will not be shown in the samples list. Find out which web vitals are required in the [Browser Support](/product/performance/web-vitals/web-vitals-concepts/#browser-support) table.
 </Note>
 
 At the center of the **Page Overview**, Web Vital p75 values and scores are displayed. Clicking a Web Vital score will open a slideout panel containing a variety of **Page Load** samples with good to poor scores. Each sample contains an **Event ID** that can be clicked to open the [Trace Details](/concepts/key-terms/tracing/trace-view/#product-walkthrough-trace-details-page) page for further investigation. If there is a [Replay](/product/session-replay/) or [Profile](/product/profiling/) associated with the sample page load, links will be included in the associated table columns.


### PR DESCRIPTION
Adds a note to clarify web vitals samples list in page overview:
![image](https://github.com/getsentry/sentry-docs/assets/83961295/b03c496b-a9d5-4efb-b515-bc9bae513e55)
