### PR TITLE
API examples syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "parse-numeric-range": "^1.3.0",
     "platformicons": "^6.0.3",
     "prism-sentry": "^1.0.2",
-    "prismjs": "^1.27.0",
     "query-string": "^6.13.1",
     "react": "^18",
     "react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.8",
     "framer-motion": "^10.12.16",
     "gray-matter": "^4.0.3",
+    "hast-util-to-jsx-runtime": "^2.3.2",
     "hastscript": "^8.0.0",
     "image-size": "^1.1.1",
     "js-cookie": "^3.0.5",

--- a/src/components/apiExamples/apiExamples.module.scss
+++ b/src/components/apiExamples/apiExamples.module.scss
@@ -19,3 +19,17 @@
     margin: 0;
   }
 }
+
+.copied {
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  margin: 0;
+  padding: 0 6px;
+  border-radius: 2px;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.25);
+  border: none;
+  color: var(--white);
+  transition: opacity 150ms;
+}

--- a/src/components/apiExamples/apiExamples.module.scss
+++ b/src/components/apiExamples/apiExamples.module.scss
@@ -10,12 +10,6 @@
   padding: 0.75rem;
 }
 
-.api-block-example.request {
-  color: var(--white);
-  background-color: var(--code-background);
-  border-radius: 4px;
-}
-
 .api-block-example.response {
   background-color: var(--code-background);
   color: var(--white);

--- a/src/components/apiExamples/apiExamples.module.scss
+++ b/src/components/apiExamples/apiExamples.module.scss
@@ -1,4 +1,6 @@
 .api-block-example {
+  background-color: var(--code-background);
+  color: var(--white);
   border: none;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
@@ -8,11 +10,6 @@
   margin-bottom: 0;
   font-size: 0.8rem;
   padding: 0.75rem;
-}
-
-.api-block-example.response {
-  background-color: var(--code-background);
-  color: var(--white);
 }
 
 .api-params dd {

--- a/src/components/apiExamples/apiExamples.module.scss
+++ b/src/components/apiExamples/apiExamples.module.scss
@@ -12,12 +12,12 @@
 
 .api-block-example.request {
   color: var(--white);
-  background-color: #2d2d2d;
+  background-color: var(--code-background);
   border-radius: 4px;
 }
 
 .api-block-example.response {
-  background: #2d2d2d;
+  background-color: var(--code-background);
   color: var(--white);
 }
 

--- a/src/components/apiExamples/apiExamples.module.scss
+++ b/src/components/apiExamples/apiExamples.module.scss
@@ -19,17 +19,3 @@
     margin: 0;
   }
 }
-
-.copied {
-  position: absolute;
-  right: 4px;
-  top: 4px;
-  margin: 0;
-  padding: 0 6px;
-  border-radius: 2px;
-  font-size: 0.85rem;
-  background: rgba(255, 255, 255, 0.25);
-  border: none;
-  color: var(--white);
-  transition: opacity 150ms;
-}

--- a/src/components/apiExamples/apiExamples.tsx
+++ b/src/components/apiExamples/apiExamples.tsx
@@ -3,23 +3,20 @@
 import {Fragment, useState} from 'react';
 import {jsx, jsxs} from 'react/jsx-runtime';
 import {toJsxRuntime} from 'hast-util-to-jsx-runtime';
+import {Nodes} from 'hastscript/lib/create-h';
 import bash from 'refractor/lang/bash.js';
-import javascript from 'refractor/lang/javascript.js';
 import json from 'refractor/lang/json.js';
 import {refractor} from 'refractor/lib/core.js';
 
 import {type API} from 'sentry-docs/build/resolveOpenAPI';
 
-refractor.register(json);
-refractor.register(javascript);
-refractor.register(bash);
-
-import {Nodes} from 'hastscript/lib/create-h';
-
 import styles from './apiExamples.module.scss';
 
 import {CodeBlock} from '../codeBlock';
 import {CodeTabs} from '../codeTabs';
