### PR TITLE
ref(angular): Update Replay lazy load instructions

### DIFF
--- a/platform-includes/configuration/integrations/lazy-loading-replay/javascript.angular.mdx
+++ b/platform-includes/configuration/integrations/lazy-loading-replay/javascript.angular.mdx
@@ -2,10 +2,14 @@
 Sentry.init({
   // Note, replayIntegration is NOT instantiated below:
   integrations: [],
+
+  // Replay sample rates still have to be set in `Sentry.init`:
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
 });
 
 // Sometime later
-import("@sentry/angular").then(lazyLoadedSentry => {
-  Sentry.addIntegration(lazyLoadedSentry.replayIntegration());
+Sentry.lazyLoadIntegration("replayIntegration").then((replayIntegration) => {
+  Sentry.addIntegration(replayIntegration());
 });
 ```

--- a/platform-includes/configuration/integrations/lazy-loading-replay/javascript.angular.mdx
+++ b/platform-includes/configuration/integrations/lazy-loading-replay/javascript.angular.mdx
@@ -1,4 +1,4 @@
-```javascript {filename: main.ts} {3, 7-8}
+```javascript {filename: main.ts} {3, 6-7, 11-15}
 Sentry.init({
   // Note, replayIntegration is NOT instantiated below:
   integrations: [],

--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -49,6 +49,8 @@ To learn more about Session Replay privacy, [read our docs.](/platforms/javascri
 
 ### Lazy-loading Replay
 
-Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `addIntegration`:
+Once you've added the integration, Replay will start automatically. If you don't want to start it immediately (lazy-load it), you can use `lazyLoadIntegration`:
 
 <PlatformContent includePath="configuration/integrations/lazy-loading-replay" />
+
+You can lazy-load the `replayIntegration` directly in `main.ts` (as shown in the example) but also in other parts of your application, for example a lazy-loaded module or component.


### PR DESCRIPTION
This PR updates the documentation how to correctly lazy-load the replay intergration in Angular apps with minimal bundle size implications. Unfortunately, Angular/Webpack don't play in our favour here so we can't use the same dynamic import snippet without initial bundle size hit penalties. More details here: https://github.com/getsentry/sentry-docs/issues/6477#issuecomment-2337877761

finally closes https://github.com/getsentry/sentry-docs/issues/6477

