### PR TITLE
feat(apple): Add docs for beforeSendSpan

### DIFF
--- a/docs/platforms/apple/common/configuration/filtering.mdx
+++ b/docs/platforms/apple/common/configuration/filtering.mdx
@@ -21,3 +21,10 @@ All Sentry SDKs support the <PlatformIdentifier name="before-send" /> callback m
 <PlatformContent includePath="configuration/before-send/" />
 
 Note also that breadcrumbs can be filtered, as discussed in [our Breadcrumbs documentation](/product/error-monitoring/breadcrumbs/).
+
+
+## Filtering Spans
+
+To prevent certain spans from being reported to Sentry, use the <PlatformIdentifier name="before-send-span" /> configuration option, which allows you to provide a function to evaluate the current span and drop it if it's not one you want.
+
+<PlatformContent includePath="configuration/before-send-span" />

--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -220,5 +220,6 @@ Learn more about <PlatformLink to="/configuration/sampling/">configuring the sam
 ## Filtering Spans
 
 To prevent certain spans from being reported to Sentry, use the <PlatformIdentifier name="before-send-span" /> configuration option, which allows you to provide a function to evaluate the current span and drop it if it's not one you want.
+This API is available from Cocoa SDK version 8.30.0 and above.
 
 <PlatformContent includePath="configuration/before-send-span" />

--- a/platform-includes/configuration/before-send-span/apple.mdx
+++ b/platform-includes/configuration/before-send-span/apple.mdx
@@ -9,9 +9,9 @@ SentrySDK.start { options in
         // Modify or drop the span here
         if (span.description == "unimportant span") {
             // Don't send the span to Sentry
-            return nil;
+            return nil
         }
-        return span;
+        return span
     }
 }
 ```

--- a/platform-includes/configuration/before-send-span/apple.mdx
+++ b/platform-includes/configuration/before-send-span/apple.mdx
@@ -1,0 +1,33 @@
+<SignInNote />
+
+```swift {tabTitle:Swift}
+import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.beforeSendSpan = { span in
+        // Modify or drop the span here
+        if (span.description == "unimportant span") {
+            // Don't send the span to Sentry
+            return nil;
+        }
+        return span;
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import Sentry;
+
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.beforeSendSpan = ^id<SentrySpan> _Nullable (id<SentrySpan> _Nonnull span) {
+        // Modify or drop the span here
+        if ([span.description isEqualToString:@"unimportant span"]) {
+            // Don't send the span to Sentry
+            return nil;
+        }
+        return span;
+    };
+}];
+```


### PR DESCRIPTION

## DESCRIBE YOUR PR

Add docs for beforeSendSpan similar to JS.

Cocoa PR https://github.com/getsentry/sentry-cocoa/pull/4095. We have to wait until we release Cocoa 8.30.0 to merge this.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

