### PR TITLE
docs: Update legacy commands to `sentry-cli files`

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -120,11 +120,11 @@ sentry-cli releases set-commits "$VERSION" --auto --ignore-missing
 
 When you are working with JavaScript and other platforms, you can upload release artifacts to Sentry which are then considered during processing. The most common release artifact are [source maps](/platforms/javascript/sourcemaps/) for which `sentry-cli` has specific support.
 
-To manage release artifacts the `sentry-cli releases files` command can be used which itself provides various sub commands.
+To manage release artifacts the `sentry-cli files` command can be used which itself provides various sub commands.
 
 ### Upload Files
 
-The most common use case is to upload files. For the generic upload the `sentry-cli releases files VERSION upload` command can be used. However since most release artifacts are JavaScript source map related we have a [Upload Source Maps](#sentry-cli-sourcemaps) convenience method for that.
+The most common use case is to upload files. For the generic upload the `sentry-cli files upload` command can be used. However since most release artifacts are JavaScript source map related we have a [Upload Source Maps](#sentry-cli-sourcemaps) convenience method for that.
 
 Files uploaded are typically named with a full (eg: `http://example.com/foo.js`) or truncated URL (eg: `~/foo.js`).
 
@@ -133,7 +133,7 @@ Release artifacts are only considered at time of event processing. So while itâ€
 The first argument to `upload` is the path to the file, the second is an optional URL we should associate it with. Note that if you want to use an abbreviated URL (eg: `~/foo.js`) make sure to use single quotes to avoid the expansion by the shell to your home folder.
 
 ```bash
-sentry-cli releases files "$VERSION" upload /path/to/file '~/file.js'
+sentry-cli files upload --release "$VERSION" /path/to/file '~/file.js'
 ```
 
 ### Upload Source Maps
@@ -217,7 +217,7 @@ sentry-cli sourcemaps upload /path/to/sourcemaps --ignore-file .sentryignore
 To list uploaded files, the following command can be used:
 
 ```bash
-sentry-cli releases files "$VERSION" list
+sentry-cli files list --release "$VERSION"
 ```
 
 This will return a list of all uploaded files for that release.
@@ -227,8 +227,8 @@ This will return a list of all uploaded files for that release.
 You can also delete already uploaded files. Either by name or all files at once:
 
 ```bash
-sentry-cli releases files "$VERSION" delete NAME_OF_FILE
-sentry-cli releases files "$VERSION" delete --all
+sentry-cli files delete --release "$VERSION" NAME_OF_FILE
+sentry-cli files delete --release "$VERSION" --all
 ```
 
 ## Creating Deploys


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Replaces all references to the legacy `sentry-cli releases files ...` commands with the `sentry-cli files ...` commands, introduced in Sentry CLI 2.0.0. This change excludes the `sentry-cli releases files upload-sourcemaps` command, which we address in #10274.

Resolves #10269

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
