### PR TITLE
fix(docs): Broken trace explorer redirect link

### DIFF
--- a/docs/product/explore/traces/index.mdx
+++ b/docs/product/explore/traces/index.mdx
@@ -8,7 +8,7 @@ description: "Learn how to use the Traces page to search span data, including co
 The Traces page is currently in beta. Beta features are still in progress and may have bugs. We recognize the irony.
 </Note>
 
-The [**Traces**](https://sentry.io/orgredirect/organizations/:orgslug/performance/traces/) page lets you search for individual spans that make up a trace, linked by a trace id. This gives you a connected view of your application from the frontend to the backend and/or between different applications and workflows. You can query and find particular distributed traces to help you debug problems or optimize hot paths in your application.
+The [**Traces**](https://sentry.io/orgredirect/organizations/:orgslug/traces/) page lets you search for individual spans that make up a trace, linked by a trace id. This gives you a connected view of your application from the frontend to the backend and/or between different applications and workflows. You can query and find particular distributed traces to help you debug problems or optimize hot paths in your application.
 
 
 ### Build a New Traces Query


### PR DESCRIPTION
## DESCRIBE YOUR PR

Trace Explorer is no longer at `/performance/traces/` and it's now `/traces/`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
