### PR TITLE
fix(product): fix Performance Getting Started links

### DIFF
--- a/docs/product/performance/getting-started.mdx
+++ b/docs/product/performance/getting-started.mdx
@@ -8,95 +8,95 @@ If you don't already have performance monitoring enabled, use the links for supp
 
 ## Supported SDKs
 
-- <PlatformLinkWithLogo platform="dotnet" url="/platforms/dotnet/performance" />
+- <PlatformLinkWithLogo platform="dotnet" url="/platforms/dotnet/tracing" />
 
-  - [ASP.NET Core](/platforms/dotnet/guides/aspnetcore/performance)
-  - [OpenTelemetry](/platforms/dotnet/performance/instrumentation/opentelemetry/)
+  - [ASP.NET Core](/platforms/dotnet/guides/aspnetcore/tracing)
+  - [OpenTelemetry](/platforms/dotnet/tracing/instrumentation/opentelemetry/)
 
-- <PlatformLinkWithLogo platform="go" url="/platforms/go/performance" />
+- <PlatformLinkWithLogo platform="go" url="/platforms/go/tracing" />
 
-  - [Echo](/platforms/go/guides/echo/performance/)
-  - [FastHTTP](/platforms/go/guides/fasthttp/performance/)
-  - [Gin](/platforms/go/guides/gin/performance/)
-  - [Iris](/platforms/go/guides/iris/performance/)
-  - [Martini](/platforms/go/guides/martini/performance/)
-  - [Negroni](/platforms/go/guides/negroni/performance/)
-  - [net/http](/platforms/go/guides/http/performance/)
-  - [OpenTelemetry](/platforms/go/performance/instrumentation/opentelemetry/)
+  - [Echo](/platforms/go/guides/echo/tracing/)
+  - [FastHTTP](/platforms/go/guides/fasthttp/tracing/)
+  - [Gin](/platforms/go/guides/gin/tracing/)
+  - [Iris](/platforms/go/guides/iris/tracing/)
+  - [Martini](/platforms/go/guides/martini/tracing/)
+  - [Negroni](/platforms/go/guides/negroni/tracing/)
+  - [net/http](/platforms/go/guides/http/tracing/)
+  - [OpenTelemetry](/platforms/go/tracing/instrumentation/opentelemetry/)
 
 - <PlatformLinkWithLogo
     platform="java"
     label="Java/Kotlin/JVM"
-    url="/platforms/java/performance"
+    url="/platforms/java/tracing"
   />
 
-  - [OpenTelemetry](/platforms/java/performance/instrumentation/opentelemetry/)
-  - [Spring](/platforms/java/guides/spring/performance/)
-  - [Spring Boot](/platforms/java/guides/spring-boot/performance/)
+  - [OpenTelemetry](/platforms/java/tracing/instrumentation/opentelemetry/)
+  - [Spring](/platforms/java/guides/spring/tracing/)
+  - [Spring Boot](/platforms/java/guides/spring-boot/tracing/)
 
 - <PlatformLinkWithLogo
     platform="javascript"
     label="JavaScript"
-    url="/platforms/javascript/performance"
+    url="/platforms/javascript/tracing"
   />
 
-  - [Angular](/platforms/javascript/guides/angular/performance/)
-  - [Ember](/platforms/javascript/guides/ember/performance/)
-  - [Electron](/platforms/javascript/guides/electron/performance/)
-  - [Gatsby](/platforms/javascript/guides/gatsby/performance/)
-  - [Next.js](/platforms/javascript/guides/nextjs/performance/)
-  - [React](/platforms/javascript/guides/react/performance/)
-  - [Vue](/platforms/javascript/guides/vue/performance/)
-  - [Svelte](/platforms/javascript/guides/svelte/performance/)
+  - [Angular](/platforms/javascript/guides/angular/tracing/)
+  - [Ember](/platforms/javascript/guides/ember/tracing/)
+  - [Electron](/platforms/javascript/guides/electron/tracing/)
+  - [Gatsby](/platforms/javascript/guides/gatsby/tracing/)
+  - [Next.js](/platforms/javascript/guides/nextjs/tracing/)
+  - [React](/platforms/javascript/guides/react/tracing/)
+  - [Vue](/platforms/javascript/guides/vue/tracing/)
+  - [Svelte](/platforms/javascript/guides/svelte/tracing/)
 
 - <PlatformLinkWithLogo
     platform="android"
