### PR TITLE
docs(replayIntegration): Add snippets without top level await

### DIFF
--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -61,3 +61,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/angular");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/angular');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/angular');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -58,24 +58,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/angular");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/angular');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/angular');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/angular").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -60,3 +60,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/astro");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/astro');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/astro');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -57,24 +57,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/astro");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/astro');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/astro');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/astro").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -50,8 +50,6 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/electron/renderer");
-Sentry.addIntegration(replayIntegration());
 import("@sentry/electron/renderer").then(lazyLoadedSentry => {
   Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
 });

--- a/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -52,22 +52,7 @@ Sentry.init({
 // Sometime later
 const { replayIntegration } = await import("@sentry/electron/renderer");
 Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/electron/renderer');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/electron/renderer');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/electron/renderer").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -53,3 +53,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/electron/renderer");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/electron/renderer');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/electron/renderer');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -51,24 +51,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/ember");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/ember');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/ember');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/ember").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -54,3 +54,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/ember");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/ember');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/ember');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -56,24 +56,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/gatsby");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/gatsby');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/gatsby');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/gatsby").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -59,3 +59,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/gatsby");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/gatsby');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/gatsby');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -54,3 +54,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/browser");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/browser');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/browser');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -51,24 +51,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/browser");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/browser');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/browser');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/browser").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -58,24 +58,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/nextjs");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/nextjs');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/nextjs');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/nextjs").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -1,6 +1,6 @@
 On your client-side NextJS app, add:
 
-```javascript {8,12,14-20}
+```javascript {8,12,14-20} {filename:sentry.client.config.ts}
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
@@ -51,7 +51,7 @@ To learn more about session replay privacy, [read our docs.](/platforms/javascri
 
 Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
 
-```javascript
+```javascript {filename:sentry.client.config.ts}
 Sentry.init({
   // Note, Replay is NOT instantiated below:
   integrations: [],
@@ -60,4 +60,22 @@ Sentry.init({
 // Sometime later
 const { replayIntegration } = await import("@sentry/nextjs");
 Sentry.addIntegration(replayIntegration());
+```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/nextjs');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/nextjs');
+  Sentry.addIntegration(replayIntegration());
+})();
 ```

--- a/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/platform-includes/session-replay/setup/javascript.react.mdx
@@ -59,3 +59,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/react");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/react');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/react');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/platform-includes/session-replay/setup/javascript.react.mdx
@@ -56,24 +56,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/react");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/react');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/react');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/react").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -58,24 +58,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/remix");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/remix');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/remix');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/remix").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -61,3 +61,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/remix");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/remix');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/remix');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -59,3 +59,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/svelte");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/svelte');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/svelte');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -56,24 +56,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/svelte");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/svelte');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/svelte');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/svelte").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -58,24 +58,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/sveltekit");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/sveltekit');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/sveltekit');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/sveltekit").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```

--- a/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -61,3 +61,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/sveltekit");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/sveltekit');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/sveltekit');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -63,3 +63,21 @@ Sentry.init({
 const { replayIntegration } = await import("@sentry/vue");
 Sentry.addIntegration(replayIntegration());
 ```
+
+If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
+
+```javascript {tabTitle:Function Definition}
+async function loadReplay() {
+  const { replayIntegration } = await import('@sentry/vue');
+  Sentry.addIntegration(replayIntegration());
+}
+
+loadReplay();
+```
+
+```javascript {tabTitle:IIFE}
+(async () => {
+  const { replayIntegration } = await import('@sentry/vue');
+  Sentry.addIntegration(replayIntegration());
+})();
+```

--- a/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -60,24 +60,7 @@ Sentry.init({
 });
 
 // Sometime later
-const { replayIntegration } = await import("@sentry/vue");
-Sentry.addIntegration(replayIntegration());
-```
-
-If your setup does not support top level await, you can create a function and immediately call it (or write an IIFE).
-
-```javascript {tabTitle:Function Definition}
-async function loadReplay() {
-  const { replayIntegration } = await import('@sentry/vue');
-  Sentry.addIntegration(replayIntegration());
-}
-
-loadReplay();
-```
-
-```javascript {tabTitle:IIFE}
-(async () => {
-  const { replayIntegration } = await import('@sentry/vue');
-  Sentry.addIntegration(replayIntegration());
-})();
+import("@sentry/vue").then(lazyLoadedSentry => {
+  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+});
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adding snippets for setups without top level await support. Also added filename arguments to the Next.js replayIntegration docs.
ref https://github.com/getsentry/sentry-javascript/issues/12364 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

