### PR TITLE
fix(python): `propagate_scope` is `True` by default

### DIFF
--- a/docs/platforms/python/integrations/default-integrations.mdx
+++ b/docs/platforms/python/integrations/default-integrations.mdx
@@ -84,7 +84,7 @@ _Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`_
 
 Reports crashing threads.
 
-This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the scope will be shared between threads and scope data (such as tags) will be transferred from the parent thread to the child thread.
+This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the current scope will be shared between threads and scope data (such as tags) will be transferred from the parent thread to the child thread.
 
 Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is still sometimes necessary if you want to propagate context data into a thread pool, for example.
 

--- a/docs/platforms/python/integrations/default-integrations.mdx
+++ b/docs/platforms/python/integrations/default-integrations.mdx
@@ -84,7 +84,7 @@ _Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`_
 
 Reports crashing threads.
 
-This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the scope will be shared between threads and scope data (such as tags) is transferred from the parent thread to the child thread.
+This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the scope will be shared between threads and scope data (such as tags) will be transferred from the parent thread to the child thread.
 
 Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is still sometimes necessary if you want to propagate context data into a thread pool, for example.
 

--- a/docs/platforms/python/integrations/default-integrations.mdx
+++ b/docs/platforms/python/integrations/default-integrations.mdx
@@ -84,7 +84,7 @@ _Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`_
 
 Reports crashing threads.
 
-This integration also accepts an option `propagate_scope`, which, when set to `True`, changes the way clients are transferred between threads and transfers scope data (such as tags) from the parent thread to the child thread. This option is currently disabled (`False`) by default, but this may change in the future.
+This integration also accepts an option `propagate_scope`, which, when set to `True`, changes the way clients are transferred between threads and transfers scope data (such as tags) from the parent thread to the child thread. This option is enabled by default.
 
 Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is still sometimes necessary if you want to propagate context data into a thread pool, for example.
 

--- a/docs/platforms/python/integrations/default-integrations.mdx
+++ b/docs/platforms/python/integrations/default-integrations.mdx
@@ -84,7 +84,7 @@ _Import name: `sentry_sdk.integrations.threading.ThreadingIntegration`_
 
 Reports crashing threads.
 
-This integration also accepts an option `propagate_scope`, which, when set to `True`, changes the way clients are transferred between threads and transfers scope data (such as tags) from the parent thread to the child thread. This option is enabled by default.
+This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the scope will be shared between threads and scope data (such as tags) is transferred from the parent thread to the child thread.
 
 Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is still sometimes necessary if you want to propagate context data into a thread pool, for example.
 
@@ -111,7 +111,7 @@ with isolation_scope() as thread_scope:
     tr.join()
 ```
 
-### Example B: Automatic propagation
+### Automatic propagation
 
 ```python
 import threading


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The `propagate_scope` option of the `ThreadingIntegration` in Python is on by default, but the docs say otherwise.

- Fix ^
- Clarify behavior a bit more
- Fix heading (there is no "Example A")

Fixes https://github.com/getsentry/sentry-docs/issues/10148

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
