### PR TITLE
impr(apple): Uncaught NSExceptions on macOS

### DIFF
--- a/platform-includes/capture-error/apple.mdx
+++ b/platform-includes/capture-error/apple.mdx
@@ -119,4 +119,6 @@ func applicationDidFinishLaunching(_ aNotification: Notification) {
 }
 ```
 
+Once you have configured your application to crash whenever an uncaught exception occurs, the Apple SDK will capture those automatically. You don't need to manually call `captureException`.
+
 </PlatformSection>

--- a/platform-includes/capture-error/apple.mdx
+++ b/platform-includes/capture-error/apple.mdx
@@ -97,6 +97,12 @@ do {
 
 ## Capturing Uncaught Exceptions
 
+<Note>
+
+The SDK can't install the uncaught exception handler if a debugger is attached. To test these locally, ensure you've unchecked the "Debug executable" option in your app's Xcode scheme's Run action.
+
+</Note>
+
 By default, macOS applications do not crash whenever an uncaught exception occurs. To enable this with Sentry:
 
 1. Open the application's `Info.plist` file


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Mention that users don't need to manually call captureException for uncaught NSExceptions on macOS when configured correctly.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
