### PR TITLE
feat(node): Add docs for skipping instrumentation

### DIFF
--- a/docs/platforms/javascript/common/install/esm.mdx
+++ b/docs/platforms/javascript/common/install/esm.mdx
@@ -48,3 +48,19 @@ NODE_OPTIONS="--import ./instrument.mjs" npm run start
 ```
 
 We do not support ESM in Node versions before 18.19.0.
+
+## Skipping instrumentation
+
+By default, all packages are wrapped under the hood by [import-in-the-middle](https://www.npmjs.com/package/import-in-the-middle). If you run into a problem with a package, you can skip instrumentation for it by configuring `registerEsmLoaderHooks` in your `Sentry.init()` config:
+
+```javascript {tabTitle:ESM} {filename: instrument.mjs}
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  registerEsmLoaderHooks: {
+    // Provide a list of package names to exclude from instrumentation
+    exclude: ["package-name"],
+  },
+});
+```


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/10802

For now I only added `exclude` docs there, I guess that is the most important one!

Need to also add this to late initialization, once the next release is out.