### PR TITLE
Update for Ruby otel-rack post v0.24.0

### DIFF
--- a/platform-includes/performance/opentelemetry-setup/ruby.mdx
+++ b/platform-includes/performance/opentelemetry-setup/ruby.mdx
@@ -23,8 +23,7 @@ end
 OpenTelemetry.propagation = Sentry::OpenTelemetry::Propagator.new
 ```
 
-Note that if you need extra Sentry features such as tags / user, you will need to re-order the middleware as below to
-make sure Sentry's scope management works properly.
+Note that if you are using the Ruby OpenTelemetry gem [*pre-v0.24.0*](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rack#rack-middleware-vs-rack-events) along with extra Sentry features such as tags / user, you will need to re-order the middleware as below to make sure Sentry's scope management works properly. (After v0.24.0, the gem [uses Rack Events rather than a middleware.](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rack#rack-middleware-vs-rack-events))
 
 ```ruby {filename:config/initializers/otel.rb}
 Rails.application.config.middleware.move_after(


### PR DESCRIPTION
The Ruby otel gem uses Rack Events rather than a middleware since v0.24.0, so the instructions for ordering middlewares no longer work.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
