### PR TITLE
fix(python): Replace deprecated start_span parameter

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -51,7 +51,7 @@ def eat_slice(slice):
 def eat_pizza(pizza):
     with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
         while pizza.slices > 0:
-            with sentry_sdk.start_span(description="Eat Slice"):
+            with sentry_sdk.start_span(name="Eat Slice"):
                 eat_slice(pizza.slices.pop())
 
 ```
@@ -94,10 +94,10 @@ def swallow():
     ...
 
 def eat_slice(slice):
-    with sentry_sdk.start_span(description="Eat Slice"):
-        with sentry_sdk.start_span(description="Chew"):
+    with sentry_sdk.start_span(name="Eat Slice"):
+        with sentry_sdk.start_span(name="Chew"):
             chew()
-        with sentry_sdk.start_span(description="Swallow"):
+        with sentry_sdk.start_span(name="Swallow"):
             swallow()
 
 ```

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
@@ -48,7 +48,7 @@ with sentry_sdk.start_transaction(
     # Create the span
     with sentry_sdk.start_span(
         op="queue.publish",
-        description="queue_producer",
+        name="queue_producer",
     ) as span:
         # Set span data
         span.set_data("messaging.message.id", message_id)
@@ -118,7 +118,7 @@ with sentry_sdk.start_transaction(transaction):
     # Create the span
     with sentry_sdk.start_span(
         op="queue.process",
-        description="queue_consumer",
+        name="queue_consumer",
     ) as span:
         # Set span data
         span.set_data("messaging.message.id", message["message_id"])

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/requests-module.mdx
@@ -22,7 +22,7 @@ import requests
 def make_request(method, url):
     span = sentry_sdk.start_span(
         op="http.client",
-        description="%s %s" % (method, url),
+        name="%s %s" % (method, url),
     )
 
     span.set_data("http.request.method", method)

--- a/docs/product/insights/llm-monitoring/getting-started/index.mdx
+++ b/docs/product/insights/llm-monitoring/getting-started/index.mdx
@@ -62,7 +62,7 @@ def some_llm_call():
     """
     This function is an example of calling an LLM provider that isn't officially supported by Sentry.
     """
-    with sentry_sdk.start_span(op="ai.chat_completions.create.examplecom", description="Example.com LLM") as span:
+    with sentry_sdk.start_span(op="ai.chat_completions.create.examplecom", name="Example.com LLM") as span:
         result = requests.get('https://example.com/api/llm-chat?question=say+hello').json()
         # this annotates the tokens used by the LLM so that they show up in the graphs in the dashboard
         record_token_usage(span, total_tokens=result["usage"]["total_tokens"])

--- a/platform-includes/performance/add-spans-example/python.mdx
+++ b/platform-includes/performance/add-spans-example/python.mdx
@@ -9,7 +9,7 @@ import sentry_sdk
 
 def process_item(item):
     # omitted code...
-    with sentry_sdk.start_span(op="http", description="GET /") as span:
+    with sentry_sdk.start_span(op="http", name="GET /") as span:
         response = my_custom_http_library.request("GET", "/")
         span.set_tag("http.status_code", response.status_code)
         span.set_data("http.foobarsessionid", get_foobar_sessionid())


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
We've deprecated the `description` parameter to `start_span` in favor of `name`. Manual instrumentation examples in the docs still use `description`. Changing that.

Fixes https://github.com/getsentry/sentry-python/issues/3594

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Oct 2
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

