### PR TITLE
chore(ngrok): Move Ngrok Docs to Centralized Place

### DIFF
--- a/develop-docs/backend/development-server.mdx
+++ b/develop-docs/backend/development-server.mdx
@@ -28,5 +28,5 @@ This will do literally nothing except bring up the web workers. You are now resp
 
 Use `sentry run --help` to see what you might be missing by not running devserver.
 
-To run the development server with ngrok, see [Developing with Ngrok](/ngrok/).
+To run the development server with ngrok, see [Developing with Ngrok](/development/ngrok/).
 

--- a/develop-docs/backend/development-server.mdx
+++ b/develop-docs/backend/development-server.mdx
@@ -28,30 +28,5 @@ This will do literally nothing except bring up the web workers. You are now resp
 
 Use `sentry run --help` to see what you might be missing by not running devserver.
 
+To run the development server with ngrok, see [Developing with Ngrok](/ngrok/).
 
-## Using ngrok
-
-The development server can be operated behind ngrok for when you need to receive traffic from the outside world. This comes up frequently when working with integrations. Start off by defining a configuration file for `ngrok`:
-
-```yaml
-version: '2'
-authtoken: <YOUR-NGROK-AUTHTOKEN>
-tunnels:
-  acme-org
-    proto: http
-    hostname: <yourname>.ngrok.dev
-    addr: 8010
-    host_header: 'rewrite'
-```
-
-Next start up ngrok with your configuration file:
-
-```shell
-ngrok start --all --config ngrok.yml`
-```
-
-When starting devserver provide your ngrok domain
-
-```shell
-sentry devserver --ngrok=<yourname>.ngrok.dev
-```

--- a/develop-docs/development/database-migrations/index.mdx
+++ b/develop-docs/development/database-migrations/index.mdx
@@ -409,6 +409,8 @@ There is a script in both sentry & getsentry that are functionally equivalent. I
 
 The `split-silo-database` scripts use silo annotations on models to selectively dump your monolith database into the siloed databases.
 
+You might need to set `SENTRY_MONOLITH_REGION="us"` in your sentry config in order to successfully update the organization mappings.
+
 ### Apply Migrations to siloed databases
 
 You have two options for maintaining siloed databases:

--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -160,42 +160,7 @@ In the above setup your local environment will use org slug domains, and send re
 
 ### Ngrok and siloed servers
 
-To combine ngrok and local development servers you’ll need to reserve multiple domains in ngrok, and create a configuration file for ngrok:
-
-```yaml
-version: '2'
-authtoken: <YOUR-NGROK-AUTHTOKEN>
-tunnels:
-  acme-org:
-    proto: http
-    hostname: acme.<yourname>.ngrok.dev
-    addr: 8000
-  control-silo:
-    proto: http
-    hostname: <yourname>.ngrok.dev
-    host_header: 'rewrite'
-    addr: 8000
-  region-silo:
-    proto: http
-    hostname: us.<yourname>.ngrok.dev
-    addr: 8010
-    host_header: 'rewrite'
-```
-
-Then run all the required servers
-
-```shell
-# Run a control silo with ngrok
-sentry devserver --silo=control --ngrok <yourname>.ngrok.dev
-
-# Run a region silo without ngrok
-sentry devserver --silo=region --ngrok <yourname>.ngrok.dev
-
-# Run ngrok
-ngrok start --all --config regions.yml
-```
-
-This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/development/ngrok/">ngrok docs</Link>.
+Refer to <Link to="/development/ngrok/">ngrok docs</Link>.
 
 ### Siloed Django Shell
 

--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -195,7 +195,7 @@ sentry devserver --silo=region --ngrok <yourname>.ngrok.dev
 ngrok start --all --config regions.yml
 ```
 
-This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/backend/development-server/">developement server</Link>.
+This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/develop/ngrok/">developer docs</Link>.
 
 ### Siloed Django Shell
 

