### PR TITLE
Fix space typo after beforeSend on line 11

### DIFF
--- a/docs/platforms/react-native/user-feedback/index.mdx
+++ b/docs/platforms/react-native/user-feedback/index.mdx
@@ -8,6 +8,6 @@ sidebar_order: 6000
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> or the return value of the method capturing an event.
+Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>  or the return value of the method capturing an event.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />


### PR DESCRIPTION
**Typo on Docs:** 
"For example, to get the eventId, you can use beforeSendor the return value of the method capturing an event."

**Fix:**
"For example, to get the eventId, you can use beforeSend or the return value of the method capturing an event.

<img width="698" alt="Screenshot 2024-08-12 at 11 07 07 AM" src="https://github.com/user-attachments/assets/fc0bd8cf-0c4d-430d-a446-353fb5cae1d7">


**IS YOUR CHANGE URGENT?**  
Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x ] None: Not urgent, can wait up to 1 week+

