### PR TITLE
fix(Apple): Show Apple profiling pages only on supported platforms

### DIFF
--- a/docs/platforms/apple/common/profiling/index.mdx
+++ b/docs/platforms/apple/common/profiling/index.mdx
@@ -2,6 +2,14 @@
 title: Set Up Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
+supported:
+  - apple
+  - apple.ios
+  - apple.macos
+notSupported:
+  - apple.tvos
+  - apple.watchos
+  - apple.visionos
 ---
 
 <PlatformContent includePath="profiling/index/preface" />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

On Apple platforms, we only [officially support Profiling for iOS and macOS](https://docs.sentry.io/product/explore/profiling/). This PR hides the Profiling page on the guides for the other platforms (tvOS, watchOS, visionOS).

Also created an issue to follow up with details on platform support, especially for hybrid (mobile) SDKs: https://github.com/getsentry/team-mobile/issues/191

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
