### PR TITLE
feat: Improve algolia search results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ public/page-data
 tsconfig.tsbuildinfo
 
 public/mdx-images/*
+
+# yalc
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toolbar": "^1.0.4",
     "@radix-ui/themes": "^2.0.3",
-    "@sentry-internal/global-search": "^1.0.0",
+    "@sentry-internal/global-search": "^1.1.0",
     "@sentry/nextjs": "8.20.0",
     "@types/mdx": "^2.0.9",
     "algoliasearch": "^4.23.3",

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -41,9 +41,7 @@ export function DocPage({
 
   const pathname = serverContext().path.join('/');
 
-  const searchPlatforms = [currentPlatform?.name, currentGuide?.platform].filter(
-    isTruthy
-  );
+  const searchPlatforms = [currentPlatform?.name, currentGuide?.name].filter(isTruthy);
 
   const leafNode = nodeForPath(rootNode, path);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,10 +2639,10 @@
     "@sentry/types" "8.20.0"
     "@sentry/utils" "8.20.0"
 
-"@sentry-internal/global-search@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@sentry-internal/global-search/-/global-search-1.0.0.tgz"
-  integrity sha512-u4UUwxinDhUJ0kA4xGGQTr3QGJAWh7GRdFls9ys8coV7WjPNYt91MHfOWVdFzgeU6f4aO7RKE8uxSb/fkZiagQ==
+"@sentry-internal/global-search@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/global-search/-/global-search-1.1.0.tgz#108f11149a2516ea96b8a544fb4f8a0c046288e2"
+  integrity sha512-PL2oGOxr0vdnfPwVczs7VuV8bKhypbi1yN13gAT42AxgaSk3joBWzlEzLo7SXK53zBTWVyM2SAyBDzHWXEerJg==
   dependencies:
     "@types/react" ">=16"
     "@types/react-dom" ">=16"


### PR DESCRIPTION
- Applies custom search settings from `sentry-global-search`
- Tags algolia records with their respective sdk and framework names for improving path bias (when searching from react guide, results will prioritise records within the guide)
- Updates search settings for algolia client to include framework name for improving search results

relates to [#10592](https://github.com/getsentry/sentry-docs/issues/10592)