### PR TITLE
docs(js): Add troubleshooting section on terser

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -386,6 +386,12 @@ export default defineConfig({
 
 </Expandable>
 
+<Expandable permalink title="Terser plugin build errors">
+
+<Include name="terser-plugin-build-error-troubleshooting.mdx" />
+
+</Expandable>
+
 <PlatformSection supported={['javascript.angular']}>
 
 <Expandable

--- a/includes/terser-plugin-build-error-troubleshooting.mdx
+++ b/includes/terser-plugin-build-error-troubleshooting.mdx
@@ -1,0 +1,3 @@
+If you're using a custom webpack plugin that utilizes Terser or another minifier, you might encounter build errors due to a known webpack bug. This issue has been fixed in webpack version 5.85.1 and later.
+
+For more details about this issue, see [webpack/terser-plugin build errors](https://github.com/getsentry/sentry-javascript/issues/14091).


### PR DESCRIPTION
Adds a troubleshooting section for build-errors when using a minifier like terser.

documents https://github.com/getsentry/sentry-javascript/issues/14091