-    url="/platforms/android/performance"
+    url="/platforms/android/tracing"
   />
 
 - <PlatformLinkWithLogo
     platform="react-native"
-    url="/platforms/react-native/performance"
+    url="/platforms/react-native/tracing"
   />
 
 - <PlatformLinkWithLogo
     platform="apple"
     label="iOS"
-    url="/platforms/apple/guides/ios/performance/"
+    url="/platforms/apple/guides/ios/tracing/"
   />
 
 - <PlatformLinkWithLogo
     platform="flutter"
-    url="/platforms/flutter/performance"
+    url="/platforms/flutter/tracing"
   />
 
-- <PlatformLinkWithLogo platform="native" url="/platforms/native/performance" />
+- <PlatformLinkWithLogo platform="native" url="/platforms/native/tracing" />
 
-- <PlatformLinkWithLogo platform="javascript" url="/platforms/javascript/guides/node/performance" />
+- <PlatformLinkWithLogo platform="javascript" url="/platforms/javascript/guides/node/tracing" />
 
-  - [AWS Lambda](/platforms/javascript/guides/aws-lambda/)
-  - [Express](/platforms/javascript/guides/express/#monitor-performance)
-  - [Google Cloud Functions](/platforms/javascript/guides/gcp-functions/)
-  - [Koa](/platforms/javascript/guides/koa/#monitor-performance)
-  - [OpenTelemetry](/platforms/javascript/guides/node/performance/instrumentation/opentelemetry/)
+  - [AWS Lambda](/platforms/javascript/guides/aws-lambda/tracing/)
+  - [Express](/platforms/javascript/guides/express/tracing/)
+  - [Google Cloud Functions](/platforms/javascript/guides/gcp-functions/tracing/)
+  - [Koa](/platforms/javascript/guides/koa/tracing/)
+  - [OpenTelemetry](/platforms/javascript/guides/node/tracing/instrumentation/opentelemetry/)
 
-- <PlatformLinkWithLogo platform="python" url="/platforms/python/performance" />
+- <PlatformLinkWithLogo platform="python" url="/platforms/python/tracing" />
 
-  - [OpenTelemetry](/platforms/python/performance/instrumentation/opentelemetry/)
+  - [OpenTelemetry](/platforms/python/tracing/instrumentation/opentelemetry/)
 
-- <PlatformLinkWithLogo platform="php" url="/platforms/php/performance" />
+- <PlatformLinkWithLogo platform="php" url="/platforms/php/tracing" />
 
-  - [Laravel](/platforms/php/guides/laravel/performance/)
-  - [Symfony](/platforms/php/guides/symfony/performance/)
+  - [Laravel](/platforms/php/guides/laravel/tracing/)
+  - [Symfony](/platforms/php/guides/symfony/tracing/)
 
-- <PlatformLinkWithLogo platform="ruby" url="/platforms/ruby/performance" />
+- <PlatformLinkWithLogo platform="ruby" url="/platforms/ruby/tracing" />
 
-  - [DelayedJob](/platforms/ruby/guides/delayed_job/performance/)
-  - [OpenTelemetry](/platforms/ruby/performance/instrumentation/opentelemetry/)
-  - [Rails](/platforms/ruby/guides/rails/)
-  - [Resque](/platforms/ruby/guides/resque/performance)
-  - [Sidekiq](/platforms/ruby/guides/sidekiq/performance)
+  - [DelayedJob](/platforms/ruby/guides/delayed_job/tracing/)
+  - [OpenTelemetry](/platforms/ruby/tracing/instrumentation/opentelemetry/)
+  - [Rails](/platforms/ruby/guides/rails/tracing/)
+  - [Resque](/platforms/ruby/guides/resque/tracing)
+  - [Sidekiq](/platforms/ruby/guides/sidekiq/tracing)
 
-- <PlatformLinkWithLogo platform="rust" url="/platforms/rust/performance" />
+- <PlatformLinkWithLogo platform="rust" url="/platforms/rust/tracing" />
 
-- <PlatformLinkWithLogo platform="unity" url="/platforms/unity/performance" />
+- <PlatformLinkWithLogo platform="unity" url="/platforms/unity/tracing" />


### PR DESCRIPTION
The Getting Started page for Performance had mostly broken links, since they still pointed to `.../performance/` instead of the new `.../tracing/` pages. There were also a few platforms that pointed to a generic page that I linked to the more specific tracing page instead.

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
