### PR TITLE
Make `allowUrls` and `denyUrls` more precise

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -73,7 +73,7 @@ When a string or a non-error object is raised, Sentry creates a synthetic except
 
 ### Using `allowUrls` and `denyUrls`
 
-You can construct an allowed list of domains which may raise exceptions that should be sent to Sentry. For example, if your scripts are loaded from `cdn.example.com` and your site is `example.com`, you can set `allowUrls` to:
+You can construct an allowed list of domains for errors. Only errors created within these domains will be captured. For example, if your scripts are loaded from `cdn.example.com` and your site is `example.com`, you can set `allowUrls` to:
 
 ```javascript
 Sentry.init({
@@ -81,7 +81,7 @@ Sentry.init({
 });
 ```
 
-You can also use `denyUrls` if you want to block specific URLs from sending exceptions to Sentry.
+You can also use `denyUrls` if you want to block errors created on specific URLs from being sent to Sentry.
 
 ### Using `thirdPartyErrorFilterIntegration`
 
@@ -157,7 +157,7 @@ export default {
 
 Next, add the `thirdPartyErrorFilterIntegration` to your Sentry initialization:
 
-```js {3-14}
+```javascript {3-14}
 Sentry.init({
   integrations: [
     Sentry.thirdPartyErrorFilterIntegration({

--- a/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/inboundfilters.mdx
@@ -39,14 +39,14 @@ _Type: `(string|RegExp)[]`_
 
 <Include name="platforms/configuration/options/ignore-transactions.mdx" />
 
-### `denyUrls`
-
-_Type: `(string|RegExp)[]`_
-
-<Include name="platforms/configuration/options/deny-urls.mdx" />
-
 ### `allowUrls`
 
 _Type: `(string|RegExp)[]`_
 
 <Include name="platforms/configuration/options/allow-urls.mdx" />
+
+### `denyUrls`
+
+_Type: `(string|RegExp)[]`_
+
+<Include name="platforms/configuration/options/deny-urls.mdx" />

--- a/includes/platforms/configuration/options/allow-urls.mdx
+++ b/includes/platforms/configuration/options/allow-urls.mdx
@@ -1,6 +1,6 @@
 An array of strings or regex patterns that match the URLs of scripts where errors have been created.
-Only errors that have been created on these URLs will be sent sent to Sentry.
-If you use this option, only Errors whose top stack frame file URL contains (string) or matches (regex) at least one entry in the array will be sent.
+Only errors that have been created on these URLs will be sent to Sentry.
+If you use this option, errors will only be sent when the top stack frame file URL contains (string) or matches (regex) at least one entry in the `allowUrls` array.
 
 For example, if you add `'foo.com'` to the array, errors created on `https://bar.com/myfile/foo.com` will be captured because URL will be matched with "contains" logic and the last segment of the URL contains `foo.com`.
 

--- a/includes/platforms/configuration/options/allow-urls.mdx
+++ b/includes/platforms/configuration/options/allow-urls.mdx
@@ -1,1 +1,15 @@
-A list of strings or regex patterns that match error URLs which should exclusively be sent to Sentry. If you use this option, only errors whose entire file URL contains (string) or matches (regex) at least one entry in the list will be sent. As a result, if you add `'foo.com'` to it, it will also match on `https://bar.com/myfile/foo.com`. Keep in mind that this only applies for captured exceptions, not raw message events. By default, all errors are sent.
+An array of strings or regex patterns that match the URLs of scripts where errors have been created.
+Only errors that have been created on these URLs will be sent sent to Sentry.
+If you use this option, only Errors whose top stack frame file URL contains (string) or matches (regex) at least one entry in the array will be sent.
+
+For example, if you add `'foo.com'` to the array, errors created on `https://bar.com/myfile/foo.com` will be captured because URL will be matched with "contains" logic and the last segment of the URL contains `foo.com`.
+
+This matching logic applies for captured exceptions, not raw message events. By default, all errors are sent.
+
+If your scripts are loaded from `cdn.example.com` and your site is `example.com`, you can set `allowUrls` to the follwing to exclusively capture errors being created in scripts in these locations:
+
+```javascript
+Sentry.init({
+  allowUrls: [/https?:\/\/((cdn|www)\.)?example\.com/],
+});
+```

--- a/includes/platforms/configuration/options/allow-urls.mdx
+++ b/includes/platforms/configuration/options/allow-urls.mdx
@@ -1,6 +1,7 @@
 An array of strings or regex patterns that match the URLs of scripts where errors have been created.
 Only errors that have been created on these URLs will be sent to Sentry.
-If you use this option, errors will only be sent when the top stack frame file URL contains (string) or matches (regex) at least one entry in the `allowUrls` array.
+If you use this option, errors will only be sent when the top stack frame file URL contains or matches at least one entry in the allowUrls array.
+All string entries in the array will be matched with `stackFrameUrl.contains(entry)`, while all RegEx entries will be matched with `stackFrameUrl.match(entry)`.
 
 For example, if you add `'foo.com'` to the array, errors created on `https://bar.com/myfile/foo.com` will be captured because URL will be matched with "contains" logic and the last segment of the URL contains `foo.com`.
 

--- a/includes/platforms/configuration/options/deny-urls.mdx
+++ b/includes/platforms/configuration/options/deny-urls.mdx
@@ -1,5 +1,5 @@
 An array of strings or regex patterns that match the URLs of scripts where errors have been created.
-Only errors that have been created on these URLs will not be sent sent to Sentry.
-If you use this option, Errors whose top stack frame file URL contains (string) or matches (regex) at least one entry in the array will not be sent.
+Errors that have been created on these URLs won't be sent to Sentry.
+If you use this option, errors will not be sent when the top stack frame file URL contains (string) or matches (regex) at least one entry in the `allowUrls` array.
 
-This matching logic applies for captured exceptions, not raw message events. By default, all errors are sent.
+This matching logic applies to captured exceptions not raw message events. By default, all errors are sent.

--- a/includes/platforms/configuration/options/deny-urls.mdx
+++ b/includes/platforms/configuration/options/deny-urls.mdx
@@ -1,1 +1,5 @@
-A list of strings or regex patterns that match error URLs that should not be sent to Sentry. Errors whose entire file URL contains (string) or matches (regex) at least one entry in the list will not be sent. As a result, if you add `'foo.com'` to the list, it will also match on `https://bar.com/myfile/foo.com`. Keep in mind that this only applies for captured exceptions, not raw message events. By default, all errors are sent.
+An array of strings or regex patterns that match the URLs of scripts where errors have been created.
+Only errors that have been created on these URLs will not be sent sent to Sentry.
+If you use this option, Errors whose top stack frame file URL contains (string) or matches (regex) at least one entry in the array will not be sent.
+
+This matching logic applies for captured exceptions, not raw message events. By default, all errors are sent.

--- a/includes/platforms/configuration/options/deny-urls.mdx
+++ b/includes/platforms/configuration/options/deny-urls.mdx
@@ -1,5 +1,6 @@
 An array of strings or regex patterns that match the URLs of scripts where errors have been created.
 Errors that have been created on these URLs won't be sent to Sentry.
-If you use this option, errors will not be sent when the top stack frame file URL contains (string) or matches (regex) at least one entry in the `allowUrls` array.
+If you use this option, errors will not be sent when the top stack frame file URL contains or matches at least one entry in the `denyUrls` array.
+All string entries in the array will be matched with `stackFrameUrl.contains(entry)`, while all RegEx entries will be matched with `stackFrameUrl.match(entry)`.
 
 This matching logic applies to captured exceptions not raw message events. By default, all errors are sent.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR makes the docs around `allowUrls` and `denyUrls` more precise. There is a subtle but very important difference between where an error was *created*, where it has been *thrown*, and where it has been *captured*. These option concern themselves with where an error has been *created*.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+