### PR TITLE
docs(development/testing) Docs about temporary test models

### DIFF
--- a/develop-docs/development/testing.mdx
+++ b/develop-docs/development/testing.mdx
@@ -139,7 +139,7 @@ developers yelling at you later for slowing down CI.
 
 If you have a use case where you need to test some behavior of a model (e.g. custom field, or custom lookup), those kind of test shouldn't be tied to the existent models since they can change at any time.
 
-In the codebase, for this case, we have a special Django app `fixtures` which will not generate migrations, and models created as a part of this app won't end up in the production, but will only exist during the duration of the test. We have [multiple examples](https://github.com/getsentry/sentry/blob/774af7dc287a1f9199ce855953c9e9184d8bb9c5/tests/sentry/db/models/fields/test_jsonfield.py) of this in our codebase.
+In the codebase, for this case, we have a special Django app `fixtures` which will not generate migrations, and models created as a part of this app won't end up in the production, but will only exist during the duration of the test. There are [multiple examples](https://github.com/getsentry/sentry/blob/774af7dc287a1f9199ce855953c9e9184d8bb9c5/tests/sentry/db/models/fields/test_jsonfield.py) of this in our codebase.
 
 To create test models, modify the `Meta` of your test model, and assign the model to the `fixtures` app:
 

--- a/develop-docs/development/testing.mdx
+++ b/develop-docs/development/testing.mdx
@@ -139,7 +139,7 @@ developers yelling at you later for slowing down CI.
 
 If you have a use case where you need to test some behavior of a model (e.g. custom field, or custom lookup), those kind of test shouldn't be tied to the existent models since they can change at any time.
 
-In the codebase, for this case, we have a special Django app `fixtures` which will not generate migrations, and models created as a part of this app won't end up in the production, but will only exist during the duration of the test.
+In the codebase, for this case, we have a special Django app `fixtures` which will not generate migrations, and models created as a part of this app won't end up in the production, but will only exist during the duration of the test. We have [multiple examples](https://github.com/getsentry/sentry/blob/774af7dc287a1f9199ce855953c9e9184d8bb9c5/tests/sentry/db/models/fields/test_jsonfield.py) of this in our codebase.
 
 To create test models, modify the `Meta` of your test model, and assign the model to the `fixtures` app:
 

--- a/develop-docs/development/testing.mdx
+++ b/develop-docs/development/testing.mdx
@@ -135,6 +135,23 @@ If the test runner detects that you used the Django `TestCase` class but you did
 end up needing it, it will yell at you. This protects you against other
 developers yelling at you later for slowing down CI.
 
+### Database tests on temporary models
+
+If you have a use case where you need to test some behavior of a model (e.g. custom field, or custom lookup), those kind of test shouldn't be tied to the existent models since they can change at any time.
+
+In the codebase, for this case, we have a special Django app `fixtures` which will not generate migrations, and models created as a part of this app won't end up in the production, but will only exist during the duration of the test.
+
+To create test models, modify the `Meta` of your test model, and assign the model to the `fixtures` app:
+
+```python
+class MyTestModel(models.Model):
+    ... # some fields
+    
+    class Meta:
+        app_label = "fixtures"
+        
+```
+
 ### External Services
 
 Use the `responses` library to add stub responses for an outbound API requests your code is making.


### PR DESCRIPTION
Added a section about temporary models which can be used when developer needs to test a behaviour of a feature that is not tied to a specific model (e.g. custom lookup, or custom field).

I have struggled with this, and I wish I had a docs where I could have looked this up, when I needed it.