### PR TITLE
fix(docs): add redirect for list your organizations api

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3282,6 +3282,10 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/api/projects/register-a-new-service-hook/',
   },
   {
+    from: '/api/organizations/list-your-organizations/',
+    to: '/api/users/list-your-organizations/',
+  },
+  {
     from: '/clients/cocoa/',
     to: '/platforms/apple/',
   },


### PR DESCRIPTION
https://docs.sentry.io/api/organizations/list-your-organizations/ is a broken link.

 it's moved to https://docs.sentry.io/api/users/list-your-organizations/ i believe