### PR TITLE
Merge and move Symfony Monolog docs

### DIFF
--- a/docs/platforms/php/guides/laravel/index.mdx
+++ b/docs/platforms/php/guides/laravel/index.mdx
@@ -41,22 +41,21 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         Integration::handles($exceptions);
-    })->create();
+    })
+    ->create();
 ```
 
-Alternatively, you can configure Sentry in your [Laravel Log Channel](usage/#log-channels), allowing you to log `info` and `debug` as well.
+Alternatively, you can configure Sentry as a [Laravel Log Channel](usage/#log-channels).
 
 ## Configure
 
 Configure the Sentry DSN with this command:
-
 
 ```shell
 php artisan sentry:publish --dsn=___PUBLIC_DSN___
 ```
 
 It creates the config file (`config/sentry.php`) and adds the `DSN` to your `.env` file.
-
 
 ```shell {filename:.env}
 SENTRY_LARAVEL_DSN=___PUBLIC_DSN___

--- a/docs/platforms/php/guides/symfony/index.mdx
+++ b/docs/platforms/php/guides/symfony/index.mdx
@@ -17,10 +17,11 @@ Install the `sentry/sentry-symfony` bundle:
 composer require sentry/sentry-symfony
 ```
 
+If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the typical error listener approach, you need this [additional configuration](integrations/monolog/) to log the errors correctly.
+
 ## Configure
 
 Add your DSN to your `.env` file:
-
 
 ```plain {filename:.env}
 ###> sentry/sentry-symfony ###
@@ -31,26 +32,6 @@ SENTRY_DSN="___PUBLIC_DSN___"
 <Alert level="warning">
   In order to receive stack trace arguments in your errors, make sure to set `zend.exception_ignore_args: Off` in your php.ini
 </Alert>
-
-### Monolog Integration
-
-If you are using [Monolog](https://github.com/Seldaek/monolog) to report events instead of the typical error listener approach, you need this additional configuration to log the errors correctly:
-
-{/* <!-- prettier-ignore --> */}
-```yaml {filename:config/packages/sentry.yaml}
-sentry:
-    register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
-    register_error_handler: false # Disables the ErrorListener, ExceptionListener and FatalErrorListener integrations of the base PHP SDK
-
-monolog:
-    handlers:
-        sentry:
-            type: sentry
-            level: !php/const Monolog\Logger::ERROR
-            hub_id: Sentry\State\HubInterface
-            fill_extra_context: true # Enables sending monolog context to Sentry
-            process_psr_3_messages: false # Disables the resolution of PSR-3 placeholders in reported messages
-```
 
 ## Verify
 

--- a/docs/platforms/php/guides/symfony/integrations/monolog.mdx
+++ b/docs/platforms/php/guides/symfony/integrations/monolog.mdx
@@ -30,4 +30,6 @@ monolog:
             type: sentry
             level: !php/const Monolog\Logger::ERROR # Configures the level of messages to capture as events
             hub_id: Sentry\State\HubInterface
+            fill_extra_context: true # Enables sending monolog context to Sentry
+            process_psr_3_messages: false # Disables the resolution of PSR-3 placeholders in reported messages
 ```

--- a/docs/platforms/php/guides/symfony/integrations/monolog.mdx
+++ b/docs/platforms/php/guides/symfony/integrations/monolog.mdx
@@ -12,7 +12,7 @@ sentry:
     register_error_handler: false # Disables the ErrorListener, ExceptionListener and FatalErrorListener integrations of the base PHP SDK
 
 services:
-    # Configure the breadcrumb handler as a service
+    # (Optionally) Configure the breadcrumb handler as a service (needed for the breadcrumb Monolog handler)
     Sentry\Monolog\BreadcrumbHandler:
         arguments:
             - '@Sentry\State\HubInterface'
@@ -20,7 +20,7 @@ services:
 
 monolog:
     handlers:
-        # Register the breadcrumb handler as a Monolog handler
+        # (Optionally) Register the breadcrumb handler as a Monolog handler
         sentry_breadcrumbs:
             type: service
             name: sentry_breadcrumbs

--- a/docs/platforms/php/guides/symfony/integrations/monolog.mdx
+++ b/docs/platforms/php/guides/symfony/integrations/monolog.mdx
@@ -6,7 +6,11 @@ description: "Learn how to enable Sentry's Symfony SDK to capture Monolog events
 When using [Monolog](https://github.com/Seldaek/monolog) you can configure a [breadcrumb](../../enriching-events/breadcrumbs/) handler to capture Monolog messages as breadcrumbs and a handler that captures messages as events in Sentry.
 The breadcrumb handler will not send anything to Sentry directly, it only records breadcrumbs that will be attached to any event or exception sent to Sentry.
 
-```yaml
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+    register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
+    register_error_handler: false # Disables the ErrorListener, ExceptionListener and FatalErrorListener integrations of the base PHP SDK
+
 services:
     # Configure the breadcrumb handler as a service
     Sentry\Monolog\BreadcrumbHandler:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Noticed the Monolog docs are now a bit duplicated and also right there in the getting started guide even though it's not strictly needed. Move everything to the monolog integration and leave a note about it in the installation guide (similar to how we handle this for Laravel).

Also a little tweak to the wording about log channels in Laravel, was a bit verbose.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)