### PR TITLE
fix: correct syntax for native-sdk custom trace instrumentation

### DIFF
--- a/platform-includes/performance/add-spans-example/native.mdx
+++ b/platform-includes/performance/add-spans-example/native.mdx
@@ -14,7 +14,7 @@ void perform_checkout() {
     sentry_span_t *validation_span = sentry_transaction_start_child(
         tx,
         "validation",
-        "validating shopping cart",
+        "validating shopping cart"
     );
 
     validate_shopping_cart(); // Some long process, maybe a sync http request.
@@ -25,8 +25,8 @@ void perform_checkout() {
     sentry_span_t *process_span = sentry_transaction_start_child(
         tx,
         "process",
-        "processing shopping cart",
-    )
+        "processing shopping cart"
+    );
 
     process_shopping_cart(); // Another time consuming process.
 

--- a/platform-includes/performance/connect-errors-spans/native.mdx
+++ b/platform-includes/performance/connect-errors-spans/native.mdx
@@ -7,7 +7,7 @@ Errors reported to Sentry are automatically linked to any running transaction or
 ```c
 sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
     "checkout",
-    "perform-checkout",
+    "perform-checkout"
 );
 sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
@@ -17,7 +17,7 @@ sentry_set_span(tx);
 // Errors captured after the line above will be linked to the transaction
 sentry_value_t exc = sentry_value_new_exception(
     "ParseIntError",
-    "invalid digit found in string",
+    "invalid digit found in string"
 );
 
 sentry_value_t event = sentry_value_new_event();

--- a/platform-includes/performance/enable-manual-instrumentation/native.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/native.mdx
@@ -4,7 +4,9 @@ To instrument certain regions of your code, you can create transactions to captu
 // Enable tracing by setting a sample rate above 0
 sentry_options_t *options = sentry_options_new();
 sentry_options_set_traces_sample_rate(options, 0.2);
-//...
+// ...
+// (Configure tracing unrelated options as you see fit)
+// ...
 sentry_init(options);
 
 // Transactions can be started by providing the name and the operation

--- a/platform-includes/performance/enable-manual-instrumentation/native.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/native.mdx
@@ -4,13 +4,13 @@ To instrument certain regions of your code, you can create transactions to captu
 // Enable tracing by setting a sample rate above 0
 sentry_options_t *options = sentry_options_new();
 sentry_options_set_traces_sample_rate(options, 0.2);
-...
+//...
 sentry_init(options);
 
 // Transactions can be started by providing the name and the operation
 sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
     "transaction name",
-    "transaction operation",
+    "transaction operation"
 );
 sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
@@ -18,7 +18,7 @@ sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_nul
 sentry_span_t *span = sentry_transaction_start_child(
     tx,
     "child operation",
-    "child description",
+    "child description"
 );
 
 // ...


### PR DESCRIPTION
## DESCRIBE YOUR PR
Fixes erroneous syntax on page https://docs.sentry.io/platforms/native/tracing/instrumentation/custom-instrumentation/  (trailing commas, missing semicolons, non-commented ellipsis)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
