### PR TITLE
fix: Use correct platform page titles

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -10,11 +10,16 @@ import {DocPage} from 'sentry-docs/components/docPage';
 import {Home} from 'sentry-docs/components/home';
 import {Include} from 'sentry-docs/components/include';
 import {PlatformContent} from 'sentry-docs/components/platformContent';
-import {getDocsRootNode, nodeForPath} from 'sentry-docs/docTree';
+import {
+  getCurrentPlatformOrGuide,
+  getDocsRootNode,
+  nodeForPath,
+} from 'sentry-docs/docTree';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 import {getDevDocsFrontMatter, getDocsFrontMatter, getFileBySlug} from 'sentry-docs/mdx';
 import {mdxComponents} from 'sentry-docs/mdxComponents';
 import {setServerContext} from 'sentry-docs/serverContext';
+import {formatGuideOrPlatformTitle} from 'sentry-docs/utils';
 
 export async function generateStaticParams() {
   const docs = await (isDeveloperDocs ? getDevDocsFrontMatter() : getDocsFrontMatter());
@@ -133,7 +138,12 @@ export async function generateMetadata({params}: MetadataProps): Promise<Metadat
   if (params.path) {
     const pageNode = nodeForPath(rootNode, params.path);
     if (pageNode) {
-      title = pageNode.frontmatter.title;
+      const guideOrPlatform = getCurrentPlatformOrGuide(rootNode, params.path);
+      title =
+        pageNode.frontmatter.title +
+        (guideOrPlatform
+          ? ` | Sentry for ${formatGuideOrPlatformTitle(guideOrPlatform.name)}`
+          : '');
       description = pageNode.frontmatter.description ?? '';
     }
   }

--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -10,16 +10,11 @@ import {DocPage} from 'sentry-docs/components/docPage';
 import {Home} from 'sentry-docs/components/home';
 import {Include} from 'sentry-docs/components/include';
 import {PlatformContent} from 'sentry-docs/components/platformContent';
-import {
-  getCurrentPlatformOrGuide,
-  getDocsRootNode,
-  nodeForPath,
-} from 'sentry-docs/docTree';
+import {getDocsRootNode, nodeForPath} from 'sentry-docs/docTree';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 import {getDevDocsFrontMatter, getDocsFrontMatter, getFileBySlug} from 'sentry-docs/mdx';
 import {mdxComponents} from 'sentry-docs/mdxComponents';
 import {setServerContext} from 'sentry-docs/serverContext';
-import {formatGuideOrPlatformTitle} from 'sentry-docs/utils';
 
 export async function generateStaticParams() {
   const docs = await (isDeveloperDocs ? getDevDocsFrontMatter() : getDocsFrontMatter());
@@ -138,12 +133,7 @@ export async function generateMetadata({params}: MetadataProps): Promise<Metadat
   if (params.path) {
     const pageNode = nodeForPath(rootNode, params.path);
     if (pageNode) {
-      const guideOrPlatform = getCurrentPlatformOrGuide(rootNode, params.path);
-      title =
-        pageNode.frontmatter.title +
-        (guideOrPlatform
-          ? ` | Sentry for ${formatGuideOrPlatformTitle(guideOrPlatform.name)}`
-          : '');
+      title = pageNode.frontmatter.title;
       description = pageNode.frontmatter.description ?? '';
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,33 +14,44 @@ export function sortBy<A>(arr: A[], comp: (v: A) => number): A[] {
   });
 }
 
-export const capitilize = (str: string) => {
+export const capitalize = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
 export const formatGuideOrPlatformTitle = (title: string) => {
   const lowerCase = title.toLowerCase();
-  if (lowerCase === 'ios') {
-    return 'iOS';
-  }
 
-  if (lowerCase === 'macos') {
-    return 'macOS';
-  }
+  switch (lowerCase) {
+    case 'ios':
+      return 'iOS';
 
-  if (lowerCase === 'tvos') {
-    return 'tvOS';
-  }
+    case 'macos':
+      return 'macOS';
 
-  if (lowerCase === 'visionos') {
-    return 'visionOS';
-  }
+    case 'tvos':
+      return 'tvOS';
 
-  if (lowerCase === 'watchos') {
-    return 'watchOS';
-  }
+    case 'visionos':
+      return 'visionOS';
 
-  return capitilize(title);
+    case 'watchos':
+      return 'watchOS';
+
+    case 'dotnet':
+      return '.NET';
+
+    case 'kotlin-multiplatform':
+      return 'Kotlin Multiplatform';
+
+    case 'php':
+      return 'PHP';
+
+    case 'react-native':
+      return 'React Native';
+
+    default:
+      return capitalize(title);
+  }
 };
 
 export const uniqByReference = <T>(arr: T[]): T[] => Array.from(new Set(arr));


### PR DESCRIPTION
Updates some of the platform page titles.

Closes [#11219](https://github.com/getsentry/sentry-docs/issues/11219)

