### PR TITLE
Ignore the whole /changelog before Algolia index build

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -24,7 +24,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       # Remove the changelog directory to avoid a build error due to missing `DATABASE_URL`
       # and save some build time
-      - run: rm -r app/changelog/feed.xml
+      - run: rm -r app/changelog
       - run: yarn build
       # bun seems to be the most straightforward way to run a TypeScript script
       # without introducing another dependency like ts-node or tsx for everyone else

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -23,7 +23,7 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
       # Remove the changelog directory to avoid a build error due to missing `DATABASE_URL`
-      # and save some build time
+      # and save some build time.
       - run: rm -r app/changelog
       - run: yarn build
       # bun seems to be the most straightforward way to run a TypeScript script


### PR DESCRIPTION
I noticed the Algolia index script is failing lately after adding a `_admin/create` under `/changelog`

this entails deleting the whole `/changelog` directory before the build