### PR TITLE
Remove mention of sentinel and prefix actions

### DIFF
--- a/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
+++ b/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
@@ -154,11 +154,6 @@ As an example, `-group ^-group` removes the matching frame and all frames above 
 - `app`: marks or unmarks a frame in-app
 - `group`: adds or removes a frame from grouping
 
-{/*<!--
-- `sentinel`: marks a frame as [sentinel frame](#sentinel--prefix-frames)
-- `prefix`: marks a frame as [prefix frame](#sentinel--prefix-frames)
--->*/}
-
 ### Variable Actions
 
 A limited set of _variables_ can be defined (`variable=value`):


### PR DESCRIPTION
These two actions are being removed in https://github.com/getsentry/sentry/pull/76994 since they were never shipped to GA.