### PR TITLE
feat(nestjs): Add SentryTraced feature

### DIFF
--- a/docs/platforms/javascript/guides/nestjs/features/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/index.mdx
@@ -1,0 +1,15 @@
+---
+title: NestJS Features
+description: "Learn how Sentry's NestJS SDK exposes features for first class integration with NestJS."
+---
+
+<Note>
+  This SDK is considered **experimental and in an alpha state**. It may experience breaking changes. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. This
+  SDK currently only supports [Solid](https://www.solidjs.com/) and is not yet officially compatible with
+  [Solid Start](https://start.solidjs.com/).
+</Note>
+
+The Sentry Solid SDK offers Solid-specific features for first class integration with the framework.
+
+<PageGrid />

--- a/docs/platforms/javascript/guides/nestjs/features/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/index.mdx
@@ -5,11 +5,9 @@ description: "Learn how Sentry's NestJS SDK exposes features for first class int
 
 <Note>
   This SDK is considered **experimental and in an alpha state**. It may experience breaking changes. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. This
-  SDK currently only supports [Solid](https://www.solidjs.com/) and is not yet officially compatible with
-  [Solid Start](https://start.solidjs.com/).
+  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns.
 </Note>
 
-The Sentry Solid SDK offers Solid-specific features for first class integration with the framework.
+The Sentry NestJS SDK offers NestJS-specific features for first class integration with the framework.
 
 <PageGrid />

--- a/docs/platforms/javascript/guides/nestjs/features/sentry-traced-decorator.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/sentry-traced-decorator.mdx
@@ -1,0 +1,25 @@
+---
+title: SentryTraced Decorator
+description: "Learn about Sentry's SentryTraced decorator."
+---
+
+<Note>
+  The `@SentryTraced` decorator is available from version `@sentry/nestjs` 8.15.0 and up.
+</Note>
+
+The NestJS SDK now includes a @SentryTraced decorator that allows you to collect spans for any function it decorates.
+This feature enables more granular performance monitoring and helps you gather detailed insights into the performance
+of individual functions within your application.
+
+To get started import `@SentryTraced` from `@sentry/nestjs` and use it to decorate a function of your choice.
+
+```jsx
+import { SentryTraced } from '@sentry/nestjs';
+
+export class MyService {
+  @SentryTraced()
+  myFunction() {
+    // Your function logic here
+  }
+}
+```

--- a/docs/platforms/javascript/guides/nestjs/features/sentry-traced-decorator.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/sentry-traced-decorator.mdx
@@ -7,13 +7,13 @@ description: "Learn about Sentry's SentryTraced decorator."
   The `@SentryTraced` decorator is available from version `@sentry/nestjs` 8.15.0 and up.
 </Note>
 
-The NestJS SDK now includes a @SentryTraced decorator that allows you to collect spans for any function it decorates.
+The NestJS SDK includes a `@SentryTraced` decorator that will create spans whenever the method it decorates is invoked.
 This feature enables more granular performance monitoring and helps you gather detailed insights into the performance
 of individual functions within your application.
 
-To get started import `@SentryTraced` from `@sentry/nestjs` and use it to decorate a function of your choice.
+To get started import `SentryTraced` from `@sentry/nestjs` and use it to decorate a function of your choice:
 
-```jsx
+```typescript
 import { SentryTraced } from '@sentry/nestjs';
 
 export class MyService {


### PR DESCRIPTION
Adds a page for the recently `@SentryTraced` decorator to the nest documentation.
