### PR TITLE
remove imports for dotnet

### DIFF
--- a/docs/platforms/dotnet/common/migration/index.mdx
+++ b/docs/platforms/dotnet/common/migration/index.mdx
@@ -398,8 +398,6 @@ Changed how to initialize Sentry:
 
 
 ```csharp
-using Sentry;
-
 // Initialize with DSN
 SentrySdk.Init("___PUBLIC_DSN___");
 
@@ -414,7 +412,6 @@ For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it
 
 
 ```csharp
-using Sentry;
 using Sentry.AspNet;
 
 SentrySdk.Init(o =>

--- a/docs/platforms/dotnet/common/tracing/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/index.mdx
@@ -22,8 +22,6 @@ First, enable tracing and configure the sample rate for transactions. Set the sa
 The two options are meant to be mutually exclusive. If you set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.
 
 ```csharp {diff}
-using Sentry;
-
 + // Add this to the SDK initialization callback
 + // Example uniform sample rate: capture 100% of transactions
 + options.TracesSampleRate = 1.0;

--- a/docs/platforms/dotnet/common/user-feedback/index.mdx
+++ b/docs/platforms/dotnet/common/user-feedback/index.mdx
@@ -17,8 +17,6 @@ User Feedback for **[ASP.NET](/platforms/dotnet/guides/aspnet/user-feedback/#int
 You can create a form to collect the user input in your preferred framework, and use the SDK's API to send the information to Sentry. You can also use the widget, as described below. If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use this API:
 
 ```csharp {tabTitle:C#}
-using Sentry;
-
 var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
 
 SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");

--- a/docs/platforms/dotnet/guides/aspnet/index.mdx
+++ b/docs/platforms/dotnet/guides/aspnet/index.mdx
@@ -37,7 +37,6 @@ You configure the SDK in the `Global.asax.cs`:
 ```csharp {"onboardingOptions": {"performance": "21-24, 34-43"}}
 using System;
 using System.Web;
-using Sentry;
 using Sentry.AspNet;
 using Sentry.EntityFramework; // If you also installed Sentry.EntityFramework
 using Sentry.Extensibility;

--- a/docs/platforms/dotnet/guides/aspnet/tracing/included-instrumentation.mdx
+++ b/docs/platforms/dotnet/guides/aspnet/tracing/included-instrumentation.mdx
@@ -18,7 +18,6 @@ using System;
 using System.Configuration;
 using System.Web.Mvc;
 using System.Web.Routing;
-using Sentry;
 using Sentry.AspNet;
 
 namespace AspNetMvc
@@ -87,7 +86,6 @@ Transactions created by this integration are automatically added to the current 
 ```csharp
 using System;
 using System.Web.Mvc;
-using Sentry;
 
 public class HomeController : Controller
 {

--- a/docs/platforms/dotnet/guides/aspnetcore/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/dotnet/guides/aspnetcore/tracing/instrumentation/automatic-instrumentation.mdx
@@ -32,7 +32,6 @@ Transactions created by this integration are automatically added to the current 
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Sentry;
 
 public class HomeController : Controller
 {

--- a/docs/platforms/dotnet/guides/entityframework/index.mdx
+++ b/docs/platforms/dotnet/guides/entityframework/index.mdx
@@ -48,7 +48,6 @@ For example, configuring an ASP.NET app with _global.asax_:
 ```csharp {filename:global.asax} {"onboardingOptions": {"performance": "16-18, 27-36"}}
 using System;
 using System.Configuration;
-using Sentry;
 using Sentry.AspNet;
 
 public class MvcApplication : System.Web.HttpApplication

--- a/docs/platforms/dotnet/guides/uwp/index.mdx
+++ b/docs/platforms/dotnet/guides/uwp/index.mdx
@@ -29,7 +29,6 @@ The SDK should be initialized in the constructor of your application class (usua
 
 
 ```csharp {"onboardingOptions": {"performance": "18-21"}}
-using Sentry;
 using Sentry.Protocol;
 using UnhandledExceptionEventArgs = Windows.UI.Xaml.UnhandledExceptionEventArgs;
 

--- a/docs/platforms/dotnet/guides/winforms/index.mdx
+++ b/docs/platforms/dotnet/guides/winforms/index.mdx
@@ -33,7 +33,6 @@ A complete example of the recommended startup is as follows:
 ```csharp {"onboardingOptions": {"performance": "32-35"}}
 using System;
 using System.Windows.Forms;
-using Sentry;
 
 namespace WindowsFormsApp1
 {

--- a/docs/platforms/dotnet/guides/winui/index.mdx
+++ b/docs/platforms/dotnet/guides/winui/index.mdx
@@ -35,7 +35,6 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 <OnboardingOptionButtons options={['error-monitoring', 'performance']}/>
 
 ```csharp {"onboardingOptions": {"performance": "17-20"}}
-using Sentry;
 using Sentry.Protocol;
 
 sealed partial class App : Application
@@ -82,7 +81,6 @@ Do not initialize the SDK in the `OnLaunched` event of the application or the `H
 
 ```csharp
 // Add these to your existing using statements.
-using Sentry;
 using Sentry.Protocol;
 using UnhandledExceptionEventArgs = Microsoft.UI.Xaml.UnhandledExceptionEventArgs;
 

--- a/docs/platforms/unity/user-feedback/index.mdx
+++ b/docs/platforms/unity/user-feedback/index.mdx
@@ -17,8 +17,6 @@ User Feedback for **[ASP.NET](/platforms/dotnet/guides/aspnet/user-feedback/#int
 You can create a form to collect the user input in your preferred framework, and use the SDK's API to send the information to Sentry. You can also use the widget, as described below. If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use this API:
 
 ```csharp {tabTitle:C#}
-using Sentry;
-
 var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
 
 SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");

--- a/platform-includes/capture-error/dotnet.mdx
+++ b/platform-includes/capture-error/dotnet.mdx
@@ -1,8 +1,6 @@
 In C# you can capture any exception object that you caught:
 
 ```csharp
-using Sentry;
-
 try
 {
     AFunctionThatMightFail();

--- a/platform-includes/capture-message/dotnet.mdx
+++ b/platform-includes/capture-message/dotnet.mdx
@@ -1,11 +1,7 @@
 ```csharp
-using Sentry;
-
 SentrySdk.CaptureMessage("Something went wrong");
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.CaptureMessage("Something went wrong")
 ```

--- a/platform-includes/configuration/before-send-transaction/dotnet.mdx
+++ b/platform-includes/configuration/before-send-transaction/dotnet.mdx
@@ -1,8 +1,6 @@
 A `Func<SentryTransaction, Hint, SentryTransaction?>` can be used to update the transaction or drop it by returning `null` before it gets sent to Sentry. For example:
 
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 options.SetBeforeSendTransaction((sentryTransaction, hint) =>
 {

--- a/platform-includes/configuration/before-send-transaction/powershell.mdx
+++ b/platform-includes/configuration/before-send-transaction/powershell.mdx
@@ -7,7 +7,7 @@ Start-Sentry {
     # Add this to the SDK initialization callback
     $_.SetBeforeSendTransaction([System.Func[Sentry.SentryTransaction, Sentry.SentryTransaction]] {
             param([Sentry.SentryTransaction]$sentryTransaction)
-            
+
             # Modify the transaction
             if ($sentryTransaction.Operation -eq 'http.server')
             {
@@ -20,9 +20,6 @@ Start-Sentry {
 ```
 
 ```csharp
-using Sentry;
-
-
 options.SetBeforeSendTransaction((sentryTransaction, hint) =>
 {
 });

--- a/platform-includes/configuration/before-send/dotnet.mdx
+++ b/platform-includes/configuration/before-send/dotnet.mdx
@@ -1,8 +1,6 @@
 A `Func<SentryEvent, Hint, SentryEvent?>` can be used to mutate, discard (return null), or return a completely new event.
 
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 options.SetBeforeSend((sentryEvent, hint) =>
 {

--- a/platform-includes/configuration/config-intro/dotnet.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.mdx
@@ -2,8 +2,6 @@ For example, initialize with `SentrySdk.Init` in your `Program.cs` file:
 
 
 ```csharp
-using Sentry;
-
 SentrySdk.Init(options =>
 {
     // A Sentry Data Source Name (DSN) is required.

--- a/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
@@ -3,8 +3,6 @@ pass the option object along for modifications:
 
 
 ```csharp
-using Sentry;
-
 SentryXamarin.Init(o =>
 {
     o.Dsn = "___PUBLIC_DSN___";

--- a/platform-includes/configuration/sample-rate/dotnet.mdx
+++ b/platform-includes/configuration/sample-rate/dotnet.mdx
@@ -1,13 +1,9 @@
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 options.SampleRate = 0.25;
 ```
 
 ```fsharp
-open Sentry
-
 // Add this to the SDK initialization callback
 options.SampleRate <- 0.25  // Capture 25%
 ```

--- a/platform-includes/distributed-tracing/custom-instrumentation/dotnet.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/dotnet.mdx
@@ -12,7 +12,6 @@ Here's an example using RabbitMQ of how to extract and store incoming tracing in
 using System.Text;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
-using Sentry;
 
 var factory = new ConnectionFactory()
 {
@@ -62,7 +61,6 @@ If you're not using the `SentryHttpMessageHandler`, you can generate this tracin
 
 ```csharp
 using RabbitMQ.Client;
-using Sentry;
 
 var factory = new ConnectionFactory()
 {

--- a/platform-includes/enriching-events/attachment-init-with-bytes/dotnet.mdx
+++ b/platform-includes/enriching-events/attachment-init-with-bytes/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     // Add an in-memory attachment to the current scope
@@ -9,8 +7,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     // Add an in-memory attachment to the current scope

--- a/platform-includes/enriching-events/attachment-init-with-path/dotnet.mdx
+++ b/platform-includes/enriching-events/attachment-init-with-path/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     // Add a file attachment to the current scope
@@ -9,8 +7,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     // Add a file attachment to the current scope

--- a/platform-includes/enriching-events/attachment-init-with-path/unity.mdx
+++ b/platform-includes/enriching-events/attachment-init-with-path/unity.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.AddAttachment(Path.Combine(Application.persistentDataPath, "file.log"));

--- a/platform-includes/enriching-events/attachment-max-size/dotnet.mdx
+++ b/platform-includes/enriching-events/attachment-max-size/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 options.MaxAttachmentSize = 5 * 1024 * 1024; // 5 MiB
 ```

--- a/platform-includes/enriching-events/attachment-upload/dotnet.mdx
+++ b/platform-includes/enriching-events/attachment-upload/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // Global Scope
 SentrySdk.ConfigureScope(scope =>
 {

--- a/platform-includes/enriching-events/attachment-upload/unity.mdx
+++ b/platform-includes/enriching-events/attachment-upload/unity.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.AddAttachment(Path.Combine(Application.persistentDataPath, "file.log"));

--- a/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dotnet.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 options.SetBeforeBreadcrumb(breadcrumb
     // Ignore breadcrumbs from Spammy logger
@@ -10,8 +8,6 @@ options.SetBeforeBreadcrumb(breadcrumb
 ```
 
 ```fsharp
-open Sentry
-
 // Add this to the SDK initialization callback
 options.SetBeforeBreadcrumb(fun breadcrumb ->
     // Ignore breadcrumbs from Spammy logger

--- a/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/dotnet.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.AddBreadcrumb(
     message: "Authenticated user " + user.Email,
     category: "auth",
@@ -8,8 +6,6 @@ SentrySdk.AddBreadcrumb(
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.AddBreadcrumb(
     "Authenticated user " + user.Email,
     "auth",

--- a/platform-includes/enriching-events/event-processors/dotnet.mdx
+++ b/platform-includes/enriching-events/event-processors/dotnet.mdx
@@ -3,7 +3,6 @@
 You can create your own event processors by implementing the `ISentryEventProcessor` interface. You can also create custom processors for transactions by implementing the `ISentryTransactionProcessor`.
 
 ```csharp
-using Sentry;
 using Sentry.Extensibility;
 
 public class CustomEventProcessor : ISentryEventProcessor

--- a/platform-includes/enriching-events/scopes/configure-scope/dotnet.mdx
+++ b/platform-includes/enriching-events/scopes/configure-scope/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.SetTag("my-tag", "my value");

--- a/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
+++ b/platform-includes/enriching-events/scopes/scope-callback-param/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // will be tagged with my-tag="my value"
 SentrySdk.CaptureException(new Exception("my error"), scope =>
 {

--- a/platform-includes/enriching-events/set-context/dotnet.mdx
+++ b/platform-includes/enriching-events/set-context/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.Contexts["character"] = new
@@ -13,8 +11,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(fun scope ->
     scope.Contexts["character"] <- {|
         Name = "Mighty Fighter"

--- a/platform-includes/enriching-events/set-context/unity.mdx
+++ b/platform-includes/enriching-events/set-context/unity.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 class PlayerCharacter
 {
     public string Name { get; set; }

--- a/platform-includes/enriching-events/set-tag/dotnet.mdx
+++ b/platform-includes/enriching-events/set-tag/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.SetTag("page.locale", "de-at");
@@ -8,8 +6,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(fun scope ->
     scope.SetTag("page.locale", "de-at")
     )

--- a/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
+++ b/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
@@ -27,8 +27,6 @@ For more information on how to dynamically set event tags via `NLog.config`, see
 ```
 
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     // You can still use NLog layouts in code to set configured propertes
@@ -37,8 +35,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     // You can still use NLog layouts in code to set configured propertes

--- a/platform-includes/enriching-events/set-transaction-name/dotnet.mdx
+++ b/platform-includes/enriching-events/set-transaction-name/dotnet.mdx
@@ -1,5 +1,3 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
 ```

--- a/platform-includes/enriching-events/set-transaction-name/unity.mdx
+++ b/platform-includes/enriching-events/set-transaction-name/unity.mdx
@@ -1,5 +1,3 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope => scope.TransactionName = "UserListViewModel");
 ```

--- a/platform-includes/enriching-events/set-user/dotnet.mdx
+++ b/platform-includes/enriching-events/set-user/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.User = new SentryUser
@@ -11,8 +9,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     scope.User <- SentryUser(Email = "john.doe@example.com")

--- a/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
+++ b/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
@@ -27,8 +27,6 @@
 ```
 
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.User = new User
@@ -39,8 +37,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     scope.User <- User(Email = "john.doe@example.com")

--- a/platform-includes/enriching-events/unset-user/dotnet.mdx
+++ b/platform-includes/enriching-events/unset-user/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.User = new SentryUser();
@@ -8,8 +6,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     scope.User <- SentryUser()

--- a/platform-includes/getting-started-config/dotnet.aspnet.mdx
+++ b/platform-includes/getting-started-config/dotnet.aspnet.mdx
@@ -5,7 +5,6 @@ using System;
 using System.Configuration;
 using System.Web.Mvc;
 using System.Web.Routing;
-using Sentry;
 using Sentry.AspNet;
 
 namespace AspNetMvc

--- a/platform-includes/getting-started-config/dotnet.mdx
+++ b/platform-includes/getting-started-config/dotnet.mdx
@@ -2,8 +2,6 @@ For example, initialize with `SentrySdk.Init` in your `Program.cs` file:
 
 
 ```csharp
-using Sentry;
-
 SentrySdk.Init(options =>
 {
     // A Sentry Data Source Name (DSN) is required.

--- a/platform-includes/getting-started-config/dotnet.xamarin.mdx
+++ b/platform-includes/getting-started-config/dotnet.xamarin.mdx
@@ -3,8 +3,6 @@ on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate fo
 
 
 ```csharp
-using Sentry;
-
 SentryXamarin.Init(o =>
 {
     o.AddXamarinFormsIntegration();

--- a/platform-includes/getting-started-verify/dotnet.mdx
+++ b/platform-includes/getting-started-verify/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 try
 {
     throw null;
@@ -12,8 +10,6 @@ catch (Exception ex)
 ```
 
 ```fsharp
-open Sentry
-
 try
     raise <| NullReferenceException ()
 with ex ->

--- a/platform-includes/getting-started-verify/unity.mdx
+++ b/platform-includes/getting-started-verify/unity.mdx
@@ -1,5 +1,4 @@
 ```csharp
-using Sentry;
 using UnityEngine;
 
 public class TestMonoBehaviour : MonoBehaviour

--- a/platform-includes/performance/always-inherit-sampling-decision/dotnet.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 sentryOptions.TracesSampler = context =>
 {
     if (context.TransactionContext.IsParentSampled is true)

--- a/platform-includes/performance/configure-sample-rate/dotnet.mdx
+++ b/platform-includes/performance/configure-sample-rate/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 // Example uniform sample rate: capture 100% of transactions
 options.TracesSampleRate = 1.0;

--- a/platform-includes/performance/custom-sampling-context/dotnet.mdx
+++ b/platform-includes/performance/custom-sampling-context/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // The following data will take part in the sampling decision
 var samplingContext = new Dictionary<string, object?>
 {

--- a/platform-includes/performance/force-sampling-decision/dotnet.mdx
+++ b/platform-includes/performance/force-sampling-decision/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // IsSampled -> true
 var transactionContext = new TransactionContext("GET /search", "http", true);
 

--- a/platform-includes/performance/retrieve-transaction/dotnet.mdx
+++ b/platform-includes/performance/retrieve-transaction/dotnet.mdx
@@ -3,8 +3,6 @@
 In cases where you want to attach Spans to an already ongoing Transaction you can use `SentrySdk.GetSpan()`. If there is a running Transaction or Span currently on the scope, this method will return a `SentryTransaction` or `Span`; otherwise, it returns `null`.
 
 ```csharp
-using Sentry;
-
 var span = SentrySdk.GetSpan();
 
 if (span == null)

--- a/platform-includes/performance/traces-sampler-as-sampler/dotnet.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 // Add this to the SDK initialization callback
 // To set a uniform sample rate
 options.TracesSampleRate = 1.0;

--- a/platform-includes/sensitive-data/set-tag/dotnet.mdx
+++ b/platform-includes/sensitive-data/set-tag/dotnet.mdx
@@ -1,7 +1,5 @@
 ```csharp
-using Sentry;
-
-DateTime date = new DateTime(1990,12,08);
+var date = new DateTime(1990,12,08);
 
 SentrySdk.ConfigureScope(scope =>
 {

--- a/platform-includes/sensitive-data/set-user/dotnet.mdx
+++ b/platform-includes/sensitive-data/set-user/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.User.Id = "user.id";

--- a/platform-includes/set-extra/dotnet.mdx
+++ b/platform-includes/set-extra/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.SetExtra("character.name", "Mighty Fighter");
@@ -8,8 +6,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(fun scope ->
     scope.SetExtra("character.name", "Mighty Fighter")
     )

--- a/platform-includes/set-level/dotnet.mdx
+++ b/platform-includes/set-level/dotnet.mdx
@@ -1,6 +1,4 @@
 ```csharp
-using Sentry;
-
 SentrySdk.ConfigureScope(scope =>
 {
     scope.Level = SentryLevel.Warning;
@@ -8,8 +6,6 @@ SentrySdk.ConfigureScope(scope =>
 ```
 
 ```fsharp
-open Sentry
-
 SentrySdk.ConfigureScope(
   fun scope ->
     scope.Level <- SentryLevel.Warning

--- a/platform-includes/set-level/unity.mdx
+++ b/platform-includes/set-level/unity.mdx
@@ -1,5 +1,3 @@
 ```csharp
-using Sentry;
-
 SentrySdk.CaptureException(new Exception(), s => s.Level = SentryLevel.Warning);
 ```


### PR DESCRIPTION
As announced here: https://blog.sentry.io/sentry-dotnet-sdk-4-for-dotnet-8/

`using Sentry;` is no longer needed.