### PR TITLE
chore(feedback): Update info on self hosted flags and support

### DIFF
--- a/develop-docs/application/feedback-architecture.mdx
+++ b/develop-docs/application/feedback-architecture.mdx
@@ -4,10 +4,12 @@ title: User Feedback Architecture
 
 **The goal of this doc is to give engineers an in-depth understanding of User Feedback's backend.**
 It will:
+
 1. describe the relevant ingestion pipelines, data models, and functions.
 2. explain the difference between “feedback”, “user reports”, and “crash reports”, and why we built and need to support each.
 
 ## Creation sources
+
 When broken down, there are **5** ways to create feedback in our system 😵‍💫.
 (But 4 of them, related to user reports, are quite similar!) A good reference is the
 `FeedbackCreationSource(Enum)` in [create_feedback.py](https://github.com/getsentry/sentry/blob/2b642e149c79b251e1c2f4339fc73d656347d74e/src/sentry/feedback/usecases/create_feedback.py#L33-L33).
@@ -26,10 +28,12 @@ release, url, etc.
 `CRASH_REPORT_EMBED_FORM`: The [crash report modal](https://docs.sentry.io/product/user-feedback/#crash-report-modal)
 
 ## How feedback is stored
+
 On the backend, each feedback submission in Sentry's UI is **an un-grouped issue occurrence**,
 saved via the [issues platform](https://develop.sentry.dev/issue-platform/).
 The entrypoint is [**`create_feedback_issue()`**](https://github.com/getsentry/sentry/blob/2b642e149c79b251e1c2f4339fc73d656347d74e/src/sentry/feedback/usecases/create_feedback.py#L184-L184),
 which
+
 1. filters feedback with empty or spam messages. Note **anonymous feedbacks are not filtered** (missing name and/or email).
 2. sends to issues pipeline in a standardized format. To make sure it is never grouped, we use a random UUID for the fingerprint.
 
@@ -63,7 +67,8 @@ event[”contexts”][”feedback”] = {
 - This doc refers to the payload format (`event` in the pseudo-code above) as a “**feedback event”**.
 - The feedback [widget](https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-widget), which is installed by default, sends these envelopes.
 - API: for SDK v8.0.0+, we use the `sendFeedback` function.
-<br/><br/>
+  <br />
+  <br />
 
 ### Ingest diagram
 
@@ -73,13 +78,15 @@ event[”contexts”][”feedback”] = {
 In Relay v24.5.1, we migrated feedback to its own kafka topic + consumer,
 `ingest-feedback-events`. This decouples risk and ownership from errors
 (`ingest-events`).
-<br/>
+
+<br />
 
 ### Attachments
 
 We only use attachments for the widget’s screenshot feature, which allows users
 to submit **at most 1 screenshot per feedback**. Attachments are another [item type](https://develop.sentry.dev/sdk/envelopes/#attachment)
 in an envelope.
+
 - SDK v8.0.0+, Relay v24.5.1+: Sends the feedback and attachment items in the same envelope.
 - SDK < v8, all Relay versions: Sends a separate envelope for each item.
 
@@ -100,12 +107,15 @@ user_report = {
 	"comments": <optional str>,
 }
 ```
-<br/>
+
+<br />
 
 ### Ingest diagram
+
 ![](https://mermaid.ink/svg/pako:eNp9VNtq3DAQ_ZVBEHAgy77vQ6EkDfShF7KhUKzFaOXZtYgtqbpsCUn-vaOxvWmT3frF4-HozJkzIz8J7VoUK7EPyndwfyOtTDFvx8812hQeS0qmgN6F1KBtvTM21VIsc8Sw2CG2W6UfpNiMQB1U7JoJPrhW9YS9Lkm44yT8MPh7ghMdvf6uuctWJ-NsrG_nCBYQsgVjIeAOQ8AwlYrqgE1RMVYrSaAndmZokmuO0iZdqBIek42JMeNJHlgsPsCzFJ9vAQ9kAfjgNMaIrRTPZ9jfZpnjbMlj2xcXgPaAvfMI3njsjWWA8r7-6XKAj973Rqviw2bWNZ8oau6wVzwhDhihSIc3uqqN3WNMC5WS0t1AjcTNJZOPAAa_t3BWNc4ZlG2BRwojIk7yZjHfv63vi5A3-3GG_NTJ9wvzX2VsYgTfq7RzYSjZkz4ziWs0LVAeMFS0hZMhTutMrJZmSmvIlrzi-JilSxGTC1hXX-fwcnMCSG18KiuypvuhBl4Pm7eqrtbltbym2T10jrrg02MDpafJLm4yLrNvST87e2oVvYtpHzDWFZk2xVKMerjcLOVXxmDIG95aFs2K_qUUV4LUD8q0dO2fpAWQInU4EHZFYW_2XZJC2hcCqpzc-tFqsUoh45UYhd4YRXd1EKud6iNlsTVU68v4I-H_ycsfwTWaqg)
 [diagram source](https://mermaid.live/edit#pako:eNp9VNtq3DAQ_ZVBEHAgy77vQ6EkDfShF7KhUKzFaOXZtYgtqbpsCUn-vaOxvWmT3frF4-HozJkzIz8J7VoUK7EPyndwfyOtTDFvx8812hQeS0qmgN6F1KBtvTM21VIsc8Sw2CG2W6UfpNiMQB1U7JoJPrhW9YS9Lkm44yT8MPh7ghMdvf6uuctWJ-NsrG_nCBYQsgVjIeAOQ8AwlYrqgE1RMVYrSaAndmZokmuO0iZdqBIek42JMeNJHlgsPsCzFJ9vAQ9kAfjgNMaIrRTPZ9jfZpnjbMlj2xcXgPaAvfMI3njsjWWA8r7-6XKAj973Rqviw2bWNZ8oau6wVzwhDhihSIc3uqqN3WNMC5WS0t1AjcTNJZOPAAa_t3BWNc4ZlG2BRwojIk7yZjHfv63vi5A3-3GG_NTJ9wvzX2VsYgTfq7RzYSjZkz4ziWs0LVAeMFS0hZMhTutMrJZmSmvIlrzi-JilSxGTC1hXX-fwcnMCSG18KiuypvuhBl4Pm7eqrtbltbym2T10jrrg02MDpafJLm4yLrNvST87e2oVvYtpHzDWFZk2xVKMerjcLOVXxmDIG95aFs2K_qUUV4LUD8q0dO2fpAWQInU4EHZFYW_2XZJC2hcCqpzc-tFqsUoh45UYhd4YRXd1EKud6iNlsTVU68v4I-H_ycsfwTWaqg)
-<br/>
+
+<br />
 
 ### Shimming to feedback
 
@@ -125,7 +135,7 @@ Simplified diagram:
 ![](https://mermaid.ink/svg/pako:eNpdULtuwzAM_BWBUwIkzm4UXZq1QIF0MwNDlllLTfSoKAUokvx7ZasZWi06kMfj8a6g_EjQwhRl0OJ9j06Ux9rYPvn-g2gcpDqJ7fZZ3BCapkG4CXZ5kN3qMH-7l7NRJ-0z0_qIDtPSfAx8ZYqGWNCFXOLkI83zIfSffqirKu4QKEYfWQTPSYToFTGLmQVH8fRXbZfDKBPxIlXoUyTuVghvvxihOqnSi5X_B9XdsAFL0UozlgSucw0habLFZFvg2Uw6IaC7F6LMyR--nYI2xUwbqB72Rpbk7KNIoyk3vtZIl2TvP_9DeX4)
 [diagram source](https://mermaid.live/edit#pako:eNpdULtuwzAM_BWBUwIkzm4UXZq1QIF0MwNDlllLTfSoKAUokvx7ZasZWi06kMfj8a6g_EjQwhRl0OJ9j06Ux9rYPvn-g2gcpDqJ7fZZ3BCapkG4CXZ5kN3qMH-7l7NRJ-0z0_qIDtPSfAx8ZYqGWNCFXOLkI83zIfSffqirKu4QKEYfWQTPSYToFTGLmQVH8fRXbZfDKBPxIlXoUyTuVghvvxihOqnSi5X_B9XdsAFL0UozlgSucw0habLFZFvg2Uw6IaC7F6LMyR--nYI2xUwbqB72Rpbk7KNIoyk3vtZIl2TvP_9DeX4)
 
-<br/>
+<br />
 
 ### Envelopes
 
@@ -134,7 +144,8 @@ User reports are also sent to Relay in [envelope format](https://develop.sentry.
 item header will read `"user_report"`.**
 
 The SDK function that sends these is `captureUserFeedback`.
-<br/>
+
+<br />
 
 ### Django endpoint
 
@@ -143,7 +154,8 @@ to Sentry, with
 `/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/`.
 
 See [https://docs.sentry.io/api/projects/submit-user-feedback/](https://docs.sentry.io/api/projects/submit-user-feedback/).
-<br/>
+
+<br />
 
 ### Crash reports
 
@@ -154,8 +166,9 @@ data is the same as user reports.
 You can install it as an [SDK integration](https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal).
 
 We implement it as a Django view:
-* URL: `/api/embed/error-page/`
-* Python Class: `error_page_embed.ErrorPageEmbedView`
+
+- URL: `/api/embed/error-page/`
+- Python Class: `error_page_embed.ErrorPageEmbedView`
 
 Crash reports are also shimmed to feedback. The pipeline is the same as the
 `/user-feedback` endpoint.
@@ -186,12 +199,23 @@ filters, **skipping emails if:**
 
 ---
 
-## Feature flags for self-hosted
-To disable all UI features and/or ingestion, set these to false:
-* `organizations:user-feedback-ui`
-* `organizations:feedback-visible`
-* `organizations:user-feedback-ingest`
+## Self-hosted support
 
-To disable auto spam filters, set these to false:
-* `organizations:user-feedback-spam-filter-ingest`
-* `organizations:user-feedback-spam-filter-actions`
+This feature is available if you enable the following feature flags:
+
+- `organizations:user-feedback-ingest`
+- `organizations:user-feedback-ui`
+- `organizations:user-feedback-replay-clip`
+
+Auto-registered flags for issue platform (you won't be able to grep these in the sentry repo, but you need to enable them too):
+
+- `organizations:feedback-ingest`
+- `organizations:feedback-visible`
+- `organizations:feedback-post-process-group`
+
+---
+
+Auto/AI spam filters are currently unsupported. Make sure `organizations:user-feedback-spam-filter-ingest` is false.
+
+You may optionally enable `organizations:user-feedback-spam-filter-actions` to
+manually mark feedback as spam.

--- a/develop-docs/application/feedback-architecture.mdx
+++ b/develop-docs/application/feedback-architecture.mdx
@@ -201,7 +201,7 @@ filters, **skipping emails if:**
 
 ## Self-hosted support
 
-This feature is available if you enable the following feature flags:
+This feature is available if you enable the following feature flags.
 
 - `organizations:user-feedback-ingest`
 - `organizations:user-feedback-ui`
@@ -213,7 +213,9 @@ Auto-registered flags for issue platform (you won't be able to grep these in the
 - `organizations:feedback-visible`
 - `organizations:feedback-post-process-group`
 
-User feedback will be available on a feature-complete version of Sentry by v24.8.0.
+You need to have v24.4.2 or higher in order to use the full functionality of UF
+(ex: screenshots). Lower versions may have limited functionality. Also note
+feedback is only available in feature-complete Sentry, _not_ errors-only.
 
 ---
 

--- a/develop-docs/application/feedback-architecture.mdx
+++ b/develop-docs/application/feedback-architecture.mdx
@@ -213,6 +213,8 @@ Auto-registered flags for issue platform (you won't be able to grep these in the
 - `organizations:feedback-visible`
 - `organizations:feedback-post-process-group`
 
+User feedback will be available on a feature-complete version of Sentry by v24.8.0.
+
 ---
 
 Auto/AI spam filters are currently unsupported. Make sure `organizations:user-feedback-spam-filter-ingest` is false.


### PR DESCRIPTION
Update after verifying https://github.com/getsentry/self-hosted/pull/3193 works. Even after that's merged, this helps people who are on outdated branches