### PR TITLE
ref(js): Adjust and update JS transaction grouping example code

### DIFF
--- a/platform-includes/performance/group-transaction-example/javascript.mdx
+++ b/platform-includes/performance/group-transaction-example/javascript.mdx
@@ -1,7 +1,7 @@
 ```javascript
-// All JavaScript-based SDKs include this function, so it's safe to replace `@sentry/node`
+// All JavaScript-based SDKs include this function, so it's safe to replace `@sentry/browser`
 // with your particular SDK
-import { addEventProcessor } from "@sentry/node";
+import { addEventProcessor } from "@sentry/browser";
 
 addEventProcessor((event) => {
   if (event.type === "transaction") {
@@ -11,7 +11,7 @@ addEventProcessor((event) => {
 });
 ```
 
-For browser JavaScript applications using the `BrowserTracing` integration, the `beforeStartSpan` option can be used to better group `navigation`/`pageload` transactions together based on URL.
+For browser JavaScript applications using `browserTracingIntegration` integration, the `beforeStartSpan` option can be used to better group `navigation`/`pageload` transactions together based on URL.
 
 ```javascript
 import * as Sentry from "@sentry/browser";


### PR DESCRIPTION
While reviewing https://github.com/getsentry/sentry-docs/pull/11133, I noticed another inconsistency between v7 and v8 code on this page. This PR changes `BrowserTracing`->`browserTracingIntegration` and slightly adjusts the import in the code snippet above to better fit the browser docs. 