### PR TITLE
fix(apple): Fix default integration name

### DIFF
--- a/docs/platforms/apple/common/integrations/default.mdx
+++ b/docs/platforms/apple/common/integrations/default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Default Integrations
-description: "Learn more about the SentryCrashIntegration, SentryAutoBreadcrumbTrackingIntegration, SentryAutoSessionTrackingIntegration, and SentryOutOfMemoryTrackingIntegration, which are enabled by default."
+description: "Learn more about the SentryCrashIntegration, SentryAutoBreadcrumbTrackingIntegration, SentryAutoSessionTrackingIntegration, and SentryWatchdogTerminationTrackingIntegration, which are enabled by default."
 ---
 
 All of Sentry’s SDKs provide integrations, which extend functionality of the SDK.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Change SentryOutOfMemoryTrackingIntegration to
SentryWatchdogTerminationTrackingIntegration as it was renamed over one year ago.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

