### PR TITLE
fix(.NET): Added `BeforeSendTransaction` to common options

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -228,9 +228,9 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 <ConfigKey name="before-send-transaction">
 
-This function is called with an SDK-specific transaction object, and can return a modified transaction object, or `null` to skip reporting the transaction. This can be used, for instance, for manual PII stripping before sending.
+This function is called with an SDK-specific transaction object, and can return a modified transaction object, or `null` to skip reporting the transaction. This can be used, for instance, for manual PII-stripping before sending.
 
-By the time <PlatformIdentifier name="before-send-transaction" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
+By the time <PlatformIdentifier name="before-send-transaction" /> is executed, all scope data has already been applied to the event and further modification of the scope won't have any effect.
 
 </ConfigKey>
 

--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -226,6 +226,14 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 </ConfigKey>
 
+<ConfigKey name="before-send-transaction">
+
+This function is called with an SDK-specific transaction object, and can return a modified transaction object, or `null` to skip reporting the transaction. This can be used, for instance, for manual PII stripping before sending.
+
+By the time <PlatformIdentifier name="before-send-transaction" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
+
+</ConfigKey>
+
 ## Transport Options
 
 Transports are used to send events to Sentry. Transports can be customized to some degree to better support highly specific deployments.


### PR DESCRIPTION
Since it was missing. And it's common.