### PR TITLE
chore(Android): Add troubleshooting entry about Sentry.init

### DIFF
--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -4,6 +4,16 @@ description: "Troubleshoot and resolve common issues with the Android SDK."
 sidebar_order: 9000
 ---
 
+## Obfuscated stack traces, missing Android-specific context
+
+If stack traces don't get unobfuscated properly, even though <PlatformLink to="/enhance-errors/proguard/">mapping files are uploaded correctly</PlatformLink>, or if Android context information is missing from events, a possible reason is that the SDK is initialized with `Sentry.init` instead of `SentryAndroid.init`.
+
+<Alert level="warning">
+For manual initialization on Android, <PlatformLink to="/configuration/manual-init/#manual-initialization">always use `SentryAndroid.init`</PlatformLink>.
+</Alert>
+
+From SDK version `8.0.0` on, using `Sentry.init` on Android will cause a compile-time exception.
+
 ## Excluding Unwanted Resources from APK/AAB
 
 The Sentry Android SDK bundles some resources transitively from the Sentry Java SDK that are not required for Android apps. It's not possible to exclude these resources when publishing the SDK, but you can add the following snippet to your `app/build.gradle` file to reduce the final APK size by a bit:

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -6,13 +6,13 @@ sidebar_order: 9000
 
 ## Obfuscated stack traces, missing Android-specific context
 
-If stack traces don't get unobfuscated properly, even though <PlatformLink to="/enhance-errors/proguard/">mapping files are uploaded correctly</PlatformLink>, or if Android context information is missing from events, a possible reason is that the SDK is initialized with `Sentry.init` instead of `SentryAndroid.init`.
+If stack traces don't get deobfuscated properly, even though <PlatformLink to="/enhance-errors/proguard/">mapping files are uploaded correctly</PlatformLink>, or if Android context information is missing from events, a possible reason is that the SDK is initialized with `Sentry.init` instead of `SentryAndroid.init`.
 
 <Alert level="warning">
 For manual initialization on Android, <PlatformLink to="/configuration/manual-init/#manual-initialization">always use `SentryAndroid.init`</PlatformLink>.
 </Alert>
 
-From SDK version `8.0.0` on, using `Sentry.init` on Android will cause a compile-time exception.
+From SDK version `8.0.0` on, using `Sentry.init` on Android will throw an `IllegalArgumentException`.
 
 ## Excluding Unwanted Resources from APK/AAB
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add troubleshooting entry warning that Sentry.init should not be used on Android, but rather SentryAndroid.init

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
