### PR TITLE
Add background to inline code blocks in headings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -140,6 +140,13 @@
     Courier, monospace;
 
   --fade-in-animation: fadeIn;
+
+  /* https://storybook.sentry.dev/?path=/story/core-colors--page */
+  --gray-500: #2B2233;
+  --gray-400: #3E3446;
+  --gray-300: #80708F;
+  --gray-200: #DBD6E1;
+  --gray-100: #EBE6EF;
 }
 
 body {

--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -24,7 +24,11 @@
 
     code {
       color: var(--darkPurple);
-      font-weight: 600;
+      font-weight: 400;
+      background-color: var(--gray-100);
+      padding: 3px 6px;
+      border-radius: 4px;
+      white-space: nowrap;
     }
 
     scroll-margin-top: calc(var(--header-height) + 1.5rem);


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

- Adds a background to inline code blocks in headings
- Adds style guide colors
- Prevent line wrapping of inline code blocks in headings
- Reduce font weight to be in line with style guide

Fixes https://github.com/getsentry/sentry-docs/issues/10426

Before:

![Screenshot 2024-06-19 at 14 17 01](https://github.com/getsentry/sentry-docs/assets/8118419/8b9f6737-75cf-4283-9931-6f5cdcb45f4d)


After:

![Screenshot 2024-06-19 at 14 16 43](https://github.com/getsentry/sentry-docs/assets/8118419/ce7a2a40-ca72-4b77-a7b7-38561523d109)


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+