### PR TITLE
Add back tRPC middleware/integration

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/trpc.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/trpc.mdx
@@ -1,0 +1,57 @@
+---
+title: trpcMiddleware
+description: "Capture spans & errors for tRPC handlers."
+supported:
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.electron
+  - javascript.nextjs
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
+  - javascript.bun
+---
+
+<Alert level="info">
+
+This integration only works inside server environments (Node.js, Bun, Deno).
+
+</Alert>
+
+_Import name: `Sentry.trpcMiddleware`_
+
+The Sentry tRPC middleware creates spans for your and improves error capturing for tRPC handlers.
+
+The `trpcMiddleware` is not a traditional SDK integration in the sense that your are **not** supposed to add it to the `integrations` option.
+Instead, add it as a middleware to your tRPC router.
+
+```javascript
+import * as Sentry from "@sentry/node";
+import { initTRPC } from "@trpc/server";
+
+const t = initTRPC.context().create();
+
+const sentryMiddleware = t.middleware(
+  Sentry.trpcMiddleware({
+    attachRpcInput: true,
+  })
+);
+
+const sentrifiedProcedure = t.procedure.use(sentryMiddleware);
+```
+
+## Options
+
+### `attachRpcInput`
+
+_Type: `boolean`_
+
+Defaults to `false`. If enabled, the RPC input will be captured in reported events.

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -61,3 +61,4 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
@@ -33,3 +33,4 @@
 | [`requestDataIntegration`](./requestdata)                 |                  |            |        ✓        |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.bun.mdx
+++ b/platform-includes/configuration/integrations/javascript.bun.mdx
@@ -29,3 +29,4 @@
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.deno.mdx
+++ b/platform-includes/configuration/integrations/javascript.deno.mdx
@@ -16,3 +16,4 @@
 | [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |          |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |          |                        |
 | [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |          |           ✓            |
+| [`trpcMiddleware`](./trpc)                          |                  |     ✓      |        ✓        |          |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
@@ -33,3 +33,4 @@
 | [`requestDataIntegration`](./requestdata)                 |                  |            |        ✓        |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -67,6 +67,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
 
 ### Edge Integrations
 

--- a/platform-includes/configuration/integrations/javascript.node.mdx
+++ b/platform-includes/configuration/integrations/javascript.node.mdx
@@ -31,3 +31,4 @@
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -61,3 +61,4 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -61,3 +61,4 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Adds back docs for the tRPC integration that got lost somewhere during v8.

Fixes https://github.com/getsentry/sentry-docs/issues/10372#issuecomment-2172501157

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): simply asap because this is missing and people looking for it are lost
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+