### PR TITLE
feat(platform): Display requested title in platform redirect

### DIFF
--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -1,5 +1,6 @@
 import {redirect} from 'next/navigation';
 
+import {Alert} from 'sentry-docs/components/alert';
 import {DocPage} from 'sentry-docs/components/docPage';
 import {PlatformIcon} from 'sentry-docs/components/platformIcon';
 import {SmartLink} from 'sentry-docs/components/smartLink';
@@ -14,16 +15,31 @@ export default async function Page({
   if (Array.isArray(next)) {
     next = next[0];
   }
+
   // discard the hash
   const [pathname, _] = next.split('#');
   const rootNode = await getDocsRootNode();
+  const defaultTitle = 'Platform Specific Content';
+  let description = '';
+  const platformInfo =
+    "The page you are looking for is customized for each platform. Select your platform below and we'll direct you to the most specific documentation on it.";
+  let title = defaultTitle;
+
   // get rid of irrelevant platforms for the `next` path
   const platformList = extractPlatforms(rootNode).filter(platform_ => {
-    return !!nodeForPath(rootNode, [
+    const node = nodeForPath(rootNode, [
       'platforms',
       platform_.key,
       ...pathname.split('/').filter(Boolean),
     ]);
+
+    // extract title and description for displaying it on page
+    if (node && title === defaultTitle && pathname.length > 0) {
+      title = node.frontmatter.title ?? title;
+      description = node.frontmatter.description || '';
+    }
+
+    return !!node;
   });
 
   if (platformList.length === 0) {
@@ -42,7 +58,8 @@ export default async function Page({
   }
 
   const frontMatter = {
-    title: 'Platform Specific Content',
+    title,
+    description,
   };
 
   // make the Sidebar aware of the current path
@@ -50,10 +67,7 @@ export default async function Page({
 
   return (
     <DocPage frontMatter={frontMatter}>
-      <p>
-        The page you are looking for is customized for each platform. Select your platform
-        below and we&apos;ll direct you to the most specific documentation on it.
-      </p>
+      <Alert level="info">{platformInfo}</Alert>
 
       <ul>
         {platformList.map(p => (


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-docs/issues/10517

With this change we display the title and description of the requested page (if it exists).

## before 
<img width="1215" alt="Screenshot 2024-10-24 at 13 02 44" src="https://github.com/user-attachments/assets/f327d7e2-65f4-40c5-86c0-0e1abaa670e9">

## after
<img width="1152" alt="Screenshot 2024-10-24 at 12 58 33" src="https://github.com/user-attachments/assets/61c2740f-3e52-467b-a2fd-57410cbe32db">

The risk here is that different platforms might have different titles and descriptions for the same page, and in this PR we just take the first one we find (which is usually .NET I think). I tested out some pages and it seemed to work fine every time.