### PR TITLE
build: Add build command for dev docs on vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:developer-docs": "yarn enforce-redirects && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn dev",
     "build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
     "build": "yarn enforce-redirects && prisma generate && next build",
+    "vercel:build:developer-docs": "rm -r app/changelog && yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
     "start": "next start",
     "migrate:dev": "dotenv -e .env.development -- yarn prisma migrate reset",
     "lint": "next lint",


### PR DESCRIPTION
We're doing this so that we can gradually migrate away from calling `rm -r app/changelog` in vercel.