### PR TITLE
[Python] Document `failed_request_status_codes` option better

### DIFF
--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -134,8 +134,8 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
   A `set` of integers that will determine which status codes should be reported to Sentry.
 
-  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://fastapi.tiangolo.com/reference/exceptions/?h=httpexception) exceptions should be
-  reported to Sentry. Other unhandled exceptions, which do not have a `status_code` attribute, are always reported to Sentry.
+  The `failed_request_status_codes` option determines whether [`HTTPException`](https://fastapi.tiangolo.com/reference/exceptions/?h=httpexception) exceptions should be
+  reported to Sentry. Unhandled exceptions that don't have a `status_code` attribute will always be reported to Sentry.
 
   Examples of valid `failed_request_status_codes`:
 

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -134,7 +134,7 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
   A `set` of integers that will determine which status codes should be reported to Sentry.
 
-  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://www.starlette.io/exceptions/#httpexception) exceptions should be
+  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://fastapi.tiangolo.com/reference/exceptions/?h=httpexception) exceptions should be
   reported to Sentry. Other unhandled exceptions, which do not have a `status_code` attribute, are always reported to Sentry.
 
   Examples of valid `failed_request_status_codes`:

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -134,6 +134,9 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
   A `set` of integers that will determine which status codes should be reported to Sentry.
 
+  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://www.starlette.io/exceptions/#httpexception) exceptions should be
+  reported to Sentry. Other unhandled exceptions, which do not have a `status_code` attribute, are always reported to Sentry.
+
   Examples of valid `failed_request_status_codes`:
 
   - `{500}` will only send events on HTTP 500.

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -91,8 +91,8 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
   A `set` of integers that will determine which status codes should be reported to Sentry.
 
-  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://www.starlette.io/exceptions/#httpexception) exceptions should be
-  reported to Sentry. Other unhandled exceptions, which do not have a `status_code` attribute, are always reported to Sentry.
+  The `failed_request_status_codes` option determines whether [`HTTPException`](https://www.starlette.io/exceptions/#httpexception) exceptions should be
+  reported to Sentry. Unhandled exceptions that don't have a `status_code` attribute will always be reported to Sentry.
 
   Examples of valid `failed_request_status_codes`:
 

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -91,6 +91,9 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
   A `set` of integers that will determine which status codes should be reported to Sentry.
 
+  The `failed_request_status_codes` option only controls whether [`HTTPException`](https://www.starlette.io/exceptions/#httpexception) exceptions should be
+  reported to Sentry. Other unhandled exceptions, which do not have a `status_code` attribute, are always reported to Sentry.
+
   Examples of valid `failed_request_status_codes`:
 
   - `{500}` will only send events on HTTP 500.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Better describe `failed_request_status_codes` option.

Preview:
- https://sentry-docs-git-antonpirker-pythonfailedrequeststatuscodes.sentry.dev/platforms/python/integrations/starlette/#options
- https://sentry-docs-git-antonpirker-pythonfailedrequeststatuscodes.sentry.dev/platforms/python/integrations/fastapi/#options

Fixes #11488

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
