### PR TITLE
Clarify Ownership Rules > Evaluation Flow

### DIFF
--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -131,18 +131,18 @@ path:dist/frontend/components/*    #frontend
 
 When Sentry receives an event with a stack trace filepath: `dist/frontend/components/sidebar.js`, we:
 
-1. Evaluate against the code owners top-to-bottom; we get one match with two owners in the rule.
+1. Evaluate against the code owners top-to-bottom; we get one match.
 
-   a. Evaluate the rule left-to-right; we choose the first owner.
+2. Evaluate against the ownership rules top-to-bottom; we get two matches with two owners in the rule.
 
-2. Evaluate against the ownership rules top-to-bottom; we get two matches.
+   a. Evaluate the rule left-to-right; we choose the last owner.
 
 The matches, in order, are:
 
 ```
 [
   "codeowners:*.js                    #ecosystem",
-  "path:*.js                          #ecosystem",
+  "path:*.js                          #frontend",
   "path:dist/frontend/components/*    #frontend"
 ]
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Based on the docs and my own observations, I feel like the evaluation flow is documented incorrectly. 

The docs state "If there are multiple owners in the rule, left-to-right. After evaluation, the last rule matching returns the assignment.". But then stated in the example: "Evaluate the rule left-to-right; we choose the first owner." Shouldn't this be "we choose the last owner" then?

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
