### PR TITLE
:bug: fix(open api resolver): Add Support for No Parameter API Documentation

### DIFF
--- a/src/build/open-api/types.ts
+++ b/src/build/open-api/types.ts
@@ -41,7 +41,7 @@ export type DeRefedOpenAPI = {
     [key: string]: {
       [key: string]: {
         operationId: string;
-        parameters: Parameter[];
+        parameters: Parameter[] | undefined;
         requestBody: {
           content: {
             'application/json': {

--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -128,10 +128,10 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
           slug: slugify(apiData.operationId),
           summary: apiData.summary,
           descriptionMarkdown: apiData.description,
-          pathParameters: apiData.parameters.filter(
+          pathParameters: (apiData.parameters || []).filter(
             p => p.in === 'path'
           ) as APIParameter[],
-          queryParameters: apiData.parameters.filter(
+          queryParameters: (apiData.parameters || []).filter(
             p => p.in === 'query'
           ) as APIParameter[],
           requestBodyContent: {


### PR DESCRIPTION
some Sentry endpoints don't have any parameters, neither `path` nor `query`. An example would be [`DocIntegrationsEndpoint`](https://github.com/getsentry/sentry/blob/5d91f6af15832688bd18839866e07bd2afbb0ed4/src/sentry/integrations/api/endpoints/doc_integrations_index.py#L23)

currently our Open API Resolver makes the assumption that there will always be parameters, so when trying to document parameter-less endpoints, we see the following error:

```
Error: Cannot read properties of undefined (reading 'filter')

 summary: apiData.summary,
  130 |           descriptionMarkdown: apiData.description,
> 131 |           pathParameters: apiData.parameters.filter(
      |                                              ^
  132 |             p => p.in === 'path'
  133 |           ) as APIParameter[],
  134 |           queryParameters: apiData.parameters.filter(
```

in this pr, i update the type of parameters to union with `undefined` to reflect that it might not exist and handle that case when building the api categories for documentation.


API documentation without the parameter will now look something like:
<img width="529" alt="image" src="https://github.com/user-attachments/assets/fcc43daf-85c5-4819-bf70-952c155cf19d">
