### PR TITLE
fix(js): Use rewriteframes integration function name in the examples

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/rewriteframes.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/rewriteframes.mdx
@@ -36,8 +36,8 @@ Function that takes the frame, applies a transformation, and returns it.
 
 For example, if the full path to your file is `/www/src/app/file.js`:
 
-| Usage                             | Path in Stack Trace      | Description                                                                                                                   |
-| --------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `RewriteFrames()`                 | `app:///file.js`         | The default behavior is to replace the absolute path, except the filename, and prefix it with the default prefix (`app:///`). |
-| `RewriteFrames({prefix: 'foo/'})` | `foo/file.js`            | Prefix `foo/` is used instead of the default prefix `app:///`.                                                                |
-| `RewriteFrames({root: '/www'})`   | `app:///src/app/file.js` | `root` is defined as `/www`, so only that part is trimmed from the beginning of the path.                                     |
+| Usage                                        | Path in Stack Trace      | Description                                                                                                                   |
+| -------------------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `rewriteFramesIntegration()`                 | `app:///file.js`         | The default behavior is to replace the absolute path, except the filename, and prefix it with the default prefix (`app:///`). |
+| `rewriteFramesIntegration({prefix: 'foo/'})` | `foo/file.js`            | Prefix `foo/` is used instead of the default prefix `app:///`.                                                                |
+| `rewriteFramesIntegration({root: '/www'})`   | `app:///src/app/file.js` | `root` is defined as `/www`, so only that part is trimmed from the beginning of the path.                                     |


### PR DESCRIPTION
This PR fixes the old ClassName integration in the examples table.