### PR TITLE
feat(python): Use new scope API

### DIFF
--- a/develop-docs/sdk/hub_and_scope_refactoring.mdx
+++ b/develop-docs/sdk/hub_and_scope_refactoring.mdx
@@ -183,11 +183,11 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 		</tr>
 		<tr>
 			<td rowspan="2" style={{verticalAlign: "middle"}}><code>with configure_scope() as scope</code></td>
-			<td><code>scope = Scope.get_isolation_scope()</code></td>
+			<td><code>scope = get_isolation_scope()</code></td>
 			<td>Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).</td>
 		</tr>
 		<tr>
-			<td><code>scope = Scope.get_current_scope()</code></td>
+			<td><code>scope = get_current_scope()</code></td>
 			<td>Should affect the whole span or a part of code isolated via a forked current scope with <code>new_scope</code>.</td>
 		</tr>
 		<tr>

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -118,18 +118,18 @@ a task, and so on) or just a specific part of the code.
 If you want your scope change to affect a smaller unit of code such as a span, use the current scope.
 
 ```python diff
-- with configure_scope() as scope:
+- with sentry_sdk.configure_scope() as scope:
 -     # do something with scope
-+ scope = get_current_scope()
++ scope = sentry_sdk.get_current_scope()
 + # do something with scope
 ```
 
 If you want your scope change to affect the whole transaction, use the isolation scope.
 
 ```python diff
-- with configure_scope() as scope:
+- with sentry_sdk.configure_scope() as scope:
 -     # do something with scope
-+ scope = get_isolation_scope()
++ scope = sentry_sdk.get_isolation_scope()
 + # do something with scope
 ```
 
@@ -154,18 +154,18 @@ Scope pushing translates to forking a scope in `2.0`. You either want to fork th
 If you only want to apply something to a smaller, localized part of the code, fork the current scope with `new_scope()`:
 
 ```python diff
-- with push_scope() as scope:
+- with sentry_sdk.push_scope() as scope:
 -     # do something
-+ with new_scope() as scope:
++ with sentry_sdk.new_scope() as scope:
 +     # do something
 ```
 
 If you're wrapping a whole request-response cycle or a whole execution of a task, fork the isolation scope:
 
 ```python diff
-- with push_scope() as scope:
+- with sentry_sdk.push_scope() as scope:
 -     # do something
-+ with isolation_scope() as scope:
++ with sentry_sdk.isolation_scope() as scope:
 +     # do something
 ```
 

--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -67,7 +67,7 @@ The old APIs will continue to work in 2.0, but we recommend migrating to their n
 
 ### Activating a Custom Hub
 
-If you were using a custom hub to isolate event data, we recommend using a custom isolation scope instead. To activate the custom isolation scope, you will need to explicitly pass the isolation scope to the `use_isolation_scope`, which creates a context manager that activates the scope. Here is an example of how to change your code to make it work:
+If you were using a custom hub to isolate event data, we recommend using a custom isolation scope instead. To activate the custom isolation scope, you will need to explicitly pass the isolation scope to `use_isolation_scope`, which creates a context manager that activates the scope. Here is an example of how to change your code to make it work:
 
 ```python diff
   import sentry_sdk
@@ -106,7 +106,7 @@ If you previously used `with sentry_sdk.Hub(sentry_sdk.Hub.current)` to clone th
 
 `sentry_sdk.isolation_scope` is a context manager that creates a new isolation scope by forking the current isolation scope. The forked isolation scope is activated during the context manager's lifetime, providing a similar level of isolation within the context manager as the previous `Hub`-based approach.
 
-Note that using `sentry_sdk.isolation_scope()` is equivalent to `sentry_sdk.scope.use_isolation_scope(sentry_sdk.Scope.get_isolation_scope().fork())`.
+Note that using `sentry_sdk.isolation_scope()` is equivalent to `sentry_sdk.scope.use_isolation_scope(sentry_sdk.get_isolation_scope().fork())`.
 
 ### Scope Configuring
 
@@ -120,7 +120,7 @@ If you want your scope change to affect a smaller unit of code such as a span, u
 ```python diff
 - with configure_scope() as scope:
 -     # do something with scope
-+ scope = Scope.get_current_scope()
++ scope = get_current_scope()
 + # do something with scope
 ```
 
@@ -129,7 +129,7 @@ If you want your scope change to affect the whole transaction, use the isolation
 ```python diff
 - with configure_scope() as scope:
 -     # do something with scope
-+ scope = Scope.get_isolation_scope()
++ scope = get_isolation_scope()
 + # do something with scope
 ```
 
@@ -143,7 +143,7 @@ transaction = sentry_sdk.transaction(...)
 - with sentry_sdk.configure_scope() as scope:
 -     scope.set_transaction_name("new-transaction-name")
 
-+ scope = sentry_sdk.Scope.get_current_scope()
++ scope = sentry_sdk.get_current_scope()
 + scope.set_transaction_name("new-transaction-name")
 ```
 

--- a/platform-includes/enriching-events/scopes/configure-scope/python.mdx
+++ b/platform-includes/enriching-events/scopes/configure-scope/python.mdx
@@ -1,8 +1,7 @@
 ```python
 import sentry_sdk
-from sentry_sdk.scope import Scope
 
-scope = Scope.get_current_scope()
+scope = sentry_sdk.get_current_scope()
 scope.set_tag("my-tag", "my value")
 scope.user = {"id": 42, "email": "john.doe@example.com"}
 


### PR DESCRIPTION

## DESCRIBE YOUR PR
In https://github.com/getsentry/sentry-python/pull/3357, we'll be adding new top-level API to interact with scopes, so that:
- `sentry_sdk.Scope.get_current_scope()` becomes `sentry_sdk.get_current_scope()`
- `sentry_sdk.Scope.get_isolation_scope()` becomes `sentry_sdk.get_isolation_scope()`
- `sentry_sdk.Scope.get_global_scope()` becomes `sentry_sdk.get_global_scope()`


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: Aug 2
- [ ] None: Not urgent, can wait up to 1 week+


## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
