### PR TITLE
docs: Delete inaccurate, confusing block

### DIFF
--- a/docs/product/sentry-basics/integrate-backend/capturing-errors.mdx
+++ b/docs/product/sentry-basics/integrate-backend/capturing-errors.mdx
@@ -128,8 +128,6 @@ To enrich the data of the message events we've captured with `capture_message`:
    sentry_sdk.capture_message("You caught me!", "fatal")
    ```
 
-   > We're using the `push_scope` method that allows us to send data with one specific event on a local scope. We're setting a custom tag, user context attribute (email), and extra data on the local scope to enrich the data on the message event.
-
 3. Save your changes and trigger the `/message` endpoint again.
 
 4. Open the issue’s detail page from the [**Issues**](https://sentry.io/orgredirect/organizations/:orgslug/issues/) page.


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The code snippet no longer uses `push_scope`. This block is incorrect as a result.

Rather than fix the block, I think it makes more sense simply to delete it. I think the page already provides enough context around what we are doing.


## IS YOUR CHANGE URGENT?  
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
