### PR TITLE
fix(apple): Use id<SentrySpan> in performance obj-c code snippets

### DIFF
--- a/platform-includes/performance/add-spans-example/apple.mdx
+++ b/platform-includes/performance/add-spans-example/apple.mdx
@@ -40,12 +40,12 @@ func performCheckout()
 {
   // This will create a new Transaction for you
 
-  id<Span> transaction = [SentrySDK startTransactionWithName:@"checkout",
+  id<SentrySpan> transaction = [SentrySDK startTransactionWithName:@"checkout",
                                                    operation:@"perform-checkout"
   );
 
   // Validate the cart
-  id<Span> validationSpan = [transaction startChildWithOperation:@"validation",
+  id<SentrySpan> validationSpan = [transaction startChildWithOperation:@"validation",
                                                      description:@"validating shopping cart"];
 
   [self validateShoppingCart]; //Some long process, maybe a sync http request.
@@ -53,7 +53,7 @@ func performCheckout()
   [validationSpan finish];
 
   // Process the order
-  id<Span> processSpan = [transaction startChildWithOperation:@"process",
+  id<SentrySpan> processSpan = [transaction startChildWithOperation:@"process",
                                                   description:@"processing shopping cart"];
 
   [self processShoppingCart]; //Another time consuming process.

--- a/platform-includes/performance/custom-sampling-context/apple.mdx
+++ b/platform-includes/performance/custom-sampling-context/apple.mdx
@@ -27,7 +27,7 @@ NSDictionary<NSString *, id> *samplingContext = @{
     @"search_results": searchResults
 };
 
-id<Span> transaction =
+id<SentrySpan> transaction =
 [SentrySDK startTransactionWithContext: [[SentryTransactionContext alloc] initWithName:@"GET /search"
                                                                              operation:@"http"]
                  customSamplingContext: samplingContext];

--- a/platform-includes/performance/enable-manual-instrumentation/apple.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/apple.mdx
@@ -24,11 +24,11 @@ transaction.finish(); // Finishing the transaction will send it to Sentry
 @import Sentry;
 
 // Transaction can be started by providing, at minimum, the name and the operation
-id<Span> transaction = [SentrySDK startTransactionWithName:@"transaction-name"
+id<SentrySpan> transaction = [SentrySDK startTransactionWithName:@"transaction-name"
                                                  operation:@"transaction-operation"];
 
 // Transactions can have child spans (and those spans can have child spans as well)
-id<Span> span = [transaction startChildWithOperation:@"child-operation"];
+id<SentrySpan> span = [transaction startChildWithOperation:@"child-operation"];
 
 // ...
 // (Perform the operation represented by the span/transaction)

--- a/platform-includes/performance/force-sampling-decision/apple.mdx
+++ b/platform-includes/performance/force-sampling-decision/apple.mdx
@@ -13,5 +13,5 @@ SentryTransactionContext *transactionContext = [[TransactionContext alloc] initW
                                                                               operation:@"http"
                                                                                 sampled:kSentrySampleDecisionYes];
 
-id<Span> transaction = [SentrySDK startTransactionWithContext:transactionContext];
+id<SentrySpan> transaction = [SentrySDK startTransactionWithContext:transactionContext];
 ```

--- a/platform-includes/performance/retrieve-transaction/apple.mdx
+++ b/platform-includes/performance/retrieve-transaction/apple.mdx
@@ -17,7 +17,7 @@ if span == nil {
 ```objc {tabTitle:Objective-C}
 @import Sentry;
 
-id<Span> span = SentrySDK.span;
+id<SentrySpan> span = SentrySDK.span;
 
 if (span == nil) {
     span = [SentrySDK startTransactionWithName:@"task" operation:@"op"];


### PR DESCRIPTION
I've noticed our Apple docs mention Span protocol, but that didn't work for me. Should it be `SentrySpan`?