### PR TITLE
docs(react): Add error boundary docs for react-router

### DIFF
--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -90,7 +90,7 @@ When using `react-router`, errors thrown inside route elements will only be re-t
 Note, that this only applies to render method and lifecycle errors since React doesn't need error boundaries to handle errors in event handlers.
 </Note>
 
-To send errors to Sentry when using a custom error boundary, use the `Sentry.captureException` method:
+To send errors to Sentry while using a custom error boundary, use the `Sentry.captureException` method:
 
 ```jsx {11, 27}
 // router setup

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -84,7 +84,7 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 
 ### Custom Error Boundaries
 
-When using `react-router`, errors thrown inside route elements will only be re-thrown in **development mode**. In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
+When using `react-router`, errors thrown inside route elements will only be re-thrown in **development mode** while using [`strict mode`](https://react.dev/reference/react/StrictMode). In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
 
 <Note>
 Note, that this only applies to render method and lifecycle errors since React doesn't need error boundaries to handle errors in event handlers.
@@ -119,7 +119,9 @@ import * as Sentry from "@sentry/react";
 export function YourCustomRootErrorBoundary() {
   const error = useRouteError() as Error;
 
-  Sentry.captureException(error);
+  React.useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
 
   return (
     <div>

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -82,6 +82,55 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 
 </Alert>
 
+### Custom Error Boundaries
+
+When using `react-router`, errors thrown inside route elements are only re-thrown in **development mode**. In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
+
+<Alert>
+Note that this only applies to render method and lifecycle errors, since React doesn't need error boundaries to handle errors in event handlers.
+</Alert>
+
+To send errors to Sentry when using a custom error boundary, use the `Sentry.captureException` method:
+
+```jsx {11, 27}
+// router setup
+const sentryCreateBrowserRouter = wrapCreateBrowserRouter(createBrowserRouter);
+const router = sentryCreateBrowserRouter([
+  {
+    path: "/",
+    element: <YourLayout />,
+    children: [
+      {
+        path: "",
+        element: <Outlet />,
+        errorElement: <YourCustomRootErrorBoundary />,
+        children: [
+          // other routes ... 
+        ],
+      },
+    ],
+  },
+]);
+
+// error boundary
+import { useRouteError } from "react-router-dom";
+import * as Sentry from "@sentry/react";
+
+export function YourCustomRootErrorBoundary() {
+  const error = useRouteError() as Error;
+
+  Sentry.captureException(error);
+
+  return (
+    <div>
+      <h1>Ouch!</h1>
+    </div>
+  );
+}
+
+```
+
+
 ### Usage With `<Routes />` Component
 
 If you're using the `<Routes />` component from `react-router-dom` to define your routes, wrap [`Routes`](https://reactrouter.com/en/main/components/routes) using `Sentry.withSentryReactRouterV6Routing`. This creates a higher order component, which will enable Sentry to reach your router context. You can also use `Sentry.withSentryReactRouterV6Routing` for `Routes` inside `BrowserRouter`. `MemoryRouter`, and `HashRouter` components:

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -86,9 +86,9 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 
 When using `react-router`, errors thrown inside route elements will only be re-thrown in **development mode**. In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
 
-<Alert>
-Note that this only applies to render method and lifecycle errors, since React doesn't need error boundaries to handle errors in event handlers.
-</Alert>
+<Note>
+Note, that this only applies to render method and lifecycle errors since React doesn't need error boundaries to handle errors in event handlers.
+</Note>
 
 To send errors to Sentry when using a custom error boundary, use the `Sentry.captureException` method:
 

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -84,7 +84,7 @@ You can instrument [`createMemoryRouter`](https://reactrouter.com/en/main/router
 
 ### Custom Error Boundaries
 
-When using `react-router`, errors thrown inside route elements are only re-thrown in **development mode**. In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
+When using `react-router`, errors thrown inside route elements will only be re-thrown in **development mode**. In production, these errors won't be surfaced unless manually captured. If you **don't** have a custom error boundary in place, `react-router` will create a default one that "swallows" all errors.
 
 <Alert>
 Note that this only applies to render method and lifecycle errors, since React doesn't need error boundaries to handle errors in event handlers.

--- a/docs/platforms/javascript/guides/react/features/react-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router.mdx
@@ -92,7 +92,7 @@ Note, that this only applies to render method and lifecycle errors since React d
 
 To send errors to Sentry while using a custom error boundary, use the `Sentry.captureException` method:
 
-```jsx {11, 27}
+```jsx {11, 28}
 // router setup
 const sentryCreateBrowserRouter = wrapCreateBrowserRouter(createBrowserRouter);
 const router = sentryCreateBrowserRouter([


### PR DESCRIPTION
Add docs for error boundaries in react router.

closes [#9337](https://github.com/getsentry/sentry-docs/issues/9337)