+
+refractor.register(bash);
+refractor.register(json);
 
 type ExampleProps = {
   api: API;

--- a/src/components/apiExamples/apiExamples.tsx
+++ b/src/components/apiExamples/apiExamples.tsx
@@ -18,13 +18,15 @@ import {Nodes} from 'hastscript/lib/create-h';
 
 import styles from './apiExamples.module.scss';
 
+import {CodeBlock} from '../codeBlock';
+import {CodeTabs} from '../codeTabs';
+
 type ExampleProps = {
   api: API;
   selectedResponse: number;
   selectedTabView: number;
 };
 
-const requestStyles = `${styles['api-block-example']} ${styles.request}`;
 const responseStyles = `${styles['api-block-example']} ${styles.response}`;
 
 // overwriting global code block font size
@@ -112,15 +114,20 @@ export function ApiExamples({api}: Props) {
 
   return (
     <Fragment>
-      <div className="api-block">
-        <pre className={requestStyles}>
-          {toJsxRuntime(refractor.highlight(apiExample.join(' \\\n'), 'bash') as Nodes, {
-            Fragment,
-            jsx,
-            jsxs,
-          })}
-        </pre>
-      </div>
+      <CodeTabs>
+        <CodeBlock language="bash">
+          <pre>
+            {toJsxRuntime(
+              refractor.highlight(apiExample.join(' \\\n'), 'bash') as Nodes,
+              {
+                Fragment,
+                jsx,
+                jsxs,
+              }
+            )}
+          </pre>
+        </CodeBlock>
+      </CodeTabs>
       <div className="api-block">
         <div className="api-block-header response">
           <div className="tabs-group">

--- a/src/components/apiExamples/apiExamples.tsx
+++ b/src/components/apiExamples/apiExamples.tsx
@@ -32,6 +32,10 @@ type Props = {
   api: API;
 };
 
+const codeToJsx = (code: string, lang = 'json') => {
+  return toJsxRuntime(refractor.highlight(code, lang) as Nodes, {Fragment, jsx, jsxs});
+};
+
 export function ApiExamples({api}: Props) {
   const apiExample = [
     `curl https://sentry.io${api.apiPath}`,
@@ -96,16 +100,7 @@ export function ApiExamples({api}: Props) {
     <Fragment>
       <CodeTabs>
         <CodeBlock language="bash">
-          <pre>
-            {toJsxRuntime(
-              refractor.highlight(apiExample.join(' \\\n'), 'bash') as Nodes,
-              {
-                Fragment,
-                jsx,
-                jsxs,
-              }
-            )}
-          </pre>
+          <pre>{codeToJsx(apiExample.join(' \\\n'), 'bash')}</pre>
         </CodeBlock>
       </CodeTabs>
       <div className="api-block">
@@ -152,29 +147,16 @@ export function ApiExamples({api}: Props) {
           {selectedTabView === 0 &&
             (exampleJson ? (
               <code className="!text-[0.8rem]">
-                {toJsxRuntime(
-                  refractor.highlight(
-                    JSON.stringify(exampleJson, null, 2),
-                    'json'
-                  ) as Nodes,
-                  {Fragment, jsx, jsxs}
-                )}
+                {codeToJsx(JSON.stringify(exampleJson, null, 2), 'json')}
               </code>
             ) : (
               strFormat(api.responses[selectedResponse].description)
             ))}
           {selectedTabView === 1 && (
             <code className="!text-[0.8rem]">
-              {toJsxRuntime(
-                refractor.highlight(
-                  JSON.stringify(
-                    api.responses[selectedResponse].content?.schema,
-                    null,
-                    2
-                  ),
-                  'json'
-                ) as Nodes,
-                {Fragment, jsx, jsxs}
+              {codeToJsx(
+                JSON.stringify(api.responses[selectedResponse].content?.schema, null, 2),
+                'json'
               )}
             </code>
           )}

--- a/src/components/apiExamples/apiExamples.tsx
+++ b/src/components/apiExamples/apiExamples.tsx
@@ -27,11 +27,6 @@ type ExampleProps = {
   selectedTabView: number;
 };
 
-const responseStyles = `${styles['api-block-example']} ${styles.response}`;
-
-// overwriting global code block font size
-const jsonCodeBlockStyles = `!text-[0.8rem] language-json`;
-
 function Example({api, selectedTabView, selectedResponse}: ExampleProps) {
   let exampleJson: any;
   if (api.responses[selectedResponse].content?.examples) {
@@ -43,10 +38,10 @@ function Example({api, selectedTabView, selectedResponse}: ExampleProps) {
   }
 
   return (
-    <pre className={responseStyles}>
+    <pre className={styles['api-block-example']}>
       {selectedTabView === 0 &&
         (exampleJson ? (
-          <code className={jsonCodeBlockStyles}>
+          <code className="!text-[0.8rem]">
             {toJsxRuntime(
               refractor.highlight(JSON.stringify(exampleJson, null, 2), 'json') as Nodes,
               {Fragment, jsx, jsxs}
@@ -56,7 +51,7 @@ function Example({api, selectedTabView, selectedResponse}: ExampleProps) {
           strFormat(api.responses[selectedResponse].description)
         ))}
       {selectedTabView === 1 && (
-        <code className={jsonCodeBlockStyles}>
+        <code className="!text-[0.8rem]">
           {toJsxRuntime(
             refractor.highlight(
               JSON.stringify(api.responses[selectedResponse].content?.schema, null, 2),

--- a/src/components/apiPage/styles.scss
+++ b/src/components/apiPage/styles.scss
@@ -7,6 +7,10 @@
   box-shadow: rgba(0, 0, 0, 0.07) 0px 0px 0px 1px;
   margin-bottom: var(--paragraph-margin-bottom);
 }
+.dark .api-block {
+  border: 1px solid var(--border-color);
+  box-shadow: none;
+}
 
 .api-block-header {
   border-top-left-radius: 3px;

--- a/src/components/apiPage/styles.scss
+++ b/src/components/apiPage/styles.scss
@@ -61,6 +61,8 @@
 
 .response-status-btn-group {
   border-radius: 3px;
+  margin-left: auto;
+  margin-right: 1rem;
 }
 
 .response-status-btn {

--- a/src/components/apiPage/styles.scss
+++ b/src/components/apiPage/styles.scss
@@ -31,7 +31,7 @@
 }
 
 .api-block-header.response {
-  background: #2d2d2d;
+  background-color: var(--code-background);
   border-bottom: 1px solid #444;
   color: var(--white);
   display: flex;

--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -5,8 +5,7 @@
 
   pre {
     background-color: var(--code-background);
-    border: 1px solid #40364a;
-    border-radius: 0;
+    border-radius: 0 0 0.25rem 0.25rem;
     margin-top: 0;
     margin-bottom: 0;
   }

--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -4,7 +4,7 @@
   }
 
   pre {
-    background: #251f3d;
+    background-color: var(--code-background);
     border: 1px solid #40364a;
     border-radius: 0;
     margin-top: 0;

--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -136,7 +136,7 @@ const Container = styled('div')`
 `;
 
 const TabBar = styled('div')`
-  background: #251f3d;
+  background: var(--code-background);
   border-bottom: 1px solid #40364a;
   height: 36px;
   display: flex;

--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -10,6 +10,7 @@
 .prose {
   --heading-color: var(--darkPurple);
   --link-decoration: none;
+  --code-background: #251f3d;
   h1,
   h2,
   h3,

--- a/src/components/docPage/type.scss
+++ b/src/components/docPage/type.scss
@@ -175,7 +175,12 @@
   }
 
   dt + dd {
+    margin-top: 0.25rem;
     margin-bottom: var(--paragraph-margin-bottom);
+  }
+
+  dd > p {
+    margin-top: 0;
   }
 
   [data-onboarding-option].hidden {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6905,6 +6905,27 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-jsx-runtime@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.2.tgz#6d11b027473e69adeaa00ca4cfb5bb68e3d282fa"
+  integrity sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    estree-util-is-identifier-name "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    mdast-util-mdx-expression "^2.0.0"
+    mdast-util-mdx-jsx "^3.0.0"
+    mdast-util-mdxjs-esm "^2.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^1.0.0"
+    unist-util-position "^5.0.0"
+    vfile-message "^4.0.0"
+
 hast-util-to-parse5@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,7 +10201,7 @@ prisma@^5.8.1:
   dependencies:
     "@prisma/engines" "5.12.1"
 
-prismjs@^1.23.0, prismjs@^1.27.0:
+prismjs@^1.23.0:
   version "1.29.0"
   resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==


### PR DESCRIPTION
The intent was to unify the syntax highlighting logic for API examples and other docs,
but API examples have specific requirements that prevent us from reusing existing logic

code blocks are usually handled though `CodeTabs`, which adds tabs and manages the corresponding code blocks, but we need more tabs (api responses for example)

The curl bash snippet was possible to handle using a simple `CodeBlock`

I tried to use the same syntax highlighting libraries (using refractor) server side, and gave the API examples code blocks the same look and behavior as elsewhere

verify [here](https://sentry-docs-git-api-syntax-highlighting.sentry.dev/api/alerts/retrieve-a-metric-alert-rule-for-an-organization/)

closes #11093
