### PR TITLE
Remove "early adopter" mention from Reprocessing

### DIFF
--- a/docs/organization/early-adopter-features/index.mdx
+++ b/docs/organization/early-adopter-features/index.mdx
@@ -18,6 +18,5 @@ Limitations:
 ## Current Early Adopter Features
 
 - [Issue Status](/product/issues/states-triage/) tags
-- [Issue Reprocessing](/product/issues/reprocessing/)
 - [Span Summary](/product/performance/transaction-summary/#span-summary)
 - [Investigation Mode](/product/performance/retention-priorities/#investigation-mode) for retention priorities in Tracing

--- a/docs/product/issues/reprocessing/index.mdx
+++ b/docs/product/issues/reprocessing/index.mdx
@@ -9,7 +9,7 @@ files](/platforms/native/data-management/debug-files/) only after they have been
 
 <Include name="only-error-issues-note.mdx" />
 
-After becoming an Early Adopter, you will find a new action when viewing an issue:
+You can find the following action when viewing an issue:
 
 !["Reprocess Event" action among advanced actions on issue details page](./img/reprocessing-action.png)
 


### PR DESCRIPTION
The "Reprocess Event" action is now available for everyone.