### PR TITLE
fix: Fix replay privacy code example

### DIFF
--- a/docs/platforms/javascript/common/session-replay/privacy.mdx
+++ b/docs/platforms/javascript/common/session-replay/privacy.mdx
@@ -154,7 +154,7 @@ import { Event, ReplayEvent } from "@sentry/types";
 
 Sentry.addEventProcessor((event) => {
   // Ensure that we specifically look at replay events
-  if (event.type !== "replay_event") {
+  if (!isReplayEvent(event)) {
     // Return the event, otherwise the event will be dropped
     return event;
   }

--- a/docs/platforms/javascript/common/session-replay/privacy.mdx
+++ b/docs/platforms/javascript/common/session-replay/privacy.mdx
@@ -130,23 +130,49 @@ To scrub the URL in a recording event, use the above `beforeAddRecordingEvent`.
 To scrub the URL in a replay event, use `addEventProcessor`:
 
 ```javascript
-Sentry.addEventProcessor(event) => {
+Sentry.addEventProcessor((event) => {
   // Ensure that we specifically look at replay events
-  if (event.type !== 'replay_event') {
+  if (event.type !== "replay_event") {
     // Return the event, otherwise the event will be dropped
     return event;
   }
 
   // Your URL scrubbing function
-  function urlScrubber(url: string) {
-    return url.replace(/([a-z0-9]{3}\.[a-z]{5}\.[a-z]{7})/, '[Filtered]');
+  function urlScrubber(url) {
+    return url.replace(/([a-z0-9]{3}\.[a-z]{5}\.[a-z]{7})/, "[Filtered]");
   }
 
   // Scrub all URLs with your scrubbing function
-  event.urls = event.urls.map(urlScrubber);
+  event.urls = event.urls && event.urls.map(urlScrubber);
 
   return event;
 });
+```
+
+```typescript
+import { Event, ReplayEvent } from "@sentry/types";
+
+Sentry.addEventProcessor((event) => {
+  // Ensure that we specifically look at replay events
+  if (event.type !== "replay_event") {
+    // Return the event, otherwise the event will be dropped
+    return event;
+  }
+
+  // Your URL scrubbing function
+  function urlScrubber(url: string): string {
+    return url.replace(/([a-z0-9]{3}\.[a-z]{5}\.[a-z]{7})/, "[Filtered]");
+  }
+
+  // Scrub all URLs with your scrubbing function
+  event.urls = event.urls && event.urls.map(urlScrubber);
+
+  return event;
+});
+
+function isReplayEvent(event: Event): event is ReplayEvent {
+  return event.type === "replay_event";
+}
 ```
 
 ### Deprecated Options


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/11090

Our old snippet had some typos in it. Now, the JS example should be fine.
Because the example does not work well in TS, for this case I opted to also add a TS example too.