### PR TITLE
feat: Add pnpm installation to all JS snippets

### DIFF
--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -27,7 +27,7 @@ curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="{{@inject apps.version
 
 This will automatically download the correct version of `sentry-cli` for your operating system and install it. If necessary, it will prompt for your admin password for `sudo`. For a different installation location or for systems without `sudo` (like Windows), you can `export INSTALL_DIR=/custom/installation/path` before running this command.
 
-To verify it’s installed correctly you can bring up the help:
+To verify it's installed correctly you can bring up the help:
 
 ```bash
 sentry-cli --help
@@ -37,8 +37,16 @@ sentry-cli --help
 
 There is also the option to install `sentry-cli` via npm for specialized use cases. This, for instance, is useful for build servers. The package is called `@sentry/cli` and in the post installation it will download the appropriate release binary:
 
-```bash
+```bash {tabTitle:npm}
 npm install @sentry/cli
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/cli
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/cli
 ```
 
 You can then find it in the `.bin` folder:
@@ -47,7 +55,7 @@ You can then find it in the `.bin` folder:
 ./node_modules/.bin/sentry-cli --help
 ```
 
-In case you want to install this with npm system wide with sudo you will need to pass `-–unsafe-perm` to it:
+In case you want to install this with npm system wide with sudo you will need to pass `--unsafe-perm` to it:
 
 ```bash
 sudo npm install -g @sentry/cli --unsafe-perm

