### PR TITLE
feat(electron): Add screenshot permissions config detail

### DIFF
--- a/platform-includes/user-feedback/setup/javascript.electron.mdx
+++ b/platform-includes/user-feedback/setup/javascript.electron.mdx
@@ -12,3 +12,16 @@ Sentry.init({
   ],
 });
 ```
+
+### Screenshot Permissions
+
+Screenshot capture uses `navigator.mediaDevices.getDisplayMedia()` to capture
+the window which is denied by default in Electron. To enable this feature, you
+need to set a `setDisplayMediaRequestHandler` callback in the Electron main
+process and allow access to the requesting frame.
+
+```javascript
+session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
+  callback({ video: request.frame });
+});
+```


### PR DESCRIPTION
- Ref: https://github.com/getsentry/sentry-electron/issues/1001

By default Electron denies access to `navigator.mediaDevices.getDisplayMedia()` which is required to capture screenshots used in the feedback widget.

This PR adds some extra docs that detail how to allow these permissions.