### PR TITLE
Fix broken anchor link `withActiveSpan`

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -30,7 +30,7 @@ In contrast, **inactive spans** will never have children automatically associate
 
 A key constraint for active spans is that they can only be made active inside of a callback. This constraint exists because otherwise it becomes impossible to associate spans with the correct parent span when working with asynchronous code.
 
-In places where you are not able to wrap executing code in a callback (e.g. when working with hooks or similar) you have to work with inactive spans, and can combine this with [withActiveSpan](#with-active-span) to manually associate child spans with the correct parent span.
+In places where you are not able to wrap executing code in a callback (e.g. when working with hooks or similar) you have to work with inactive spans, and can combine this with [withActiveSpan](#withactivespan) to manually associate child spans with the correct parent span.
 
 <PlatformCategorySection supported={['browser']}>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
- Reference to anchor link for `withActiveSpan` was broken

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
