### PR TITLE
fix(search): Use correct urls for cross-search results

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -70,7 +70,9 @@ const config = isDeveloperDocs ? developerDocsSites : userDocsSites;
 const search = new SentryGlobalSearch(config);
 
 function relativizeUrl(url: string) {
-  return url.replace(/^(https?:\/\/docs\.sentry\.io)(?=\/|$)/, '');
+  return isDeveloperDocs
+    ? url
+    : url.replace(/^(https?:\/\/docs\.sentry\.io)(?=\/|$)/, '');
 }
 
 type Props = {


### PR DESCRIPTION
Relativizing cross-search results leads to 404 urls on dev-docs.

fixes https://github.com/getsentry/sentry-docs/issues/11411
fixes https://github.com/getsentry/sentry-docs/issues/11391
fixes https://github.com/getsentry/sentry-docs/issues/11381
fixes https://github.com/getsentry/sentry-docs/issues/11317