### PR TITLE
[Python] Remove links to defunct sample apps

### DIFF
--- a/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
@@ -67,8 +67,6 @@ def lambda_handler(event, context):
     # ...
 ```
 
-Check out Sentry's [AWS sample apps](https://github.com/getsentry/examples/tree/master/aws-lambda/python) for detailed examples.
-
 <Alert level="info" title="Note">
 
 If you're using another web framework inside of AWS Lambda, that framework may catch exceptions before we see them. Make sure to enable the framework-specific integration if it exists. See [_the Python main page_](/platforms/python/) for more information.

--- a/docs/platforms/python/integrations/gcp-functions/index.mdx
+++ b/docs/platforms/python/integrations/gcp-functions/index.mdx
@@ -58,8 +58,6 @@ def http_function_entrypoint(request):
     # ...
 ```
 
-Check out Sentry's [GCP sample apps](https://github.com/getsentry/examples/tree/master/gcp-cloud-functions) for detailed examples.
-
 <Alert level="info" title="Note">
 
 If you are using a web framework inside of your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.


### PR DESCRIPTION
The repository with the sample are has been archived because those samples are outdated (last touched 4 years ago)
Removing the links to those sample apps, because they probably lead to more confusion than they help users.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
