### PR TITLE
docs: fix integration usage to prevent error

### DIFF
--- a/platform-includes/performance/group-transaction-example/javascript.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.mdx
@@ -19,7 +19,7 @@ import * as Sentry from "@sentry/browser";
 Sentry.init({
   // ...
   integrations: [
-    browserTracingIntegration({
+    Sentry.browserTracingIntegration({
       beforeStartSpan: (context) => {
         return {
           ...context,


### PR DESCRIPTION
Since the import above uses `import * as Sentry...`, let's ensure `browserTracingIntegration` is used from `Sentry. browserTracingIntegration`.