### PR TITLE
docs(js): Update package install page

### DIFF
--- a/docs/platforms/javascript/common/install/npm.mdx
+++ b/docs/platforms/javascript/common/install/npm.mdx
@@ -35,4 +35,24 @@ notSupported:
   - javascript.cloudflare
 ---
 
-<PlatformContent includePath="getting-started-install" />
+The npm package for Sentry offers several advantages for specific use cases:
+
+- **Framework-specific features**: If you're using a framework like React or Vue, installing the corresponding Sentry SDK (e.g., `@sentry/react` or `@sentry/vue`) via npm provides framework-specific features and optimizations.
+
+- **Full public API access**: The npm package exposes the complete set of Sentry's public APIs, allowing for more extensive customization and functionality.
+
+- **Version control**: Installing via npm gives you full control over the SDK version, enabling you to manage updates and ensure compatibility with your project.
+
+- **Build process integration**: Using the npm package allows for better integration with your build process and bundling tools.
+
+```bash {tabTitle:npm}
+npm install @sentry/browser --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/browser
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/browser
+```


### PR DESCRIPTION
Currently the install docs for js browser include the loader script for npm installation. This is potentially misleading.

Before:
<img width="1291" alt="Screenshot 2024-10-18 at 10 57 53" src="https://github.com/user-attachments/assets/40a581ec-790f-4b3d-956b-eb5f66554516">

After:

<img width="1282" alt="Screenshot 2024-10-18 at 11 02 21" src="https://github.com/user-attachments/assets/98f27908-2247-4adc-a89c-3124f4624c1b">
