### PR TITLE
fix(docs): Fix missing python configure SDK code snippet

### DIFF
--- a/platform-includes/getting-started-config/python.mdx
+++ b/platform-includes/getting-started-config/python.mdx
@@ -1,0 +1,14 @@
+```python {"onboardingOptions": {"performance": "5-7", "profiling": "8-11"}}
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,
+)
+```


### PR DESCRIPTION
In our SDK docs, for most of the platforms we were missing init SDK code snippet for python in **Configure** section (e.g. [AIOHTTP](https://docs.sentry.io/platforms/python/integrations/aiohttp/)).

This is because we were missing `python.mdx` as a platfrom in our `platform-includes/getting-started-config/` directory.

The code snippet here is the same as for the default Python SDK configuration.