### PR TITLE
feat(issue-priority): Remove EA banner from page on issue priority

### DIFF
--- a/docs/product/issues/issue-priority/index.mdx
+++ b/docs/product/issues/issue-priority/index.mdx
@@ -4,14 +4,6 @@ sidebar_order: 31
 description: "Learn how Sentry prioritizes issue actionability."
 ---
 
-<Note>
-
-This feature is only available to Early Adopters. To opt in, make sure your organization's [Early Adopter toggle](https://sentry.io/orgredirect/organizations/:orgslug/settings/organization/) is on.
-
-Have feedback? Please let us know in the [GitHub discussion](https://github.com/getsentry/sentry/discussions/68908).
-
-</Note>
-
 Issue priority sorts the issues Sentry receives into **High**, **Medium** and **Low** priority buckets. This helps you identify and address critical, high-priority errors that may be impacting your application's functionality and user experience first.
 
 ## How Priority Works


### PR DESCRIPTION
Issue priority will be GA soon, so we no longer need this banner.