### PR TITLE
feat(python): Add disabled_integrations config option

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -4,7 +4,7 @@ description: "Learn more about how to configure the SDK. These options are set w
 sidebar_order: 1
 ---
 
-The Python SDK is configurable using a variety of options. Options are set when the SDK is first
+SDKs are configurable using a variety of options. The options are largely standardized among SDKs, but there are some differences to better accommodate platform peculiarities. Options are set when the SDK is first
 initialized.
 
 <PlatformContent includePath="configuration/config-intro" />

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -4,7 +4,7 @@ description: "Learn more about how to configure the SDK. These options are set w
 sidebar_order: 1
 ---
 
-SDKs are configurable using a variety of options. The options are largely standardized among SDKs, but there are some differences to better accommodate platform peculiarities. Options are set when the SDK is first
+The Python SDK is configurable using a variety of options. Options are set when the SDK is first
 initialized.
 
 <PlatformContent includePath="configuration/config-intro" />
@@ -205,9 +205,13 @@ Set this boolean to `False` to disable sending of client reports. Client reports
 
 List of integrations to enable in addition to [auto-enabling integrations](/platforms/python/integrations). This setting can be used to override the default config options for a specific auto-enabling integration or to add an integration that is not auto-enabled.
 
+<ConfigKey name="disabled-integrations" />
+
+List of integrations that will be disabled. This setting can be used to explicitly turn off specific [auto-enabling](/platforms/python/integrations/#available-integrations) or [default](/platforms/python/integrations/default-integrations/) integrations.
+
 <ConfigKey name="auto-enabling-integrations" />
 
-Configures whether [auto-enabling integrations](/platforms/python/integrations/default-integrations/) should be enabled. The default is `True`.
+Configures whether [auto-enabling integrations](/platforms/python/integrations/#available-integrations) should be enabled. The default is `True`.
 
 When set to `False`, no auto-enabling integrations will be enabled by default, even if the corresponding framework/library is detected.
 

--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -166,7 +166,7 @@ sentry_sdk.init(
 ```
 
 It's also possible to disable all integrations that are added automatically.
-There are two types of these:
+There are two types of automatically added integrations:
 
 * **Auto-enabling integrations** like `FlaskIntegration` are automatically added
   if the SDK detects you have the corresponding package (like Flask) installed.

--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -151,19 +151,34 @@ sentry_sdk.init(
 
 ### Disabling Integrations
 
-There are two types of integrations that are added automatically:
+To disable an integration, use the [`disabled_integrations`](/platforms/python/configuration/options/#disabled-integrations) config option:
 
+```python
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+sentry_sdk.init(
+    # Do not use the Flask integration even if Flask is installed.
+    disabled_integrations=[
+        FlaskIntegration(),
+    ],
+)
+```
+
+It's also possible to disable all integrations that are added automatically.
+There are two types of these:
+
+* **Auto-enabling integrations** like `FlaskIntegration` are automatically added
+  if the SDK detects you have the corresponding package (like Flask) installed.
+  This happens as long as the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option is set to
+  `True` (default).
 * **Default integrations** like `logging` or `excepthook` are always enabled,
   regardless of what packages you have installed, as long as the
   [`default_integrations`](/platforms/python/configuration/options/#default-integrations) option is `True` (default). They provide essential
   SDK functionality like error deduplication or event flushing at interpreter
   shutdown.
-* **Auto-enabling integrations** like `FlaskIntegration` are automatically added
-  if the SDK detects you have the corresponding package (like Flask) installed.
-  This happens as long as the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option is set to
-  `True` (default).
 
-To disable a specific auto-enabling integration, first disable all auto-enabling integrations by setting the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option to `False`. Then, explicitly enable all the auto-enabling integrations you wish to use by setting the [`integrations`](/platforms/python/configuration/options/#integrations) configuration option.
+To disable all auto-enabling integrations, you can use the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option:
 
 ```python
 import sentry_sdk
@@ -178,7 +193,7 @@ sentry_sdk.init(
 )
 ```
 
-To disable one of the [default integrations](default-integrations/),
+To disable all [default integrations](default-integrations/),
 set [`default_integrations`](/platforms/python/configuration/options/#default-integrations) to `False`. Note that this disables _all_ automatically
 added integrations, both default and auto-enabling. Any integrations you want to use
 then have to be manually specified via the [`integrations`](/platforms/python/configuration/options/#integrations) config option.

--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -165,12 +165,11 @@ sentry_sdk.init(
 )
 ```
 
-It's also possible to disable all integrations that are added automatically.
-There are two types of automatically added integrations:
+It's also possible to disable all automatically-added integrations. There are two types:
 
-* **Auto-enabling integrations** like `FlaskIntegration` are automatically added
-  if the SDK detects you have the corresponding package (like Flask) installed.
-  This happens as long as the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option is set to
+* **Auto-enabled integrations** like `FlaskIntegration` are automatically added
+  if the SDK detects that you have a corresponding package (like Flask) installed.
+  This happens when the [`auto_enabling_integrations`](/platforms/python/configuration/options/#auto-enabling-integrations) option is set to
   `True` (default).
 * **Default integrations** like `logging` or `excepthook` are always enabled,
   regardless of what packages you have installed, as long as the


### PR DESCRIPTION
## DESCRIBE YOUR PR
With https://github.com/getsentry/sentry-python/issues/3166 we're adding a new config option to the Python SDK. Most of our integrations are now auto-enabled, making it harder to opt out of single integrations. `disabled_integrations` solves this issue.

Preview:
- basic options page https://sentry-docs-git-ivana-pythondisabled-integrations.sentry.dev/platforms/python/configuration/options/#integration-configuration
- integrations page https://sentry-docs-git-ivana-pythondisabled-integrations.sentry.dev/platforms/python/integrations/#disabling-integrations

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): July 23
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)