### PR TITLE
feat(Apple): Extra instructions to Upload debug Symbols

### DIFF
--- a/platform-includes/debug-symbols-apple/_default.mdx
+++ b/platform-includes/debug-symbols-apple/_default.mdx
@@ -95,6 +95,11 @@ Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` t
 <OrgAuthTokenNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
+#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
+#if [[ "$(uname -m)" == arm64 ]]; then
+#    export PATH="/opt/homebrew/bin:$PATH"
+#fi
+
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
@@ -109,6 +114,11 @@ fi
 ```
 
 ```bash {tabTitle:Error on failures - blocking}
+#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
+#if [[ "$(uname -m)" == arm64 ]]; then
+#    export PATH="/opt/homebrew/bin:$PATH"
+#fi
+
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___

--- a/platform-includes/debug-symbols-apple/_default.mdx
+++ b/platform-includes/debug-symbols-apple/_default.mdx
@@ -95,10 +95,9 @@ Another option is to use warnings, and then set `GCC_TREAT_WARNINGS_AS_ERRORS` t
 <OrgAuthTokenNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
-#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
-#if [[ "$(uname -m)" == arm64 ]]; then
-#    export PATH="/opt/homebrew/bin:$PATH"
-#fi
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
 
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
@@ -114,10 +113,9 @@ fi
 ```
 
 ```bash {tabTitle:Error on failures - blocking}
-#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
-#if [[ "$(uname -m)" == arm64 ]]; then
-#    export PATH="/opt/homebrew/bin:$PATH"
-#fi
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
 
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___

--- a/platform-includes/source-context/apple.mdx
+++ b/platform-includes/source-context/apple.mdx
@@ -48,6 +48,11 @@ You can upload your sources to Sentry after every build through Xcode. To do thi
 <OrgAuthTokenNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
+#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
+#if [[ "$(uname -m)" == arm64 ]]; then
+#    export PATH="/opt/homebrew/bin:$PATH"
+#fi
+
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
@@ -62,6 +67,11 @@ fi
 ```
 
 ```bash {tabTitle:Error on failures - blocking}
+#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
+#if [[ "$(uname -m)" == arm64 ]]; then
+#    export PATH="/opt/homebrew/bin:$PATH"
+#fi
+
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___

--- a/platform-includes/source-context/apple.mdx
+++ b/platform-includes/source-context/apple.mdx
@@ -48,10 +48,9 @@ You can upload your sources to Sentry after every build through Xcode. To do thi
 <OrgAuthTokenNote />
 
 ```bash {tabTitle:Warn on failures - nonblocking}
-#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
-#if [[ "$(uname -m)" == arm64 ]]; then
-#    export PATH="/opt/homebrew/bin:$PATH"
-#fi
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
 
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
@@ -67,10 +66,9 @@ fi
 ```
 
 ```bash {tabTitle:Error on failures - blocking}
-#Uncomment the following lines if you installed sentry-cli via Homebrew in a Apple Silicon Mac
-#if [[ "$(uname -m)" == arm64 ]]; then
-#    export PATH="/opt/homebrew/bin:$PATH"
-#fi
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
 
 if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___


### PR DESCRIPTION
Xcode may not detect homebrew installs in a Apple Silicon device.
This problem was raised in [this issue](https://github.com/getsentry/sentry-docs/issues/7597). 