### PR TITLE
fix: Add docs for v7 loader integrations

### DIFF
--- a/platform-includes/configuration/capture-console/javascript.mdx
+++ b/platform-includes/configuration/capture-console/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.captureConsoleIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.captureConsoleIntegration) {
+      Sentry.addIntegration(Sentry.captureConsoleIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/capture-console/javascript.mdx
+++ b/platform-includes/configuration/capture-console/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.captureConsoleIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/captureconsole.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'captureconsole.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/contextlines/javascript.mdx
+++ b/platform-includes/configuration/contextlines/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.contextLinesIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/contextlines.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'contextlines.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/contextlines/javascript.mdx
+++ b/platform-includes/configuration/contextlines/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.contextLinesIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.contextLinesIntegration) {
+      Sentry.addIntegration(Sentry.contextLinesIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/debug/javascript.mdx
+++ b/platform-includes/configuration/debug/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.debugIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.debugIntegration) {
+      Sentry.addIntegration(Sentry.debugIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/debug/javascript.mdx
+++ b/platform-includes/configuration/debug/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.debugIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/debug.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'debug.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/dedupe/javascript.mdx
+++ b/platform-includes/configuration/dedupe/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.dedupeIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/dedupe.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'dedupe.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/dedupe/javascript.mdx
+++ b/platform-includes/configuration/dedupe/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.dedupeIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.dedupeIntegration) {
+      Sentry.addIntegration(Sentry.dedupeIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -10,7 +10,7 @@ Sentry.init({
 Sentry.addIntegration(Sentry.reportingObserverIntegration());
 ```
 
-```html {tabTitle: Loader (v7)} TODO
+```html {tabTitle: Loader (v7)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
@@ -35,9 +35,8 @@ Sentry.addIntegration(Sentry.reportingObserverIntegration());
   // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
   window.Sentry &&
     Sentry.onLoad(function () {
-      const integration = Sentry.reportingObserverIntegration?.();
-      if (integration) {
-        Sentry.addIntegration(integration);
+      if (Sentry.reportingObserverIntegration) {
+        Sentry.addIntegration(Sentry.reportingObserverIntegration());
       }
     });
 </script>

--- a/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations-lazy/javascript.mdx
@@ -10,7 +10,40 @@ Sentry.init({
 Sentry.addIntegration(Sentry.reportingObserverIntegration());
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)} TODO
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      integrations: [],
+    });
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+
+<script>
+  // Later in your application
+  // By calling this inside of `Sentry.onLoad()`, we can be sure the SDK has been initialized at this point.
+  window.Sentry &&
+    Sentry.onLoad(function () {
+      const integration = Sentry.reportingObserverIntegration?.();
+      if (integration) {
+        Sentry.addIntegration(integration);
+      }
+    });
+</script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.reportingObserverIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
+++ b/platform-includes/configuration/enable-pluggable-integrations/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.reportingObserverIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.reportingObserverIntegration) {
+      Sentry.addIntegration(Sentry.reportingObserverIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.extraErrorDataIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/extraerrordata.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'extraerrordata.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/extra-error-data/javascript.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.extraErrorDataIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+   if (Sentry.extraErrorDataIntegration) {
+      Sentry.addIntegration(Sentry.extraErrorDataIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/http-client/javascript.mdx
+++ b/platform-includes/configuration/http-client/javascript.mdx
@@ -12,7 +12,7 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
@@ -21,11 +21,36 @@ Sentry.init({
       sendDefaultPii: true,
     });
 
-    Sentry.lazyLoadIntegration("httpClientIntegration").then(
-      (integration) => {
-        Sentry.addIntegration(integration());
-      }
-    );
+    const integration = Sentry.httpClientIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/httpclient.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'httpclient.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      // This option is required for capturing headers and cookies.
+      sendDefaultPii: true,
+    });
+
+    Sentry.lazyLoadIntegration("httpClientIntegration").then((integration) => {
+      Sentry.addIntegration(integration());
+    });
   };
 </script>
 

--- a/platform-includes/configuration/http-client/javascript.mdx
+++ b/platform-includes/configuration/http-client/javascript.mdx
@@ -21,9 +21,8 @@ Sentry.init({
       sendDefaultPii: true,
     });
 
-    const integration = Sentry.httpClientIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.httpClientIntegration) {
+      Sentry.addIntegration(Sentry.httpClientIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.reportingObserverIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+   if (Sentry.reportingObserverIntegration) {
+      Sentry.addIntegration(Sentry.reportingObserverIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/reporting-observer/javascript.mdx
+++ b/platform-includes/configuration/reporting-observer/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.reportingObserverIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/reportingobserver.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'reportingobserver.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.rewriteFramesIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+   if (Sentry.rewriteFramesIntegration) {
+      Sentry.addIntegration(Sentry.rewriteFramesIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/rewrite-frames/javascript.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.rewriteFramesIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/rewriteframes.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'rewriteframes.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {

--- a/platform-includes/configuration/sessiontiming/javascript.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.mdx
@@ -15,9 +15,8 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({});
 
-    const integration = Sentry.sessionTimingIntegration?.();
-    if (integration) {
-      Sentry.addIntegration(integration);
+    if (Sentry.sessionTimingIntegration) {
+      Sentry.addIntegration(Sentry.sessionTimingIntegration());
     }
   };
 </script>

--- a/platform-includes/configuration/sessiontiming/javascript.mdx
+++ b/platform-includes/configuration/sessiontiming/javascript.mdx
@@ -9,7 +9,31 @@ Sentry.init({
 });
 ```
 
-```html {tabTitle: Loader}
+```html {tabTitle: Loader (v7)}
+<script>
+  // Configure sentryOnLoad before adding the Loader Script
+  window.sentryOnLoad = function () {
+    Sentry.init({});
+
+    const integration = Sentry.sessionTimingIntegration?.();
+    if (integration) {
+      Sentry.addIntegration(integration);
+    }
+  };
+</script>
+
+<script
+  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/sessiontiming.min.js"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'sessiontiming.min.js', 'sha384-base64') }}"
+  crossorigin="anonymous"
+></script>
+```
+
+```html {tabTitle: Loader (v8)}
 <script>
   // Configure sentryOnLoad before adding the Loader Script
   window.sentryOnLoad = function () {
@@ -36,7 +60,7 @@ Sentry.init({
 ></script>
 <script
   src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/sessiontiming.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'debug.min.js', 'sha384-base64') }}"
+  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'sessiontiming.min.js', 'sha384-base64') }}"
   crossorigin="anonymous"
 ></script>
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/12758

I updated the docs for using pluggable integrations with the loader to the v8 syntax, however the loader is not yet even fully out with v8 support, which leads to confusion and problems.

This PR ensures we have docs for both v7 and v8 of the loader, so this should work both ways.