### PR TITLE
fix: Update sorting order for guides on platform filter

### DIFF
--- a/src/components/platformFilter/index.tsx
+++ b/src/components/platformFilter/index.tsx
@@ -38,11 +38,15 @@ export function PlatformFilter({platforms}: {platforms: Platform[]}) {
     uniqByReference(matches.map(x => (x.type === 'platform' ? x : x.platform))).map(p => {
       return {
         ...p,
-        guides: p.guides.filter(g => matches.some(m => m.key === g.key)),
+        guides: matches
+          .filter(m => m.type === 'guide' && m.platform.key === p.key)
+          .map(m => p.guides.find(g => g.key === m.key)!)
+          .filter(Boolean),
         integrations: p.integrations.filter(i => matches.some(m => m.key === i.key)),
       };
     })
   );
+
   return (
     <div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 py-8 md:items-end">

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -195,9 +195,15 @@ export function PlatformSelector({
                     platform={{
                       ...platform,
                       // only keep guides that are in the matches list
-                      guides: platform.guides.filter(g =>
-                        matches.some(m => m.key === g.key)
-                      ),
+                      guides: platform.guides
+                        .filter(g =>
+                          matches.some(m => m.key === g.key && m.type === 'guide')
+                        )
+                        .sort((a, b) => {
+                          const indexA = matches.findIndex(m => m.key === a.key);
+                          const indexB = matches.findIndex(m => m.key === b.key);
+                          return indexA - indexB;
+                        }),
 
                       integrations: platform.integrations.filter(i =>
                         matches.some(m => m.key === i.key)


### PR DESCRIPTION
Based on feedback that the `node` guide is not immediately visible for filtering SDKs for `node`.

## Before:
<img width="908" alt="Screenshot 2024-10-11 at 11 57 57" src="https://github.com/user-attachments/assets/335a6d30-442b-4473-93ae-1fbd63b7330a">

## After:
<img width="919" alt="Screenshot 2024-10-11 at 11 57 41" src="https://github.com/user-attachments/assets/bc51fb1b-6099-4faf-8246-c34b5a27a99c">

