### PR TITLE
feat(python): Add failed_request_status_codes to integrations

### DIFF
--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -43,7 +43,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 The following information about your FastAPI project will be available to you on Sentry.io:
 
-- All exceptions leading to an Internal Server Error are captured and reported.
+- By default, all exceptions leading to an Internal Server Error are captured and reported. The HTTP status codes to report on are configurable via the `failed_request_status_codes` [option](#options).
 - Request data such as URL, HTTP method, headers, form data, and JSON payloads is attached to all issues.
 - Sentry excludes raw bodies and multipart file uploads.
 - Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
@@ -80,10 +80,12 @@ sentry_sdk.init(
     # same as above
     integrations=[
         StarletteIntegration(
-            transaction_style="endpoint"
+            transaction_style="endpoint",
+            failed_request_status_codes=[403, range(500, 599)],
         ),
         FastApiIntegration(
-            transaction_style="endpoint"
+            transaction_style="endpoint",
+            failed_request_status_codes=[403, range(500, 599)],
         ),
     ]
 )
@@ -125,6 +127,19 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
   - `"product_detail"` if you set `transaction_style="endpoint"`
 
   The default is `"url"`.
+
+- `failed_request_status_codes`:
+
+  A list of integers or containers (objects that allow membership checks via `in`)
+  of integers that will determine which status codes should be reported to Sentry.
+
+  Examples of valid `failed_request_status_codes`:
+
+  - `[500]` will only send events on HTTP 500.
+  - `[400, range(500, 599)]` will send events on HTTP 400 as well as the 500-599 range.
+  - `[500, 503]` will send events on HTTP 500 and 503.
+
+  The default is `[range(500, 599)]`.
 
 ## Supported Versions
 

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -41,7 +41,7 @@ It takes a couple of moments for the data to appear in [sentry.io](https://sentr
 
 ## Behavior
 
-- All exceptions leading to an Internal Server Error are reported.
+- By default, all exceptions leading to an Internal Server Error are reported. The HTTP status codes to report on are configurable via the `failed_request_status_codes` [option](#options).
 
 - Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
 
@@ -59,6 +59,7 @@ sentry_sdk.init(
     integrations=[
         StarletteIntegration(
             transaction_style="endpoint",
+            failed_request_status_codes=[403, range(500, 599)],
         )
     ],
 )
@@ -83,6 +84,19 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
   - `"product_detail"` if you set `transaction_style="endpoint"`
 
   The default is `"url"`.
+
+- `failed_request_status_codes`:
+
+  A list of integers or containers (objects that allow membership checks via `in`)
+  of integers that will determine which status codes should be reported to Sentry.
+
+  Examples of valid `failed_request_status_codes`:
+
+  - `[500]` will only send events on HTTP 500.
+  - `[400, range(500, 599)]` will send events on HTTP 400 as well as the 500-599 range.
+  - `[500, 503]` will send events on HTTP 500 and 503.
+
+  The default is `[range(500, 599)]`.
 
 ## Supported Versions
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Adding a new option to the Starlette and FastAPI integrations to configure the status code to create events on in https://github.com/getsentry/sentry-python/pull/3008.

Direct links to preview:

- FastAPI: https://sentry-docs-git-ivana-python-failed-request-status-codes.sentry.dev/platforms/python/integrations/fastapi/
- Starlette: https://sentry-docs-git-ivana-python-failed-request-status-codes.sentry.dev/platforms/python/integrations/starlette/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
