### PR TITLE
develop: https devserver not supported

### DIFF
--- a/develop-docs/development/environment/index.mdx
+++ b/develop-docs/development/environment/index.mdx
@@ -55,20 +55,6 @@ You can create other users with `sentry createuser`.
 
 Please refer to [Frontend Development Server](/frontend/development-server/) and [Backend Development Server](/backend/development-server/) for alternative ways to bring up the Sentry UI.
 
-### Enabling HTTPS
-
-You may wish to run the development server in HTTPS mode. This can be done by generating and installing local certificates.
-
-We will be using [mkcert](https://github.com/FiloSottile/mkcert) to create and install a locally-trusted, development certificate. The following will install `mkcert` and then create and install the local certificates.
-
-```shell
-brew install mkcert
-brew install nss # if you use Firefox
-yarn mkcert-localhost
-```
-
-Running `sentry devserver` will automatically use HTTPS when the certificates have been installed.
-
 ### Ingestion Pipeline (Relay) aka Sending Events to your Dev Environment
 
 <Link to="/services/relay/">Relay</Link> and the ingest workers are not started by default. Follow the instructions below to start them so you can send events to your dev environment Sentry instance:


### PR DESCRIPTION
tl;dr we had a bespoke form of https devserver support a long time ago https://github.com/getsentry/sentry/pull/60734 but @evanpurkhiser  tried to replace it but then wasn't able to get it to work so was reverted (but evan forgot to update the docs): https://github.com/getsentry/sentry/pull/60673#issuecomment-1832745402