### PR TITLE
Update manual-setup.mdx

### DIFF
--- a/docs/platforms/javascript/guides/remix/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/remix/manual-setup.mdx
@@ -171,12 +171,12 @@ export const ErrorBoundary: V2_ErrorBoundaryComponent = () => {
 
 Sentry won't be able to capture your unexpected server-side errors automatically on Remix v2. To work around this, instrument the [`handleError`](https://remix.run/docs/en/main/file-conventions/entry.server#handleerror) function in your server entry point.
 
-If you're using Sentry Remix SDK version `7.87.0` or higher, you can use `wrapRemixHandleError` to export as your `handleError` function.
+If you're using Sentry Remix SDK version `7.87.0` or higher, you can use `wrapHandleErrorWithSentry` to export as your `handleError` function.
 
 ```typescript {filename: entry.server.tsx (@sentry/remix >= 7.87.0)}
-import { wrapRemixHandleError } from "@sentry/remix";
+import { wrapHandleErrorWithSentry } from "@sentry/remix";
 
-export const handleError = wrapRemixHandleError;
+export const handleError = wrapHandleErrorWithSentry;
 ```
 
 For SDK versions older than `7.87.0`, you can use `Sentry.captureRemixServerException` to capture errors inside `handleError`.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
While following the documentation over at https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup I founded that the method `wrapRemixHandleError` is marked as deprecated.

Digging through the issues I found https://github.com/getsentry/sentry-javascript/pull/10370. This PR fix the reference to the new method.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
