### PR TITLE
set highlight to plaintext

### DIFF
--- a/docs/security-legal-pii/security/ip-ranges.mdx
+++ b/docs/security-legal-pii/security/ip-ranges.mdx
@@ -16,7 +16,7 @@ apply to self-hosted or single tenant.
 Sentry's dashboard and API are both served from different domains, depending
 on your organization's data storage location. The IP addresses are:
 
-```
+```plaintext
 sentry.io 35.186.247.156/32
 us.sentry.io 35.186.247.156/32
 de.sentry.io 34.36.122.224/32, 34.36.87.148/32
@@ -31,26 +31,26 @@ Sentry's Event Ingestion respects two domains within a Data Source Name (DSN):
 
 Sentry's apex domain (`sentry.io`) accepts events from the same IP address as the Dashboard and API:
 
-```
+```plaintext
 35.186.247.156/32
 ```
 
 Sentry's organization subdomains (`o<number>.ingest.sentry.io` and `o<number>.us.ingest.sentry.io`) accept events from a separate IP address:
 
-```
+```plaintext
 34.120.195.249/32
 ```
 
 Sentry's organization subdomains in the EU (`o<number>.ingest.de.sentry.io`) accept events from:
 
-```
+```plaintext
 34.120.62.213/32
 130.211.36.74/32
 ```
 
 Sentry's legacy ingestion hostname (`app.getsentry.com`) accepts events from a separate IP address:
 
-```
+```plaintext
 34.96.102.34/32
 ```
 
@@ -66,7 +66,8 @@ In some circumstances the Hosted Sentry infrastructure might send HTTP requests 
 Sentry uses the following IP addresses to make outbound requests:
 
 US Data Storage Location
-```
+
+```plaintext
 35.184.238.160/32
 104.155.159.182/32
 104.155.149.19/32
@@ -74,7 +75,8 @@ US Data Storage Location
 ```
 
 EU Data Storage Location
-```
+
+```plaintext
 34.141.31.19/32
 34.141.4.162/32
 35.234.78.236/32
@@ -115,7 +117,7 @@ To allow access to source maps with Apache you can use this example. It can eith
 
 All email is delivered from [SendGrid](https://sendgrid.com/) from the following dedicated, static IP addresses:
 
-```
+```plaintext
 167.89.86.73
 167.89.84.75
 167.89.84.14
@@ -128,13 +130,13 @@ These IP addresses are only for Sentry use.
 Sentry uses the following IP addresses for uptime checks:
 
 US
-```
+```plaintext
 34.123.33.225
 34.41.121.171
 ```
 
 EU
-```
+```plaintext
 34.159.197.47
 35.242.231.10
 ```


### PR DESCRIPTION
The highlighting defaults to _Bash_ when not defined. This causes IP addresses to have some odd coloring.

Before:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/43493fd0-102f-4b32-ab3a-06143369e319">

Instead, I'm explicitly setting them to `plaintext` to disable the highlighting.

After:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/7560e56b-5742-4acd-903b-59e0c60cecf5">

