### PR TITLE
fix: Incorrect Vue component names in `trackComponents`

### DIFF
--- a/docs/platforms/javascript/guides/vue/features/component-tracking.mdx
+++ b/docs/platforms/javascript/guides/vue/features/component-tracking.mdx
@@ -34,11 +34,11 @@ Sentry.init({
   trackComponents: true,
   // OR
   trackComponents: [
-    "App",
-    "RwvHeader",
-    "RwvFooter",
-    "RwvArticleList",
-    "Pagination",
+    "<App>",
+    "<RwvHeader>",
+    "<RwvFooter>",
+    "<RwvArticleList>",
+    "<Pagination>",
   ],
 });
 ```

--- a/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.vue.mdx
@@ -30,7 +30,7 @@ If you want to track child components, you can configure the SDK using additiona
 Sentry.init({
   Vue,
   tracesSampleRate: 0.1,
-  trackComponents: ["Header", "Navigation", "Footer"],
+  trackComponents: ["<Header>", "<Navigation>", "<Footer>"],
   hooks: ["create", "mount"],
 });
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

This PR fixes the documentation of `trackComponents` in Vue integration by surrounding component names with `<>`. I've added this based on discussion in getsentry/sentry-javascript#13484.

Alternatively, `sentry-javascript`'s Vue integration could be modified to allow matching both components surrounded with `<>` and without.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
