### PR TITLE
fix(metro): add missing config file names

### DIFF
--- a/docs/platforms/react-native/manual-setup/metro.mdx
+++ b/docs/platforms/react-native/manual-setup/metro.mdx
@@ -21,7 +21,7 @@ The Sentry React Native SDK allows multiple ways to configure the Sentry Metro S
 
 The example below shows how to use the Sentry Metro Serializer if you don't have any `customSerializers` (the default configuration).
 
-```javascript {tabTitle:React Native}
+```javascript {tabTitle:React Native} {filename:metro.config.js}
 const { getDefaultConfig } = require("@react-native/metro-config");
 const { withSentryConfig } = require('@sentry/react-native/metro');
 
@@ -29,7 +29,7 @@ const config = getDefaultConfig(__dirname);
 module.exports = withSentryConfig(config);
 ```
 
-```javascript {tabTitle:Expo}
+```javascript {tabTitle:Expo} {filename:metro.config.js}
 // const { getDefaultConfig } = require("expo/metro-config");
 const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
@@ -41,7 +41,7 @@ const config = getSentryExpoConfig(config, {});
 
 If you already have a custom serializer, you can wrap it with the Sentry Metro Serializer and call `options.sentryBundleCallback` before serializing the bundle content.
 
-```javascript {tabTitle:React Native}
+```javascript {tabTitle:React Native} {filename:metro.config.js}
 const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 const { withSentryConfig } = require('@sentry/react-native/metro');
 
@@ -79,3 +79,4 @@ export type Bundle = {
 
 - Sentry Metro Serializer can't add Debug ID to the Hermes Composed Source Maps. Please see [Manual Upload With Hermes](/platforms/react-native/sourcemaps#manual-upload-with-hermes) guide on how to add Debug ID to the Hermes Composed Source Maps.
 - If you see `Debug ID was not found in the bundle.` error message the `sentryBundleCallback` was not called by your custom serializer.
+- Metro configuration is optional in Expo projects, to create it call `npx expo customize metro.config.js`. Read more about [Customizing Expo Metro Configuration](https://docs.expo.dev/guides/customizing-metro/).

--- a/docs/platforms/react-native/manual-setup/metro.mdx
+++ b/docs/platforms/react-native/manual-setup/metro.mdx
@@ -79,4 +79,4 @@ export type Bundle = {
 
 - Sentry Metro Serializer can't add Debug ID to the Hermes Composed Source Maps. Please see [Manual Upload With Hermes](/platforms/react-native/sourcemaps#manual-upload-with-hermes) guide on how to add Debug ID to the Hermes Composed Source Maps.
 - If you see `Debug ID was not found in the bundle.` error message the `sentryBundleCallback` was not called by your custom serializer.
-- Metro configuration is optional in Expo projects, to create it call `npx expo customize metro.config.js`. Read more about [Customizing Expo Metro Configuration](https://docs.expo.dev/guides/customizing-metro/).
+- If Metro configuration is missing in your Expo project, create it using `npx expo customize metro.config.js`. Read more about [Customizing Expo Metro Configuration](https://docs.expo.dev/guides/customizing-metro/).


### PR DESCRIPTION
This PR adds `metro.config.js` file name to the code snippets. This helps users to identify where should they modify their Metro configuration.