### PR TITLE
fix: Include `./docs` in lambda files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ const nextConfig = {
 
     // We need to ensure these files are available for the `/platform-redirect` endpoint
     outputFileTracingIncludes: {
-      '/**': ['./docs/**/*'],
+      '/**/*': ['./docs/**/*'],
     },
   },
 

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,11 @@ const nextConfig = {
 
   experimental: {
     serverComponentsExternalPackages: ['rehype-preset-minify'],
+
+    // We need to ensure these files are available for the `/platform-redirect` endpoint
+    outputFileTracingIncludes: {
+      '/**': ['./docs/**/*'],
+    },
   },
 
   webpack: (config, _options) => {


### PR DESCRIPTION
Should fix the `/platform-redirect` endpoint which is currently crashing on vercel.