### PR TITLE
chore(Apple): Update docs to use @import Sentry;

### DIFF
--- a/platform-includes/performance/connect-errors-spans/apple.mdx
+++ b/platform-includes/performance/connect-errors-spans/apple.mdx
@@ -17,7 +17,7 @@ do {
 ```
 
 ```objc {tabTitle:Objective-C}
-#import <Sentry/Sentry.h>
+@import Sentry;
 
 id<SentrySpan> transaction = [SentrySDK startTransactionWithName:@"Transaction Name" operation:@"operation" bindToScope:YES];
 NSError * error;

--- a/platform-includes/performance/custom-sampling-context/apple.mdx
+++ b/platform-includes/performance/custom-sampling-context/apple.mdx
@@ -19,7 +19,7 @@ transaction.context.spanDescription = "search results"
 ```
 
 ```objc {tabTitle:Objective-C}
-#import <Sentry/Sentry.h>
+@import Sentry;
 
 // The following data will take part in the sampling decision
 NSDictionary<NSString *, id> *samplingContext = @{

--- a/platform-includes/performance/traces-sample-rate/apple.mdx
+++ b/platform-includes/performance/traces-sample-rate/apple.mdx
@@ -7,7 +7,7 @@ SentrySDK.start { options in
 ```
 
 ```objc {tabTitle:Objective-C}
-#import <Sentry/Sentry.h>
+@import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
     options.tracesSampleRate = @0.2;

--- a/platform-includes/performance/traces-sampler-as-sampler/apple.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/apple.mdx
@@ -37,7 +37,7 @@ SentrySDK.start { configureOptions in
 ```
 
 ```objc {tabTitle:Objective-C}
-#import <Sentry/Sentry.h>
+@import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions * _Nonnull options) {
     options.dsn = @"___PUBLIC_DSN___";


### PR DESCRIPTION
## DESCRIBE YOUR PR
As we move away from Objective-C and create more features in Swift, these new features will only be available for use in other Objective-C projects if the developer imports the Sentry module instead of the umbrella header.

So I changed the Objective-c code snippets to reflect this.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)