### PR TITLE
fix(.NET): Updated supported framework version

### DIFF
--- a/docs/platforms/dotnet/guides/wpf/index.mdx
+++ b/docs/platforms/dotnet/guides/wpf/index.mdx
@@ -3,7 +3,7 @@ title: WPF
 description: "Learn more about how Sentry's .NET SDK works with Windows Presentation Foundation (WPF) applications."
 ---
 
-Sentry's .NET SDK works with Windows Presentation Foundation applications through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry). It works with WPF apps running on .NET Framework 4.6.1, .NET Core 3.0 or higher.
+Sentry's .NET SDK works with Windows Presentation Foundation applications through the [Sentry NuGet package](https://www.nuget.org/packages/Sentry). It works with WPF apps running on .NET Framework 4.6.2, .NET Core 3.0 or higher.
 
 ## Features
 

--- a/docs/platforms/dotnet/index.mdx
+++ b/docs/platforms/dotnet/index.mdx
@@ -14,7 +14,7 @@ If you don't already have an account and Sentry project established, head over t
 
 </Note>
 
-This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with the latest .NET and .NET Core platforms, as well as .NET Standard 2.0 and .NET Framework 4.6.1 or newer. You can use it with applications written in C#, VB.NET, F#, and other .NET programming languages. For older versions, such as .NET Framework 3.5, you may continue to use our <Link rel={`nofollow`} to={`/platforms/dotnet/legacy-sdk/`}>legacy SDK</Link>, until further notice. Check out related guides in the dropdown menu on the left.
+This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with the latest .NET and .NET Core platforms, as well as .NET Standard 2.0 and .NET Framework 4.6.2 or newer. You can use it with applications written in C#, VB.NET, F#, and other .NET programming languages. For older versions, such as .NET Framework 3.5, you may continue to use our <Link rel={`nofollow`} to={`/platforms/dotnet/legacy-sdk/`}>legacy SDK</Link>, until further notice. Check out related guides in the dropdown menu on the left.
 
 ## Features
 

--- a/platform-includes/getting-started-primer/dotnet.mdx
+++ b/platform-includes/getting-started-primer/dotnet.mdx
@@ -1,6 +1,6 @@
 The Sentry .NET SDK supports all recent versions of the .NET platform, and integrates well with a variety of popular frameworks and packages in the ecosystem. You can use it with applications written in C#, VB.NET, F#, and other .NET programming languages. It gives developers helpful hints for where and why an error or performance issue might have occurred.
 
-This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with the latest .NET and .NET Core platforms, as well as .NET Standard 2.0 and .NET Framework 4.6.1 or newer. For older versions, such as .NET Framework 3.5, you may continue to use our <Link rel={`nofollow`} to={`/platforms/dotnet/legacy-sdk/`}>legacy SDK</Link>, until further notice.
+This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with the latest .NET and .NET Core platforms, as well as .NET Standard 2.0 and .NET Framework 4.6.2 or newer. For older versions, such as .NET Framework 3.5, you may continue to use our <Link rel={`nofollow`} to={`/platforms/dotnet/legacy-sdk/`}>legacy SDK</Link>, until further notice.
 
 **Features:**
 


### PR DESCRIPTION
This got bumped to from `4.6.1` to `4.6.2`