### PR TITLE
fix: Ensure diff code block lines are formatted correctly

### DIFF
--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -79,22 +79,16 @@
 
   /* Diff highlighting, classes provided by rehype-prism-plus */
   /* Set inserted line (+) color */
-  /* Move the margin left and adjust width so we can keep the parent padding  */
   :global(.diff-inserted),
   :global(.inserted) {
     background-color: rgba(16, 185, 129, 0.2);
-    margin-left: -12px;
-    width: calc(100% + 12px);
   }
 
   /* Diff highlighting, classes provided by rehype-prism-plus */
   /* Set deleted line (-) color */
-  /* Move the margin left and adjust width so we can keep the parent padding  */
   :global(.diff-deleted),
   :global(.deleted) {
     background-color: rgba(239, 68, 68, 0.2);
-    margin-left: -12px;
-    width: calc(100% + 12px);
   }
 }
 


### PR DESCRIPTION
This PR removes the negative margin from the changed lines in the diff view to fix the vertical alignment of the changed and unchanged lines I noticed in https://github.com/getsentry/sentry-docs/issues/11568. 

I'm not sure if this is the best way to fix this so please feel free to close the PR in favour of a better solution! Especially because it seems like we added the negative margin specifically to fix formatting previously in https://github.com/getsentry/sentry-docs/pull/10996/files.


potentially fixes https://github.com/getsentry/sentry-docs/issues/11568

before:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/22f0fd10-45b4-4524-8203-3046310604c5">


after: 
![image](https://github.com/user-attachments/assets/83f2d3eb-2c4b-46e2-ac4d-e1a18e32dfd9)
