### PR TITLE
Update index.mdx to resolve ValueError

### DIFF
--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -123,7 +123,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 - `transaction_style`:
 
-  How to name transactions showing up in Sentry tracing.
+  How to name transactions that show up in Sentry tracing.
 
   - `"/myproject/myview/<foo>"` if you set `transaction_style="url"`.
   - `"myproject.myview"` if you set `transaction_style="function_name"`.

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -126,7 +126,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
   How to name transactions showing up in Sentry tracing.
 
   - `"/myproject/myview/<foo>"` if you set `transaction_style="url"`.
-  - `"myproject.myview"` if you set `transaction_style="endpoint"`.
+  - `"myproject.myview"` if you set `transaction_style="function_name"`.
 
   The default is `"url"`.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Changed 'endpoint' to 'function_name' within documentation. Found under 'how to name transactions showing in Sentry Tracing'.

Resolves a ValueError when configuring Sentry for Django: 
`ValueError: Invalid value for transaction_style: endpoint (must be in ('function_name', 'url'))`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
