### PR TITLE
fix: Fix typo in Node SDK late init

### DIFF
--- a/docs/platforms/javascript/common/install/late-initializtion.mdx
+++ b/docs/platforms/javascript/common/install/late-initializtion.mdx
@@ -64,7 +64,7 @@ In your CJS application, use the `@sentry/node/preload` hook with `--import` to 
 
 ```bash
 # Note: This is only available for Node v18.19.0 onwards.
-node --import @sentry/node/preload app.,js
+node --import @sentry/node/preload app.js
 ```
 
 Then, in your application you can call `Sentry.init()` at a later point:


### PR DESCRIPTION
Just stumpled across this typo 