### PR TITLE
fix(remix): Fix remix migration docs

### DIFF
--- a/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
@@ -72,7 +72,7 @@ We now support the following integrations out of the box with 0 configuration:
    dsn: "___PUBLIC_DSN___",
    integrations: [
 -    new Sentry.BrowserTracing({
--      routingInstrumentation: Sentry.routingInstrumentation(
+-      routingInstrumentation: Sentry.remixRouterInstrumentation(
 -        useEffect,
 -        useLocation,
 -        useMatches

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
@@ -27,6 +27,14 @@ export const handleError = Sentry.wrapRemixHandleError;
 // rest of your code and imports
 ```
 
+<Note>
+  Since
+  [8.10.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.10.0),
+  you can also setup `@sentry/remix` with a new `autoInstrumentRemix: true`
+  option. See <PlatformLink to="/manual-setup">Manual Setup</PlatformLink> for
+  details on how to use this option.
+</Note>
+
 2. Remove any performance related integrations from your server-side init in `entry.server.tsx`.
 
 All performance auto-instrumentation will be automatically enabled if the package is found. You do not need to add any integration yourself, and `autoDiscoverNodePerformanceMonitoringIntegrations()` has also been removed.
@@ -56,16 +64,26 @@ We now support the following integrations out of the box with 0 configuration:
 3. Move your client-side `Sentry.init` call so that it is called before any other `require`/`import` statements in `entry.client.tsx`.
 
 ```JavaScript diff
+ import { useLocation, useMatches } from "@remix-run/react";
  import * as Sentry from "@sentry/remix";
+ import { useEffect } from "react";
 
  Sentry.init({
    dsn: "___PUBLIC_DSN___",
--  integrations: [
+   integrations: [
 -    new Sentry.BrowserTracing({
--      routingInstrumentation: Sentry.routingInstrumentation(router),
--    })
--  ],
-+  integrations: [Sentry.browserTracingIntegration({ router })],
+-      routingInstrumentation: Sentry.routingInstrumentation(
+-        useEffect,
+-        useLocation,
+-        useMatches
+-      ),
+-    }),
++     Sentry.browserTracingIntegration({
++      useEffect,
++      useLocation,
++      useMatches,
++    }),
+   ],
  });
 ```
 

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.angular.mdx
@@ -34,10 +34,10 @@
    dsn: "___PUBLIC_DSN___",
 -  integrations: [
 -    new Sentry.BrowserTracing({
--      routingInstrumentation: Sentry.routingInstrumentation(router),
+-      routingInstrumentation: Sentry.routingInstrumentation(),
 -    })
 -  ],
-+  integrations: [Sentry.browserTracingIntegration({ router })],
++  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
 

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.vue.mdx
@@ -32,12 +32,13 @@
 
  Sentry.init({
    dsn: "___PUBLIC_DSN___",
+   app,
 -  integrations: [
 -    new Sentry.BrowserTracing({
 -      routingInstrumentation: Sentry.vueRouterInstrumentation(router),
 -    })
 -  ],
-+  integrations: [Sentry.browserTracingIntegration({ router })],
++  integrations: [Sentry.browserTracingIntegration()],
  });
 ```
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/10615

This PR fixes some incorrect migration guide examples (mostly referencing a router variable that does not exist in some places). In addition, it also adds a note to the remix docs about the new remix setup, linking there at least, to indicate that something changed there.