### PR TITLE
fix(python): Remove outdated Hub mentions

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -153,13 +153,13 @@ To enable performance monitoring for the functions specified in `functions_to_tr
 
 ## Accessing the Current Transaction
 
-To change data in an already ongoing transaction, use `Hub.current.scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
+To change data in an already ongoing transaction, use `Scope.get_current_scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
 
 ```python
 import sentry_sdk
 
 def eat_pizza(pizza):
-    transaction = sentry_sdk.Hub.current.scope.transaction
+    transaction = sentry_sdk.Scope.get_current_scope().transaction
 
     if transaction is not None:
         transaction.set_tag("num_of_slices", len(pizza.slices))
@@ -170,16 +170,16 @@ def eat_pizza(pizza):
 
 ## Accessing the Current Span
 
-To change data in the current span, use `sentry_sdk.Hub.current.scope.span`. This property will return a span if there's one running, otherwise it will return `None`.
+To change data in the current span, use `get_current_span()`. This function will return a span if there's one running, otherwise it will return `None`.
 
-In this example, we'll set a tag in the span created by the `@sentry_sdk.trace` decorator.
+In this example, we'll set a tag in the span created by the `@trace` decorator.
 
 ```python
 import sentry_sdk
 
 @sentry_sdk.trace
 def eat_slice(slice):
-    span = sentry_sdk.Hub.current.scope.span
+    span = sentry_sdk.get_current_span()
 
     if span is not None:
         span.set_tag("slice_id", slice.id)

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -153,7 +153,7 @@ To enable performance monitoring for the functions specified in `functions_to_tr
 
 ## Accessing the Current Transaction
 
-To change data in an already ongoing transaction, use `Scope.get_current_scope.transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
+To change data in an already ongoing transaction, use `Scope.get_current_scope().transaction`. This property will return a transaction if there's one running, otherwise it will return `None`.
 
 ```python
 import sentry_sdk


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The custom instrumentation page still says `Hub.current` is the way to get the current transaction and span. This was deprecated in SDK 2.0 and will be removed soon. Updating to the currently recommended way of doing things.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
