### PR TITLE
docs(python): Update attachment docs for 2.x

### DIFF
--- a/platform-includes/enriching-events/add-attachment/python.mdx
+++ b/platform-includes/enriching-events/add-attachment/python.mdx
@@ -1,4 +1,4 @@
-Because attachments live on the [`Scope`](/platforms/python/enriching-events/scopes/), the SDK sends all attachments on a given `Scope` with every non-transaction event captured within the `Scope`. It's also possible to send an attachment with all events, including transactions by setting the `add_to_transactions` option to `True`.
+Because attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>, the SDK sends all attachments on a given `Scope` with every non-transaction event captured within the `Scope`. It's also possible to send an attachment with all events, including transactions by setting the `add_to_transactions` option to `True`.
 
 ```python
 # Add an attachment

--- a/platform-includes/enriching-events/add-attachment/python.mdx
+++ b/platform-includes/enriching-events/add-attachment/python.mdx
@@ -1,4 +1,4 @@
-Attachments live on the [`Scope`](/platforms/python/enriching-events/scopes/). The SDK sends all attachments on a given `Scope` with every non-transaction event captured within the `Scope`. Optionally, an attachment can be sent with all events, including transactions, when the attachment is added with the `add_to_transactions` option set to `True`.
+Because attachments live on the [`Scope`](/platforms/python/enriching-events/scopes/), the SDK sends all attachments on a given `Scope` with every non-transaction event captured within the `Scope`. It's also possible to send an attachment with all events, including transactions by setting the `add_to_transactions` option to `True`.
 
 ```python
 # Add an attachment

--- a/platform-includes/enriching-events/add-attachment/python.mdx
+++ b/platform-includes/enriching-events/add-attachment/python.mdx
@@ -1,28 +1,27 @@
-Attachments live on the `Scope` and will be sent with all events.
+Attachments live on the [`Scope`](/platforms/python/enriching-events/scopes/). The SDK sends all attachments on a given `Scope` with every non-transaction event captured within the `Scope`. Optionally, an attachment can be sent with all events, including transactions, when the attachment is added with the `add_to_transactions` option set to `True`.
 
 ```python
 # Add an attachment
-from sentry_sdk import configure_scope
+from sentry_sdk import Scope
 
-with configure_scope() as scope:
-    scope.add_attachment(bytes=b"Hello World!", filename="attachment.txt")
-    scope.add_attachment(path="/path/to/attachment/file.txt")
+# Scope.get_current_scope() or Scope.get_global_scope() can also be used.
+# Read about the different scopes on our Scope docs page.
+scope = Scope.get_isolation_scope()
+
+# Add attachment titled "attachment.txt" with content "Hello World!"
+scope.add_attachment(bytes=b"Hello World!", filename="attachment.txt")
+
+# Attach the file located at /path/to/attachment/file.txt
+scope.add_attachment(path="/path/to/attachment/file.txt")
+
+# This attachment will also be sent with transactions
+scope.add_attachment(path="/other/attachment.txt", add_to_transactions=True)
 ```
 
-An attachment has the following fields:
 
-`path`
-
-The path to the attachment file. The `filename` and `content_type` will be inferred if not explicitly provided when using this mode.
-
-`bytes`
-
-The content of the attachment as bytes.
-
-`filename`
-
-The filename is required if using `bytes` and will be displayed in [sentry.io](https://sentry.io).
-
-`content_type`
-
-The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
+The `add_attachment` method has the following parameters:
+  - `bytes`: Raw bytes of the attachment, or a function that returns the raw bytes. Must be provided unless a `path` to the attachment file is provided.
+  - `filename`: The filename of the attachment which we display in Sentry. Optional only if a `path` is provided, since we can infer the `filename` from the `path`.
+  - `path`: Path to a file to attach. Must be provided unless `bytes` is provided.
+  - `content_type`: The attachment's [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml). If not provided, it will be guessed from the attachment's file name provided via `filename` or inferred from `path`.
+  - `add_to_transactions`: Whether to add this attachment to transactions. Defaults to `False`.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Update attachment docs to reflect new API added in Python SDK 2.0.0, and introduce other general improvements to the page.

Depends on https://github.com/getsentry/sentry-python/pull/3342, which adds parameter documentation to the API Docs.

Fixes: #10844
Related: getsentry/sentry-python#3340

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)