### PR TITLE
fix(integration): Adds a redirect from old launchdarkly doc link to new path

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -665,6 +665,10 @@ const userDocsRedirects = [
     source: '/platforms/react-native/manual-setup/codepush/',
     destination: '/platforms/react-native/sourcemaps/uploading/codepush/',
   },
+  {
+    source: '/organization/integrations/launchdarkly/',
+    destination: '/organization/integrations/feature-flag/launchdarkly/',
+  },
 ];
 
 /**


### PR DESCRIPTION
The `/organization/integrations/launchdarkly/` path no longer works and should be redirected to `/organization/integrations/feature-flag/launchdarkly/`