### PR TITLE
fix: Exclude code snippets with injects from formatting

### DIFF
--- a/src/remark-format-code.js
+++ b/src/remark-format-code.js
@@ -11,8 +11,14 @@ export default function remarkFormatCodeBlocks() {
       // skip code blocks with diff meta as they might have
       // broken syntax due to + and - characters
       // or with `onboardingOptions` as they need to have predictable line numbers
+      // or @inject statements as they ofeten lead to unnecessary line breaks
       .filter(
-        node => !(node.meta?.includes('diff') || node.meta?.includes('onboardingOptions'))
+        node =>
+          !(
+            node.meta?.includes('diff') ||
+            node.meta?.includes('onboardingOptions') ||
+            node.value?.includes('@inject packages')
+          )
       )
       .map(node => formatCode(node));
 

--- a/src/remark-format-code.js
+++ b/src/remark-format-code.js
@@ -11,7 +11,7 @@ export default function remarkFormatCodeBlocks() {
       // skip code blocks with diff meta as they might have
       // broken syntax due to + and - characters
       // or with `onboardingOptions` as they need to have predictable line numbers
-      // or @inject statements as they ofeten lead to unnecessary line breaks
+      // or `@inject` statements as they often lead to unnecessary line breaks
       .filter(
         node =>
           !(


### PR DESCRIPTION
Skip codesnippets that use a `@inject` value from formatting as they lead to unintended linebreaks

fixes [#10765](https://github.com/getsentry/sentry-docs/issues/10765)
