### PR TITLE
chore(Mobile): Fixes tracing options casing, updates options

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -268,7 +268,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 <ConfigKey name="enable-tracing">
 
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
 
 </ConfigKey>
 
@@ -281,12 +281,6 @@ A number between 0 and 1, controlling the percentage chance a given transaction 
 <ConfigKey name="traces-sampler">
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
-
-</ConfigKey>
-
-<ConfigKey name="tracing-origins">
-
-An optional property that configures which downstream services receive the `sentry-trace` header attached to HTTP requests. It contains a list of URLs or regex against which URLs are matched. If not set, the `sentry-trace` header is attached to every request executed from an instrumented client.
 
 </ConfigKey>
 
@@ -310,12 +304,6 @@ Set this boolean to `false` to disable tracing for `OPTIONS` requests. This opti
 
 ## Profiling Options
 
-<ConfigKey name="enable-tracing">
-
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
-
-</ConfigKey>
-
 <ConfigKey name="profiles-sample-rate">
 
 A number between 0 and 1, controlling the percentage chance a given profile will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies only to sampled transactions created in the app. Either this or <PlatformIdentifier name="profiles-sampler" /> must be defined to enable profiling.
@@ -330,6 +318,6 @@ A function responsible for determining the percentage chance a given profile wil
 
 <ConfigKey name="enable-app-start-profiling">
 
-A boolean value, if true, the startup process, including ContentProviders, Application and first Activity creation, will be profiled. Note that `profiles-sample-rate` or `profiles-sampler` must be defined.
+A boolean value, if true, the startup process, including ContentProviders, Application and first Activity creation, will be profiled. Note that <PlatformIdentifier name="profiles-sample-rate" /> or <PlatformIdentifier name="profiles-sampler" /> must be defined.
 
 </ConfigKey>

--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -318,6 +318,6 @@ A function responsible for determining the percentage chance a given profile wil
 
 <ConfigKey name="enable-app-start-profiling">
 
-A boolean value, if true, the startup process, including ContentProviders, Application and first Activity creation, will be profiled. Note that <PlatformIdentifier name="profiles-sample-rate" /> or <PlatformIdentifier name="profiles-sampler" /> must be defined.
+A boolean value that determines whether the app start process will be profiled. When true, the startup process, including ContentProviders, Application and first Activity creation, will be profiled. Note that <PlatformIdentifier name="profiles-sample-rate" /> or <PlatformIdentifier name="profiles-sampler" /> must be defined.
 
 </ConfigKey>

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -162,7 +162,7 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
     options.initialScope = ^(SentryScope *scope) {
-        scope setTagValue:@"my value" forKey:@"my-tag"];
+        [scope setTagValue:@"my value" forKey:@"my-tag"];
         return scope;
     };
 }];
@@ -245,7 +245,7 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 <ConfigKey name="enable-tracing">
 
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
 
 </ConfigKey>
 

--- a/docs/platforms/dart/configuration/options.mdx
+++ b/docs/platforms/dart/configuration/options.mdx
@@ -196,3 +196,35 @@ Transports are used to send events to Sentry. Transports can be customized to so
 Switches out the transport used to send events. How this works depends on the SDK. It can, for instance, be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
 
 </ConfigKey>
+
+## Tracing Options
+
+<ConfigKey name="enable-tracing">
+
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
+
+</ConfigKey>
+
+<ConfigKey name="traces-sample-rate">
+
+A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or <PlatformIdentifier name="traces-sampler" /> must be defined to enable tracing.
+
+</ConfigKey>
+
+<ConfigKey name="traces-sampler">
+
+A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
+
+</ConfigKey>
+
+<ConfigKey name="trace-propagation-targets">
+
+An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
+
+The option may contain a list of strings or regex against which the URLs of outgoing requests are matched.
+If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
+String entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
+
+If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the instrumented client.
+
+</ConfigKey>

--- a/docs/platforms/flutter/configuration/options.mdx
+++ b/docs/platforms/flutter/configuration/options.mdx
@@ -231,6 +231,38 @@ Switches out the transport used to send events. How this works depends on the SD
 
 </ConfigKey>
 
+## Tracing Options
+
+<ConfigKey name="enable-tracing">
+
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
+
+</ConfigKey>
+
+<ConfigKey name="traces-sample-rate">
+
+A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or <PlatformIdentifier name="traces-sampler" /> must be defined to enable tracing.
+
+</ConfigKey>
+
+<ConfigKey name="traces-sampler">
+
+A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
+
+</ConfigKey>
+
+<ConfigKey name="trace-propagation-targets">
+
+An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
+
+The option may contain a list of strings or regex against which the URLs of outgoing requests are matched.
+If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
+String entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
+
+If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the instrumented client.
+
+</ConfigKey>
+
 ## Experimental Features
 
 <ConfigKey name="experimental">

--- a/docs/platforms/kotlin-multiplatform/configuration/options.mdx
+++ b/docs/platforms/kotlin-multiplatform/configuration/options.mdx
@@ -245,12 +245,6 @@ A function responsible for determining the percentage chance a given transaction
 
 </ConfigKey>
 
-<ConfigKey name="tracing-origins">
-
-An optional property that configures which downstream services receive the `sentry-trace` header attached to HTTP requests. It contains a list of URLs or regex against which URLs are matched. If not set, the `sentry-trace` header is attached to every request executed from an instrumented client.
-
-</ConfigKey>
-
 <ConfigKey name="trace-propagation-targets">
 
 An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.

--- a/docs/platforms/kotlin-multiplatform/configuration/options.mdx
+++ b/docs/platforms/kotlin-multiplatform/configuration/options.mdx
@@ -229,7 +229,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 <ConfigKey name="enable-tracing">
 
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
 
 </ConfigKey>
 

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -243,7 +243,7 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 <ConfigKey name="enable-tracing">
 
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
+A boolean value, if true, transactions and trace data will be generated and captured. This will set the <PlatformIdentifier name="traces-sample-rate" /> to the recommended default of 1.0 if <PlatformIdentifier name="traces-sample-rate" /> is not defined. Note that <PlatformIdentifier name="traces-sample-rate" /> and <PlatformIdentifier name="traces-sampler" /> take precedence over this option.
 
 </ConfigKey>
 

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -267,7 +267,7 @@ The option may contain a list of strings or regex against which the URLs of outg
 If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
 String entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
 
-If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the instrumented client.
+If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is only attached to outgoing requests that contain `localhost` in their URL or requests whose URL starts with a `'/'` (for example `GET /api/v1/users`).
 
 </ConfigKey>
 

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -259,6 +259,18 @@ A function responsible for determining the percentage chance a given transaction
 
 </ConfigKey>
 
+<ConfigKey name="trace-propagation-targets">
+
+An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
+
+The option may contain a list of strings or regex against which the URLs of outgoing requests are matched.
+If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
+String entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
+
+If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the instrumented client.
+
+</ConfigKey>
+
 ## Experimental Features
 
 <ConfigKey name="experimental">


### PR DESCRIPTION
## DESCRIBE YOUR PR

- Fixes options casing for all Mobile platforms
fixes https://github.com/getsentry/sentry-docs/issues/10237
- Removes outdated `tracing-origins` options (Android, KMP)
- Adds missing `trace-propagation-targets` option (RN)
- Adds whole section for Dart/Flutter

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] ideally June 11, latest June 20 :) 

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

