### PR TITLE
docs(cli): Document `send-event` format

### DIFF
--- a/docs/cli/send-event.mdx
+++ b/docs/cli/send-event.mdx
@@ -70,7 +70,7 @@ sentry-cli send-event -m "a failure" -t task:create-user
 
 ## Stored Events
 
-As of version `1.71`, the `send-event` command can accept an optional argument that specifies a path to the stored JSON representation of an event. When used, it will load the file, validate the event and send it to Sentry.
+As of version `1.71`, the `send-event` command can accept an optional argument that specifies a path to the stored JSON representation of an [event payload](https://develop.sentry.dev/sdk/event-payloads/). When used, it will load the file, validate the event and send it to Sentry.
 
 ```bash
 sentry-cli send-event ./events/20211029150006.json


### PR DESCRIPTION
Link to the [Event Payloads](https://develop.sentry.dev/sdk/event-payloads/) page from the `send-event` command page, so that users know what format their event should follow.

Closes https://github.com/getsentry/sentry-docs/issues/9538

## IS YOUR CHANGE URGENT?  

Not urgent


## PRE-MERGE CHECKLIST


- [x] Checked Vercel preview for correctness, including links
- [ ] ~~PR was reviewed and approved by any necessary SMEs (subject matter experts)~~
   - Skipping, because this is a very simple change
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

