### PR TITLE
fix(ruby): Make traces_sampler example safe

### DIFF
--- a/platform-includes/performance/traces-sampler-as-sampler/ruby.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/ruby.mdx
@@ -9,7 +9,7 @@ Sentry.init do |config|
 
     # the sampling context also has the full rack environment if you want to check the path directly
     rack_env = sampling_context[:env]
-    return 0.0 if rack_env['PATH_INFO'] =~ /health_check/
+    return 0.0 if rack_env && rack_env['PATH_INFO'] =~ /health_check/
 
     # transaction_context is the transaction object in hash form
     # keep in mind that sampling happens right after the transaction is initialized


### PR DESCRIPTION
see 
https://github.com/getsentry/sentry-ruby/issues/2399#issuecomment-2360157202