### PR TITLE
feat(replay): Add warning message for Angular default Change Detection Strategy

### DIFF
--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -26,6 +26,12 @@ description: "Learn how to enable Session Replay in your app if it is not alread
 
 By default, our Session Replay SDK masks all DOM text content, images, and user input, giving you heightened confidence that no sensitive data will leave the browser. To learn more, see <PlatformLink to="/session-replay/privacy">Session Replay Privacy</PlatformLink>.
 
+<PlatformSection supported={["javascript.angular"]}>
+  <Alert level="error">
+    Angular's [default "Change Detection" strategy](https://angular.dev/api/core/ChangeDetectionStrategy#Default) monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you only use the `OnPush` strategy when using Angular.
+  </Alert>
+</PlatformSection>
+
 ## Pre-requisites
 
 <PlatformContent includePath="session-replay/pre-requisites" />

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -28,7 +28,7 @@ By default, our Session Replay SDK masks all DOM text content, images, and user 
 
 <PlatformSection supported={["javascript.angular"]}>
   <Alert level="danger">
-    Angular's <ExternalLink href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</ExternalLink> monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you use the `OnPush` strategy when using Angular.
+    Angular's <ExternalLink href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</ExternalLink> monkeypatches browser globals and can break or cause performance regressions in your application when using Session Replay. To avoid this, we recommend you use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -28,7 +28,7 @@ By default, our Session Replay SDK masks all DOM text content, images, and user 
 
 <PlatformSection supported={["javascript.angular"]}>
   <Alert level="danger">
-    Angular's [default "Change Detection" strategy](https://angular.dev/api/core/ChangeDetectionStrategy#Default) monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you only use the `OnPush` strategy when using Angular.
+    Angular's [default "Change Detection" strategy](https://angular.dev/api/core/ChangeDetectionStrategy#Default) monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -28,7 +28,7 @@ By default, our Session Replay SDK masks all DOM text content, images, and user 
 
 <PlatformSection supported={["javascript.angular"]}>
   <Alert level="danger">
-    Angular's <ExternalLink href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</ExternalLink> monkeypatches browser globals and can break or cause performance regressions in your application when using Session Replay. To avoid this, we recommend you use the `OnPush` strategy when using Angular.
+    Angular's <a target="_blank" rel="noopener noreferrer" href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</a> monkeypatches browser globals and can break or cause performance regressions in your application when using Session Replay. To avoid this, we recommend you use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -27,7 +27,7 @@ description: "Learn how to enable Session Replay in your app if it is not alread
 By default, our Session Replay SDK masks all DOM text content, images, and user input, giving you heightened confidence that no sensitive data will leave the browser. To learn more, see <PlatformLink to="/session-replay/privacy">Session Replay Privacy</PlatformLink>.
 
 <PlatformSection supported={["javascript.angular"]}>
-  <Alert level="error">
+  <Alert level="danger">
     Angular's [default "Change Detection" strategy](https://angular.dev/api/core/ChangeDetectionStrategy#Default) monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you only use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -28,7 +28,7 @@ By default, our Session Replay SDK masks all DOM text content, images, and user 
 
 <PlatformSection supported={["javascript.angular"]}>
   <Alert level="danger">
-    Angular's [default "Change Detection" strategy](https://angular.dev/api/core/ChangeDetectionStrategy#Default) monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you use the `OnPush` strategy when using Angular.
+    Angular's <ExternalLink href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</ExternalLink> monkeypatches browser globals and can break or cause performance regressions to your application when using Session Replay. We recommend you use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>
 


### PR DESCRIPTION
Add a warning message for Angular as it can break customer sites (or lead to performance problems) when using the default change detection strategy due to their monkeypatching of globals (Zone.js)
