### PR TITLE
Note that `thirdPartyErrorFilterIntegration` is not supported with Loader or CDN bundles

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -192,7 +192,7 @@ If you choose a mode to only apply tags, the tags can then be used in Sentry to 
 <Note>
 
 The `thirdPartyErrorFilterIntegration` will not work with the [Sentry Loader Script or CDN Bundles](https://docs.sentry.io/platforms/javascript/install/loader/).
-This is the case because the Sentry Loader Script and CDN Bundles would be detected by the integration as "third party", causing it to apply the chosen behaviour for almost all events, because the Sentry SDK wraps a lot of browser-native API.
+This is the case because the Sentry Loader Script and CDN Bundles are detected as "third party" by the integration. This makes it apply the chosen behavior to almost all events, since the Sentry SDK wraps many browser-native APIs.
 
 </Note>
 

--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -189,6 +189,13 @@ There are four modes you can choose from:
 
 If you choose a mode to only apply tags, the tags can then be used in Sentry to filter your issue stream with the `third_party_code` tag in the issue search bar.
 
+<Note>
+
+The `thirdPartyErrorFilterIntegration` will not work with the [Sentry Loader Script or CDN Bundles](https://docs.sentry.io/platforms/javascript/install/loader/).
+This is the case because the Sentry Loader Script and CDN Bundles would be detected by the integration as "third party", causing it to apply the chosen behaviour for almost all events, because the Sentry SDK wraps a lot of browser-native API.
+
+</Note>
+
 ## Filtering Transaction Events
 
 To prevent certain transactions from being reported to Sentry, use the <PlatformIdentifier name="traces-sampler" /> or <PlatformIdentifier name="before-send-transaction" /> configuration option, which allows you to provide a function to evaluate the current transaction and drop it if it's not one you want.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Adds a note to the `thirdPartyErrorFilterIntegration` docs that explains why it is not supported in conjunction with the loader and CDN bundles.

Resolves https://github.com/getsentry/sentry-javascript/issues/13297

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+