### PR TITLE
docs(insights): Remove EA note from Queries re: MongoDB

### DIFF
--- a/docs/product/insights/queries.mdx
+++ b/docs/product/insights/queries.mdx
@@ -40,8 +40,6 @@ Query monitoring works best with up-to-date SDK versions. The following minimum 
 
 Sentry tries to extract metrics for all SQL-like dialects, as well as MongoDB. Other NoSQL databases like Elasticsearch, graph databases like Neo4j, and other non-SQL database systems are not currently eligible for this feature.
 
-<Note>MongoDB support is currently available to [Early Adopters](/organization/early-adopter-features/). Early Adopter features are still in-progress and may have bugs. We recognize the irony.</Note>
-
 If you are using <PlatformLink to="/tracing/instrumentation/automatic-instrumentation">automatic instrumentation</PlatformLink>, query monitoring should work without any configuration. If you've manually instrumented Sentry, you'll need to make sure that your spans conform to our standards for the best experience:
 
 - The span `op` field is set to an [eligible value](https://develop.sentry.dev/sdk/performance/span-operations/#database).


### PR DESCRIPTION
MongoDB support in the Queries module has GA'd, so we can remove the early adopters note.