### PR TITLE
fix: 404 links in develop-docs

### DIFF
--- a/develop-docs/sdk/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/event-payloads/contexts.mdx
@@ -277,7 +277,7 @@ system. For some well-known runtimes, Sentry will attempt to parse `name` and
 
 : _Optional_. An object that provides meta-data for Linux distributions. The values correspond to entries from the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#Options) configuration. Contains the following keys:
 
-- `name`: A stable name for each distribution. This maps to `ID` in `/etc/os-release` (examples: `ubuntu`, `rhel`, `alpine`; a full list of tested identifiers is available in the [Native SDK repository](https://github.com/getsentry/sentry-native/blob/master/tests/fixtures/os_releases/distribution_names.txt).
+- `name`: A stable name for each distribution. This maps to `ID` in `/etc/os-release` (examples: `ubuntu`, `rhel`, `alpine`; a full list of tested identifiers is available in the [Native SDK repository](https://github.com/getsentry/sentry-native/blob/feat/add_linux_distros_to_os_context/tests/fixtures/os_releases/distribution_names.txt).
 - `version`: _Optional_. Typically identifies at least the major release version number. This maps to `VERSION_ID` in `/etc/os-release`. Distributions with rolling releases only, will not provide a version.
 - `pretty_name`: _Optional_. Typically provides the full name, full version, and release alias. This maps to `PRETTY_NAME` in `/etc/os-release` (examples: `Ubuntu 22.04.4 LTS`, `Raspian GNU/Linux 10 (buster)`).
 


### PR DESCRIPTION
Fix a link in the os-context documentation that points to the Native SDK repo. The old link pointed to the `master`, but the respective [feature-branch](https://github.com/getsentry/sentry-native/pull/963) wasn't merged due to a change in plans :-)

Let's link to the branch until the feature is adapted across all repos (given that the contents linked to will not change).

cc: @stephanie-anderson, @kahest 