### PR TITLE
ref(node): Show CJS and ESM import versions in dedicated SDK import code snippet

### DIFF
--- a/platform-includes/enriching-events/import/javascript.node.mdx
+++ b/platform-includes/enriching-events/import/javascript.node.mdx
@@ -1,3 +1,7 @@
-```javascript
+```javascript {tabTitle: CommonJS}
+const Sentry = require("@sentry/node");
+```
+
+```javascript {tabTitle: ESM}
 import * as Sentry from "@sentry/node";
 ```


### PR DESCRIPTION
We use this snippet in a bunch of places where we once tell users how they import their SDK on top of the page and all other snippets on the page are import-less. It came up in internal feedback about users being confused why this only shows import (ESM) syntax when most of our highler level guides have both options and default to CJS. So this PR adds a CJS version and defaults to it instead of ESM.