### PR TITLE
Migration to 2.x: last_event_id function was restored

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -48,10 +48,6 @@ sentry_sdk.init(
 
 The signature for the experimental Sentry Metrics callback function set with `before_emit_metric` has changed from `before_emit_callback(key, tags)` to `before_emit_callback(key, value, unit, tags)`.
 
-## API
-
-The API function `last_event_id()` was removed. The last event ID is still returned by `capture_event()`, `capture_exception()`, and `capture_message()`.
-
 ## Custom Instrumentation
 
 Hub-based APIs as well as some scope-based APIs (like `configure_scope()` and `push_scope()`) are now deprecated as a consequence of [reworking](/platforms/python/enriching-events/scopes/) the way the SDK saves and propagates data internally. Instead, SDK 2.0 introduces the concept of a global, isolation and current scope. In short:


### PR DESCRIPTION
## DESCRIBE YOUR PR

The `last_event_id` function was restored in 2.2.0 (see the [changelog](https://github.com/getsentry/sentry-python/blob/2.13.0/CHANGELOG.md?plain=1#L370)), but the upgrade notes still state that the function was removed.

## IS YOUR CHANGE URGENT?  

- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

I did no checks myself.

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
