### PR TITLE
add ignoreRoutes for SentryNavigatorObserver in sentry-dart

### DIFF
--- a/docs/platforms/flutter/integrations/routing-instrumentation.mdx
+++ b/docs/platforms/flutter/integrations/routing-instrumentation.mdx
@@ -261,7 +261,7 @@ SentryNavigatorObserver(
 
 ### Ignore Routes
 
-Set `ignoreRoutes` if you want routes to be ignored and not pushed to Sentry servers.
+Set `ignoreRoutes` if you want routes to be ignored and not processed by the navigation observer.
 Empty by default.
 
 ```dart

--- a/docs/platforms/flutter/integrations/routing-instrumentation.mdx
+++ b/docs/platforms/flutter/integrations/routing-instrumentation.mdx
@@ -109,8 +109,6 @@ There are two ways to set up TTID:
 
 The default setup is enabled automatically, but only provides an approximation of TTID. To set a more accurate TTID, manually wrap the desired widget with `SentryDisplayWidget`, as shown below:
 
-
-
 ```dart
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -258,6 +256,20 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 /// Only track navigation breadcrumbs
 SentryNavigatorObserver(
   enableAutoTransactions: false,
+)
+```
+
+### Ignore Routes
+
+Set `ignoreRoutes` if you want routes to be ignored and not pushed to Sentry servers.
+Empty by default.
+
+```dart
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Ignore matching routes
+SentryNavigatorObserver(
+  ignoreRoutes: ["/ignoreThisRoute", "/my/ignored/route"],
 )
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Add ignoreRoutes for SentryNavigatorObserver in sentry-dart
[2218](https://github.com/getsentry/sentry-dart/pull/2218)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
