### PR TITLE
fix(docs): fix mobile redaction

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -84,8 +84,8 @@ If you encounter any data not being redacted with the default settings, please l
 To disable redaction altogether (not to be used on applications with sensitive data):
 
 ```swift
-options.experimental.sessionReplay.redactAllText = true
-options.experimental.sessionReplay.redactAllImages = true
+options.experimental.sessionReplay.redactAllText = false
+options.experimental.sessionReplay.redactAllImages = false
 ```
 
 ## Error Linking

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -87,9 +87,9 @@ To disable redaction altogether (not to be used on applications with sensitive d
 
 ```javascript
 Sentry.mobileReplayIntegration({
-  maskAllText: true,
-  maskAllImages: true,
-  maskAllVectors: true,
+  maskAllText: false,
+  maskAllImages: false,
+  maskAllVectors: false,
 }),
 ```
 


### PR DESCRIPTION
redaction is enabled (`true`) by default. to disable it we should set it to `false`