### PR TITLE
update uptime schedule behavior description

### DIFF
--- a/docs/product/alerts/uptime-monitoring/index.mdx
+++ b/docs/product/alerts/uptime-monitoring/index.mdx
@@ -11,9 +11,7 @@ In the current version, uptime is [automatically configured](/product/alerts/upt
 
 ## Uptime Check Criteria
 
-Our uptime monitoring system verifies the availability of your URLs
-by performing GET requests at regular 5-minute intervals.
-For a URL to be considered up and running, the response must meet the following criteria:
+Our uptime monitoring system verifies the availability of your URLs by performing GET requests at regular 1-minute intervals. For a URL to be considered up and running, the response must meet the following criteria:
 
 1. **Successful Response (2xx Status Codes):**
 The URL must return an HTTP status code in the 200–299 range, indicating a successful request.
@@ -28,7 +26,7 @@ allowing you to address the underlying connectivity problems.
 ## Notifications
 
 An uptime alert continuously monitors the configured URL with the criteria defined above. If a failure is detected,
-a new [uptime issue](/product/issues/issue-details/uptime-issues/) with failed check and related errors details will be created.
+a new [uptime issue](/product/issues/issue-details/uptime-issues/) with failed check and related errors details will be created. To avoid triggering false alerts due to transient issues like network glitches, a new issue is created only after detecting a minimum of three consecutive failures following the initial downtime detection.
 
 To start getting notifications for a new downtime issue, [configure an issue alert](/product/alerts/create-alerts/issue-alert-config/) and choose the issue category "uptime". Then choose how you'd like to be notified (via email, Slack, and so on).
 


### PR DESCRIPTION
Updates uptime's schedule description to once a minute, and adds a note three consecutive failures must be detected before creating a new uptime issue.