### PR TITLE
feat: enable hiding pages in sidebar + pricing docs updates

### DIFF
--- a/docs/pricing/quotas/index.mdx
+++ b/docs/pricing/quotas/index.mdx
@@ -31,7 +31,6 @@ The first 6 actions in the list can all be done in [sentry.io](https://sentry.io
 | Action | Errors | Span Units | Replays |Attachments |
 | ------ | ------ | ------------ | ----------- |----------- |
 | [Ensure spike protection is enabled](#spike-protection) | &check; | &check; |  | &check; |
-| [Set a spend allocation budget](#spend-allocation) | &check; | &check; |  | &check; |
 | [Adjust your quota](#adjusting-your-quota) | &check; | &check; | &check; | &check; |
 | [Rate limit your events or attachments](#rate-limits) | &check; |  |  | &check; |
 | [Review repeated events](#event-repetition) | &check; |  |  |  |

--- a/docs/pricing/quotas/spend-allocation.mdx
+++ b/docs/pricing/quotas/spend-allocation.mdx
@@ -7,7 +7,7 @@ description: "Learn how to allocate reserved volume to specific projects so that
 
 <Note>
 
-This feature is only available to organizations with a Business or Enterprise plan.
+This feature is only available to organizations with an Enterprise plan.
 
 </Note>
 

--- a/docs/pricing/quotas/spend-allocation.mdx
+++ b/docs/pricing/quotas/spend-allocation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Spend Allocation"
+sidebar_hidden: true
 sidebar_order: 20
 description: "Learn how to allocate reserved volume to specific projects so that the most important projects are always monitored."
 ---

--- a/docs/pricing/quotas/spike-protection.mdx
+++ b/docs/pricing/quotas/spike-protection.mdx
@@ -66,7 +66,6 @@ We recommend taking the following steps to manage your spikes:
 - Set up [metric alerts](/product/alerts/alert-types/#metric-alerts) for the number of events in a project.
 - If a specific release version has caused the spike, add the version identifier to the project's [inbound filters](/pricing/quotas/manage-event-stream-guide/#inbound-data-filters) to avoid accepting events from that release.
 - Set up a [pay-as-you-go budget](/pricing/#pricing-how-it-works) to make sure you have time to adjust your volume in the event of a future spike.
-- Set up [spend allocations](/pricing/quotas/#spend-allocation) to ensure your critical projects are guaranteed a portion of your reserved volume, even if there are spikes in other projects.
 
 To review the events that were dropped to save your quota with Spike Protection, go to the "Usage Stats" tab of the **Stats** page for your Sentry org and select the event of interest from the "Category" dropdown. You'll be able to see project-level details of your stats by using the project selector.
 

--- a/src/components/dynamicNav.tsx
+++ b/src/components/dynamicNav.tsx
@@ -10,6 +10,7 @@ type Node = {
   [key: string]: any;
   context: {
     [key: string]: any;
+    sidebar_hidden?: boolean;
     sidebar_order?: number;
     sidebar_title?: string;
     title?: string;
@@ -62,7 +63,11 @@ export const renderChildren = (
   return sortPages(
     children.filter(
       ({name, node}) =>
-        node && !!node.context.title && name !== '' && exclude.indexOf(node.path) === -1
+        node &&
+        !!node.context.title &&
+        name !== '' &&
+        exclude.indexOf(node.path) === -1 &&
+        !node.context.sidebar_hidden
     ),
     ({node}) => node!
   ).map(({node, children: nodeChildren}) => {

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -203,6 +203,7 @@ type NavNode = {
   context: {
     draft: boolean;
     title: string;
+    sidebar_hidden?: boolean;
     sidebar_order?: number;
     sidebar_title?: string;
   };
@@ -215,6 +216,7 @@ const docNodeToNavNode = (node: DocNode): NavNode => ({
     title: node.frontmatter.title,
     sidebar_order: node.frontmatter.sidebar_order,
     sidebar_title: node.frontmatter.sidebar_title,
+    sidebar_hidden: node.frontmatter.sidebar_hidden,
   },
   path: '/' + node.path + '/',
 });
@@ -300,6 +302,7 @@ function PlatformSidebar({rootNode, platformName, guideName}: PlatformSidebarPro
         title: n.frontmatter.title,
         sidebar_order: n.frontmatter.sidebar_order,
         sidebar_title: n.frontmatter.sidebar_title,
+        sidebar_hidden: n.frontmatter.sidebar_hidden,
       },
       path: '/' + n.path + '/',
     };

--- a/src/types/frontmatter.ts
+++ b/src/types/frontmatter.ts
@@ -37,6 +37,11 @@ export interface FrontMatter {
   notoc?: boolean;
 
   /**
+   * Set this to true to hide from the sidebar
+   */
+  sidebar_hidden?: boolean;
+
+  /**
    * The order of this page in auto generated sidebars and grids.
    */
   sidebar_order?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,7 @@ export const splitToChunks = <T>(numChunks: number, arr: T[]): T[][] => {
 
 type Page = {
   context: {
+    sidebar_hidden?: boolean;
     sidebar_order?: number;
     sidebar_title?: string;
     title?: string;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adds the `sidebar_hidden` attribute to the frontmatter for hiding pages from the sidebar + remove references to spend allocations

Closes https://getsentry.atlassian.net/browse/RV-1723

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
