### PR TITLE
Add CSS rule to fix color of bold links

### DIFF
--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -130,6 +130,10 @@
     font-weight: 500;
   }
 
+  a strong {
+    color: var(--accent);
+  }
+
   .anchorlink,
   .anchorlink.before {
     display: flex;

--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -111,6 +111,10 @@
     color: var(--accent);
     font-weight: normal;
 
+    strong {
+      color: var(--accent);
+    }
+
     img {
       display: inline-block;
     }
@@ -130,9 +134,6 @@
     font-weight: 500;
   }
 
-  a strong {
-    color: var(--accent);
-  }
 
   .anchorlink,
   .anchorlink.before {

--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -134,7 +134,6 @@
     font-weight: 500;
   }
 
-
   .anchorlink,
   .anchorlink.before {
     display: flex;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Fix for https://github.com/getsentry/sentry-docs/issues/11313

To verify:
Go to https://sentry-docs-git-bold-link-color.sentry.dev/product/performance/filters-display/widgets/#most-time-consuming-queries

You will see that the bolded links are now the same color as the non-bolded links (rgb(106, 95, 193)). The styles do not leak into any other text.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
