### PR TITLE
Add note about restarting terminal after devenv sync

### DIFF
--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -21,6 +21,8 @@ When you're done with setup, you'll want to also review the <Link to="/developme
 
 Simply run `devenv sync` inside of your sentry or getsentry repo.
 
+NOTE: After running `devenv sync` you may need to restart your terminal to continue.
+
 
 ## Running the Development Server
 


### PR DESCRIPTION
I hit a wall twice in a row here where I ran `devenv sync`, but the `sentry` command wasn't on my path until I restarted my terminal and `cd` into my Sentry project install.

After which it ran this:

```
❯ cd Projects/getsentry
direnv: loading ~/Projects/getsentry/.envrc
SUCCESS!
direnv: export +NODE_OPTIONS +PIP_DISABLE_PIP_VERSION_CHECK +PYTHONUNBUFFERED +SENTRY_DEVENV_HOME +SENTRY_DEVSERVICES_DSN +SENTRY_INSTRUMENTATION +SENTRY_UI_HOT_RELOAD +VIRTUAL_ENV +XDG_CACHE_HOME +XDG_CONFIG_DIRS +XDG_CONFIG_HOME +XDG_DATA_DIRS +XDG_DATA_HOME +XDG_RUNTIME_DIR +XDG_STATE_HOME ~PATH
```

... and everything went fine from there.
