### PR TITLE
feat(js): Improve trace propagation docs for browser JS

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -46,7 +46,7 @@ const client = Sentry.init({
   ],
 });
 
-// Emit pageload manually
+// Start the pageload span manually
 const sentryTrace = getSentryTraceStringFromSomewhere();
 const baggage = getBaggageStringFromSomewhere();
 

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -30,6 +30,35 @@ Sentry.init({
 });
 ```
 
+### Continuing a Trace Manually
+
+By default, the `browserTracingIntegration` will automatically continue a trace found in a `<meta>` tag `sentry-trace` and `baggage`.
+If you want to continue a different trace, for example because you cannot propagate the trace through meta tags but you do it through some different mechanism, you can do this as follows:
+
+```javascript
+const client = Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.browserTracingIntegration({
+      // Disable default pageload instrumentation
+      instrumentPageLoad: false,
+    }),
+  ],
+});
+
+// Emit pageload manually
+const sentryTrace = getSentryTraceStringFromSomewhere();
+const baggage = getBaggageStringFromSomewhere();
+
+Sentry.startBrowserTracingPageLoadSpan(
+  client,
+  {
+    name: window.location.pathname,
+  },
+  { sentryTrace, baggage }
+);
+```
+
 ## Enabling Distributed Tracing without `BrowserTracing`
 
 If you don't want to use the `BrowserTracing` integration, you can manually extract and inject tracing data in your application to connect multiple systems. For this, you must:
@@ -54,24 +83,29 @@ Some Sentry backend SDKs provide a built-in way to inject these `<meta>` tags in
 Then, on `pageload` you can do the following:
 
 ```javascript
+import { propagationContextFromHeaders } from "@sentry/utils";
+import * as Sentry from "@sentry/browser";
+
 // Read meta tag values
 const sentryTrace = document.querySelector("meta[name=sentry-trace]")?.content;
 const baggage = document.querySelector("meta[name=baggage]")?.content;
 
-Sentry.continueTrace({ sentryTrace, baggage }, () => {
-  Sentry.startSpan(
-    {
-      name: `Pageload: ${window.location.pathname}`,
-      op: "pageload",
-    },
-    () => {
-      // do something
-    }
-  );
-});
+// Generate a propagation context from the meta tags
+const propagationContext = propagationContextFromHeaders(sentryTrace, baggage);
+Sentry.getCurrentScope().setPropagationContext(propagationContext);
+
+Sentry.startSpan(
+  {
+    name: `Pageload: ${window.location.pathname}`,
+    op: "pageload",
+  },
+  () => {
+    // do something
+  }
+);
 ```
 
-In this example, we create a new transaction that is attached to the trace specified in the `sentry-trace` and `baggage` HTML `<meta>` tags.
+In this example, we create a new root span that is attached to the trace specified in the `sentry-trace` and `baggage` HTML `<meta>` tags.
 
 </PlatformCategorySection>
 

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -15,7 +15,7 @@ If you are using a different package, and have not enabled tracing, you can manu
 
 <PlatformCategorySection supported={['browser']}>
 
-To enable distributed tracing for your frontend, add the `BrowserTracing` integration to your `Sentry.init()` options as described in the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/">Automatic Instrumentation</PlatformLink> docs.
+To enable distributed tracing for your frontend, add `browserTracingIntegration` to your `Sentry.init()` options as described in the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/">Automatic Instrumentation</PlatformLink> docs.
 
 If you want to use distributed tracing but not tracing, set the `tracesSampleRate` option to `0`.
 
@@ -32,8 +32,8 @@ Sentry.init({
 
 ### Continuing a Trace Manually
 
-By default, the `browserTracingIntegration` will automatically continue a trace found in a `<meta>` tag `sentry-trace` and `baggage`.
-If you want to continue a different trace, for example because you cannot propagate the trace through meta tags but you do it through some different mechanism, you can do this as follows:
+By default, the `browserTracingIntegration` will automatically continue a trace found in a `<meta>` tags - see <PlatformLink to="/tracing/trace-propagation/#automatic-trace-propagation">Automatic Trace Propagation</PlatformLink> for details.
+If you want to continue a different trace, for example because you cannot propagate the trace through meta tags but through some different mechanism, you can do this as follows:
 
 ```javascript
 const client = Sentry.init({
@@ -59,9 +59,9 @@ Sentry.startBrowserTracingPageLoadSpan(
 );
 ```
 
-## Enabling Distributed Tracing without `BrowserTracing`
+## Enabling Distributed Tracing without `browserTracingIntegration`
 
-If you don't want to use the `BrowserTracing` integration, you can manually extract and inject tracing data in your application to connect multiple systems. For this, you must:
+If you don't want to use the `browserTracingIntegration` integration, you can manually extract and inject tracing data in your application to connect multiple systems. For this, you must:
 
 - Extract and store incoming tracing information from HTML `<meta>` tags when loading the page.
 - Inject tracing information to any outgoing requests.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -8,9 +8,24 @@ Sentry.init({
 });
 ```
 
+### Automatic Trace Propagation
+
+By default, the `browserTracingIntegration` will automatically continue a trace found in a `<meta>` tags that look like this:
+
+```html
+<html>
+  <head>
+    <meta name="sentry-trace" content="SENTRY_TRACE_STRING_HERE" />
+    <meta name="sentry-baggage" content="SENTRY_BAGGAGE_STRING_HERE" />
+  </head>
+</html>
+```
+
+If you want to continue a trace from a server, e.g. in a server rendered application, the server will have to emit these meta tags into the rendered HTML. You do not need to configure anything to continue traces from `<meta>` tags, if you use `browserTracingIntegration`.
+
 ### Custom Instrumentation
 
-If you don't want to use tracing, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
+If you don't want to use `browserTracingIntegration`, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
 
 If you're using version `7.57.x` or below, you'll need to have our <PlatformLink to="/tracing/">tracing feature enabled</PlatformLink> in order for distributed tracing to work.
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -15,8 +15,8 @@ By default, the `browserTracingIntegration` will automatically continue a trace 
 ```html
 <html>
   <head>
-    <meta name="sentry-trace" content="SENTRY_TRACE_STRING_HERE" />
-    <meta name="sentry-baggage" content="SENTRY_BAGGAGE_STRING_HERE" />
+    <meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1" />
+    <meta name="sentry-baggage" content="sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=0.2,sentry-sampled=true,..." />
   </head>
 </html>
 ```


### PR DESCRIPTION
I noticed that the docs for trace propagation in browser where partially incorrect, and partially missing in details.

This PR:

1. Adds docs on how to continue a trace manually when using `browserTracingIntegration`
2. Adds docs about automatic trace propagation through meta tags
3. Fixes the docs for custom trace propagation without `browserTracingIntegration`