### PR TITLE
fix: Use /orgredirect/ instead of linking to sentry org

### DIFF
--- a/docs/concepts/migration/index.mdx
+++ b/docs/concepts/migration/index.mdx
@@ -69,7 +69,7 @@ Your data will be encrypted end-to-end during the relocation process. The only f
 
 ### 1. Sign up with a promo code
 
-Before you begin the relocation process, [sign up](https://sentry.io/signup/relocate/) for a new account on Sentry. If you already have a Sentry account, login and navigate to the [relocation landing page](https://sentry.sentry.io/relocation/). In either case, you should see a page like this:
+Before you begin the relocation process, [sign up](https://sentry.io/signup/relocate/) for a new account on Sentry. If you already have a Sentry account, login and navigate to the [relocation landing page](https://sentry.io/relocation/). In either case, you should see a page like this:
 
 ![Relocation getting started page](./img/relocation-landing-page.png)
 

--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -12,7 +12,7 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
 
 2. Go to your Azure Org's settings to make sure third-party access via OAuth is enabled.
 
-3. In [Sentry.io](https://sentry.sentry.io/settings/organization/), navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
+3. In [Sentry.io](https://sentry.io/orgredirect/organizations/:orgslug/settings/organization/), navigate to **Settings > Integrations > Azure DevOps** and click "Add Installation".
 
    ![Install Azure DevOps integration](./img/azure-devops-install.png)
 

--- a/docs/pricing/quotas/spike-protection.mdx
+++ b/docs/pricing/quotas/spike-protection.mdx
@@ -61,7 +61,7 @@ While Spike Protection notifications are turned off by default, you can turn the
 
 We recommend taking the following steps to manage your spikes:
 
-- Check to see which issues are [consuming your quota](https://sentry.sentry.io/stats/).
+- Check to see which issues are [consuming your quota](https://sentry.io/orgredirect/organizations/:orgslug/stats/).
 - Set [rate limits](/pricing/quotas/manage-event-stream-guide/#rate-limiting) on the DSN keys for the projects related to the spike.
 - Set up [metric alerts](/product/alerts/alert-types/#metric-alerts) for the number of events in a project.
 - If a specific release version has caused the spike, add the version identifier to the project's [inbound filters](/pricing/quotas/manage-event-stream-guide/#inbound-data-filters) to avoid accepting events from that release.

--- a/docs/product/explore/profiling/profile-details.mdx
+++ b/docs/product/explore/profiling/profile-details.mdx
@@ -4,7 +4,7 @@ sidebar_order: 50
 description: "Learn how to explore your profile data using the Profile Details page."
 ---
 
-Profiling data can be used to gain insight into what methods and lines of your code are slow. Each profile has a detailed view that gives information about what happened in your code while the profile was collected and offers different ways to explore your profile data. This information can be found by going to the [Profiling page](https://sentry.sentry.io/profiling/) in sentry.io, clicking on a “Transaction” and then selecting a “Profile ID.”
+Profiling data can be used to gain insight into what methods and lines of your code are slow. Each profile has a detailed view that gives information about what happened in your code while the profile was collected and offers different ways to explore your profile data. This information can be found by going to the [Profiling page](https://sentry.io/orgredirect/organizations/:orgslug/profiling/) in sentry.io, clicking on a “Transaction” and then selecting a “Profile ID.”
 
 ![Profiling details page](./img/profiling-details.png)
 

--- a/docs/product/issues/issue-details/replay-issues/index.mdx
+++ b/docs/product/issues/issue-details/replay-issues/index.mdx
@@ -21,7 +21,7 @@ While you can enable **session replay** with JavaScript SDK version 7.27.0, or h
 
 ## Detection Criteria
 
-"Slow clicks" (also called "dead clicks") are only detected on `<button>`, `<input>`, and `<a>` elements that don't lead to updates to the DOM or a page scroll within 7 seconds). When the user clicks on one of these elements 3 or more times within that 7 second time frame, it indicates frustration, and the SDK registers a "rage click". 
+"Slow clicks" (also called "dead clicks") are only detected on `<button>`, `<input>`, and `<a>` elements that don't lead to updates to the DOM or a page scroll within 7 seconds). When the user clicks on one of these elements 3 or more times within that 7 second time frame, it indicates frustration, and the SDK registers a "rage click".
 
 ### Why am I seeing too many or too few rage clicks?
 There might be fewer rage clicks than you expect if the user stopped waiting for the site to respond before the 7 second threshold and instead chose to to something else. This is why the rage click issues that you *do* see are so valuable, because the user that clicked at least 3 times and continued waiting at least 7 seconds for the site to respond is likely very frustrated.
@@ -44,7 +44,7 @@ Sentry.replayIntegration({
 
 To set up alerts and get notified when a rage click occurs, follow these steps:
 
-1. Create a new [Alert Rule](https://sentry.sentry.io/alerts/new/issue/) in Sentry.
+1. Create a new [Alert Rule](https://sentry.io/orgredirect/organizations/:orgslug/alerts/new/issue/) in Sentry.
 2. In the "Set conditions" section, set the "IF" filter to "The issue's category is equal to", then choose "Replay" from the dropdown.
 3. Add an optional filter if you like.
 5. Choose the action to be performed in the "THEN" dropdown.

--- a/docs/product/issues/issue-details/replay-issues/index.mdx
+++ b/docs/product/issues/issue-details/replay-issues/index.mdx
@@ -21,7 +21,7 @@ While you can enable **session replay** with JavaScript SDK version 7.27.0, or h
 
 ## Detection Criteria
 
-"Slow clicks" (also called "dead clicks") are only detected on `<button>`, `<input>`, and `<a>` elements that don't lead to updates to the DOM or a page scroll within 7 seconds). When the user clicks on one of these elements 3 or more times within that 7 second time frame, it indicates frustration, and the SDK registers a "rage click".
+"Slow clicks" (also called "dead clicks") are only detected on `<button>`, `<input>`, and `<a>` elements that don't lead to updates to the DOM or a page scroll within 7 seconds). When the user clicks on one of these elements 3 or more times within that 7 second time frame, it indicates frustration, and the SDK registers a "rage click". 
 
 ### Why am I seeing too many or too few rage clicks?
 There might be fewer rage clicks than you expect if the user stopped waiting for the site to respond before the 7 second threshold and instead chose to to something else. This is why the rage click issues that you *do* see are so valuable, because the user that clicked at least 3 times and continued waiting at least 7 seconds for the site to respond is likely very frustrated.
@@ -44,7 +44,7 @@ Sentry.replayIntegration({
 
 To set up alerts and get notified when a rage click occurs, follow these steps:
 
-1. Create a new [Alert Rule](https://sentry.io/orgredirect/organizations/:orgslug/alerts/new/issue/) in Sentry.
+1. Create a new [Alert Rule](https://sentry.sentry.io/alerts/new/issue/) in Sentry.
 2. In the "Set conditions" section, set the "IF" filter to "The issue's category is equal to", then choose "Replay" from the dropdown.
 3. Add an optional filter if you like.
 5. Choose the action to be performed in the "THEN" dropdown.

--- a/docs/security-legal-pii/security/ai-ml-policy.mdx
+++ b/docs/security-legal-pii/security/ai-ml-policy.mdx
@@ -16,7 +16,7 @@ Sentry is at a juncture where prior heuristics-based approaches cannot sustain t
 
 To train and validate models for grouping, notifications, and workflow improvements, Sentry will need access to additional service data to deliver a better user experience.
 
-You can update these settings within the new “Service Data Usage” section of the **Legal & Compliance** page in [Sentry](https://sentry.sentry.io/orgredirect/organizations/:orgslug/settings/legal/), which is located within the “Usage & Billing” Settings.
+You can update these settings within the new “Service Data Usage” section of the **Legal & Compliance** page in [Sentry](https://sentry.io/orgredirect/organizations/:orgslug/settings/legal/), which is located within the “Usage & Billing” Settings.
 
 ## Use of Non-Identifying Data
 


### PR DESCRIPTION
Test plan:
1. Login to an org that is not sentry.sentry.io
   Example: demo.sentry.io
3. Visit the links, you should be redirected to `demo.sentry.io/**`