### PR TITLE
Fix a property name typo from `release` to `dist`

### DIFF
--- a/includes/sentry-cli-sourcemaps.mdx
+++ b/includes/sentry-cli-sourcemaps.mdx
@@ -115,7 +115,7 @@ Sentry.init({
   // These values must be identical to the release and dist names specified during upload
   // with the `sentry-cli`.
   release: "<release_name>",
-  release: "<dist_name>",
+  dist: "<dist_name>",
 });
 ```
 


### PR DESCRIPTION
While reading the docs on source maps [Associating dist with Artifact Bundle](https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/typescript/#associating-dist-with-artifact-bundle), I found a typo in one of the examples where the `release` property exist twice but the second time it should be `dist`.

![Image](https://github.com/user-attachments/assets/a77c6a45-5387-4b46-8546-d8177038fdbc)



## IS YOUR CHANGE URGENT?  
Not urgent, can wait up to 1 week+


