### PR TITLE
feat: Clarify that org auth tokens should be used for bundler plugins

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -54,6 +54,9 @@ If you are on an older version and you want to upload source maps we recommend u
 </Note>
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-nx.mdx
@@ -53,7 +53,7 @@ If you are on an older version and you want to upload source maps we recommend u
 
 </Note>
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -82,6 +82,9 @@ If you are on an older version and you want to upload source maps we recommend u
 </Note>
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/angular-webpack.mdx
@@ -81,7 +81,7 @@ If you are on an older version and you want to upload source maps we recommend u
 
 </Note>
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
@@ -38,7 +38,7 @@ pnpm add @sentry/esbuild-plugin --save-dev
 
 ### Configure
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
@@ -39,6 +39,9 @@ pnpm add @sentry/esbuild-plugin --save-dev
 ### Configure
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/rollup.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/rollup.mdx
@@ -38,7 +38,7 @@ pnpm add @sentry/rollup-plugin --save-dev
 
 ### Configuration
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/rollup.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/rollup.mdx
@@ -39,6 +39,9 @@ pnpm add @sentry/rollup-plugin --save-dev
 ### Configuration
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
@@ -36,7 +36,7 @@ pnpm add @sentry/vite-plugin --save-dev
 
 ### Configuration
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
@@ -37,6 +37,9 @@ pnpm add @sentry/vite-plugin --save-dev
 ### Configuration
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/webpack.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/webpack.mdx
@@ -38,6 +38,9 @@ pnpm add @sentry/webpack-plugin --save-dev
 ### Configuration
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/webpack.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/webpack.mdx
@@ -37,7 +37,7 @@ pnpm add @sentry/webpack-plugin --save-dev
 
 ### Configuration
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when building your project.
 We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -49,7 +49,7 @@ yarn add @sentry/vite-plugin --dev
 pnpm add @sentry/vite-plugin --save-dev
 ```
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with a `.env.sentry-build-plugin` file in the working directory when building your project.
 You likely want to add the auth token as an environment variable to your CI/CD environment.
 

--- a/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -50,6 +50,9 @@ pnpm add @sentry/vite-plugin --save-dev
 ```
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with a `.env.sentry-build-plugin` file in the working directory when building your project.
 You likely want to add the auth token as an environment variable to your CI/CD environment.
 

--- a/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -40,6 +40,9 @@ pnpm add @sentry/vite-plugin --save-dev
 Learn more about configuring the plugin in our [Sentry Vite Plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
 
 To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
+
+Alternatively, you can also use a [User Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/account/api/auth-tokens/), with the "Project: Read & Write" and "Release: Admin" permissions.
+
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with a `.env.sentry-build-plugin` file in the working directory when building your project.
 You likely want to add the auth token as an environment variable to your CI/CD environment.
 

--- a/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -39,7 +39,7 @@ pnpm add @sentry/vite-plugin --save-dev
 
 Learn more about configuring the plugin in our [Sentry Vite Plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
 
-To upload source maps you have to configure an auth token.
+To upload source maps you have to configure an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with a `.env.sentry-build-plugin` file in the working directory when building your project.
 You likely want to add the auth token as an environment variable to your CI/CD environment.
 


### PR DESCRIPTION
We do link to org auth tokens further down, but it does not hurt to be explicit there.

Closes https://github.com/getsentry/sentry-docs/issues/9524