### PR TITLE
feat(docs): Add clarification of trace completeness with rate limiting

### DIFF
--- a/docs/concepts/key-terms/tracing/distributed-tracing.mdx
+++ b/docs/concepts/key-terms/tracing/distributed-tracing.mdx
@@ -243,7 +243,7 @@ Put simply: as a result of this head-based approach, where the decision is made 
 
 <Alert level="warning">
 
-Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting or quota enforcement drops one or more transactions. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
+Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting or quota enforcement drops them. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
 
 </Alert>
 

--- a/docs/concepts/key-terms/tracing/distributed-tracing.mdx
+++ b/docs/concepts/key-terms/tracing/distributed-tracing.mdx
@@ -243,7 +243,7 @@ Put simply: as a result of this head-based approach, where the decision is made 
 
 <Alert level="warning">
 
-Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting drops one or more transactions. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
+Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting or quota enforcement drops one or more transactions. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
 
 </Alert>
 

--- a/docs/concepts/key-terms/tracing/distributed-tracing.mdx
+++ b/docs/concepts/key-terms/tracing/distributed-tracing.mdx
@@ -242,7 +242,9 @@ On the other hand, when your backend processes the requests from B's browser, it
 Put simply: as a result of this head-based approach, where the decision is made once in the originating service and passed to all subsequent services, either all of the transactions for a given trace are collected, or none are, so there shouldn't be any incomplete traces.
 
 <Alert level="warning">
+
 Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting drops one or more transactions. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
+
 </Alert>
 
 ## Viewing Trace Data

--- a/docs/concepts/key-terms/tracing/distributed-tracing.mdx
+++ b/docs/concepts/key-terms/tracing/distributed-tracing.mdx
@@ -241,6 +241,10 @@ On the other hand, when your backend processes the requests from B's browser, it
 
 Put simply: as a result of this head-based approach, where the decision is made once in the originating service and passed to all subsequent services, either all of the transactions for a given trace are collected, or none are, so there shouldn't be any incomplete traces.
 
+<Alert level="warning">
+Dynamic sampling ensures complete traces by retaining all transactions associated with a trace if the head transaction is preserved. Despite dynamic sampling providing trace completeness, transactions or other items (errors, replays, etc.) may still be missing from a trace when rate limiting drops one or more transactions. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
+</Alert>
+
 ## Viewing Trace Data
 
 Through [Performance](/product/performance/) and [Discover](/product/discover-queries/), you can view trace data in the [Trace Details](/concepts/key-terms/tracing/trace-view/) page.


### PR DESCRIPTION
This PR adds a warning in the docs of traces to clarify how rate limiting and traces work together.

Closes: https://github.com/getsentry/team-ingest/issues/315