### PR TITLE
Use `sentry-cli sourcemaps upload` instead of legacy command

### DIFF
--- a/docs/platforms/react-native/manual-setup/ram-bundles.mdx
+++ b/docs/platforms/react-native/manual-setup/ram-bundles.mdx
@@ -22,12 +22,11 @@ If you use the official `react-native-sentry` integration of version `0.43.1` or
 
 ## Uploading Bundles Manually
 
-Starting from version `1.43.0`, `sentry-cli` provides two additional parameters to the `upload-sourcemaps` command to simplify bundle uploads: `--bundle` and `--bundle-sourcemap`. Using those parameters, you can pass the path to the application bundle, along with its source map, and the bundle will be automatically extracted before the upload, if necessary:
+Starting from version `1.43.0`, `sentry-cli` provides two additional parameters to the `sourcemaps upload` command to simplify bundle uploads: `--bundle` and `--bundle-sourcemap`. Using those parameters, you can pass the path to the application bundle, along with its source map, and the bundle will be automatically extracted before the upload, if necessary:
 
 ```bash {tabTitle:Android}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files <release> \
-    upload-sourcemaps \
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+    --release <release> \
     --dist <dist> \
     --strip-prefix $projectRoot/fullFolder \
     --bundle index.android.bundle \
@@ -35,9 +34,8 @@ node_modules/@sentry/cli/bin/sentry-cli releases \
 ```
 
 ```bash {tabTitle:iOS}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files <release> \
-    upload-sourcemaps \
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+    --release <release> \
     --dist <dist> \
     --strip-prefix $projectRoot/fullFolder \
     --bundle main.jsbundle \

--- a/docs/platforms/react-native/sourcemaps/troubleshooting/legacy-uploading-methods.mdx
+++ b/docs/platforms/react-native/sourcemaps/troubleshooting/legacy-uploading-methods.mdx
@@ -63,25 +63,17 @@ The source map's name must be the bundle's name appended with `.map` for source 
 ### 3. Upload the bundle and source maps
 
 ```bash {tabTitle:Android}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files <release> \
-    upload-sourcemaps \
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+    --release <release> \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
     index.android.bundle index.android.bundle.map
 ```
 
 ```bash {tabTitle:iOS}
-node_modules/@sentry/cli/bin/sentry-cli releases \
-    files <release> \
-    upload-sourcemaps \
+node_modules/@sentry/cli/bin/sentry-cli sourcemaps upload \
+    --release <release> \
     --dist <dist> \
     --strip-prefix /path/to/project/root \
     main.jsbundle main.jsbundle.map
 ```
-
-<Note>
-
-If you're using `sentry-cli` prior to version 1.59.0, pass `--rewrite` to the `upload-sourcemaps` command to fix up the source maps before the upload (inlines sources and so forth). Version 1.59.0 does this automatically.
-
-</Note>

--- a/docs/product/releases/setup/release-automation/circleci/index.mdx
+++ b/docs/product/releases/setup/release-automation/circleci/index.mdx
@@ -59,7 +59,7 @@ notify-sentry-deploy:
           export SENTRY_RELEASE=$(sentry-cli releases propose-version)
           sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
           sentry-cli releases set-commits $SENTRY_RELEASE --auto
-          sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
+          sentry-cli sourcemaps upload --release $SENTRY_RELEASE path-to-sourcemaps-if-applicable
           sentry-cli releases finalize $SENTRY_RELEASE
           sentry-cli deploys new -e $SENTRY_ENVIRONMENT
 ```
@@ -68,6 +68,6 @@ For more details about the release management concepts in the snippet above, see
 
 **Notes**:
 
-- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `sourcemaps upload` line.
 - If you can’t install a repository integration, send commit metadata using the [create release endpoint](/product/releases/associate-commits/#using-the-api) or omit the `set-commits` line.
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/docs/product/releases/setup/release-automation/jenkins/index.mdx
+++ b/docs/product/releases/setup/release-automation/jenkins/index.mdx
@@ -67,7 +67,7 @@ pipeline {
                     export SENTRY_RELEASE=$(sentry-cli releases propose-version)
                     sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
                     sentry-cli releases set-commits $SENTRY_RELEASE --auto
-                    sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps /path/to/sourcemaps
+                    sentry-cli sourcemaps upload --release $SENTRY_RELEASE /path/to/sourcemaps
                     sentry-cli releases finalize $SENTRY_RELEASE
                     sentry-cli deploys new -e $SENTRY_ENVIRONMENT
                 '''
@@ -79,7 +79,7 @@ pipeline {
 
 **Notes**:
 
-- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `sourcemaps upload` line.
 - If you can’t install a repository integration, send commit metadata using the [create release endpoint](/product/releases/associate-commits/#using-the-api) or omit the `set-commits` line.
 - `credentials('sentry-auth-token')` refers to the ID of the credentials just added to Jenkins.
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.
@@ -106,13 +106,13 @@ If you're using Freestyle projects, you need to add another build step after dep
 
    sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
    sentry-cli releases set-commits $SENTRY_RELEASE --auto
-   sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
+   sentry-cli sourcemaps upload --release $SENTRY_RELEASE path-to-sourcemaps-if-applicable
    sentry-cli releases finalize $SENTRY_RELEASE
    sentry-cli deploys new -e $SENTRY_ENVIRONMENT
    ```
 
    **Notes**:
 
-   - If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+   - If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `sourcemaps upload` line.
    - If you can’t install a repository integration, send commit metadata using the [create release endpoint](/product/releases/associate-commits/#using-the-api) or omit the `set-commits` line.
    - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed. To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/docs/product/releases/setup/release-automation/travis-ci/index.mdx
+++ b/docs/product/releases/setup/release-automation/travis-ci/index.mdx
@@ -52,7 +52,7 @@ jobs:
         export SENTRY_RELEASE=$(sentry-cli releases propose-version)
         sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
         sentry-cli releases set-commits $SENTRY_RELEASE --auto
-        sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
+        sentry-cli sourcemaps upload --release $SENTRY_RELEASE path-to-sourcemaps-if-applicable
         sentry-cli releases finalize $SENTRY_RELEASE
         sentry-cli deploys new -e $SENTRY_ENVIRONMENT
 ```
@@ -61,6 +61,6 @@ For more details about the release management concepts in the snippet above, see
 
 **Notes**:
 
-- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `upload-sourcemaps` line.
+- If you’re not deploying a project that requires source maps or you've sent source maps to Sentry using another method, omit the `sourcemaps upload` line.
 - If you can’t install a repository integration, send commit metadata using the [create release endpoint](/product/releases/associate-commits/#using-the-api) or omit the `set-commits` line (`set-commits` is required for suspect commits).
 - `sentry-cli releases propose-version` defaults to the commit SHA of the commit being deployed (recommended). To set this to a different version, modify `SENTRY_RELEASE` to the preferred version.

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -84,7 +84,7 @@ You will need to upload source maps to make sense of the events you receive in S
 For example, if you are using Capacitor with Ionic-Angular, upload your `www` folder on **every build** you release. The values for `<release_name>` and `<dist>` must match the values passed into `Sentry.init` for events to be deminified correctly.
 
 ```bash {tabTitle: Ionic}
-sentry-cli releases files <release_name> upload-sourcemaps ./www --dist <dist>
+sentry-cli sourcemaps upload --release <release_name>  --dist <dist> ./www
 ```
 
 Learn more about uploading [source maps](/platforms/javascript/guides/capacitor/sourcemaps/).

--- a/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
@@ -70,7 +70,7 @@ If your `sourceMappingURL` comment is similar to:
 An example `sentry-cli` command to upload these files correctly would look like this (assuming you're in the `/scripts` directory, running your web server from one directory higher, which is why we're using the `--url-prefix` option):
 
 ```shell
-sentry-cli releases files VERSION upload-sourcemaps . --url-prefix '~/scripts'
+sentry-cli sourcemaps upload --url-prefix '~/scripts' .
 ```
 
 This command uploads all JavaScript files in the current directory. The Artifacts page in Sentry should now look like:
@@ -84,13 +84,13 @@ This command uploads all JavaScript files in the current directory. The Artifact
 Alternately you can specify which files to upload. For example:
 
 ```
-sentry-cli releases files VERSION upload-sourcemaps script.min.js script.min.js.map --url-prefix '~/scripts'
+sentry-cli sourcemaps upload --url-prefix '~/scripts' script.min.js script.min.js.map
 ```
 
 You can also upload it with the fully qualified URL. For example:
 
 ```
-sentry-cli releases files VERSION upload-sourcemaps . --url-prefix 'http://localhost:8000/scripts'
+sentry-cli sourcemaps upload --url-prefix 'http://localhost:8000/scripts' .
 ```
 
 ### Using the API

--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -347,7 +347,7 @@ If your `sourceMappingURL` comment is similar to:
 An example `sentry-cli` command to upload these files correctly would look like this (assuming you're in the `/scripts` directory, running your web server from one directory higher, which is why we're using the `--url-prefix` option):
 
 ```shell
-sentry-cli releases files VERSION upload-sourcemaps . --url-prefix '~/scripts'
+sentry-cli sourcemaps upload --url-prefix '~/scripts' .
 ```
 
 This command uploads all JavaScript files in the current directory. The Artifacts page in Sentry should now look like:
@@ -361,13 +361,13 @@ This command uploads all JavaScript files in the current directory. The Artifact
 Alternately you can specify which files to upload. For example:
 
 ```
-sentry-cli releases files VERSION upload-sourcemaps script.min.js script.min.js.map --url-prefix '~/scripts'
+sentry-cli sourcemaps upload --url-prefix '~/scripts' script.min.js script.min.js.map
 ```
 
 You can also upload it with the fully qualified URL. For example:
 
 ```
-sentry-cli releases files VERSION upload-sourcemaps . --url-prefix 'http://localhost:8000/scripts'
+sentry-cli sourcemaps upload --url-prefix 'http://localhost:8000/scripts' .
 ```
 
 #### Using the API


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This change removes all references to the legacy `sentry-cli releases files upload-sourcemaps` command, and replaces then with references to `sentry-cli sourcemaps upload`, the new command.

Resolves #10270

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
