### PR TITLE
fix(angular): Ensure sourcemaps links have correct text color

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.angular.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.angular.mdx
@@ -36,18 +36,21 @@ To generate source maps, you need to add the `sourceMap` option to your `angular
 ```
 
 <Alert>
-Generating sourcemaps may expose them to the public, potentially causing your source code to be leaked. You can prevent this by configuring your server to deny access to `.js.map` files, or by deleting the sourcemaps before deploying your application.
+  Generating sourcemaps may expose them to the public, potentially causing your
+  source code to be leaked. You can prevent this by configuring your server to
+  deny access to `.js.map` files, or by deleting the sourcemaps before deploying
+  your application.
 </Alert>
 
 #### Uploading Source Maps
 
 To upload your Angular project's source maps to Sentry, we recommend one of these options:
 
-- [**Angular CLI and Sentry webpack plugin**](./uploading/angular-webpack/) <br/>
+- [Angular CLI and Sentry webpack plugin](./uploading/angular-webpack/) <br/>
   Use the Angular CLI, a custom Angular builder and the Sentry webpack plugin to set releases and upload source maps automatically when running `ng build`.
-- [**Nx Angular CLI and Sentry webpack plugin**](./uploading/angular-nx/) <br/>
+- [Nx Angular CLI and Sentry webpack plugin](./uploading/angular-nx/) <br/>
   If you're using Nx, use `@nx/angular` CLI and the Sentry webpack plugin to set releases and upload source maps automatically when running `nx build`.
-- [**Sentry CLI**](./uploading/cli/)<br/>
+- [Sentry CLI](./uploading/cli/)<br/>
   Upload source maps manually using the Sentry CLI.
 
 Take a look at this [guide for further options to upload source maps](./uploading/).


### PR DESCRIPTION
Just noticed that if you make a link bold, the text color changes, making the link no longer appear purple. Might be a one-off though because we rarely make lists like this afaict

EDIT: Looks like any bold link is no longer coloured purple. Should we fix this? I guess there's rarely a reason to make a link bold so maybe it's also just fine if we leave it as-is