### PR TITLE
unity: il2cpp line number update

### DIFF
--- a/docs/platforms/unity/configuration/il2cpp/index.mdx
+++ b/docs/platforms/unity/configuration/il2cpp/index.mdx
@@ -18,13 +18,15 @@ The Sentry SDK provides line number support for IL2CPP builds for the following 
 
 When you build with IL2CPP, errors in your game will happen in the native code. Also, the mapping between your C# code and the generated C++ code is part of the build process and isn't shipped with your game. That means the event the Sentry SDK reports can only contain the native stack trace. To provide you with C# line numbers, the Sentry server needs to have access to that line mapping through [Debug Information Files](/platforms/unity/data-management/debug-files/).
 
-This feature is enabled by default. You can opt out of it through the editor configuration window by selecting **Tools -> Sentry -> Advanced -> IL2CPP line numbers** or [programmatically](/platforms/unity/configuration/options/#programmatic-configuration).
+The support for line numbers in C# Exceptions with IL2CPP relies on the debug symbol upload.
+With the automated debug symbol upload enabled, the [Sentry SDK will upload the line mapping automatically](/platforms/unity/native-support/#debug-symbols).
+
+**This feature is enabled by default**. You can opt out of it through the editor configuration window by selecting **Tools -> Sentry -> Advanced -> IL2CPP line numbers** or [programmatically](/platforms/unity/configuration/options/#programmatic-configuration).
 
 ```csharp
+// If you need to disable this feature, you can set it to 'false':
 options.Il2CppLineNumberSupportEnabled = false;
 ```
-
-The support for line numbers in C# Exceptions with IL2CPP relies on the debug symbol upload. With the automated debug symbol upload enabled, the [Sentry SDK will upload the line mapping automatically](/platforms/unity/native-support/#debug-symbols).
 
 ### Known Limitations
 


### PR DESCRIPTION
Uploading symbols is critical, we should mention that earlier and make it more prominent

Disabling is the least relevant thing (also why would someone disable, should we say it on the docs?)