### PR TITLE
docs(flutter): Add  `Rewrite Frames` documentation

### DIFF
--- a/docs/platforms/flutter/configuration/draining.mdx
+++ b/docs/platforms/flutter/configuration/draining.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shutdown and Draining
-sidebar_order: 70
+sidebar_order: 80
 description: "Learn more about the default behavior of our SDK if the application shuts down unexpectedly."
 ---
 

--- a/docs/platforms/flutter/configuration/rewriteframes.mdx
+++ b/docs/platforms/flutter/configuration/rewriteframes.mdx
@@ -1,10 +1,12 @@
 ---
 title: Rewrite Frames
 sidebar_order: 70
-description: "Learn more about rewriting frames of the stack trace."
+description: "Learn how and why to rewrite stack trace frames in Sentry's flutter SDK."
 ---
 
-There are instances where you might want to rewrite frames of a stack trace before sending it to Sentry. For example, when you are publishing your Flutter application on the web and want to set a `url_prefix` because it is not deployed at the root of your URL. In this case, the absolute path of your stack frames also needs to include the same prefix so that the source maps can be found for deobfuscation. To set the `url_prefix`, you can use the [Sentry Dart Plugin](https://github.com/getsentry/sentry-dart-plugin). Below is a sample of how to update the stack frame's absolute path to include the prefix using the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> hook.
+There are times when you may want to rewrite stack trace frames before sending them to Sentry. For example, if you're publishing your Flutter application on the web and want to set a `url_prefix` because it's not deployed at the root of your URL. In this case, the absolute path of your stack frames also needs to include the same prefix so that the source maps can be found for deobfuscation. 
+
+To set the `url_prefix`, use the [Sentry Dart Plugin](https://github.com/getsentry/sentry-dart-plugin). Below is an example of how to update the stack frame's absolute path to include the prefix using the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> hook.
 
 ```dart
 options.beforeSend = (event, hint) async {

--- a/docs/platforms/flutter/configuration/rewriteframes.mdx
+++ b/docs/platforms/flutter/configuration/rewriteframes.mdx
@@ -1,0 +1,30 @@
+---
+title: Rewrite Frames
+sidebar_order: 70
+description: "Learn more about rewriting frames of the stack trace."
+---
+
+There are instances where you might want to rewrite frames of a stack trace before sending it to Sentry. For example, when you are publishing your Flutter application on the web and want to set a `url_prefix` because it is not deployed at the root of your URL. In this case, the absolute path of your stack frames also needs to include the same prefix so that the source maps can be found for deobfuscation. To set the `url_prefix`, you can use the [Sentry Dart Plugin](https://github.com/getsentry/sentry-dart-plugin). Below is a sample of how to update the stack frame's absolute path to include the prefix using the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> hook.
+
+```dart
+options.beforeSend = (event, hint) async {
+  final exceptions = event.exceptions?.map((exception) {
+    final stackTrace = exception.stackTrace;
+    if (stackTrace != null) {
+      final frames = stackTrace.frames.map((frame) {
+        const baseUrl = 'https://example.com/';
+        final modifiedAbsPath = frame.absPath?.replaceFirst(
+          baseUrl,
+          '${baseUrl}my_prefix/',
+        );
+        return frame.copyWith(absPath: modifiedAbsPath);
+      }).toList();
+      return exception.copyWith(
+        stackTrace: SentryStackTrace(frames: frames),
+      );
+    }
+    return exception;
+  }).toList();
+  return event.copyWith(exceptions: exceptions ?? []);
+};
+```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add flutter documentation on how to rewrite stack frames using `beforeSend` hook. This is needed if users need to set `url_prefix` for Flutter web applications.

Relates to https://github.com/getsentry/sentry-dart/issues/2111

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)