### PR TITLE
docs(js): use client from init method in js snippets

### DIFF
--- a/platform-includes/performance/automatic-instrumentation-custom-routing/javascript.mdx
+++ b/platform-includes/performance/automatic-instrumentation-custom-routing/javascript.mdx
@@ -5,7 +5,7 @@ By default, the `browserTracingIntegration()` will create a `pageload` span for 
 To make sure that spans are created correctly for a custom routing setup, you'll need to opt out of the default span creation by setting `instrumentNavigation: false` and `instrumentPageLoad: false` in the `browserTracingIntegration()` options. You can then manually create spans like this:
 
 ```javascript
-Sentry.init({
+const client = Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       // disable automatic span creation
@@ -14,8 +14,6 @@ Sentry.init({
     }),
   ],
 });
-
-const client = Sentry.getClient()
 
 // We start the pageload span as early as possible!
 let pageLoadSpan = Sentry.startBrowserTracingPageLoadSpan(client, {

--- a/platform-includes/performance/opentelemetry-setup/javascript.node.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.node.mdx
@@ -33,7 +33,7 @@ function setupSentry() {
   setupGlobalHub();
 
   // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
-  Sentry.init({
+  const client = Sentry.init({
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
     // set the instrumenter to use OpenTelemetry instead of Sentry
@@ -41,7 +41,6 @@ function setupSentry() {
     // ...
   });
 
-  const client = getClient();
   setupEventContextTrace(client);
 
   // You can wrap whatever local storage context manager you want to use


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Simplify code snippets for client generation in js.
[#12495](https://github.com/getsentry/sentry-javascript/issues/12495)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

Note: we need to wait until https://github.com/getsentry/sentry-javascript/pull/12585 is released until we merge this.

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
