### PR TITLE
docs(python): Document how to migrate custom `Hub` usage

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -65,6 +65,19 @@ The SDK will take care of deciding what data belongs on which scope as long as y
 
 The old APIs will continue to work in 2.0, but we recommend migrating to their new counterparts as soon as possible since they will be removed in the next major release.
 
+### Activating a Custom Hub
+
+If you were using a custom hub to isolate event data, we recommend using a custom isolation scope instead. To activate the custom isolation scope, you will need to explicitly pass the isolation scope to the `use_isolation_scope`, which creates a context manager that activates the scope. Here is an example of how to change your code to make it work:
+
+```python diff
+  import sentry_sdk
++ import sentry_sdk.scope
+
+- with my_hub:
++ with sentry_sdk.scope.use_isolation_scope(my_isolation_scope):
+      sentry_sdk.capture_message("I am isolated")
+```
+
 ### Activating Current Hub Clone
 
 If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone the current hub and activate the clone, you should now use `with sentry_sdk.isolation_scope()`, like so:

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -78,6 +78,19 @@ If you were using a custom hub to isolate event data, we recommend using a custo
       sentry_sdk.capture_message("I am isolated")
 ```
 
+### Cloning a Hub
+
+If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now fork an isolation scope by calling the scope's `fork()` method, like this:
+
+```python diff
+- import sentry_sdk
+
+- my_cloned_hub = sentry_sdk.Hub(my_hub)
++ my_cloned_isolation_scope = my_isolation_scope.fork()
+```
+
+You can follow the previous section's instructions to activate the cloned isolation scope.
+
 ### Activating Current Hub Clone
 
 If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone the current hub and activate the clone, you should now use `with sentry_sdk.isolation_scope()`, like so:
@@ -92,6 +105,8 @@ If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone th
 ```
 
 `sentry_sdk.isolation_scope` is a context manager that creates a new isolation scope by forking the current isolation scope. The forked isolation scope is activated during the context manager's lifetime, providing a similar level of isolation within the context manager as the previous `Hub`-based approach.
+
+Note that using `sentry_sdk.isolation_scope()` is equivalent to `sentry_sdk.scope.use_isolation_scope(sentry_sdk.Scope.get_isolation_scope().fork())`.
 
 ### Scope Configuring
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Add documentation to inform users that custom `Hub` usage (i.e. `with my_hub` statements) should be replaced with the `sentry_sdk.use_isolation_scope` context manager. Depends on #10506.

Resolves #10499

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