--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -195,7 +195,7 @@ sentry devserver --silo=region --ngrok <yourname>.ngrok.dev
 ngrok start --all --config regions.yml
 ```
 
-This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/develop/ngrok/">developer docs</Link>.
+This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/development/ngrok/">ngrok docs</Link>.
 
 ### Siloed Django Shell
 

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -61,7 +61,8 @@ getsentry devserver --ngrok=<yourname>.ngrok.io
 
 To debug issues related to integration middleware as well as issues relating to latency induced by RPC calls, you can run your local environment in silo mode. 
 
-To learn more about how silo mode works in the local environment, refer to <Link to="/devlopment/environment/#running-siloed-instances"> Running Siloed Instances</Link>.
+To learn more about how silo mode works in the local environment, refer to <Link to="development/environment/#running-siloed-instances"> Running Siloed Instances</Link>.
+
 
 ### Step 1: Split Local DB into Silos
 By default `sentry devserver` will run a monolith mode application server. You can also run ``devserver`` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -36,7 +36,7 @@ ngrok start --all --config ngrok.yml
 ```
 
 ### Step 3: Start Devserver
-It is reccomended to use `getsentry` while working with integrations. When starting the devserver, use the `--ngrok` flag:
+It is recommended to use `getsentry` while working with integrations. When starting the devserver, use the `--ngrok` flag:
 ```shell
 getsentry devserver --ngrok=<yourname>.ngrok.io
 ```

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -1,0 +1,42 @@
+---
+title: Developing with Ngrok
+description: This document explains how to use ngrok with the development server.
+sidebar_title: Ngrok
+sidebar_order: 30
+---
+
+# Using ngrok
+
+The development server can be operated behind ngrok for when you need to receive traffic from the outside world. This comes up frequently when working with integrations. 
+
+## Ngrok in `monolith` mode
+
+The following are the steps will setup ngrok for integrations in `monolith` mode:
+
+### Step 1: Create Ngrok Config File
+Start off by defining a configuration file for `ngrok`:
+
+```yaml
+version: '2'
+authtoken: <YOUR-NGROK-AUTHTOKEN>
+tunnels:
+  acme-org:
+    proto: http
+    hostname: <yourdomain>.ngrok.io
+    addr: 8000
+    host_header: "rewrite"
+```
+
+You can grab your auth token from https://dashboard.ngrok.com/get-started/your-authtoken
+
+### Step 2: Start Ngrok
+Next start up ngrok with your configuration file:
+```shell
+ngrok start --all --config ngrok.yml
+```
+
+### Step 3: Start Devserver
+When starting the devserver, use the `--ngrok` flag:
+```shell
+sentry devserver --ngrok=<yourname>.ngrok.io
+```

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -36,7 +36,7 @@ ngrok start --all --config ngrok.yml
 ```
 
 ### Step 3: Start Devserver
-When starting the devserver, use the `--ngrok` flag:
+It is reccomended to use `getsentry` while working with integrations. When starting the devserver, use the `--ngrok` flag:
 ```shell
-sentry devserver --ngrok=<yourname>.ngrok.io
+getsentry devserver --ngrok=<yourname>.ngrok.io
 ```

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -98,6 +98,8 @@ ngrok start --all --config region.yml
 ```
 
 ### Step 4: Start Devserver
+In two separate terminal windows, start the devserver for the control and region silos:
+
 ```shell
 getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=region
 getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -5,16 +5,32 @@ sidebar_title: Ngrok
 sidebar_order: 30
 ---
 
-# Using ngrok
+# Using Ngrok
 
 The development server can be operated behind ngrok for when you need to receive traffic from the outside world. This comes up frequently when working with integrations. 
 
-## Ngrok in `monolith` mode
+It is recommended to use `getsentry` while working with integrations as it will automatically set up the correct configurations for you.
 
-The following are the steps will setup ngrok for integrations in `monolith` mode:
+Note, if the following instructions aren't working and you are using `getsentry`, check if there is some configuration that is set for your environment that is updating the following options and configs:
+```
+SENTRY_OPTIONS["system.url-prefix"]
+SENTRY_OPTIONS["system.base-hostname"]
+SENTRY_FEATURES["system:multi-region"]
+
+CSRF_TRUSTED_ORIGINS
+ALLOWED_HOSTS
+SESSION_COOKIE_DOMAIN
+CSRF_COOKIE_DOMAIN
+SUDO_COOKIE_DOMAIN
+```
+`dev.py` in `getsentry` should automatically set the correct values for these configurations.
+
+## Ngrok in Monolith mode
+
+The following steps will setup ngrok in `monolith` mode:
 
 ### Step 1: Create Ngrok Config File
-Start off by defining a configuration file for `ngrok`, for example `ngrok.yml`:
+Start off by defining a configuration file for `ngrok`, for example `ngrok.yml`:
 
 ```yaml
 version: '2'
