### PR TITLE
self-hosted: minimum system requirements

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -23,20 +23,9 @@ git checkout ${VERSION}
 sudo ./install.sh
 ```
 
-## Recommended system resource
+## Required Minimum System Resources
 
-Depending on your usage, required system resource to run Sentry may varies. Minimum system specification for running Sentry looks like this:
-
-- 2 CPU cores
-- 4 GB RAM
-
-Having a machine that have lower system specification than that will fail the installation script.
-
-Current recommended system specification for running Sentry is:
-
-- 4 CPU cores
-- 16 GB RAM
-- 20 GB free disk storage space
+These requirements are detailed [here](https://github.com/getsentry/self-hosted/blob/master/README.md#requirements).
 
 Depending on your traffic volume, you may want to increase your system specification to handle increased load. If increasing the disk storage space isn't possible, you can migrate your storage to use external storage such as AWS S3 or Google Cloud Storage (GCS). Decreasing your `SENTRY_RETENTION_DAYS` environment variable to lower numbers will save some storage space from being full, at the cost of having shorter data retention period.
 

--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -25,7 +25,12 @@ sudo ./install.sh
 
 ## Required Minimum System Resources
 
-These requirements are detailed [here](https://github.com/getsentry/self-hosted/blob/master/README.md#requirements).
+We require at least Docker 19.03.6 and Compose 2.19.0.
+
+These are the minimum requirements:
+- 4 CPU Cores
+- 16 GB RAM
+- 20 GB Free Disk Space
 
 Depending on your traffic volume, you may want to increase your system specification to handle increased load. If increasing the disk storage space isn't possible, you can migrate your storage to use external storage such as AWS S3 or Google Cloud Storage (GCS). Decreasing your `SENTRY_RETENTION_DAYS` environment variable to lower numbers will save some storage space from being full, at the cost of having shorter data retention period.
 


### PR DESCRIPTION
current stuff is outdated, felt it would be best to just link to our readme since that's more updated in tandem with `install/_min-requirements.sh    `