### PR TITLE
docs(screen-loads): Link out to TTID/TTFD for native SDKs

### DIFF
--- a/docs/product/insights/mobile-vitals/screen-loads.mdx
+++ b/docs/product/insights/mobile-vitals/screen-loads.mdx
@@ -18,20 +18,20 @@ Sentry tracks TTID automatically, but [TTFD](/product/insights/mobile-vitals/#ti
 
 - `>=5.0` for automatic activity transactions
 - `>=6.10.0` for [TTID](/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display)
-- `>=6.17.0` for [TTFD](/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-full-display), (released March, 2023)
+- `>=6.17.0` for [TTFD](/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-full-display)
 
 **For iOS:**
 
 - `>=7.12.0` for UIViewController transactions
-- `>=8.4.0` for [TTID](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display)+[TTFD](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-full-display), (released April, 2023)
+- `>=8.4.0` for [TTID](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display)+[TTFD](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-full-display)
 
 **For Flutter:**
 
-- `>=7.18.0` [TTID+TTFD for Routing Instrumentation](/platforms/flutter/integrations/routing-instrumentation/#time-to-initial-display) (released March, 2024)
+- `>=7.18.0` [TTID+TTFD for Routing Instrumentation](/platforms/flutter/integrations/routing-instrumentation/#time-to-initial-display)
 
 **For React Native:**
 
-- `>=5.20.0` [TTID+TTFD for React Navigation](/platforms/react-native/performance/instrumentation/time-to-display/) (released March, 2024)
+- `>=5.20.0` [TTID+TTFD for React Navigation](/platforms/react-native/performance/instrumentation/time-to-display/)
 
 By default, the **Screen Loads** page displays metrics for the two releases with the highest screen counts for the time range you’ve selected. To choose a different set of releases to compare, use the “release selector” at the top of the page.
 

--- a/docs/product/insights/mobile-vitals/screen-loads.mdx
+++ b/docs/product/insights/mobile-vitals/screen-loads.mdx
@@ -17,13 +17,13 @@ Sentry tracks TTID automatically, but [TTFD](/product/insights/mobile-vitals/#ti
 **For Android:**
 
 - `>=5.0` for automatic activity transactions
-- `>=6.10.0` for TTID
-- `>=6.17.0` for TTFD, (released March, 2023)
+- `>=6.10.0` for [TTID](/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display)
+- `>=6.17.0` for [TTFD](/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-full-display), (released March, 2023)
 
 **For iOS:**
 
 - `>=7.12.0` for UIViewController transactions
-- `>=8.4.0` for TTID+TTFD, (released April, 2023)
+- `>=8.4.0` for [TTID](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display)+[TTFD](/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#time-to-full-display), (released April, 2023)
 
 **For Flutter:**
 


### PR DESCRIPTION
Adds links for Android and iOS instructions for instrumenting TTFD. Flutter and RN do a good job at linking out to their pages, but snippets for iOS and Android are harder to discover.