### PR TITLE
feat(performance): removes fid note and update webvitals intro to clarify field data

### DIFF
--- a/docs/product/insights/web-vitals/index.mdx
+++ b/docs/product/insights/web-vitals/index.mdx
@@ -6,13 +6,9 @@ description: "Understand your application's performance score and how each web v
 
 <Include name="feature-available-for-plan-business.mdx" />
 
-<Note>
-On March 12, 2024, Google replaced [First Input Display (FID)](/product/insights/web-vitals/web-vitals-concepts/#first-input-delay-fid) with [Interaction to Next Paint (INP)](/product/insights/web-vitals/web-vitals-concepts/#interaction-to-next-paint-inp) as a Core Web Vital. To begin collecting INP measurements, make sure your Javascript SDK version is [7.104.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.104.0) or higher and that the option [`enableInp`](/platforms/javascript/performance/instrumentation/automatic-instrumentation/#enableinp) is on. FID measurements are no longer shown in the **Web Vitals** page, but can still be accessed in [Discover](/product/explore/discover-queries). You may see changes to your performance score during this transition.
-</Note>
-
 Web vitals are a set of metrics that measure the quality of the user experience on a web page. To learn more about these metrics, see [Web Vitals Concepts](/product/insights/web-vitals/web-vitals-concepts/).
 
-In Sentry, web vitals are used to calculate a [Performance Score](#performance-score) for your web application. Using these metrics, we surface the pages that have the most [opportunity](#opportunity) to improve your app's overall performance.
+In Sentry, web vitals are gathered from real user traffic with [supported browsers](web-vitals-concepts/#browser-support), on your instrumented web apps. These web vitals are used to calculate a [Performance Score](#performance-score) for your web application. Using these metrics, we surface the pages that have the most [opportunity](#opportunity) to improve your app's overall performance.
 
 The gif below walks through how to get insights on your web vitals.
 

--- a/docs/product/insights/web-vitals/index.mdx
+++ b/docs/product/insights/web-vitals/index.mdx
@@ -8,7 +8,7 @@ description: "Understand your application's performance score and how each web v
 
 Web vitals are a set of metrics that measure the quality of the user experience on a web page. To learn more about these metrics, see [Web Vitals Concepts](/product/insights/web-vitals/web-vitals-concepts/).
 
-In Sentry, web vitals are gathered from real user traffic with [supported browsers](web-vitals-concepts/#browser-support), on your instrumented web apps. These web vitals are used to calculate a [Performance Score](#performance-score) for your web application. Using these metrics, we surface the pages that have the most [opportunity](#opportunity) to improve your app's overall performance.
+For your instrumented web apps, Sentry gathers web vitals from real user traffic through [supported browsers](web-vitals-concepts/#browser-support). These web vitals are used to calculate a [Performance Score](#performance-score) for your web application. Using these metrics, we surface the pages that have the most [opportunity](#opportunity) to improve your app's overall performance.
 
 The gif below walks through how to get insights on your web vitals.
 

--- a/docs/product/insights/web-vitals/web-vitals-concepts.mdx
+++ b/docs/product/insights/web-vitals/web-vitals-concepts.mdx
@@ -6,10 +6,6 @@ description: "Learn more about web vitals and how each metric relates to your ap
 
 [Web Vitals](https://web.dev/vitals/) are a set of metrics defined by Google to measure render time, response time, and layout shift. Each data point provides insights about the overall [performance](/product/performance/) of your application.
 
-<Note>
-On March 12, 2024, Google replaced [First Input Display (FID)](#first-input-delay-fid) with [Interaction to Next Paint (INP)](#interaction-to-next-paint-inp) as a Core Web Vital. To begin collecting INP measurements, make sure your Javascript SDK version is [7.104.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.104.0) or higher and that the option [`enableInp`](/platforms/javascript/performance/instrumentation/automatic-instrumentation/#enableinp) is on. FID measurements are no longer shown in the **Web Vitals** page, but can still be accessed in [Discover](/product/explore/discover-queries).
-</Note>
-
 The in-browser Sentry SDKs collect web vitals information (where supported) and adds that information to frontend [transactions](/product/performance/transaction-summary/). These web vitals are then summarized in the [**Performance > Web Vitals** page](/product/insights/web-vitals/) to give you a quick overview of how each page is performing for your users.
 
 ![Visualization of Web Vitals](../img/diagram-transaction-vitals.png)


### PR DESCRIPTION
- Removes the FID deprecation note, since it's been over 90 days and no longer needed
- Updates the web vitals intro to clarify that webvitals data come from real user traffic