--- a/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
+++ b/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
@@ -18,11 +18,15 @@ Please open an issue in the [Sentry Testkit repository](https://zivl.github.io/s
 ## Installation
 
 ```bash {tabTitle:npm}
-npm install --save-dev sentry-testkit
+npm install sentry-testkit --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add sentry-testkit --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add sentry-testkit --save-dev
 ```
 
 ### Using in tests

--- a/docs/platforms/javascript/common/best-practices/web-workers.mdx
+++ b/docs/platforms/javascript/common/best-practices/web-workers.mdx
@@ -29,14 +29,18 @@ notSupported:
 
 Sentry's Browser SDK supports [Web Workers API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). To capture unhandled errors from Web Workers:
 
-Install `@sentry/browser` using `yarn` or `npm`:
+Install `@sentry/browser` using your package manager:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/browser
+npm install @sentry/browser --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/browser
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
 ```
 
 Then you can use it:

--- a/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/v8-opentelemetry.mdx
@@ -52,7 +52,7 @@ In this case, you need to set `skipOpenTelemetrySetup: true` in your `Sentry.ini
 1. First, install the `@sentry/opentelemetry` package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/opentelemetry
+npm install @sentry/opentelemetry --save
 ```
 
 ```bash {tabTitle:yarn}

--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -66,15 +66,15 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 Install the Sentry Webpack plugin:
 
 ```shell {tabTitle:npm}
-npm install --save-dev @sentry/webpack-plugin
+npm install @sentry/webpack-plugin --save-dev
 ```
 
-```shell {tabTitle:Yarn}
-yarn add -D  @sentry/webpack-plugin
+```shell {tabTitle:yarn}
+yarn add @sentry/webpack-plugin --dev
 ```
 
 ```shell {tabTitle:pnpm}
-pnpm add -D @sentry/webpack-plugin
+pnpm add @sentry/webpack-plugin --save-dev
 ```
 
 
@@ -106,15 +106,15 @@ Learn more about configuring the plugin in our [Sentry webpack plugin documentat
 Install the Sentry esbuild plugin:
 
 ```shell {tabTitle:npm}
-npm install --save-dev @sentry/esbuild-plugin
+npm install @sentry/esbuild-plugin --save-dev
 ```
 
-```shell {tabTitle:Yarn}
-yarn add -D  @sentry/esbuild-plugin
+```shell {tabTitle:yarn}
+yarn add @sentry/esbuild-plugin --dev
 ```
 
 ```shell {tabTitle:pnpm}
-pnpm add -D @sentry/esbuild-plugin
+pnpm add @sentry/esbuild-plugin --save-dev
 ```
 
 Then, follow the [official Nx documentation](https://nx.dev/nx-api/angular/executors/browser-esbuild#examples) to register the Sentry esbuild plugin (`@sentry/esbuild-plugin`) in your `project.json` file. For example:

--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -21,11 +21,15 @@ Before you start configuring the source maps upload, make sure that you're [gene
 Install the custom webpack builder for Angular and the Sentry webpack plugin:
 
 ```shell {tabTitle:npm}
-npm install --save-dev @angular-builders/custom-webpack @sentry/webpack-plugin
+npm install @angular-builders/custom-webpack @sentry/webpack-plugin --save-dev
 ```
 
-```shell {tabTitle:Yarn}
-yarn add --dev @angular-builders/custom-webpack @sentry/webpack-plugin
+```shell {tabTitle:yarn}
+yarn add @angular-builders/custom-webpack @sentry/webpack-plugin --dev
+```
+
+```shell {tabTitle:pnpm}
+pnpm add @angular-builders/custom-webpack @sentry/webpack-plugin --save-dev
 ```
 
 ## Configure

--- a/docs/platforms/javascript/guides/angular/angular1.mdx
+++ b/docs/platforms/javascript/guides/angular/angular1.mdx
@@ -16,11 +16,15 @@ From version 7 onwards, the Sentry JavaScript SDK will not support AngularJS 1.x
 Install `@sentry/browser` and `@sentry/integrations` using `yarn` or `npm`:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/browser@6 @sentry/integrations@6
+npm install @sentry/browser@6 @sentry/integrations@6 --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/browser@6 @sentry/integrations@6
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser@6 @sentry/integrations@6
 ```
 
 and afterwards using it like this:

--- a/docs/platforms/javascript/guides/astro/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/astro/manual-setup.mdx
@@ -11,10 +11,10 @@ This guide also explains how to further customize your SDK setup.
 ## Manual Installation
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/astro
+npm install @sentry/astro --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/astro
 ```
 

--- a/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/aws-serverless` (minimum version `8.0.0`) package 
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/aws-serverless @sentry/profiling-node
+npm install @sentry/aws-serverless @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/aws-serverless @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/aws-serverless @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/connect/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/connect/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -29,8 +29,7 @@ Once configured, all unhandled exceptions and native crashes are automatically c
 Our Sentry Wizard can help with the setup process. Make sure you have installed the `@sentry/wizard` npm package globally, then run:
 
 ```shell
-npm install -g @sentry/wizard
-sentry-wizard --integration electron
+npx @sentry/wizard@latest -i electron
 ```
 
 This will guide you through the installation and configuration process and suggest useful tools for development. If you instead prefer to setup manually, keep reading.

--- a/docs/platforms/javascript/guides/express/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/express/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/fastify/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/fastify/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -12,14 +12,18 @@ categories:
   options={["error-monitoring", "performance", "session-replay"]}
 />
 
-To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry’s Gatsby SDK):
+To use Sentry with your Gatsby application, you will need to use `@sentry/gatsby` (Sentry's Gatsby SDK):
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/gatsby
+npm install @sentry/gatsby --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/gatsby
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/gatsby
 ```
 
 <Note>

--- a/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/google-cloud-serverless` (minimum version `8.0.0`)
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/google-cloud-serverless @sentry/profiling-node
+npm install @sentry/google-cloud-serverless @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/google-cloud-serverless @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/google-cloud-serverless @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/hapi/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/hapi/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/koa/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/koa/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/nestjs/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/nestjs` package installed.
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/nestjs @sentry/profiling-node
+npm install @sentry/nestjs @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/nestjs @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/nestjs @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -9,10 +9,10 @@ If you can't (or prefer not to) run the [automatic setup](/platforms/javascript/
 ## Installation
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/nextjs
+npm install @sentry/nextjs --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/nextjs
 ```
 

--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -22,11 +22,15 @@ You have to have the `@sentry/node` (minimum version `7.44.1`) package installed
 </Note>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 ## Enabling Profiling

--- a/docs/platforms/javascript/guides/remix/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/remix/manual-setup.mdx
@@ -15,10 +15,10 @@ If you can't (or prefer not to) run the [automatic setup](/platforms/javascript/
 Get started by installing the Sentry Remix SDK:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/remix
+npm install @sentry/remix --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/remix
 ```
 

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -9,10 +9,10 @@ If you can't (or prefer not to) run the <PlatformLink to="/#install">automatic s
 ## Install
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/sveltekit
+npm install @sentry/sveltekit --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/sveltekit
 ```
 

--- a/docs/platforms/javascript/guides/wasm/index.mdx
+++ b/docs/platforms/javascript/guides/wasm/index.mdx
@@ -11,14 +11,19 @@ Sentry's Wasm integration enhances the Browser SDK, and allows it to provide mor
 
 ## Install
 
-Install `@sentry/browser` and `@sentry/wasm` using `yarn` or `npm`:
+Install `@sentry/browser` and `@sentry/wasm` using your package manager:
 
-```bash {tabTitle:Yarn}
+
+```bash {tabTitle:npm}
+npm install @sentry/browser @sentry/wasm --save
+```
+
+```bash {tabTitle:yarn}
 yarn add @sentry/browser @sentry/wasm
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/browser @sentry/wasm
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser @sentry/wasm
 ```
 
 ## Configure

--- a/docs/platforms/javascript/legacy-sdk/integrations.mdx
+++ b/docs/platforms/javascript/legacy-sdk/integrations.mdx
@@ -602,7 +602,7 @@ Unless you have specific reasons not to, it’s recommended to instead the new [
 In the root of your React Native project, install raven-js via npm:
 
 ```bash
-npm install --save raven-js
+npm install raven-js --save
 ```
 
 At the top of your main application file (e.g. index.ios.js and/or index.android.js), add the following code:

--- a/docs/platforms/react-native/manual-setup/expo.mdx
+++ b/docs/platforms/react-native/manual-setup/expo.mdx
@@ -21,11 +21,15 @@ npx expo install @sentry/react-native
 ```
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/react-native
+npm install @sentry/react-native --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react-native
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react-native
 ```
 
 ### Intialize the SDK

--- a/docs/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/docs/platforms/react-native/manual-setup/manual-setup.mdx
@@ -4,18 +4,22 @@ description: "Learn about manual configuration for iOS and Android."
 sidebar_order: 3
 ---
 
-If you can’t (or prefer not to) run the [automatic setup](/platforms/react-native), use the instructions below to configure your application.
+If you can't (or prefer not to) run the [automatic setup](/platforms/react-native), use the instructions below to configure your application.
 
 ## Install SDK Package
 
 Install the `@sentry/react-native` package:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/react-native
+npm install @sentry/react-native --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react-native
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react-native
 ```
 
 ## iOS

--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -14,8 +14,12 @@ First, remove `sentry-expo` from your dependencies:
 npm uninstall sentry-expo
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn remove sentry-expo
+```
+
+```bash {tabTitle:pnpm}
+pnpm remove sentry-expo
 ```
 
 ### Install `@sentry/react-native`
@@ -27,11 +31,15 @@ npx expo install @sentry/react-native
 ```
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/react-native
+npm install @sentry/react-native --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react-native
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react-native
 ```
 
 ### Fix Imports

--- a/docs/product/sentry-basics/integrate-frontend/initialize-sentry-sdk.mdx
+++ b/docs/product/sentry-basics/integrate-frontend/initialize-sentry-sdk.mdx
@@ -33,8 +33,16 @@ Sentry captures data by using a platform-specific SDK that you add to your appli
 
    Make sure you're in the `frontend-tutorial` project folder.
 
-   ```bash
-   npm install --save @sentry/react
+   ```bash {tabTitle:npm}
+   npm install @sentry/react --save
+   ```
+
+   ```bash {tabTitle:yarn}
+   yarn add @sentry/react
+   ```
+
+   ```bash {tabTitle:pnpm}
+   pnpm add @sentry/react
    ```
 
 1. Import and initialize the SDK.

--- a/includes/sourcemaps-create-react-app.mdx
+++ b/includes/sourcemaps-create-react-app.mdx
@@ -27,7 +27,7 @@ Install Sentry CLI as a dev-dependency with the package manager of your choice:
 npm install @sentry/cli --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/cli --dev
 ```
 

--- a/platform-includes/configuration/capture-console/javascript.mdx
+++ b/platform-includes/configuration/capture-console/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/contextlines/javascript.mdx
+++ b/platform-includes/configuration/contextlines/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/debug/javascript.mdx
+++ b/platform-includes/configuration/debug/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/dedupe/javascript.mdx
+++ b/platform-includes/configuration/dedupe/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/http-client/javascript.mdx
+++ b/platform-includes/configuration/http-client/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/module-metadata/javascript.mdx
+++ b/platform-includes/configuration/module-metadata/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/requestdata/javascript.mdx
+++ b/platform-includes/configuration/requestdata/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/node";
 
 Sentry.init({

--- a/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/configuration/sessiontiming/javascript.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.mdx
@@ -1,6 +1,6 @@
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/getting-started-config/javascript.deno.mdx
+++ b/platform-includes/getting-started-config/javascript.deno.mdx
@@ -13,7 +13,7 @@ Sentry.init({
 });
 ```
 
-```javascript {tabTitle: npm} {"onboardingOptions": {"performance": "5-9" }}
+```javascript {tabTitle:npm} {"onboardingOptions": {"performance": "5-9" }}
 import * as Sentry from "npm:@sentry/deno";
 
 Sentry.init({

--- a/platform-includes/getting-started-config/javascript.mdx
+++ b/platform-includes/getting-started-config/javascript.mdx
@@ -4,7 +4,7 @@ Note that configuration differs slightly depending on how you installed the Sent
 
 <SignInNote />
 
-```javascript {tabTitle: npm}
+```javascript {tabTitle:npm}
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({

--- a/platform-includes/getting-started-install/javascript.angular.mdx
+++ b/platform-includes/getting-started-install/javascript.angular.mdx
@@ -1,9 +1,13 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/angular
+npm install @sentry/angular --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/angular
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/angular
 ```
 
 ### Angular Version Compatibility

--- a/platform-includes/getting-started-install/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-install/javascript.aws-lambda.mdx
@@ -1,11 +1,15 @@
 <OnboardingOption optionId="profiling" hideForThisOption>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/aws-serverless
+npm install @sentry/aws-serverless --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/aws-serverless
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/aws-serverless
 ```
 
 </OnboardingOption>
@@ -13,11 +17,15 @@ yarn add @sentry/aws-serverless
 <OnboardingOption optionId="profiling">
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/aws-serverless @sentry/profiling-node
+npm install @sentry/aws-serverless @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/aws-serverless @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/aws-serverless @sentry/profiling-node
 ```
 
 </OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-install/javascript.capacitor.mdx
@@ -1,19 +1,47 @@
-Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the framework you're using, such as Angular in this example:
+Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the framework you're using:
 
 ```bash {tabTitle:Angular}
 # npm
-npm install --save @sentry/capacitor @sentry/angular
+npm install @sentry/capacitor @sentry/angular --save
 
 # yarn
 yarn add @sentry/capacitor @sentry/angular
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/angular
 ```
 
-```bash {tabTitle:Other Frameworks}
+```bash {tabTitle:React}
 # npm
-npm install --save @sentry/capacitor
+npm install @sentry/capacitor @sentry/react --save
 
 # yarn
-yarn add @sentry/capacitor
+yarn add @sentry/capacitor @sentry/react
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/react
+```
+
+```bash {tabTitle:Vue}
+# npm
+npm install @sentry/capacitor @sentry/vue --save
+
+# yarn
+yarn add @sentry/capacitor @sentry/vue
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/vue
+```
+
+```bash {tabTitle:Other}
+# npm
+npm install @sentry/capacitor @sentry/browser --save
+
+# yarn
+yarn add @sentry/capacitor @sentry/browser
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/browser
 ```
 
 ### Capacitor 2 - Android Specifics

--- a/platform-includes/getting-started-install/javascript.electron.mdx
+++ b/platform-includes/getting-started-install/javascript.electron.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/electron
+npm install @sentry/electron --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/electron
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/electron
 ```

--- a/platform-includes/getting-started-install/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-install/javascript.gcp-functions.mdx
@@ -1,16 +1,31 @@
 <OnboardingOption optionId="profiling" hideForThisOption>
 
-```bash
-  "@sentry/google-cloud-serverless": "^{{@inject packages.version('sentry.javascript.node') }}"
+```bash {tabTitle:npm}
+npm install @sentry/google-cloud-serverless --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/google-cloud-serverless
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/google-cloud-serverless
 ```
 
 </OnboardingOption>
 
 <OnboardingOption optionId="profiling">
 
-```bash
-  "@sentry/google-cloud-serverless": "^{{@inject packages.version('sentry.javascript.node') }}",
-  "@sentry/profiling-node": "^{{@inject packages.version('sentry.javascript.node') }}"
+```bash {tabTitle:npm}
+npm install @sentry/google-cloud-serverless @sentry/profiling-node --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/google-cloud-serverless @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/google-cloud-serverless @sentry/profiling-node
 ```
 
 </OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.mdx
+++ b/platform-includes/getting-started-install/javascript.mdx
@@ -14,11 +14,15 @@ The Loader Script allows you to configure some SDK features from the Sentry UI, 
 Alternatively, you can also install the SDK via a package manager:
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/browser
+npm install @sentry/browser --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/browser
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
 ```
 
 <Note>

--- a/platform-includes/getting-started-install/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-install/javascript.nestjs.mdx
@@ -1,11 +1,15 @@
 <OnboardingOption optionId="profiling" hideForThisOption>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/nestjs
+npm install @sentry/nestjs --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/nestjs
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/nestjs
 ```
 
 </OnboardingOption>
@@ -13,11 +17,15 @@ yarn add @sentry/nestjs
 <OnboardingOption optionId="profiling">
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/nestjs @sentry/profiling-node
+npm install @sentry/nestjs @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/nestjs @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/nestjs @sentry/profiling-node
 ```
 
 </OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.node.mdx
+++ b/platform-includes/getting-started-install/javascript.node.mdx
@@ -1,11 +1,15 @@
 <OnboardingOption optionId="profiling" hideForThisOption>
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node
+npm install @sentry/node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node
 ```
 
 </OnboardingOption>
@@ -13,11 +17,15 @@ yarn add @sentry/node
 <OnboardingOption optionId="profiling">
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/node @sentry/profiling-node
+npm install @sentry/node @sentry/profiling-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
 ```
 
 </OnboardingOption>

--- a/platform-includes/getting-started-install/javascript.react.mdx
+++ b/platform-includes/getting-started-install/javascript.react.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/react
+npm install @sentry/react --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react
 ```

--- a/platform-includes/getting-started-install/javascript.solid.mdx
+++ b/platform-includes/getting-started-install/javascript.solid.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/solid
+npm install @sentry/solid --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/solid
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/solid
 ```

--- a/platform-includes/getting-started-install/javascript.svelte.mdx
+++ b/platform-includes/getting-started-install/javascript.svelte.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/svelte
+npm install @sentry/svelte --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/svelte
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/svelte
 ```

--- a/platform-includes/getting-started-install/javascript.vue.mdx
+++ b/platform-includes/getting-started-install/javascript.vue.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/vue
+npm install @sentry/vue --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vue
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vue
 ```

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
@@ -29,7 +29,7 @@ Client-side Integrations:
 
 <Include name="migration/javascript-v8/v7-deprecation/browser-tracing" />
 
-```JavaScript {tabTitle: npm} diff
+```JavaScript {tabTitle:npm} diff
  import * as Sentry from "@sentry/browser";
 
  Sentry.init({

--- a/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
@@ -5,11 +5,15 @@ OpenTelemetry support is only available for server-side instrumentation on Node 
 </Alert>
 
 ```bash {tabTitle:npm}
-npm install @sentry/nextjs @sentry/opentelemetry-node
+npm install @sentry/nextjs @sentry/opentelemetry-node --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/nextjs @sentry/opentelemetry-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/nextjs @sentry/opentelemetry-node
 ```
 
 The minimum required version of the `@sentry/node` and the `@sentry/opentelemetry-node` package is `7.20.0` and their versions should always be aligned.

--- a/platform-includes/performance/opentelemetry-install/javascript.node.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.node.mdx
@@ -1,9 +1,13 @@
 ```bash {tabTitle:npm}
-npm install @sentry/node @sentry/opentelemetry
+npm install @sentry/node @sentry/opentelemetry --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/node @sentry/opentelemetry
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/opentelemetry
 ```
 
 The minimum required version of the `@sentry/node` and the `@sentry/opentelemetry` package is `7.75.0` and their versions should always be aligned.

--- a/platform-includes/profiling/automatic-instrumentation-intro/_default.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/_default.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/browser --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/browser
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/browser
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.angular.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.angular.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/angular --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/angular
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/angular
+```bash {tabTitle:pnpm}
+pnpm add @sentry/angular
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.electron.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.electron.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/electron --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/electron
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/electron
+```bash {tabTitle:pnpm}
+pnpm add @sentry/electron
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.nextjs.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.nextjs.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/nextjs --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/nextjs
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/nextjs
+```bash {tabTitle:pnpm}
+pnpm add @sentry/nextjs
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.react.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.react.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/react --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/react
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/react
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.remix.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.remix.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/remix
+npm install @sentry/remix --save
 ```
 
 ```bash {tabTitle:yarn}
 yarn add @sentry/remix
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/remix
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.svelte.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.svelte.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/svelte --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/svelte
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/svelte
+```bash {tabTitle:pnpm}
+pnpm add @sentry/svelte
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.sveltekit.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.sveltekit.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/sveltekit --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/sveltekit
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/sveltekit
+```bash {tabTitle:pnpm}
+pnpm add @sentry/sveltekit
 ```

--- a/platform-includes/profiling/automatic-instrumentation-intro/javascript.vue.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-intro/javascript.vue.mdx
@@ -1,7 +1,11 @@
+```bash {tabTitle:npm}
+npm install @sentry/vue --save
+```
+
 ```bash {tabTitle:yarn}
 yarn add @sentry/vue
 ```
 
-```bash {tabTitle:npm}
-npm install --save @sentry/vue
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vue
 ```

--- a/platform-includes/session-replay/install/javascript.angular.mdx
+++ b/platform-includes/session-replay/install/javascript.angular.mdx
@@ -1,8 +1,8 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/angular
+npm install @sentry/angular --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/angular
 ```
 

--- a/platform-includes/session-replay/install/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/install/javascript.capacitor.mdx
@@ -2,32 +2,44 @@ Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the 
 
 ```bash {tabTitle:Angular}
 # npm
-npm install --save @sentry/capacitor @sentry/angular
+npm install @sentry/capacitor @sentry/angular --save
 
 # yarn
 yarn add @sentry/capacitor @sentry/angular
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/angular
 ```
 
 ```bash {tabTitle:React}
 # npm
-npm install --save @sentry/capacitor @sentry/react
+npm install @sentry/capacitor @sentry/react --save
 
 # yarn
 yarn add @sentry/capacitor @sentry/react
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/react
 ```
 
 ```bash {tabTitle:Vue}
 # npm
-npm install --save @sentry/capacitor @sentry/vue
+npm install @sentry/capacitor @sentry/vue --save
 
 # yarn
 yarn add @sentry/capacitor @sentry/vue
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/vue
 ```
 
 ```bash {tabTitle:Other}
 # npm
-npm install --save @sentry/capacitor @sentry/browser
+npm install @sentry/capacitor @sentry/browser --save
 
 # yarn
 yarn add @sentry/capacitor @sentry/browser
+
+# pnpm
+pnpm add @sentry/capacitor @sentry/browser
 ```

--- a/platform-includes/session-replay/install/javascript.electron.mdx
+++ b/platform-includes/session-replay/install/javascript.electron.mdx
@@ -1,9 +1,13 @@
 The Replay integration is **already included** with the Electron SDK package.
 
-```bash {tabTitle: npm}
-npm install --save @sentry/electron
+```bash {tabTitle:npm}
+npm install @sentry/electron --save
 ```
 
-```bash {tabTitle: Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/electron
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/electron
 ```

--- a/platform-includes/session-replay/install/javascript.gatsby.mdx
+++ b/platform-includes/session-replay/install/javascript.gatsby.mdx
@@ -1,9 +1,13 @@
 The Replay integration is **already included** with the Gatsby SDK package.
 
-```bash {tabTitle: npm}
-npm install --save @sentry/gatsby
+```bash {tabTitle:npm}
+npm install @sentry/gatsby --save
 ```
 
-```bash {tabTitle: Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/gatsby
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/gatsby
 ```

--- a/platform-includes/session-replay/install/javascript.mdx
+++ b/platform-includes/session-replay/install/javascript.mdx
@@ -1,11 +1,15 @@
 The Replay integration is **already included** in your browser or framework SDK NPM packages. If you're using CDN bundles instead of NPM packages, you need to load the Replay integration CDN bundle in addition to your browser bundle:
 
-```bash {tabTitle: npm}
-npm install --save @sentry/browser
+```bash {tabTitle:npm}
+npm install @sentry/browser --save
 ```
 
-```bash {tabTitle: Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/browser
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
 ```
 
 ```html {tabTitle: Loader}

--- a/platform-includes/session-replay/install/javascript.react.mdx
+++ b/platform-includes/session-replay/install/javascript.react.mdx
@@ -1,9 +1,13 @@
 The Replay integration is **already included** with the React SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/react
+npm install @sentry/react --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react
 ```

--- a/platform-includes/session-replay/install/javascript.svelte.mdx
+++ b/platform-includes/session-replay/install/javascript.svelte.mdx
@@ -1,9 +1,9 @@
 The Replay integration is **already included** with the Svelte SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/svelte
+npm install @sentry/svelte --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/svelte
 ```

--- a/platform-includes/session-replay/install/javascript.vue.mdx
+++ b/platform-includes/session-replay/install/javascript.vue.mdx
@@ -1,9 +1,9 @@
 The Replay integration is **already included** with the Vue SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/vue
+npm install @sentry/vue --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vue
 ```

--- a/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -13,8 +13,16 @@ If you use Vite to build your project, you can use the [Vite plugin](/platforms/
 
 First, install the plugin if you haven't already done so:
 
-```bash
-npm install --save-dev @sentry/vite-plugin
+```bash {tabTitle:npm}
+npm install @sentry/vite-plugin --save-dev
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/vite-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vite-plugin --save-dev
 ```
 
 Then, add the plugin to your Vite configuration:

--- a/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -41,8 +41,12 @@ If you're using Vite in you Svelte project, you can use Sentry's Vite plugin for
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vite-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vite-plugin --save-dev
 ```
 
 To upload source maps you have to configure an auth token.

--- a/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -27,8 +27,12 @@ You can use the Sentry Vite plugin to automatically create [releases](/product/r
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vite-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vite-plugin --save-dev
 ```
 
 #### Configuration

--- a/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
+++ b/platform-includes/sourcemaps/upload/esbuild/javascript.mdx
@@ -24,8 +24,12 @@ Install the Sentry esbuild plugin:
 npm install @sentry/esbuild-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/esbuild-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/esbuild-plugin --save-dev
 ```
 
 ### Configure

--- a/platform-includes/sourcemaps/upload/rollup/javascript.mdx
+++ b/platform-includes/sourcemaps/upload/rollup/javascript.mdx
@@ -24,8 +24,12 @@ Install the Sentry Rollup plugin:
 npm install @sentry/rollup-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/rollup-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/rollup-plugin --save-dev
 ```
 
 ### Configuration

--- a/platform-includes/sourcemaps/upload/vite/javascript.mdx
+++ b/platform-includes/sourcemaps/upload/vite/javascript.mdx
@@ -24,8 +24,12 @@ Install the Sentry Vite plugin:
 npm install @sentry/vite-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vite-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vite-plugin --save-dev
 ```
 
 ### Configuration

--- a/platform-includes/sourcemaps/upload/webpack/javascript.mdx
+++ b/platform-includes/sourcemaps/upload/webpack/javascript.mdx
@@ -24,8 +24,12 @@ Install the Sentry webpack plugin:
 npm install @sentry/webpack-plugin --save-dev
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/webpack-plugin --dev
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/webpack-plugin --save-dev
 ```
 
 ### Configuration

--- a/platform-includes/user-feedback/install/javascript.angular.mdx
+++ b/platform-includes/user-feedback/install/javascript.angular.mdx
@@ -1,8 +1,8 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/angular
+npm install @sentry/angular --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/angular
 ```
 

--- a/platform-includes/user-feedback/install/javascript.electron.mdx
+++ b/platform-includes/user-feedback/install/javascript.electron.mdx
@@ -1,7 +1,11 @@
 ```bash {tabTitle:npm}
-npm install --save @sentry/electron
+npm install @sentry/electron --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/electron
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/electron
 ```

--- a/platform-includes/user-feedback/install/javascript.gatsby.mdx
+++ b/platform-includes/user-feedback/install/javascript.gatsby.mdx
@@ -1,9 +1,13 @@
 The User Feedback integration is **already included** with the Gatsby SDK package.
 
-```bash {tabTitle: npm}
-npm install --save @sentry/gatsby
+```bash {tabTitle:npm}
+npm install @sentry/gatsby --save
 ```
 
-```bash {tabTitle: Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/gatsby
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/gatsby
 ```

--- a/platform-includes/user-feedback/install/javascript.mdx
+++ b/platform-includes/user-feedback/install/javascript.mdx
@@ -1,11 +1,15 @@
 The User Feedback integration is **already included** in your browser or framework SDK NPM packages. If you're using CDN bundles instead of NPM packages, you need to load the User Feedback integration CDN bundle in addition to your browser bundle:
 
-```bash {tabTitle: npm}
-npm install --save @sentry/browser
+```bash {tabTitle:npm}
+npm install @sentry/browser --save
 ```
 
-```bash {tabTitle: Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/browser
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
 ```
 
 ```html {tabTitle: CDN}

--- a/platform-includes/user-feedback/install/javascript.react.mdx
+++ b/platform-includes/user-feedback/install/javascript.react.mdx
@@ -1,9 +1,13 @@
 The User Feedback integration is **already included** with the React SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/react
+npm install @sentry/react --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/react
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react
 ```

--- a/platform-includes/user-feedback/install/javascript.svelte.mdx
+++ b/platform-includes/user-feedback/install/javascript.svelte.mdx
@@ -1,9 +1,13 @@
 The User Feedback integration is **already included** with the Svelte SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/svelte
+npm install @sentry/svelte --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/svelte
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/svelte
 ```

--- a/platform-includes/user-feedback/install/javascript.vue.mdx
+++ b/platform-includes/user-feedback/install/javascript.vue.mdx
@@ -1,9 +1,13 @@
 The User Feedback integration is **already included** with the Vue SDK package.
 
 ```bash {tabTitle:npm}
-npm install --save @sentry/vue
+npm install @sentry/vue --save
 ```
 
-```bash {tabTitle:Yarn}
+```bash {tabTitle:yarn}
 yarn add @sentry/vue
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/vue
 ```


### PR DESCRIPTION
Based on some feedback internally, add `pnpm add` snippets to all SDK onboarding config. 

Also refactor relevant npm/yarn installation so that all follow the same format (package manager - command - package name(s) - flags)
