### PR TITLE
ref(onboarding): Update word

### DIFF
--- a/docs/platforms/dotnet/common/index.mdx
+++ b/docs/platforms/dotnet/common/index.mdx
@@ -34,4 +34,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/elixir/index.mdx
+++ b/docs/platforms/elixir/index.mdx
@@ -37,4 +37,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/go/common/index.mdx
+++ b/docs/platforms/go/common/index.mdx
@@ -32,4 +32,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/java/common/index.mdx
+++ b/docs/platforms/java/common/index.mdx
@@ -30,4 +30,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -142,4 +142,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/kotlin-multiplatform/index.mdx
+++ b/docs/platforms/kotlin-multiplatform/index.mdx
@@ -36,7 +36,7 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 ## Supported Platforms
 

--- a/docs/platforms/native/common/index.mdx
+++ b/docs/platforms/native/common/index.mdx
@@ -30,4 +30,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/powershell/index.mdx
+++ b/docs/platforms/powershell/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: PowerShell
-caseStyle: PascalCase   
+caseStyle: PascalCase
 supportLevel: production
 sdk: sentry.dotnet.powershell
 categories:
@@ -42,4 +42,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -67,7 +67,7 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
 <Note>
 

--- a/docs/platforms/ruby/common/index.mdx
+++ b/docs/platforms/ruby/common/index.mdx
@@ -42,4 +42,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/unity/index.mdx
+++ b/docs/platforms/unity/index.mdx
@@ -40,4 +40,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -122,4 +122,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -59,4 +59,4 @@ Learn more about manually capturing an error or message in our <PlatformLink to=
 
 </Note>
 
-To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.


### PR DESCRIPTION
Users in a new organization who are going through the onboarding process should select a project (if multiple are available) on the issue stream page (the default page when opening sentry.io), rather than clicking on the 'Projects' sidebar item, as suggested in the docs.

Noticed this when dogfooding Sentry using Next.js