### PR TITLE
Adds a note that source maps are not uploaded for debug mode in React Native / Expo

### DIFF
--- a/docs/platforms/react-native/sourcemaps/index.mdx
+++ b/docs/platforms/react-native/sourcemaps/index.mdx
@@ -53,4 +53,4 @@ sentry {
 
 ### Debug Builds
 
-Note that automatic uploading of source maps for debug builds is disabled because symbolication is handled directly by the Metro development server. In a development environment, Metro automatically provides the symbolication needed to translate stack traces into readable source code. As a result, there is no need to upload source maps for these types of builds.
+Symbolication is handled directly by the Metro development server, automatically providing the symbolication needed to translate stack traces into readable source code in a development environment. There's no need to upload source maps for these types of builds which is why the automatic uploading of source maps is disabled. 

--- a/docs/platforms/react-native/sourcemaps/index.mdx
+++ b/docs/platforms/react-native/sourcemaps/index.mdx
@@ -51,6 +51,6 @@ sentry {
 }
 ```
 
-### Debug and Simulator Builds
+### Debug Builds
 
-Note that uploading source maps for debug or simulator builds is disabled because symbolication is handled directly by the Metro development server. In a development environment, Metro automatically provides the symbolication needed to translate stack traces into readable source code. As a result, there is no need to upload source maps for these types of builds.
+Note that automatic uploading of source maps for debug builds is disabled because symbolication is handled directly by the Metro development server. In a development environment, Metro automatically provides the symbolication needed to translate stack traces into readable source code. As a result, there is no need to upload source maps for these types of builds.

--- a/docs/platforms/react-native/sourcemaps/index.mdx
+++ b/docs/platforms/react-native/sourcemaps/index.mdx
@@ -50,3 +50,7 @@ sentry {
     uploadNativeSymbols = shouldSentryAutoUpload()
 }
 ```
+
+### Debug and Simulator Builds
+
+Note that uploading source maps for debug or simulator builds is disabled because symbolication is handled directly by the Metro development server. In a development environment, Metro automatically provides the symbolication needed to translate stack traces into readable source code. As a result, there is no need to upload source maps for these types of builds.

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -17,7 +17,7 @@ Sentry's React Native SDK works out of the box with Expo applications. To see re
 
 ## Automatic Upload for Release
 
-When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Pugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`.
+When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Pugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`. Note that uploading source maps for debug or simulator builds is disabled, as symbolication is handled by the Metro dev server.
 
 ## Manual Upload for EAS Updates
 
@@ -47,7 +47,6 @@ npx sentry-expo-upload-sourcemaps dist
 
 - `dist` is the default output directory of `eas update`.
 - Uploaded source maps have no associated releases. This is expected as updates can apply to multiple releases.
-- Uploading of source maps for debug or simulator builds is disabled.
 
 ## Notes
 

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -17,7 +17,7 @@ Sentry's React Native SDK works out of the box with Expo applications. To see re
 
 ## Automatic Upload for Release
 
-When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Pugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`. Note that uploading source maps for debug builds is disabled, as symbolication is handled by the Metro dev server.
+When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Plugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`. Because symbolication is already handled by the Metro dev server, automatic uploading of source maps for debug builds is disabled.
 
 ## Manual Upload for EAS Updates
 

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -47,6 +47,7 @@ npx sentry-expo-upload-sourcemaps dist
 
 - `dist` is the default output directory of `eas update`.
 - Uploaded source maps have no associated releases. This is expected as updates can apply to multiple releases.
+- Uploading of source maps for debug or simulator builds is disabled.
 
 ## Notes
 

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -17,7 +17,7 @@ Sentry's React Native SDK works out of the box with Expo applications. To see re
 
 ## Automatic Upload for Release
 
-When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Pugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`. Note that uploading source maps for debug or simulator builds is disabled, as symbolication is handled by the Metro dev server.
+When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Pugin are added to your application configuration, source maps for the native builds are uploaded automatically during EAS Builds and when building the native application release locally using `npx expo prebuild`. Note that uploading source maps for debug builds is disabled, as symbolication is handled by the Metro dev server.
 
 ## Manual Upload for EAS Updates
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Fixes https://github.com/getsentry/sentry-react-native/issues/3743

This PR adds a note highlighting that source maps are not uploaded for debug mode in Expo. Note that there is a [similar note in the React Native section](https://github.com/getsentry/sentry-docs/blob/master/docs/platforms/react-native/manual-setup/manual-setup.mdx?plain=1#L90). 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
