### PR TITLE
feat(nestjs): Update nestjs error monitoring setup

### DIFF
--- a/platform-includes/getting-started-use/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-use/javascript.nestjs.mdx
@@ -14,9 +14,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-Then you can add the SentryModule as a root module:
-
-<Note>The SentryModule needs to be registered before any other module that should be instrumented by Sentry.</Note>
+Afterwards, add the SentryModule as a root module to your main module:
 
 ```javascript {filename: app.module.ts} {2, 8}
 import { Module } from '@nestjs/common';
@@ -31,6 +29,45 @@ import { AppService } from './app.service';
   ],
   controllers: [AppController],
   providers: [AppService],
+})
+export class AppModule {}
+```
+
+In case you are using a global catch-all exception filter (which is either a filter registered with
+app.useGlobalFilters() or a filter registered in your app module providers annotated with an empty @Catch() decorator),
+add a @WithSentry() decorator to the catch() method of this global error filter. This decorator will report all
+unexpected errors that are received by your global error filter to Sentry:
+
+```javascript {2, 6}
+import { Catch, ExceptionFilter } from '@nestjs/common';
+import { WithSentry } from '@sentry/nestjs';
+
+@Catch()
+export class YourCatchAllExceptionFilter implements ExceptionFilter {
+  @WithSentry()
+  catch(exception, host): void {
+    // your implementation here
+  }
+}
+```
+
+In case you do not have a global catch-all exception filter, add the `SentryGlobalFilter` to the providers of your main
+module. This filter will report all unhandled errors that are not caught by any other error filter to Sentry.
+**Important:** The `SentryGlobalFilter` needs to be registered before any other exception filters.
+
+```javascript {3, 9}
+import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+
+@Module({
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: SentryGlobalFilter,
+    },
+    // ..other providers
+  ],
 })
 export class AppModule {}
 ```


### PR DESCRIPTION
Updates nestjs documentation with a new setup introduced in 8.27. Users now need to manually either add the `SentryGlobalFilter` or decorate existing global error handlers.

Note: Should be merged after 8.27 is released.