### PR TITLE
Update troubleshooting.mdx - Add `DAY` when using `INTERVAL` while referencing the `SENTRY_RETENTION_DAYS` variable

### DIFF
--- a/develop-docs/self-hosted/troubleshooting.mdx
+++ b/develop-docs/self-hosted/troubleshooting.mdx
@@ -144,7 +144,7 @@ docker compose run --rm -T postgres bash -c "apt update && apt install -y --no-i
 
 If the script above still does not clear up enough disk space, you can try the following in Postgres. This will lead to data loss in event details. _SENTRY_RETENTION_DAYS_ will need to be filled in manually.
 ```sql
-DELETE FROM public.nodestore_node WHERE "timestamp" < NOW() - INTERVAL '[SENTRY_RETENTION_DAYS]';
+DELETE FROM public.nodestore_node WHERE "timestamp" < NOW() - INTERVAL '[SENTRY_RETENTION_DAYS] DAY';
 VACUUM FULL public.nodestore_node;
 ```
 


### PR DESCRIPTION
Add `DAY` in the `INTERVAL` keyword used to manually purge the nodestore_node table to prevent accidentally purging (almost) the entire table, since the days would be used as seconds.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

When manually purging events from the nodestore_node table, the example request in the documentation makes use of the `INTERVAL`  keyword, referencing the `$SENTRY_RETENTION_DAYS` variable, but without specifying the `DAY` keyword to `INTERVAL`, which can lead people to input days that will be interpreted as seconds by PostgreSQL.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
