### PR TITLE
fix queue monitoring 404s

### DIFF
--- a/docs/product/insights/caches/index.mdx
+++ b/docs/product/insights/caches/index.mdx
@@ -31,7 +31,7 @@ Starting with the [Cache page](https://sentry.io/orgredirect/organizations/:orgs
 
 ## Instrumentation
 
-Cache monitoring currently supports [auto instrumentation](/platform-redirect/?next=%2Fperformance%2Finstrumentation%2Fautomatic-instrumentation) for [Django's cache framework](https://docs.djangoproject.com/en/5.0/topics/cache/) when the [cache_spans option](https://docs.sentry.io/platforms/python/integrations/django/#options) is set to `True`. Other frameworks require custom instrumentation.
+Cache monitoring currently supports [auto instrumentation](/platform-redirect/?next=%2Ftracing%2Finstrumentation%2Fautomatic-instrumentation) for [Django's cache framework](https://docs.djangoproject.com/en/5.0/topics/cache/) when the [cache_spans option](https://docs.sentry.io/platforms/python/integrations/django/#options) is set to `True`. Other frameworks require custom instrumentation.
 
 ### Custom instrumentation
 

--- a/docs/product/insights/queue-monitoring/index.mdx
+++ b/docs/product/insights/queue-monitoring/index.mdx
@@ -31,14 +31,14 @@ The **Queues** page gives you a high-level overview so that you can see where me
 
 ### Prerequisites and Limitations
 
-Queues currently supports [auto instrumentation](/platform-redirect/?next=%2Fperformance%2Finstrumentation%2Fautomatic-instrumentation) for the [Celery Distributed Task Queue](https://docs.celeryq.dev/en/stable/) in Python. Other messaging systems can be monitored using custom instrumentation.
+Queues currently supports [auto instrumentation](/platform-redirect/?next=%2Ftracing%2Finstrumentation%2Fautomatic-instrumentation) for the [Celery Distributed Task Queue](https://docs.celeryq.dev/en/stable/) in Python. Other messaging systems can be monitored using custom instrumentation.
 
 Instructions for custom instrumentation in various languages are linked to below:
 
-- [Python SDK](/platforms/python/performance/instrumentation/custom-instrumentation/queues-module/)
-- [JavaScript SDK](/platforms/javascript/guides/node/performance/instrumentation/custom-instrumentation/queues-module/)
-- [Laravel SDK](/platforms/php/guides/laravel/performance/instrumentation/custom-instrumentation/)
-- [Java SDK](/platforms/java/distributed-tracing/custom-instrumentation/)
-- [Ruby SDK](/platforms/ruby/performance/instrumentation/custom-instrumentation/queues-module/)
-- [.NET SDK](/platforms/dotnet/distributed-tracing/custom-instrumentation/)
-- [Symfony SDK](/platforms/php/guides/symfony/distributed-tracing/custom-instrumentation/)
+- [Python SDK](/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module/)
+- [JavaScript SDK](/platforms/javascript/guides/node/tracing/instrumentation/custom-instrumentation/queues-module/)
+- [Laravel SDK](/platforms/php/guides/laravel/tracing/instrumentation/custom-instrumentation/)
+- [Java SDK](/platforms/java/tracing/instrumentation/custom-instrumentation/queues-module/)
+- [Ruby SDK](/platforms/ruby/tracing/instrumentation/custom-instrumentation/queues-module/)
+- [.NET SDK](/platforms/dotnet/tracing/instrumentation/custom-instrumentation/queues-module/)
+- [Symfony SDK](/platforms/php/guides/symfony/tracing/instrumentation/custom-instrumentation/)


### PR DESCRIPTION
fixes  #10463

There were some links still pointing to `platforms/x/performance` instead of tracing,
and links not pointing deep enough to queue monitoring