### PR TITLE
fix(python): Performance onboarding install snippet

### DIFF
--- a/public/_platforms/python/performance-onboarding-1-install.json
+++ b/public/_platforms/python/performance-onboarding-1-install.json
@@ -5,5 +5,5 @@
     "name": "Python",
     "aliases": [],
     "categories": [],
-    "body": "<h4 id=\"install\" style=\"position:relative;\">Install</h4>\n<p>Install our Python SDK using <code>pip</code></p>\n<div class=\"gatsby-highlight\" data-language=\"bash\"><pre class=\"language-bash highlight\"><code class=\"language-bash\"><span class=\"token function\">pip</span> <span class=\"token function\">install</span> <span class=\"token string\">\"@sentry/browser\"</span> sentry-sdk</code></pre></div>"
+    "body": "<h4 id=\"install\" style=\"position:relative;\">Install</h4>\n<p>Install our Python SDK using <code>pip</code></p>\n<div class=\"gatsby-highlight\" data-language=\"bash\"><pre class=\"language-bash highlight\"><code class=\"language-bash\"><span class=\"token function\">pip</span> <span class=\"token function\">install</span> sentry-sdk</code></pre></div>"
 }


### PR DESCRIPTION
Fix incorrect install snippet in python performance onboarding.
`pip install "@sentry/browser" sentry-sdk ` -> `pip install sentry-sdk`

closes https://github.com/getsentry/sentry/issues/76517