### PR TITLE
fix(.NET): Removed deprecated `EnableTracing`

### DIFF
--- a/docs/platforms/dotnet/guides/aspnet/tracing/included-instrumentation.mdx
+++ b/docs/platforms/dotnet/guides/aspnet/tracing/included-instrumentation.mdx
@@ -42,9 +42,6 @@ namespace AspNetMvc
                 // When configuring for the first time, to see what the SDK is doing:
                 o.Debug = true;
 
-                // This option will enable Sentry's tracing features. You still need to start transactions and spans.
-                o.EnableTracing = true;
-
                 // Example sample rate for your transactions: captures 10% of transactions
                 o.TracesSampleRate = 0.1;
             });

--- a/docs/platforms/dotnet/guides/blazor-webassembly/index.mdx
+++ b/docs/platforms/dotnet/guides/blazor-webassembly/index.mdx
@@ -39,7 +39,7 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.UseSentry(options =>
 {
         options.Dsn = "___PUBLIC_DSN___";
-        options.EnableTracing = true;
+        options.TracesSampleRate = 0.1;
         // When configuring for the first time, to see what the SDK is doing:
         // options.Debug = true;
 

--- a/platform-includes/configuration/config-intro/dotnet.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.mdx
@@ -24,9 +24,6 @@ SentrySdk.Init(options =>
     // Enabling this option is recommended for client applications only. It ensures all threads use the same global scope.
     options.IsGlobalModeEnabled = false;
 
-    // This option will enable Sentry's tracing features. You still need to start transactions and spans.
-    options.EnableTracing = true;
-
     // Example sample rate for your transactions: captures 10% of transactions
     options.TracesSampleRate = 0.1;
 });

--- a/platform-includes/getting-started-config/dotnet.aspnet.mdx
+++ b/platform-includes/getting-started-config/dotnet.aspnet.mdx
@@ -25,9 +25,6 @@ namespace AspNetMvc
                 // Get ASP.NET integration
                 o.AddAspNet();
 
-                // This option will enable Sentry's tracing features. You still need to start transactions and spans.
-                o.EnableTracing = true;
-
                 // Example sample rate for your transactions: captures 10% of transactions
                 o.TracesSampleRate = 0.1;
             });

--- a/platform-includes/getting-started-config/dotnet.mdx
+++ b/platform-includes/getting-started-config/dotnet.mdx
@@ -24,9 +24,6 @@ SentrySdk.Init(options =>
     // Enabling this option is recommended for client applications only. It ensures all threads use the same global scope.
     options.IsGlobalModeEnabled = false;
 
-    // This option will enable Sentry's tracing features. You still need to start transactions and spans.
-    options.EnableTracing = true;
-
     // Example sample rate for your transactions: captures 10% of transactions
     options.TracesSampleRate = 0.1;
 });


### PR DESCRIPTION
The .NET SDK has deprecated `EnableTracing` from the options in favor of relying on `TracesSampleRate` [here](https://github.com/getsentry/sentry-dotnet/pull/3381).