### PR TITLE
beforeStartSpan in JS has to always return options

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -71,7 +71,7 @@ You will need to configure your web server [CORS](https://developer.mozilla.org/
 
 ### beforeStartSpan
 
-`beforeStartSpan` is called at the start of every `pageload` or `navigation` span, and is passed an object containing data about the span which will be started. With `beforeStartSpan` you can modify that data or drop the transaction entirely by returning `undefined`.
+`beforeStartSpan` is called at the start of every `pageload` or `navigation` span, and is passed an object containing data about the span which will be started. With `beforeStartSpan` you can modify that data.
 
 <PlatformContent includePath="performance/beforeNavigate-example" />
 


### PR DESCRIPTION
The ways the function is implemented it can't be used for dropping transactions.

https://github.com/getsentry/sentry-javascript/blob/d265d927ee87d5c50fdebc62da926ddea3c95912/packages/browser/src/tracing/browserTracingIntegration.ts#L241