### PR TITLE
fix: use correct regional ingest domain for ORG_INGEST_DOMAIN

### DIFF
--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -214,7 +214,7 @@ export async function fetchCodeKeywords(): Promise<CodeKeywords> {
         PROJECT_SLUG: project.projectSlug,
         ORG_ID: project.organizationId,
         ORG_SLUG: project.organizationSlug,
-        ORG_INGEST_DOMAIN: `o${project.organizationId}.ingest.sentry.io`,
+        ORG_INGEST_DOMAIN: parsedDsn.host ?? `o${project.organizationId}.ingest.sentry.io`,
         MINIDUMP_URL: formatMinidumpURL(parsedDsn),
         UNREAL_URL: formatUnrealEngineURL(parsedDsn),
         title: `${project.organizationSlug} / ${project.projectSlug}`,


### PR DESCRIPTION
## DESCRIBE YOUR PR
When selecting a project in the EU, the DSN selector on certain code blocks (for example, [Security Policy Reporting](https://docs.sentry.io/security-legal-pii/security/security-policy-reporting/)) suggests to use the US's `oXXX.ingest.sentry.io` domain, what is wrong:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/864448a0-c182-4662-894a-1f155b274c36">
This PR fixes it by using a correct regional host for the ORG_INGEST_DOMAIN.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
