### PR TITLE
fix(changelog): Use useActionState for server actions

### DIFF
--- a/apps/changelog/src/app/changelog/%5Fadmin/[id]/edit/page.tsx
+++ b/apps/changelog/src/app/changelog/%5Fadmin/[id]/edit/page.tsx
@@ -1,13 +1,8 @@
-import {Fragment, Suspense} from 'react';
+import {Fragment, Suspense, useActionState} from 'react';
 import Link from 'next/link';
 
 import {prismaClient} from '@/server/prisma-client';
-import {editChangelog} from '@/server/actions/changelog';
-import {TitleSlug} from '@/client/components/titleSlug';
-import {FileUpload} from '@/client/components/fileUpload';
-import {Select} from '@/client/components/ui/Select';
-import {ForwardRefEditor} from '@/client/components/forwardRefEditor';
-import {Button} from '@/client/components/ui/Button';
+import {EditChangelogForm} from '@/client/components/forms/editChangelogForm';
 
 export default async function ChangelogCreatePage({params}: {params: {id: string}}) {
   const categories = await prismaClient.category.findMany({
@@ -38,59 +33,7 @@ export default async function ChangelogCreatePage({params}: {params: {id: string
 
   return (
     <section className="overflow-x-auto col-start-3 col-span-8">
-      <form action={editChangelog} className="px-2 w-full">
-        <input type="hidden" name="id" value={changelog.id} />
-        <TitleSlug defaultSlug={changelog.slug} defaultTitle={changelog.title} />
-        <FileUpload defaultFile={changelog.image || ''} />
-        <div className="my-6">
-          <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
-            Summary
-            <Fragment>
-              &nbsp;<span className="font-bold text-secondary">*</span>
-            </Fragment>
-          </label>
-          <textarea name="summary" className="w-full" required>
-            {changelog.summary}
-          </textarea>
-          <span className="text-xs text-gray-500 italic">
-            This will be shown in the list
-          </span>
-        </div>
-        <div>
-          <Select
-            name="categories"
-            className="mt-1 mb-6"
-            label="Category"
-            placeholder="Select Category"
-            defaultValue={changelog.categories.map(category => ({
-              label: category.name,
-              value: category.name,
-            }))}
-            options={categories.map(category => ({
-              label: category.name,
-              value: category.name,
-            }))}
-            isMulti
-          />
-        </div>
-
-        <Suspense fallback={null}>
-          <ForwardRefEditor
-            name="content"
-            defaultValue={changelog.content || ''}
-            className="w-full"
-          />
-        </Suspense>
-
-        <footer className="flex items-center justify-between mt-2 mb-8">
-          <Link href="/changelog/_admin" className="underline text-gray-500">
-            Return to Changelogs list
-          </Link>
-          <div>
-            <Button type="submit">Update</Button>
-          </div>
-        </footer>
-      </form>
+      <EditChangelogForm changelog={changelog} categories={categories} />
     </section>
   );
 }

--- a/apps/changelog/src/app/changelog/%5Fadmin/confirm.tsx
+++ b/apps/changelog/src/app/changelog/%5Fadmin/confirm.tsx
@@ -1,26 +1,29 @@
 'use client';
 
-import type {PropsWithChildren} from 'react';
+import {ServerActionPayloadInterface} from '@/server/actions/serverActionPayload.interface';
+import {useActionState, type PropsWithChildren} from 'react';
 
 export default function Confirm({
   action,
   changelog,
   children,
 }: PropsWithChildren<{
-  action: (formData: FormData) => Promise<void | {
-    message: string;
-  }>;
+  action: (
+    currentFormState: ServerActionPayloadInterface,
+    formData: FormData
+  ) => Promise<ServerActionPayloadInterface>;
   changelog: {id: string};
 }>) {
+  const [_state, formAction] = useActionState(action, {});
   return (
     <form
-      action={action}
+      action={formAction}
       className="inline-block"
       onSubmit={e => {
         e.preventDefault();
         // eslint-disable-next-line no-alert
         if (confirm('Are you sure?')) {
-          action(new FormData(e.currentTarget));
+          formAction(new FormData(e.currentTarget));
         }
       }}
     >

--- a/apps/changelog/src/app/changelog/%5Fadmin/create/page.tsx
+++ b/apps/changelog/src/app/changelog/%5Fadmin/create/page.tsx
@@ -1,15 +1,9 @@
-import {Fragment} from 'react';
-import Link from 'next/link';
 import {prismaClient} from '@/server/prisma-client';
-import {createChangelog} from '@/server/actions/changelog';
-import {TitleSlug} from '@/client/components/titleSlug';
-import {FileUpload} from '@/client/components/fileUpload';
-import {Select} from '@/client/components/ui/Select';
-import {ForwardRefEditor} from '@/client/components/forwardRefEditor';
-import {Button} from '@/client/components/ui/Button';
+
 import {getServerSession} from 'next-auth/next';
 import {notFound} from 'next/navigation';
 import {authOptions} from '@/server/authOptions';
+import {CreateChangelogForm} from '@/client/components/forms/createChangelogForm';
 
 export default async function ChangelogCreatePage() {
   const session = await getServerSession(authOptions);
@@ -26,48 +20,7 @@ export default async function ChangelogCreatePage() {
 
   return (
     <section className="overflow-x-auto col-start-3 col-span-8">
-      <form action={createChangelog} className="px-2 w-full">
-        <TitleSlug />
-        <FileUpload />
-        <div className="my-6">
-          <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
-            Summary
-            <Fragment>
-              &nbsp;<span className="font-bold text-secondary">*</span>
-            </Fragment>
-          </label>
-          <textarea name="summary" className="w-full" required />
-          <span className="text-xs text-gray-500 italic">
-            This will be shown in the list
-          </span>
-        </div>
-        <div>
-          <Select
-            name="categories"
-            className="mt-1 mb-6"
-            label="Category"
-            placeholder="Select Category"
-            options={categories.map(category => ({
-              label: category.name,
-              value: category.name,
-            }))}
-            isMulti
-          />
-        </div>
-
-        <ForwardRefEditor name="content" className="w-full" />
-
-        <footer className="flex items-center justify-between mt-2">
-          <Link href="/changelog/_admin" className="underline text-gray-500">
-            Return to Changelogs list
-          </Link>
-          <div>
-            <Button type="submit">Create (not published yet)</Button>
-            <br />
-            <span className="text-xs text-gray-500 italic">You can publish it later</span>
-          </div>
-        </footer>
-      </form>
+      <CreateChangelogForm categories={categories} />
     </section>
   );
 }

--- a/apps/changelog/src/client/components/forms/createChangelogForm.tsx
+++ b/apps/changelog/src/client/components/forms/createChangelogForm.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {createChangelog} from '@/server/actions/changelog';
+import {TitleSlug} from '@/client/components/titleSlug';
+import {FileUpload} from '@/client/components/fileUpload';
+import {Select} from '@/client/components/ui/Select';
+import {ForwardRefEditor} from '@/client/components/forwardRefEditor';
+import {Button} from '@/client/components/ui/Button';
+import {Fragment, useActionState} from 'react';
+import Link from 'next/link';
+import {Category} from '@prisma/client';
+
+export const CreateChangelogForm = ({categories}: {categories: Category[]}) => {
+  const [_state, formAction] = useActionState(createChangelog, {});
+  return (
+    <form action={formAction} className="px-2 w-full">
+      <TitleSlug />
+      <FileUpload />
+      <div className="my-6">
+        <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
+          Summary
+          <Fragment>
+            &nbsp;<span className="font-bold text-secondary">*</span>
+          </Fragment>
+        </label>
+        <textarea name="summary" className="w-full" required />
+        <span className="text-xs text-gray-500 italic">
+          This will be shown in the list
+        </span>
+      </div>
+      <div>
+        <Select
+          name="categories"
+          className="mt-1 mb-6"
+          label="Category"
+          placeholder="Select Category"
+          options={categories.map(category => ({
+            label: category.name,
+            value: category.name,
+          }))}
+          isMulti
+        />
+      </div>
+
+      <ForwardRefEditor name="content" className="w-full" />
+
+      <footer className="flex items-center justify-between mt-2">
+        <Link href="/changelog/_admin" className="underline text-gray-500">
+          Return to Changelogs list
+        </Link>
+        <div>
+          <Button type="submit">Create (not published yet)</Button>
+          <br />
+          <span className="text-xs text-gray-500 italic">You can publish it later</span>
+        </div>
+      </footer>
+    </form>
+  );
+};

--- a/apps/changelog/src/client/components/forms/editChangelogForm.tsx
+++ b/apps/changelog/src/client/components/forms/editChangelogForm.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import {editChangelog} from '@/server/actions/changelog';
+import {TitleSlug} from '@/client/components/titleSlug';
+import {FileUpload} from '@/client/components/fileUpload';
+import {Select} from '@/client/components/ui/Select';
+import {ForwardRefEditor} from '@/client/components/forwardRefEditor';
+import {Button} from '@/client/components/ui/Button';
+import {Fragment, Suspense, useActionState} from 'react';
+import {Changelog, Category} from '@prisma/client';
+import Link from 'next/link';
+
+export const EditChangelogForm = ({
+  changelog,
+  categories,
+}: {
+  changelog: Changelog;
+  categories: Category[];
+}) => {
+  const [_state, formAction] = useActionState(editChangelog, {});
+  return (
+    <form action={formAction} className="px-2 w-full">
+      <input type="hidden" name="id" value={changelog.id} />
+      <TitleSlug defaultSlug={changelog.slug} defaultTitle={changelog.title} />
+      <FileUpload defaultFile={changelog.image || ''} />
+      <div className="my-6">
+        <label htmlFor="summary" className="block text-xs font-medium text-gray-700">
+          Summary
+          <Fragment>
+            &nbsp;<span className="font-bold text-secondary">*</span>
+          </Fragment>
+        </label>
+        <textarea name="summary" className="w-full" required>
+          {changelog.summary}
+        </textarea>
+        <span className="text-xs text-gray-500 italic">
+          This will be shown in the list
+        </span>
+      </div>
+      <div>
+        <Select
+          name="categories"
+          className="mt-1 mb-6"
+          label="Category"
+          placeholder="Select Category"
+          defaultValue={categories.map(category => ({
+            label: category.name,
+            value: category.name,
+          }))}
+          options={categories.map(category => ({
+            label: category.name,
+            value: category.name,
+          }))}
+          isMulti
+        />
+      </div>
+
+      <Suspense fallback={null}>
+        <ForwardRefEditor
+          name="content"
+          defaultValue={changelog.content || ''}
+          className="w-full"
+        />
+      </Suspense>
+
+      <footer className="flex items-center justify-between mt-2 mb-8">
+        <Link href="/changelog/_admin" className="underline text-gray-500">
+          Return to Changelogs list
+        </Link>
+        <div>
+          <Button type="submit">Update</Button>
+        </div>
+      </footer>
+    </form>
+  );
+};

--- a/apps/changelog/src/server/actions/changelog.ts
+++ b/apps/changelog/src/server/actions/changelog.ts
@@ -1,154 +1,180 @@
-"use server";
+'use server';
 
-import { revalidatePath, revalidateTag } from "next/cache";
-import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth/next";
-import { prismaClient } from "../prisma-client";
-import { authOptions } from "../authOptions";
+import {revalidatePath, revalidateTag} from 'next/cache';
+import {redirect} from 'next/navigation';
+import {getServerSession} from 'next-auth/next';
+import {prismaClient} from '../prisma-client';
+import {authOptions} from '../authOptions';
+import {ServerActionPayloadInterface} from './serverActionPayload.interface';
 
-export async function unpublishChangelog(formData: FormData) {
+const unauthorizedPayload: ServerActionPayloadInterface = {
+  success: false,
+  message: 'Unauthorized',
+};
+
+export async function unpublishChangelog(
+  _currentState: ServerActionPayloadInterface,
+  formData: FormData
+): Promise<ServerActionPayloadInterface> {
   const session = await getServerSession(authOptions);
 
   if (!session) {
-    return { message: "Unauthorized" };
+    return unauthorizedPayload;
   }
-  const id = formData.get("id") as string;
+  const id = formData.get('id') as string;
 
   try {
     await prismaClient.changelog.update({
-      where: { id },
-      data: { published: false, publishedAt: null },
+      where: {id},
+      data: {published: false, publishedAt: null},
     });
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("DELETE ACTION ERROR:", error);
-    return { message: "Unable to unpublish changelog" };
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to unpublish changelog', success: false};
   }
 
-  revalidateTag("changelogs");
-  revalidateTag("changelog-detail");
-  return revalidatePath(`/changelog/_admin`);
+  revalidateTag('changelogs');
+  revalidateTag('changelog-detail');
+  revalidatePath(`/changelog/_admin`);
+  return {success: true};
 }
 
-export async function publishChangelog(formData: FormData) {
+export async function publishChangelog(
+  _currentState: ServerActionPayloadInterface,
+  formData: FormData
+): Promise<ServerActionPayloadInterface> {
   const session = await getServerSession();
 
   if (!session) {
-    return { message: "Unauthorized" };
+    return unauthorizedPayload;
   }
-  const id = formData.get("id") as string;
+  const id = formData.get('id') as string;
 
   try {
     await prismaClient.changelog.update({
-      where: { id },
-      data: { published: true, publishedAt: new Date().toISOString() },
+      where: {id},
+      data: {published: true, publishedAt: new Date().toISOString()},
     });
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("DELETE ACTION ERROR:", error);
-    return { message: "Unable to publish changelog" };
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to publish changelog', success: false};
   }
 
-  revalidateTag("changelogs");
-  revalidateTag("changelog-detail");
-  return revalidatePath(`/changelog/_admin`);
+  revalidateTag('changelogs');
+  revalidateTag('changelog-detail');
+  revalidatePath(`/changelog/_admin`);
+  return {success: true};
 }
 
-export async function createChangelog(formData: FormData) {
+export async function createChangelog(
+  _currentState: ServerActionPayloadInterface,
+  formData: FormData
+): Promise<ServerActionPayloadInterface> {
   const session = await getServerSession(authOptions);
   if (!session) {
-    return { message: "Unauthorized" };
+    return unauthorizedPayload;
   }
-  const categories = formData.getAll("categories");
+  console.log({formData});
+  const categories = formData.getAll('categories');
   await prismaClient.category.createMany({
-    data: categories.map((category) => ({ name: category as string })),
+    data: categories.map(category => ({name: category as string})),
     skipDuplicates: true,
   });
-  const connect = categories.map((category) => {
-    return { name: category as string };
+  const connect = categories.map(category => {
+    return {name: category as string};
   });
 
   if (session.user?.email == null) {
-    throw new Error("Invariant: Users must have emails");
+    throw new Error('Invariant: Users must have emails');
   }
 
   const user = await prismaClient.user.findUnique({
-    where: { email: session.user.email },
+    where: {email: session.user.email},
   });
 
   const data = {
-    title: formData.get("title") as string,
-    content: formData.get("content") as string,
-    summary: formData.get("summary") as string,
-    image: formData.get("image") as string,
-    slug: formData.get("slug") as string,
-    author: user ? { connect: { id: user.id } } : undefined,
-    categories: formData.get("categories") !== "" ? { connect } : {},
+    title: formData.get('title') as string,
+    content: formData.get('content') as string,
+    summary: formData.get('summary') as string,
+    image: formData.get('image') as string,
+    slug: formData.get('slug') as string,
+    author: user ? {connect: {id: user.id}} : undefined,
+    categories: formData.get('categories') !== '' ? {connect} : {},
   };
 
-  await prismaClient.changelog.create({ data });
+  await prismaClient.changelog.create({data});
 
   return redirect(`/changelog/_admin`);
 }
 
-export async function editChangelog(formData: FormData) {
+export async function editChangelog(
+  _currentState: ServerActionPayloadInterface,
+  formData: FormData
+): Promise<ServerActionPayloadInterface> {
   const session = await getServerSession(authOptions);
   if (!session) {
-    return { message: "Unauthorized" };
+    return unauthorizedPayload;
   }
-  const id = formData.get("id") as string;
-  const categories = formData.getAll("categories");
+  const id = formData.get('id') as string;
+  const categories = formData.getAll('categories');
   await prismaClient.category.createMany({
-    data: categories.map((category) => ({ name: category as string })),
+    data: categories.map(category => ({name: category as string})),
     skipDuplicates: true,
   });
-  const connect = categories.map((category) => {
-    return { name: category as string };
+  const connect = categories.map(category => {
+    return {name: category as string};
   });
 
   try {
     const data = {
-      title: formData.get("title") as string,
-      content: formData.get("content") as string,
-      summary: formData.get("summary") as string,
-      image: formData.get("image") as string,
-      slug: formData.get("slug") as string,
-      categories:
-        formData.get("categories") !== "" ? { set: [...connect] } : { set: [] },
+      title: formData.get('title') as string,
+      content: formData.get('content') as string,
+      summary: formData.get('summary') as string,
+      image: formData.get('image') as string,
+      slug: formData.get('slug') as string,
+      categories: formData.get('categories') !== '' ? {set: [...connect]} : {set: []},
     };
 
     await prismaClient.changelog.update({
-      where: { id },
+      where: {id},
       data,
     });
-  } catch (error) {
+  } catch (error: any) {
     // eslint-disable-next-line no-console
-    console.error("EDIT ACTION ERROR:", error);
-    return { message: error };
+    console.error('EDIT ACTION ERROR:', error);
+    return {message: (error as Error).message, success: false};
   }
 
-  revalidateTag("changelogs");
-  revalidateTag("changelog-detail");
+  revalidateTag('changelogs');
+  revalidateTag('changelog-detail');
   return redirect(`/changelog/_admin`);
 }
 
-export async function deleteChangelog(formData: FormData) {
+export async function deleteChangelog(
+  _currentState: ServerActionPayloadInterface,
+  formData: FormData
+): Promise<ServerActionPayloadInterface> {
   const session = await getServerSession(authOptions);
   if (!session) {
-    return { message: "Unauthorized" };
+    return unauthorizedPayload;
   }
-  const id = formData.get("id") as string;
+  const id = formData.get('id') as string;
   try {
     await prismaClient.changelog.delete({
-      where: { id },
+      where: {id},
     });
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("DELETE ACTION ERROR:", error);
-    return { message: "Unable to delete changelog" };
+    console.error('DELETE ACTION ERROR:', error);
+    return {message: 'Unable to delete changelog', success: false};
   }
 
-  revalidateTag("changelogs");
-  revalidateTag("changelog-detail");
-  return revalidatePath(`/changelog/_admin`);
+  revalidateTag('changelogs');
+  revalidateTag('changelog-detail');
+  revalidatePath(`/changelog/_admin`);
+  return {
+    success: true,
+  };
 }

--- a/apps/changelog/src/server/actions/serverActionPayload.interface.ts
+++ b/apps/changelog/src/server/actions/serverActionPayload.interface.ts
@@ -1,0 +1,4 @@
+export interface ServerActionPayloadInterface {
+  message?: string;
+  success?: boolean;
+}


### PR DESCRIPTION
This pr adds [useActionState](https://react.dev/reference/react/useActionState) for all changelog server actions.
Although the payloads are currently not used (they were not used before either), this fixes the type errors we got from passing these actions directly to the forms.