### PR TITLE
Documented specific case when UseSentryTracing must be called manually

### DIFF
--- a/docs/platforms/dotnet/common/tracing/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/index.mdx
@@ -31,6 +31,31 @@ using Sentry;
 
 Learn more about tracing <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">TracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
+<PlatformSection supported={["dotnet.aspnetcore"]} notSupported={["dotnet"]}>
+
+## Middleware
+
+Sentry's ASP.NET Core integration includes middleware to automatically capture each incoming HTTP request and turn it into a transaction.
+
+Ordinarily this middleware gets added automatically immediately after ASP.NET Core's `EndpointRoutingMiddleware`. However, if you using `WebApplicationBuilder` and calling `UseRouting` explicitly then you will need to manually add the Sentry tracing middleware by calling `UseSentryTracing` immediately after `UseRouting`.
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseSentry(o =>
+{
+    o.Dsn = "___PUBLIC_DSN___";
+    o.TracesSampleRate = 1.0;
+    // Add any other configuration options
+});
+var app = builder.Build();
+app.UseRouting();
+app.UseSentryTracing();
+// Add any other Middleware
+app.Run();
+```
+
+</PlatformSection>
+
 ## Verify
 
 Test out tracing by starting and finishing a transaction, which you _must_ do so transactions can be sent to Sentry. Learn how in our <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink> content.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

In the specific use case decribed [here](<https://github.com/getsentry/sentry-dotnet/issues/3423#issuecomment-2202576482>) when people are using `WebApplicationBuilder` but need/want to control when the `EndpointRoutingMiddleware` is added, they need to manually call `UseSentryTracing`. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ x ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
cc: @bitsandfoxes 

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
