### PR TITLE
docs: Update FastAPI/Starlette `failed_request_status_codes` docs

### DIFF
--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -81,12 +81,12 @@ sentry_sdk.init(
     integrations=[
         StarletteIntegration(
             transaction_style="endpoint",
-            failed_request_status_codes=[403, range(500, 599)],
+            failed_request_status_codes={403, *range(500, 599)},
             http_methods_to_capture=("GET",),
         ),
         FastApiIntegration(
             transaction_style="endpoint",
-            failed_request_status_codes=[403, range(500, 599)],
+            failed_request_status_codes={403, *range(500, 599)},
             http_methods_to_capture=("GET",),
         ),
     ]
@@ -132,16 +132,16 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
 - `failed_request_status_codes`:
 
-  A list of integers or containers (objects that allow membership checks via `in`)
-  of integers that will determine which status codes should be reported to Sentry.
+  A `set` of integers that will determine which status codes should be reported to Sentry.
 
   Examples of valid `failed_request_status_codes`:
 
-  - `[500]` will only send events on HTTP 500.
-  - `[400, range(500, 599)]` will send events on HTTP 400 as well as the 500-599 range.
-  - `[500, 503]` will send events on HTTP 500 and 503.
+  - `{500}` will only send events on HTTP 500.
+  - `{400, *range(500, 600)}` will send events on HTTP 400 as well as the 5xx range.
+  - `{500, 503}` will send events on HTTP 500 and 503.
+  - `set()` (the empty set) will not send events for any HTTP status code.
 
-  The default is `[range(500, 599)]`.
+  The default is `{*range(500, 600)}`, meaning that all 5xx status codes are reported to Sentry.
 
 - `http_methods_to_capture`:
 

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -59,7 +59,7 @@ sentry_sdk.init(
     integrations=[
         StarletteIntegration(
             transaction_style="endpoint",
-            failed_request_status_codes=[403, range(500, 599)],
+            failed_request_status_codes={403, *range(500, 599)},
             middleware_spans=False,
             http_methods_to_capture=("GET",),
         )
@@ -89,16 +89,16 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
 - `failed_request_status_codes`:
 
-  A list of integers or containers (objects that allow membership checks via `in`)
-  of integers that will determine which status codes should be reported to Sentry.
+  A `set` of integers that will determine which status codes should be reported to Sentry.
 
   Examples of valid `failed_request_status_codes`:
 
-  - `[500]` will only send events on HTTP 500.
-  - `[400, range(500, 599)]` will send events on HTTP 400 as well as the 500-599 range.
-  - `[500, 503]` will send events on HTTP 500 and 503.
+  - `{500}` will only send events on HTTP 500.
+  - `{400, *range(500, 600)}` will send events on HTTP 400 as well as the 5xx range.
+  - `{500, 503}` will send events on HTTP 500 and 503.
+  - `set()` (the empty set) will not send events for any HTTP status code.
 
-  The default is `[range(500, 599)]`.
+  The default is `{*range(500, 600)}`, meaning that all 5xx status codes are reported to Sentry.
 
 - `middleware_spans`:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
We have slightly changed the `failed_request_status_codes` API for FastAPI and Starlette in https://github.com/getsentry/sentry-python/pull/3563. The old API is still supported, but it is deprecated, so the docs should only document the new API.

Closes [#11434](https://github.com/getsentry/sentry-docs/issues/11434)


## IS YOUR CHANGE URGENT?  
None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)