### PR TITLE
feat(tracing): Add searchable span properties

### DIFF
--- a/docs/concepts/search/searchable-properties/events.mdx
+++ b/docs/concepts/search/searchable-properties/events.mdx
@@ -480,7 +480,8 @@ Returns results with an approximate percentile of the field to the level. The le
 
 ### `platform`
 
-Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`.
+Name of the platform. This defaults to `other` and is only a property for platforms from this list:
+`as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `go`, `groovy`, `haskell`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`, `ruby`
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/index.mdx
+++ b/docs/concepts/search/searchable-properties/index.mdx
@@ -12,6 +12,7 @@ Sentry's searchable properties fall into one of five categories:
 
 - [Issue properties](/product/sentry-basics/search/searchable-properties/issues/)
 - [Event properties](/product/sentry-basics/search/searchable-properties/events/)
+- [Span properties](/concepts/search/searchable-properties/spans/)
 - [Session Replay properties](/product/sentry-basics/search/searchable-properties/session-replay/)
 - [User Feedback properties](/product/sentry-basics/search/searchable-properties/user-feedback/)
 - [Release properties](/product/sentry-basics/search/searchable-properties/releases/)

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -80,7 +80,7 @@ The [total transfer size](https://developer.mozilla.org/en-US/docs/Web/API/Perfo
 
 ### `messaging.destination.name`
 
-The queue name or topic from which the message is consumed from or published to.
+The queue name or topic that the message is written or published to. The consumer also reads from this queue.
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -8,7 +8,7 @@ Spans are the underlying data element captured in Sentry SDKs that together make
 
 You can search by span properties in the following [Sentry](https://sentry.io) pages:
 
-- Traces - when searching for a trace containing spans with matching properties
+- [Traces](/product/explore/traces/) - when searching for a trace containing spans with matching properties
 
 When you search for span properties within the **Traces** page, the search will return any trace that contains _one or more spans_ that match your span properties filter.
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -184,7 +184,7 @@ Application-specific internal identifier for the user.
 
 ### `user.username`
 
-Username, which is typically a better label than user.id.
+Username, which is typically a better label than `user.id`.
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -141,7 +141,7 @@ The HTTP response status code.
 
 ### `system`
 
-Database system (e.g., `postresql` or `mysql`).
+Database system (e.g., `postgresql` or `mysql`).
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -4,17 +4,17 @@ description: "Learn more about searchable span properties."
 sidebar_order: 21
 ---
 
-Spans are the underlying data element captured in Sentry SDKs to build a trace.
+Spans are the underlying data element captured in Sentry SDKs that together make up a trace.
 
-You can search by span properties in the following [sentry.io](https://sentry.io) pages:
+You can search by span properties in the following [Sentry](https://sentry.io) pages:
 
 - Traces - when searching for a trace containing spans with matching properties
 
-When searching on span properties within the **Traces** page, the search will return any trace that contains _one or more spans_ matching the supplied span properties filter.
+When you search for span properties within the **Traces** page, the search will return any trace that contains _one or more spans_ that match your span properties filter.
 
 ## Searchable Properties
 
-Below is a list of keys and tokens that can be used in the span search.
+Below is a list of keys and tokens that can be used in the span search:
 
 <DefinitionList>
 
@@ -44,13 +44,13 @@ Parameterized and scrubbed description of the span.
 
 ### `device.class`
 
-Device class is a synthesized field calculated based off device info found in context such as model (for iOS devices), and device specs like processor_frequency (for Android devices).
+Device class is a synthesized field that's calculated by using device info found in context such as model (for iOS devices), and device specs like processor_frequency (for Android devices).
 
 - **Type:** string
 
 ### `environment`
 
-Refers to your code deployment naming convention. For example, `development`, `testing`, `staging` and so on. [Learn more](/product/sentry-basics/environments/). In some pages of [sentry.io](https://sentry.io/), you filter on environment using a dropdown.
+Refers to your code deployment naming convention. For example, `development`, `testing`, `staging` and so on. [Learn more](/product/sentry-basics/environments/). In some pages of [Sentry](https://sentry.io/), you filter on environment using a dropdown.
 
 - **Type:** string
 
@@ -92,13 +92,13 @@ The unique ID of a message from the queue or messaging system.
 
 ### `op`
 
-Span operation
+Span operation.
 
 - **Type:** string
 
 ### `os.name`
 
-Name of the operating system
+Name of the operating system.
 
 - **Type:** string
 
@@ -110,7 +110,7 @@ Name of the platform. This is only a metrics property for [valid platforms](http
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+A release is a version of your code deployed to an environment. You can create a token that matches a release exactly, or pick the most recent release by using `release:latest`.
 
 - **Type:** string
 
@@ -146,7 +146,7 @@ Database system (e.g., `postresql` or `mysql`).
 
 ### `trace.status`
 
-The success or failure status of a span's trace.
+The span trace's success or failure status.
 
 - **Type:** string
 
@@ -171,7 +171,7 @@ Operation of the containing transaction.
 
 ### `user.email`
 
-An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.
+An alternative or addition to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.
 
 - **Type:** string
 
@@ -183,7 +183,7 @@ Application-specific internal identifier for the user.
 
 ### `user.username`
 
-Username, which is typically a better label than the user.id.
+Username, which is typically a better label than user.id.
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -1,0 +1,190 @@
+---
+title: Span Properties
+description: "Learn more about searchable span properties."
+sidebar_order: 21
+---
+
+Spans are the underlying data element captured in Sentry SDKs to build a trace.
+
+You can search by span properties in the following [sentry.io](https://sentry.io) pages:
+
+- Traces - when searching for a trace containing spans with matching properties
+
+When searching on span properties within the **Traces** page, the search will return any trace that contains _one or more spans_ matching the supplied span properties filter.
+
+## Searchable Properties
+
+Below is a list of keys and tokens that can be used in the span search.
+
+<DefinitionList>
+
+### `action`
+
+The type of span action.
+
+- **Type:** string
+
+### `browser.name`
+
+The name of the browser that generated the span.
+
+- **Type:** string
+
+### `cache.hit`
+
+Whether a cache read has hit or missed the queried cache key. Values are `'true'` or `'false'`.
+
+- **Type:** string
+
+### `description`
+
+Parameterized and scrubbed description of the span.
+
+- **Type:** string
+
+### `device.class`
+
+Device class is a synthesized field calculated based off device info found in context such as model (for iOS devices), and device specs like processor_frequency (for Android devices).
+
+- **Type:** string
+
+### `environment`
+
+Refers to your code deployment naming convention. For example, `development`, `testing`, `staging` and so on. [Learn more](/product/sentry-basics/environments/). In some pages of [sentry.io](https://sentry.io/), you filter on environment using a dropdown.
+
+- **Type:** string
+
+### `file_extension`
+
+The file extension of a resource span.
+
+- **Type:** string
+
+### `http.decoded_response_content_length`
+
+The [decoded body size](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/decodedBodySize) of the resource.
+
+- **Type:** string
+
+### `http.response_content_length`
+
+The [encoded body size](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/encodedBodySize) of the resource.
+
+- **Type:** string
+
+### `http.response_transfer_size`
+
+The [total transfer size](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize) of the resource.
+
+- **Type:** string
+
+### `messaging.destination.name`
+
+The queue name or topic from which the message is consumed from or published to.
+
+- **Type:** string
+
+### `messaging.message.id`
+
+The unique ID of a message from the queue or messaging system.
+
+- **Type:** string
+
+### `op`
+
+Span operation
+
+- **Type:** string
+
+### `os.name`
+
+Name of the operating system
+
+- **Type:** string
+
+### `platform`
+
+Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`.
+
+- **Type:** string
+
+### `release`
+
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+
+- **Type:** string
+
+### `resource.render_blocking_status`
+
+The [render blocking status](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus) of the resource.
+
+- **Type:** string
+
+### `sdk.name`
+
+Name of the Sentry SDK that sent the event.
+
+- **Type:** string
+
+### `sdk.version`
+
+Version of the Sentry SDK that sent the event.
+
+- **Type:** string
+
+### `status_code`
+
+The HTTP response status code.
+
+- **Type:** string
+
+### `system`
+
+Database system (e.g., `postresql` or `mysql`).
+
+- **Type:** string
+
+### `trace.status`
+
+The success or failure status of a span's trace.
+
+- **Type:** string
+
+### `transaction`
+
+Name of the containing transaction.
+
+- **Type:** string
+
+
+### `transaction.method`
+
+HTTP method of the containing transaction.
+
+- **Type:** string
+
+### `transaction.op`
+
+Operation of the containing transaction.
+
+- **Type:** string
+
+### `user.email`
+
+An alternative, or addition, to the username. Sentry is aware of email addresses and can therefore display things such as Gravatars and unlock messaging capabilities.
+
+- **Type:** string
+
+### `user.id`
+
+Application-specific internal identifier for the user.
+
+- **Type:** string
+
+### `user.username`
+
+Username, which is typically a better label than the user.id.
+
+- **Type:** string
+
+</DefinitionList>

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -104,7 +104,8 @@ Name of the operating system.
 
 ### `platform`
 
-Name of the platform. This is only a metrics property for [valid platforms](https://github.com/getsentry/relay/blob/9d0d2dc54233d46043a369e1dacf7db900953c14/relay-general/src/protocol/constants.rs#L1-L21), defaulting to `other`.
+Name of the platform. This defaults to `other` and is only a property for platforms from this list:
+`as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `go`, `groovy`, `haskell`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`, `ruby`
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -44,7 +44,7 @@ Parameterized and scrubbed description of the span.
 
 ### `device.class`
 
-Device class is a synthesized field that's calculated by using device info found in context such as model (for iOS devices), and device specs like processor_frequency (for Android devices).
+Device class is a synthesized field that's calculated by using device info found in context such as model (for iOS devices), and device specs like `processor_frequency` (for Android devices).
 
 - **Type:** string
 


### PR DESCRIPTION
Added searchable span properties to the search concepts section of the docs. Required by https://github.com/getsentry/sentry-docs/pull/10246