### PR TITLE
fix(apple): change link from react native manual setup to ios manual setup

### DIFF
--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -48,7 +48,7 @@ brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios
 ```
 
 This will patch your project and configure the SDK. You'll only need to patch the project once, then you'll be able to add the patched files to your version control system.
-If you prefer, you can also [set up the SDK manually](/platforms/react-native/manual-setup/manual-setup/) or follow the instructions below to adapt the [configuration](#configure).
+If you prefer, you can also [set up the SDK manually](/platforms/apple/guides/ios/manual-setup/) or follow the instructions below to adapt the [configuration](#configure).
 
 <Expandable title="The following tasks will be performed by the Sentry Wizard">
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Manual setup link in the iOS docs is the wrong platform, should be iOS and not React Native

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
