### PR TITLE
[Python] Update docs for `last_event_id` in migration guide

### DIFF
--- a/docs/platforms/python/migration/1.x-to-2.x.mdx
+++ b/docs/platforms/python/migration/1.x-to-2.x.mdx
@@ -50,7 +50,7 @@ The signature for the experimental Sentry Metrics callback function set with `be
 
 ## API
 
-The API function `last_event_id()` was removed. The last event ID is still returned by `capture_event()`, `capture_exception()`, and `capture_message()`.
+The API function `last_event_id()` was removed in 2.0.0, but was brought back by public demand in 2.2.0. The last event ID is returned by `capture_event()`, `capture_exception()`, and `capture_message()` in all SDK versions.
 
 ## Custom Instrumentation
 


### PR DESCRIPTION
Fixes #10798

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
