### PR TITLE
docs: Use `sentry-cli deploys` instead of legacy command

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -236,7 +236,7 @@ sentry-cli releases files "$VERSION" delete --all
 You can also associate deploys with releases. To create a deploy you first create a release and then a deploy for it. At the very least, you should supply the “environment” the deploy goes to (production, staging etc.). You can freely define this:
 
 ```bash
-sentry-cli releases deploys "$VERSION" new -e ENVIRONMENT
+sentry-cli deploys new --release "$VERSION" -e ENVIRONMENT
 ```
 
 Optionally, you can also define how long the deploy took:
@@ -245,11 +245,11 @@ Optionally, you can also define how long the deploy took:
 start=$(date +%s)
 ...
 now=$(date +%s)
-sentry-cli releases deploys "$VERSION" new -e ENVIRONMENT -t $((now-start))
+sentry-cli deploys new --release "$VERSION" -e ENVIRONMENT -t $((now-start))
 ```
 
 Deploys can be listed too (however they cannot be deleted):
 
 ```bash
-sentry-cli releases deploys "$VERSION" list
+sentry-cli deploys list --release "$VERSION"
 ```

--- a/docs/product/releases/setup/release-automation/circleci/index.mdx
+++ b/docs/product/releases/setup/release-automation/circleci/index.mdx
@@ -61,7 +61,7 @@ notify-sentry-deploy:
           sentry-cli releases set-commits $SENTRY_RELEASE --auto
           sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
           sentry-cli releases finalize $SENTRY_RELEASE
-          sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+          sentry-cli deploys new -e $SENTRY_ENVIRONMENT
 ```
 
 For more details about the release management concepts in the snippet above, see the full documentation on [release management](/product/cli/releases/).

--- a/docs/product/releases/setup/release-automation/jenkins/index.mdx
+++ b/docs/product/releases/setup/release-automation/jenkins/index.mdx
@@ -69,7 +69,7 @@ pipeline {
                     sentry-cli releases set-commits $SENTRY_RELEASE --auto
                     sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps /path/to/sourcemaps
                     sentry-cli releases finalize $SENTRY_RELEASE
-                    sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+                    sentry-cli deploys new -e $SENTRY_ENVIRONMENT
                 '''
             }
         }
@@ -108,7 +108,7 @@ If you're using Freestyle projects, you need to add another build step after dep
    sentry-cli releases set-commits $SENTRY_RELEASE --auto
    sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
    sentry-cli releases finalize $SENTRY_RELEASE
-   sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+   sentry-cli deploys new -e $SENTRY_ENVIRONMENT
    ```
 
    **Notes**:

--- a/docs/product/releases/setup/release-automation/travis-ci/index.mdx
+++ b/docs/product/releases/setup/release-automation/travis-ci/index.mdx
@@ -54,7 +54,7 @@ jobs:
         sentry-cli releases set-commits $SENTRY_RELEASE --auto
         sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
         sentry-cli releases finalize $SENTRY_RELEASE
-        sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+        sentry-cli deploys new -e $SENTRY_ENVIRONMENT
 ```
 
 For more details about the release management concepts in the snippet above, see the full documentation on [release management](/product/cli/releases/).


### PR DESCRIPTION
Replace all mentions of the legacy `sentry-cli releases deploys ...` commands with the `sentry-cli deploys ...` commands introduced in Sentry CLI v2.0.0.

Resolves #10268

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
