### PR TITLE
feat(angular): Add documentation for Sentry's `ErrorHandler` 

### DIFF
--- a/docs/platforms/javascript/guides/angular/features/error-handler.mdx
+++ b/docs/platforms/javascript/guides/angular/features/error-handler.mdx
@@ -3,14 +3,11 @@ title: Angular Error Handler
 description: "Learn about Sentry's Angular SDK Error Handler and how to configure it."
 ---
 
-Sentry's Angular SDK provides a custom Angular `ErrorHandler` that automatically extracts and captures errors in your Angular application. The main benefit is that Angular often wraps errors in its own error classes, making
-it hard for Sentry to extract the important data correctly without a custom error handler.
-
-On this page, you'll learn how to work with the the SDKs `ErrorHandler` if you need to customize it further.
+Angular often wraps errors in its own error classes, making it hard for Sentry to extract the important data correctly without a custom error handler, which is where Sentry's Angular SDK `ErrorHandler` can help. On this page, you'll learn how to customize the SDK's `ErrorHandler` to work for your use case.
 
 ## Using the Sentry `ErrorHandler`
 
-Simply register the Sentry `ErrorHandler` in your Angular application's providers. We recommend to do this in your main `app.config.ts` or `app.module.ts` file to ensure that the `ErrorHandler` is available everywhere in your application.
+To get started, register the Sentry `ErrorHandler` in your Angular application's providers. We recommend to do this in your main `app.config.ts` or `app.module.ts` file to ensure that the `ErrorHandler` is available everywhere in your application.
 
 ```typescript {tabTitle:App Config} {filename:app.config.ts} {3,8-11}
 import { ApplicationConfig, ErrorHandler } from "@angular/core";
@@ -48,24 +45,24 @@ export class AppModule {}
 
 ### Options
 
-Optionally, you can configure the behavior of the `ErrorHandler` by passing an object to the `createErrorHandler` function. The following options are available:
+As an alternative, you can configure the behavior of the `ErrorHandler` by passing an object to the `createErrorHandler` function. The following options are available:
 
 #### `logErrors`
 
 _Type: `boolean` Default: `true`_
 
-Log errors to the console. This is `true` by default, to ensure consistency with Angular's default behavior.
+Lets you log errors to the console. This is `true` by default to ensure consistency with Angular's default behavior.
 
 #### `extractor`
 
 _Type: `function` Default: `undefined`_
 
-A function that extracts the raw, incoming error object. By default, the SDK uses its own extraction logic but you can override it by providing your own function.
+Lets you extract the raw, incoming error object. The SDK uses its own extraction logic by default, but you can override it by providing your own function.
 
 ## Multiple Error Handlers
 
-Angular doesn't allow providing multiple `ErrorHandler` instances in the same Angular application in `app.config.ts` or `app.module.ts`.
-Therefore, if you're using your own error handler or you want to add additional logic to Sentry's `ErrorHandler`, extend Sentry's `ErrorHandler`:
+Angular doesn't let you provide multiple `ErrorHandler` instances in the same Angular application in `app.config.ts` or `app.module.ts`.
+Therefore, if you're using your own error handler or you want to add additional logic to Sentry's `ErrorHandler`, you have to extend Sentry's `ErrorHandler` like in the example below:
 
 ```typescript
 import * as Sentry from "@sentry/angular";

