### PR TITLE
feat: Add errorboundary changes to v8 migration guide

### DIFF
--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -9,7 +9,7 @@ If you need to support older versions of React, please use Sentry Gatsby SDK `7.
 ### Updated error types to be `unknown` instead of `Error`.
 
 In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
-`beforeCapture`. to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
+`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
 lifecycle method the Sentry `ErrorBoundary` component uses.
 
 As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -6,6 +6,24 @@ If you need to support older versions of React, please use Sentry Gatsby SDK `7.
 
 <Include name="migration/javascript-v8/compatible-browsers" />
 
+### Updated error types to be `unknown` instead of `Error`.
+
+In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
+`beforeCapture`. to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
+lifecycle method the Sentry `ErrorBoundary` component uses.
+
+As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):
+
+> error: The `error` that was thrown. In practice, it will usually be an instance of `Error` but this is not guaranteed
+> because JavaScript allows to throw any value, including strings or even `null`.
+
+This means you will have to use `instanceof Error` or similar to explicitly make sure that the error thrown was an
+instance of `Error`.
+
+The Sentry SDK maintainers also went ahead and made a PR to update the
+[TypeScript definitions of `componentDidCatch`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69434) for the
+React package - this will be released with React 20.
+
 ### Removal of Gatsby Initialization via plugin options
 
 In `8.x`, we are removing the ability to initialize the Gatsby SDK via plugin options.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.gatsby.mdx
@@ -6,11 +6,11 @@ If you need to support older versions of React, please use Sentry Gatsby SDK `7.
 
 <Include name="migration/javascript-v8/compatible-browsers" />
 
-### Updated error types to be `unknown` instead of `Error`.
+### Updated error types to be `unknown` instead of `Error`
 
 In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
-`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
-lifecycle method the Sentry `ErrorBoundary` component uses.
+`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches the behavior of `componentDidCatch`, which is the
+lifecycle method Sentry's `ErrorBoundary` component uses.
 
 As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):
 
@@ -22,7 +22,7 @@ instance of `Error`.
 
 The Sentry SDK maintainers also went ahead and made a PR to update the
 [TypeScript definitions of `componentDidCatch`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69434) for the
-React package - this will be released with React 20.
+React package. This will be released with React 20.
 
 ### Removal of Gatsby Initialization via plugin options
 

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
@@ -9,7 +9,7 @@ If you need to support older versions of React, please use Sentry Next.js SDK `7
 ### Updated error types to be `unknown` instead of `Error`.
 
 In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
-`beforeCapture`. to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
+`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
 lifecycle method the Sentry `ErrorBoundary` component uses.
 
 As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
@@ -6,11 +6,11 @@ If you need to support older versions of React, please use Sentry Next.js SDK `7
 
 <Include name="migration/javascript-v8/compatible-browsers" />
 
-### Updated error types to be `unknown` instead of `Error`.
+### Updated error types to be `unknown` instead of `Error`
 
 In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
-`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
-lifecycle method the Sentry `ErrorBoundary` component uses.
+`beforeCapture` to be `unknown` instead of `Error`. This more accurately matches the behavior of `componentDidCatch`, which is the
+lifecycle method Sentry's `ErrorBoundary` component uses.
 
 As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):
 
@@ -22,4 +22,4 @@ instance of `Error`.
 
 The Sentry SDK maintainers also went ahead and made a PR to update the
 [TypeScript definitions of `componentDidCatch`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69434) for the
-React package - this will be released with React 20.
+React package. This will be released with React 20.

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.react.mdx
@@ -5,3 +5,21 @@ Sentry React SDK `8.x` supports React version `16.0.0` or higher.
 If you need to support older versions of React, please use Sentry Next.js SDK `7.x`.
 
 <Include name="migration/javascript-v8/compatible-browsers" />
+
+### Updated error types to be `unknown` instead of `Error`.
+
+In v8, we are changing the `ErrorBoundary` error types returned from `onError`, `onReset`, `onUnmount`, and
+`beforeCapture`. to be `unknown` instead of `Error`. This more accurately matches behaviour of `componentDidCatch`, the
+lifecycle method the Sentry `ErrorBoundary` component uses.
+
+As per the [React docs on error boundaries](https://react.dev/reference/react/Component#componentdidcatch):
+
+> error: The `error` that was thrown. In practice, it will usually be an instance of `Error` but this is not guaranteed
+> because JavaScript allows to throw any value, including strings or even `null`.
+
+This means you will have to use `instanceof Error` or similar to explicitly make sure that the error thrown was an
+instance of `Error`.
+
+The Sentry SDK maintainers also went ahead and made a PR to update the
+[TypeScript definitions of `componentDidCatch`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69434) for the
+React package - this will be released with React 20.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add errorboundary changes to v8 migration guide for react and gatsby docs, based on feedback from https://github.com/getsentry/sentry-javascript/discussions/12571

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
