### PR TITLE
Fix call pattern for Ruby event in `before_send`

### DIFF
--- a/platform-includes/configuration/before-send-fingerprint/ruby.mdx
+++ b/platform-includes/configuration/before-send-fingerprint/ruby.mdx
@@ -3,7 +3,7 @@ Sentry.init do |config|
   # ...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
-      event.fingerprint = ["database-unavailable"]
+      event[:fingerprint] = ["database-unavailable"]
     end
 
     event

--- a/platform-includes/configuration/before-send-hint/ruby.mdx
+++ b/platform-includes/configuration/before-send-hint/ruby.mdx
@@ -3,7 +3,7 @@ Sentry.init do |config|
   # ...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionNotEstablished)
-      event.fingerprint = ["database-unavailable"]
+      event[:fingerprint] = ["database-unavailable"]
     end
 
     event

--- a/platform-includes/set-fingerprint/database-connection/ruby.mdx
+++ b/platform-includes/set-fingerprint/database-connection/ruby.mdx
@@ -3,7 +3,7 @@ Sentry.init do |config|
   #...
   config.before_send = lambda do |event, hint|
     if hint[:exception].is_a?(ActiveRecord::ConnectionTimeoutError)
-      event.fingerprint = ["database-connection-error"]
+      event[:fingerprint] = ["database-connection-error"]
     end
 
     event

--- a/platform-includes/set-fingerprint/rpc/ruby.mdx
+++ b/platform-includes/set-fingerprint/rpc/ruby.mdx
@@ -15,7 +15,7 @@ Sentry.init do |config|
     exception = hint[:exception]
 
     if exception.is_a?(RPCError)
-      event.fingerprint = ["{{default}}", exception.code, exception.function_name]
+      event[:fingerprint] = ["{{default}}", exception.code, exception.function_name]
     end
 
     event


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
In the `before_send` lambda, the `event` argument is a hash. Calling `event.fingerprint` results in a `NoMethodError`, and the event is not sent to Sentry.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
