### PR TITLE
Renamed Apple errorSampleRate option to onErrorSampleRate

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -46,7 +46,7 @@ SentrySDK.start(configureOptions: { options in
   options.debug = true
 
   // Currently under experimental options:
-  options.experimental.sessionReplay.errorSampleRate = 1.0
+  options.experimental.sessionReplay.onErrorSampleRate = 1.0
   options.experimental.sessionReplay.sessionSampleRate = 1.0
 })
 ```
@@ -57,7 +57,7 @@ SentrySDK.start(configureOptions: { options in
 
 While you're testing, we recommend that you set `sessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `errorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `onErrorSampleRate` set to `1.0`.
 
 ## Sampling
 
@@ -65,12 +65,12 @@ Sampling allows you to control how much of your website's traffic will result in
 
 1. `sessionSampleRate` - The sample rate for
    replays that begin recording immediately and last the entirety of the user's session.
-2. `errorSampleRate` - The sample rate for
+2. `onErrorSampleRate` - The sample rate for
    replays that are recorded when an error happens. This type of replay will record
    up to a minute of events prior to the error and continue recording until the session
    ends.
 
-Sampling begins as soon as a session starts. `sessionSampleRate` is evaluated first. If it's sampled, the replay recording will begin. Otherwise, `errorSampleRate` is evaluated and if it's sampled, the integration will begin buffering the replay and will only upload it to Sentry if an error occurs. The remainder of the replay will behave similarly to a whole-session replay.
+Sampling begins as soon as a session starts. `sessionSampleRate` is evaluated first. If it's sampled, the replay recording will begin. Otherwise, `onErrorSampleRate` is evaluated and if it's sampled, the integration will begin buffering the replay and will only upload it to Sentry if an error occurs. The remainder of the replay will behave similarly to a whole-session replay.
 
 ## Privacy
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Renamed Apple `errorSampleRate` option to `onErrorSampleRate` in order to keep consistency with other SDKs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


This should wait for https://github.com/getsentry/sentry-cocoa/pull/4218