### PR TITLE
fix(platform): Automatically scroll to search hits on same page

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "remark-prism": "^1.3.6",
     "rss": "^1.2.2",
     "sass": "^1.69.5",
-    "search-insights": "^2.2.3",
+    "search-insights": "^2.17.2",
     "server-only": "^0.0.1",
     "sharp": "^0.33.4",
     "tailwindcss-scoped-preflight": "^3.0.4",

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -247,8 +247,8 @@ export function Search({path, autoFocus, searchPlatforms = [], showChatBot}: Pro
         );
 
         // close the search results and scroll to the heading if it exists
+        setInputFocus(false);
         if (foundHeading) {
-          setInputFocus(false);
           foundHeading.scrollIntoView({
             behavior: 'smooth',
           });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11110,10 +11110,10 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-search-insights@^2.2.3:
-  version "2.13.0"
-  resolved "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz"
-  integrity sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==
+search-insights@^2.17.2:
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.17.2.tgz#d13b2cabd44e15ade8f85f1c3b65c8c02138629a"
+  integrity sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==
 
 section-matter@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This pr checks if a search result is on the current page and if so, automatically scrolls the result into the view.

related to https://github.com/getsentry/sentry-docs/issues/11699

