### PR TITLE
Update docs on running getsentry locally

### DIFF
--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -16,13 +16,11 @@ After installation you should be able to run `devenv bootstrap` which will guide
 
 When you're done with setup, you'll want to also review the <Link to="/development/workflow/">development workflow</Link>.
 
-
 ## Keeping your environment up-to-date
 
 Simply run `devenv sync` inside of your sentry or getsentry repo.
 
 NOTE: After running `devenv sync` you may need to restart your terminal to continue.
-
 
 ## Running the Development Server
 
@@ -73,7 +71,9 @@ Running `sentry devserver` will automatically use HTTPS when the certificates ha
 
 ### Ingestion Pipeline (Relay) aka Sending Events to your Dev Environment
 
-<Link to="/services/relay/">Relay</Link> and the ingest workers are not started by default. Follow the instructions below to start them so you can send events to your dev environment Sentry instance:
+<Link to="/services/relay/">Relay</Link> and the ingest workers are not started by
+default. Follow the instructions below to start them so you can send events to your
+dev environment Sentry instance:
 
 - Set `SENTRY_USE_RELAY = True` in `~/.sentry/sentry.conf.py`. This will tell `sentry devservices up` to also start services that Relay needs.
 - Run `sentry devservices up` to start the services Relay needs. (like for example Kafka)
@@ -108,6 +108,8 @@ sentry devservices up snuba
 
 See also: <Link to="/sentry-vs-getsentry/">Sentry vs Getsentry</Link>
 
+Before running `getsentry`, you might need to run `devenv sync` inside the `getsentry` directory if you have previously run `sentry` locally, as there might be differences between the environments.
+
 Just like running `sentry` (see above), you can start the `devservices` using the following command in the `getsentry` folder:
 
 ```shell
@@ -122,9 +124,7 @@ getsentry devserver --workers
 
 **Note**: You **cannot** have both sentry and getsentry devserver running at the same time.
 
-After the server warms up for a little while, you must access it
-at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/).
-Using localhost doesn't work.
+After the server warms up, access it at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/). Using localhost won't work. Note that the **http** protocol is used, not **https**. If you encounter a certificate error while accessing it locally, it might be because your browser has remembered that `dev.getsentry.net` previously used the https protocol (possibly while running `yarn dev-ui`) and is now redirecting all http requests to https. To resolve this, open the site in an **incognito window** of your browser.
 
 If you need to overwrite configuration options for your local
 environment, you can create `getsentry/conf/settings/devlocal.py` and put the
@@ -132,16 +132,16 @@ configuration option overrides there. This module will be automatically imported
 by `dev.py` if it exists.
 
 To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run
+
 ```shell
 getsentry devserver --workers --ingest
 ```
 
-
 ## Running siloed instances
 
-By default `sentry devserver` will run a monolith mode application server. You can also run ``devserver`` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.
+By default `sentry devserver` will run a monolith mode application server. You can also run `devserver` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.
 
-The devserver command supports  `--silo` option that lets you create siloed instances. Any workers, consumers, or celery-beat processes will be started with the same silo mode.
+The devserver command supports `--silo` option that lets you create siloed instances. Any workers, consumers, or celery-beat processes will be started with the same silo mode.
 
 ```shell
 # Start control silo servers
@@ -150,6 +150,7 @@ sentry devserver --silo=control --celery-beat --workers
 # Start region silo servers
 sentry devserver --silo=region --celery-beat --workers --ingest
 ```
+
 Siloed servers have the following port assignments:
 
 - 8000 - Webpack

--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -71,9 +71,7 @@ Running `sentry devserver` will automatically use HTTPS when the certificates ha
 
 ### Ingestion Pipeline (Relay) aka Sending Events to your Dev Environment
 
-<Link to="/services/relay/">Relay</Link> and the ingest workers are not started by
-default. Follow the instructions below to start them so you can send events to your
-dev environment Sentry instance:
+<Link to="/services/relay/">Relay</Link> and the ingest workers are not started by default. Follow the instructions below to start them so you can send events to your dev environment Sentry instance:
 
 - Set `SENTRY_USE_RELAY = True` in `~/.sentry/sentry.conf.py`. This will tell `sentry devservices up` to also start services that Relay needs.
 - Run `sentry devservices up` to start the services Relay needs. (like for example Kafka)


### PR DESCRIPTION
I had a few pain points while running getsentry locally, so I have updated the docs to save someone else (and my future self) the trouble next time getsentry is going to be run locally