### PR TITLE
ref(js): Update custom Node Otel setup docs

### DIFF
--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -111,7 +111,17 @@ If you want to add your own http/node-fetch instrumentation, you have to follow 
 
 ### Custom HTTP Instrumentation
 
-You won't be able to add `@opentelemetry/instrumentation-http` yourself and will need to use `httpIntegration` in order for Sentry to work as expected. If you want to use custom configuration for your HTTP instrumentation, you can use the <PlatformLink to="/configuration/integrations/http/">httpIntegration configuration</PlatformLink>.
+You can add your own `@opentelemetry/instrumentation-http` instance in your setup. However, in this case, you need to disable span creation in Sentry's `httpIntegration`:
+
+```javascript
+const sentryClient = Sentry.init({
+  dsn: "___DSN___",
+  skipOpenTelemetrySetup: true,
+  integrations: [Sentry.httpIntegration({ spans: false })],
+});
+```
+
+It's important that `httpIntegration` is still registered this way to ensure that the Sentry SDK can correctly isolate requests, for example when capturing errors.
 
 ### Custom Node Fetch Instrumentation
 
@@ -168,3 +178,26 @@ const provider = new NodeTracerProvider({
 // Validate that the setup is correct
 Sentry.validateOpenTelemetrySetup();
 ```
+## ESM loaders
+
+If your application is running in ESM (`import`/`export` syntax), OpenTelemetry requires a [special setup](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md) to work correctly.
+The Sentry SDK will automatically detect if your application is running in ESM mode and by default [register a loader hook](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md#instrumentation-hook-required-for-esm) itself.
+If you are also registering a loader hook, you need to disable Sentry's loader hook:
+
+```javascript
+Sentry.init({
+  skipOpenTelemetrySetup: true,
+  registerEsmLoaderHooks: false,
+});
+```
+
+<Note>
+
+Registering loader hooks multiple times might result in duplicated spans being created.
+[More details.](https://github.com/getsentry/sentry-javascript/issues/14065#issuecomment-2435546961)
+
+</Note>
+
+Alternatively, you can also use Sentry's loader hook and remove your own loader hook registration code.
+In this case, ensure that you initialize the Sentry SDK in its own file and you load this file prior to your application via `node --import instrument.mjs your-app.mjs`.
+<PlatformLink to="/install">Learn more about ESM installation methods.</PlatformLink>

--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -202,4 +202,6 @@ Registering loader hooks multiple times might result in duplicated spans being c
 
 Alternatively, you can also use Sentry's loader hook and remove your own loader hook registration code.
 In this case, ensure that you initialize the Sentry SDK in its own file and load this file prior to your application via `node --import instrument.mjs your-app.mjs`.
+<PlatformSection supported={['javascript.node']}>
 <PlatformLink to="/install">Learn more about ESM installation methods.</PlatformLink>
+</PlatformSection>

--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -105,7 +105,7 @@ If tracing is not enabled (no `tracesSampleRate` is defined in the SDK configura
   </Note>
 </PlatformSection>
 
-These are needed to make sure that trace propagation works correctly. Additionally, the HTTP instrumentation is configured to ensure that request isolation is automatically applied for Sentry.
+These are needed to make sure that trace propagation works correctly.
 
 If you want to add your own http/node-fetch instrumentation, you have to follow the following steps:
 
@@ -113,7 +113,7 @@ If you want to add your own http/node-fetch instrumentation, you have to follow 
 
 _Available since SDK version 8.35.0_
 
-You can add your own `@opentelemetry/instrumentation-http` instance in your setup. However, in this case, you need to disable span creation in Sentry's `httpIntegration`:
+You can add your own `@opentelemetry/instrumentation-http` instance in your OpenTelemetry setup. However, in this case, you need to disable span creation in Sentry's `httpIntegration`:
 
 ```javascript
 const sentryClient = Sentry.init({

--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -111,6 +111,8 @@ If you want to add your own http/node-fetch instrumentation, you have to follow 
 
 ### Custom HTTP Instrumentation
 
+_Available since SDK version 8.35.0_
+
 You can add your own `@opentelemetry/instrumentation-http` instance in your setup. However, in this case, you need to disable span creation in Sentry's `httpIntegration`:
 
 ```javascript

--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -180,7 +180,7 @@ const provider = new NodeTracerProvider({
 // Validate that the setup is correct
 Sentry.validateOpenTelemetrySetup();
 ```
-## ESM loaders
+## ESM Loaders
 
 If your application is running in ESM (`import`/`export` syntax), OpenTelemetry requires a [special setup](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md) to work correctly.
 The Sentry SDK will automatically detect if your application is running in ESM mode and by default [register a loader hook](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md#instrumentation-hook-required-for-esm) itself.
@@ -201,5 +201,5 @@ Registering loader hooks multiple times might result in duplicated spans being c
 </Note>
 
 Alternatively, you can also use Sentry's loader hook and remove your own loader hook registration code.
-In this case, ensure that you initialize the Sentry SDK in its own file and you load this file prior to your application via `node --import instrument.mjs your-app.mjs`.
+In this case, ensure that you initialize the Sentry SDK in its own file and load this file prior to your application via `node --import instrument.mjs your-app.mjs`.
 <PlatformLink to="/install">Learn more about ESM installation methods.</PlatformLink>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR updates the Custom Node Otel setup page by:

- showing how users can now add their own HttpInstrumentation (possible since we added `httpIntegration({spans: false})` in 8.35.0
- adding a section discussing ESM loaders and that only one loader hook (either their own or Sentry's) should be registered (we learned about this in https://github.com/getsentry/sentry-javascript/issues/14065)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
