### PR TITLE
feat(js): Add docs on how to disable distributed tracing

### DIFF
--- a/docs/platforms/javascript/common/distributed-tracing/index.mdx
+++ b/docs/platforms/javascript/common/distributed-tracing/index.mdx
@@ -33,4 +33,8 @@ If you run any JavaScript applications in your distributed system, make sure tha
 
 <PlatformContent includePath="distributed-tracing/how-to-use/" />
 
+<Alert level="info" >
+
 Remember that in order to propagate trace information through your whole distributed system, you have to use Sentry in all of the involved services and applications. Take a look at the respective SDK documentation to learn how distributed tracing can be enabled for each platform.
+
+</Alert>

--- a/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -9,3 +9,16 @@ Sentry.init({
   tracePropagationTargets: ["https://myproject.org", /^\/api\//],
 });
 ```
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -13,3 +13,16 @@ Sentry.init({
 If you don't want to use performance monitoring, you can set up <PlatformLink to="/distributed-tracing/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
 
 If you're using version `7.57.x` or below, you'll need to have our <PlatformLink to="/performance/">performance monitoring feature enabled</PlatformLink> in order for distributed tracing to work.
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -12,3 +12,16 @@ Sentry.init({
 ```
 
 If you're using version `7.57.x` or below, you'll need to have our <PlatformLink to="/performance/">performance monitoring feature enabled</PlatformLink> in order for distributed tracing to work.
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -12,3 +12,16 @@ Sentry.init({
 ### Custom Instrumentation
 
 If you don't want to use performance monitoring, you can set up <PlatformLink to="/distributed-tracing/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -33,7 +33,7 @@ The `name` attributes must be the strings `"sentry-trace"` and `"baggage"` and t
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` on the client side. See <PlatformLink to="/distributed-tracing/dealing-with-cors-issues/">Dealing with CORS Issues</PlatformLink> for more information.
 
-```tsx
+```javascript
 // entry.client.tsx
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -43,3 +43,16 @@ Sentry.init({
 ```
 
 If you're using version `7.57.x` or below, you'll need to have our <PlatformLink to="/performance/">performance monitoring feature enabled</PlatformLink> in order for distributed tracing to work.
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -10,3 +10,16 @@ Sentry.init({
 ```
 
 If you're using version `7.57.x` or below, you'll need to have our <PlatformLink to="/performance/">performance monitoring feature enabled</PlatformLink> for distributed tracing to work.
+
+### Disabling Distributed Tracing
+
+If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Overwrite the defaults to ensure no trace headers are sent
+  tracePropagationTargets: [],
+});
+```


### PR DESCRIPTION
This adds a new section in JS distributed tracing docs on how to disable distributed tracing.

This came up a few times now, esp. in relation to people using OTEL on the backend, where they may not want to propagate traces from a frontend (for whatever reason).