### PR TITLE
.relay/config.yml is a relative path

### DIFF
--- a/docs/product/relay/options.mdx
+++ b/docs/product/relay/options.mdx
@@ -4,7 +4,7 @@ description: "Configure Relay to suit the needs of your organization."
 sidebar_order: 3
 ---
 
-Configuration for Relay is recorded either in the file `.relay/config.yml` (relative to the working directory), or when noted, can be overridden through an environment variable. To change the config location, pass the `--config` option to any Relay command:
+Configuration for Relay is typically recorded in the file `.relay/config.yml` (relative to the working directory). Configuration options can be overridden through environment variables. To change the config location, pass the `--config` option to any Relay command:
 
 ```shell
 ❯ ./relay run --config /path/to/folder

--- a/docs/product/relay/options.mdx
+++ b/docs/product/relay/options.mdx
@@ -4,7 +4,7 @@ description: "Configure Relay to suit the needs of your organization."
 sidebar_order: 3
 ---
 
-Configuration for Relay is recorded either in the file `.relay/config.yml` (relative to working directory), or when noted, can be overridden through an environment variable. To change the config location, pass the `--config` option to any Relay command:
+Configuration for Relay is recorded either in the file `.relay/config.yml` (relative to the working directory), or when noted, can be overridden through an environment variable. To change the config location, pass the `--config` option to any Relay command:
 
 ```shell
 ❯ ./relay run --config /path/to/folder

--- a/docs/product/relay/options.mdx
+++ b/docs/product/relay/options.mdx
@@ -4,7 +4,7 @@ description: "Configure Relay to suit the needs of your organization."
 sidebar_order: 3
 ---
 
-Configuration for Relay is recorded either in the file `.relay/config.yml`, or when noted, can be overridden through an environment variable. To change the config location, pass the `--config` option to any Relay command:
+Configuration for Relay is recorded either in the file `.relay/config.yml` (relative to working directory), or when noted, can be overridden through an environment variable. To change the config location, pass the `--config` option to any Relay command:
 
 ```shell
 ❯ ./relay run --config /path/to/folder


### PR DESCRIPTION
Clarify that the default config path for Relay is relative to the current working directory.

Fixes https://github.com/getsentry/relay/issues/3763.