### PR TITLE
fix(crons): Add note that certain celery schedules are not supported

### DIFF
--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -30,6 +30,9 @@ app.conf.beat_schedule = {
     },
 }
 ```
+<Note>
+Please note that only crontab parseable schedules will be successfully upserted.
+</Note>
 
 Next, we need to initialize Sentry. Where to do this depends on how you run beat:
 - If beat is running in your worker process (that is, you're running your worker with the `-B`/`--beat` option), initialize Sentry in either the `celeryd_init` or `beat_init` signal.


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry-python/issues/3131

We currently don't support all celery schedules, so add a note here that schedules defined in celery config have to be parseable via traditional crontab syntax