### PR TITLE
docs(nextjs): Update Next.js GlobalError prop type

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -183,7 +183,10 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
   return (
     <html>
       <body>
-        {/* Passing `0` as `statusCode` as the type has to be a number, but we do not get a status code here. */}
+        {/* `NextError` is the default Next.js error page component. Its type
+        definition requires a `statusCode` prop. However, since the App Router
+        does not expose status codes for errors, we simply pass 0 to render a
+        generic error message. */}
         <NextError statusCode={0} />
       </body>
     </html>

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -175,11 +175,7 @@ import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
-export default function GlobalError({
-  error,
-}: {
-  error: Error & { digest?: string };
-}) {
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -187,8 +183,8 @@ export default function GlobalError({
   return (
     <html>
       <body>
-        {/* This is the default Next.js error component but it doesn't allow omitting the statusCode property yet. */}
-        <NextError statusCode={undefined as any} />
+        {/* Passing `0` as `statusCode` as the type has to be a number, but we do not get a status code here. */}
+        <NextError statusCode={0} />
       </body>
     </html>
   );


### PR DESCRIPTION
## DESCRIBE YOUR PR
Updates the Next.js snippet to not use type casting anymore
related to https://github.com/getsentry/sentry-wizard/pull/592

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


