### PR TITLE
document sentry cli SENTRY_ALLOW_FAILURE

### DIFF
--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -110,6 +110,11 @@ The name of the environment to be appended to `User-Agent` header.
 
 The header that will be added to every outgoing request in `key:value` format.
 
+`SENTRY_ALLOW_FAILURE`
+
+Note: This option will ignore the CLI's failure when uploading symbols. **BE AWARE** this will unblock your CI in case Sentry has issues, but you won't have unminified/unsymbolicated crashes in production. 
+When using this flag, you should download your sourcemaps/debug files from CI, to re-run the upload symbols command at a later point once Sentry is available.
+
 (_http.keepalive_):
 
 This ini only setting is used to control the behavior of the SDK with regards to HTTP keepalives. The default is _true_ but it can be set to _false_ to disable keepalive support.


### PR DESCRIPTION
Relates to:

* https://docs.sentry.io/platforms/react-native/troubleshooting/#failing-build-due-to-sentry-cli
* https://github.com/getsentry/sentry-cli/pull/1343#issuecomment-1409433148
* https://x.com/thepanta82/status/1833542391115952425