### PR TITLE
fix(python-filtering): update filtering example with optional return type in Python

### DIFF
--- a/docs/platforms/python/configuration/filtering/index.mdx
+++ b/docs/platforms/python/configuration/filtering/index.mdx
@@ -30,7 +30,7 @@ Suppose that you wish prevent all errors of type `ZeroDivisionError` from being 
 import sentry_sdk
 from sentry_sdk.types import Event, Hint
 
-def my_before_send(event: Event, hint: Hint) -> Event:
+def my_before_send(event: Event, hint: Hint) -> Event | None:
     # Filter out all ZeroDivisionError events.
     # Note that the exception type is available in the hint,
     # but we should handle the case where the exception info


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Refine the Python filtering configuration example to explicitly indicate the return type as `Event | None`, clarifying that the function can return either `Event` or `None`. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
