### PR TITLE
Update "Sign in" wording to "Go to Sentry"

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -80,7 +80,7 @@
 # Product Areas - www.notion.so/sentry/473791bae5bf43399d46093050b77bf0
 - name: 'Product Area: Unknown'
   color: '8D5494'
-- name: 'Product Area: Sign In'
+- name: 'Product Area: Go to Sentry'
   color: '8D5494'
 - name: 'Product Area: Issues'
   color: '8D5494'

--- a/apps/changelog/src/client/components/navbar.tsx
+++ b/apps/changelog/src/client/components/navbar.tsx
@@ -508,7 +508,7 @@ const NAV_ITEMS: NavItemsProps[] = [
   },
   {
     id: 'siginIn',
-    title: 'Sign In',
+    title: 'Go to Sentry',
     type: 'a',
     to: 'https://sentry.io/auth/login',
     variant: 'ghost',

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -68,7 +68,7 @@ export function Header({pathname, searchPlatforms, noSearch}: Props) {
           <NavLink href="https://sentry.io/changelog/">Changelog</NavLink>
           <NavLink href="https://try.sentry-demo.com/demo/start/">Sandbox</NavLink>
           <Fragment>
-            <NavLink href="https://sentry.io/">Sign In</NavLink>
+            <NavLink href="https://sentry.io/">Go to Sentry</NavLink>
             <NavLink
               href="https://sentry.io/signup/"
               className="transition-all duration-300 ease-in-out hover:bg-gradient-to-r hover:from-[#fa7faa] hover:via-[#ff9691] hover:to-[#ffb287]"

--- a/src/components/mobileMenu/index.tsx
+++ b/src/components/mobileMenu/index.tsx
@@ -59,7 +59,7 @@ export function MobileMenu({pathname, searchPlatforms}: Props) {
                 <Link href="https://try.sentry-demo.com/demo/start/">Sandbox</Link>
               </DropdownMenu.Item>
               <DropdownMenu.Item className={styles.DropdownMenuItem} asChild>
-                <Link href="https://sentry.io/">Sign In</Link>
+                <Link href="https://sentry.io/">Go to Sentry</Link>
               </DropdownMenu.Item>
               <DropdownMenu.Item className={styles.DropdownMenuItem} asChild>
                 <Link href="https://sentry.io/signup/">Get Started</Link>


### PR DESCRIPTION
This PR addresses https://github.com/getsentry/sentry-docs/issues/11557.

I think I changed all relevant instances of "Sign in" to "Go to Sentry" with my limited contextual knowledge!