### PR TITLE
feat(icons): Add icon for Litestar framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.6",
     "parse-numeric-range": "^1.3.0",
-    "platformicons": "^6.0.2",
+    "platformicons": "^6.0.3",
     "prism-sentry": "^1.0.2",
     "prismjs": "^1.27.0",
     "query-string": "^6.13.1",

--- a/src/components/platformIcon.tsx
+++ b/src/components/platformIcon.tsx
@@ -80,6 +80,7 @@ import KotlinSVG from 'platformicons/svg/kotlin.svg';
 import LangchainSVG from 'platformicons/svg/langchain.svg';
 import LaravelSVG from 'platformicons/svg/laravel.svg';
 import LinuxSVG from 'platformicons/svg/linux.svg';
+import LitestarSVG from 'platformicons/svg/litestar.svg';
 import LogbackSVG from 'platformicons/svg/logback.svg';
 import LoguruSVG from 'platformicons/svg/loguru.svg';
 import MauiSVG from 'platformicons/svg/maui.svg';
@@ -216,6 +217,7 @@ import KotlinSVGLarge from 'platformicons/svg_80x80/kotlin.svg';
 import LangchainSVGLarge from 'platformicons/svg_80x80/langchain.svg';
 import LaravelSVGLarge from 'platformicons/svg_80x80/laravel.svg';
 import LinuxSVGLarge from 'platformicons/svg_80x80/linux.svg';
+import LitestarSVGLarge from 'platformicons/svg_80x80/litestar.svg';
 import LogbackSVGLarge from 'platformicons/svg_80x80/logback.svg';
 import LoguruSVGLarge from 'platformicons/svg_80x80/loguru.svg';
 import MauiSVGLarge from 'platformicons/svg_80x80/maui.svg';
@@ -597,6 +599,10 @@ const formatToSVG = {
     sm: LinuxSVG,
     lg: LinuxSVGLarge,
   },
+  litestar: {
+    sm: LitestarSVG,
+    lg: LitestarSVGLarge,
+  },
   logback: {
     sm: LogbackSVG,
     lg: LogbackSVGLarge,
@@ -954,6 +960,7 @@ export const PLATFORM_TO_ICON = {
   'python-huey': 'huey',
   'python-huggingface_hub': 'huggingface',
   'python-langchain': 'langchain',
+  'python-litestar': 'litestar',
   'python-loguru': 'loguru',
   'python-openai': 'openai',
   'python-pylons': 'python',
@@ -965,6 +972,7 @@ export const PLATFORM_TO_ICON = {
   'python-sanic': 'sanic',
   'python-serverless': 'serverless',
   'python-starlette': 'starlette',
+  'python-starlite': 'litestar',
   'python-strawberry': 'strawberry',
   'python-spark': 'apache-spark',
   'python-sqlalchemy': 'sqlalchemy',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9475,10 +9475,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-platformicons@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-6.0.2.tgz#a4e43dcdfba09201e0780ce15bbeadf5c0f323d0"
-  integrity sha512-YUVj9GTxhMeee4IScqA4sGRGJVsO1/++Xahrr0IeONBIOnlH2RwM/VBZ1L9WjSlR+z9HtE49DUCxH1omzCVcnA==
+platformicons@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-6.0.3.tgz#c167ab68c1cdb1a4d97665118b65ebccf7dcbe00"
+  integrity sha512-Z83ePiRqlA8yXQI1Y28/xv/7hGW/2BajJESxbnTjQkBjs2vGFAQjMs5E/mkOJoNuDKfEeaHgD7xOqajvARd4AQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add icon for Python's Litestar framework integration. Use the same icon for Starlite as well, since Starlite is Litestar's old name, which is still used in old versions.

Closes #10933


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] N/a ~~PR was reviewed and approved by any necessary SMEs (subject matter experts)~~
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)