### PR TITLE
fix python http errors 404

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -66,6 +66,10 @@ type Redirect = {
 /** Note: if you want to set redirects for developer docs, set them below in `DEVELOPER_DOCS_REDIRECTS` */
 const USER_DOCS_REDIRECTS: Redirect[] = [
   {
+    from: '/platforms/python/http_errors/',
+    to: '/platforms/python/integrations/django/http_errors/',
+  },
+  {
     from: '/platforms/javascript/guides/react/configuration/integrations/trycatch/',
     to: '/platforms/javascript/configuration/integrations/browserapierrors/',
   },


### PR DESCRIPTION
I think this is most suitable redirect for this error

Closes [#10968](https://github.com/getsentry/sentry-docs/issues/10968)