### PR TITLE
ref(react): Improve React Router instrumentation docs

### DIFF
--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -23,7 +23,7 @@ _(Available in version 7 and above)_
 
 To use React Router v6 with Sentry:
 
-Add `Sentry.reactRouterV6BrowserTracingIntegration` instead of the regular `Sentry.browserTracingIntegration` and provide the required react functions:
+Add `Sentry.reactRouterV6BrowserTracingIntegration` instead of the regular `Sentry.browserTracingIntegration` and provide the required React hooks and router functions:
 
     - `useEffect` hook from `react`
     - `useLocation` and `useNavigationType` hooks from `react-router-dom`

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -23,15 +23,15 @@ _(Available in version 7 and above)_
 
 To use React Router v6 with Sentry:
 
-Add `Sentry.reactRouterV6BrowserTracingIntegration` instead of the regular `Sentry.browserTracingIntegration` and provide the functions it needs to enable performance tracing:
+Add `Sentry.reactRouterV6BrowserTracingIntegration` instead of the regular `Sentry.browserTracingIntegration` and provide the required react functions:
 
     - `useEffect` hook from `react`
     - `useLocation` and `useNavigationType` hooks from `react-router-dom`
-    - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages.
+    - `createRoutesFromChildren` and `matchRoutes` functions from `react-router-dom` or `react-router` packages, depending on which package you're using.
 
 <Alert level="warning">
 
-Make sure `Sentry.reactRouterV6BrowserTracingIntegration` is initialized by your `Sentry.init` call, before you wrap `<Routes />` component or `useRoutes` hook. Otherwise, the routing instrumentation may not work properly.
+Make sure you call `Sentry.init`, **before** you wrap your `<Routes />` component or the `useRoutes` hook. Otherwise, the routing instrumentation may not work properly.
 
 </Alert>
 
@@ -43,8 +43,16 @@ If you choose to create your router instance with [`createBrowserRouter`](https:
 
 <SignInNote />
 
-```javascript
-import { createBrowserRouter } from "react-router-dom";
+```javascript {2-8, 15-21, 26-33}
+import React from "react";
+import {
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router-dom";
+
 import * as Sentry from "@sentry/react";
 
 Sentry.init({
@@ -65,7 +73,7 @@ const sentryCreateBrowserRouter =
   Sentry.wrapCreateBrowserRouter(createBrowserRouter);
 
 const router = sentryCreateBrowserRouter([
-  // ...
+  // your routes...
 ]);
 ```
 
@@ -81,7 +89,7 @@ If you're using the `<Routes />` component from `react-router-dom` to define you
 
 <SignInNote />
 
-```javascript
+```javascript {3-11, 18-24, 29, 33-35}
 import React from "react";
 import ReactDOM from "react-dom";
 import {
@@ -93,6 +101,7 @@ import {
   createRoutesFromChildren,
   matchRoutes,
 } from "react-router-dom";
+
 import * as Sentry from "@sentry/react";
 
 Sentry.init({
@@ -136,7 +145,8 @@ If you specify your route definitions as an object to the [`useRoutes` hook](htt
 
 <SignInNote />
 
-```javascript
+```javascript {2-10, 15-21, 26, 29-31}
+import React from "react";
 import {
   createRoutesFromChildren,
   matchRoutes,
@@ -144,14 +154,14 @@ import {
   useNavigationType,
   useRoutes,
 } from "react-router-dom";
+
 import { wrapUseRoutes } from "@sentry/react";
-import { useEffect } from "react";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.reactRouterV6BrowserTracingIntegration({
-      useEffect,
+      useEffect: React.useEffect,
       useLocation,
       useNavigationType,
       createRoutesFromChildren,
@@ -165,7 +175,7 @@ const useSentryRoutes = wrapUseRoutes(useRoutes);
 
 function App() {
   return useSentryRoutes([
-    // ...
+    // your routes...
   ]);
 }
 
@@ -191,7 +201,7 @@ We recommend you use the `withSentryRouting` higher order component to create a 
 
 <SignInNote />
 
-```javascript
+```javascript {1, 7, 14-16, 28-30}
 import {Route, Router, Switch } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 
@@ -206,7 +216,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.reactRouterV5BrowserTracingIntegration({ history }),
-    // or
+    // OR
     Sentry.reactRouterV4BrowserTracingIntegration({ history }),
   ],
 
@@ -232,7 +242,7 @@ If you don't want to wrap individual routes, you can still specify parameterized
 
 <SignInNote />
 
-```javascript
+```javascript {1,8-10,15-19}
 import { Route, Router, Switch, matchPath } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 
@@ -279,7 +289,7 @@ To use the router integration, import and set a custom routing instrumentation a
 
 <SignInNote />
 
-```javascript
+```javascript {18-23}
 import * as Router from "react-router";
 
 import * as Sentry from "@sentry/react";


### PR DESCRIPTION
While creating a small react router test app, I tried to apply our RR6 routing instrumentation and ran into every possible pitfall along the way. First, I imported the hooks from the wrong packages, then I missed that I need to apply `wrapCreateBrowserRouter` and ultimately (not my proudest moment lol) missed calling `sentryCreateBrowserRouter`.

Because IMO it's really easy to fall into at least one of these problems, I thought, our code snippet highlighting feature would work well here because the setup is (compared to other routing instrumentations) quite involved. So this PR adds some highlighting to the various RR version code snippets and slightly streamlines wording.

Example:
![image](https://github.com/user-attachments/assets/087d3c93-6c12-4954-87e7-af10583c0e1f)

Note: All snippet highlights assume that `Sentry.init` was already set up beforehand which I think is a fair assumption, given this is a guide on a sub-page.