### PR TITLE
fix(javascript): Move best practices docs to shared environments

### DIFF
--- a/docs/platforms/javascript/common/best-practices/multiple-sentry-instances.mdx
+++ b/docs/platforms/javascript/common/best-practices/multiple-sentry-instances.mdx
@@ -18,20 +18,9 @@ keywords:
     "multiple clients",
     "BrowserClient",
     "NodeClient",
-    "Browser Extension",
-    "VSCode Extension",
-    "Widgets",
     "monorepo",
   ]
 ---
-
-These best practices are relevant for you if you set up Sentry in one of the following use-cases:
-
-- Browser Extensions
-- VSCode Extensions
-- Third-Party Widgets
-- Libraries
-- Any other scenario where you might have multiple Sentry instances running in the same environment
 
 <Note>
 

--- a/docs/platforms/javascript/common/best-practices/shared-environments.mdx
+++ b/docs/platforms/javascript/common/best-practices/shared-environments.mdx
@@ -18,12 +18,26 @@ keywords:
     "BrowserClient",
     "NodeClient",
     "shared environment",
-    "browser extension",
-    "VSCode extension",
+    "Browser Extension",
+    "VSCode Extension",
+    "Widgets",
   ]
 ---
 
-When setting up Sentry in a shared environment where multiple Sentry instances may run, for example, in a browser extension or plugin architecture, you should **not use `Sentry.init()`**, as this will pollute the global state. If your browser extension uses `Sentry.init()`, and the website the extension is running on also uses Sentry, the extension may send events to the website's Sentry project, or vice versa.
+These best practices are relevant for you if you set up Sentry in one of the following use-cases:
+
+- Browser Extensions
+- VSCode Extensions
+- Third-Party Widgets
+- Plugin Architecture
+- Libraries
+- Any other scenario where you might have multiple Sentry instances running in the same environment
+
+<Note>
+
+When setting up Sentry in a shared environment where multiple Sentry instances may run, you should **not use `Sentry.init()`**, as this will pollute the global state. If your browser extension uses `Sentry.init()`, and a website also uses Sentry, the extension may send events to the website's Sentry project, or vice versa.
+
+</ Note>
 
 For such scenarios, you have to set up a client manually as seen in the example below.
 In addition, you should also avoid adding any integrations that use global state, like `Breadcrumbs` or `GlobalHandlers`. Furthermore, some default integrations that use the global state have to be filtered as in the example below.


### PR DESCRIPTION
## DESCRIBE YOUR PR

One part of the docs should be in "Shared Environments" (not "Multiple Sentry Instances"). The relevant docs part is moved.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