@@ -36,7 +52,54 @@ ngrok start --all --config ngrok.yml
 ```
 
 ### Step 3: Start Devserver
-It is recommended to use `getsentry` while working with integrations. When starting the devserver, use the `--ngrok` flag:
+When starting the devserver, use the `--ngrok` flag:
 ```shell
 getsentry devserver --ngrok=<yourname>.ngrok.io
 ```
+
+## Ngrok in Silo mode
+
+To debug issues related to integration middleware as well as issues relating to latency induced by RPC calls, you can run your local environment in silo mode. 
+
+To learn more about how silo mode works in the local environment, refer to <Link to="/devlopment/environment/#running-siloed-instances"> Running Siloed Instances</Link>.
+
+### Step 1: Split Local DB into Silos
+By default `sentry devserver` will run a monolith mode application server. You can also run ``devserver`` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.
+
+
+### Step 2: Create Ngrok Config File
+To combine ngrok and local development servers you'll need to reserve multiple domains in ngrok, and create a configuration file for ngrok:
+
+```yaml
+version: "2"
+authtoken: <YOUR-NGROK-AUTHTOKEN>
+tunnels:
+  acme-org:
+    proto: http
+    hostname: acme-org.<yourname>.ngrok.io
+    addr: 8000
+  control-silo:
+    proto: http
+    hostname: <yourname>.ngrok.io
+    host_header: "rewrite"
+    addr: 8000
+  region-silo:
+    proto: http
+    hostname: us.<yourname>.ngrok.io
+    addr: 8010
+    host_header: "rewrite"
+```
+
+### Step 3: Start Ngrok
+Next start up ngrok with your configuration file:
+```shell
+ngrok start --all --config region.yml
+```
+
+### Step 4: Start Devserver
+```shell
+getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=region
+getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control
+```
+
+This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production.  

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -14,7 +14,7 @@ The development server can be operated behind ngrok for when you need to receive
 The following are the steps will setup ngrok for integrations in `monolith` mode:
 
 ### Step 1: Create Ngrok Config File
-Start off by defining a configuration file for `ngrok`:
+Start off by defining a configuration file for `ngrok`, for example `ngrok.yml`:
 
 ```yaml
 version: '2'
@@ -22,7 +22,7 @@ authtoken: <YOUR-NGROK-AUTHTOKEN>
 tunnels:
   acme-org:
     proto: http
-    hostname: <yourdomain>.ngrok.io
+    hostname: <yourname>.ngrok.io
     addr: 8000
     host_header: "rewrite"
 ```

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -61,7 +61,7 @@ getsentry devserver --ngrok=<yourname>.ngrok.io
 
 To debug issues related to integration middleware as well as issues relating to latency induced by RPC calls, you can run your local environment in silo mode. 
 
-To learn more about how silo mode works in the local environment, refer to <Link to="development/environment/#running-siloed-instances"> Running Siloed Instances</Link>.
+To learn more about how silo mode works in the dev environment, refer to <Link to="/environment/#running-siloed-instances"> Running Siloed Instances</Link>.
 
 
 ### Step 1: Split Local DB into Silos

--- a/develop-docs/development/ngrok.mdx
+++ b/develop-docs/development/ngrok.mdx
@@ -103,4 +103,7 @@ getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=r
 getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control
 ```
 
-This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production.  
+This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production.
+
+### Setting up integrations
+When setting up integrations for your local environment and the above setup, you should add the secrets and configurations for the integrations in the `getsentry/conf/settings/devlocal.py` file. 


### PR DESCRIPTION
Currently our Ngrok docs exist in Notion, in multiple dev doc pages which makes setting things up really difficult. We should have 1 authoritative source for setting up ngrok. 

Here i moved and slightly update the ngrok instructions that existed in `development-server` to its own page. 

after this, i will move the ngrok instructions for split silo there as well (with improvements to the setup) and fix all the links so we have 1 central place to setup ngrok. 🙌🏽 

Edit: Photo is Outdated, please take a look at the actual markdown.
![image](https://github.com/user-attachments/assets/ec6eca8b-1ef9-4d6a-99e3-73422435354b)

