### PR TITLE
feat(docs): Add sourcemaps upload video to javascript docs

### DIFF
--- a/platform-includes/sourcemaps/primer/javascript.cloudflare.mdx
+++ b/platform-includes/sourcemaps/primer/javascript.cloudflare.mdx
@@ -1,5 +1,6 @@
 To enable readable stack traces in your Sentry errors, you need to upload your source maps to Sentry.
+Learn how to unminify your JavaScript code by watching this video or reading the step-by-step instructions below.
 
-![Readable Stack Traces](./readable-stacktraces.png)
+<VimeoEmbed id="956055420?h=f428eeda43" />
 
 If you are using plain Cloudflare Workers, set `upload_source_maps = true` to your `wrangler.toml` file to enable source map generation.

--- a/platform-includes/sourcemaps/primer/javascript.mdx
+++ b/platform-includes/sourcemaps/primer/javascript.mdx
@@ -1,3 +1,4 @@
 To enable readable stack traces in your Sentry errors, you need to upload your source maps to Sentry.
+Learn how to unminify your JavaScript code by watching this video or reading the step-by-step instructions below.
 
-![Readable Stack Traces](./readable-stacktraces.png)
+<VimeoEmbed id="956055420?h=f428eeda43" />

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -26,7 +26,7 @@ export function VimeoEmbed({id, className}: Video) {
   return (
     <ResponsiveEmbed className={className}>
       <StyledVimeoIframe
-        src={`https://player.vimeo.com/video/${id}?dnt=true`}
+        src={`https://player.vimeo.com/video/${id}&dnt=true`}
         frameBorder="0"
         allowFullScreen
       />


### PR DESCRIPTION
Closes: #10342

## DESCRIBE YOUR PR
Replaces the sourcemaps upload image with a video explaining how to generate and upload sourcemaps using the wizard.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
