### PR TITLE
feat(apple): Docs for resume and pause AppHangs

### DIFF
--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -7,6 +7,9 @@ description: "Learn about how to add app hang detection reporting."
 <Note>
 
 We recommend disabling this feature for Widgets and Live Activities because it might detect false positives.
+Furthermore, the Cocoa SDK might report app hangs when the OS opens a system dialog asking for specific permissions,
+such as whether the user wants to allow your app to paste from the clipboard. As we can't reliably detect these scenarios,
+we advise you to [pause and resume tracking app hangs](#pause-and-resume-app-hang-tracking) to circumvent that problem.
 
 </Note>
 
@@ -99,5 +102,32 @@ SentrySDK.start { options in
     options.dsn = @"___PUBLIC_DSN___";
     options.appHangTimeoutInterval = 1;
 }];
+
+```
+
+### Pause and Resume App Hang Tracking
+
+Starting with version 8.30.0, you can pause and resume app hang tracking at runtime with the following methods:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.pauseAppHangTracking()
+
+// Do something that might cause the app to hang,
+// and you don't want the Cocoa SDK to report it.
+
+SentrySDK.resumeAppHangTracking()
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK pauseAppHangTracking];
+
+// Do something that might cause the app to hang,
+// and you don't want the Cocoa SDK to report it.
+
+[SentrySDK resumeAppHangTracking];
 
 ```

--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -107,7 +107,8 @@ SentrySDK.start { options in
 
 ### Pause and Resume App Hang Tracking
 
-Starting with version 8.30.0, you can pause and resume app hang tracking at runtime with the following methods:
+Starting with version 8.30.0, you can pause and resume app hang tracking at runtime with `SentrySDK.pauseAppHangTracking()` and `SentrySDK.resumeAppHangTracking().
+These methods don't stop the <PlatformLink to="/configuration/metric-kit">MetricKit</PlatformLink> integration from reporting [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic).
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -7,6 +7,7 @@ description: "Learn about how to add app hang detection reporting."
 <Note>
 
 We recommend disabling this feature for Widgets and Live Activities because it might detect false positives.
+
 Furthermore, the Cocoa SDK might report app hangs when the OS opens a system dialog asking for specific permissions,
 such as whether the user wants to allow your app to paste from the clipboard. As we can't reliably detect these scenarios,
 we advise you to [pause and resume tracking app hangs](#pause-and-resume-app-hang-tracking) to circumvent that problem.

--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -10,7 +10,7 @@ We recommend disabling this feature for Widgets and Live Activities because it m
 
 Furthermore, the Cocoa SDK might report app hangs when the OS opens a system dialog asking for specific permissions,
 such as whether the user wants to allow your app to paste from the clipboard. As we can't reliably detect these scenarios,
-we advise you to [pause and resume tracking app hangs](#pause-and-resume-app-hang-tracking) to circumvent that problem.
+we advise you to [pause and resume tracking app hangs](#pause-and-resume-app-hang-tracking) to circumvent this problem.
 
 </Note>
 

--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -107,7 +107,7 @@ SentrySDK.start { options in
 
 ### Pause and Resume App Hang Tracking
 
-Starting with version 8.30.0, you can pause and resume app hang tracking at runtime with `SentrySDK.pauseAppHangTracking()` and `SentrySDK.resumeAppHangTracking().
+Starting with version 8.30.0, you can pause and resume app hang tracking at runtime with `SentrySDK.pauseAppHangTracking()` and `SentrySDK.resumeAppHangTracking()`.
 These methods don't stop the <PlatformLink to="/configuration/metric-kit">MetricKit</PlatformLink> integration from reporting [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic).
 
 ```swift {tabTitle:Swift}


### PR DESCRIPTION


## DESCRIBE YOUR PR

Add docs for resuming and pausing app hangs.

We can only merge this after releasing Cocoa 8.30.0. Related Cocoa PR https://github.com/getsentry/sentry-cocoa/pull/4077.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
