### PR TITLE
ref(remix-metric): Update tabs naming

### DIFF
--- a/platform-includes/metrics/configure/javascript.remix.mdx
+++ b/platform-includes/metrics/configure/javascript.remix.mdx
@@ -3,7 +3,7 @@ Metrics work out of the box by calling `Sentry.init`, no further setup is requir
 ```javascript {tabTitle:JavaScript (Client)}
 // entry.client.tsx
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  dsn: '___PUBLIC_DSN___',
   // Only needed for SDK versions < 8.0.0
   // integrations: [
   //   Sentry.metrics.metricsAggregatorIntegration(),

--- a/platform-includes/metrics/configure/javascript.remix.mdx
+++ b/platform-includes/metrics/configure/javascript.remix.mdx
@@ -14,7 +14,7 @@ Sentry.init({
 ```javascript {tabTitle:JavaScript (Server)}
 // entry.server.tsx
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
+  dsn: '___PUBLIC_DSN___',
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,

--- a/platform-includes/metrics/configure/javascript.remix.mdx
+++ b/platform-includes/metrics/configure/javascript.remix.mdx
@@ -1,9 +1,9 @@
 Metrics work out of the box by calling `Sentry.init`, no further setup is required.
 
-```JavaScript
+```javascript {tabTitle:JavaScript (Client)}
 // entry.client.tsx
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Only needed for SDK versions < 8.0.0
   // integrations: [
   //   Sentry.metrics.metricsAggregatorIntegration(),
@@ -11,10 +11,10 @@ Sentry.init({
 });
 ```
 
-```JavaScript
+```javascript {tabTitle:JavaScript (Server)}
 // entry.server.tsx
 Sentry.init({
-  dsn: '___PUBLIC_DSN___',
+  dsn: "___PUBLIC_DSN___",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,


### PR DESCRIPTION
**Before:**
![image](https://github.com/getsentry/sentry-docs/assets/29228205/712c3148-88e6-42a5-82a6-fde0b65affa9)


**After:**

![image](https://github.com/getsentry/sentry-docs/assets/29228205/a9bab668-e581-42a5-9b91-e7768276e6ff)



**Disclaimer:**

I'm updating this because I found it confusing while looking at the tabs. After noticing a helpful comment in the code, I've decided to improve the visibility of the tab names.