### PR TITLE
ref(profiling): add doc for the profile_chunk item type

### DIFF
--- a/develop-docs/sdk/envelopes.mdx
+++ b/develop-docs/sdk/envelopes.mdx
@@ -597,6 +597,23 @@ in JSON.
 
 *None*
 
+### Profile Chunk
+
+Item type `"profile_chunk"`. This Item contains a profile_chunk (profile sample format V2) payload encoded
+in JSON.
+
+**Constraints:**
+
+*None*
+
+**Envelope Headers:**
+
+*None*
+
+**Additional Item Headers:**
+
+*None*
+
 ### Check-Ins
 
 Item type `"check_in"` contains a check-in payload encoded as JSON.

--- a/develop-docs/sdk/telemetry/profiles/sample-format-v2.mdx
+++ b/develop-docs/sdk/telemetry/profiles/sample-format-v2.mdx
@@ -291,7 +291,7 @@ It's suggested to remove unnecessary data like thread data without samples from
 ## Ingestion
 
 After this payload is generated, serialize it as JSON, pack it into an
-[Envelope](/sdk/envelopes/) with the item type `profile_chunk` and send 
+[Envelope](/sdk/envelopes/) with the item type [`profile_chunk`](/sdk/envelopes/#profile-chunk) and send 
 it to Relay.
 
 This envelope should look like this:


### PR DESCRIPTION
Add documentation for the `profile_chunk` item type referred by the _Profile Sample Format V2_ documented in this previous [PR](viglia/ref/add-profile_chunk-item-type-doc).

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

