### PR TITLE
feat(nestjs): Add SentryCron feature

### DIFF
--- a/docs/platforms/javascript/guides/nestjs/features/sentry-cron-decorator.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/sentry-cron-decorator.mdx
@@ -1,0 +1,41 @@
+---
+title: SentryCron Decorator
+description: "Learn about Sentry's SentryCron decorator."
+---
+
+<Note>
+  The `@SentryCron` decorator is available from version `@sentry/nestjs` 8.16.0 and up.
+</Note>
+
+The NestJS SDK includes a `@SentryCron` decorator that can be used to augment the native NestJS `@Cron` decorator to
+send check-ins to Sentry before and after each cron job run.
+
+To get started, import SentryCron from @sentry/nestjs and use it to decorate a cron job function in your NestJS application.
+
+<Note>
+  The `@SentryCron` decorator needs to be applied after the `@Cron` decorator, or else the instrumentation does not work.
+</Note>
+
+```typescript
+import { Cron } from '@nestjs/schedule';
+import { SentryCron, MonitorConfig } from '@sentry/nestjs';
+import type { MonitorConfig } from '@sentry/types';
+
+const monitorConfig: MonitorConfig = {
+  schedule: {
+    type: "crontab",
+    value: "* * * * *",
+  },
+  checkinMargin: 2, // In minutes. Optional.
+  maxRuntime: 10, // In minutes. Optional.
+  timezone: "America/Los_Angeles", // Optional.
+};
+
+export class MyCronService {
+  @Cron('* * * * *')
+  @SentryCron('my-monitor-slug', monitorConfig)
+  handleCron() {
+    // Your cron job logic here
+  }
+}
+```

--- a/docs/platforms/javascript/guides/nestjs/features/sentry-cron-decorator.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/sentry-cron-decorator.mdx
@@ -10,7 +10,7 @@ description: "Learn about Sentry's SentryCron decorator."
 The NestJS SDK includes a `@SentryCron` decorator that can be used to augment the native NestJS `@Cron` decorator to
 send check-ins to Sentry before and after each cron job run.
 
-To get started, import SentryCron from @sentry/nestjs and use it to decorate a cron job function in your NestJS application.
+To get started, import `SentryCron` from `@sentry/nestjs` and use it to decorate a cron job function in your NestJS application.
 
 <Note>
   The `@SentryCron` decorator needs to be applied after the `@Cron` decorator, or else the instrumentation does not work.


### PR DESCRIPTION
Add documentation for the new nest `@SentryCron` decorator.

Prepared this now so it can already be reviewed but should be merged after the next SDK release.