### PR TITLE
onboarding: dotnet list package

### DIFF
--- a/docs/platforms/dotnet/index.mdx
+++ b/docs/platforms/dotnet/index.mdx
@@ -53,14 +53,17 @@ Install the **NuGet** package to add the Sentry dependency:
   </Note>
 
   ```shell {tabTitle:.NET Core CLI}
+  dotnet add package Sentry -v {{@inject packages.version('sentry.dotnet') }}
   dotnet add package Sentry.Profiling -v {{@inject packages.version('sentry.dotnet.profiling') }}
   ```
 
   ```powershell {tabTitle:Package Manager}
+  Install-Package Sentry -Version {{@inject packages.version('sentry.dotnet') }}  
   Install-Package Sentry.Profiling -Version {{@inject packages.version('sentry.dotnet.profiling') }}
   ```
 
   ```shell {tabTitle:Paket CLI}
+  paket add Sentry --version {{@inject packages.version('sentry.dotnet') }}
   paket add Sentry.Profiling --version {{@inject packages.version('sentry.dotnet.profiling') }}
     ```
 </OnboardingOption>
@@ -75,7 +78,6 @@ SentrySdk.Init(options =>
 {
     options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.us.sentry.io/5428537";
     options.Debug = true;
-    options.AutoSessionTracking = true;
     // A fixed sample rate of 1.0 - 100% of all transactions are getting sent
     options.TracesSampleRate = 1.0f;
     // A sample rate for profiling - this is relative to TracesSampleRate


### PR DESCRIPTION
onboarding is incorrectly dictating only `Sentry.Profiling` when the profiling checkbox is chcked. It should add it to the existing `Sentry` package.