### PR TITLE
Fix wrong operator spacing in docs

### DIFF
--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -27,7 +27,7 @@
   pre[class^='language-']:has(:global(.code-diff)) {
     padding-right: 0;
 
-    & :global(.token.operator) {
+    & span[class^='diff-'] :global(.token.operator):first-child {
       padding-right: 12px;
     }
   }
@@ -36,7 +36,7 @@
     padding-left: 0;
     padding-right: 0;
 
-    & :global(.code-line) {
+    &  :global(.code-line) {
       padding-left: 12px;
       padding-right: 12px;
     }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
I noticed what appeared to be a double space after the `=` in the example at https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-configuring
Upon further inspection, this turned out to be an extra padding that was introduced in:
* #10996

The passing was supposed to only apply to the `+`/`-` at the beginning of a diff line, but it's actually applied to all operators.

This PR attempts to apply the the change only to the `+`/`-` by using a more specific CSS selector.

I'm not sure I got the syntax right though, and there is no CI that builds the doc on forks, so I'm opening a draft PR here to test.  The idea is that the `+`/`-` are the first children in a `span` with class `diff-inserted` or `diff-deleted`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
