### PR TITLE
docs(python): Document how to migrate Hub clones

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -78,6 +78,19 @@ If you were using a custom hub to isolate event data, we recommend using a custo
       sentry_sdk.capture_message("I am isolated")
 ```
 
+### Cloning a Hub
+
+If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now call fork an isolation scope by calling the scope's `fork()` method, like so:
+
+```python diff
+- import sentry_sdk
+
+- my_cloned_hub = sentry_sdk.Hub(my_hub)
++ my_cloned_isolation_scope = my_isolation_scope.fork()
+```
+
+You can follow the previous section's instructions to activate the cloned isolation scope.
+
 ### Activating Current Hub Clone
 
 If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone the current hub and activate the clone, you should now use `with sentry_sdk.isolation_scope()`, like so:
@@ -92,6 +105,8 @@ If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone th
 ```
 
 `sentry_sdk.isolation_scope` is a context manager that creates a new isolation scope by forking the current isolation scope. The forked isolation scope is activated during the context manager's lifetime, providing a similar level of isolation within the context manager as the previous `Hub`-based approach.
+
+Note that using `sentry_sdk.isolation_scope()` is equivalent to `sentry_sdk.scope.use_isolation_scope(sentry_sdk.Scope.get_isolation_scope().fork())`.
 
 ### Scope Configuring
 

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -80,7 +80,7 @@ If you were using a custom hub to isolate event data, we recommend using a custo
 
 ### Cloning a Hub
 
-If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now call fork an isolation scope by calling the scope's `fork()` method, like so:
+If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now fork an isolation scope by calling the scope's `fork()` method, like so:
 
 ```python diff
 - import sentry_sdk

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -80,7 +80,7 @@ If you were using a custom hub to isolate event data, we recommend using a custo
 
 ### Cloning a Hub
 
-If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now fork an isolation scope by calling the scope's `fork()` method, like so:
+If you previously cloned a hub by passing a hub to the `Hub` constructor, you should now fork an isolation scope by calling the scope's `fork()` method, like this:
 
 ```python diff
 - import sentry_sdk


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document that Hub clones should be replaced with isolation scope forks. Depends on #10521.

Resolves #10524

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
