### PR TITLE
fix: Update Slack Sentry Docs

### DIFF
--- a/docs/organization/integrations/notification-incidents/slack/index.mdx
+++ b/docs/organization/integrations/notification-incidents/slack/index.mdx
@@ -54,7 +54,7 @@ Set up an alert rule by going to **Alerts** and clicking "Create Alert". From he
 
 #### Issue Alerts
 
-In [issue alerts](/product/alerts/alert-types/#issue-alerts), select "Send a Slack notification" in the actions dropdown and then select your workspace and channel. You can optionally select any tags to include in the alert as well as other text in the "notes" section. Mentions are supported in the "notes" section - to @ a user, include their user id like `@<USER_ID>`.
+In [issue alerts](/product/alerts/alert-types/#issue-alerts), select "Send a Slack notification" in the actions dropdown and then select your workspace and channel. You can optionally select any tags to include in the alert as well as other text in the "notes" section. Mentions are supported in the "notes" section - to @ a user, include their user id like `<@USER_ID>`.
 
 ![Slack issue alert action](./img/slack_issue_alert.png)
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
While going through the sentry slack docs, noticed that `@<USER_ID>` should actually be `<@USER_ID>`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
