### PR TITLE
Fix wording of `trace_propagation_targets` to be correct

### DIFF
--- a/docs/platforms/php/common/configuration/options.mdx
+++ b/docs/platforms/php/common/configuration/options.mdx
@@ -248,9 +248,8 @@ A function responsible for determining the percentage chance a given transaction
 
 An optional property that controls which downstream services receive tracing data, in the form of a `sentry-trace` and a `baggage` header attached to any outgoing HTTP requests.
 
-The option may contain a list of strings against which the URLs of outgoing requests are matched.
-If one of the entries in the list matches the URL of an outgoing request, trace data will be attached to that request.
-Entries do not have to be full matches, meaning the URL of a request is matched when it _contains_ a string provided through the option.
+The option may contain a list of strings against which the hosts of outgoing requests are matched.
+If one of the entries in the list matches the host of an outgoing request, trace data will be attached to that request.
 
 If <PlatformIdentifier name="trace-propagation-targets" /> is not provided, trace data is attached to every outgoing request from the [instrumented client](../../tracing/instrumentation/requests-module/).
 To disable sending trace data to any downstream service, set this option to an empty array (`[]`).


### PR DESCRIPTION
## DESCRIBE YOUR PR

The option works a little different from other SDKs so the wording was updated to be correct.

Fixes getsentry/sentry-php#1782

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)