### PR TITLE
Fix links to manual cache instrumentation

### DIFF
--- a/docs/product/insights/caches/index.mdx
+++ b/docs/product/insights/caches/index.mdx
@@ -38,12 +38,11 @@ Cache monitoring currently supports [auto instrumentation](/platform-redirect/?n
 
 If available, custom instrumentation is documented on an environment-by-environment basis as listed below:
 
-- [Python SDK](/platforms/python/performance/instrumentation/custom-instrumentation/caches-module/)
-- [JavaScript SDKs](/platforms/javascript/guides/node/performance/instrumentation/custom-instrumentation/caches-module/)
-- [Laravel SDK](/platforms/php/guides/laravel/performance/instrumentation/custom-instrumentation/)
-- [Java SDK](/platforms/java/performance/instrumentation/custom-instrumentation/)
-- [Ruby SDK](/platforms/ruby/performance/instrumentation/custom-instrumentation/caches-module/)
-- [.NET SDK](/platforms/dotnet/performance/instrumentation/custom-instrumentation/)
-- [Symfony SDK](/platforms/php/guides/symfony/performance/instrumentation/custom-instrumentation/)
+- [Python SDK](/platforms/python/tracing/instrumentation/custom-instrumentation/caches-module/)
+- [JavaScript SDKs](/platforms/javascript/guides/node/tracing/instrumentation/custom-instrumentation/caches-module/)
+- [PHP SDK](/platforms/php/tracing/instrumentation/custom-instrumentation/caches-module/)
+- [Java SDK](/platforms/java/tracing/instrumentation/custom-instrumentation/caches-module/)
+- [Ruby SDK](/platforms/ruby/tracing/instrumentation/custom-instrumentation/caches-module/)
+- [.NET SDK](/platforms/dotnet/tracing/instrumentation/custom-instrumentation/caches-module/)
 
 To see what cache data can be set on spans, see the [Cache Module Developer Specification](https://develop.sentry.dev/sdk/performance/modules/caches/).

--- a/docs/product/insights/queue-monitoring/index.mdx
+++ b/docs/product/insights/queue-monitoring/index.mdx
@@ -38,8 +38,8 @@ Instructions for custom instrumentation in various languages are linked to below
 
 - [Python SDK](/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module/)
 - [JavaScript SDK](/platforms/javascript/guides/node/tracing/instrumentation/custom-instrumentation/queues-module/)
-- [Laravel SDK](/platforms/php/guides/laravel/tracing/instrumentation/custom-instrumentation/)
+- [PHP SDK](/platforms/php/tracing/instrumentation/custom-instrumentation/queues-module/)
 - [Java SDK](/platforms/java/tracing/instrumentation/custom-instrumentation/queues-module/)
 - [Ruby SDK](/platforms/ruby/tracing/instrumentation/custom-instrumentation/queues-module/)
 - [.NET SDK](/platforms/dotnet/tracing/instrumentation/custom-instrumentation/queues-module/)
-- [Symfony SDK](/platforms/php/guides/symfony/tracing/instrumentation/custom-instrumentation/)
+


### PR DESCRIPTION
The links to the manual instrumentation on https://docs.sentry.io/product/insights/caches/#instrumentation are wrong.