### PR TITLE
Adds breadcrumb origin field

### DIFF
--- a/develop-docs/sdk/event-payloads/breadcrumbs.mdx
+++ b/develop-docs/sdk/event-payloads/breadcrumbs.mdx
@@ -91,6 +91,10 @@ Contains a dictionary whose contents depend on the breadcrumb type. Additional p
 
 : This defines the severity level of the breadcrumb. Allowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, and `debug`. Levels are used in the UI to emphasize and deemphasize the crumb. The default is `info`.
 
+`origin` (optional)
+
+: A string representing the origin of the breadcrumb. This is typically used to identify source of the breadcrumb. For example hybrid SDKs can identify native breadcrumbs from JS or Flutter.
+
 `timestamp` (recommended)
 
 : A timestamp representing when the breadcrumb occurred. The format is either a string as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float) value representing the number of seconds that have elapsed since the [Unixepoch](https://en.wikipedia.org/wiki/Unix_time).  

--- a/develop-docs/sdk/event-payloads/breadcrumbs.mdx
+++ b/develop-docs/sdk/event-payloads/breadcrumbs.mdx
@@ -93,7 +93,7 @@ Contains a dictionary whose contents depend on the breadcrumb type. Additional p
 
 `origin` (optional)
 
-: A string representing the origin of the breadcrumb. This is typically used to identify source of the breadcrumb. For example hybrid SDKs can identify native breadcrumbs from JS or Flutter.
+: A string representing the origin of the breadcrumb. This is typically used to identify the source of the breadcrumb. For example hybrid SDKs can identify native breadcrumbs from JS or Flutter.
 
 `timestamp` (recommended)
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Closes https://github.com/getsentry/sentry-cocoa/issues/4043
Is blocked by the implementation of https://github.com/getsentry/sentry-java/issues/3470

This PR adds the documentation for the new optional `breadcrumb`field `origin` used to identify source of the breadcrumb.


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
