### PR TITLE
Fix incorrect user-agent value for uptime

### DIFF
--- a/docs/product/alerts/uptime-monitoring/troubleshooting.mdx
+++ b/docs/product/alerts/uptime-monitoring/troubleshooting.mdx
@@ -21,7 +21,7 @@ If you need to configure your firewall allowlist to include Sentry's Uptime Bot,
 Our uptime check requests use the following `User-Agent`:
 
 ```
-Mozilla/5.0 (compatible; SentryUptimeBot/1.0; +http://docs.sentry.io/product/alerts/uptime-monitoring/)
+SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)
 ```
 
 ### IP Addresses


### PR DESCRIPTION
Updates uptime's user-agent to match our system:

https://github.com/getsentry/sentry/blob/74cc8f6a555922c491534ebc8f11cc82be726780/src/sentry/uptime/detectors/tasks.py#L37