### PR TITLE
fix(js): Clarify tree shaking docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/tree-shaking.mdx
+++ b/docs/platforms/javascript/common/configuration/tree-shaking.mdx
@@ -104,7 +104,7 @@ For more information on custom webpack configurations in Next.js, see [Custom We
 
 ### Manual Tree Shaking
 
-If you want to tree shake optional code, remove the code from your build output by replacing various flags in the Sentry SDK.
+If you want to tree shake optional code, remove the code from your build output by replacing various flags in the Sentry SDK. Note that if you already configured tree shaking via the Sentry Bundler Plugins, you do not need to do this manually - the plugins will take care of it for you.
 
 **The following flags are available:**
 


### PR DESCRIPTION
This was brought up by a customer, they configured both the bundler plugins _and_ the manual tree shaking, and were confused that there was no difference.