### PR TITLE
fix(remix): Add verify step to manual guide

### DIFF
--- a/docs/platforms/javascript/guides/remix/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/remix/manual-setup.mdx
@@ -225,6 +225,11 @@ export function handleError(
 
 After you've completed this setup, the SDK will automatically capture unhandled errors and promise rejections, and monitor performance in the client. You can also [manually capture errors](/platforms/javascript/guides/remix/usage).
 
+## Verify
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up.
+
+<PlatformContent includePath="getting-started-verify" />
+
 <Note>
 
 You can refer to [Remix Docs](https://remix.run/docs/en/main/guides/envvars#browser-environment-variables) to learn how to use your Sentry DSN with environment variables.


### PR DESCRIPTION
The verify step was missing in the manual guide for remix 

**Before**
<img width="830" alt="image" src="https://github.com/user-attachments/assets/25a57587-28de-4d61-8587-c8ee12677c4b">


**After**

<img width="929" alt="image" src="https://github.com/user-attachments/assets/a9e2a64c-388b-4b8b-9089-dd579e84c523">

closes https://github.com/getsentry/sentry/issues/78337
