### PR TITLE
Remove wrong redirect for artifact bundles

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -298,10 +298,6 @@
       "destination": "/platforms/python/$2"
     },
     {
-      "source": "/platforms/javascript/guides/([^/]*)/sourcemaps/troubleshooting_js/artifact-bundles/",
-      "destination": "/platforms/javascript/guides/$1/sourcemaps/troubleshooting_js/"
-    },
-    {
       "source": "/platforms/javascript/guides/([^/]*)/sourcemaps/troubleshooting_js/uploading-without-debug-ids/",
       "destination": "/platforms/javascript/guides/$1/sourcemaps/troubleshooting_js/"
     },


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The redirect was wrong causing the sidebar item "What are Artifact Bundles" to redirect to the parent page "Troubleshooting Source Maps"

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): ASAP, things are broken.
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+
