### PR TITLE
Revert "docs(js): Fix default integration examples"

### DIFF
--- a/docs/platforms/javascript/common/best-practices/multiple-sentry-instances.mdx
+++ b/docs/platforms/javascript/common/best-practices/multiple-sentry-instances.mdx
@@ -37,19 +37,18 @@ import {
   Scope,
 } from "@sentry/browser";
 
+// filter integrations that use the global variable
+const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
+  return !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(
+    defaultIntegration.name
+  );
+});
 
 const client = new BrowserClient({
   dsn: "___PUBLIC_DSN___",
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  // filter integrations that use the global variable
-  integrations: (defaultIntegrations) =>
-    defaultIntegrations.filter(
-      (integration) =>
-        !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(
-          integration.name
-        )
-    ),
+  integrations: integrations,
 });
 
 const scope = new Scope();
@@ -90,18 +89,20 @@ function happyIntegration() {
   };
 }
 
+// filter integrations that use the global variable
+const integrations = Sentry.getDefaultIntegrations({}).filter(
+  (defaultIntegration) => {
+    return !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(
+      defaultIntegration.name
+    );
+  }
+);
 
 const client1 = new Sentry.BrowserClient({
   dsn: "___PUBLIC_DSN___",
   transport: Sentry.makeFetchTransport,
   stackParser: Sentry.defaultStackParser,
-  // filter integrations that use the global variable
-  integrations: (defaultIntegrations) => [
-    ...defaultIntegrations.filter(
-      (integration) => !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(integration.name)
-    ),
-    happyIntegration(),
-  ],
+  integrations: [...integrations, happyIntegration()],
   beforeSend(event) {
     console.log("client 1", event);
     return null; // Returning `null` prevents the event from being sent
@@ -114,12 +115,7 @@ const client2 = new Sentry.BrowserClient({
   dsn: "___PUBLIC_DSN___", // Can be a different DSN
   transport: Sentry.makeFetchTransport,
   stackParser: Sentry.defaultStackParser,
-  integrations: (defaultIntegrations) => [
-    ...defaultIntegrations.filter(
-      (integration) => !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(integration.name)
-    ),
-    happyIntegration(),
-  ],
+  integrations: [...integrations, happyIntegration()],
   beforeSend(event) {
     console.log("client 2", event);
     return null; // Returning `null` prevents the event from being sent

--- a/docs/platforms/javascript/common/best-practices/shared-environments.mdx
+++ b/docs/platforms/javascript/common/best-practices/shared-environments.mdx
@@ -59,15 +59,20 @@ import {
   Scope,
 } from "@sentry/browser";
 
+// filter integrations that use the global variable
+const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
+  return ![
+    "BrowserApiErrors",
+    "Breadcrumbs",
+    "GlobalHandlers",
+  ].includes(defaultIntegration.name);
+});
+
 const client = new BrowserClient({
   dsn: "___PUBLIC_DSN___",
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  // filter integrations that use the global variable
-  integrations: (defaultIntegrations) => 
-    defaultIntegrations.filter(
-      (integration) => !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(integration.name)
-    ),
+  integrations: integrations,
 });
 
 const scope = new Scope();


### PR DESCRIPTION
Reverts getsentry/sentry-docs#11577

This was a mistake, integrations can be added directly to a client, just not on the init call.