### PR TITLE
feat: Add docs for `profilesSampler` function in JS

### DIFF
--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -37,7 +37,6 @@ pnpm add @sentry/node @sentry/profiling-node
 
 To enable profiling, import `@sentry/profiling-node`, add `ProfilingIntegration` to your `integrations`, and set the `profilesSampleRate`.
 
-
 ```javascript
 const Sentry = require("@sentry/node");
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
@@ -67,11 +66,32 @@ Sentry.startSpan(
 );
 ```
 
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/node");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add our Profiling integration
+    nodeProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```
+
 ## Enable Continuous Profiling
 
 <Include name="feature-stage-beta.mdx" />
 
-_(New in version 8.28.0)
+_(New in version 8.28.0)_
 
 The current profiling implementation stops the profiler automatically after 30 seconds (unless you manually stop it earlier). Naturally, this limitation makes it difficult to get full coverage of your app's execution. We now offer an experimental continuous mode, where profiling data is periodically uploaded while running, with no limit on how long the profiler may run.
 
@@ -84,11 +104,11 @@ If you previously set `profilesSampleRate` or `profilesSampler` to use transacti
 </Note>
 
 ```js
-const Sentry = require('@sentry/node');
+const Sentry = require("@sentry/node");
 
 Sentry.init({
-    dsn: "___PUBLIC_DSN___" ,
-})
+  dsn: "___PUBLIC_DSN___",
+});
 
 Sentry.profiler.startProfiling();
 

--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -48,7 +48,12 @@ Sentry.init({
     nodeProfilingIntegration(),
   ],
   tracesSampleRate: 1.0,
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
+
+  // Set profilesSampleRate to 1.0 to profile every transaction.
+  // Since profilesSampleRate is relative to tracesSampleRate,
+  // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+  // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
+  // results in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 
@@ -80,7 +85,8 @@ Sentry.init({
   ],
   tracesSampleRate: 1.0,
 
-  // This function will be called for every sampled span to determine if it should be profiled
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
   profilesSampler: (samplingContext) => {
     return 1.0;
   },

--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -53,7 +53,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 

--- a/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
@@ -24,3 +24,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/browser");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
@@ -24,3 +24,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/angular");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
@@ -19,7 +19,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
@@ -23,3 +23,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/astro");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
@@ -26,3 +26,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/electron/renderer");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
@@ -22,7 +22,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
@@ -23,3 +23,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript {filename:sentry.client.config.js|ts}
+const Sentry = require("@sentry/nextjs");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
@@ -19,7 +19,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
@@ -24,3 +24,26 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/react");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
@@ -24,3 +24,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript {filename:entry.client.tsx}
+const Sentry = require("@sentry/remix");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
@@ -24,3 +24,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/svelte");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
@@ -19,7 +19,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
@@ -23,3 +23,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript {filename:hooks.client.js}
+const Sentry = require("@sentry/sveltekit");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
@@ -20,7 +20,7 @@ Sentry.init({
   // Since profilesSampleRate is relative to tracesSampleRate,
   // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
-  // results in 25% of transactions being profiled (0.5*0.5=0.25)
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
 });
 ```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
@@ -24,3 +24,25 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
+
+Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
+
+```javascript
+const Sentry = require("@sentry/vue");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add browser profiling integration to the list of integrations
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+
+  // This function will be called for every sampled span
+  // to determine if it should be profiled
+  profilesSampler: (samplingContext) => {
+    return 1.0;
+  },
+});
+```


### PR DESCRIPTION
This adds docs for `profilesSampler` in browser JS & Node.

Closes https://github.com/getsentry/sentry-docs/issues/10010