### PR TITLE
Added get started button to docs header with initial styling

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -59,6 +59,12 @@ export function Header({pathname, searchPlatforms, noSearch}: Props) {
           <NavLink href="https://sentry.io/changelog/">Changelog</NavLink>
           <NavLink href="https://try.sentry-demo.com/demo/start/">Sandbox</NavLink>
           <NavLink href="https://sentry.io/">Sign In</NavLink>
+          <NavLink
+            href="https://sentry.io/signup/"
+            className="transition-all duration-300 ease-in-out hover:bg-gradient-to-r hover:from-[#fa7faa] hover:via-[#ff9691] hover:to-[#ffb287]"
+          >
+            Get Started
+          </NavLink>
         </div>
         <div className="lg:hidden ml-auto">
           <MobileMenu pathname={pathname} searchPlatforms={searchPlatforms} />


### PR DESCRIPTION
Added the additional "Get Started" button from the [welcome page](https://sentry.io/welcome/ page). The color looks correct on hover, however I could not find a way for the transition styles to take effect. Please let me know if there is anything to touch up.