### PR TITLE
fix: Fix too large build output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,9 @@ const nextConfig = {
 
   experimental: {
     serverComponentsExternalPackages: ['rehype-preset-minify'],
+    outputFileTracingExcludes: {
+      '/**/*': ['./.git/**/*', './apps/**/*'],
+    },
   },
 
   webpack: (config, _options) => {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "./apps/*"
   ],
   "scripts": {
-    "dev": "yarn enforce-redirects && concurrently \"yarn sidecar\" \"node ./src/hotReloadWatcher.mjs\" \"next dev\"",
-    "dev:developer-docs": "yarn enforce-redirects && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn dev",
-    "build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
-    "build": "yarn enforce-redirects && prisma generate && next build",
-    "vercel:build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
-    "start": "next start",
+    "dev": "yarn enforce-redirects && concurrently \"yarn sidecar\" \"node ./src/hotReloadWatcher.mjs\" \"NEXT_TELEMETRY_DISABLED=1 next dev\"",
+    "dev:developer-docs": "yarn enforce-redirects && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn dev",
+    "build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn build",
+    "build": "yarn enforce-redirects && prisma generate && NEXT_TELEMETRY_DISABLED=1 next build",
+    "vercel:build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn build",
+    "start": "NEXT_TELEMETRY_DISABLED=1 next start",
     "migrate:dev": "dotenv -e .env.development -- yarn prisma migrate reset",
     "lint": "next lint",
     "lint:ts": "tsc --skipLibCheck",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "./apps/*"
   ],
   "scripts": {
-    "dev": "yarn enforce-redirects && concurrently \"yarn sidecar\" \"node ./src/hotReloadWatcher.mjs\" \"NEXT_TELEMETRY_DISABLED=1 next dev\"",
-    "dev:developer-docs": "yarn enforce-redirects && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn dev",
-    "build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn build",
-    "build": "yarn enforce-redirects && prisma generate && NEXT_TELEMETRY_DISABLED=1 next build",
-    "vercel:build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 NEXT_TELEMETRY_DISABLED=1 yarn build",
-    "start": "NEXT_TELEMETRY_DISABLED=1 next start",
+    "dev": "yarn enforce-redirects && concurrently \"yarn sidecar\" \"node ./src/hotReloadWatcher.mjs\" \"next dev\"",
+    "dev:developer-docs": "yarn enforce-redirects && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn dev",
+    "build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
+    "build": "yarn enforce-redirects && prisma generate && next build",
+    "vercel:build:developer-docs": "yarn enforce-redirects && git submodule init && git submodule update && NEXT_PUBLIC_DEVELOPER_DOCS=1 yarn build",
+    "start": "next start",
     "migrate:dev": "dotenv -e .env.development -- yarn prisma migrate reset",
     "lint": "next lint",
     "lint:ts": "tsc --skipLibCheck",


### PR DESCRIPTION
I have the theory that the .git folder is sometimes included in our lambdas, causing the vercel build to fail because the lambdas are too large.