### PR TITLE
docs: Tweak `sample_rate` copy

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -65,7 +65,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -63,7 +63,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/dart/configuration/options.mdx
+++ b/docs/platforms/dart/configuration/options.mdx
@@ -65,7 +65,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -100,7 +100,7 @@ Additionally, if you are running with the ASP.NET Core integration, you will als
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/elixir/configuration/options.mdx
+++ b/docs/platforms/elixir/configuration/options.mdx
@@ -41,7 +41,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/flutter/configuration/options.mdx
+++ b/docs/platforms/flutter/configuration/options.mdx
@@ -65,7 +65,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -65,7 +65,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -78,7 +78,7 @@ Sets the URL that will be used to transport captured events. This can be used to
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/kotlin-multiplatform/configuration/options.mdx
+++ b/docs/platforms/kotlin-multiplatform/configuration/options.mdx
@@ -65,7 +65,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -53,7 +53,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/php/common/configuration/options.mdx
+++ b/docs/platforms/php/common/configuration/options.mdx
@@ -58,7 +58,7 @@ By default all types of errors are be reported (equivalent to `E_ALL`).
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/powershell/configuration/options.mdx
+++ b/docs/platforms/powershell/configuration/options.mdx
@@ -73,7 +73,7 @@ By default, the SDK reports `debug` when the debugger is attached. Otherwise, th
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -47,7 +47,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -53,7 +53,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/rust/common/configuration/options.mdx
+++ b/docs/platforms/rust/common/configuration/options.mdx
@@ -47,7 +47,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/unity/configuration/options.mdx
+++ b/docs/platforms/unity/configuration/options.mdx
@@ -113,7 +113,7 @@ By default, the SDK reports `editor` when running inside the Unity Editor. Other
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 

--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -47,7 +47,7 @@ By default the SDK will try to read this value from the `SENTRY_ENVIRONMENT` env
 
 <ConfigKey name="sample-rate">
 
-Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0` which means that 100% of error events are sent. If set to `0.1` only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </ConfigKey>
 


### PR DESCRIPTION
I was doing some copy+paste and got some copywriting feedback here: https://github.com/getsentry/sentry/pull/71924#discussion_r1624912295

So I thought I could also update the source.