### PR TITLE
develop: UF remove language from snippet

### DIFF
--- a/develop-docs/application/feedback-architecture.mdx
+++ b/develop-docs/application/feedback-architecture.mdx
@@ -52,7 +52,7 @@ offers 2 improvements:
 
 The user's submission is wrapped in a context object:
 
-```Python/Javascript
+```
 event[”contexts”][”feedback”] = {
 	"name": <user-provided>,
 	"contact_email": <user-provided>,

--- a/develop-docs/application/feedback-architecture.mdx
+++ b/develop-docs/application/feedback-architecture.mdx
@@ -52,17 +52,18 @@ offers 2 improvements:
 
 The user's submission is wrapped in a context object:
 
-```
+```Pseudo-code
 event[”contexts”][”feedback”] = {
 	"name": <user-provided>,
 	"contact_email": <user-provided>,
 	"message": <user-provided>,
 	"url": <referring web page>,
-	"source": <developer-provided, ex: "widget">
+	"source": <developer-provided, ex: "widget">,
+	"associated_event_id": <developer-provided, should be a valid error event in the same project>
 }
 
-// all fields are technically optional, but recommended
-// the widget can be configured to require a non-empty email and/or name
+// All fields are optional except message.
+// The widget can be configured to require a non-empty email and/or name.
 ```
 
 - This doc refers to the payload format (`event` in the pseudo-code above) as a “**feedback event”**.
@@ -100,7 +101,7 @@ a separate topic and storage, and the UI makes a separate request for them.
 
 The deprecated way of sending feedback is as a **user report**. This is a simple typed dict:
 
-```Python/Javascript
+```Pseudo-code
 user_report = {
 	"event_id": <required UUID str>,
 	"email": <optional str>,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a5eb4431-ada0-447b-b221-3cf33f3a902e)

Currently shows like this ^

We should go with `JavaScript` or if pseudo code maybe don't specify it at all (this PR attempts the latter)