### PR TITLE
chore(deno-docs): Fix incorrect import link for Deno SDK

### DIFF
--- a/platform-includes/configuration/capture-console/javascript.deno.mdx
+++ b/platform-includes/configuration/capture-console/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/contextlines/javascript.deno.mdx
+++ b/platform-includes/configuration/contextlines/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/debug/javascript.deno.mdx
+++ b/platform-includes/configuration/debug/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/dedupe/javascript.deno.mdx
+++ b/platform-includes/configuration/dedupe/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/extra-error-data/javascript.deno.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/rewrite-frames/javascript.deno.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/sessiontiming/javascript.deno.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.deno.mdx
@@ -1,7 +1,7 @@
 <SignInNote />
 
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/crons/setup/javascript.deno.mdx
+++ b/platform-includes/crons/setup/javascript.deno.mdx
@@ -5,7 +5,7 @@ _requires SDK version 7.88.0 or higher_
 Use the `DenoCron` integration to monitor your [`Deno.cron`](https://deno.com/blog/cron) calls and get notified when a schedule job is missed (or doesn't start when expected), if it fails due to a problem in the runtime (such as an error), or if it fails by exceeding its maximum runtime.
 
 ```TypeScript
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/performance/configure-sample-rate/javascript.deno.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.deno.mdx
@@ -2,7 +2,7 @@
 
 ```javascript
 // Import from the Deno registry
-import * as Sentry from "https://deno.land/x/sentry/index.mjs";
+import * as Sentry from "https://deno.land/x/sentry/build/index.mjs";
 
 // or import from npm registry
 import * as Sentry from "npm:@sentry/deno";


### PR DESCRIPTION
fixes [this issue in sentry](https://github.com/getsentry/sentry-javascript/issues/12698)

Changes the import link in the Deno SDK docs to the correct link, according to the issue linked above. 