### PR TITLE
feat: Giscus comments based on GH discussions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.0.0",
+    "@giscus/react": "^3.0.0",
     "@google-cloud/storage": "^7.7.0",
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/components/comments/index.tsx
+++ b/src/components/comments/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+import Giscus, {GiscusProps} from '@giscus/react';
+
+export default function GisccusComments({
+  id,
+  repo,
+  repoId,
+  category,
+  categoryId,
+  mapping,
+  term,
+  strict,
+  reactionsEnabled,
+  emitMetadata,
+  inputPosition,
+  theme,
+  lang,
+  loading,
+}: GiscusProps) {
+  return (
+    <Giscus
+      id={id}
+      repo={repo}
+      repoId={repoId}
+      category={category}
+      categoryId={categoryId}
+      mapping={mapping}
+      term={term}
+      strict={strict}
+      reactionsEnabled={reactionsEnabled}
+      emitMetadata={emitMetadata}
+      inputPosition={inputPosition}
+      theme={theme}
+      lang={lang}
+      loading={loading}
+    />
+  );
+}

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -9,6 +9,7 @@ import './type.scss';
 
 import {Breadcrumbs} from '../breadcrumbs';
 import {CodeContextProvider} from '../codeContext';
+import GisccusComments from '../comments';
 import {GitHubCTA} from '../githubCTA';
 import {Header} from '../header';
 import {PlatformSdkDetail} from '../platformSdkDetail';
@@ -73,6 +74,19 @@ export function DocPage({
                 <CodeContextProvider>{children}</CodeContextProvider>
               </div>
               {hasGithub && <GitHubCTA />}
+              <GisccusComments
+                id="comments"
+                repo="a-hariti/sentry-docs"
+                repoId="R_kgDOMU8RQg"
+                category="Announcements"
+                categoryId="DIC_kwDOMU8RQs4Ch2U0"
+                mapping="pathname"
+                reactionsEnabled="1"
+                emitMetadata="0"
+                theme="light"
+                lang="en"
+                loading="lazy"
+              />
             </div>
           </div>
 

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io vercel.live; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io reload.getsentry.net storage.googleapis.com; img-src * 'self' data: www.google.com www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com; worker-src blob:; report-uri https://o1.ingest.sentry.io/api/1267915/security/?sentry_key=ad63ba38287245f2803dc220be959636; report-to csp"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sentry-cdn.com www.googletagmanager.com plausible.io vercel.live; connect-src 'self' *.sentry.io sentry.io *.algolia.net *.algolianet.com *.algolia.io plausible.io reload.getsentry.net storage.googleapis.com; img-src * 'self' data: www.google.com www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' fonts.gstatic.com; frame-src demo.arcade.software player.vimeo.com giscus.app; worker-src blob:; report-uri https://o1.ingest.sentry.io/api/1267915/security/?sentry_key=ad63ba38287245f2803dc220be959636; report-to csp"
         },
         {
           "key": "NEL",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,6 +908,13 @@
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz"
   integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
+"@giscus/react@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@giscus/react/-/react-3.0.0.tgz#fdadce2c7e4023eb4fdbcc219cdd97f6d7aa17f0"
+  integrity sha512-hgCjLpg3Wgh8VbTF5p8ZLcIHI74wvDk1VIFv12+eKhenNVUDjgwNg2B1aq/3puyHOad47u/ZSyqiMtohjy/OOA==
+  dependencies:
+    giscus "^1.5.0"
+
 "@google-cloud/paginator@^5.0.0":
   version "5.0.0"
   resolved "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz"
@@ -1340,6 +1347,18 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@lit-labs/ssr-dom-shim@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz#2f3a8f1d688935c704dbc89132394a41029acbb8"
+  integrity sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==
+
+"@lit/reactive-element@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.4.tgz#8f2ed950a848016383894a26180ff06c56ae001b"
+  integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.2.0"
 
 "@mark.probst/unicode-properties@~1.1.0":
   version "1.1.0"
@@ -3289,6 +3308,11 @@
   version "4.0.5"
   resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
+"@types/trusted-types@^2.0.2":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.2"
@@ -5875,6 +5899,13 @@ get-tsconfig@^4.5.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
+giscus@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/giscus/-/giscus-1.5.0.tgz#8299fa056b2ed31ec8b05d4645871e016982b4b2"
+  integrity sha512-t3LL0qbSO3JXq3uyQeKpF5CegstGfKX/0gI6eDe1cmnI7D56R7j52yLdzw4pdKrg3VnufwCgCM3FDz7G1Qr6lg==
+  dependencies:
+    lit "^3.1.2"
+
 github-slugger@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz"
@@ -7604,6 +7635,31 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+lit-element@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.1.0.tgz#cea3eb25f15091e3fade07c4d917fa6aaf56ba7d"
+  integrity sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.2.0"
+    "@lit/reactive-element" "^2.0.4"
+    lit-html "^3.2.0"
+
+lit-html@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.2.0.tgz#cb09071a8a1f5f0850873f9143f18f0260be1fda"
+  integrity sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.2.0.tgz#2189d72bccbc335f733a67bfbbd295f015e68e05"
+  integrity sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==
+  dependencies:
+    "@lit/reactive-element" "^2.0.4"
+    lit-element "^4.1.0"
+    lit-html "^3.2.0"
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
enable users to login with GH account and leave comments on docs,

which will show up under the repo discussions and on the docs page ofc.

Setup guide: https://giscus.app: basically install the Giscus app and enable Discussions

Currently I have it setup to my [personal fork](https://github.com/a-hariti/sentry-docs) for the preview

TODO:
- [ ] Point to actual repo
- [ ] Adjust to dark mode when dark mode PR is merged
- [ ] is the pathname -> discussion mapping enough given the dev docs/user docs situation?
