### PR TITLE
fix(releases): Document `release:latest` filter behaviour

### DIFF
--- a/docs/concepts/search/searchable-properties/events.mdx
+++ b/docs/concepts/search/searchable-properties/events.mdx
@@ -505,7 +505,7 @@ Returns results with an approximate percentile of the field. Replace "XY" with 5
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/issues.mdx
+++ b/docs/concepts/search/searchable-properties/issues.mdx
@@ -312,7 +312,7 @@ The id of the project.
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/releases.mdx
+++ b/docs/concepts/search/searchable-properties/releases.mdx
@@ -22,7 +22,7 @@ Below is a list of keys and tokens that can be used in the release search.
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/session-replay.mdx
+++ b/docs/concepts/search/searchable-properties/session-replay.mdx
@@ -222,7 +222,7 @@ Similar to the `click.selector` search property, but only queries on [rage click
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release.
+A release is a version of your code deployed to an environment. You can create a token with an exact match of the version of a release, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 
 - **Type:** string
 

--- a/docs/concepts/search/searchable-properties/spans.mdx
+++ b/docs/concepts/search/searchable-properties/spans.mdx
@@ -135,7 +135,7 @@ Name of the platform. This defaults to `other` and is only a property for platfo
 
 ### `release`
 
-A release is a version of your code deployed to an environment. You can create a token that matches a release exactly, or pick the most recent release by using `release:latest`.
+A release is a version of your code deployed to an environment. You can create a token that matches a release exactly, or pick the most recent release by using `release:latest`. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 
 - **Type:** string
 

--- a/docs/product/releases/usage/sorting-filtering.mdx
+++ b/docs/product/releases/usage/sorting-filtering.mdx
@@ -20,7 +20,7 @@ On the **Releases** page, you can use the "Sort By" dropdown to sort releases by
 
 Search on the **Releases** page supports both raw text and query syntax, and you can search using the following properties:
 
-- `release` - Search based on string comparison.
+- `release` - Search based on string comparison, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
 - `release.stage` - Search releases with matching adoption stage. Can be `adopted`, `low_adoption`, or `replaced`. Learn more about [release adoption stages](/product/releases/health/#adoption-stages).
 
 If you are using our [semantic versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:

--- a/docs/product/releases/usage/sorting-filtering.mdx
+++ b/docs/product/releases/usage/sorting-filtering.mdx
@@ -20,7 +20,7 @@ On the **Releases** page, you can use the "Sort By" dropdown to sort releases by
 
 Search on the **Releases** page supports both raw text and query syntax, and you can search using the following properties:
 
-- `release` - Search based on string comparison, or `release:latest` to pick the most recent release. [Learn more](/product/releases/usage/sorting-filtering/#latest-release).
+- `release` - Search based on string comparison, or `release:latest` to pick the most recent release. [Learn more](#latest-release).
 - `release.stage` - Search releases with matching adoption stage. Can be `adopted`, `low_adoption`, or `replaced`. Learn more about [release adoption stages](/product/releases/health/#adoption-stages).
 
 If you are using our [semantic versioning](/platform-redirect/?next=/configuration/releases/%23bind-the-version) format, you can use the following query tokens:

--- a/docs/product/releases/usage/sorting-filtering.mdx
+++ b/docs/product/releases/usage/sorting-filtering.mdx
@@ -30,3 +30,7 @@ If you are using our [semantic versioning](/platform-redirect/?next=/configurati
 - `release.build` - Search releases with matching build numbers.
 
 Learn more about search queries in our [full Search documentation](/concepts/search/).
+
+## Latest Release
+
+The special `release:latest` filter intelligently finds the most recent release for every selected project. For projects that use [Semantic Version](/platform-redirect/?next=/configuration/releases/%23bind-the-version) numbers, the latest release is one with the highest version number. For projects that use Commit SHA for versioning, the latest release is the most recent one.


### PR DESCRIPTION
The Dashboards team got some feedback that the `"release:latest"` filter didn't work as people expected. It was not clear what exactly the filter does. This PR adds a bit of documentation to explain what's going on, and links to it in the appropriate places.
