### PR TITLE
feat(js): Remove setTransactionName migration from js sdk docs

### DIFF
--- a/includes/migration/javascript-v8/v7-deprecation/general.mdx
+++ b/includes/migration/javascript-v8/v7-deprecation/general.mdx
@@ -161,12 +161,6 @@ _Deprecation introduced in `7.93.0`._
 Instead, you can get the currently active span via `Sentry.getActiveSpan()`. Setting a span on the scope happens
 automatically when you use the new performance APIs `startSpan()` and `startSpanManual()`.
 
-### Deprecate `scope.setTransactionName()`
-
-_Deprecation introduced in `7.93.0`._
-
-Instead, either set this as attributes or tags, or use an event processor to set `event.transaction`.
-
 ### Deprecate `scope.getTransaction()` and `getActiveTransaction()`
 
 _Deprecation introduced in `7.93.0`._


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

ref https://github.com/getsentry/sentry-docs/issues/10563

We undeprecated `setTransactionName` in https://github.com/getsentry/sentry-javascript/pull/10966 - these migration docs are wrong.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
