### PR TITLE
add 'runWithClient' example to http-integration.mdx

### DIFF
--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -4,6 +4,24 @@ description: "Learn more about the Sentry HTTP integration for the Dart SDK."
 sidebar_order: 2
 ---
 
+## Using the `runWithClient` function (recommended)
+
+With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
+
+### Usage
+
+```dart {filename:http_client.dart}{tabTitle: commonMain}
+import 'package:http/http.dart';
+import 'package:sentry/sentry.dart';
+
+final sentryHttpClient = SentryHttpClient();
+
+await runWithClient(() async {
+  var response = await get(Uri.https('www.example.com', ''));
+  print(response.body);
+}, () => sentryHttpClient);
+```
+
 ## Reporting Bad HTTP Requests as Errors
 
 The `SentryHttpClient` can also catch exceptions that may occur during requests — for example [`SocketException`](https://api.dart.dev/stable/2.13.4/dart-io/SocketException-class.html).
@@ -91,20 +109,4 @@ var uriResponse = await client.post('https://example.com/whatsit/create',
 }
 
 await transaction.finish(status: SpanStatus.ok());
-```
-
-## Using the `runWithClient` function
-
-With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
-
-```dart
-import 'package:http/http.dart';
-import 'package:sentry/sentry.dart';
-
-final sentryHttpClient = SentryHttpClient();
-
-await runWithClient(() async {
-  var response = await get(Uri.https('www.example.com', ''));
-  print(response.body);
-}, () => sentryHttpClient);
 ```

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -6,7 +6,7 @@ sidebar_order: 2
 
 ## Using the `runWithClient` function
 
-With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
+With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html), you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
 
 ### Usage
 

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -4,20 +4,33 @@ description: "Learn more about the Sentry HTTP integration for the Dart SDK."
 sidebar_order: 2
 ---
 
-## Using the `runWithClient` function (recommended)
+## Using the `runWithClient` function
 
 With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
 
 ### Usage
 
-```dart {filename:http_client.dart}{tabTitle: commonMain}
+```dart {filename:http_client.dart}{tabTitle: default}
+import 'package:sentry/sentry.dart';
+
+final client = SentryHttpClient();
+
+try {
+  final response = await client.get(Uri.https('www.example.com', ''));
+  print(response.body);
+} finally {
+  client.close();
+}
+```
+
+```dart {filename:http_client.dart}{tabTitle: runWithClient}
 import 'package:http/http.dart';
 import 'package:sentry/sentry.dart';
 
 final sentryHttpClient = SentryHttpClient();
 
 await runWithClient(() async {
-  var response = await get(Uri.https('www.example.com', ''));
+  final response = await get(Uri.https('www.example.com', ''));
   print(response.body);
 }, () => sentryHttpClient);
 ```
@@ -31,11 +44,11 @@ import 'package:sentry/sentry.dart';
 
 var client = SentryHttpClient();
 try {
-var uriResponse = await client.post('https://example.com/whatsit/create',
-     body: {'name': 'doodle', 'color': 'blue'});
- print(await client.get(uriResponse.bodyFields['uri']));
+  var uriResponse = await client.post('https://example.com/whatsit/create',
+    body: {'name': 'doodle', 'color': 'blue'});
+  print(await client.get(uriResponse.bodyFields['uri']));
 } finally {
- client.close();
+  client.close();
 }
 ```
 
@@ -72,11 +85,11 @@ var client = SentryHttpClient(
 );
 
 try {
-var uriResponse = await client.post('https://example.com/whatsit/create',
-     body: {'name': 'doodle', 'color': 'blue'});
- print(await client.get(uriResponse.bodyFields['uri']));
+  var uriResponse = await client.post('https://example.com/whatsit/create',
+    body: {'name': 'doodle', 'color': 'blue'});
+  print(await client.get(uriResponse.bodyFields['uri']));
 } finally {
- client.close();
+  client.close();
 }
 ```
 
@@ -101,11 +114,11 @@ final transaction = Sentry.startTransaction(
 
 var client = SentryHttpClient();
 try {
-var uriResponse = await client.post('https://example.com/whatsit/create',
-     body: {'name': 'doodle', 'color': 'blue'});
- print(await client.get(uriResponse.bodyFields['uri']));
+  var uriResponse = await client.post('https://example.com/whatsit/create',
+    body: {'name': 'doodle', 'color': 'blue'});
+  print(await client.get(uriResponse.bodyFields['uri']));
 } finally {
- client.close();
+  client.close();
 }
 
 await transaction.finish(status: SpanStatus.ok());

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -92,3 +92,19 @@ var uriResponse = await client.post('https://example.com/whatsit/create',
 
 await transaction.finish(status: SpanStatus.ok());
 ```
+
+## Using the `runWithClient` function
+
+With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
+
+```dart
+import 'package:http/http.dart';
+import 'package:sentry/sentry.dart';
+
+final sentryHttpClient = SentryHttpClient();
+
+await runWithClient(() async {
+  var response = await get(Uri.https('www.example.com', ''));
+  print(response.body);
+}, () => sentryHttpClient);
+```

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -6,7 +6,7 @@ sidebar_order: 2
 
 ## Using the `SentryHttpClient` function
 
-Depending on your use case, you can either use the `SentryHttpClient` directly and call its methods (see the `default` tab), or you can use the [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) function (see the `runWithClient` tab). With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html), a fresh instance of the `client` is used and the other instances are not affected. It also runs in a separate [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html), allowing you to override the functionality of the existing [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html).
+You can use the `SentryHttpClient` and call its methods directly, or you can use it with the [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) function. If you need to use a fresh instance of the `client` (so that other instances are not affected) or to run in a separate [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html), which allows you to override the functionality of the existing [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html), then use the `runWithClient` function (see the `runWithClient` tab). Otherwise, just use `SentryHttpClient` directly and call its methods (see the `default` tab).
 
 ### Usage
 

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -4,9 +4,9 @@ description: "Learn more about the Sentry HTTP integration for the Dart SDK."
 sidebar_order: 2
 ---
 
-## Using the `runWithClient` function
+## Using the `SentryHttpClient` function
 
-With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html), you can define a global `SentryHttpClient` and run it in its own [`Zone`](https://api.dart.dev/stable/3.4.4/dart-async/Zone-class.html).
+Depending on your use case, you can either use the `SentryHttpClient` directly and call its methods (see the `default` tab), or you can use the [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html) function (see the `runWithClient` tab). With [`runWithClient`](https://pub.dev/documentation/http/latest/http/runWithClient.html), a fresh instance of the `client` is used and the other instances are not affected. It also runs in a separate [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html), allowing you to override the functionality of the existing [`Zone`](https://api.dart.dev/stable/3.5.0/dart-async/Zone-class.html).
 
 ### Usage
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Based on the issue in the sentry-dart repo [1192](https://github.com/getsentry/sentry-dart/issues/1192), I added an example for using the [runWithClient](https://pub.dev/documentation/http/latest/http/runWithClient.html) function.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
