### PR TITLE
fix(changelog): Add dotenv-cli as dev dependency

### DIFF
--- a/apps/changelog/package.json
+++ b/apps/changelog/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^18.3.0",
     "@types/rss": "^0.0.32",
     "autoprefixer": "^10.4.17",
+    "dotenv-cli": "^7.4.2",
     "eslint": "^8",
     "eslint-config-next": "^15.0.0-canary.83",
     "postcss": "^8.4.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,6 +4778,16 @@ dotenv-cli@^7.4.1:
     dotenv-expand "^10.0.0"
     minimist "^1.2.6"
 
+dotenv-cli@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-7.4.2.tgz#c158a818de08e1fbc51d310f628cbace9075b734"
+  integrity sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    dotenv "^16.3.0"
+    dotenv-expand "^10.0.0"
+    minimist "^1.2.6"
+
 dotenv-expand@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz"


### PR DESCRIPTION
`yarn migrate:dev` fails because `dotenv` is not available, `dotenv-cli` as a dev dependency makes it work.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

