### PR TITLE
chore(flagpole): Remove Instructions to add flag to `flagpole.flagpole_only_features`

### DIFF
--- a/develop-docs/application/feature-flags/flagpole.mdx
+++ b/develop-docs/application/feature-flags/flagpole.mdx
@@ -160,7 +160,7 @@ To see the latest context properties available, check out the repo-specific cont
 
 ## Rolling out a new Flagpole feature
 
-Creating a new Flagpole Feature is currently a 3 step process:
+Creating a new Flagpole Feature is currently a 2 step process:
 1. Register a new feature in Sentry's `temporary.py` file or GetSentry's `features.py` file with the Flagpole strategy:
 ```python
 features.add(
@@ -192,9 +192,6 @@ file should contain a top-level `options` object containing your feature object,
 and a `flagpole.flagpole_only_features` list option containing the name of the
 feature you want to test, without the `feature.` prefix:
 ```yaml
-options:
-  flagpole.flagpole_only_features: ['organizations:is_sentry']
-
   'feature.organizations:is_sentry':
     created_at: '2024-06-01T00:00:00.000000'
     enabled: false
@@ -208,10 +205,6 @@ options:
       name: is_sentry
       rollout: 100
 ```
-
-_Note:_ The `flagpole_only_features` option will only be required while
-Flagpole is actively being rolled out.
-
 
 You can push your feature option to your local devserver using the following `getsentry` CLI command:
 

--- a/develop-docs/application/feature-flags/flagpole.mdx
+++ b/develop-docs/application/feature-flags/flagpole.mdx
@@ -176,8 +176,6 @@ features.add(
 feature.<feature_scope>:<feature_name>
 ```
 
-3. Add the feature name to the `flagpole.flagpole_only_features` list in sentry-options-automator's default [`app.yaml`](https://github.com/getsentry/sentry-options-automator/blob/483737d45dbc68253e926c3f860b5ae33111697b/options/default/app.yaml#L219) file, omitting the `feature.` prefix.
-
 Once the option change is deployed, the feature checks will immediately be active in all environments and regions.
 
 _Note:_ The feature config should not be merged until the registration commit in step 1 has been fully deployed to all target environments. This is because Options Automator will fail to push options to any environments missing the option registration.


### PR DESCRIPTION
Because all flags are Flagpole only features and we don't have to add them to `flagpole.flagpole_only_features`, we should delete this from the docs.