### PR TITLE
chore(codeowners): Add owners-api to `resolveOpenAPI.ts`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # Requiring review from security team for Content-Security-Policy changes
 /vercel.json @getsentry/security
 
+# owners-api is tagged here but anyone can just approve the SHA Bump PRs
+/src/build/resolveOpenAPI.ts @getsentry/owners-api
 
 # Codeowners listed below are used as a reference for the Sentry team to know who to contact for a given area of the codebase.
 


### PR DESCRIPTION
Docs Team gets a bunch of PRs such as https://github.com/getsentry/sentry-docs/pull/10657. 

We should always approve, but for a sanity check lets make sure owners-api approve these prs.