### PR TITLE
self-hosted: link to updated nginx configuration

### DIFF
--- a/develop-docs/self-hosted/reverse-proxy.mdx
+++ b/develop-docs/self-hosted/reverse-proxy.mdx
@@ -42,53 +42,7 @@ Endpoint for health checks is available on `/_health/` endpoint using HTTP proto
 
 We recommend installing NGINX since that's what we are using on [sentry.io](https://sentry.io/).
 
-```nginx
-error_log /var/log/nginx/error.log warn;
-
-# generated 2024-04-29, Mozilla Guideline v5.7, nginx 1.24.0, OpenSSL 3.0.13, modern configuration, no HSTS, no OCSP
-# https://ssl-config.mozilla.org/#server=nginx&version=1.24.0&config=modern&openssl=3.0.13&hsts=false&ocsp=false&guideline=5.7
-server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
-
-    ssl_certificate /etc/letsencrypt/live/sentry.yourcompany.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/sentry.yourcompany.com/privkey.pem;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-    ssl_session_tickets off;
-
-    ssl_dhparam /etc/letsencrypt/ffdhe2048.txt;
-
-    # modern configuration
-    ssl_protocols TLSv1.3;
-    ssl_prefer_server_ciphers off;
-
-    proxy_buffering on;
-    proxy_buffer_size    128k;
-    proxy_buffers        4 256k;
-
-    location / {
-        include proxy_params;
-        proxy_pass http://your-sentry-ip:9000;
-    }
-}
-
-server {
-    server_name sentry.yourcompany.com;
-    listen 80;
-    listen [::]:80;
-
-    root /var/www/html;
-    # Allow certbot to do http-01 challenges
-    location /.well-known/ {
-        try_files $uri =404;
-    }
-    # otherwise redirect to HTTPS
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-```
+[Here's](https://github.com/getsentry/self-hosted/blob/master/nginx/nginx.conf) an example configuration.
 
 To use NGINX with ACME server such as Let's Encrypt, refer to this [blog post by Nginx](https://www.nginx.com/blog/using-free-ssltls-certificates-from-lets-encrypt-with-nginx/).
 


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-docs/pull/10776.