### PR TITLE
feat(js): add enableLongAnimationFrame to javascript docs

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -131,6 +131,15 @@ This option determines whether spans for long tasks automatically get created.
 
 The default is `true`.
 
+### enableLongAnimationFrame
+<Note>
+The `enableInp` option requires SDK [version 8.18.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.18.0) or higher.
+</Note>
+
+This option determines whether spans for long animation frames automatically get created. If both `enableLongAnimationFrame` and `enableLongTask` are enabled, Sentry will send long animation frames and fallback to long tasks if long animation frames are not supported by the browser.
+
+The default is `false`.
+
 ### enableInp
 
 <Note>

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -136,7 +136,7 @@ The default is `true`.
 The `enableLongAnimationFrame` option requires SDK [version 8.18.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.18.0) or higher.
 </Note>
 
-This option determines whether spans for long animation frames automatically get created. If both `enableLongAnimationFrame` and `enableLongTask` are enabled, Sentry will send long animation frames and fallback to long tasks if long animation frames are not supported by the browser.
+This option determines whether spans for long animation frames get created automatically. If both `enableLongAnimationFrame` and `enableLongTask` are enabled, Sentry will send long animation frames and fallback to long tasks (if long animation frames aren't supported by the browser).
 
 The default is `false`.
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -133,7 +133,7 @@ The default is `true`.
 
 ### enableLongAnimationFrame
 <Note>
-The `enableInp` option requires SDK [version 8.18.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.18.0) or higher.
+The `enableLongAnimationFrame` option requires SDK [version 8.18.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.18.0) or higher.
 </Note>
 
 This option determines whether spans for long animation frames automatically get created. If both `enableLongAnimationFrame` and `enableLongTask` are enabled, Sentry will send long animation frames and fallback to long tasks if long animation frames are not supported by the browser.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adds the `enableLongAnimationFrame` option to the js docs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
