### PR TITLE
chore(reprocessed-events): Change wording to clarify applicability

### DIFF
--- a/includes/only-error-issues-note.mdx
+++ b/includes/only-error-issues-note.mdx
@@ -1,5 +1,5 @@
 <Note>
 
-This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/). Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/)) do not support this feature.
+This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/) with debug information files, excluding source maps. Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/)) do not support this feature.
 
 </Note>


### PR DESCRIPTION
Change that reprocessed issues feature is only available for issues with debug information files, excluding source maps