### PR TITLE
adjust self-hosted hard stop documentation

### DIFF
--- a/develop-docs/self-hosted/releases.mdx
+++ b/develop-docs/self-hosted/releases.mdx
@@ -41,15 +41,26 @@ Finally, to upgrade, just run `./install.sh`.
 
 ### Hard Stops
 
-These are the hard stops that you need to go through in order to pick up significant database changes:
+When upgrading one must upgrade to **each** hard stop to pick up significant database changes.
 
-```
-<your.sentry.version> -> 9.1.2 -> 21.5.0 -> 21.6.3 -> 23.6.2 -> 23.11.0 -> latest
-```
+These are the hard stops that one needs to go through:
+
+- 9.1.2
+- 21.5.0
+- 21.6.3
+- 23.6.2
+- 23.11.0
+- 24.8.0
 
 Versions to avoid upgrading to:
 - `23.7.0` (issues around database migrations and the Django 3 upgrade)
 
+As an example if one wants to go from `22.8.0` to `24.2.0` one needs the following upgrade path:
+
+```
+# example
+(initial: 22.8.0) -> 23.6.2 -> 23.11.0 -> 24.2.0
+```
 
 ## Nightly Builds
 


### PR DESCRIPTION
- add `24.8.0` as a pre-squash hard stop (for commits similar to: https://github.com/getsentry/sentry/pull/76507 )
- change hard stops to a list so they don't need a scroll back
- add an example upgrade
