### PR TITLE
docs(python): Fix migration guide Hub cloning

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -65,9 +65,10 @@ The SDK will take care of deciding what data belongs on which scope as long as y
 
 The old APIs will continue to work in 2.0, but we recommend migrating to their new counterparts as soon as possible since they will be removed in the next major release.
 
-### Hub Cloning
+### Activating Current Hub Clone
 
-Creating a new isolation scope provides a similar level of isolation to what you'd previously get by using a hub clone:
+If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone the current hub and activate the clone, you should now use `with sentry_sdk.isolation_scope()`, like so:
+
 
 ```python diff
   import sentry_sdk
@@ -76,6 +77,8 @@ Creating a new isolation scope provides a similar level of isolation to what you
 + with sentry_sdk.isolation_scope() as scope:
       sentry_sdk.capture_message("I am isolated!")
 ```
+
+`sentry_sdk.isolation_scope` is a context manager that creates a new isolation scope by forking the current isolation scope. The forked isolation scope is activated during the context manager's lifetime, providing a similar level of isolation within the context manager as the previous `Hub`-based approach.
 
 ### Scope Configuring
 

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -70,10 +70,11 @@ The old APIs will continue to work in 2.0, but we recommend migrating to their n
 Creating a new isolation scope provides a similar level of isolation to what you'd previously get by using a hub clone:
 
 ```python diff
-- hub = Hub(Hub.current)
-- # do something
-+ with isolation_scope() as scope:
-+     # do something
+  import sentry_sdk
+
+- with sentry_sdk.Hub(sentry_sdk.Hub.current) as hub:
++ with sentry_sdk.isolation_scope() as scope:
+      sentry_sdk.capture_message("I am isolated!")
 ```
 
 ### Scope Configuring


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The before and after are not entirely equivalent in our example under "Hub cloning" in our migration guide; this PR fixes the discrepancy

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
