### PR TITLE
Make sourcemaps upload less misleading with regards to dist and release

### DIFF
--- a/includes/sentry-cli-sourcemaps.mdx
+++ b/includes/sentry-cli-sourcemaps.mdx
@@ -60,7 +60,24 @@ sentry-cli sourcemaps upload /path/to/directory
 
 Open up Sentry and navigate to **Project Settings > Source Maps**. If you choose “Artifact Bundles” in the tabbed navigation, you'll see all the artifact bundles that have been successfully uploaded to Sentry.
 
+### 5. Deploy your Application
+
+If you're following this guide from your local machine, then you've successfully:
+
+1. Generated minified source and source map files (artifacts) by running your application's build process
+2. Injected Debug IDs into the artifacts you've just generated
+3. Uploaded those artifacts to Sentry with our upload command
+
+The last step is deploying a new version of your application using the generated artifacts you created in step one. **We strongly recommend that you integrate `sentry-cli` into your CI/CD Pipeline**, to ensure each subsequent deploy will automatically inject debug IDs into each artifact and upload them directly to Sentry.
+
 ### Optional Steps
+
+<Alert title="Warning">
+
+Only follow these optional steps if you have concluded that you absolutely need them.
+Using `release` and `dist` values will make your artifact upload more specific, but will also make the entire process less forgiving, which may lead to your code not being unminified by Sentry.
+
+</Alert>
 
 #### Associating `release` with Artifact Bundle
 
@@ -91,18 +108,19 @@ Either wait until the first event with the new release set in `Sentry.init` is s
 
 In addition to `release`, you can also add a `dist` to your uploaded artifacts, to set the distribution identifier for uploaded files. To do so, run the `sourcemaps upload` command with the additional `--dist` option.
 
+Provide `release` and `dist` properties in your SDK options.
+
+```javascript
+Sentry.init({
+  // These values must be identical to the release and dist names specified during upload
+  // with the `sentry-cli`.
+  release: "<release_name>",
+  release: "<dist_name>",
+});
+```
+
 The distribution identifier is used to distinguish between multiple files of the same name within a single release. `dist` can be used to disambiguate build or deployment variants.
 
 ```bash
 sentry-cli sourcemaps upload --release=<release_name> --dist=<dist_name> /path/to/directory
 ```
-
-### 5. Deploy your Application
-
-If you're following this guide from your local machine, then you've successfully:
-
-1. Generated minified source and source map files (artifacts) by running your application's build process
-2. Injected Debug IDs into the artifacts you've just generated
-3. Uploaded those artifacts to Sentry with our upload command
-
-The last step is deploying a new version of your application using the generated artifacts you created in step one. **We strongly recommend that you integrate `sentry-cli` into your CI/CD Pipeline**, to ensure each subsequent deploy will automatically inject debug IDs into each artifact and upload them directly to Sentry.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

I found a user on discord who was setting `dist` and `release` which was not good for them and is not a good idea in 95% of the cases so I wanted to move it down a bit so that user's are less likely to do so. Also add a note to only do this when being really sure about it.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+