### PR TITLE
Reduce Sampling footprint in "Set Up Tracing"

### DIFF
--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -6,13 +6,6 @@ sidebar_order: 4000
 
 With [tracing](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
-<PlatformCategorySection supported={["server", "serverless"]}>
-<Note>
-
-If you’re adopting Tracing in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
-
-</Note>
-
 <Include name="opentelemetry-available.mdx" />
 
 </PlatformCategorySection>
@@ -53,7 +46,9 @@ Verify that tracing is working correctly by using our <PlatformLink to="/tracing
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry. Once testing is complete, you may want to set a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switch to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
-If you leave your sample rate at `1.0`, a transaction will be sent every time a user loads a page or navigates within your app. Depending on the amount of traffic your application gets, this may mean a lot of transactions. If you have a high-load, backend application, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
+### Sampling
+
+Leaving your sample rate at `1.0` means that traces will be started for every page load, navigation, and other events like function calls within your application. Depending on the amount of traffic your application gets, you may want to consider setting a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switching to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions.
 
 ## Next Steps
 

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 4000
 
 With [tracing](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
-<Include name="opentelemetry-available.mdx" />
+<PlatformCategorySection supported={["server", "serverless"]}>
 
 </PlatformCategorySection>
 


### PR DESCRIPTION
Reviewing this page I realized sentry warned me repeatedly about Sampling. The docs don't actually tell me why. Just have a blue info panel and a paragraph as part of the validation section, which actually that is a sub point, and nothing you can specifically "verify"

I proposes this reduction

Also, i don't think the OTel instrumentation is really necessary top of the page, it is distracing IMO, and more relevant to next steps with custom instrumentation. We are explaining how the sausage is made, directing you to learn how to make your own, and no one has even tried the sausage yet