### PR TITLE
docs: Remove incorrect mention of tracing on Dramatiq docs

### DIFF
--- a/docs/platforms/python/integrations/dramatiq/index.mdx
+++ b/docs/platforms/python/integrations/dramatiq/index.mdx
@@ -3,8 +3,7 @@ title: Dramatiq
 description: "Learn how to import and use the Dramatiq integration."
 ---
 
-The Dramatiq integration adds support for the
-[Dramatiq](https://dramatiq.io/) background tasks library.
+The Dramatiq integration adds support for the [Dramatiq](https://dramatiq.io/) background tasks library.
 
 The Dramatiq integration only reports errors. Tracing is not yet supported.
 

--- a/docs/platforms/python/integrations/dramatiq/index.mdx
+++ b/docs/platforms/python/integrations/dramatiq/index.mdx
@@ -6,6 +6,8 @@ description: "Learn how to import and use the Dramatiq integration."
 The Dramatiq integration adds support for the
 [Dramatiq](https://dramatiq.io/) background tasks library.
 
+The Dramatiq integration only reports errors. Tracing is not yet supported.
+
 <Alert level="info">
   This is the successor of the original `DramatiqIntegration` that can be found here: https://github.com/jacobsvante/sentry-dramatiq
 
@@ -26,27 +28,12 @@ Add `DramatiqIntegration()` to your `integrations` list:
 
 <SignInNote />
 
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](/product/explore/profiling/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
-<OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling"]}
-/>
-
-```python {"onboardingOptions": {"performance": "6-8", "profiling": "9-12"}}
+```python
 import sentry_sdk
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for tracing.
-    traces_sample_rate=1.0,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,
     integrations=[
         DramatiqIntegration(),
     ],


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Dramatiq integration docs page states that the Dramatiq integration supports tracing, but it only supports errors.

This change corrects the page accordingly.

Fixes #11143

## IS YOUR CHANGE URGENT?  

Would be good to merge sooner rather than later since this PR corrects incorrect information in our docs. There is no specific deadline, though.

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
