### PR TITLE
fix(js): Remove duplicated "latest SDK" prerequisite

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -3,10 +3,9 @@
 <PlatformSection notSupported={["javascript.capacitor", "javascript.cordova", "javascript.solid", "javascript.solidstart"]}>
 
 <Note>
-  We've released v8 of the JavaScript SDKs. If you're using version
-  7.x, we recommend upgrading to the latest version. Check out the [Migration
-  docs](./migration/v7-to-v8/)
-  to learn how to make the switch.
+  We've released version 8 of the JavaScript SDKs. If you're using version 7.x,
+  we recommend upgrading to the latest version. Check out the [Migration
+  docs](./migration/v7-to-v8/) to learn how to make the switch.
 </Note>
 
 </PlatformSection>
@@ -27,9 +26,7 @@ Check out the other SDKs we support in the left-hand dropdown.
 
 ## Prerequisites
 
-
 - A [Sentry account](https://sentry.io/signup/) and [Project](/product/projects/).
-- **Recommended:** Latest version of our [JavaScript SDK](./migration/v7-to-v8/).
 
 </PlatformSection>
 
@@ -68,7 +65,7 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 ## Install
 
 <PlatformCategorySection notSupported={["server"]}>
-  <PlatformSection notSupported={["javascript", 'javascript.cordova']}>
+  <PlatformSection notSupported={["javascript", "javascript.cordova"]}>
     <OnboardingOptionButtons
       options={["error-monitoring", "performance", "session-replay"]}
     />
@@ -90,9 +87,9 @@ Select which Sentry features you'd like to install in addition to Error Monitori
     />
   </PlatformSection>
 
-  In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
 
-  Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
+Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
   <PlatformSection supported={["javascript.bun"]}>
     <OnboardingOptionButtons options={["error-monitoring", "performance"]} />
@@ -125,12 +122,13 @@ Sentry supports multiple versions of React Router. To learn how to configure the
 
 <PlatformSection supported={["javascript.bun"]}>
 
-  ## Use
+## Use
 
-  <PlatformContent includePath="getting-started-use" />
+{" "}
+
+<PlatformContent includePath="getting-started-use" />
 
 </PlatformSection>
-
 
 ## Verify
 


### PR DESCRIPTION
Removes duplicated and somewhat confusing entry that the "Latest JavaScript SDK" was a prerequesite in the getting started guides (second red square in screenshot). For now we have the alert that people should upgrade to v8 SDK. We probably can remove that too, once we have versioned docs or after a couple of months. 

<img width="745" alt="image" src="https://github.com/user-attachments/assets/c0a58888-db71-4bee-b3a0-0b75d7ac4642">
