### PR TITLE
Update docs to match native sdk backend defaults

### DIFF
--- a/docs/platforms/native/configuration/backends/index.mdx
+++ b/docs/platforms/native/configuration/backends/index.mdx
@@ -13,9 +13,8 @@ crashes. The backend is configured at build-time, using the `SENTRY_BACKEND`
 CMake option, with support for the following options:
 
 - [`crashpad`](crashpad/): This uses the out-of-process crashpad handler.
-  It is used as the default on Windows and macOS.
+  It is used as the default on Windows, macOS and Linux.
 - `breakpad`: This uses the in-process breakpad handler.
-  It is used as the default on Linux.
 - `inproc`: A small in-process handler which is supported on all platforms,
   and is used as default on Android.
 - `none`: This builds `sentry-native` without a backend, so it does not handle


### PR DESCRIPTION
## DESCRIBE YOUR PR
The default for Linux used to be breakpad but was changed to crashpad in https://github.com/getsentry/sentry-native/commit/164da7919172b0df9c7b75efbc36e6e897124415

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
