### PR TITLE
Improve <Expandable />

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -6,7 +6,7 @@ notSupported: ["javascript.capacitor"]
 sidebar_order: 9000
 ---
 
-<Expandable title="Updating to a new Sentry SDK version">
+<Expandable permalink title="Updating to a new Sentry SDK version">
 
 If you update your Sentry SDK to a new major version, you might encounter breaking changes that need some adaption on your end.
 Check out our [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md) to learn everything you need
@@ -14,7 +14,7 @@ to know to get up and running again with the latest Sentry features.
 
 </Expandable>
 
-<Expandable title="Debugging additional data">
+<Expandable permalink title="Debugging additional data">
 
 You can view the JSON payload of an event to see how Sentry stores additional data in the event. The shape of the data may not exactly match the description.
 
@@ -24,7 +24,7 @@ For more details, see the [full documentation on Event Payload](https://develop.
 
 </Expandable>
 
-<Expandable title="Max JSON payload size">
+<Expandable permalink title="Max JSON payload size">
 
 `maxValueLength` has a default value of 250, but you can adjust this value according to your needs if your messages are longer. Please note that not every single value is affected by this option.
 
@@ -32,7 +32,7 @@ For more details, see the [full documentation on Event Payload](https://develop.
 
 <PlatformCategorySection supported={['browser']}>
 
-<Expandable title="CORS attributes and headers">
+<Expandable permalink title="CORS attributes and headers">
 
 To gain visibility into a JavaScript exception thrown from scripts originating from different origins, do two things:
 
@@ -73,7 +73,7 @@ Most community CDNs properly set an `Access-Control-Allow-Origin` header.
 
 <PlatformCategorySection supported={['browser']}>
 
-<Expandable title="Unexpected OPTIONS request">
+<Expandable permalink title="Unexpected OPTIONS request">
 
 If your application started to misbehave because of performing additional OPTIONS requests, it is most likely an issue with unwanted `sentry-trace` request headers, which can happen when you are using too generic a configuration for our Tracing Integration in the Browser SDK.
 
@@ -83,7 +83,7 @@ To fix this, change the `tracePropagationTargets` option during SDK initializati
 </PlatformCategorySection>
 
 <PlatformCategorySection supported={['browser']}>
-<Expandable title="`instrument.js` Line Numbers for Console Log statements">
+<Expandable permalink title="`instrument.js` Line Numbers for Console Log statements">
 
 If `instrument.js` displays in your console while debugging, add Sentry to your [Framework Ignore List](https://developer.chrome.com/docs/devtools/settings/ignore-list/#skip-extensions) by adding this pattern: `/@sentry/`
 
@@ -93,7 +93,7 @@ Chrome then ignores the SDK stack frames when debugging.
 </PlatformCategorySection>
 
 <PlatformCategorySection supported={['browser']}>
-<Expandable title="Dealing with Ad-Blockers">
+<Expandable permalink title="Dealing with Ad-Blockers">
 
 When you are using our CDN, ad-blocking or script-blocking extensions may prevent our SDK from being fetched and initialized properly. Because of this, any call to the SDKs API will fail and may cause your application to behave unexpectedly.
 
@@ -105,7 +105,7 @@ You can work around our CDN bundles being blocked by [using our NPM packages](#u
 
 </Expandable>
 
-<Expandable title="Using the `tunnel` Option">
+<Expandable permalink title="Using the `tunnel` Option">
 
 <PlatformSection supported={["javascript.nextjs"]}>
 
@@ -266,7 +266,7 @@ curl https://browser.sentry-cdn.com/5.20.1/bundle.min.js -o sentry.browser.5.20.
 
 The last option is to use `Proxy` guard, which will make sure that your code won't break, even when you call our SDK, which was blocked. `Proxy` is supported by all browser except Internet Explorer, though there are no extensions in this browser. Also if `Proxy` is not in any of your user's browser, it will be silently skipped, so you don't have to worry about it breaking anything.
 
-Place this snippet immediately **above** the `<Expandable>` tag containing our CDN bundle. The snippet in a readable format presents like this:
+Place permalink this snippet immediately **above** the `<Expandable>` tag containing our CDN bundle. The snippet in a readable format presents like this:
 
 ```javascript
 if ("Proxy" in window) {
@@ -308,7 +308,7 @@ If you would like to copy and paste the snippet directly, here it is minified:
 
 </PlatformCategorySection>
 
-<Expandable title="Third party promise libraries">
+<Expandable permalink title="Third party promise libraries">
 
 When you include and configure Sentry, our JavaScript SDK automatically attaches global handlers to _capture_ uncaught exceptions and unhandled promise rejections. You can disable this default behavior by changing the `onunhandledrejection` option to `false` in your GlobalHandlers integration and manually hook into each event handler, then call `Sentry.captureException` or `Sentry.captureMessage` directly.
 
@@ -316,7 +316,7 @@ You may also need to manage your configuration if you are using a third-party li
 
 </Expandable>
 
-<Expandable title="Events with 'Non-Error Exception'">
+<Expandable permalink title="Events with 'Non-Error Exception'">
 
 If you’re seeing errors with the message “Non-Error exception (or promise rejection) captured with keys: x, y, z.”, this happens when you a) call `Sentry.captureException()` with a plain object, b) throw a plain object, or c) reject a promise with a plain object.
 
@@ -328,7 +328,7 @@ To get better insight into these error events, we recommend finding where the pl
 
 <PlatformCategorySection supported={['browser']}>
 
-<Expandable title="Capturing resource 404s">
+<Expandable permalink title="Capturing resource 404s">
 
 By default, Sentry does not capture errors when a resource (like an image or a css file) fails to load. If you would like it to do so, you can use the following code. (Note: We recommend loading Sentry as early as possible in any case, but this method in particular will only work if Sentry is loaded before other resources.)
 
@@ -359,7 +359,7 @@ Remember to pass in `true` as the second parameter to `addEventListener()`. With
 </Expandable>
 </PlatformCategorySection>
 
-<Expandable title="Build errors with vite">
+<Expandable permalink title="Build errors with vite">
 
 If you're using the [Vite Bundler](https://vitejs.dev/) and a Sentry NPM package, and you see the following error:
 
@@ -383,7 +383,7 @@ export default defineConfig({
 
 </Expandable>
 
-<Expandable title="Missing module `diagnostics_channel`">
+<Expandable permalink title="Missing module `diagnostics_channel`">
 
 <Include name="diagnostics-channel-build-error-troubleshooting.mdx" />
 

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -266,7 +266,7 @@ curl https://browser.sentry-cdn.com/5.20.1/bundle.min.js -o sentry.browser.5.20.
 
 The last option is to use `Proxy` guard, which will make sure that your code won't break, even when you call our SDK, which was blocked. `Proxy` is supported by all browser except Internet Explorer, though there are no extensions in this browser. Also if `Proxy` is not in any of your user's browser, it will be silently skipped, so you don't have to worry about it breaking anything.
 
-Place permalink this snippet immediately **above** the `<Expandable>` tag containing our CDN bundle. The snippet in a readable format presents like this:
+Place this snippet immediately **above** the `<Expandable>` tag containing our CDN bundle. The snippet in a readable format presents like this:
 
 ```javascript
 if ("Proxy" in window) {

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -10,27 +10,16 @@ type Props = {
   permalink?: boolean;
 };
 
-type ExpandedProps = {
-  isExpanded: boolean;
-};
-
-const ExpandedIndicator = styled(({isExpanded: _, ...props}) => (
-  <ArrowDown {...props} />
-))<ExpandedProps>`
+const Arrow = styled(({...props}) => <ArrowDown {...props} />)<{className: string}>`
   user-select: none;
   transition: transform 200ms ease-in-out;
-  transform: rotate(${p => (p.isExpanded ? '180deg' : '0')});
   stroke-width: 3px;
   position: absolute;
   right: 0;
   top: 4px;
 `;
 
-const ExpandableBody = styled.div<ExpandedProps>`
-  display: ${props => (props.isExpanded ? 'block' : 'none')};
-`;
-
-const ExpandableWrapper = styled.div`
+const Details = styled.details`
   background: var(--accent-2);
   border-color: var(--accent-12);
   border-left: 3px solid var(--accent-12);
@@ -38,6 +27,9 @@ const ExpandableWrapper = styled.div`
   padding: 0.5rem 1rem;
   h2 {
     margin-top: 0;
+  }
+  &[open] .expandable-arrow {
+    transform: rotate(180deg);
   }
 `;
 
@@ -53,7 +45,7 @@ const header = (title: string, permalink?: boolean) =>
     <h2 id={slugify(title)} className="!mb-0">
       <a
         href={'#' + slugify(title)}
-        className="!text-[1rem] !font-medium hover:!no-underline !text-darkPurple"
+        className="w-full !text-[1rem] !font-medium hover:!no-underline !text-[var(--foreground)]"
       >
         {title}
       </a>
@@ -83,17 +75,12 @@ export function Expandable({title, children, permalink}: Props) {
   }, [title, permalink]);
 
   return (
-    <ExpandableWrapper>
-      <p
-        className="m-0 font-medium cursor-pointer relative pr-8 select-none"
-        onClick={() => {
-          setIsExpanded(!isExpanded);
-        }}
-      >
-        {header(title, permalink)}
-        <ExpandedIndicator isExpanded={isExpanded} />
-      </p>
-      <ExpandableBody isExpanded={isExpanded}>{children}</ExpandableBody>
-    </ExpandableWrapper>
+    <Details open={isExpanded}>
+      <summary className="m-0 font-medium cursor-pointer relative pr-8 select-none appearance-none list-none">
+        {header(title, true)}
+        <Arrow className="expandable-arrow" />
+      </summary>
+      {children}
+    </Details>
   );
 }


### PR DESCRIPTION
- use native `<details />` element
- <kbd>Ctrl</kbd><kbd>F</kbd> expands corresponding matches
- add missing `permalink` flags

Closes #11183
