### PR TITLE
feat(javascript): Add documentation for injecting Html `<meta>` tags

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -169,7 +169,7 @@ In this example, we create a new transaction that is attached to the trace speci
 
 </PlatformCategorySection>
 
-### Inject Tracing Information to Outgoing Requests
+### Inject Tracing Information into Outgoing Requests
 
 For distributed tracing to work, the two headers that you extracted and stored in the active root span, `sentry-trace` and `baggage`, must be added to outgoing HTTP requests.
 
@@ -204,6 +204,45 @@ fetch("https://example.com", {
 In this example, tracing information is propagated to the project running at `https://example.com`. If this project uses a Sentry SDK, it will extract and save the tracing information for later use.
 
 The two services are now connected with your custom distributed tracing implementation.
+
+<PlatformCategorySection supported={['server', 'serverless']}>
+
+### Injecting Tracing Information into HTML
+
+If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information into the HTML that's initially served to the client.
+When the frontend SDK is initialized, it will automatically pick up the tracing information from the HTML and continue the trace.
+Note that your browser SDK needs to register `browserTracingIntegration` for this to work.
+
+```javascript
+function renderHtml() {
+  const metaTagValues = Sentry.getMetaTagValues(
+    Sentry.getCurrentScope(),
+    Sentry.getCurrentSpan(),
+    Sentry.getClient()
+  );
+
+  return `
+    <html>
+      <head>
+        <meta name="sentry-trace" content="${metaTagValues["sentry-trace"]}">
+        <meta name="baggage" content="${metaTagValues.baggage}">
+      </head>
+      <body>
+        <!-- Your HTML content -->
+      </body>
+    </html>
+  `;
+}
+```
+
+<Note>
+
+This setup is only required if you have a custom SSR or HTML page generation setup.
+If you're using a meta framework like Next.js, the respective Sentry SDK already takes care of setting the tracing information automatically.
+
+</Note>
+
+</PlatformCategorySection>
 
 ### Starting a New Trace
 

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -209,16 +209,13 @@ The two services are now connected with your custom distributed tracing implemen
 
 ### Injecting Tracing Information into HTML
 
-If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces.
-You can do this by injecting your server's tracing information `<meta>` tags into the HTML that's initially served to the client.
-When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace.
-Note that your browser SDK needs to register `browserTracingIntegration` for this to work.
+If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information `<meta>` tags into the HTML that's initially served to the client. When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace. Note, that your browser SDK needs to register `browserTracingIntegration` for this to work.
 
 ```javascript
 function renderHtml() {
   const metaTagValues = Sentry.getMetaTagValues(
     Sentry.getCurrentScope(),
-    Sentry.getCurrentSpan(),
+    Sentry.getActiveSpan(),
     Sentry.getClient()
   );
 

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -209,8 +209,9 @@ The two services are now connected with your custom distributed tracing implemen
 
 ### Injecting Tracing Information into HTML
 
-If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information into the HTML that's initially served to the client.
-When the frontend SDK is initialized, it will automatically pick up the tracing information from the HTML and continue the trace.
+If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces.
+You can do this by injecting your server's tracing information `<meta>` tags into the HTML that's initially served to the client.
+When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace.
 Note that your browser SDK needs to register `browserTracingIntegration` for this to work.
 
 ```javascript

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -209,7 +209,7 @@ The two services are now connected with your custom distributed tracing implemen
 
 ### Injecting Tracing Information into HTML
 
-If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information `<meta>` tags into the HTML that's initially served to the client. When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace. Note, that your browser SDK needs to register `browserTracingIntegration` for this to work.
+If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information as `<meta>` tags into the HTML that's initially served to the client. When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace. Note, that your browser SDK needs to register `browserTracingIntegration` for this to work.
 
 ```javascript
 function renderHtml() {

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -205,7 +205,7 @@ In this example, tracing information is propagated to the project running at `ht
 
 The two services are now connected with your custom distributed tracing implementation.
 
-<PlatformCategorySection supported={['server', 'serverless']}>
+<PlatformCategorySection notSupported={['browser']}>
 
 ### Injecting Tracing Information into HTML
 

--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -209,15 +209,30 @@ The two services are now connected with your custom distributed tracing implemen
 
 ### Injecting Tracing Information into HTML
 
-If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information as `<meta>` tags into the HTML that's initially served to the client. When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace. Note, that your browser SDK needs to register `browserTracingIntegration` for this to work.
+If you're server-side rendering HTML and you use a Sentry SDK in your browser application, you can connect the backend and frontend traces by injecting your server's tracing information as `<meta>` tags into the HTML that's initially served to the browser. When the frontend SDK is initialized, it will automatically pick up the tracing information from the `<meta>` tags and continue the trace. Note, that your browser SDK needs to register `browserTracingIntegration` for this to work.
 
-```javascript
+The easiest and recommended way to do this is to use the `Sentry.getTraceMetaTags()`:
+
+```javascript {5} {filename:index.js}
 function renderHtml() {
-  const metaTagValues = Sentry.getMetaTagValues(
-    Sentry.getCurrentScope(),
-    Sentry.getActiveSpan(),
-    Sentry.getClient()
-  );
+  return `
+    <html>
+      <head>
+        ${Sentry.getTraceMetaTags()}
+      </head>
+      <body>
+        <!-- Your HTML content -->
+      </body>
+    </html>
+  `;
+}
+```
+
+Alternatively, if you need more control over how meta tags are generated, you can use `Sentry.getTraceData()` to get only the meta tag values and generate the meta tags yourself:
+
+```javascript {2, 7-8} {filename:index.js}
+function renderHtml() {
+  const metaTagValues = Sentry.getTraceData();
 
   return `
     <html>
@@ -233,13 +248,6 @@ function renderHtml() {
 }
 ```
 
-<Note>
-
-This setup is only required if you have a custom SSR or HTML page generation setup.
-If you're using a meta framework like Next.js, the respective Sentry SDK already takes care of setting the tracing information automatically.
-
-</Note>
-
 </PlatformCategorySection>
 
 ### Starting a New Trace
@@ -251,7 +259,7 @@ This means that spans or errors collected by the SDK during this new trace will 
 
 To start a new trace that remains valid throughout the duration of a callback, use `startNewTrace`:
 
-```javascript {2-6}
+```javascript {2-9}
 myButton.addEventListener("click", async () => {
   Sentry.startNewTrace(() => {
     Sentry.startSpan(


### PR DESCRIPTION
To be merged after https://github.com/getsentry/sentry-javascript/pull/13201 is released.

This PR adds documentation for 
- `getTraceData` introduced in https://github.com/getsentry/sentry-javascript/pull/13134
- `getTraceMetaTags` introduced in https://github.com/getsentry/sentry-javascript/pull/13201

which both give users the ability to propagate backend -> frontend traces via `<meta>` Html tags.

closes https://github.com/getsentry/sentry-docs/issues/7671



