### PR TITLE
feat(node): Add documentation for `request` param in `httpIntegration` callbacks

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -45,12 +45,22 @@ If set to false, no breadcrumbs will be captured.
 
 ### `ignoreOutgoingRequests`
 
-_Type: `(url: string) => boolean`_
+_Type: `(url: string, request: RequestOptions) => boolean`_
 
-Allows you to define a method to filter out outgoing requests based on the URL. If the method returns `true`, the request will be ignored.
+Allows you to define a method to filter out outgoing requests based on the URL. If the method returns `true`, no spans or breadcrumbs will be captured for the outgoing request.
+
+The callback function receives two arguments:
+
+- `url`: The full URL of the outgoing request, including the protocol, host, port, path and query string. For example: `https://someService.com/users?name=John`.
+- `request`: An object of type `RequestOptions` containing the outgoing request's options. You can use this to filter on properties like the the request method or headers.
 
 ### `ignoreIncomingRequests`
 
-_Type: `(url: string) => boolean`_
+_Type: `(urlPath: string, request: IncomingMessage) => boolean`_
 
-Allows you to define a method to filter out incoming requests based on the URL. If the method returns `true`, the request will be ignored.
+Allows you to define a method to filter out incoming requests based on the URL. If the method returns `true`, no span or transaction will be captured for the incoming request.
+
+The callback function receives two arguments:
+
+- `urlPath`: The URL path of the incoming request, including the query string if available. For example: `/users?name=John`.
+- `request`: An object of type `IncomingMessage` containing the incoming request. You can use this to filter on properties like the the request method or headers.

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -51,8 +51,8 @@ Allows you to define a method to filter out outgoing requests based on the URL. 
 
 The callback function receives two arguments:
 
-- `url`: The full URL of the outgoing request, including the protocol, host, port, path and query string. For example: `https://someService.com/users?name=John`.
-- `request`: An object of type `RequestOptions` containing the outgoing request's options. You can use this to filter on properties like the the request method or headers.
+- `url`: The full URL of the outgoing request, including the protocol, host, port, path and query string. For example: `https://example.com/users?name=John`.
+- `request`: An object of type `RequestOptions` containing the outgoing request's options. You can use this to filter on properties like the request method or headers.
 
 ### `ignoreIncomingRequests`
 
@@ -63,4 +63,4 @@ Allows you to define a method to filter out incoming requests based on the URL. 
 The callback function receives two arguments:
 
 - `urlPath`: The URL path of the incoming request, including the query string if available. For example: `/users?name=John`.
-- `request`: An object of type `IncomingMessage` containing the incoming request. You can use this to filter on properties like the the request method or headers.
+- `request`: An object of type `IncomingMessage` containing the incoming request. You can use this to filter on properties like the request method or headers.


### PR DESCRIPTION
This PR adds documentation for the new `request` parameter passed as a second argument to the `ignoreOutgoingRequests` and `ignoreIncomingRequests` callbacks.

ref https://github.com/getsentry/sentry-javascript/issues/12913