### PR TITLE
proper build scripts for dev docs and sdk docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "dev": "yarn vercel-json && concurrently \"yarn sidecar\" \"node ./src/hotReloadWatcher.mjs\" \"next dev\"",
     "dev:developer-docs": "DEVELOPER_DOCS=1 yarn dev",
-    "build:developer-docs": "DEVELOPER_DOCS=1 yarn build",
-    "build": "prisma generate && git submodule init && git submodule update && yarn vercel-json && DEVELOPER_DOCS=1 next build",
+    "build:developer-docs": "DEVELOPER_DOCS=1 && git submodule init && git submodule update && yarn build",
+    "build": "prisma generate && yarn vercel-json && next build",
     "start": "next start",
     "migrate:dev": "dotenv -e .env.development -- yarn prisma migrate reset",
     "lint": "next lint",


### PR DESCRIPTION
fix `package.json` build scripts for sdk docs vs dev docs

should be merged before launching #10345