### PR TITLE
fix: remove spans and on-demand from spend allocation docs

### DIFF
--- a/docs/pricing/quotas/spend-allocation.mdx
+++ b/docs/pricing/quotas/spend-allocation.mdx
@@ -11,7 +11,7 @@ This feature is only available to organizations with an Enterprise plan.
 
 </Note>
 
-Spend Allocation gives you the ability to prioritize your most important projects (or make sure that smaller projects don't get ignored). You can do this by setting aside a set amount of reserved volume (errors, spans, and attachments) to be used by those projects each month. This ensures that all the projects that are important to you are always monitored, regardless of the volume other projects consume.
+Spend Allocation gives you the ability to prioritize your most important projects (or make sure that smaller projects don't get ignored). You can do this by setting aside a set amount of reserved volume (errors and attachments) to be used by those projects each month. This ensures that all the projects that are important to you are always monitored, regardless of the volume other projects consume.
 
 <Note>
 
@@ -23,11 +23,11 @@ The per-project allocation you set is the **minimum** not the **maximum** number
 
 To get started with Spend Allocation, look at your total reserved volume and decide how much of it you'd like to allocate to the projects you want monitored. For example, if your total reserved volume is 1M events, and you have two important projects, you can decide to allocate 300K events to project 1, 250k events to project 2, and leave the remaining unallocated pool of 450k events for all other projects.
 
-For each project, you'll need to specify how much of your allocation goes to errors, spans, and attachments.
+For each project, you'll need to specify how much of your allocation goes to errors and attachments.
 
 <Note>
 
-With Spend Allocation, excess event consumption may come from your [on-demand budget](/pricing/#on-demand-capacity), <b>even if you still have reserved volume available.</b>
+With Spend Allocation, excess event consumption may come from your [pay-as-you-go budget](/pricing/), <b>even if you still have reserved volume available.</b>
 
 </Note>
 
@@ -45,7 +45,7 @@ To enable spend allocation for your Org, you have to have **Manager, Billing, or
 
 ![Empty spend allocation page](./img/spend-allocation-empty.png)
 
-2. Select the project, the event category (errors, spans, or attachments), and the allocation amount you'd like to set aside for that project. You can choose your allocations by volume or spend. Repeat the process for each event type you'd like to allocate to.
+2. Select the project, the event category (errors or attachments), and the allocation amount you'd like to set aside for that project. You can choose your allocations by volume or spend. Repeat the process for each event type you'd like to allocate to.
 
 ![Create spend allocation modal](./img/spend-allocation-creation.png)
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Spans does not have spend allocations support yet so removed this from the docs + corrected on-demand to PAYG.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)