### PR TITLE
feat(related_issues): Trace Timeline & Related Issues requires global-views

### DIFF
--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -73,11 +73,17 @@ The trace navigator (which is displayed below the date) is an abbreviated view o
 A node will be red if it is associated with errors.
 Click "View Full Trace" to display the [Trace View](/product/sentry-basics/tracing/trace-view).
 
+{/* This feature requires multi-projects for the events endpoint */}
+<Include name="feature-available-for-plan-trial-team.mdx" />
+
 ### Related Issues
 
 ![Trace Related Issue](./img/trace_related_issue.png)
 
 Sometimes the Trace Navigator will be replaced by a Related Issue. A Related Issue is a different issue that occurred during the same trace as the event in view. This is useful for understanding the context of the current issue and may help you identify its root cause. A Related Issue allows the developer to quickly navigate between the two related events.
+
+{/* This feature requires multi-projects for the events endpoint */}
+<Include name="feature-available-for-plan-trial-team.mdx" />
 
 ## Suspect Commits
 


### PR DESCRIPTION
Add this note to Trace Timeline and Related Issues:
> This feature is available only if your organization is on [a Trial, Team, or higher plan](https://sentry.io/pricing/).