### PR TITLE
fix(docs): fix 404 lint error

### DIFF
--- a/docs/api/auth.mdx
+++ b/docs/api/auth.mdx
@@ -25,7 +25,7 @@ You can create authentication tokens within Sentry by [creating an internal inte
 
 Some API endpoints require an authentication token that's associated with your user account, rather than an authentication token from an internal integration. These auth tokens can be created within Sentry on the "User settings" page (**User settings > User Auth Tokens**) and assigned specific scopes.
 
-The endpoints that require a user authentication token are specific to your user, such as [List Your Organizations](/api/organizations/list-your-organizations/).
+The endpoints that require a user authentication token are specific to your user, such as [Retrieve an Organization](/api/organizations/retrieve-an-organization/).
 
 ## DSN Authentication
 


### PR DESCRIPTION
the link https://docs.sentry.io/api/organizations/list-your-organization/ does not exist