### PR TITLE
feat: Add codemods for migrating Sentry.js from v7.x to v8.x

### DIFF
--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -14,7 +14,7 @@ dependencies on OpenTelemetry.
 
 ## Codemods
 
-To assist with the upgrade, we've collaborated with the team at codemod.com to publish codemods that will automatically update your code to many of the new APIs and patterns in Sentry.js v8. Run the following codemods to automatically update your code for Sentry.js v8 migration:
+To assist with the upgrade from Sentry.js v7.x to v8.x, we have added features that utilize codemods to automatically update your code to many of the new APIs and patterns. Run the following command to automatically update your code for Sentry.js v8 migration:
 
 ```bash
 npx codemod sentry/v8/migration-recipe

--- a/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
+++ b/docs/platforms/javascript/common/migration/v7-to-v8/index.mdx
@@ -12,6 +12,25 @@ The main goal of version 8 is to improve our performance monitoring APIs, integr
 version is breaking because we removed deprecated APIs, restructured npm package contents, and introduced new
 dependencies on OpenTelemetry.
 
+## Codemods
+
+To assist with the upgrade, we've collaborated with the team at codemod.com to publish codemods that will automatically update your code to many of the new APIs and patterns in Sentry.js v8. Run the following codemods to automatically update your code for Sentry.js v8 migration:
+
+```bash
+npx codemod sentry/v8/migration-recipe
+```
+
+This will run the following codemods from the Sentry.js Codemod repository:
+
+- **sentry/v8/removal-of-addGlobalEventProcessor**
+- **sentry/v8/Removal-Sentry.configureScope-method**
+- **sentry/v8/removal-Severity-Enum**
+- **sentry/v8/remove-replay-package-and-update-integration**
+- **sentry/v8/replace-span-status-from-http-code**
+- **sentry/v8/removal-of-void-from-transport-return-types**
+
+Each of these codemods automates the changes listed in the v8 migration guide. For a complete list of available Sentry.js codemods and further details, see the [codemod registry](https://codemod.com/registry?q=sentry).
+
 ## Migration Codemod
 
 Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. To fix most of the deprecations on `7.x`, you can use the [`@sentry/migr8`](https://www.npmjs.com/package/@sentry/migr8) codemod to automatically update your SDK usage. `@sentry/migr8` requires Node 18+.

--- a/includes/migration/javascript-v8/browser-other-changes.mdx
+++ b/includes/migration/javascript-v8/browser-other-changes.mdx
@@ -13,6 +13,11 @@ The `@sentry/replay` package is no longer required. Instead you can import the r
    ],
  });
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/remove-replay-package-and-update-integration
+  > ```
 
 ### Change of Replay default options (`unblock` and `unmask`)
 

--- a/includes/migration/javascript-v8/general-other-changes.mdx
+++ b/includes/migration/javascript-v8/general-other-changes.mdx
@@ -27,6 +27,11 @@ to access and mutate the current scope.
 - });
 + Sentry.getCurrentScope().setTag("key", "value");
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/Removal-Sentry.configureScope-method
+  > ```
 
 ### `tracingOrigins` has been replaced by `tracePropagationTargets`
 
@@ -86,6 +91,11 @@ this has been removed in `8.x`. You should now use the `SeverityLevel` type dire
 - const level = Severity.error;
 + const level: SeverityLevel = "error";
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/removal-Severity-Enum
+  > ```
 
 #### Removal of `spanStatusfromHttpCode` in favour of `getSpanStatusFromHttpCode`
 
@@ -95,6 +105,11 @@ In `8.x`, we are removing the `spanStatusfromHttpCode` function in favor of `get
 - const spanStatus = spanStatusfromHttpCode(200);
 + const spanStatus = getSpanStatusFromHttpCode(200);
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/replace-span-status-from-http-code
+  > ```
 
 ### `framesToPop` applies to parsed frames
 
@@ -117,6 +132,11 @@ the promise. This means that the `void` return type is no longer allowed.
 +  send(event: Event): Promise<TransportMakeRequestResponse>;
  }
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/removal-of-void-from-transport-return-types
+  > ```
 
 ### `extraErrorDataIntegration` changes
 
@@ -147,3 +167,8 @@ In `8.x`, we are removing the `addGlobalEventProcessor` function in favor of `ad
    return event;
  });
 ```
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod sentry/v8/removal-of-addGlobalEventProcessor
+  > ```


### PR DESCRIPTION
This PR enhances the Sentry.js v8.x migration guide by incorporating codemod integration to streamline the upgrade process for developers. The motivation behind this change is to provide a more efficient and time-saving approach for migrating from v7.x to v8.x, helping the community upgrade with ease.

Key changes include:

1. **Introducing Codemods**: Added a section in the migration guide to highlight the availability of codemods for automating common migration tasks.
2. **Codemod Recipe**: Provided a codemod recipe that runs the following codemods from the Sentry.js Codemod repository:
   ```
   npx codemod sentry/v8/migration-recipe
   ```
   - **sentry/v8/removal-of-addGlobalEventProcessor**
   - **sentry/v8/Removal-Sentry.configureScope-method**
   - **sentry/v8/removal-Severity-Enum**
   - **sentry/v8/remove-replay-package-and-update-integration**
   - **sentry/v8/replace-span-status-from-http-code**
   - **sentry/v8/removal-of-void-from-transport-return-types**

By incorporating these changes, the migration guide now provides a more comprehensive and efficient solution for upgrading to Sentry.js v8.x, helping developers save time and effort during the migration process.