### PR TITLE
Fix DisableUnobservedTaskExceptionCapture method name

### DIFF
--- a/docs/platforms/dotnet/common/configuration/disable-integrations.mdx
+++ b/docs/platforms/dotnet/common/configuration/disable-integrations.mdx
@@ -22,7 +22,7 @@ options.DisableAppDomainUnhandledExceptionCapture()
 
 Disables automatic capture of unhandled exceptions.
 
-## DisableTaskUnobservedTaskExceptionCapture
+## DisableUnobservedTaskExceptionCapture
 
 Disables automatic capture of Unobserved Task Exceptions.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The `DisableTaskUnobservedTaskExceptionCapture` method was deprecated a few years ago[^1] in favor of `DisableUnobservedTaskExceptionCapture`, which was removed around 9 months ago[^2] for v4.

[^1]: https://github.com/getsentry/sentry-dotnet/pull/2034
[^2]: https://github.com/getsentry/sentry-dotnet/pull/2841

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
