### PR TITLE
fix(apple): Docs for enableMetricKitAttachments

### DIFF
--- a/docs/platforms/apple/common/configuration/metric-kit.mdx
+++ b/docs/platforms/apple/common/configuration/metric-kit.mdx
@@ -34,3 +34,23 @@ SentrySDK.start { options in
     options.enableMetricKit = YES;
 }];
 ```
+
+You can enable `enableMetricKitAttachments` to view the raw MetricKit diagnostic payload in JSON format as an attachment on the converted event in Sentry. This feature is available on Cocoa 8.29.0 and up.
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.enableMetricKitAttachments = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.enableMetricKitAttachments = YES;
+}];
+```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add docs for enableMetricKitAttachments available on Cocoa 8.29.0 and above.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

