### PR TITLE
Link to migration docs instead of GitHub

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -5,7 +5,7 @@
 <Note>
   We have recently released v8 of the JavaScript SDKs. If you're using version
   7.x, we recommend upgrading to the latest version. Check out the [Migration
-  docs](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecations-in-7x)
+  docs](../migration/v7-to-v8/)
   to learn how to update your code to be compatible with v8.
 </Note>
 

--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -5,7 +5,7 @@
 <Note>
   We have recently released v8 of the JavaScript SDKs. If you're using version
   7.x, we recommend upgrading to the latest version. Check out the [Migration
-  docs](../migration/v7-to-v8/)
+  docs](./migration/v7-to-v8/)
   to learn how to update your code to be compatible with v8.
 </Note>
 


### PR DESCRIPTION
Link to the docs-based migration guides, because they are more customized per SDK.