### PR TITLE
feat: Add docs about request isolation in Node SDK

### DIFF
--- a/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
@@ -21,7 +21,7 @@ notSupported:
 
 In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> is automatically forked around request boundaries. This means that each request will have its own isolation scope, and data set on the isolation scope will only apply to events captured during that request. This is done automatically by the SDK.
 
-However, the request isolation happens when the request itself is processed. This means that if you e.g. have a middleware where you want to set Sentry data (e.g. `Sentry.setUser()` in an auth middleware), you have to manually fork the isolation scope with `Sentry.withIsolationScope()` - see [Using withIsolationScope](../scopes/#using-withisolationscope).
+However, the request isolation happens when the request callback itself is being executed. This means that if you e.g. have a middleware where you want to set Sentry data (e.g. `Sentry.setUser()` in an auth middleware), you have to manually fork the isolation scope with `Sentry.withIsolationScope()` - see [Using withIsolationScope](../scopes/#using-withisolationscope).
 
 This is also necessary if you want to isolate a non-request process, e.g. a background job.
 

--- a/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
@@ -21,27 +21,16 @@ notSupported:
 
 In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> is automatically forked around request boundaries. This means that each request will have its own isolation scope, and data set on the isolation scope will only apply to events captured during that request. This is done automatically by the SDK.
 
-However, the request isolation happens when the request callback itself is being executed. This means that if you e.g. have a middleware where you want to set Sentry data (e.g. `Sentry.setUser()` in an auth middleware), you have to manually fork the isolation scope with `Sentry.withIsolationScope()` - see [Using withIsolationScope](../scopes/#using-withisolationscope).
+However, tehre are also other cases where you may want to have isolation, for example in background jobs or when you want to isolate a specific part of your code. In these cases, you can use `Sentry.withIsolationScope()` to create a new isolation scope that is valid inside of the callback you pass to it - see [Using withIsolationScope](../scopes/#using-withisolationscope).
 
-This is also necessary if you want to isolate a non-request process, e.g. a background job.
-
-The following example shows how you can use `withIsolationScope` to attach a user and a tag in an auth middleware:
+The following example shows how you can use `withIsolationScope` to attach data for a specific job run:
 
 ```javascript
-const auth = (req, res, next) => {
-  Sentry.withIsolationScope(() => {
-    const authUser = findUserForHeader(req.headers["authorization"]);
-    if (!authUser) {
-      Sentry.setTag("Authenticated", false);
-      Sentry.setUser(null);
-      next(new Error("Authentication Error"));
-    } else {
-      Sentry.setTag("Authenticated", true);
-      Sentry.setUser(authUser);
-      next();
-    }
+async function job(jobId) {
+  return Sentry.withIsolationScope(async () => {
+    // Only valid for events in this callback
+    Sentry.setTag("jobId", jobId);
+    await doSomething();
   });
-};
+}
 ```
-
-This way, the user & tag will only be attached to events captured during the request that passed the auth middleware.

--- a/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
@@ -21,7 +21,7 @@ notSupported:
 
 In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> is automatically forked around request boundaries. This means that each request will have its own isolation scope, and data set on the isolation scope will only apply to events captured during that request. This is done automatically by the SDK.
 
-However, tehre are also other cases where you may want to have isolation, for example in background jobs or when you want to isolate a specific part of your code. In these cases, you can use `Sentry.withIsolationScope()` to create a new isolation scope that is valid inside of the callback you pass to it - see [Using withIsolationScope](../scopes/#using-withisolationscope).
+However, there are also other cases where you may want to have isolation, for example in background jobs or when you want to isolate a specific part of your code. In these cases, you can use `Sentry.withIsolationScope()` to create a new isolation scope that is valid inside of the callback you pass to it - see [Using withIsolationScope](../scopes/#using-withisolationscope).
 
 The following example shows how you can use `withIsolationScope` to attach data for a specific job run:
 

--- a/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
@@ -1,0 +1,47 @@
+---
+title: Process Isolation
+description: "Learn more about how process isolation (or request isolation) works in the Sentry SDK."
+supported:
+  - javascript.nextjs
+  - javascript.node
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.nuxt
+  - javascript.solidstart
+  - javascript.sveltekit
+  - javascript.astro
+  - javascript.remix
+notSupported:
+  - javascript
+---
+
+In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> is automatically forked around request boundaries. This means that each request will have its own isolation scope, and data set on the isolation scope will only apply to events captured during that request. This is done automatically by the SDK.
+
+However, the request isolation happens when the request itself is processed. This means that if you e.g. have a middleware where you want to set Sentry data (e.g. `Sentry.setUser()` in an auth middleware), you have to manually fork the isolation scope with `Sentry.withIsolationScope()` - see [Using withIsolationScope](../scopes/#using-withisolationscope).
+
+This is also necessary if you want to isolate a non-request process, e.g. a background job.
+
+The following example shows how you can use `withIsolationScope` to attach a user and a tag in an auth middleware:
+
+```javascript
+const auth = (req, res, next) => {
+  Sentry.withIsolationScope(() => {
+    const authUser = findUserForHeader(req.headers["authorization"]);
+    if (!authUser) {
+      Sentry.setTag("Authenticated", false);
+      Sentry.setUser(null);
+      next(new Error("Authentication Error"));
+    } else {
+      Sentry.setTag("Authenticated", true);
+      Sentry.setUser(authUser);
+      next();
+    }
+  });
+};
+```
+
+This way, the user & tag will only be attached to events captured during the request that passed the auth middleware.

--- a/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/process-isolation/index.mdx
@@ -19,11 +19,11 @@ notSupported:
   - javascript
 ---
 
-In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> is automatically forked around request boundaries. This means that each request will have its own isolation scope, and data set on the isolation scope will only apply to events captured during that request. This is done automatically by the SDK.
+In server-side environments, the <PlatformLink to='/enriching-events/scopes'>isolation scope</PlatformLink> automatically forks around request boundaries. This is done automatically by the SDK. As a result, each request has its own isolation scope, and data set on the isolation scope only applies to events captured during that request. 
 
-However, there are also other cases where you may want to have isolation, for example in background jobs or when you want to isolate a specific part of your code. In these cases, you can use `Sentry.withIsolationScope()` to create a new isolation scope that is valid inside of the callback you pass to it - see [Using withIsolationScope](../scopes/#using-withisolationscope).
+However, there are also other times when you may want to have isolation, for example, in background jobs or when you want to isolate a specific part of your code. In these cases, you can use `Sentry.withIsolationScope()` to create a new isolation scope that's valid inside of the callback you pass to it. Learn more about using [withIsolationScope](../scopes/#using-withisolationscope).
 
-The following example shows how you can use `withIsolationScope` to attach data for a specific job run:
+The following example shows how you can use `withIsolationScope` to attach data to a specific job run:
 
 ```javascript
 async function job(jobId) {

--- a/docs/platforms/javascript/common/enriching-events/request-isolation/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/request-isolation/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Process Isolation
-description: "Learn more about how process isolation (or request isolation) works in the Sentry SDK."
+title: Request Isolation
+description: "Learn more about how request isolation (or process isolation) works in the Sentry SDK."
 supported:
   - javascript.nextjs
   - javascript.node

--- a/docs/platforms/javascript/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/scopes/index.mdx
@@ -143,3 +143,11 @@ In the following example we use <PlatformIdentifier name="with-scope" /> to atta
 The scope inside the `withScope()` callback is only valid inside of the callback. Once the callback ends, the scope will be removed and no longer applied. The inner scope is only applied to events that are captured inside of the callback. `withScope()` will clone (or fork) the current scope, so that the current scope is not modified. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
+
+<PlatformCategorySection supported={['server']}>
+## Using `withIsolationScope`
+
+`withIsolationScope` works fundamentally the same as `withScope`, but it will fork the isolation scope instead of the current scope. Generally, the isolation scope is meant to be forked less frequently than the current scope, and in most cases the SDK will handle this automatically for you. But in cases where you e.g. want to capture SDK events in a middleware (which happens before the request is processed and thus before the SDKs automatic handling), or if you want to isolate a non-request process (e.g. a background job), you can use `withIsolationScope` to create a new isolation scope that is only active for the duration of the callback:
+
+<PlatformContent includePath="enriching-events/scopes/with-isolation-scope" />
+</PlatformCategorySection>

--- a/docs/platforms/javascript/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/scopes/index.mdx
@@ -147,7 +147,9 @@ even call <PlatformIdentifier name="clear" /> to briefly remove all context info
 <PlatformCategorySection supported={['server']}>
 ## Using `withIsolationScope`
 
-`withIsolationScope` works fundamentally the same as `withScope`, but it will fork the isolation scope instead of the current scope. Generally, the isolation scope is meant to be forked less frequently than the current scope, and in most cases the SDK will handle this automatically for you. But in cases where you e.g. want to capture SDK events in a middleware (which happens before the request is processed and thus before the SDKs automatic handling), or if you want to isolate a non-request process (e.g. a background job), you can use `withIsolationScope` to create a new isolation scope that is only active for the duration of the callback:
+`withIsolationScope` works fundamentally the same as `withScope`, but it will fork the isolation scope instead of the current scope. Generally, the isolation scope is meant to be forked less frequently than the current scope, and in most cases the SDK will handle this automatically for you.
+
+But in cases where you e.g. want to isolate a non-request process (e.g. a background job), you can use `withIsolationScope` to create a new isolation scope that is only active for the duration of the callback:
 
 <PlatformContent includePath="enriching-events/scopes/with-isolation-scope" />
 </PlatformCategorySection>

--- a/platform-includes/enriching-events/scopes/with-isolation-scope/javascript.mdx
+++ b/platform-includes/enriching-events/scopes/with-isolation-scope/javascript.mdx
@@ -1,0 +1,13 @@
+```javascript
+Sentry.withIsolationScope(function () {
+  // This user & tag is set inside of this callback
+  Sentry.setUser({ id: "123" });
+  Sentry.setTag("my-tag", "my value");
+
+  // will be tagged with my-tag="my value" & user
+  Sentry.captureException(new Error("my error"));
+});
+
+// will not be tagged with my-tag & user
+Sentry.captureException(new Error("my other error"));
+```


### PR DESCRIPTION
This adds docs for how to use `withIsolationScope`.

Additionally, it also adds a new section (for server SDKs) under "enriching events" describing how process isolation works. We lack docs for this as of now, and this is something users may def. fall into.

It would be ideal if we could somehow auto-fork this for middlewares, but in the meanwhile...

See https://github.com/getsentry/sentry-javascript/discussions/12191#discussioncomment-10667098 for how this affects users.