### PR TITLE
feat(replay-javascript): Streamline verify instructions

### DIFF
--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -22,20 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by triggering a test error somewhere in your Angular app, for example in your main app component:
+### Verify
 
-```html {filename: app.component.html}
-<button (click)="throwTestError()">Test Sentry Error</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Then, in your `app.component.ts` add:
-
-```javascript {filename: app.component.ts}
-public throwTestError(): void {
-  throw new Error("Sentry Test Error");
-}
-```
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.angular.mdx
+++ b/platform-includes/session-replay/setup/javascript.angular.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -41,7 +41,8 @@ Session Replay can only be included on the client side.
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 
 ### PII & Privacy Considerations

--- a/platform-includes/session-replay/setup/javascript.astro.mdx
+++ b/platform-includes/session-replay/setup/javascript.astro.mdx
@@ -37,6 +37,13 @@ Session Replay can only be included on the client side.
 
 </Alert>
 
+### Verify
+
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+
+
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII) and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:

--- a/platform-includes/session-replay/setup/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/setup/javascript.capacitor.mdx
@@ -34,7 +34,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 Personally identifiable information (PII) and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:

--- a/platform-includes/session-replay/setup/javascript.capacitor.mdx
+++ b/platform-includes/session-replay/setup/javascript.capacitor.mdx
@@ -30,14 +30,11 @@ Sentry.init({
 });
 ```
 
-Session replays with errors, will always be captured with the settings above.
-You can verify this by adding the following snippet anywhere in your code and running it:
+### Verify
 
-```javascript
-setTimeout(() => {
-  throw new Error("Sentry Test Error");
-});
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 Personally identifiable information (PII) and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:

--- a/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -22,14 +22,12 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following snippet anywhere in your renderer code and running it:
+### Verify
 
-```javascript
-setTimeout(() => {
-  throw new Error("Sentry Test Error");
-});
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII) and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:

--- a/platform-includes/session-replay/setup/javascript.electron.mdx
+++ b/platform-includes/session-replay/setup/javascript.electron.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -22,14 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following snippet anywhere in your code and running it:
+### Verify
 
-```javascript
-setTimeout(() => {
-  throw new Error("Sentry Test Error");
-});
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.ember.mdx
+++ b/platform-includes/session-replay/setup/javascript.ember.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -22,19 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  onClick={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.gatsby.mdx
+++ b/platform-includes/session-replay/setup/javascript.gatsby.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -27,7 +27,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.mdx
+++ b/platform-includes/session-replay/setup/javascript.mdx
@@ -23,14 +23,12 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following snippet anywhere in your code and running it:
+### Verify
 
-```javascript
-setTimeout(() => {
-  throw new Error("Sentry Test Error");
-});
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+
 ### PII & Privacy Considerations
 
 Personally identifiable information (PII), and privacy are important considerations when enabling Session Replay. There are multiple ways in which Sentry helps you avoid collecting PII, including:

--- a/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -24,19 +24,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  onClick={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.nextjs.mdx
+++ b/platform-includes/session-replay/setup/javascript.nextjs.mdx
@@ -28,7 +28,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/platform-includes/session-replay/setup/javascript.react.mdx
@@ -22,19 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  onClick={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.react.mdx
+++ b/platform-includes/session-replay/setup/javascript.react.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -24,19 +24,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  onClick={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.remix.mdx
+++ b/platform-includes/session-replay/setup/javascript.remix.mdx
@@ -28,7 +28,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -22,19 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  on:click={() => {
-    throw new Error("Sentry Frontend Error");
-  }}
->
-  Throw error
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.svelte.mdx
+++ b/platform-includes/session-replay/setup/javascript.svelte.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -24,19 +24,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript
-<button
-  type="button"
-  on:click={() => {
-    throw new Error("Sentry Frontend Error");
-  }}
->
-  Throw error
-</button>
-```
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
+
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.sveltekit.mdx
+++ b/platform-includes/session-replay/setup/javascript.sveltekit.mdx
@@ -28,7 +28,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -22,23 +22,11 @@ Sentry.init({
 });
 ```
 
-With the settings above, session replays with errors are always captured.
-You can verify this by adding the following button to your app and pressing it:
+### Verify
 
-```javascript {filename:App.vue}
-// ...
-<button @click="throwError">Throw error</button>
-// ...
+While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-export default {
-  // ...
-  methods: {
-    throwError() {
-      throw new Error('Sentry Error');
-    }
-  }
-};
-```
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
 
 ### PII & Privacy Considerations
 

--- a/platform-includes/session-replay/setup/javascript.vue.mdx
+++ b/platform-includes/session-replay/setup/javascript.vue.mdx
@@ -26,7 +26,8 @@ Sentry.init({
 
 While you're testing, we recommend that you set `replaysSessionSampleRate` to `1.0`. This ensures that every user session will be sent to Sentry.
 
-Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysErrorSampleRate` set to `1.0`.
+Once testing is complete, **we recommend lowering this value in production**. We still recommend keeping `replaysOnErrorSampleRate` set to `1.0`, so that, whenever possible, every error has an associated replay with additional debugging context.
+
 
 ### PII & Privacy Considerations
 


### PR DESCRIPTION
Streamline the verify instructions for configuring replay using a JS SDK so they match the in-product docs.

![Screenshot 2024-09-10 at 08 59 27](https://github.com/user-attachments/assets/854ca7dc-d6cf-48a4-a4dc-437fee8b3f97)


closes https://github.com/getsentry/sentry/issues/77136