### PR TITLE
feat(native): add a compressed minidump endpoint example

### DIFF
--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -113,7 +113,7 @@ documents.
 
 ## Uploading a Compressed Minidump
 
-You can compress your minidump using `gzip` if its size exceeds the limits in the next section.
+You can compress your minidump using `gzip` if its size exceeds the [limits](#size-limits) in the next section.
 
 In this case, you would `POST` the minidump as a gzip-encoded binary:
 

--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -111,6 +111,59 @@ curl -X POST \
 For the full list of supported values, see [_Event Payloads_](https://develop.sentry.dev/sdk/event-payloads/) and linked
 documents.
 
+## Uploading a Compressed Minidump
+
+You can compress your minidump using `gzip` if its size exceeds the limits in the next section.
+
+In this case, you would `POST` the minidump as a gzip-encoded binary:
+
+```bash
+gzip mini.dmp
+
+curl -X POST \
+  '___MINIDUMP_URL___' \
+  -H 'content-type:application/x-dmp' \
+  -H 'content-encoding: gzip' \
+  --data-binary @mini.dmp.gz
+```
+
+Since `curl` doesn't allow adding multipart form fields to "data" `POST` requests, you cannot easily pass additional data as fields as in the previous section's examples.
+
+In that case, you must construct the multipart content manually and compress it as a whole:
+
+```bash
+# Use a consistent multipart boundary throughout the example 
+# and ensure it is a unique string inside the entire multipart body
+printf -- '--boundary_minidumpXYZ\r\n' > multipart_body.txt
+
+# Add additional data via JSON or using the bracket syntax (the latter requiring a field for each entry)
+printf -- 'Content-Disposition: form-data; name="sentry"\r\n\r\n' >> multipart_body.txt
+printf -- '{"release":"my-project-name@2.3.12","tags":{"mytag":"value"}}\r\n' >> multipart_body.txt
+
+# Add the boundary before each field (in this case the minidump)
+printf -- '--boundary_minidumpXYZ\r\n' >> multipart_body.txt
+
+# Add the minidump field header
+printf -- 'Content-Disposition: form-data; name="upload_file_minidump"; filename="mini.dmp"\r\n' >> multipart_body.txt
+printf -- 'Content-Type: application/x-dmp\r\n\r\n' >> multipart_body.txt
+
+# Append the minidump content
+cat mini.dmp >> multipart_body.txt
+
+# Add the closing boundary
+printf -- '\r\n--boundary_minidumpXYZ--\r\n' >> multipart_body.txt
+
+# Compress the entire multipart body
+gzip multipart_body.txt
+
+# Send the compressed multipart body with curl
+curl -X POST \
+     '___MINIDUMP_URL___' \
+     -H 'Content-Type: multipart/form-data; boundary=boundary_minidumpXYZ' \
+     -H 'Content-Encoding: gzip' \
+     --data-binary @multipart_body.txt.gz
+```
+
 ## Size Limits
 
 Event ingestion imposes limits on the size and number of fields in multipart

--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -127,9 +127,9 @@ curl -X POST \
   --data-binary @mini.dmp.gz
 ```
 
-Since `curl` doesn't allow adding multipart form fields to "data" `POST` requests, you cannot easily pass additional data as fields as in the previous section's examples.
+Since `curl` doesn't allow adding multipart form fields to "data" `POST` requests, you can't easily pass additional data as fields as in the previous section's examples.
 
-In that case, you must construct the multipart content manually and compress it as a whole:
+To get around this, you must construct the multipart content manually and compress it as a whole:
 
 ```bash
 # Use a consistent multipart boundary throughout the example 

--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -111,58 +111,7 @@ curl -X POST \
 For the full list of supported values, see [_Event Payloads_](https://develop.sentry.dev/sdk/event-payloads/) and linked
 documents.
 
-## Uploading a Compressed Minidump
-
-You can compress your minidump using `gzip` if its size exceeds the [limits](#size-limits) in the next section.
-
-In this case, you would `POST` the minidump as a gzip-encoded binary:
-
-```bash
-gzip mini.dmp
-
-curl -X POST \
-  '___MINIDUMP_URL___' \
-  -H 'content-type:application/x-dmp' \
-  -H 'content-encoding: gzip' \
-  --data-binary @mini.dmp.gz
-```
-
-Since `curl` doesn't allow adding multipart form fields to "data" `POST` requests, you can't easily pass additional data as fields as in the previous section's examples.
-
-To get around this, you must construct the multipart content manually and compress it as a whole:
-
-```bash
-# Use a consistent multipart boundary throughout the example 
-# and ensure it is a unique string inside the entire multipart body
-printf -- '--boundary_minidumpXYZ\r\n' > multipart_body.txt
-
-# Add additional data via JSON or using the bracket syntax (the latter requiring a field for each entry)
-printf -- 'Content-Disposition: form-data; name="sentry"\r\n\r\n' >> multipart_body.txt
-printf -- '{"release":"my-project-name@2.3.12","tags":{"mytag":"value"}}\r\n' >> multipart_body.txt
-
-# Add the boundary before each field (in this case the minidump)
-printf -- '--boundary_minidumpXYZ\r\n' >> multipart_body.txt
-
-# Add the minidump field header
-printf -- 'Content-Disposition: form-data; name="upload_file_minidump"; filename="mini.dmp"\r\n' >> multipart_body.txt
-printf -- 'Content-Type: application/x-dmp\r\n\r\n' >> multipart_body.txt
-
-# Append the minidump content
-cat mini.dmp >> multipart_body.txt
-
-# Add the closing boundary
-printf -- '\r\n--boundary_minidumpXYZ--\r\n' >> multipart_body.txt
-
-# Compress the entire multipart body
-gzip multipart_body.txt
-
-# Send the compressed multipart body with curl
-curl -X POST \
-     '___MINIDUMP_URL___' \
-     -H 'Content-Type: multipart/form-data; boundary=boundary_minidumpXYZ' \
-     -H 'Content-Encoding: gzip' \
-     --data-binary @multipart_body.txt.gz
-```
+If your minidump's size exceeds the [limits](#size-limits) in the next section, you can compress it using `gzip`, `zstd`, `bzip2` or `xz` and refer the `upload_file_minidump` to the compressed file instead of the plain minidump.
 
 ## Size Limits
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The docs currently do not describe how the minidump endpoint can be used when sending compressed payloads. This is often necessary when customers produce minidumps bigger than our upload limits.

Fixes #7575.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)