### PR TITLE
feat(macos): Add NSApplicationCrashOnExceptions to usage

### DIFF
--- a/docs/platforms/apple/guides/macos/features/index.mdx
+++ b/docs/platforms/apple/guides/macos/features/index.mdx
@@ -8,7 +8,7 @@ Sentry's Apple SDK for macOS enables automatic reporting of errors and exception
 
 <Note>
 
-For macOS, a simple [manual setup](/platforms/apple/guides/macos/usage/#capturing-uncaught-exceptions-in-macos) is required for the SDK to report uncaught exceptions.
+For macOS, a simple [manual setup](/platforms/apple/guides/macos/usage/#capturing-uncaught-exceptions) is required for the SDK to report uncaught exceptions.
 
 </Note>
 

--- a/platform-includes/capture-error/apple.mdx
+++ b/platform-includes/capture-error/apple.mdx
@@ -105,7 +105,7 @@ By default, macOS applications do not crash whenever an uncaught exception occur
 
 Alternatively, you can set the `NSApplicationCrashOnExceptions` flag:
 
-```swift {tabTitle:Swift}
+```swift {tabTitle:Swift} {4-4}
 import Sentry
 
 func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/platform-includes/capture-error/apple.mdx
+++ b/platform-includes/capture-error/apple.mdx
@@ -95,12 +95,28 @@ do {
 
 <PlatformSection supported={["apple.macos"]}>
 
-## Capturing Uncaught Exceptions in macOS
+## Capturing Uncaught Exceptions
 
 By default, macOS applications do not crash whenever an uncaught exception occurs. To enable this with Sentry:
 
 1. Open the application's `Info.plist` file
 2. Search for `Principal class` (the entry is expected to be `NSApplication`)
 3. Replace `NSApplication` with `SentryCrashExceptionApplication`
+
+Alternatively, you can set the `NSApplicationCrashOnExceptions` flag:
+
+```swift {tabTitle:Swift}
+import Sentry
+
+func applicationDidFinishLaunching(_ aNotification: Notification) {
+    UserDefaults.standard.register(defaults: ["NSApplicationCrashOnExceptions": true])
+
+    SentrySDK.start { options in
+        // ...
+    }
+
+    return true
+}
+```
 
 </PlatformSection>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add info on how to use `NSApplicationCrashOnExceptions` flag to enable handling of uncaught exceptions.

fixes https://github.com/getsentry/sentry-docs/issues/9313

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
