### PR TITLE
feat(insights): add note to clarify difference in webvital thresholds between google and sentry

### DIFF
--- a/docs/product/insights/web-vitals/index.mdx
+++ b/docs/product/insights/web-vitals/index.mdx
@@ -88,7 +88,7 @@ A **Page Load Performance Score** is comprised of up to 4 individual **Web Vital
 | [Time To First Byte](/product/insights/web-vitals/web-vitals-concepts/#time-to-first-byte-ttfb) (TTFB)           | [200ms](https://www.desmos.com/calculator/ykzahw9goi)  | [400ms](https://www.desmos.com/calculator/ykzahw9goi)  | ~14%   |
 
 <Note>
-These thresholds are set to match Google Lighthouse as close as possible, but there may be differences since Sentry operates on real user data, whereas Google Lighthouse operates on lab data.
+These thresholds are meant to match Google Lighthouse as closely as possible, but there may be some differences because Sentry operates on real user data, whereas Google Lighthouse operates on lab data.
 
 Some browsers may not support all **Web Vitals** used in Sentry's **Performance Score** calculation, so weights are dynamically adjusted depending on which ones are available on the browser.
 

--- a/docs/product/insights/web-vitals/index.mdx
+++ b/docs/product/insights/web-vitals/index.mdx
@@ -88,6 +88,8 @@ A **Page Load Performance Score** is comprised of up to 4 individual **Web Vital
 | [Time To First Byte](/product/insights/web-vitals/web-vitals-concepts/#time-to-first-byte-ttfb) (TTFB)           | [200ms](https://www.desmos.com/calculator/ykzahw9goi)  | [400ms](https://www.desmos.com/calculator/ykzahw9goi)  | ~14%   |
 
 <Note>
+These thresholds are set to match Google Lighthouse as close as possible, but there may be differences since Sentry operates on real user data, whereas Google Lighthouse operates on lab data.
+
 Some browsers may not support all **Web Vitals** used in Sentry's **Performance Score** calculation, so weights are dynamically adjusted depending on which ones are available on the browser.
 
 Find out which Web Vitals are required to calculate Page Load Performance Scores in the [Browser Support](/product/insights/web-vitals/web-vitals-concepts/#browser-support) table.


### PR DESCRIPTION
Add note to clarify difference in webvital thresholds between google and sentry

https://github.com/getsentry/sentry-docs/issues/9754
![image](https://github.com/getsentry/sentry-docs/assets/83961295/2819aa36-594b-4c47-bdd2-9ae0d75a50f6)