--- a/docs/platforms/javascript/guides/angular/features/error-handler.mdx
+++ b/docs/platforms/javascript/guides/angular/features/error-handler.mdx
@@ -1,0 +1,85 @@
+---
+title: Angular Error Handler
+description: "Learn about Sentry's Angular SDK Error Handler and how to configure it."
+---
+
+Sentry's Angular SDK provides a custom Angular `ErrorHandler` that automatically extracts and captures errors in your Angular application. The main benefit is that Angular often wraps errors in its own error classes, making
+it hard for Sentry to extract the important data correctly without a custom error handler.
+
+On this page, you'll learn how to work with the the SDKs `ErrorHandler` if you need to customize it further.
+
+## Using the Sentry `ErrorHandler`
+
+Simply register the Sentry `ErrorHandler` in your Angular application's providers. We recommend to do this in your main `app.config.ts` or `app.module.ts` file to ensure that the `ErrorHandler` is available everywhere in your application.
+
+```typescript {tabTitle:App Config} {filename:app.config.ts} {3,8-11}
+import { ApplicationConfig, ErrorHandler } from "@angular/core";
+
+import * as Sentry from "@sentry/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    // ...
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler(),
+    },
+  ],
+};
+export class AppModule {}
+```
+
+```typescript {tabTitle:NGModule Config} {filename:app.module.ts} {3,8-11}
+import { ErrorHandler, NgModule } from "@angular/core";
+
+import * as Sentry from "@sentry/angular";
+
+@NgModule({
+  // ...
+  providers: [
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler(),
+    },
+  ],
+})
+export class AppModule {}
+```
+
+### Options
+
+Optionally, you can configure the behavior of the `ErrorHandler` by passing an object to the `createErrorHandler` function. The following options are available:
+
+#### `logErrors`
+
+_Type: `boolean` Default: `true`_
+
+Log errors to the console. This is `true` by default, to ensure consistency with Angular's default behavior.
+
+#### `extractor`
+
+_Type: `function` Default: `undefined`_
+
+A function that extracts the raw, incoming error object. By default, the SDK uses its own extraction logic but you can override it by providing your own function.
+
+## Multiple Error Handlers
+
+Angular doesn't allow providing multiple `ErrorHandler` instances in the same Angular application in `app.config.ts` or `app.module.ts`.
+Therefore, if you're using your own error handler or you want to add additional logic to Sentry's `ErrorHandler`, extend Sentry's `ErrorHandler`:
+
+```typescript
+import * as Sentry from "@sentry/angular";
+
+export class CustomErrorHandler extends Sentry.ErrorHandler {
+  constructor() {
+    // Pass options to Sentry's ErrorHandler here. For Example:
+    super({ logErrors: false });
+  }
+
+  handleError(error: any): void {
+    // Your custom error handling logic
+    // Call Sentry's error handler to capture errors:
+    super.handleError(error);
+  }
+}
+```

--- a/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/platform-includes/getting-started-config/javascript.angular.mdx
@@ -71,7 +71,7 @@ import * as Sentry from "@sentry/angular";
 export class AppModule {}
 ```
 
-The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. You can also customize the behavior by setting a couple of handler [options](https://github.com/getsentry/sentry-javascript/blob/master/packages/angular/src/errorhandler.ts).
+The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. Cou can further [configure](./features/error-handler) Sentry's `ErrorHandler` behavior.
 
 <OnboardingOption optionId="performance">
 The `Sentry.TraceService` listens to the Angular router for tracing. To inject `TraceService`, register the `APP_INITIALIZER` provider as shown above. Alternatively, you can also require the `TraceService` from inside your `AppModule` constructor:

--- a/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/platform-includes/getting-started-config/javascript.angular.mdx
@@ -71,7 +71,7 @@ import * as Sentry from "@sentry/angular";
 export class AppModule {}
 ```
 
-The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. Cou can further [configure](./features/error-handler) Sentry's `ErrorHandler` behavior.
+The `Sentry.createErrorHandler` function initializes a Sentry-specific `ErrorHandler` that automatically sends errors caught by Angular to Sentry. Learn how to further configure Sentry's `ErrorHandler` behavior [here](./features/error-handler).
 
 <OnboardingOption optionId="performance">
 The `Sentry.TraceService` listens to the Angular router for tracing. To inject `TraceService`, register the `APP_INITIALIZER` provider as shown above. Alternatively, you can also require the `TraceService` from inside your `AppModule` constructor:


### PR DESCRIPTION
builds on top of #11356 

This PR adds a new "Angular Features" sub page for the Angular SDK's `ErrorHandler`. Previously, the config options and some edge cases around the handler were undocumented and users had to ask for clarifications in GitHub and Discord. 

The new page now explains 
- what the error handler does / why it's necessary
- a couple of options (omitted the old `reportDialog` options in favour of User Feedback)
- how to handle multiple error handlers

ref https://github.com/getsentry/sentry-javascript/issues/13636
